### PR TITLE
Add client id to `admin_peers` RPC API 

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
@@ -58,7 +58,7 @@ namespace Nethermind.JsonRpc.Modules.Admin
         private string CalculateClientId(PublicKey nodeKey)
         {
             byte[] publicKeyBytes = nodeKey.Bytes;
-            return (publicKeyBytes is null ? Keccak.Zero : Keccak.Compute(publicKeyBytes)).ToString(false);
+            return (publicKeyBytes is null ? Keccak.Zero.ValueHash256 : ValueKeccak.Compute(publicKeyBytes)).ToString(false);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
@@ -6,12 +6,14 @@ using System.Globalization;
 using System.Net;
 using Nethermind.Network;
 using Nethermind.Stats.Model;
+using Nethermind.Core.Crypto;
 
 namespace Nethermind.JsonRpc.Modules.Admin
 {
     public class PeerInfo
     {
-        public string ClientId { get; set; }
+        public string Name { get; set; }
+        public string Id { get; }
         public string Host { get; set; }
         public int Port { get; set; }
         public string Address { get; set; }
@@ -36,7 +38,8 @@ namespace Nethermind.JsonRpc.Modules.Admin
                     $"{nameof(PeerInfo)} cannot be created for a {nameof(Peer)} with an unknown {peer.Node}");
             }
 
-            ClientId = peer.Node.ClientId;
+            Name = peer.Node.ClientId;
+            Id = CalculateClientId(peer.Node.Id);
             Host = peer.Node.Host is null ? null : IPAddress.Parse(peer.Node.Host).MapToIPv4().ToString();
             Port = peer.Node.Port;
             Address = peer.Node.Address.ToString();
@@ -50,6 +53,12 @@ namespace Nethermind.JsonRpc.Modules.Admin
                 EthDetails = peer.Node.EthDetails;
                 LastSignal = (peer.InSession ?? peer.OutSession)?.LastPingUtc.ToString(CultureInfo.InvariantCulture);
             }
+        }
+
+        private string CalculateClientId(PublicKey nodeKey)
+        {
+            byte[] publicKeyBytes = nodeKey.Bytes;
+            return (publicKeyBytes is null ? Keccak.Zero : Keccak.Compute(publicKeyBytes)).ToString(false);
         }
     }
 }


### PR DESCRIPTION
Add client id to `admin_peers` RPC API 

Related https://github.com/NethermindEth/nethermind/issues/7536

## Changes

- Add id to `admin_peers` RPC API 
- Update `clientId` -> `name`


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Screenshots
<img width="1258" alt="Screenshot 2024-11-04 at 13 42 38" src="https://github.com/user-attachments/assets/501fd963-24a4-4449-a680-1c15441f208a">

## Notes
Regarding updating the `clientId` parameter to `name`, I believe that refers to the client name. However, I've only updated it in the admin_peers RPC API, keeping `clientId` unchanged in other functions. 
