### PR TITLE
Add Labels to ChainParameters to Enable Hardforks via Single Timestamp

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
@@ -12,34 +12,13 @@ namespace Nethermind.Specs.Test;
 public class ChainParametersTests
 {
     [Test]
-    public void ChainParameters_should_have_same_properties_as_chainSpecParamsJson()
-    {
-        string[] chainParametersExceptions = {
-            "Registrar"
-        };
-        string[] chainSpecParamsJsonExceptions = {
-            "ChainId", "EnsRegistrar", "NetworkId"
-        };
-        IEnumerable<string> chainParametersProperties = typeof(ChainParameters).GetProperties()
-            .Where(x => !chainParametersExceptions.Contains(x.Name))
-            .Select(x => x.Name);
-        IEnumerable<string> chainSpecParamsJsonProperties = typeof(ChainSpecParamsJson).GetProperties()
-            .Where(x => !chainSpecParamsJsonExceptions.Contains(x.Name)).
-            Select(x => x.Name);
-
-        Assert.That(chainParametersProperties, Is.EquivalentTo(chainSpecParamsJsonProperties));
-    }
-
-    [Test]
     public void SettingDencunTransitionTimestamp_SetsAllEipTimestamps()
     {
         var chainParameters = new ChainParameters();
         ulong timestamp = 0x65687fd0;
 
-        // Set Dencun label timestamp
         chainParameters.DencunTransitionTimestamp = timestamp;
 
-        // Verify all associated EIPs are set to the same timestamp
         Assert.That(chainParameters.Eip4844TransitionTimestamp, Is.EqualTo(timestamp));
         Assert.That(chainParameters.Eip4788TransitionTimestamp, Is.EqualTo(timestamp));
         Assert.That(chainParameters.Eip1153TransitionTimestamp, Is.EqualTo(timestamp));
@@ -52,35 +31,106 @@ public class ChainParametersTests
     {
         var chainParameters = new ChainParameters();
         ulong timestamp = 0x65687fd0;
+
         chainParameters.Eip4844TransitionTimestamp = timestamp;
         chainParameters.Eip4788TransitionTimestamp = timestamp;
         chainParameters.Eip1153TransitionTimestamp = timestamp;
         chainParameters.Eip5656TransitionTimestamp = timestamp;
         chainParameters.Eip6780TransitionTimestamp = timestamp;
+
         Assert.That(chainParameters.DencunTransitionTimestamp, Is.EqualTo(timestamp));
     }
-
 
     [Test]
     public void GettingDencunTransitionTimestamp_ReturnsNullWhenTimestampsDiffer()
     {
         var chainParameters = new ChainParameters();
         ulong timestamp = 0x65687fd0;
+
         chainParameters.Eip4844TransitionTimestamp = timestamp;
         chainParameters.Eip4788TransitionTimestamp = timestamp;
         chainParameters.Eip1153TransitionTimestamp = timestamp;
         chainParameters.Eip5656TransitionTimestamp = timestamp;
-        chainParameters.Eip6780TransitionTimestamp = timestamp + 1; // Conflict is made here
-        Assert.That(chainParameters.DencunTransitionTimestamp, Is.Null); // Test to see if Dencun label getter returns null due to conflict or not
+        chainParameters.Eip6780TransitionTimestamp = timestamp + 1; // Conflict
+
+        Assert.That(chainParameters.DencunTransitionTimestamp, Is.Null);
     }
 
     [Test]
-    public void ValidateNoTimestampConflicts_ReturnsTrueWhenAllMatch()
+    public void GettingCancunTransitionTimestamp_ReturnsTimestampWhenAllMatch()
     {
         var chainParameters = new ChainParameters();
-        ulong timestamp = 0x65687fd0;
-        chainParameters.DencunTransitionTimestamp = timestamp;
-        Assert.That(chainParameters.ValidateNoTimestampConflicts(), Is.True);
+        ulong timestamp = 0x12345abc;
+
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp;
+        chainParameters.Eip6780TransitionTimestamp = timestamp;
+
+        Assert.That(chainParameters.CancunTransitionTimestamp, Is.EqualTo(timestamp));
+    }
+
+    [Test]
+    public void GettingCancunTransitionTimestamp_ReturnsNullWhenTimestampsDiffer()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0x12345abc;
+
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp;
+        chainParameters.Eip6780TransitionTimestamp = timestamp + 1; // Conflict
+
+        Assert.That(chainParameters.CancunTransitionTimestamp, Is.Null);
+    }
+
+    [Test]
+    public void AreHardforkTimestampsEqual_ReturnsTrueWhenAllMatch()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0xabcdef01;
+
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp;
+        chainParameters.Eip6780TransitionTimestamp = timestamp;
+
+        Assert.That(chainParameters.AreHardforkTimestampsEqual("Dencun", "Cancun", "EIP-1153", "EIP-5656", "EIP-6780"), Is.True);
+    }
+
+    [Test]
+    public void AreHardforkTimestampsEqual_ReturnsFalseWhenTimestampsDiffer()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0xabcdef01;
+
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp + 1; // Conflict
+        chainParameters.Eip6780TransitionTimestamp = timestamp;
+
+        Assert.That(chainParameters.AreHardforkTimestampsEqual("Dencun", "Cancun", "EIP-1153", "EIP-5656", "EIP-6780"), Is.False);
+    }
+
+    [Test]
+    public void GetHardforkMapping_ReturnsCorrectMappingForValidHardfork()
+    {
+        var mapping = ChainParameters.GetHardforkMapping("Dencun");
+        Assert.That(mapping, Is.Not.Null);
+
+        var chainParameters = new ChainParameters { Eip4844TransitionTimestamp = 0x12345abc };
+        Assert.That(mapping!(chainParameters), Is.EqualTo(0x12345abc));
+    }
+
+    [Test]
+    public void GetHardforkMapping_ReturnsNullForInvalidHardfork()
+    {
+        var mapping = ChainParameters.GetHardforkMapping("InvalidHardfork");
+        Assert.That(mapping, Is.Null);
     }
 
 }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
