### PR TITLE
Support the deprecated `.cfg` extension in `-c` option

### DIFF
--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -51,7 +51,7 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
 
             try
             {
-                if (_logger.IsInfo) _logger.Warn($"Loading assembly {pluginAssembly}");
+                if (_logger.IsInfo) _logger.Info($"Loading assembly {pluginAssembly}");
                 string assemblyPath = _fileSystem.Path.Combine(pluginAssembliesDir, assemblyName);
                 Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
                 AssemblyLoadContext.Default.Resolving += (_, name) =>
@@ -73,7 +73,7 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
                     {
                         if (!PluginTypes.Contains(type))
                         {
-                            if (_logger.IsInfo) _logger.Warn($"  Found plugin type {pluginAssembly}");
+                            if (_logger.IsInfo) _logger.Info($"  Found plugin type {pluginAssembly}");
                             _pluginTypes.Add(type);
                         }
                     }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -403,6 +403,15 @@ IConfigProvider CreateConfigProvider(ParseResult parseResult)
                 }
             }
         }
+        // For backward compatibility. To be removed in the future.
+        else if (Path.GetExtension(configFile).Equals(".cfg", StringComparison.Ordinal))
+        {
+            var name = Path.GetFileNameWithoutExtension(configFile)!;
+
+            configFile = $"{configFile[..^4]}.json";
+
+            logger.Warn($"'{name}.cfg' is deprecated. Use '{name}' instead.");
+        }
     }
     else
     {

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -123,6 +123,8 @@ async Task<int> ConfigureAsync(string[] args)
     );
     pluginLoader.Load();
 
+    CheckForDeprecatedOptions(parseResult);
+
     // leaving here as an example of adding Debug plugin
     // IPluginLoader mevLoader = SinglePluginLoader<MevPlugin>.Instance;
     // CompositePluginLoader pluginLoader = new (pluginLoader, mevLoader);
@@ -268,6 +270,27 @@ void AddConfigurationOptions(CliCommand command)
 
             if (configItemAttribute?.IsPortOption == true)
                 ConfigExtensions.AddPortOptionName(configType, propertyInfo.Name);
+        }
+    }
+}
+
+void CheckForDeprecatedOptions(ParseResult parseResult)
+{
+    CliOption<string>[] deprecatedOptions =
+    [
+        BasicOptions.ConfigurationDirectory,
+        BasicOptions.DatabasePath,
+        BasicOptions.DataDirectory,
+        BasicOptions.LoggerConfigurationSource,
+        BasicOptions.PluginsDirectory
+    ];
+
+    foreach (CliToken token in parseResult.Tokens)
+    {
+        foreach (CliOption option in deprecatedOptions)
+        {
+            if (option.Aliases.Contains(token.Value, StringComparison.Ordinal))
+                logger.Warn($"{token} option is deprecated. Use {option.Name} instead.");
         }
     }
 }


### PR DESCRIPTION
## Changes

- Added backward compatibility for uncommon use cases specifying the `.cfg` extension in the `-c` option. For instance, `-c mainnet.cfg` instead of `-c mainnet`. In this case, Nethermind will handle it with a warning not to use it.
- Added warnings for deprecated command line options.
- Fixed log levels of plugin loader from "warn" to "info".

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

To be added later.
