### PR TITLE
Receipts: Add option to not recover sender and write flags

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Equivalency;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
@@ -18,6 +19,7 @@ using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using NSubstitute;
 using NSubstitute.Core;
 using NUnit.Framework;
@@ -29,6 +31,7 @@ namespace Nethermind.Blockchain.Test.Receipts;
 [TestFixture(false)]
 public class PersistentReceiptStorageTests
 {
+    private TestSpecProvider _specProvider = new TestSpecProvider(Byzantium.Instance);
     private TestMemColumnsDb<ReceiptsColumns> _receiptsDb = null!;
     private ReceiptsRecovery _receiptsRecovery = null!;
     private IBlockTree _blockTree = null!;
@@ -46,10 +49,9 @@ public class PersistentReceiptStorageTests
     [SetUp]
     public void SetUp()
     {
-        MainnetSpecProvider specProvider = MainnetSpecProvider.Instance;
-        EthereumEcdsa ethereumEcdsa = new(specProvider.ChainId);
+        EthereumEcdsa ethereumEcdsa = new(_specProvider.ChainId);
         _receiptConfig = new ReceiptConfig();
-        _receiptsRecovery = new(ethereumEcdsa, specProvider);
+        _receiptsRecovery = new(ethereumEcdsa, _specProvider);
         _receiptsDb = new TestMemColumnsDb<ReceiptsColumns>();
         _receiptsDb.GetColumnDb(ReceiptsColumns.Blocks).Set(Keccak.Zero, Array.Empty<byte>());
         _blockTree = Substitute.For<IBlockTree>();
@@ -68,7 +70,7 @@ public class PersistentReceiptStorageTests
         _decoder = new ReceiptArrayStorageDecoder(_useCompactReceipts);
         _storage = new PersistentReceiptStorage(
             _receiptsDb,
-            MainnetSpecProvider.Instance,
+            _specProvider,
             _receiptsRecovery,
             _blockTree,
             _blockStore,
@@ -111,9 +113,10 @@ public class PersistentReceiptStorageTests
     {
         var (block, receipts) = InsertBlock();
 
-        _storage.Get(block).Should().BeEquivalentTo(receipts);
+        _storage.ClearCache();
+        _storage.Get(block).Should().BeEquivalentTo(receipts, ReceiptCompareOpt);
         // second should be from cache
-        _storage.Get(block).Should().BeEquivalentTo(receipts);
+        _storage.Get(block).Should().BeEquivalentTo(receipts, ReceiptCompareOpt);
     }
 
     [Test]
@@ -126,6 +129,24 @@ public class PersistentReceiptStorageTests
         block.Hash!.Bytes.CopyTo(blockNumPrefixed[8..]);
 
         _receiptsDb.GetColumnDb(ReceiptsColumns.Blocks)[blockNumPrefixed].Should().NotBeNull();
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Get_receipts_for_block_without_recovering_sender()
+    {
+        var (block, receipts) = InsertBlock();
+        foreach (Transaction tx in block.Transactions)
+        {
+            tx.SenderAddress = null;
+        }
+
+        _storage.ClearCache();
+        _storage.Get(block, recoverSender: false).Should().BeEquivalentTo(receipts, ReceiptCompareOpt);
+
+        foreach (Transaction tx in block.Transactions)
+        {
+            tx.SenderAddress.Should().BeNull();
+        }
     }
 
     [Test]
@@ -462,5 +483,11 @@ public class PersistentReceiptStorageTests
         _receiptsRecovery.TryRecover(new ReceiptRecoveryBlock(block), receipts);
 
         return (block, receipts);
+    }
+
+    private EquivalencyAssertionOptions<TxReceipt> ReceiptCompareOpt(EquivalencyAssertionOptions<TxReceipt> opts)
+    {
+        return opts
+            .Excluding(su => su.Error);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
@@ -23,10 +23,10 @@ namespace Nethermind.Blockchain.Receipts
 
         public Hash256 FindBlockHash(Hash256 txHash) => _receiptStorage.FindBlockHash(txHash);
 
-        public TxReceipt[] Get(Block block, bool recover = true)
+        public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = true)
         {
             var receipts = _receiptStorage.Get(block);
-            if (recover && _receiptsRecovery.TryRecover(block, receipts) == ReceiptsRecoveryResult.NeedReinsert)
+            if (recover && _receiptsRecovery.TryRecover(block, receipts, recoverSender) == ReceiptsRecoveryResult.NeedReinsert)
             {
                 _receiptStorage.Insert(block, receipts);
             }
@@ -41,7 +41,7 @@ namespace Nethermind.Blockchain.Receipts
             if (recover && _receiptsRecovery.NeedRecover(receipts))
             {
                 var block = _blockFinder.FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                if (_receiptsRecovery.TryRecover(block, receipts) == ReceiptsRecoveryResult.NeedReinsert)
+                if (_receiptsRecovery.TryRecover(block, receipts, forceRecoverSender: false) == ReceiptsRecoveryResult.NeedReinsert)
                 {
                     _receiptStorage.Insert(block, receipts);
                 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptFinder.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Blockchain.Receipts
     public interface IReceiptFinder
     {
         Hash256? FindBlockHash(Hash256 txHash);
-        TxReceipt[] Get(Block block, bool recover = true);
+        TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = true);
         TxReceipt[] Get(Hash256 blockHash, bool recover = true);
         bool CanGetReceiptsByHash(long blockNumber);
         bool TryGetReceiptsIterator(long blockNumber, Hash256 blockHash, out ReceiptsIterator iterator);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Blockchain.Receipts
     public interface IReceiptStorage : IReceiptFinder
     {
         void Insert(Block block, params TxReceipt[]? txReceipts) => Insert(block, txReceipts, true);
-        void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical);
+        void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical, WriteFlags writeFlags = WriteFlags.None);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }
         bool HasBlock(long blockNumber, Hash256 hash);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain.Receipts
             return receipt?.BlockHash;
         }
 
-        public TxReceipt[] Get(Block block, bool recover = true) => Get(block.Hash);
+        public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = true) => Get(block.Hash);
 
         public TxReceipt[] Get(Hash256 blockHash, bool recover = true) =>
             _receipts.TryGetValue(blockHash, out TxReceipt[] receipts) ? receipts : Array.Empty<TxReceipt>();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Blockchain.Receipts
             }
         }
 
