### PR TITLE
Fix: remove Mining.MinGasPrice from Gnosis config

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/gnosis.json
+++ b/src/Nethermind/Nethermind.Runner/configs/gnosis.json
@@ -36,9 +36,6 @@
     ],
     "InstanceID": "1000"
   },
-  "Mining": {
-    "MinGasPrice": "1000000000"
-  },
   "EthStats": {
     "Name": "Nethermind Gnosis"
   },


### PR DESCRIPTION
Fixes issue where passing any other value than `Blocks.MinGasPrice=1` throws an [exception](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Init/Steps/MigrateConfigs.cs#L69) on Gnosis. Since this flag is deprecated it should be removed from Gnosis config.

## Changes

- Remove Mining.MinGasPrice from Gnosis config

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No