### PR TITLE
Skip marking blocks with invalid hashes as invalid chain

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/InvalidBlockHashException.cs
+++ b/src/Nethermind/Nethermind.Blockchain/InvalidBlockHashException.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+
+namespace Nethermind.Blockchain;
+
+public class InvalidBlockHashException : InvalidBlockException
+{
+    public InvalidBlockHashException(Block suggestedBlock, string message, Exception? innerException = null)
+        : base(suggestedBlock, message, innerException) { }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -268,7 +268,7 @@ public partial class BlockProcessor(
         if (!options.ContainsFlag(ProcessingOptions.NoValidation) && !_blockValidator.ValidateProcessedBlock(block, receipts, suggestedBlock, out string? error))
         {
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(suggestedBlock, "invalid block after processing"));
-            throw new InvalidBlockException(suggestedBlock, error);
+            throw new InvalidBlockHashException(suggestedBlock, error);
         }
 
         // Block is valid, copy the account changes as we use the suggested block not the processed one

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -516,7 +516,11 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             Block? invalidBlock = processingBranch.BlocksToProcess.FirstOrDefault(b => b.Hash == invalidBlockHash);
             if (invalidBlock is not null)
             {
-                InvalidBlock?.Invoke(this, new IBlockchainProcessor.InvalidBlockEventArgs { InvalidBlock = invalidBlock, });
+                if (ex is not InvalidBlockHashException)
+                {
+                    // If the block hash disagrees, do not track as invalid block for that hash as is incorrect hash
+                    InvalidBlock?.Invoke(this, new IBlockchainProcessor.InvalidBlockEventArgs { InvalidBlock = invalidBlock, });
+                }
 
                 BlockTraceDumper.LogDiagnosticRlp(invalidBlock, _logger,
                     (_options.DumpOptions & DumpOptions.Rlp) != 0,


### PR DESCRIPTION
## Changes

- If a block's hash and processed hash disagree; don't add to invalid chain as block is completely incorrect so not part of any chain

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No