### PR TITLE
Move lowest inserted body number out of blocktree

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -47,6 +47,7 @@ namespace Nethermind.Api
         ISynchronizer? Synchronizer { get; }
         ISyncModeSelector SyncModeSelector { get; }
         ISyncProgressResolver? SyncProgressResolver { get; }
+        ISyncPointers? SyncPointers { get; }
         IPivot? Pivot { get; set; }
         ISyncPeerPool? SyncPeerPool { get; }
         IPeerDifficultyRefreshPool? PeerDifficultyRefreshPool { get; }

--- a/src/Nethermind/Nethermind.Api/IApiWithStores.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithStores.cs
@@ -31,6 +31,7 @@ namespace Nethermind.Api
         IReceiptMonitor? ReceiptMonitor { get; set; }
         IWallet? Wallet { get; set; }
         IBadBlockStore? BadBlocksStore { get; set; }
+        BlockStore? BlockStore { get; set; }
 
         public ContainerBuilder ConfigureContainerBuilderFromApiWithStores(ContainerBuilder builder)
         {

--- a/src/Nethermind/Nethermind.Api/IApiWithStores.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithStores.cs
@@ -31,7 +31,6 @@ namespace Nethermind.Api
         IReceiptMonitor? ReceiptMonitor { get; set; }
         IWallet? Wallet { get; set; }
         IBadBlockStore? BadBlocksStore { get; set; }
-        BlockStore? BlockStore { get; set; }
 
         public ContainerBuilder ConfigureContainerBuilderFromApiWithStores(ContainerBuilder builder)
         {

--- a/src/Nethermind/Nethermind.Api/IBasicApi.cs
+++ b/src/Nethermind/Nethermind.Api/IBasicApi.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Autofac;
 using Nethermind.Abi;
 using Nethermind.Api.Extensions;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -63,6 +64,7 @@ namespace Nethermind.Api
             builder
                 .AddPropertiesFrom<IBasicApi>(this)
                 .AddSingleton(ConfigProvider.GetConfig<ISyncConfig>())
+                .AddSingleton(ConfigProvider.GetConfig<IReceiptConfig>())
                 .AddModule(new DbModule());
 
             return builder;

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -226,6 +226,7 @@ namespace Nethermind.Api
         public CensorshipDetector CensorshipDetector { get; set; } = null!;
         public IWallet? Wallet { get; set; }
         public IBadBlockStore? BadBlocksStore { get; set; }
+        public BlockStore? BlockStore { get; set; }
         public ITransactionComparerProvider? TransactionComparerProvider { get; set; }
         public IWebSocketsManager WebSocketsManager { get; set; } = new WebSocketsManager();
 

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -190,6 +190,7 @@ namespace Nethermind.Api
         public ISyncModeSelector SyncModeSelector => ApiWithNetworkServiceContainer?.Resolve<ISyncModeSelector>()!;
 
         public ISyncProgressResolver? SyncProgressResolver => ApiWithNetworkServiceContainer?.Resolve<ISyncProgressResolver>();
+        public ISyncPointers? SyncPointers => ApiWithNetworkServiceContainer?.Resolve<ISyncPointers>();
         public IBetterPeerStrategy? BetterPeerStrategy { get; set; }
         public IPivot? Pivot { get; set; }
         public ISyncPeerPool? SyncPeerPool => ApiWithNetworkServiceContainer?.Resolve<ISyncPeerPool>();
@@ -226,7 +227,6 @@ namespace Nethermind.Api
         public CensorshipDetector CensorshipDetector { get; set; } = null!;
         public IWallet? Wallet { get; set; }
         public IBadBlockStore? BadBlocksStore { get; set; }
-        public BlockStore? BlockStore { get; set; }
         public ITransactionComparerProvider? TransactionComparerProvider { get; set; }
         public IWebSocketsManager WebSocketsManager { get; set; } = new WebSocketsManager();
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1170,47 +1170,6 @@ public class BlockTreeTests
         Assert.That(loadedTree.LowestInsertedHeader?.Number, Is.EqualTo(expectedResult), "loaded tree");
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime), TestCaseSource(nameof(SourceOfBSearchTestCases))]
-    public void Loads_lowest_inserted_body_correctly(long beginIndex, long insertedBlocks)
-    {
-        // left old code to prove that it does not matter for the result nowadays
-        // we store and no longer binary search lowest body number
-
-        MemDb blocksDb = new();
-        blocksDb.Set(BlockTree.LowestInsertedBodyNumberDbEntryAddress, Rlp.Encode(1L).Bytes);
-
-        SyncConfig syncConfig = new()
-        {
-            PivotNumber = beginIndex.ToString(),
-        };
-
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithBlocksDb(blocksDb)
-            .WithSyncConfig(syncConfig)
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-
-        tree.SuggestBlock(Build.A.Block.Genesis.TestObject);
-
-        for (long i = beginIndex; i > beginIndex - insertedBlocks; i--)
-        {
-            Block block = Build.A.Block.WithNumber(i).WithTotalDifficulty(i).TestObject;
-            tree.Insert(block.Header);
-            tree.Insert(block);
-        }
-
-        BlockTree loadedTree = Build.A.BlockTree()
-            .WithoutSettingHead
-            .WithDatabaseFrom(builder)
-            .WithSyncConfig(syncConfig)
-            .TestObject;
-
-        Assert.That(tree.LowestInsertedBodyNumber, Is.EqualTo(null), "tree");
-        Assert.That(loadedTree.LowestInsertedBodyNumber, Is.EqualTo(1), "loaded tree");
-    }
-
-
     private static readonly object[] SourceOfBSearchTestCases =
     {
         new object[] {1L, 0L},
@@ -1362,7 +1321,6 @@ public class BlockTreeTests
 
         Assert.That(tree.BestKnownNumber, Is.EqualTo(pivotNumber + 1), "tree");
         Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(1), "loaded tree - lowest header");
-        Assert.That(tree.LowestInsertedBodyNumber, Is.EqualTo(null), "loaded tree - lowest body");
         Assert.That(loadedTree.BestKnownNumber, Is.EqualTo(pivotNumber + 1), "loaded tree");
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -16,7 +16,6 @@ public partial class BlockTree
 
     public void RecalculateTreeLevels()
     {
-        LoadLowestInsertedBodyNumber();
         LoadLowestInsertedHeader();
         LoadLowestInsertedBeaconHeader();
         LoadBestKnown();
@@ -113,13 +112,6 @@ public partial class BlockTree
         _logger.Info("Loading fork choice info");
         FinalizedHash ??= _metadataDb.Get(MetadataDbKeys.FinalizedBlockHash)?.AsRlpStream().DecodeKeccak();
         SafeHash ??= _metadataDb.Get(MetadataDbKeys.SafeBlockHash)?.AsRlpStream().DecodeKeccak();
-    }
-
-    private void LoadLowestInsertedBodyNumber()
-    {
-        LowestInsertedBodyNumber =
-            _blockStore.GetMetadata(LowestInsertedBodyNumberDbEntryAddress)?
-                .AsRlpValueContext().DecodeLong();
     }
 
     private void LoadLowestInsertedBeaconHeader()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -34,7 +34,6 @@ namespace Nethermind.Blockchain
     public partial class BlockTree : IBlockTree
     {
         // there is not much logic in the addressing here
-        public static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
         private static readonly byte[] StateHeadHashDbEntryAddress = new byte[16];
         internal static Hash256 DeletePointerAddressInDb = new(new BitArray(32 * 8, true).ToBytes());
         internal static Hash256 HeadAddressInDb = Keccak.Zero;
@@ -79,21 +78,7 @@ namespace Nethermind.Blockchain
 
         private BlockHeader? _lowestInsertedBeaconHeader;
 
-        private long? _lowestInsertedReceiptBlock;
         private long? _highestPersistedState;
-
-        public long? LowestInsertedBodyNumber
-        {
-            get => _lowestInsertedReceiptBlock;
-            set
-            {
-                _lowestInsertedReceiptBlock = value;
-                if (value.HasValue)
-                {
-                    _blockStore.SetMetadata(LowestInsertedBodyNumberDbEntryAddress, Rlp.Encode(value.Value).Bytes);
-                }
-            }
-        }
 
         public long BestKnownNumber { get; private set; }
 
@@ -169,7 +154,6 @@ namespace Nethermind.Blockchain
                              $"best queued is {BestSuggestedHeader?.Number.ToString() ?? "0"}, " +
                              $"best known is {BestKnownNumber}, " +
                              $"lowest inserted header {LowestInsertedHeader?.Number}, " +
-                             $"body {LowestInsertedBodyNumber}, " +
                              $"lowest sync inserted block number {LowestInsertedBeaconHeader?.Number}");
             ProductInfo.Network = $"{(ChainId == NetworkId ? BlockchainIds.GetBlockchainName(NetworkId) : ChainId)}";
             ThisNodeInfo.AddInfo("Chain ID     :", ProductInfo.Network);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -32,12 +32,6 @@ public class BlockTreeOverlay : IBlockTree
     public BlockHeader? BestSuggestedBeaconHeader => _overlayTree.BestSuggestedBeaconHeader ?? _baseTree.BestSuggestedBeaconHeader;
     public BlockHeader? LowestInsertedHeader => _overlayTree.LowestInsertedHeader ?? _baseTree.LowestInsertedHeader;
 
