### PR TITLE
Free some disk space from runner and revert static dotnet change

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Check sizes
         run: |
           du -k
-          df -h
+          df -k

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -38,5 +38,5 @@ jobs:
         run: dotnet build src/Nethermind/${{ matrix.solution }}.sln -c ${{ matrix.config }}
       - name: Check sizes
         run: |
-          du -h
+          du -k
           df -h

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -10,11 +10,12 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest-16-cores]
     strategy:
       matrix:
         config: [release, debug]
         solution: [Nethermind, EthereumTests, Benchmarks]
+        dotnet-version: [8.0.403, 8.0.404]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -23,7 +24,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.403
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Cache dotnet packages
         id: cache-dotnet
         uses: actions/cache@v4
@@ -35,3 +36,7 @@ jobs:
             ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
       - name: Build ${{ matrix.solution }}.sln
         run: dotnet build src/Nethermind/${{ matrix.solution }}.sln -c ${{ matrix.config }}
+      - name: Check sizes
+        run: |
+          du -h
+          df -h

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [master]
   merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         config: [release, debug]
         solution: [Nethermind, EthereumTests, Benchmarks]
+        dotnet-version: [8.0.403, 8.0.404]
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
@@ -33,7 +34,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.403
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Cache dotnet packages
         id: cache-dotnet
         uses: actions/cache@v4

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -10,13 +10,23 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: [ubuntu-latest-16-cores]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         config: [release, debug]
         solution: [Nethermind, EthereumTests, Benchmarks]
         dotnet-version: [8.0.403, 8.0.404]
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: false
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -15,26 +15,23 @@ jobs:
       matrix:
         config: [release, debug]
         solution: [Nethermind, EthereumTests, Benchmarks]
-        dotnet-version: [8.0.403, 8.0.404]
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
-          android: true
+          android: false
           dotnet: false
-          haskell: true
-          large-packages: true
+          haskell: false
+          large-packages: false
           docker-images: true
-          swap-storage: true
+          swap-storage: false
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           submodules: ${{ matrix.solution == 'EthereumTests' }}
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Cache dotnet packages
         id: cache-dotnet
         uses: actions/cache@v4

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -4,9 +4,8 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master]
+    branches: [master, kch/check_build_size]
   merge_group:
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -22,6 +22,8 @@ jobs:
           submodules: ${{ matrix.solution == 'EthereumTests' }}
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.403
       - name: Cache dotnet packages
         id: cache-dotnet
         uses: actions/cache@v4

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         config: [release, debug]
         solution: [Nethermind, EthereumTests, Benchmarks]
-        dotnet-version: [8.0.403, 8.0.404]
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
@@ -33,8 +32,6 @@ jobs:
           submodules: ${{ matrix.solution == 'EthereumTests' }}
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Cache dotnet packages
         id: cache-dotnet
         uses: actions/cache@v4
@@ -46,7 +43,3 @@ jobs:
             ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
       - name: Build ${{ matrix.solution }}.sln
         run: dotnet build src/Nethermind/${{ matrix.solution }}.sln -c ${{ matrix.config }}
-      - name: Check sizes
-        run: |
-          du -k
-          df -k

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master, kch/check_build_size]
+    branches: [master]
   merge_group:
 
 jobs:


### PR DESCRIPTION
THIS WORKS - but not proud of it.

Removes some not needed build packages to fit again into smallest runners (avoid spending extra $ on build action and allows still to use latest dotnet).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No