### PR TITLE
Fix null ref in processing stats

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Consensus.Processing
             if (block is null) return;
 
             Transaction[] txs = block.Transactions;
-            Address beneficiary = block.Header.GasBeneficiary;
+            Address beneficiary = block.Header.GasBeneficiary ?? Address.Zero;
             Transaction lastTx = txs.Length > 0 ? txs[^1] : null;
             bool isMev = false;
             if (lastTx is not null && (lastTx.SenderAddress == beneficiary || _alternateMevPayees.Contains(lastTx.SenderAddress)))


### PR DESCRIPTION
## Changes

- `block.Header.GasBeneficiary` can be `null` handle this situation

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No