@@ -29,4 +29,58 @@ public class ChainParametersTests
 
         Assert.That(chainParametersProperties, Is.EquivalentTo(chainSpecParamsJsonProperties));
     }
+
+    [Test]
+    public void SettingDencunTransitionTimestamp_SetsAllEipTimestamps()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0x65687fd0;
+
+        // Set Dencun label timestamp
+        chainParameters.DencunTransitionTimestamp = timestamp;
+
+        // Verify all associated EIPs are set to the same timestamp
+        Assert.That(chainParameters.Eip4844TransitionTimestamp, Is.EqualTo(timestamp));
+        Assert.That(chainParameters.Eip4788TransitionTimestamp, Is.EqualTo(timestamp));
+        Assert.That(chainParameters.Eip1153TransitionTimestamp, Is.EqualTo(timestamp));
+        Assert.That(chainParameters.Eip5656TransitionTimestamp, Is.EqualTo(timestamp));
+        Assert.That(chainParameters.Eip6780TransitionTimestamp, Is.EqualTo(timestamp));
+    }
+
+    [Test]
+    public void GettingDencunTransitionTimestamp_ReturnsTimestampWhenAllMatch()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0x65687fd0;
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp;
+        chainParameters.Eip6780TransitionTimestamp = timestamp;
+        Assert.That(chainParameters.DencunTransitionTimestamp, Is.EqualTo(timestamp));
+    }
+
+
+    [Test]
+    public void GettingDencunTransitionTimestamp_ReturnsNullWhenTimestampsDiffer()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0x65687fd0;
+        chainParameters.Eip4844TransitionTimestamp = timestamp;
+        chainParameters.Eip4788TransitionTimestamp = timestamp;
+        chainParameters.Eip1153TransitionTimestamp = timestamp;
+        chainParameters.Eip5656TransitionTimestamp = timestamp;
+        chainParameters.Eip6780TransitionTimestamp = timestamp + 1; // Conflict is made here
+        Assert.That(chainParameters.DencunTransitionTimestamp, Is.Null); // Test to see if Dencun label getter returns null due to conflict or not
+    }
+
+    [Test]
+    public void ValidateNoTimestampConflicts_ReturnsTrueWhenAllMatch()
+    {
+        var chainParameters = new ChainParameters();
+        ulong timestamp = 0x65687fd0;
+        chainParameters.DencunTransitionTimestamp = timestamp;
+        Assert.That(chainParameters.ValidateNoTimestampConflicts(), Is.True);
+    }
+
 }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
