### PR TITLE
Shutter: Validator registry v0 backwards compatibility

### DIFF
--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterValidatorRegistryTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterValidatorRegistryTests.cs
@@ -46,30 +46,33 @@ class ShutterValidatorRegistryTests
         }
 
         // register all 10, then deregister last 5
-        updates.Add((0, CreateUpdate(100, 10, 0, true)));
-        updates.Add((1, CreateUpdate(105, 5, 1, false)));
+        updates.Add((0, CreateUpdate(100, 10, 0, 1, true)));
+        updates.Add((1, CreateUpdate(105, 5, 1, 1, false)));
+
+        // reregister 1 with V0 signature
+        updates.Add((2, CreateUpdate(107, 1, 2, 0, true)));
 
         // invalid updates should be ignored
-        updates.Add((2, CreateUpdate(100, 10, 0, false))); // invalid nonce
-        updates.Add((3, CreateUpdate(50, 50, 0, true))); // not in validatorsInfo
+        updates.Add((3, CreateUpdate(100, 10, 0, 1, false))); // invalid nonce
+        updates.Add((4, CreateUpdate(50, 50, 0, 1, true))); // not in validatorsInfo
 
         // bad signature
-        Update badUpdate = CreateUpdate(100, 10, 2, true);
+        Update badUpdate = CreateUpdate(100, 10, 2, 1, true);
         badUpdate.Signature[34] += 1;
-        updates.Add((4, badUpdate));
+        updates.Add((5, badUpdate));
 
         Assert.Multiple(() =>
         {
             Assert.That(!contract.IsRegistered(updates, validatorsInfo, out HashSet<ulong> unregistered));
-            Assert.That(unregistered, Has.Count.EqualTo(5));
+            Assert.That(unregistered, Has.Count.EqualTo(4));
         });
     }
 
-    private static Update CreateUpdate(ulong startIndex, uint count, uint nonce, bool isRegistration)
+    private static Update CreateUpdate(ulong startIndex, uint count, uint nonce, byte version, bool isRegistration)
     {
         ValidatorRegistryContract.Message msg = new()
         {
-            Version = 1,
+            Version = version,
             ChainId = ShutterTestsCommon.ChainId,
             ContractAddress = Address.Zero.Bytes,
             StartValidatorIndex = startIndex,

--- a/src/Nethermind/Nethermind.Shutter/Contracts/ValidatorRegistryContract.cs
+++ b/src/Nethermind/Nethermind.Shutter/Contracts/ValidatorRegistryContract.cs
@@ -105,6 +105,7 @@ public class ValidatorRegistryContract(
         }
 
         Message msg = new(update.Message.AsSpan());
+
         ulong startValidatorIndex = msg.StartValidatorIndex;
         ulong endValidatorIndex = msg.StartValidatorIndex + msg.Count;
 
@@ -121,7 +122,7 @@ public class ValidatorRegistryContract(
             return false;
         }
 
-        if (msg.Version != messageVersion)
+        if (msg.Version > messageVersion)
         {
             err = $"Registration message has wrong version ({msg.Version}) should be {messageVersion}.";
             return false;
@@ -178,11 +179,12 @@ public class ValidatorRegistryContract(
                 throw new ArgumentException("Validator registry contract message was wrong length.");
             }
 
-            Version = encodedMessage[0];
+            byte version = encodedMessage[0];
+            Version = version;
             ChainId = BinaryPrimitives.ReadUInt64BigEndian(encodedMessage[1..]);
             ContractAddress = encodedMessage[9..29];
             StartValidatorIndex = BinaryPrimitives.ReadUInt64BigEndian(encodedMessage[29..37]);
-            Count = BinaryPrimitives.ReadUInt32BigEndian(encodedMessage[37..41]);
+            Count = version == 0 ? 1 : BinaryPrimitives.ReadUInt32BigEndian(encodedMessage[37..41]);
             Nonce = BinaryPrimitives.ReadUInt32BigEndian(encodedMessage[41..45]);
             IsRegistration = encodedMessage[45] == 1;
         }


### PR DESCRIPTION
## Changes

- Backwards compatibility for old validator message version: https://github.com/gnosischain/specs/pull/53/commits/32d69825f439ae6938b0d353976cb4dd29f88ff9

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
