### PR TITLE
ParallelUnbalancedWork for efficient unbalanced parallel loops

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
@@ -26,6 +26,7 @@ namespace Nethermind.Benchmark.Runner
             AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Descriptor);
             AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Statistics);
             AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Params);
+            AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Metrics);
             AddLogger(BenchmarkDotNet.Loggers.ConsoleLogger.Default);
             AddExporter(BenchmarkDotNet.Exporters.Json.JsonExporter.FullCompressed);
             AddDiagnoser(BenchmarkDotNet.Diagnosers.MemoryDiagnoser.Default);
@@ -59,7 +60,7 @@ namespace Nethermind.Benchmark.Runner
             {
                 foreach (Assembly assembly in additionalJobAssemblies)
                 {
-                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core80)), args);
+                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core90)), args);
                 }
 
                 foreach (Assembly assembly in simpleJobAssemblies)

--- a/src/Nethermind/Nethermind.Benchmark/Core/ParallelBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/ParallelBenchmark.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Threading;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Benchmarks.Core;
+
+[HideColumns("Job", "RatioSD")]
+public class ParallelBenchmark
+{
+    private int[] _times;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _times = new int[200];
+
+        for (int i = 0; i < _times.Length; i++)
+        {
+            _times[i] = i % 100;
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public void ParallelFor()
+    {
+        Parallel.For(
+            0,
+            _times.Length,
+            (i) => Thread.Sleep(_times[i]));
+    }
+
+    [Benchmark]
+    public void ParallelForEach()
+    {
+        Parallel.ForEach(
+            _times,
+            (time) => Thread.Sleep(time));
+    }
+
+    [Benchmark]
+    public void UnbalancedParallel()
+    {
+        ParallelUnbalancedWork.For<int[]>(
+            0,
+            _times.Length,
+            ParallelUnbalancedWork.DefaultOptions,
+            _times,
+            (i, value) =>
+            {
+                Thread.Sleep(value[i]);
+                return value;
+            },
+            (value) => { });
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -334,9 +334,15 @@ public partial class BlockProcessor(
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void CalculateBlooms(TxReceipt[] receipts)
     {
-        ParallelUnbalancedWork.For(0, receipts.Length, i =>
+        ParallelUnbalancedWork.For(
+            0,
+            receipts.Length,
+            ParallelUnbalancedWork.DefaultOptions,
+            receipts,
+            static (i, receipts) =>
         {
             receipts[i].CalculateBloom();
+            return receipts;
         });
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -19,6 +19,7 @@ using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
@@ -333,10 +334,8 @@ public partial class BlockProcessor(
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void CalculateBlooms(TxReceipt[] receipts)
     {
-        int index = 0;
-        Parallel.For(0, receipts.Length, _ =>
+        ParallelUnbalancedWork.For(0, receipts.Length, i =>
         {
-            int i = Interlocked.Increment(ref index) - 1;
             receipts[i].CalculateBloom();
         });
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/RecoverSignature.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/RecoverSignature.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -48,7 +49,7 @@ namespace Nethermind.Consensus.Processing
                 // so we assume the rest of txs in the block are already recovered
                 return;
 
-            Parallel.For(0, txs.Length, i =>
+            ParallelUnbalancedWork.For(0, txs.Length, i =>
             {
                 Transaction tx = txs[i];
                 if (!tx.IsHashCalculated)
@@ -111,7 +112,7 @@ namespace Nethermind.Consensus.Processing
             if (recoverFromEcdsa > 3)
             {
                 // Recover ecdsa in Parallel
-                Parallel.For(0, txs.Length, i =>
+                ParallelUnbalancedWork.For(0, txs.Length, i =>
                 {
                     Transaction tx = txs[i];
                     if (!ShouldRecoverSignatures(tx)) return;

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -281,6 +281,12 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         Count = newLength;
     }
 
+    public ref T GetRef(int index)
+    {
+        GuardIndex(index);
+        return ref _array[index];
+    }
+
     public T this[int index]
     {
         get

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -180,6 +180,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// </summary>
         public SharedCounter Index { get; } = new SharedCounter(fromInclusive);
         public SemaphoreSlim Event { get; } = new(initialCount: 0);
+        private int _activeThreads = threads;
 
         /// <summary>
         /// Gets the exclusive upper bound of the range.
@@ -189,7 +190,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// <summary>
         /// Gets the number of active threads.
         /// </summary>
-        public int ActiveThreads => Volatile.Read(ref threads);
+        public int ActiveThreads => Volatile.Read(ref _activeThreads);
 
         /// <summary>
         /// Marks a thread as completed.
@@ -197,7 +198,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// <returns>The number of remaining active threads.</returns>
         public int MarkThreadCompleted()
         {
-            var remaining = Interlocked.Decrement(ref threads);
+            var remaining = Interlocked.Decrement(ref _activeThreads);
 
             if (remaining == 0)
             {

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -77,6 +77,25 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, init, default, action, @finally);
 
     /// <summary>
+    /// Executes a parallel for loop over a range of integers, with thread-local data, initialization, and finalization functions.
+    /// </summary>
+    /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
+    /// <param name="fromInclusive">The inclusive lower bound of the range.</param>
+    /// <param name="toExclusive">The exclusive upper bound of the range.</param>
+    /// <param name="parallelOptions">An object that configures the behavior of this operation.</param>
+    /// <param name="value">The initial the local data for each thread.</param>
+    /// <param name="action">The delegate that is invoked once per iteration.</param>
+    /// <param name="finally">The function to finalize the local data for each thread.</param>
+    public static void For<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        TLocal value,
+        Func<int, TLocal, TLocal> action,
+        Action<TLocal> @finally)
+        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, null, value, action, @finally);
+
+    /// <summary>
     /// Executes a parallel for loop over a range of integers, with thread-local data.
     /// </summary>
     /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Threading;
+
+public class ParallelUnbalancedWork : IThreadPoolWorkItem
+{
+    private static readonly ParallelOptions s_parallelOptions = new()
+    {
+        // default to the number of processors
+        MaxDegreeOfParallelism = Environment.ProcessorCount
+    };
+
+    private readonly Data _data;
+
+    public static void For(int fromInclusive, int toExclusive, Action<int> action)
+        => For(fromInclusive, toExclusive, s_parallelOptions, action);
+
+    public static void For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action)
+    {
+        int threads = parallelOptions.MaxDegreeOfParallelism > 0 ? parallelOptions.MaxDegreeOfParallelism : Environment.ProcessorCount;
+
+        Data data = new(threads, fromInclusive, toExclusive, action);
+
+        for (int i = 0; i < threads - 1; i++)
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(new ParallelUnbalancedWork(data), preferLocal: false);
+        }
+
+        new ParallelUnbalancedWork(data).Execute();
+
+        if (data.ActiveThreads > 0)
+        {
+            lock (data)
+            {
+                if (data.ActiveThreads > 0)
+                {
+                    // Wait for remaining to complete
+                    Monitor.Wait(data);
+                }
+            }
+        }
+    }
+
+    public static void For<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        Func<TLocal> init,
+        Func<int, TLocal, TLocal> action,
+        Action<TLocal> @finally)
+        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, init, default, action, @finally);
+
+    public static void For<TLocal>(int fromInclusive, int toExclusive, TLocal state, Func<int, TLocal, TLocal> action)
+        => For(fromInclusive, toExclusive, s_parallelOptions, state, action);
+
+    public static void For<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        TLocal state,
+        Func<int, TLocal, TLocal> action)
+        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, null, state, action);
+
+    private ParallelUnbalancedWork(Data data)
+    {
+        _data = data;
+    }
+
+    public void Execute()
+    {
+        int i = _data.Index.GetNext();
+        while (i < _data.ToExclusive)
+        {
+            _data.Action(i);
+            i = _data.Index.GetNext();
+        }
+
+        _data.MarkThreadCompleted();
+    }
+
+    private class SharedCounter(int fromInclusive)
+    {
+        private int _index = fromInclusive;
+        public int GetNext() => Interlocked.Increment(ref _index) - 1;
+    }
+
+    private class BaseData(int threads, int fromInclusive, int toExclusive)
+    {
+        public SharedCounter Index { get; } = new SharedCounter(fromInclusive);
+        public int ToExclusive => toExclusive;
+        public int ActiveThreads => Volatile.Read(ref threads);
+
+        public int MarkThreadCompleted()
+        {
+            var remaining = Interlocked.Decrement(ref threads);
+
+            if (remaining == 0)
+            {
+                lock (this)
+                {
+                    Monitor.Pulse(this);
+                }
+            }
+
+            return remaining;
+        }
+    }
+
+    private class Data(int threads, int fromInclusive, int toExclusive, Action<int> action) :
+        BaseData(threads, fromInclusive, toExclusive)
+    {
+        public Action<int> Action => action;
+    }
+
+    private class InitProcessor<TLocal> : IThreadPoolWorkItem
+    {
+        private readonly Data<TLocal> _data;
+
+        public static void For(
+            int fromInclusive,
+            int toExclusive,
+            ParallelOptions parallelOptions,
+            Func<TLocal>? init,
+            TLocal? initValue,
+            Func<int, TLocal, TLocal> action,
+            Action<TLocal>? @finally = null)
+        {
+            var threads = parallelOptions.MaxDegreeOfParallelism > 0 ? parallelOptions.MaxDegreeOfParallelism : Environment.ProcessorCount;
+
+            var data = new Data<TLocal>(threads, fromInclusive, toExclusive, action, init, initValue, @finally);
+
+            for (int i = 0; i < threads - 1; i++)
+            {
+                ThreadPool.UnsafeQueueUserWorkItem(new InitProcessor<TLocal>(data), preferLocal: false);
+            }
+
+            new InitProcessor<TLocal>(data).Execute();
+
+            if (data.ActiveThreads > 0)
+            {
+                lock (data)
+                {
+                    if (data.ActiveThreads > 0)
+                    {
+                        // Wait for remaining to complete
+                        Monitor.Wait(data);
+                    }
+                }
+            }
+        }
+
+        private InitProcessor(Data<TLocal> data) => _data = data;
+
+        public void Execute()
+        {
+            TLocal? value = _data.Init();
+            int i = _data.Index.GetNext();
+            while (i < _data.ToExclusive)
+            {
+                value = _data.Action(i, value);
+                i = _data.Index.GetNext();
+            }
+
+            _data.Finally(value);
+
+            _data.MarkThreadCompleted();
+        }
+
+        private class Data<TValue>(int threads,
+            int fromInclusive,
+            int toExclusive,
+            Func<int, TLocal, TLocal> action,
+            Func<TValue>? init = null,
+            TValue? initValue = default,
+            Action<TValue>? @finally = null) : BaseData(threads, fromInclusive, toExclusive)
+        {
+            public Func<int, TLocal, TLocal> Action => action;
+
+            public TValue Init() => initValue ?? (init is not null ? init.Invoke() : default)!;
+
+            public void Finally(TValue value)
+            {
+                @finally?.Invoke(value);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Core.Threading;
 /// </summary>
 public class ParallelUnbalancedWork : IThreadPoolWorkItem
 {
-    private static readonly ParallelOptions s_parallelOptions = new()
+    public static readonly ParallelOptions DefaultOptions = new()
     {
         // default to the number of processors
         MaxDegreeOfParallelism = Environment.ProcessorCount
@@ -28,7 +28,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     /// <param name="toExclusive">The exclusive upper bound of the range.</param>
     /// <param name="action">The delegate that is invoked once per iteration.</param>
     public static void For(int fromInclusive, int toExclusive, Action<int> action)
-        => For(fromInclusive, toExclusive, s_parallelOptions, action);
+        => For(fromInclusive, toExclusive, DefaultOptions, action);
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers, with the specified options.
@@ -85,7 +85,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     /// <param name="state">The initial state of the thread-local data.</param>
     /// <param name="action">The delegate that is invoked once per iteration.</param>
     public static void For<TLocal>(int fromInclusive, int toExclusive, TLocal state, Func<int, TLocal, TLocal> action)
-        => For(fromInclusive, toExclusive, s_parallelOptions, state, action);
+        => For(fromInclusive, toExclusive, DefaultOptions, state, action);
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers, with thread-local data and specified options.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -141,7 +141,7 @@ namespace Nethermind.Evm.TransactionProcessing
             // commit - is for standard execute, we will commit thee state after execution
             // !commit - is for build up during block production, we won't commit state after each transaction to support rollbacks
             // we commit only after all block is constructed
-            bool commit = opts.HasFlag(ExecutionOptions.Commit) || !spec.IsEip658Enabled;
+            bool commit = opts.HasFlag(ExecutionOptions.Commit) || (!opts.HasFlag(ExecutionOptions.Warmup) && !spec.IsEip658Enabled);
 
             TransactionResult result;
             if (!(result = ValidateStatic(tx, header, spec, opts, out long intrinsicGas))) return result;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -356,17 +356,24 @@ public class JsonRpcService : IJsonRpcService
             }
             else if (providedParametersLength > parallelThreshold)
             {
-                ParallelUnbalancedWork.For(0, providedParametersLength, (int i) =>
+                ParallelUnbalancedWork.For(
+                    0,
+                    providedParametersLength,
+                    ParallelUnbalancedWork.DefaultOptions,
+                    (providedParameters, expectedParameters, executionParameters, hasMissing),
+                    static (i, state) =>
                 {
-                    JsonElement providedParameter = providedParameters[i];
-                    ExpectedParameter expectedParameter = expectedParameters[i];
+                    JsonElement providedParameter = state.providedParameters[i];
+                    ExpectedParameter expectedParameter = state.expectedParameters[i];
 
                     object? parameter = DeserializeParameter(providedParameter, expectedParameter);
-                    executionParameters[i] = parameter;
-                    if (!hasMissing && ReferenceEquals(parameter, Type.Missing))
+                    state.executionParameters[i] = parameter;
+                    if (!state.hasMissing && ReferenceEquals(parameter, Type.Missing))
                     {
-                        hasMissing = true;
+                        state.hasMissing = true;
                     }
+
+                    return state;
                 });
             }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -9,14 +9,13 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-
 using Nethermind.Core;
+using Nethermind.Core.Threading;
 using Nethermind.JsonRpc.Exceptions;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.State;
-
 using static Nethermind.JsonRpc.Modules.RpcModuleProvider;
 using static Nethermind.JsonRpc.Modules.RpcModuleProvider.ResolvedMethodInfo;
 
@@ -357,7 +356,7 @@ public class JsonRpcService : IJsonRpcService
             }
             else if (providedParametersLength > parallelThreshold)
             {
-                Parallel.For(0, providedParametersLength, (int i) =>
+                ParallelUnbalancedWork.For(0, providedParametersLength, (int i) =>
                 {
                     JsonElement providedParameter = providedParameters[i];
                     ExpectedParameter expectedParameter = expectedParameters[i];

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.Synchronization.FastBlocks
 {
@@ -123,7 +123,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 bool hasNonNull = false;
                 bool hasInserted = false;
-                Parallel.For(0, workingArray.Count, (i) =>
+                ParallelUnbalancedWork.For(0, workingArray.Count, (i) =>
                 {
                     if (workingArray[i] is not null)
                     {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -7,10 +7,10 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Threading;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie.Pruning;
 
@@ -175,9 +175,9 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool bufferPool)
             {
                 int totalLength = 0;
-                Parallel.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     () => 0,
-                    (i, _, local) =>
+                    (i, local) =>
                     {
                         object? data = item._data[i];
                         if (ReferenceEquals(data, _nullNode) || data is null)
@@ -236,9 +236,9 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool)
             {
                 int totalLength = 0;
-                Parallel.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     () => 0,
-                    (i, _, local) =>
+                    (i, local) =>
                     {
                         ValueRlpStream rlpStream = item.RlpStream;
                         item.SeekChild(ref rlpStream, i);


### PR DESCRIPTION
## Changes

- Added the `ParallelUnbalancedWork` class to efficiently execute parallel loops, handling unbalanced workloads.
- Implemented static For methods to support parallel execution with and without thread-local data, including initialization and finalization functions.
- Utilized thread pooling and a shared counter `SharedCounter` to distribute iterations among threads dynamically.
- Aimed to optimize performance in scenarios where the workload per iteration is uneven, ensuring better resource utilization and reduced execution time; rather than the main thread `.Wait`ing for background threads to complete
- Less allocations than `Parallel.For`

| Method             | Mean     | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
|------------------- |---------:|---------:|---------:|------:|----------:|------------:|
| ParallelFor        | 543.9 ms | 12.13 ms | 18.15 ms |  1.00 |  19.21 KB |        1.00 |
| ParallelForEach    | 488.5 ms | 12.73 ms | 17.43 ms |  0.90 |  23.12 KB |        1.20 |
| UnbalancedParallel | 413.4 ms |  1.15 ms |  1.73 ms |  0.76 |    5.00 KB |        0.26 |

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No