@@ -11,6 +11,26 @@ namespace Nethermind.Specs.Test;
 
 public class ChainParametersTests
 {
+
+    [Test]
+    public void ChainParameters_should_have_same_properties_as_chainSpecParamsJson()
+    {
+        string[] chainParametersExceptions = {
+            "Registrar"
+        };
+        string[] chainSpecParamsJsonExceptions = {
+            "ChainId", "EnsRegistrar", "NetworkId"
+        };
+        IEnumerable<string> chainParametersProperties = typeof(ChainParameters).GetProperties()
+            .Where(x => !chainParametersExceptions.Contains(x.Name))
+            .Select(x => x.Name);
+        IEnumerable<string> chainSpecParamsJsonProperties = typeof(ChainSpecParamsJson).GetProperties()
+            .Where(x => !chainSpecParamsJsonExceptions.Contains(x.Name)).
+            Select(x => x.Name);
+
+        Assert.That(chainParametersProperties, Is.EquivalentTo(chainSpecParamsJsonProperties));
+    }
+
     [Test]
     public void SettingDencunTransitionTimestamp_SetsAllEipTimestamps()
     {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -79,10 +79,6 @@ public class ChainParameters
         return dencunConflicts && cancunConflicts;
     }
 
-
-
-//////////////////////////////////////////////////////////////
-
     public long? MaxCodeSize { get; set; }
     public long? MaxCodeSizeTransition { get; set; }
     public ulong? MaxCodeSizeTransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -9,6 +9,80 @@ namespace Nethermind.Specs.ChainSpecStyle;
 
 public class ChainParameters
 {
+
+    private ulong? _dencunTransitionTimestamp;
+    private ulong? _cancunTransitionTimestamp;
+
+    public ulong? DencunTransitionTimestamp
+    {
+        get
+        {
+            if (Eip4844TransitionTimestamp == Eip4788TransitionTimestamp &&
+                Eip4788TransitionTimestamp == Eip1153TransitionTimestamp &&
+                Eip1153TransitionTimestamp == Eip5656TransitionTimestamp &&
+                Eip5656TransitionTimestamp == Eip6780TransitionTimestamp)
+            {
+                return Eip4844TransitionTimestamp;
+            }
+
+            return null;
+        }
+        set
+        {
+            _dencunTransitionTimestamp = value;
+            Eip4844TransitionTimestamp = value;
+            Eip4788TransitionTimestamp = value;
+            Eip1153TransitionTimestamp = value;
+            Eip5656TransitionTimestamp = value;
+            Eip6780TransitionTimestamp = value;
+        }
+    }
+    public ulong? CancunTransitionTimestamp
+    {
+        get
+        {
+            return (Eip4844TransitionTimestamp == _cancunTransitionTimestamp &&
+                    Eip4788TransitionTimestamp == _cancunTransitionTimestamp &&
+                    Eip1153TransitionTimestamp == _cancunTransitionTimestamp &&
+                    Eip5656TransitionTimestamp == _cancunTransitionTimestamp &&
+                    Eip6780TransitionTimestamp == _cancunTransitionTimestamp)
+                ? _cancunTransitionTimestamp
+                : null;
+        }
+        set
+        {
+            _cancunTransitionTimestamp = value;
+            Eip4844TransitionTimestamp = value;
+            Eip4788TransitionTimestamp = value;
+            Eip1153TransitionTimestamp = value;
+            Eip5656TransitionTimestamp = value;
+            Eip6780TransitionTimestamp = value;
+        }
+    }
+
+    public bool ValidateNoTimestampConflicts()
+    {
+        bool dencunConflicts = DencunTransitionTimestamp == null ||
+                            (Eip4844TransitionTimestamp == DencunTransitionTimestamp &&
+                                Eip4788TransitionTimestamp == DencunTransitionTimestamp &&
+                                Eip1153TransitionTimestamp == DencunTransitionTimestamp &&
+                                Eip5656TransitionTimestamp == DencunTransitionTimestamp &&
+                                Eip6780TransitionTimestamp == DencunTransitionTimestamp);
+
+        bool cancunConflicts = CancunTransitionTimestamp == null ||
+                            (Eip4844TransitionTimestamp == CancunTransitionTimestamp &&
+                                Eip4788TransitionTimestamp == CancunTransitionTimestamp &&
+                                Eip1153TransitionTimestamp == CancunTransitionTimestamp &&
+                                Eip5656TransitionTimestamp == CancunTransitionTimestamp &&
+                                Eip6780TransitionTimestamp == CancunTransitionTimestamp);
+
+        return dencunConflicts && cancunConflicts;
+    }
+
+
+
+//////////////////////////////////////////////////////////////
+
     public long? MaxCodeSize { get; set; }
     public long? MaxCodeSizeTransition { get; set; }
     public ulong? MaxCodeSizeTransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -12,6 +12,56 @@ namespace Nethermind.Specs.ChainSpecStyle.Json;
 
 internal class ChainSpecParamsJson
 {
+
+    [JsonPropertyName("dencun")]
+    public ulong? DencunTransitionTimestamp
+    {
+        get => _dencunTransitionTimestamp;
+        set
+        {
+            _dencunTransitionTimestamp = value;
+            Eip4844TransitionTimestamp = value;
+            Eip4788TransitionTimestamp = value;
+            Eip1153TransitionTimestamp = value;
+            Eip5656TransitionTimestamp = value;
+            Eip6780TransitionTimestamp = value;
+        }
+    }
+
+    [JsonPropertyName("cancun")]
+    public ulong? CancunTransitionTimestamp
+    {
+        get => _cancunTransitionTimestamp;
+        set
+        {
+            _cancunTransitionTimestamp = value;
+            Eip4844TransitionTimestamp = value;
+            Eip4788TransitionTimestamp = value;
+            Eip1153TransitionTimestamp = value;
+            Eip5656TransitionTimestamp = value;
+            Eip6780TransitionTimestamp = value;
+        }
+    }
+
+    private ulong? _dencunTransitionTimestamp;
+    private ulong? _cancunTransitionTimestamp;
+
+    public bool ValidateNoTimestampConflicts()
+    {
+        return (DencunTransitionTimestamp == null || (
+                    Eip4844TransitionTimestamp == DencunTransitionTimestamp &&
+                    Eip4788TransitionTimestamp == DencunTransitionTimestamp &&
+                    Eip1153TransitionTimestamp == DencunTransitionTimestamp &&
+                    Eip5656TransitionTimestamp == DencunTransitionTimestamp &&
+                    Eip6780TransitionTimestamp == DencunTransitionTimestamp))
+               &&
+               (CancunTransitionTimestamp == null || (
+                    Eip4844TransitionTimestamp == CancunTransitionTimestamp &&
+                    Eip4788TransitionTimestamp == CancunTransitionTimestamp &&
+                    Eip1153TransitionTimestamp == CancunTransitionTimestamp &&
+                    Eip5656TransitionTimestamp == CancunTransitionTimestamp &&
+                    Eip6780TransitionTimestamp == CancunTransitionTimestamp));
+    }
     public ulong? ChainId { get; set; }
     public ulong? NetworkId { get; set; }
 


### PR DESCRIPTION
This PR introduces functionality to allow grouped EIP timestamps (e.g., dencun, cancun) in ChainParameters. This simplifies the process of activating multiple EIPs simultaneously through a single label, while preserving the ability to handle individual EIP timestamps.

Fixes #7738

### Changes
- Added DencunTransitionTimestamp and CancunTransitionTimestamp to ChainParameters class.
- Implemented ValidateNoTimestampConflicts to detect and validate timestamp conflicts between labels and individual EIPs.
- Updated ChainSpecParamsJson to support grouped label serialization/deserialization.
- Added tests in ChainParametersTests to verify label functionality and conflict detection.

### Types of Changes
What types of changes does your code introduce?

- New feature (a non-breaking change that adds functionality)

### Testing
Requires testing
- Yes

If yes, did you write tests?
- Yes

#### Notes on testing
Added unit tests in ChainParametersTests to verify:

- Setting and getting label timestamps.
- Conflict detection for mismatched individual EIP timestamps.
- Valid behavior when all timestamps match.

### Documentation
Requires documentation update
- No

Requires explanation in Release Notes
- Yes

### Release Notes:
- Added support for grouped EIP timestamps (dencun, cancun) in ChainParameters for simplifying hardfork activation.