### PR TITLE
Don't double log invalid blocks

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1129,7 +1129,7 @@ namespace Nethermind.Blockchain
             }
             else
             {
-                if (_logger.IsInfo) _logger.Info($"Deleting an invalid block or its descendant {hash}");
+                if (_logger.IsDebug) _logger.Debug($"Deleting an invalid block or its descendant {hash}");
                 _blockInfoDb.Set(DeletePointerAddressInDb, hash.Bytes);
             }
         }


### PR DESCRIPTION
## Changes

- Only write one log line per invalid block, rather than two

Before

![image](https://github.com/user-attachments/assets/9b2e842e-9f2e-48d4-9422-5b9841889665)

After

![image](https://github.com/user-attachments/assets/754fc5f7-2139-48b3-b9a9-f197b3144433)


## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No