### PR TITLE
Use minimal http setup

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
+++ b/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
@@ -8,10 +8,12 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Prometheus;
 
 namespace Nethermind.Monitoring;
@@ -72,8 +74,11 @@ public sealed class NethermindKestrelMetricServer : MetricHandler
 
         // If the caller needs to customize any of this, they can just set up their own web host and inject the middleware.
         var builder = new WebHostBuilder()
-            .UseKestrel()
-            .UseIISIntegration()
+            // Explicitly build from UseKestrelCore rather than UseKestrel to
+            // not add additional transports that we don't use e.g. msquic as that
+            // adds a lot of additional idle threads to the process.
+            .UseKestrelCore()
+            .UseKestrelHttpsConfiguration()
             .Configure(app =>
             {
                 app.UseMetricServer(_configureExporter, _url);
@@ -95,25 +100,24 @@ public sealed class NethermindKestrelMetricServer : MetricHandler
 
         if (_certificate is not null)
         {
-            builder = builder.ConfigureServices(services =>
+            builder.ConfigureServices(services =>
             {
-                void configureEndpoint(ListenOptions options)
-                {
-                    options.UseHttps(_certificate);
-                }
-
                 services.Configure<KestrelServerOptions>(options =>
                 {
-                    options.Listen(IPAddress.Any, _port, configureEndpoint);
+                    options.Listen(
+                        IPAddress.Any,
+                        _port,
+                        listenOptions => listenOptions.UseHttps(_certificate)
+                    );
                 });
             });
         }
         else
         {
-            builder = builder.UseUrls(hostAddress);
+            builder.UseUrls(hostAddress);
         }
 
-        var webHost = builder.Build();
+        IWebHost webHost = builder.Build();
 
         // This is what changed
         // webHost.Start();

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -48,6 +49,11 @@ public class Startup
         {
             options.Limits.MaxRequestBodySize = jsonRpcConfig.MaxRequestBodySize;
             options.ConfigureHttpsDefaults(co => co.SslProtocols |= SslProtocols.Tls13);
+            options.ConfigureEndpointDefaults(listenOptions =>
+            {
+                listenOptions.Protocols = HttpProtocols.Http1;
+                listenOptions.DisableAltSvcHeader = true;
+            });
         });
         Bootstrap.Instance.RegisterJsonRpcServices(services);
 


### PR DESCRIPTION
## Changes

- Build using `.UseKestrelCore()` rather than `.UseKestrel()`/`.CreateDefaultBuilder()` as the later adds a lot of extra features and protocols that we don't use (span tracing, threads for quic etc)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No