### PR TITLE
Correct clique snapshot rpc api

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Consensus.Clique
         public Snapshot GetSnapshot(long? number = null)
         {
             Block head = _blockTree.Head;
-            if (number is not null && head.Number!= number)
+            if (number is not null && head.Number != number)
             {
                 head = _blockTree.FindBlock((long)number);
             }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Consensus.Clique
         public Snapshot GetSnapshot(long? number = null)
         {
             Block head = _blockTree.Head;
-            if (number is not null)
+            if (number is not null && head.Number!= number)
             {
                 head = _blockTree.FindBlock((long)number);
             }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Consensus.Clique
             Block head = _blockTree.Head;
             if (number is not null && head.Number != number)
             {
-                head = _blockTree.FindBlock((long)number);
+                head = _blockTree.FindBlock(number.Value);
             }
             return _snapshotManager.GetOrCreateSnapshot(head.Number, head.Hash);
         }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs
@@ -54,9 +54,13 @@ namespace Nethermind.Consensus.Clique
             cliqueBlockProducer.UncastVote(signer);
         }
 
-        public Snapshot GetSnapshot()
+        public Snapshot GetSnapshot(long? number = null)
         {
             Block head = _blockTree.Head;
+            if (number is not null)
+            {
+                head = _blockTree.FindBlock((long)number);
+            }
             return _snapshotManager.GetOrCreateSnapshot(head.Number, head.Hash);
         }
 
@@ -105,7 +109,7 @@ namespace Nethermind.Consensus.Clique
         public ResultWrapper<IReadOnlyDictionary<Address, bool>> clique_proposals() =>
             ResultWrapper<IReadOnlyDictionary<Address, bool>>.Success(cliqueBlockProducer?.GetProposals() ?? new Dictionary<Address, bool>());
 
-        public ResultWrapper<Snapshot> clique_getSnapshot() => ResultWrapper<Snapshot>.Success(GetSnapshot());
+        public ResultWrapper<Snapshot> clique_getSnapshot(long? number) => ResultWrapper<Snapshot>.Success(GetSnapshot(number));
 
         public ResultWrapper<Snapshot> clique_getSnapshotAtHash(Hash256 hash) => ResultWrapper<Snapshot>.Success(GetSnapshot(hash));
 

--- a/src/Nethermind/Nethermind.Consensus.Clique/ICliqueRpcModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/ICliqueRpcModule.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Consensus.Clique
         ResultWrapper<Address?> clique_getBlockSigner(Hash256? hash);
 
         [JsonRpcMethod(Description = "Retrieves a snapshot of all clique state at a given block.", IsImplemented = true)]
-        ResultWrapper<Snapshot> clique_getSnapshot();
+        ResultWrapper<Snapshot> clique_getSnapshot(long? number = null);
 
         [JsonRpcMethod(Description = "Retrieves the state snapshot at a given block.", IsImplemented = true)]
         ResultWrapper<Snapshot> clique_getSnapshotAtHash(Hash256 hash);

--- a/src/Nethermind/Nethermind.Consensus.Clique/Snapshot.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/Snapshot.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Consensus.Clique
         public Hash256 Hash { get; set; }
         public SortedList<Address, long> Signers { get; }
         public List<Vote> Votes { get; init; }
-        internal Dictionary<Address, Tally> Tally { get; }
+        public Dictionary<Address, Tally> Tally { get; }
 
         internal Snapshot(long number, Hash256 hash, SortedList<Address, long> signers, Dictionary<Address, Tally> tally)
         {

--- a/src/Nethermind/Nethermind.Consensus.Clique/Tally.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/Tally.cs
@@ -3,7 +3,7 @@
 
 namespace Nethermind.Consensus.Clique
 {
-    internal class Tally
+    public class Tally
     {
         public bool Authorize { get; }
         public int Votes { get; set; }


### PR DESCRIPTION
## Changes

- Allow `clique_getSnapshot` retrieves a snapshot of all clique state at a given block (default: latest block)
- Add tally in `clique_getSnapshot` response
Follow https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-clique#clique-getsnapshot

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Screenshots
<img width="1250" alt="Screenshot 2024-10-30 at 16 04 59" src="https://github.com/user-attachments/assets/03284a5b-263b-4e1f-8a83-d4254012ceb4">


<img width="1253" alt="Screenshot 2024-10-30 at 16 04 47" src="https://github.com/user-attachments/assets/a0ac4ca4-f906-492f-8af7-1dce6381bd42">