-    public long? LowestInsertedBodyNumber
-    {
-        get => _overlayTree.LowestInsertedBodyNumber ?? _baseTree.LowestInsertedBodyNumber;
-        set => _overlayTree.LowestInsertedBodyNumber = value;
-    }
-
     public BlockHeader? LowestInsertedBeaconHeader
     {
         get => _overlayTree.LowestInsertedBeaconHeader ?? _baseTree.LowestInsertedBeaconHeader;

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -12,51 +12,29 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Blockchain.Blocks;
 
-public class BlockStore : IBlockStore
+public class BlockStore(IDb blockDb) : IBlockStore
 {
-    private static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
-
     private readonly BlockDecoder _blockDecoder = new();
     public const int CacheSize = 128 + 32;
 
     private readonly ClockCache<ValueHash256, Block>
         _blockCache = new(CacheSize);
 
-    private long? _lowestInsertedReceiptBlock;
-    private readonly IDb _blockDb;
-
-    public BlockStore(IDb blockDb)
-    {
-        _blockDb = blockDb;
-        LowestInsertedBodyNumber = GetMetadata(LowestInsertedBodyNumberDbEntryAddress)?
-            .AsRlpValueContext().DecodeLong();
-    }
-
-    public long? LowestInsertedBodyNumber
-    {
-        get => _lowestInsertedReceiptBlock;
-        set
-        {
-            _lowestInsertedReceiptBlock = value;
-            if (value.HasValue) SetMetadata(LowestInsertedBodyNumberDbEntryAddress, Rlp.Encode(value.Value).Bytes);
-        }
-    }
-
     public void SetMetadata(byte[] key, byte[] value)
     {
-        _blockDb.Set(key, value);
+        blockDb.Set(key, value);
     }
 
     public byte[]? GetMetadata(byte[] key)
     {
-        return _blockDb.Get(key);
+        return blockDb.Get(key);
     }
 
     public bool HasBlock(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
-        return _blockDb.KeyExists(dbKey);
+        return blockDb.KeyExists(dbKey);
     }
 
     public void Insert(Block block, WriteFlags writeFlags = WriteFlags.None)
@@ -70,7 +48,7 @@ public class BlockStore : IBlockStore
         // Although cpu is the main bottleneck since NettyRlpStream uses pooled memory which avoid unnecessary allocations..
         using NettyRlpStream newRlp = _blockDecoder.EncodeToNewNettyStream(block);
 
-        _blockDb.Set(block.Number, block.Hash, newRlp.AsSpan(), writeFlags);
+        blockDb.Set(block.Number, block.Hash, newRlp.AsSpan(), writeFlags);
     }
 
     private static void GetBlockNumPrefixedKey(long blockNumber, Hash256 blockHash, Span<byte> output)
@@ -82,24 +60,24 @@ public class BlockStore : IBlockStore
     public void Delete(long blockNumber, Hash256 blockHash)
     {
         _blockCache.Delete(blockHash);
-        _blockDb.Delete(blockNumber, blockHash);
-        _blockDb.Remove(blockHash.Bytes);
+        blockDb.Delete(blockNumber, blockHash);
+        blockDb.Remove(blockHash.Bytes);
     }
 
     public Block? Get(long blockNumber, Hash256 blockHash, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = false)
     {
-        Block? b = _blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        Block? b = blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
         if (b is not null) return b;
-        return _blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        return blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
     }
 
     public byte[]? GetRlp(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
-        var b = _blockDb.Get(dbKey);
+        var b = blockDb.Get(dbKey);
         if (b is not null) return b;
-        return _blockDb.Get(blockHash);
+        return blockDb.Get(blockHash);
     }
 
     public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash)
@@ -107,8 +85,8 @@ public class BlockStore : IBlockStore
         Span<byte> keyWithBlockNumber = stackalloc byte[40];
         GetBlockNumPrefixedKey(blockNumber, blockHash, keyWithBlockNumber);
 
-        MemoryManager<byte>? memoryOwner = _blockDb.GetOwnedMemory(keyWithBlockNumber);
-        memoryOwner ??= _blockDb.GetOwnedMemory(blockHash.Bytes);
+        MemoryManager<byte>? memoryOwner = blockDb.GetOwnedMemory(keyWithBlockNumber);
+        memoryOwner ??= blockDb.GetOwnedMemory(blockHash.Bytes);
 
         return BlockDecoder.DecodeToReceiptRecoveryBlock(memoryOwner, memoryOwner?.Memory ?? Memory<byte>.Empty, RlpBehaviors.None);
     }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -12,29 +12,51 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Blockchain.Blocks;
 
-public class BlockStore(IDb blockDb) : IBlockStore
+public class BlockStore : IBlockStore
 {
+    private static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
+
     private readonly BlockDecoder _blockDecoder = new();
     public const int CacheSize = 128 + 32;
 
     private readonly ClockCache<ValueHash256, Block>
         _blockCache = new(CacheSize);
 
+    private long? _lowestInsertedReceiptBlock;
+    private readonly IDb _blockDb;
+
+    public BlockStore(IDb blockDb)
+    {
+        _blockDb = blockDb;
+        LowestInsertedBodyNumber = GetMetadata(LowestInsertedBodyNumberDbEntryAddress)?
+            .AsRlpValueContext().DecodeLong();
+    }
+
+    public long? LowestInsertedBodyNumber
+    {
+        get => _lowestInsertedReceiptBlock;
+        set
+        {
+            _lowestInsertedReceiptBlock = value;
+            if (value.HasValue) SetMetadata(LowestInsertedBodyNumberDbEntryAddress, Rlp.Encode(value.Value).Bytes);
+        }
+    }
+
     public void SetMetadata(byte[] key, byte[] value)
     {
-        blockDb.Set(key, value);
+        _blockDb.Set(key, value);
     }
 
     public byte[]? GetMetadata(byte[] key)
     {
-        return blockDb.Get(key);
+        return _blockDb.Get(key);
     }
 
     public bool HasBlock(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
-        return blockDb.KeyExists(dbKey);
+        return _blockDb.KeyExists(dbKey);
     }
 
     public void Insert(Block block, WriteFlags writeFlags = WriteFlags.None)
@@ -48,7 +70,7 @@ public class BlockStore(IDb blockDb) : IBlockStore
         // Although cpu is the main bottleneck since NettyRlpStream uses pooled memory which avoid unnecessary allocations..
         using NettyRlpStream newRlp = _blockDecoder.EncodeToNewNettyStream(block);
 
-        blockDb.Set(block.Number, block.Hash, newRlp.AsSpan(), writeFlags);
+        _blockDb.Set(block.Number, block.Hash, newRlp.AsSpan(), writeFlags);
     }
 
     private static void GetBlockNumPrefixedKey(long blockNumber, Hash256 blockHash, Span<byte> output)
@@ -60,24 +82,24 @@ public class BlockStore(IDb blockDb) : IBlockStore
     public void Delete(long blockNumber, Hash256 blockHash)
     {
         _blockCache.Delete(blockHash);
-        blockDb.Delete(blockNumber, blockHash);
-        blockDb.Remove(blockHash.Bytes);
+        _blockDb.Delete(blockNumber, blockHash);
+        _blockDb.Remove(blockHash.Bytes);
     }
 
     public Block? Get(long blockNumber, Hash256 blockHash, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = false)
     {
-        Block? b = blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        Block? b = _blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
         if (b is not null) return b;
-        return blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        return _blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
     }
 
     public byte[]? GetRlp(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
-        var b = blockDb.Get(dbKey);
+        var b = _blockDb.Get(dbKey);
         if (b is not null) return b;
-        return blockDb.Get(blockHash);
+        return _blockDb.Get(blockHash);
     }
 
     public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash)
@@ -85,8 +107,8 @@ public class BlockStore(IDb blockDb) : IBlockStore
         Span<byte> keyWithBlockNumber = stackalloc byte[40];
         GetBlockNumPrefixedKey(blockNumber, blockHash, keyWithBlockNumber);
 
-        MemoryManager<byte>? memoryOwner = blockDb.GetOwnedMemory(keyWithBlockNumber);
-        memoryOwner ??= blockDb.GetOwnedMemory(blockHash.Bytes);
+        MemoryManager<byte>? memoryOwner = _blockDb.GetOwnedMemory(keyWithBlockNumber);
+        memoryOwner ??= _blockDb.GetOwnedMemory(blockHash.Bytes);
 
         return BlockDecoder.DecodeToReceiptRecoveryBlock(memoryOwner, memoryOwner?.Memory ?? Memory<byte>.Empty, RlpBehaviors.None);
     }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
