### PR TITLE
Only initialize cache inside prewarmer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
@@ -15,6 +15,9 @@ public class BeaconBlockRootHandler(ITransactionProcessor processor, IWorldState
 {
     private const long GasLimit = 30_000_000L;
 
+    AccessList? IHasAccessList.GetAccessList(Block block, IReleaseSpec spec)
+        => BeaconRootsAccessList(block, spec).accessList;
+
     public (Address? toAddress, AccessList? accessList) BeaconRootsAccessList(Block block, IReleaseSpec spec, bool includeStorageCells = true)
     {
         BlockHeader? header = block.Header;

--- a/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/IBeaconBlockRootHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/IBeaconBlockRootHandler.cs
@@ -7,7 +7,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Blockchain.BeaconBlockRoot;
-public interface IBeaconBlockRootHandler
+public interface IBeaconBlockRootHandler : IHasAccessList
 {
     (Address? toAddress, AccessList? accessList) BeaconRootsAccessList(Block block, IReleaseSpec spec, bool includeStorageCells = true);
     void StoreBeaconRoot(Block block, IReleaseSpec spec, ITxTracer tracer);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -269,6 +269,7 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
                     finally
                     {
                         PreWarmer._envPool.Return(env);
+                        SystemTxAccessLists.Dispose();
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -18,7 +18,6 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm;
@@ -124,8 +123,7 @@ public partial class BlockProcessor(
                 if (!skipPrewarming)
                 {
                     using CancellationTokenSource cancellationTokenSource = new();
-                    (_, AccessList? accessList) = _beaconBlockRootHandler.BeaconRootsAccessList(suggestedBlock, _specProvider.GetSpec(suggestedBlock.Header));
-                    preWarmTask = preWarmer.PreWarmCaches(suggestedBlock, preBlockStateRoot, accessList, cancellationTokenSource.Token);
+                    preWarmTask = preWarmer.PreWarmCaches(suggestedBlock, preBlockStateRoot, _specProvider.GetSpec(suggestedBlock.Header), cancellationTokenSource.Token, _beaconBlockRootHandler);
                     (processedBlock, receipts) = ProcessOne(suggestedBlock, options, blockTracer);
                     // Block is processed, we can cancel the prewarm task
                     cancellationTokenSource.Cancel();

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
@@ -7,12 +7,13 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
+using Nethermind.Core.Specs;
 using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
 public interface IBlockCachePreWarmer
 {
-    Task PreWarmCaches(Block suggestedBlock, Hash256 parentStateRoot, AccessList? systemTxAccessList, CancellationToken cancellationToken = default);
+    Task PreWarmCaches(Block suggestedBlock, Hash256 parentStateRoot, IReleaseSpec spec, CancellationToken cancellationToken = default, params ReadOnlySpan<IHasAccessList> systemAccessLists);
     CacheType ClearCaches();
 }

--- a/src/Nethermind/Nethermind.Core/Eip2930/IHasAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2930/IHasAccessList.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Specs;
+
+namespace Nethermind.Core.Eip2930;
+
+public interface IHasAccessList
+{
+    AccessList? GetAccessList(Block block, IReleaseSpec spec);
+}


### PR DESCRIPTION
## Changes

- Getting BeaconBlockRootHandler AccessList initializes the rlp cache; move it inside the prewarmer rather than outside otherwise causes "Caches Rlp are not empty. Clearing them" warning.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No