### PR TITLE
Default `totalDifficulty` to 0 when fetching Fast Sync settings

### DIFF
--- a/scripts/syncSettings.py
+++ b/scripts/syncSettings.py
@@ -115,7 +115,7 @@ def fastBlocksSettings(configuration, apiUrl, blockReduced, multiplierRequiremen
         pivot = json.loads(requests.post(apiUrl, headers=headers, data=data).text)
 
     pivotHash = pivot['result']['hash']
-    pivotTotalDifficulty = int(pivot['result']['totalDifficulty'],16)
+    pivotTotalDifficulty = int(pivot['result'].get('totalDifficulty', '0x0'), 16)
     print(configuration + 'LatestBlock: ' + str(latestBlock))
     print(configuration + 'PivotNumber: ' + str(baseBlock))
     print(configuration + 'PivotHash: ' + str(pivotHash))


### PR DESCRIPTION
## Changes

- Default `totalDifficulty` to 0 when fetching Fast Sync settings

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Tested by running our Python script: https://github.com/NethermindEth/nethermind/blob/42a603b49aa7cc975d744daab7e8e8b547b109d9/scripts/syncSettings.py

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `totalDifficulty` field of a block is no longer required by the ETH JSON-RPC spec given the transition to PoS, and we can safely default it to `0` when it's not present (see https://github.com/ethereum/execution-apis/pull/570).