@@ -19,9 +19,5 @@ public interface IBlockStore
     byte[]? GetRlp(long blockNumber, Hash256 blockHash);
     ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash);
     void Cache(Block block);
-
-    // These two are used by blocktree. Try not to use them...
-    void SetMetadata(byte[] key, byte[] value);
-    byte[]? GetMetadata(byte[] key);
     bool HasBlock(long blockNumber, Hash256 blockHash);
 }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
@@ -20,5 +20,4 @@ public interface IBlockStore
     ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash);
     void Cache(Block block);
     bool HasBlock(long blockNumber, Hash256 blockHash);
-    long? LowestInsertedBodyNumber { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
@@ -20,4 +20,5 @@ public interface IBlockStore
     ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash);
     void Cache(Block block);
     bool HasBlock(long blockNumber, Hash256 blockHash);
+    long? LowestInsertedBodyNumber { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -48,11 +48,6 @@ namespace Nethermind.Blockchain
         BlockHeader? LowestInsertedHeader { get; }
 
         /// <summary>
-        /// Lowest body added in reverse fast sync insert
-        /// </summary>
-        long? LowestInsertedBodyNumber { get; set; }
-
-        /// <summary>
         /// Lowest header number added in reverse beacon sync insert. Used to determine if BeaconHeaderSync is completed.
         /// </summary>
         BlockHeader? LowestInsertedBeaconHeader { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -32,12 +32,6 @@ namespace Nethermind.Blockchain
         public BlockHeader BestSuggestedBeaconHeader => _wrapped.BestSuggestedBeaconHeader;
         public BlockHeader LowestInsertedHeader => _wrapped.LowestInsertedHeader;
 
-        public long? LowestInsertedBodyNumber
-        {
-            get => _wrapped.LowestInsertedBodyNumber;
-            set => _wrapped.LowestInsertedBodyNumber = value;
-        }
-
         public long? BestPersistedState
         {
             get => _wrapped.BestPersistedState;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -11,7 +11,6 @@ namespace Nethermind.Blockchain.Receipts
     {
         void Insert(Block block, params TxReceipt[]? txReceipts) => Insert(block, txReceipts, true);
         void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical, WriteFlags writeFlags = WriteFlags.None);
-        long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }
         bool HasBlock(long blockNumber, Hash256 hash);
         void EnsureCanonical(Block block);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -87,8 +87,6 @@ namespace Nethermind.Blockchain.Receipts
             }
         }
 
-        public long? LowestInsertedReceiptBlockNumber { get; set; }
-
         public long MigratedBlockNumber { get; set; }
 
         public int Count => _transactions.Count;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -33,12 +33,6 @@ namespace Nethermind.Blockchain.Receipts
             return false;
         }
 
-        public long? LowestInsertedReceiptBlockNumber
-        {
-            get => 0;
-            set { }
-        }
-
         public long MigratedBlockNumber { get; set; } = 0;
 
         public bool HasBlock(long blockNumber, Hash256 hash)

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -25,7 +25,6 @@ namespace Nethermind.Blockchain.Receipts
         private readonly IColumnsDb<ReceiptsColumns> _database;
         private readonly ISpecProvider _specProvider;
         private readonly IReceiptsRecovery _receiptsRecovery;
-        private long? _lowestInsertedReceiptBlock;
         private readonly IDb _blocksDb;
         private readonly IDb _defaultColumn;
         private readonly IDb _transactionDb;
@@ -65,8 +64,6 @@ namespace Nethermind.Blockchain.Receipts
             _storageDecoder = storageDecoder ?? ReceiptArrayStorageDecoder.Instance;
             _receiptConfig = receiptConfig ?? throw new ArgumentNullException(nameof(receiptConfig));
 
-            byte[] lowestBytes = _defaultColumn.Get(Keccak.Zero);
-            _lowestInsertedReceiptBlock = lowestBytes is null ? (long?)null : new RlpStream(lowestBytes).DecodeLong();
             _migratedBlockNumber = Get(MigrationBlockNumberKey, long.MaxValue);
 
             KeyValuePair<byte[], byte[]>? firstValue = _blocksDb.GetAll().FirstOrDefault();
@@ -299,19 +296,6 @@ namespace Nethermind.Blockchain.Receipts
             if (ensureCanonical)
             {
                 EnsureCanonical(block);
-            }
-        }
-
-        public long? LowestInsertedReceiptBlockNumber
-        {
-            get => _lowestInsertedReceiptBlock;
-            set
-            {
-                _lowestInsertedReceiptBlock = value;
-                if (value.HasValue)
-                {
-                    _defaultColumn.Set(Keccak.Zero, Rlp.Encode(value.Value).Bytes);
-                }
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
@@ -153,6 +153,15 @@ public static class ContainerBuilderExtensions
 
         return builder;
     }
+
+    public static ContainerBuilder Bind<TFrom, TTo>(this ContainerBuilder builder) where TFrom : TTo where TTo : notnull
+    {
+        builder.Register((it) => it.Resolve<TFrom>())
+            .As<TTo>()
+            .ExternallyOwned();
+
+        return builder;
+    }
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
 using Nethermind.Logging;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -25,14 +26,13 @@ namespace Nethermind.Facade.Test.Eth
         {
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(false));
@@ -47,14 +47,13 @@ namespace Nethermind.Facade.Test.Eth
         {
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178010L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(true));
@@ -69,14 +68,13 @@ namespace Nethermind.Facade.Test.Eth
         public void IsSyncing_ReturnsExpectedResult(long bestHeader, long currentHead, bool expectedResult)
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(bestHeader).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(currentHead).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, new SyncConfig(),
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, new SyncConfig(),
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(expectedResult));
@@ -101,8 +99,7 @@ namespace Nethermind.Facade.Test.Eth
                 PivotNumber = "1000"
             };
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(resolverDownloadingBodies);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(resolverDownloadingreceipts);
@@ -110,7 +107,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, syncConfig,
                 new StaticSelector(SyncMode.FastBlocks), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult, Is.EqualTo(CreateSyncingResult(expectedResult, 6178000L, 6178001L, SyncMode.FastBlocks)));
@@ -121,8 +118,7 @@ namespace Nethermind.Facade.Test.Eth
         {
             SyncConfig syncConfig = new();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -131,7 +127,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(100).TestObject)
                 .TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
 
             ethSyncingInfo.IsSyncing().Should().Be(false);
@@ -165,8 +161,7 @@ namespace Nethermind.Facade.Test.Eth
         public void IsSyncing_ReturnsFalseOnFastSyncWithoutPivot(long bestHeader, long currentHead)
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBlockStore blockStore = Substitute.For<IBlockStore>();
+            ISyncPointers syncPointers = Substitute.For<ISyncPointers>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -178,7 +173,7 @@ namespace Nethermind.Facade.Test.Eth
                 SnapSync = true,
                 PivotNumber = "0", // Equivalent to not having a pivot
             };
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, syncPointers, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
 

--- a/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
 using Nethermind.Logging;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -25,12 +26,13 @@ namespace Nethermind.Facade.Test.Eth
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(false));
@@ -46,12 +48,13 @@ namespace Nethermind.Facade.Test.Eth
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178010L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(true));
@@ -67,12 +70,13 @@ namespace Nethermind.Facade.Test.Eth
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(bestHeader).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(currentHead).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, new SyncConfig(),
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, new SyncConfig(),
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(expectedResult));
@@ -98,6 +102,7 @@ namespace Nethermind.Facade.Test.Eth
             };
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(resolverDownloadingBodies);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(resolverDownloadingreceipts);
@@ -105,7 +110,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
                 new StaticSelector(SyncMode.FastBlocks), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult, Is.EqualTo(CreateSyncingResult(expectedResult, 6178000L, 6178001L, SyncMode.FastBlocks)));
@@ -117,6 +122,7 @@ namespace Nethermind.Facade.Test.Eth
             SyncConfig syncConfig = new();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -125,7 +131,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(100).TestObject)
                 .TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
 
             ethSyncingInfo.IsSyncing().Should().Be(false);
@@ -160,6 +166,7 @@ namespace Nethermind.Facade.Test.Eth
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -171,7 +178,7 @@ namespace Nethermind.Facade.Test.Eth
                 SnapSync = true,
                 PivotNumber = "0", // Equivalent to not having a pivot
             };
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
 

--- a/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/Eth/EthSyncingInfoTests.cs
@@ -4,12 +4,12 @@
 using System.Threading;
 using FluentAssertions;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
 using Nethermind.Logging;
-using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -26,13 +26,13 @@ namespace Nethermind.Facade.Test.Eth
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(false));
@@ -48,13 +48,13 @@ namespace Nethermind.Facade.Test.Eth
             ISyncConfig syncConfig = new SyncConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178010L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(true));