-        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true)
+        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true, WriteFlags writeFlags = WriteFlags.None)
         {
             _receipts[block.Hash] = txReceipts;
             if (ensureCanonical)

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Blockchain.Receipts
         {
         }
 
-        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical) { }
+        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical, WriteFlags writeFlags) { }
 
         public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = false) => Array.Empty<TxReceipt>();
         public TxReceipt[] Get(Hash256 blockHash, bool recover = true) => Array.Empty<TxReceipt>();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical) { }
 
-        public TxReceipt[] Get(Block block, bool recover = true) => Array.Empty<TxReceipt>();
+        public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = false) => Array.Empty<TxReceipt>();
         public TxReceipt[] Get(Hash256 blockHash, bool recover = true) => Array.Empty<TxReceipt>();
         public bool CanGetReceiptsByHash(long blockNumber) => true;
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Blockchain.Receipts
             return null;
         }
 
-        public TxReceipt[] Get(Block block, bool recover = true)
+        public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = true)
         {
             if (block.ReceiptsRoot == Keccak.EmptyTreeHash)
             {
@@ -164,7 +164,7 @@ namespace Nethermind.Blockchain.Receipts
 
                     if (recover)
                     {
-                        _receiptsRecovery.TryRecover(block, receipts);
+                        _receiptsRecovery.TryRecover(block, receipts, forceRecoverSender: recoverSender);
                         _receiptsCache.Set(blockHash, receipts);
                     }
 
@@ -223,7 +223,7 @@ namespace Nethermind.Blockchain.Receipts
         {
             Block? block = _blockTree.FindBlock(blockHash);
             if (block is null) return Array.Empty<TxReceipt>();
-            return Get(block, recover);
+            return Get(block, recover, false);
         }
 
         public bool CanGetReceiptsByHash(long blockNumber) => blockNumber >= MigratedBlockNumber;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -263,7 +263,7 @@ namespace Nethermind.Blockchain.Receipts
         }
 
         [SkipLocalsInit]
-        public void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical = true)
+        public void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical = true, WriteFlags writeFlags = WriteFlags.None)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;
@@ -286,7 +286,7 @@ namespace Nethermind.Blockchain.Receipts
                 Span<byte> blockNumPrefixed = stackalloc byte[40];
                 GetBlockNumPrefixedKey(blockNumber, block.Hash!, blockNumPrefixed);
 
-                _blocksDb.PutSpan(blockNumPrefixed, stream.AsSpan());
+                _blocksDb.PutSpan(blockNumPrefixed, stream.AsSpan(), writeFlags);
             }
 
             if (blockNumber < MigratedBlockNumber)

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             public bool CanGetReceiptsByHash(long blockNumber) => _inStorage.CanGetReceiptsByHash(blockNumber);
             public bool TryGetReceiptsIterator(long blockNumber, Hash256 blockHash, out ReceiptsIterator iterator) => _inStorage.TryGetReceiptsIterator(blockNumber, blockHash, out iterator);
 
-            public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical) => _outStorage.Insert(block, txReceipts);
+            public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical, WriteFlags writeFlags) => _outStorage.Insert(block, txReceipts, ensureCanonical, writeFlags);
 
             public long? LowestInsertedReceiptBlockNumber
             {

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -130,7 +130,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
 
             public Hash256 FindBlockHash(Hash256 txHash) => _inStorage.FindBlockHash(txHash);
 
-            public TxReceipt[] Get(Block block, bool recover = true) => _inStorage.Get(block, recover);
+            public TxReceipt[] Get(Block block, bool recover = true, bool recoverSender = true) => _inStorage.Get(block, recover, recoverSender);
 
             public TxReceipt[] Get(Hash256 blockHash, bool recover = true) => _inStorage.Get(blockHash, recover);
 


### PR DESCRIPTION
- On Get() add option to not recover sender
  - This improve era export throughput by 4x.
- On Insert() add option to specify write flags.
  - On era export wal writes can reach 150 MBps.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
