### PR TITLE
Fix random invalid block at startup

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -30,7 +30,13 @@ using Nethermind.Wallet;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitializeStateDb), typeof(InitializePlugins), typeof(InitializeBlockTree), typeof(SetupKeyStore))]
+    [RunnerStepDependencies(
+        typeof(InitializeStateDb),
+        typeof(InitializePlugins),
+        typeof(InitializeBlockTree),
+        typeof(SetupKeyStore),
+        typeof(InitializePrecompiles)
+    )]
     public class InitializeBlockchain : IStep
     {
         private readonly INethermindApi _api;


### PR DESCRIPTION
- Fix random invalid block at startup due to initialize precompile not completed during blocktreereview.
- Reliably reproducable by adding a `Task.Delay` in `InitializePrecomple`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] No

#### Notes on testing

- Tested manually