@@ -70,13 +70,13 @@ namespace Nethermind.Facade.Test.Eth
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(bestHeader).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(currentHead).TestObject).TestObject);
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, new SyncConfig(),
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, new SyncConfig(),
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult.IsSyncing, Is.EqualTo(expectedResult));
@@ -102,7 +102,7 @@ namespace Nethermind.Facade.Test.Eth
             };
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(resolverDownloadingBodies);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(resolverDownloadingreceipts);
@@ -110,7 +110,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(6178001L).TestObject);
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6178000L).TestObject).TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
                 new StaticSelector(SyncMode.FastBlocks), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
             Assert.That(syncingResult, Is.EqualTo(CreateSyncingResult(expectedResult, 6178000L, 6178001L, SyncMode.FastBlocks)));
@@ -122,7 +122,7 @@ namespace Nethermind.Facade.Test.Eth
             SyncConfig syncConfig = new();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -131,7 +131,7 @@ namespace Nethermind.Facade.Test.Eth
             blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(100).TestObject)
                 .TestObject);
 
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
 
             ethSyncingInfo.IsSyncing().Should().Be(false);
@@ -166,7 +166,7 @@ namespace Nethermind.Facade.Test.Eth
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
-            IBodiesSyncFeed bodiesSyncFeed = Substitute.For<IBodiesSyncFeed>();
+            IBlockStore blockStore = Substitute.For<IBlockStore>();
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.IsFastBlocksBodiesFinished().Returns(false);
             syncProgressResolver.IsFastBlocksReceiptsFinished().Returns(false);
@@ -178,7 +178,7 @@ namespace Nethermind.Facade.Test.Eth
                 SnapSync = true,
                 PivotNumber = "0", // Equivalent to not having a pivot
             };
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, bodiesSyncFeed, syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, blockStore, syncConfig,
                 new StaticSelector(SyncMode.All), syncProgressResolver, LimboLogs.Instance);
             SyncingResult syncingResult = ethSyncingInfo.GetFullInfo();
 

--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -7,6 +7,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Logging;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Facade.Eth
@@ -17,12 +18,14 @@ namespace Nethermind.Facade.Eth
         private readonly ISyncConfig _syncConfig;
         private readonly ILogger _logger;
         private readonly IReceiptStorage _receiptStorage;
+        private readonly IBodiesSyncFeed _bodiesSyncFeed;
         private readonly ISyncModeSelector _syncModeSelector;
         private readonly ISyncProgressResolver _syncProgressResolver;
 
         public EthSyncingInfo(
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
+            IBodiesSyncFeed bodiesSyncFeed,
             ISyncConfig syncConfig,
             ISyncModeSelector syncModeSelector,
             ISyncProgressResolver syncProgressResolver,
@@ -30,6 +33,7 @@ namespace Nethermind.Facade.Eth
         {
             _blockTree = blockTree;
             _receiptStorage = receiptStorage;
+            _bodiesSyncFeed = bodiesSyncFeed;
             _syncConfig = syncConfig;
             _syncModeSelector = syncModeSelector;
             _syncProgressResolver = syncProgressResolver;
@@ -43,7 +47,7 @@ namespace Nethermind.Facade.Eth
             bool isSyncing = bestSuggestedNumber > headNumberOrZero + 8;
             SyncMode syncMode = _syncModeSelector.Current;
 
-            if (_logger.IsTrace) _logger.Trace($"Start - EthSyncingInfo - BestSuggestedNumber: {bestSuggestedNumber}, HeadNumberOrZero: {headNumberOrZero}, IsSyncing: {isSyncing} {_syncConfig}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
+            if (_logger.IsTrace) _logger.Trace($"Start - EthSyncingInfo - BestSuggestedNumber: {bestSuggestedNumber}, HeadNumberOrZero: {headNumberOrZero}, IsSyncing: {isSyncing} {_syncConfig}. LowestInsertedBodyNumber: {_bodiesSyncFeed.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
             if (isSyncing)
             {
                 if (_logger.IsTrace) _logger.Trace($"Too far from head - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}");
@@ -58,18 +62,18 @@ namespace Nethermind.Facade.Eth
             {
                 if (_syncConfig.DownloadReceiptsInFastSync && !_syncProgressResolver.IsFastBlocksReceiptsFinished())
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Receipts not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientReceiptsBarrier: {_syncConfig.AncientReceiptsBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
+                    if (_logger.IsTrace) _logger.Trace($"Receipts not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientReceiptsBarrier: {_syncConfig.AncientReceiptsBarrierCalc}. LowestInsertedBodyNumber: {_bodiesSyncFeed.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
                 }
 
                 if (_syncConfig.DownloadBodiesInFastSync && !_syncProgressResolver.IsFastBlocksBodiesFinished())
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Bodies not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientBodiesBarrier: {_syncConfig.AncientBodiesBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
+                    if (_logger.IsTrace) _logger.Trace($"Bodies not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientBodiesBarrier: {_syncConfig.AncientBodiesBarrierCalc}. LowestInsertedBodyNumber: {_bodiesSyncFeed.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
                 }
             }
 
-            if (_logger.IsTrace) _logger.Trace($"Node is not syncing - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
+            if (_logger.IsTrace) _logger.Trace($"Node is not syncing - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}. LowestInsertedBodyNumber: {_bodiesSyncFeed.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
             return SyncingResult.NotSyncing;
         }
 
@@ -86,6 +90,7 @@ namespace Nethermind.Facade.Eth
         }
 
         private readonly Stopwatch _syncStopwatch = new();
+
         public TimeSpan UpdateAndGetSyncTime()
         {
             if (!_syncStopwatch.IsRunning)

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -71,17 +71,6 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
         Insert(block);
     }
 
-    public void SetMetadata(byte[] key, byte[] value)
-    {
-        _metadataDict[key] = value;
-        readonlyBaseBlockStore.SetMetadata(key, value);
-    }
-
-    public byte[]? GetMetadata(byte[] key)
-    {
-        return _metadataDict.TryGetValue(key, out var value) ? value : readonlyBaseBlockStore.GetMetadata(key);
-    }
-
     public bool HasBlock(long blockNumber, Hash256 blockHash)
     {
         return _blockNumDict.ContainsKey(blockNumber);

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -75,10 +75,4 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
     {
         return _blockNumDict.ContainsKey(blockNumber);
     }
-
-    public long? LowestInsertedBodyNumber
-    {
-        get => readonlyBaseBlockStore.LowestInsertedBodyNumber;
-        set { }
-    }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -75,4 +75,10 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
     {
         return _blockNumDict.ContainsKey(blockNumber);
     }
+
+    public long? LowestInsertedBodyNumber
+    {
+        get => readonlyBaseBlockStore.LowestInsertedBodyNumber;
+        set { }
+    }
 }

--- a/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using Nethermind.Api;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Services;
 using Nethermind.Blockchain.Synchronization;
@@ -64,7 +65,7 @@ public class NodeHealthServiceTests
             blockFinder.FindBestSuggestedHeader().Returns(GetBlockHeader(2).TestObject);
         }
 
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, Substitute.For<IBlockStore>(), syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),
                 healthHintService, ethSyncingInfo, new EngineRpcCapabilitiesProvider(api.SpecProvider), api, new[] { drive }, test.IsMining);
@@ -131,7 +132,7 @@ public class NodeHealthServiceTests
 
         CustomRpcCapabilitiesProvider customProvider =
             new(test.EnabledCapabilities, test.DisabledCapabilities);
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(), Substitute.For<IBodiesSyncFeed>(),
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(), Substitute.For<IBlockStore>(),
             new SyncConfig(), syncModeSelector, Substitute.For<ISyncProgressResolver>(), new TestLogManager());
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),

--- a/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
@@ -65,7 +65,7 @@ public class NodeHealthServiceTests
             blockFinder.FindBestSuggestedHeader().Returns(GetBlockHeader(2).TestObject);
         }
 
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, Substitute.For<IBlockStore>(), syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, Substitute.For<ISyncPointers>(), syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),
                 healthHintService, ethSyncingInfo, new EngineRpcCapabilitiesProvider(api.SpecProvider), api, new[] { drive }, test.IsMining);
@@ -132,7 +132,7 @@ public class NodeHealthServiceTests
 
         CustomRpcCapabilitiesProvider customProvider =
             new(test.EnabledCapabilities, test.DisabledCapabilities);
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(), Substitute.For<IBlockStore>(),
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, Substitute.For<ISyncPointers>(),
             new SyncConfig(), syncModeSelector, Substitute.For<ISyncProgressResolver>(), new TestLogManager());
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),

--- a/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
@@ -23,6 +23,7 @@ using Nethermind.Synchronization;
 using NSubstitute;
 using NUnit.Framework;
 using Nethermind.Core.Extensions;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.HealthChecks.Test;
