### PR TITLE
Skip tracking invalid chains post merge

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -690,7 +690,11 @@ namespace Nethermind.Blockchain
 
             if (_logger.IsDebug) _logger.Debug($"Deleting invalid block {invalidBlock.ToString(Block.Format.FullHashAndNumber)}");
 
-            _invalidBlocks.Set(invalidBlock.Hash, invalidBlock);
+            if (!invalidBlock.Header.IsPoS())
+            {
+                // If PoS we will defer to consensus to determine the chain's validity; and not prevent the block being tried again
+                _invalidBlocks.Set(invalidBlock.Hash, invalidBlock);
+            }
             _badBlockStore.Insert(invalidBlock);
 
             BestSuggestedHeader = Head?.Header;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -107,7 +107,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
         _invalidChainTracker.SetChildParent(block.Hash!, block.ParentHash!);
         if (_invalidChainTracker.IsOnKnownInvalidChain(block.Hash!, out Hash256? lastValidHash))
         {
-            if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, $"block is a part of an invalid chain") + $"The last valid is {lastValidHash}");
+            if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, $"block is a part of an invalid chain") + $" The last valid is {lastValidHash}");
             return NewPayloadV1Result.Invalid(lastValidHash, $"Block {request} is known to be a part of an invalid chain.");
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
@@ -144,6 +144,11 @@ public class InvalidChainTracker : IInvalidChainTracker
             {
                 effectiveParent = Keccak.Zero;
             }
+            else
+            {
+                // For post-merge we don't track the invalid chain and defer to consensus layer
+                return;
+            }
         }
         else
         {


### PR DESCRIPTION
## Changes

- Post merge don't block consensus layer retrying blocks.
- If unclean shutdown caused a faulty state and a lot of blocks to be deleted on startup; this allows consensus to restore back to a valid state rather than blocking progress completely

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No