@@ -63,7 +64,7 @@ public class NodeHealthServiceTests
             blockFinder.FindBestSuggestedHeader().Returns(GetBlockHeader(2).TestObject);
         }
 
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),
                 healthHintService, ethSyncingInfo, new EngineRpcCapabilitiesProvider(api.SpecProvider), api, new[] { drive }, test.IsMining);
@@ -130,7 +131,7 @@ public class NodeHealthServiceTests
 
         CustomRpcCapabilitiesProvider customProvider =
             new(test.EnabledCapabilities, test.DisabledCapabilities);
-        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(),
+        IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(), Substitute.For<IBodiesSyncFeed>(),
             new SyncConfig(), syncModeSelector, Substitute.For<ISyncProgressResolver>(), new TestLogManager());
         NodeHealthService nodeHealthService =
             new(syncServer, blockchainProcessor, blockProducerRunner, new HealthChecksConfig(),

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Init.Steps
             IChainLevelInfoRepository chainLevelInfoRepository =
                 _set.ChainLevelInfoRepository = new ChainLevelInfoRepository(_get.DbProvider!.BlockInfosDb);
 
-            IBlockStore blockStore = _set.BlockStore = new BlockStore(_get.DbProvider.BlocksDb);
+            IBlockStore blockStore = new BlockStore(_get.DbProvider.BlocksDb);
             IHeaderStore headerStore = new HeaderStore(_get.DbProvider.HeadersDb, _get.DbProvider.BlockNumbersDb);
             IBadBlockStore badBlockStore = _set.BadBlocksStore = new BadBlockStore(_get.DbProvider.BadBlocksDb, initConfig.BadBlocksStored ?? 100);
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Init.Steps
             IChainLevelInfoRepository chainLevelInfoRepository =
                 _set.ChainLevelInfoRepository = new ChainLevelInfoRepository(_get.DbProvider!.BlockInfosDb);
 
-            IBlockStore blockStore = new BlockStore(_get.DbProvider.BlocksDb);
+            IBlockStore blockStore = _set.BlockStore = new BlockStore(_get.DbProvider.BlocksDb);
             IHeaderStore headerStore = new HeaderStore(_get.DbProvider.HeadersDb, _get.DbProvider.BlockNumbersDb);
             IBadBlockStore badBlockStore = _set.BadBlocksStore = new BadBlockStore(_get.DbProvider.BadBlocksDb, initConfig.BadBlocksStored ?? 100);
 

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Autofac;
 using Nethermind.Api;
 using Nethermind.Blockchain.FullPruning;
 using Nethermind.Blockchain.Synchronization;
@@ -29,6 +30,7 @@ using Nethermind.JsonRpc.Modules.Web3;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.JsonRpc.Modules.Rpc;
+using Nethermind.Synchronization.FastBlocks;
 
 namespace Nethermind.Init.Steps;
 
@@ -67,8 +69,14 @@ public class RegisterRpcModules : IStep
         StepDependencyException.ThrowIfNull(_api.PeerManager);
 
         // Used only by rpc
-        _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree, _api.ReceiptStorage!, _api.Config<ISyncConfig>(),
-            _api.SyncModeSelector!, _api.SyncProgressResolver!, _api.LogManager);
+        _api.EthSyncingInfo = new EthSyncingInfo(
+            _api.BlockTree,
+            _api.ReceiptStorage!,
+            _api.ApiWithNetworkServiceContainer!.Resolve<IBodiesSyncFeed>(),
+            _api.Config<ISyncConfig>(),
+            _api.SyncModeSelector!,
+            _api.SyncProgressResolver!,
+            _api.LogManager);
         _api.RpcModuleProvider = new RpcModuleProvider(_api.FileSystem, _jsonRpcConfig, _api.LogManager);
 
         IRpcModuleProvider rpcModuleProvider = _api.RpcModuleProvider;

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -71,8 +71,7 @@ public class RegisterRpcModules : IStep
         // Used only by rpc
         _api.EthSyncingInfo = new EthSyncingInfo(
             _api.BlockTree,
-            _api.ReceiptStorage!,
-            _api.BlockStore!,
+            _api.SyncPointers!,
             _api.Config<ISyncConfig>(),
             _api.SyncModeSelector!,
             _api.SyncProgressResolver!,

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -72,7 +72,7 @@ public class RegisterRpcModules : IStep
         _api.EthSyncingInfo = new EthSyncingInfo(
             _api.BlockTree,
             _api.ReceiptStorage!,
-            _api.ApiWithNetworkServiceContainer!.Resolve<IBodiesSyncFeed>(),
+            _api.BlockStore!,
             _api.Config<ISyncConfig>(),
             _api.SyncModeSelector!,
             _api.SyncProgressResolver!,

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -39,7 +39,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Facade.Find;
 using Nethermind.Facade.Simulate;
-using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 
@@ -164,7 +164,7 @@ namespace Nethermind.JsonRpc.Benchmark
 
             IReceiptStorage receiptStorage = new InMemoryReceiptStorage();
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, Substitute.For<IBlockStore>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
+            EthSyncingInfo ethSyncingInfo = new(blockTree,  Substitute.For<ISyncPointers>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
 
             _ethModule = new EthRpcModule(
                 new JsonRpcConfig(),

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -164,7 +164,7 @@ namespace Nethermind.JsonRpc.Benchmark
 
             IReceiptStorage receiptStorage = new InMemoryReceiptStorage();
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, Substitute.For<IBlockStore>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
 
             _ethModule = new EthRpcModule(
                 new JsonRpcConfig(),

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -164,7 +164,7 @@ namespace Nethermind.JsonRpc.Benchmark
 
             IReceiptStorage receiptStorage = new InMemoryReceiptStorage();
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo ethSyncingInfo = new(blockTree,  Substitute.For<ISyncPointers>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
+            EthSyncingInfo ethSyncingInfo = new(blockTree, Substitute.For<ISyncPointers>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
 
             _ethModule = new EthRpcModule(
                 new JsonRpcConfig(),

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -39,7 +39,9 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Facade.Find;
 using Nethermind.Facade.Simulate;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
+using NSubstitute;
 
 namespace Nethermind.JsonRpc.Benchmark
 {
@@ -162,7 +164,7 @@ namespace Nethermind.JsonRpc.Benchmark
 
             IReceiptStorage receiptStorage = new InMemoryReceiptStorage();
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
 
             _ethModule = new EthRpcModule(
                 new JsonRpcConfig(),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -28,6 +28,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.Sockets;
 using Nethermind.Specs;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 using Newtonsoft.Json.Linq;
@@ -77,7 +78,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _txPool,
                 _receiptCanonicalityMonitor,
                 _filterStore,
-                new EthSyncingInfo(_blockTree, _receiptStorage, _syncConfig,
+                new EthSyncingInfo(_blockTree, _receiptStorage, Substitute.For<IBodiesSyncFeed>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager),
                 _specProvider,
                 jsonSerializer);
@@ -192,7 +193,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Block block = Build.A.Block.WithNumber(head).TestObject;
             _blockTree.Head.Returns(block);
 
-            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, _syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, Substitute.For<IBodiesSyncFeed>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager);
 
             SyncingSubscription syncingSubscription = new(_jsonRpcDuplexClient, _blockTree, ethSyncingInfo, _logManager);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Json;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -78,7 +79,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _txPool,
                 _receiptCanonicalityMonitor,
                 _filterStore,
-                new EthSyncingInfo(_blockTree, _receiptStorage, Substitute.For<IBodiesSyncFeed>(), _syncConfig,
+                new EthSyncingInfo(_blockTree, _receiptStorage, Substitute.For<IBlockStore>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager),
                 _specProvider,
                 jsonSerializer);
@@ -193,7 +194,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Block block = Build.A.Block.WithNumber(head).TestObject;
             _blockTree.Head.Returns(block);
 
-            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, Substitute.For<IBodiesSyncFeed>(), _syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, Substitute.For<IBlockStore>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager);
 
             SyncingSubscription syncingSubscription = new(_jsonRpcDuplexClient, _blockTree, ethSyncingInfo, _logManager);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -29,6 +29,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.Sockets;
 using Nethermind.Specs;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
@@ -79,7 +80,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _txPool,
                 _receiptCanonicalityMonitor,
                 _filterStore,
-                new EthSyncingInfo(_blockTree, _receiptStorage, Substitute.For<IBlockStore>(), _syncConfig,
+                new EthSyncingInfo(_blockTree, Substitute.For<ISyncPointers>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager),
                 _specProvider,
                 jsonSerializer);
@@ -194,7 +195,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Block block = Build.A.Block.WithNumber(head).TestObject;
             _blockTree.Head.Returns(block);
 
-            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, Substitute.For<IBlockStore>(), _syncConfig,
+            EthSyncingInfo ethSyncingInfo = new(_blockTree, Substitute.For<ISyncPointers>(), _syncConfig,
                 new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager);
 
             SyncingSubscription syncingSubscription = new(_jsonRpcDuplexClient, _blockTree, ethSyncingInfo, _logManager);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -131,7 +132,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             LimboLogs.Instance,
             @this.SpecProvider,
             @this.GasPriceOracle,
-            new EthSyncingInfo(@this.BlockTree, @this.ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), new SyncConfig(),
+            new EthSyncingInfo(@this.BlockTree, @this.ReceiptStorage, Substitute.For<IBlockStore>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), @this.LogManager),
             @this.FeeHistoryOracle ??
             new FeeHistoryOracle(@this.BlockTree, @this.ReceiptStorage, @this.SpecProvider),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -32,6 +32,7 @@ using Nethermind.Config;
 using Nethermind.Db;
 using Nethermind.Facade.Simulate;
 using Nethermind.State;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
@@ -132,7 +133,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             LimboLogs.Instance,
             @this.SpecProvider,
             @this.GasPriceOracle,
-            new EthSyncingInfo(@this.BlockTree, @this.ReceiptStorage, Substitute.For<IBlockStore>(), new SyncConfig(),
+            new EthSyncingInfo(@this.BlockTree, Substitute.For<ISyncPointers>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), @this.LogManager),
             @this.FeeHistoryOracle ??
             new FeeHistoryOracle(@this.BlockTree, @this.ReceiptStorage, @this.SpecProvider),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -31,6 +31,7 @@ using Nethermind.Config;
 using Nethermind.Db;
 using Nethermind.Facade.Simulate;
 using Nethermind.State;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 
@@ -130,7 +131,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             LimboLogs.Instance,
             @this.SpecProvider,
             @this.GasPriceOracle,
-            new EthSyncingInfo(@this.BlockTree, @this.ReceiptStorage, new SyncConfig(),
+            new EthSyncingInfo(@this.BlockTree, @this.ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), @this.LogManager),
             @this.FeeHistoryOracle ??
             new FeeHistoryOracle(@this.BlockTree, @this.ReceiptStorage, @this.SpecProvider),

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -35,6 +35,7 @@ using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Test.ChainSpecStyle;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
@@ -174,7 +175,7 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             ISyncConfig syncConfig = new SyncConfig();
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBlockStore>(), syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, Substitute.For<ISyncPointers>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -174,7 +174,7 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             ISyncConfig syncConfig = new SyncConfig();
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBlockStore>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -35,6 +35,7 @@ using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Test.ChainSpecStyle;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -173,7 +174,7 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             ISyncConfig syncConfig = new SyncConfig();
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -37,6 +37,7 @@ using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using NSubstitute;
@@ -202,7 +203,7 @@ public partial class EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory? blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -203,7 +203,7 @@ public partial class EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBlockStore>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory? blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -37,6 +37,7 @@ using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -203,7 +204,7 @@ public partial class EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, Substitute.For<IBlockStore>(), syncConfig,
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, Substitute.For<ISyncPointers>(), syncConfig,
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory? blockProducerFactory = new(
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading.Tasks;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -79,7 +80,7 @@ internal static class TestRpcBlockchainExt
             LimboLogs.Instance,
             blockchain.SpecProvider,
             blockchain.GasPriceOracle,
-            new EthSyncingInfo(blockchain.BlockTree, blockchain.ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), new SyncConfig(),
+            new EthSyncingInfo(blockchain.BlockTree, blockchain.ReceiptStorage, Substitute.For<IBlockStore>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), blockchain.LogManager),
             blockchain.FeeHistoryOracle ??
             new FeeHistoryOracle(blockchain.BlockTree, blockchain.ReceiptStorage, blockchain.SpecProvider),

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
@@ -17,6 +17,7 @@ using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Optimism.Rpc;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
@@ -80,7 +81,7 @@ internal static class TestRpcBlockchainExt
             LimboLogs.Instance,
             blockchain.SpecProvider,
             blockchain.GasPriceOracle,
-            new EthSyncingInfo(blockchain.BlockTree, blockchain.ReceiptStorage, Substitute.For<IBlockStore>(), new SyncConfig(),
+            new EthSyncingInfo(blockchain.BlockTree, Substitute.For<ISyncPointers>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), blockchain.LogManager),
             blockchain.FeeHistoryOracle ??
             new FeeHistoryOracle(blockchain.BlockTree, blockchain.ReceiptStorage, blockchain.SpecProvider),

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
@@ -16,6 +16,7 @@ using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Optimism.Rpc;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 using NSubstitute;
@@ -78,7 +79,7 @@ internal static class TestRpcBlockchainExt
             LimboLogs.Instance,
             blockchain.SpecProvider,
             blockchain.GasPriceOracle,
-            new EthSyncingInfo(blockchain.BlockTree, blockchain.ReceiptStorage, new SyncConfig(),
+            new EthSyncingInfo(blockchain.BlockTree, blockchain.ReceiptStorage, Substitute.For<IBodiesSyncFeed>(), new SyncConfig(),
                 new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), blockchain.LogManager),
             blockchain.FeeHistoryOracle ??
             new FeeHistoryOracle(blockchain.BlockTree, blockchain.ReceiptStorage, blockchain.SpecProvider),

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -119,6 +119,7 @@ namespace Nethermind.Runner.Test.Ethereum
                 ApiWithNetworkServiceContainer = new ContainerBuilder()
                     .AddSingleton(Substitute.For<ISyncModeSelector>())
                     .AddSingleton(Substitute.For<ISyncProgressResolver>())
+                    .AddSingleton(Substitute.For<ISyncPointers>())
                     .AddSingleton(Substitute.For<ISynchronizer>())
                     .AddSingleton(Substitute.For<ISyncPeerPool>())
                     .AddSingleton(Substitute.For<IPeerDifficultyRefreshPool>())

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -139,11 +139,6 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
 
             public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical, WriteFlags writeFlags) => _outStorage.Insert(block, txReceipts, ensureCanonical, writeFlags);
 
-            public long? LowestInsertedReceiptBlockNumber
-            {
-                get => _outStorage.LowestInsertedReceiptBlockNumber;
-                set => _outStorage.LowestInsertedReceiptBlockNumber = value;
-            }
             public long MigratedBlockNumber
             {
                 get => _outStorage.MigratedBlockNumber;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -45,6 +45,7 @@ public class BodiesSyncFeedTests
         _metadataDb = new MemDb();
         _syncPointers = new MemorySyncPointers();
         _syncingToBlockTree = Build.A.BlockTree()
+            .WithBlocksDb(_blocksDb)
             .TestObject;
 
         for (int i = 1; i < 100; i++)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -198,11 +198,11 @@ public class BodiesSyncFeedTests
         _syncConfig.AncientBodiesBarrier = AncientBarrierInConfig;
         _syncConfig.AncientReceiptsBarrier = AncientBarrierInConfig;
         _syncConfig.PivotNumber = (AncientBarrierInConfig + 1_000_000).ToString();
-        _syncingToBlockTree.LowestInsertedBodyNumber = JustStarted ? null : _pivotBlock.Number;
+        _feed.LowestInsertedBodyNumber = JustStarted ? null : _pivotBlock.Number;
         if (previousBarrierInDb is not null)
             _metadataDb.Set(MetadataDbKeys.BodiesBarrierWhenStarted, previousBarrierInDb.Value.ToBigEndianByteArrayWithoutLeadingZeros());
         _feed.InitializeFeed();
-        _syncingToBlockTree.LowestInsertedBodyNumber = lowestInsertedBlockNumber;
+        _feed.LowestInsertedBodyNumber = lowestInsertedBlockNumber;
 
         _feed.IsFinished.Should().Be(shouldfinish);
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -159,6 +159,7 @@ public class ReceiptsSyncFeedTests
     [Test]
     public async Task Should_finish_on_start_when_receipts_not_stored()
     {
+        _syncPointers.LowestInsertedReceiptBlockNumber = 0;
         _feed = new ReceiptsSyncFeed(
             _specProvider,
             _blockTree,
@@ -274,6 +275,7 @@ public class ReceiptsSyncFeedTests
         long? previousBarrierInDb,
         bool shouldfinish)
     {
+        _syncPointers = Substitute.For<ISyncPointers>();
         _syncConfig.AncientBodiesBarrier = AncientBarrierInConfig;
         _syncConfig.AncientReceiptsBarrier = AncientBarrierInConfig;
         _pivotNumber = AncientBarrierInConfig + 1_000_000;
@@ -295,6 +297,7 @@ public class ReceiptsSyncFeedTests
         _syncConfig = syncConfig;
         _syncConfig.PivotNumber = _pivotNumber.ToString();
         _syncConfig.PivotHash = scenario.Blocks.Last()?.Hash?.ToString();
+        _syncPointers = Substitute.For<ISyncPointers>();
 
         _feed = new ReceiptsSyncFeed(
             _specProvider,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -67,7 +67,7 @@ public class ReceiptsSyncFeedTests
 
     private static readonly ISpecProvider _specProvider;
     private IReceiptStorage _receiptStorage = null!;
-    private ISyncPointers _syncPointers = new MemorySyncPointers();
+    private ISyncPointers _syncPointers = null!;
     private ISyncPeerPool _syncPeerPool = null!;
     private ReceiptsSyncFeed _feed = null!;
     private ISyncConfig _syncConfig = null!;
@@ -98,6 +98,7 @@ public class ReceiptsSyncFeedTests
     public void Setup()
     {
         _receiptStorage = Substitute.For<IReceiptStorage>();
+        _syncPointers = new MemorySyncPointers();
         _blockTree = Substitute.For<IBlockTree>();
         _metadataDb = new TestMemDb();
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -328,7 +328,6 @@ public class ReceiptsSyncFeedTests
                     : null);
 
         _receiptStorage.LowestInsertedReceiptBlockNumber.Returns((long?)null);
-        _blockTree.LowestInsertedBodyNumber.Returns(scenario.LowestInsertedBody!.Number);
     }
 
     [Test]
@@ -417,7 +416,6 @@ public class ReceiptsSyncFeedTests
         };
 
         _blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).WithStateRoot(TestItem.KeccakA).TestObject);
-        _blockTree.LowestInsertedBodyNumber.Returns(1);
 
         _receiptStorage = Substitute.For<IReceiptStorage>();
         _receiptStorage.LowestInsertedReceiptBlockNumber.Returns(2);
@@ -439,7 +437,6 @@ public class ReceiptsSyncFeedTests
         };
 
         _blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).WithStateRoot(TestItem.KeccakA).TestObject);
-        _blockTree.LowestInsertedBodyNumber.Returns(2);
         _receiptStorage = Substitute.For<IReceiptStorage>();
         _receiptStorage.LowestInsertedReceiptBlockNumber.Returns(1);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/MemorySyncPointers.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/MemorySyncPointers.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Synchronization.Test;
+
+public class MemorySyncPointers : ISyncPointers
+{
+    public long? LowestInsertedBodyNumber { get; set; }
+    public long? LowestInsertedReceiptBlockNumber { get; set; }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -685,7 +685,16 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             selector.Current.Should().Be(SyncMode.Full);
 
             CancellationTokenSource waitTokenSource = new();
-            ReceiptsSyncFeed receiptsSyncFeed = Substitute.ForPartsOf<ReceiptsSyncFeed>(MainnetSpecProvider.Instance, Substitute.For<IBlockTree>(), Substitute.For<IReceiptStorage>(), syncPeerPool, syncConfig, Substitute.For<ISyncReport>(), Substitute.For<IDb>(), LimboLogs.Instance);
+            ReceiptsSyncFeed receiptsSyncFeed = Substitute.ForPartsOf<ReceiptsSyncFeed>(
+                MainnetSpecProvider.Instance,
+                Substitute.For<IBlockTree>(),
+                Substitute.For<IReceiptStorage>(),
+                Substitute.For<ISyncPointers>(),
+                syncPeerPool,
+                syncConfig,
+                Substitute.For<ISyncReport>(),
+                Substitute.For<IDb>(),
+                LimboLogs.Instance);
             receiptsSyncFeed.When(rsf => rsf.InitializeFeed()).DoNotCallBase();
             receiptsSyncFeed.When(rsf => rsf.InitializeFeed()).Do(e =>
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
@@ -69,6 +69,7 @@ public class ReceiptSyncFeedTests
             MainnetSpecProvider.Instance,
             _syncingToBlockTree,
             _receiptStorage,
+            new MemorySyncPointers(),
             Substitute.For<ISyncPeerPool>(),
             _syncConfig,
             new NullSyncReport(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPointersTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPointersTests.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Core.Test;
+using Nethermind.Db;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test;
+
+public class SyncPointersTests
+{
+    [Test]
+    public void WhenReceiptNotStore_SetLowestInsertedReceiptTo0()
+    {
+        SyncPointers pointers = new SyncPointers(new TestMemDb(), new TestMemColumnsDb<ReceiptsColumns>(), new ReceiptConfig()
+        {
+            StoreReceipts = false
+        });
+
+        pointers.LowestInsertedReceiptBlockNumber.Should().Be(0);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -143,7 +143,6 @@ namespace Nethermind.Synchronization.Test
             };
 
             blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).WithStateRoot(TestItem.KeccakA).TestObject);
-            blockTree.LowestInsertedBodyNumber.Returns(2);
 
             SyncProgressResolver syncProgressResolver = CreateProgressResolver(blockTree, stateReader, false, syncConfig, LimboLogs.Instance);
             Assert.That(syncProgressResolver.IsFastBlocksBodiesFinished(), Is.False);
@@ -163,7 +162,6 @@ namespace Nethermind.Synchronization.Test
             };
 
             blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).WithStateRoot(TestItem.KeccakA).TestObject);
-            blockTree.LowestInsertedBodyNumber.Returns(1);
 
             SyncProgressResolver syncProgressResolver = CreateProgressResolver(blockTree, stateReader, true, syncConfig, LimboLogs.Instance);
             Assert.That(syncProgressResolver.IsFastBlocksReceiptsFinished(), Is.True);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -355,6 +355,7 @@ namespace Nethermind.Synchronization.Test
             builder
                 .AddModule(new DbModule())
                 .AddModule(new SynchronizerModule(syncConfig))
+                .AddSingleton<IReceiptConfig>(new ReceiptConfig())
                 .AddSingleton(dbProvider)
                 .AddSingleton(blockStore)
                 .AddSingleton<INodeStorage>(new NodeStorage(dbProvider.StateDb))

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -259,7 +259,8 @@ namespace Nethermind.Synchronization.Test
             InMemoryReceiptStorage receiptStorage = new();
 
             EthereumEcdsa ecdsa = new(specProvider.ChainId);
-            BlockTree tree = Build.A.BlockTree().WithoutSettingHead.TestObject;
+            IBlockStore blockStore = new BlockStore(dbProvider.BlocksDb);
+            BlockTree tree = Build.A.BlockTree().WithBlockStore(blockStore).WithoutSettingHead.TestObject;
             ITransactionComparerProvider transactionComparerProvider =
                 new TransactionComparerProvider(specProvider, tree);
 
@@ -355,6 +356,7 @@ namespace Nethermind.Synchronization.Test
                 .AddModule(new DbModule())
                 .AddModule(new SynchronizerModule(syncConfig))
                 .AddSingleton(dbProvider)
+                .AddSingleton(blockStore)
                 .AddSingleton<INodeStorage>(new NodeStorage(dbProvider.StateDb))
                 .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
                 .AddSingleton<IBlockTree>(tree)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
@@ -314,8 +315,10 @@ public class SynchronizerTests
             IDbProvider dbProvider = TestMemDbProvider.Init();
             IDb stateDb = new MemDb();
             IDb codeDb = dbProvider.CodeDb;
+            IBlockStore blockStore = new BlockStore(dbProvider.BlocksDb);
             BlockTree = Build.A.BlockTree()
                 .WithSpecProvider(new TestSingleReleaseSpecProvider(Constantinople.Instance))
+                .WithBlockStore(blockStore)
                 .WithoutSettingHead
                 .TestObject;
 
@@ -347,6 +350,7 @@ public class SynchronizerTests
                 .AddModule(new DbModule())
                 .AddModule(new SynchronizerModule(syncConfig))
                 .AddSingleton(dbProvider)
+                .AddSingleton(blockStore)
                 .AddSingleton(nodeStorage)
                 .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
                 .AddSingleton<IBlockTree>(BlockTree)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -349,6 +349,7 @@ public class SynchronizerTests
             ContainerBuilder builder = new ContainerBuilder()
                 .AddModule(new DbModule())
                 .AddModule(new SynchronizerModule(syncConfig))
+                .AddSingleton<IReceiptConfig>(new ReceiptConfig())
                 .AddSingleton(dbProvider)
                 .AddSingleton(blockStore)
                 .AddSingleton(nodeStorage)

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/IBodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/IBodiesSyncFeed.cs
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
-// SPDX-License-Identifier: LGPL-3.0-only
-
-namespace Nethermind.Synchronization.FastBlocks;
-
-public interface IBodiesSyncFeed
-{
-    long? LowestInsertedBodyNumber { get; set; }
-}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/IBodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/IBodiesSyncFeed.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Synchronization.FastBlocks;
+
+public interface IBodiesSyncFeed
+{
+    long? LowestInsertedBodyNumber { get; set; }
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
     public class ReceiptsSyncFeed : BarrierSyncFeed<ReceiptsSyncBatch?>
     {
-        protected override long? LowestInsertedNumber => _receiptStorage.LowestInsertedReceiptBlockNumber;
+        protected override long? LowestInsertedNumber => _syncPointers.LowestInsertedReceiptBlockNumber;
         protected override int BarrierWhenStartedMetadataDbKey => MetadataDbKeys.ReceiptsBarrierWhenStarted;
         protected override long SyncConfigBarrierCalc => _syncConfig.AncientReceiptsBarrierCalc;
         protected override Func<bool> HasPivot =>
@@ -41,12 +41,13 @@ namespace Nethermind.Synchronization.FastBlocks
         private readonly ISyncConfig _syncConfig;
         private readonly ISyncReport _syncReport;
         private readonly IReceiptStorage _receiptStorage;
+        private readonly ISyncPointers _syncPointers;
         private readonly ISyncPeerPool _syncPeerPool;
 
         private SyncStatusList _syncStatusList;
 
         private bool ShouldFinish => !_syncConfig.DownloadReceiptsInFastSync || AllDownloaded;
-        private bool AllDownloaded => (_receiptStorage.LowestInsertedReceiptBlockNumber ?? long.MaxValue) <= _barrier
+        private bool AllDownloaded => (_syncPointers.LowestInsertedReceiptBlockNumber ?? long.MaxValue) <= _barrier
             || WithinOldBarrierDefault;
 
         public override bool IsFinished => AllDownloaded;
@@ -55,6 +56,7 @@ namespace Nethermind.Synchronization.FastBlocks
             ISpecProvider specProvider,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
+            ISyncPointers syncPointers,
             ISyncPeerPool syncPeerPool,
             ISyncConfig syncConfig,
             ISyncReport syncReport,
@@ -62,11 +64,12 @@ namespace Nethermind.Synchronization.FastBlocks
             ILogManager logManager)
             : base(metadataDb, specProvider, logManager?.GetClassLogger() ?? default)
         {
-            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
-            _syncPeerPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
-            _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
-            _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
-            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
+            _receiptStorage = receiptStorage;
+            _syncPointers = syncPointers;
+            _syncPeerPool = syncPeerPool;
+            _syncConfig = syncConfig;
+            _syncReport = syncReport;
+            _blockTree = blockTree;
 
             if (!_syncConfig.FastSync)
             {
@@ -96,7 +99,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncStatusList = new SyncStatusList(
                 _blockTree,
                 _pivotNumber,
-                _receiptStorage.LowestInsertedReceiptBlockNumber,
+                _syncPointers.LowestInsertedReceiptBlockNumber,
                 _syncConfig.AncientReceiptsBarrier);
         }
 
@@ -136,7 +139,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 while (!_syncStatusList.TryGetInfosForBatch(_requestSize, (info) => _receiptStorage.HasBlock(info.BlockNumber, info.BlockHash), out infos))
                 {
                     token.ThrowIfCancellationRequested();
-                    _receiptStorage.LowestInsertedReceiptBlockNumber = _syncStatusList.LowestInsertWithoutGaps;
+                    _syncPointers.LowestInsertedReceiptBlockNumber = _syncStatusList.LowestInsertWithoutGaps;
                     UpdateSyncReport();
                 }
 
@@ -150,7 +153,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 // Array.Reverse(infos);
             }
 
-            _receiptStorage.LowestInsertedReceiptBlockNumber = _syncStatusList.LowestInsertWithoutGaps;
+            _syncPointers.LowestInsertedReceiptBlockNumber = _syncStatusList.LowestInsertWithoutGaps;
 
             return Task.FromResult(batch);
         }

--- a/src/Nethermind/Nethermind.Synchronization/ISyncPointers.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ISyncPointers.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Synchronization;
+
+public interface ISyncPointers
+{
+    long? LowestInsertedBodyNumber { get; set; }
+    long? LowestInsertedReceiptBlockNumber { get; set; }
+}

--- a/src/Nethermind/Nethermind.Synchronization/SyncPointers.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncPointers.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac.Features.AttributeFilters;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Db;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Synchronization;
+
+public class SyncPointers : ISyncPointers
+{
+    private readonly IDb _blocksDb;
+    private readonly IDb _defaultReceiptDbColumn;
+
+    private static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
+
+
+    private long? _lowestInsertedBodyNumber;
+    public long? LowestInsertedBodyNumber
+    {
+        get => _lowestInsertedBodyNumber;
+        set
+        {
+            _lowestInsertedBodyNumber = value;
+            if (value.HasValue) _blocksDb[LowestInsertedBodyNumberDbEntryAddress] = Rlp.Encode(value.Value).Bytes;
+        }
+    }
+
+    private long? _lowestInsertedReceiptBlock;
+
+    public long? LowestInsertedReceiptBlockNumber
+    {
+        get => _lowestInsertedReceiptBlock;
+        set
+        {
+            _lowestInsertedReceiptBlock = value;
+            if (value.HasValue)
+            {
+                _defaultReceiptDbColumn.Set(Keccak.Zero, Rlp.Encode(value.Value).Bytes);
+            }
+        }
+    }
+
+
+    public SyncPointers([KeyFilter(DbNames.Blocks)] IDb blocksDb, IColumnsDb<ReceiptsColumns> receiptsDb)
+    {
+        _blocksDb = blocksDb;
+        _defaultReceiptDbColumn = receiptsDb.GetColumnDb(ReceiptsColumns.Default);
+
+        LowestInsertedBodyNumber = _blocksDb[LowestInsertedBodyNumberDbEntryAddress]?.AsRlpValueContext().DecodeLong();
+
+        byte[] lowestBytes = _defaultReceiptDbColumn.Get(Keccak.Zero);
+        _lowestInsertedReceiptBlock = lowestBytes is null ? (long?)null : new RlpStream(lowestBytes).DecodeLong();
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -279,6 +279,7 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .AddSingleton<IFullStateFinder, FullStateFinder>()
             .AddSingleton<SyncDbTuner>()
             .AddSingleton<MallocTrimmer>()
+            .AddSingleton<ISyncPointers, SyncPointers>()
 
             // For blocks. There are two block scope, Fast and Full
             .AddScoped<SyncFeedComponent<BlocksRequest>>()

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -381,6 +381,8 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         ConfigureSingletonSyncFeed<BodiesSyncBatch, BodiesSyncFeed, BodiesSyncDownloader, FastBlocksPeerAllocationStrategyFactory>(serviceCollection);
 
+        serviceCollection.Bind<BodiesSyncFeed, IBodiesSyncFeed>();
+
         if (!syncConfig.FastSync || !syncConfig.DownloadHeadersInFastSync ||
             !syncConfig.DownloadBodiesInFastSync)
         {

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -381,8 +381,6 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         ConfigureSingletonSyncFeed<BodiesSyncBatch, BodiesSyncFeed, BodiesSyncDownloader, FastBlocksPeerAllocationStrategyFactory>(serviceCollection);
 
-        serviceCollection.Bind<BodiesSyncFeed, IBodiesSyncFeed>();
-
         if (!syncConfig.FastSync || !syncConfig.DownloadHeadersInFastSync ||
             !syncConfig.DownloadBodiesInFastSync)
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -58,22 +58,6 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public void should_update_lowest_when_needed_in_memory()
-            => TestAddAndCheckLowest(_inMemoryStorage, true);
-
-        [Test]
-        public void should_update_lowest_when_needed_persistent()
-            => TestAddAndCheckLowest(_persistentStorage, true);
-
-        [Test]
-        public void should_not_update_lowest_when_not_needed_persistent()
-            => TestAddAndCheckLowest(_persistentStorage, false);
-
-        [Test]
-        public void should_not_update_lowest_when_not_needed_in_memory()
-            => TestAddAndCheckLowest(_inMemoryStorage, false);
-
-        [Test]
         public void should_add_and_fetch_receipt_from_in_memory_storage()
             => TestAddAndGetReceipt(_inMemoryStorage);
 
@@ -99,20 +83,6 @@ namespace Nethermind.TxPool.Test
             Block block = Build.A.Block.WithNumber(0).WithTransactions(5, _specProvider).TestObject;
             TxReceipt[] receipts = _receiptFinder.Get(block.Hash);
             receipts.Should().BeEmpty();
-        }
-
-        private void TestAddAndCheckLowest(IReceiptStorage storage, bool updateLowest)
-        {
-            Transaction transaction = GetSignedTransaction();
-            Block block = GetBlock(transaction);
-            TxReceipt receipt = GetReceipt(transaction, block);
-            storage.Insert(block, receipt);
-            if (updateLowest)
-            {
-                storage.LowestInsertedReceiptBlockNumber = block.Number;
-            }
-
-            storage.LowestInsertedReceiptBlockNumber.Should().Be(updateLowest ? 1 : null);
         }
 
         private void TestAddAndGetReceipt(IReceiptStorage storage, IReceiptFinder receiptFinder = null)


### PR DESCRIPTION
- Mode LowestInsertedBodyNumber out of IBlockTree.
- Minor change, just make sense. Era and portal will just make it not very clear
- Delete some interface method from `IBlockTree` and `IBlockStore`. 
- LowestInsertedReceipt is not in IBlockTree at all. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Testing...