### PR TITLE
Faster sync tests

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -163,5 +163,5 @@ public interface ISyncConfig : IConfig
     int StateMinDistanceFromHead { get; set; }
 
     [ConfigItem(Description = "_Technical._ Run explicit GC after state sync finished.", DefaultValue = "true", HiddenFromDocs = true)]
-    bool GCOnStateSyncFinished { get; set; }
+    bool GCOnFeedFinished { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -161,4 +161,7 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = "_Technical._ Min distance of state sync from best suggested header.", DefaultValue = "32", HiddenFromDocs = true)]
     int StateMinDistanceFromHead { get; set; }
+
+    [ConfigItem(Description = "_Technical._ Run explicit GC after state sync finished.", DefaultValue = "true", HiddenFromDocs = true)]
+    bool GCOnStateSyncFinished { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -72,6 +72,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool TrieHealing { get; set; } = true;
         public int StateMaxDistanceFromHead { get; set; } = 128;
         public int StateMinDistanceFromHead { get; set; } = 32;
+        public bool GCOnStateSyncFinished { get; set; } = true;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool TrieHealing { get; set; } = true;
         public int StateMaxDistanceFromHead { get; set; } = 128;
         public int StateMinDistanceFromHead { get; set; } = 32;
-        public bool GCOnStateSyncFinished { get; set; } = true;
+        public bool GCOnFeedFinished { get; set; } = true;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Core.Test/CachedBlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CachedBlockTreeBuilder.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using NonBlocking;
+
+namespace Nethermind.Core.Test;
+
+public class CachedBlockTreeBuilder
+{
+    private static ConcurrentDictionary<string, CachedDb> _cachedDbs = new();
+    private record CachedDb(
+        MemDb blocksDb,
+        MemDb metadataDb,
+        MemDb headersDb,
+        MemDb blockNumbersDb,
+        MemDb blockInfo
+    );
+
+    public static IBlockTree BuildCached(string key, Func<BlockTreeBuilder> blockTreeBuilderFactory)
+    {
+        if (_cachedDbs.TryGetValue(key, out CachedDb? db))
+        {
+            return Build.A.BlockTree()
+                .WithBlocksDb(MemDb.CopyFrom(db.blocksDb))
+                .WithMetadataDb(MemDb.CopyFrom(db.metadataDb))
+                .WithHeadersDb(MemDb.CopyFrom(db.headersDb))
+                .WithBlocksNumberDb(MemDb.CopyFrom(db.blockNumbersDb))
+                .WithBlockInfoDb(MemDb.CopyFrom(db.blockInfo))
+                .TestObject;
+        }
+        else
+        {
+            BlockTreeBuilder builder = blockTreeBuilderFactory();
+            CachedDb cachedValue = new CachedDb(
+                MemDb.CopyFrom(builder.BlocksDb),
+                MemDb.CopyFrom(builder.MetadataDb),
+                MemDb.CopyFrom(builder.HeadersDb),
+                MemDb.CopyFrom(builder.BlockNumbersDb),
+                MemDb.CopyFrom(builder.BlockInfoDb)
+            );
+            _cachedDbs.TryAdd(key, cachedValue);
+
+            return builder.TestObject;
+        }
+    }
+
+    public static IBlockTree OfLength(int length)
+    {
+        return BuildCached($"{nameof(CachedBlockTreeBuilder)}-{length}", () => Build.A.BlockTree().OfChainLength(length));
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/CachedBlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CachedBlockTreeBuilder.cs
@@ -42,7 +42,7 @@ public class CachedBlockTreeBuilder
                 MemDb.CopyFrom(builder.BlockNumbersDb),
                 MemDb.CopyFrom(builder.BlockInfoDb)
             );
-            _cachedDbs.TryAdd(key, cachedValue);
+            _cachedDbs.GetOrAdd(key, cachedValue);
 
             return builder.TestObject;
         }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -27,6 +27,17 @@ namespace Nethermind.Db
             Name = name;
         }
 
+        public static MemDb CopyFrom(IDb anotherDb)
+        {
+            MemDb newDb = new MemDb();
+            foreach (KeyValuePair<byte[], byte[]> kv in anotherDb.GetAll())
+            {
+                newDb[kv.Key] = kv.Value;
+            }
+
+            return newDb;
+        }
+
         public MemDb() : this(0, 0)
         {
         }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -30,7 +30,13 @@ using Nethermind.Wallet;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitializeStateDb), typeof(InitializePlugins), typeof(InitializeBlockTree), typeof(SetupKeyStore))]
+    [RunnerStepDependencies(
+        typeof(InitializeStateDb),
+        typeof(InitializePlugins),
+        typeof(InitializeBlockTree),
+        typeof(SetupKeyStore),
+        typeof(InitializePrecompiles)
+    )]
     public class InitializeBlockchain : IStep
     {
         private readonly INethermindApi _api;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -276,7 +276,7 @@ public partial class BlockDownloaderTests
         peerAllocationStrategy
             .Allocate(Arg.Any<PeerInfo?>(), Arg.Any<IEnumerable<PeerInfo>>(), Arg.Any<INodeStatsManager>(), Arg.Any<IBlockTree>())
             .Returns(new PeerInfo(syncPeer1));
-        SyncPeerAllocation peerAllocation = new(peerAllocationStrategy, AllocationContexts.Blocks);
+        SyncPeerAllocation peerAllocation = new(peerAllocationStrategy, AllocationContexts.Blocks, null);
         peerAllocation.AllocateBestPeer(new List<PeerInfo>(), Substitute.For<INodeStatsManager>(), ctx.BlockTree);
         ctx.PeerPool
             .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>())
@@ -332,7 +332,7 @@ public partial class BlockDownloaderTests
             BlockTreeScenario = blockTrees,
         };
 
-        ctx.Feed = new FastSyncFeed(new SyncConfig
+        ctx.Feed = new FastSyncFeed(new TestSyncConfig
         {
             NonValidatorNode = true,
             DownloadBodiesInFastSync = false,
@@ -349,7 +349,7 @@ public partial class BlockDownloaderTests
         peerAllocationStrategy
             .Allocate(Arg.Any<PeerInfo?>(), Arg.Any<IEnumerable<PeerInfo>>(), Arg.Any<INodeStatsManager>(), Arg.Any<IBlockTree>())
             .Returns(peerInfo);
-        SyncPeerAllocation peerAllocation = new(peerAllocationStrategy, AllocationContexts.Blocks);
+        SyncPeerAllocation peerAllocation = new(peerAllocationStrategy, AllocationContexts.Blocks, null);
         peerAllocation.AllocateBestPeer(new List<PeerInfo>(), Substitute.For<INodeStatsManager>(), ctx.BlockTree);
 
         ctx.PeerPool
@@ -479,13 +479,13 @@ public partial class BlockDownloaderTests
 
         public PoSSwitcher PosSwitcher => _posSwitcher ??= new(
             MergeConfig,
-            new SyncConfig(),
+            new TestSyncConfig(),
             MetadataDb,
             BlockTree,
             SpecProvider,
             new ChainSpec(),
             LimboLogs.Instance);
-        public BeaconPivot BeaconPivot => _beaconPivot ??= new(new SyncConfig(), MetadataDb, BlockTree, _posSwitcher!, LimboLogs.Instance);
+        public BeaconPivot BeaconPivot => _beaconPivot ??= new(new TestSyncConfig(), MetadataDb, BlockTree, _posSwitcher!, LimboLogs.Instance);
 
         protected override IBetterPeerStrategy BetterPeerStrategy => _betterPeerStrategy ??=
             new MergeBetterPeerStrategy(new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), PosSwitcher, BeaconPivot, LimboLogs.Instance);
@@ -498,7 +498,7 @@ public partial class BlockDownloaderTests
                 _chainLevelHelper ??= new ChainLevelHelper(
                     BlockTree,
                     BeaconPivot,
-                    new SyncConfig(),
+                    new TestSyncConfig(),
                     LimboLogs.Instance);
             set => _chainLevelHelper = value;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -38,6 +38,7 @@ using NSubstitute;
 using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
 using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core.Test;
 
 namespace Nethermind.Synchronization.Test;
 
@@ -108,7 +109,7 @@ public partial class BlockDownloaderTests
     {
         Context ctx = new()
         {
-            BlockTree = Build.A.BlockTree().OfChainLength(1024).TestObject,
+            BlockTree = CachedBlockTreeBuilder.OfLength(1024),
         };
         BlockDownloader downloader = ctx.BlockDownloader;
 
@@ -139,7 +140,7 @@ public partial class BlockDownloaderTests
     {
         Context ctx = new()
         {
-            BlockTree = Build.A.BlockTree().OfChainLength(1024).TestObject,
+            BlockTree = CachedBlockTreeBuilder.OfLength(1024),
         };
         BlockDownloader downloader = ctx.BlockDownloader;
 
@@ -168,7 +169,7 @@ public partial class BlockDownloaderTests
     {
         Context ctx = new()
         {
-            BlockTree = Build.A.BlockTree().OfChainLength(2048 + 1).TestObject,
+            BlockTree = CachedBlockTreeBuilder.OfLength(2048 + 1),
         };
         BlockDownloader downloader = ctx.BlockDownloader;
 
@@ -186,7 +187,7 @@ public partial class BlockDownloaderTests
     {
         Context ctx = new()
         {
-            BlockTree = Build.A.BlockTree().OfChainLength(2048 + 1).TestObject,
+            BlockTree = CachedBlockTreeBuilder.OfLength(2048 + 1),
         };
         BlockDownloader downloader = ctx.BlockDownloader;
 
@@ -1024,11 +1025,9 @@ public partial class BlockDownloaderTests
 
         private SyncDispatcher<BlocksRequest>? _dispatcher;
         public SyncDispatcher<BlocksRequest> Dispatcher => _dispatcher ??= new SyncDispatcher<BlocksRequest>(
-            new SyncConfig()
+            new TestSyncConfig()
             {
                 MaxProcessingThreads = 0,
-                SyncDispatcherEmptyRequestDelayMs = 1,
-                SyncDispatcherAllocateTimeoutMs = 1
             },
             Feed!,
             BlockDownloader,
@@ -1062,7 +1061,7 @@ public partial class BlockDownloaderTests
         private readonly ReceiptsMessageSerializer _receiptsSerializer = new(MainnetSpecProvider.Instance);
         private readonly Response _flags;
 
-        public BlockTree BlockTree { get; private set; } = null!;
+        public IBlockTree BlockTree { get; private set; } = null!;
         private IReceiptStorage _receiptStorage = new InMemoryReceiptStorage();
 
         public string Name => "Mock";

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -54,7 +54,7 @@ public class BodiesSyncFeedTests
 
         _pivotBlock = _syncingFromBlockTree.FindBlock(99, BlockTreeLookupOptions.None)!;
 
-        _syncConfig = new SyncConfig()
+        _syncConfig = new TestSyncConfig()
         {
             FastSync = true,
             PivotHash = _pivotBlock.Hash!.ToString(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Stats.Model;
@@ -40,7 +41,7 @@ public class FastHeadersSyncTests
             HeadersSyncFeed _ = new HeadersSyncFeed(
                 blockTree: blockTree,
                 syncPeerPool: Substitute.For<ISyncPeerPool>(),
-                syncConfig: new SyncConfig(),
+                syncConfig: new TestSyncConfig(),
                 syncReport: Substitute.For<ISyncReport>(),
                 logManager: LimboLogs.Instance);
         });
@@ -56,7 +57,7 @@ public class FastHeadersSyncTests
         HeadersSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: Substitute.For<ISyncPeerPool>(),
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "1000",
@@ -89,7 +90,7 @@ public class FastHeadersSyncTests
         ResettableHeaderSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: syncPeerPool,
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "1000",
@@ -149,7 +150,7 @@ public class FastHeadersSyncTests
         using ResettableHeaderSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: Substitute.For<ISyncPeerPool>(),
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "500",
@@ -196,7 +197,7 @@ public class FastHeadersSyncTests
         using HeadersSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: Substitute.For<ISyncPeerPool>(),
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = pivot.Number.ToString(),
@@ -267,7 +268,7 @@ public class FastHeadersSyncTests
         ResettableHeaderSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: Substitute.For<ISyncPeerPool>(),
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "500",
@@ -321,7 +322,7 @@ public class FastHeadersSyncTests
         HeadersSyncFeed feed = new(
             blockTree: blockTree,
             syncPeerPool: Substitute.For<ISyncPeerPool>(),
-            syncConfig: new SyncConfig
+            syncConfig: new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "1000",
@@ -349,7 +350,7 @@ public class FastHeadersSyncTests
         report.HeadersInQueue.Returns(new MeasuredProgress());
         MeasuredProgress measuredProgress = new();
         report.FastBlocksHeaders.Returns(measuredProgress);
-        HeadersSyncFeed feed = new(blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" }, report, LimboLogs.Instance);
+        HeadersSyncFeed feed = new(blockTree, Substitute.For<ISyncPeerPool>(), new TestSyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" }, report, LimboLogs.Instance);
         await feed.PrepareRequest();
         blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).TestObject);
         using HeadersSyncBatch? result = await feed.PrepareRequest();
@@ -372,7 +373,7 @@ public class FastHeadersSyncTests
         report.HeadersInQueue.Returns(new MeasuredProgress());
         report.FastBlocksHeaders.Returns(new MeasuredProgress());
 
-        HeadersSyncFeed feed = new(blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" }, report, LimboLogs.Instance);
+        HeadersSyncFeed feed = new(blockTree, Substitute.For<ISyncPeerPool>(), new TestSyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" }, report, LimboLogs.Instance);
         feed.InitializeFeed();
         using HeadersSyncBatch? result = await feed.PrepareRequest();
 
@@ -406,8 +407,8 @@ public class FastHeadersSyncTests
     [TestCase(0, 192, 1, false, true)]
     public async Task Can_insert_all_good_headers_from_dependent_batch_with_missing_or_null_headers(int nullIndex, int count, int increment, bool shouldReport, bool useNulls)
     {
-        var peerChain = Build.A.BlockTree().OfChainLength(1000).TestObject;
-        var syncConfig = new SyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" };
+        var peerChain = CachedBlockTreeBuilder.OfLength(1000);
+        var syncConfig = new TestSyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" };
 
         IBlockTree localBlockTree = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig).TestObject;
         const int lowestInserted = 999;
@@ -472,7 +473,7 @@ public class FastHeadersSyncTests
         HeadersSyncFeed feed = new(
             blockTree,
             Substitute.For<ISyncPeerPool>(),
-            new SyncConfig
+            new TestSyncConfig
             {
                 FastSync = true,
                 PivotNumber = "1000",
@@ -538,7 +539,7 @@ public class FastHeadersSyncTests
     public void IsFinished_returns_false_when_headers_not_downloaded()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-        SyncConfig syncConfig = new()
+        TestSyncConfig syncConfig = new()
         {
             FastSync = true,
             DownloadBodiesInFastSync = true,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -100,7 +100,7 @@ public class ReceiptsSyncFeedTests
         _blockTree = Substitute.For<IBlockTree>();
         _metadataDb = new TestMemDb();
 
-        _syncConfig = new SyncConfig { FastSync = true };
+        _syncConfig = new TestSyncConfig { FastSync = true };
         _syncConfig.PivotNumber = _pivotNumber.ToString();
         _syncConfig.PivotHash = Keccak.Zero.ToString();
 
@@ -140,7 +140,7 @@ public class ReceiptsSyncFeedTests
     [Test]
     public void Should_throw_when_fast_block_not_enabled()
     {
-        _syncConfig = new SyncConfig { FastSync = false };
+        _syncConfig = new TestSyncConfig { FastSync = false };
         Assert.Throws<InvalidOperationException>(
             () => _feed = new ReceiptsSyncFeed(
                 _specProvider,
@@ -408,7 +408,7 @@ public class ReceiptsSyncFeedTests
     public void Is_fast_block_receipts_finished_returns_false_when_receipts_not_downloaded()
     {
         _blockTree = Substitute.For<IBlockTree>();
-        _syncConfig = new SyncConfig()
+        _syncConfig = new TestSyncConfig()
         {
             FastSync = true,
             DownloadBodiesInFastSync = true,
@@ -430,7 +430,7 @@ public class ReceiptsSyncFeedTests
     public void Is_fast_block_bodies_finished_returns_true_when_bodies_not_downloaded_and_we_do_not_want_to_download_bodies()
     {
         _blockTree = Substitute.For<IBlockTree>();
-        _syncConfig = new SyncConfig()
+        _syncConfig = new TestSyncConfig()
         {
             FastSync = true,
             DownloadBodiesInFastSync = false,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Crypto;
 using System.Net;
 using FluentAssertions;
+using Nethermind.Core.Test;
 using Nethermind.Trie;
 
 namespace Nethermind.Synchronization.Test.FastSync.SnapProtocolTests;
@@ -43,7 +44,7 @@ public class StateSyncDispatcherTests
     {
         _logManager = LimboLogs.Instance;
 
-        BlockTree blockTree = Build.A.BlockTree().OfChainLength((int)BlockTree.BestSuggestedHeader!.Number).TestObject;
+        IBlockTree blockTree = CachedBlockTreeBuilder.OfLength((int)BlockTree.BestSuggestedHeader!.Number);
         ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
         _pool = new SyncPeerPool(blockTree, new NodeStatsManager(timerFactory, LimboLogs.Instance), new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), LimboLogs.Instance, 25);
         _pool.Start();

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -55,12 +55,7 @@ namespace Nethermind.Synchronization.Test
 
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             NodeStatsManager stats = new(timerFactory, LimboLogs.Instance);
-            SyncConfig syncConfig = new()
-            {
-                MultiSyncModeSelectorLoopTimerMs = 1,
-                SyncDispatcherEmptyRequestDelayMs = 1,
-                SyncDispatcherAllocateTimeoutMs = 1
-            };
+            SyncConfig syncConfig = new TestSyncConfig();
 
             NodeStorage nodeStorage = new NodeStorage(_stateDb);
             TrieStore trieStore = new(nodeStorage, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -621,7 +621,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             syncPeerPool.InitializedPeers.Returns(peerInfos);
             syncPeerPool.AllPeers.Returns(peerInfos);
 
-            ISyncConfig syncConfig = new SyncConfig() { FastSyncCatchUpHeightDelta = 2 };
+            ISyncConfig syncConfig = new TestSyncConfig() { FastSyncCatchUpHeightDelta = 2 };
             syncConfig.FastSync = true;
 
             TotalDifficultyBetterPeerStrategy bestPeerStrategy = new(LimboLogs.Instance);
@@ -671,7 +671,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             syncPeerPool.InitializedPeers.Returns(peerInfos);
             syncPeerPool.AllPeers.Returns(peerInfos);
 
-            ISyncConfig syncConfig = new SyncConfig
+            ISyncConfig syncConfig = new TestSyncConfig
             {
                 FastSyncCatchUpHeightDelta = 2,
                 FastSync = true,

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -150,7 +150,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                 public ISyncProgressResolver SyncProgressResolver { get; set; } = null!;
 
-                public ISyncConfig SyncConfig { get; } = new SyncConfig();
+                public ISyncConfig SyncConfig { get; } = new TestSyncConfig();
 
                 public IBeaconSyncStrategy BeaconSyncStrategy { get; set; } = No.BeaconSync;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -255,12 +255,7 @@ public class SyncDispatcherTests
         TestSyncFeed syncFeed = new();
         TestDownloader downloader = new TestDownloader();
         SyncDispatcher<TestBatch> dispatcher = new(
-            new SyncConfig()
-            {
-                MultiSyncModeSelectorLoopTimerMs = 1,
-                SyncDispatcherEmptyRequestDelayMs = 1,
-                SyncDispatcherAllocateTimeoutMs = 1
-            },
+            new TestSyncConfig(),
             syncFeed,
             downloader,
             new TestSyncPeerPool(),
@@ -287,10 +282,9 @@ public class SyncDispatcherTests
 
         TestDownloader downloader = new TestDownloader();
         SyncDispatcher<TestBatch> dispatcher = new(
-            new SyncConfig()
+            new TestSyncConfig()
             {
                 MaxProcessingThreads = processingThread,
-                SyncDispatcherEmptyRequestDelayMs = 1,
             },
             syncFeed,
             downloader,

--- a/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
@@ -56,7 +56,7 @@ public class ReceiptSyncFeedTests
 
         _pivotBlock = _syncingFromBlockTree.FindBlock(99, BlockTreeLookupOptions.None)!;
 
-        _syncConfig = new SyncConfig()
+        _syncConfig = new TestSyncConfig()
         {
             FastSync = true,
             PivotHash = _pivotBlock.Hash!.ToString(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -146,7 +146,7 @@ public class ProgressTrackerTests
             .WithStateRoot(Keccak.EmptyTreeHash)
             .TestObject).TestObject;
         TestMemDb memDb = new();
-        SyncConfig syncConfig = new SyncConfig() { SnapSyncAccountRangePartitionCount = 1 };
+        SyncConfig syncConfig = new TestSyncConfig() { SnapSyncAccountRangePartitionCount = 1 };
         using ProgressTracker progressTracker = new(memDb, syncConfig, new StateSyncPivot(blockTree, syncConfig, LimboLogs.Instance), LimboLogs.Instance);
 
         progressTracker.IsFinished(out SnapSyncBatch? request);
@@ -164,7 +164,7 @@ public class ProgressTrackerTests
     private ProgressTracker CreateProgressTracker(int accountRangePartition = 1)
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.WithStateRoot(Keccak.EmptyTreeHash).TestObject).TestObject;
-        SyncConfig syncConfig = new SyncConfig() { SnapSyncAccountRangePartitionCount = accountRangePartition };
+        SyncConfig syncConfig = new TestSyncConfig() { SnapSyncAccountRangePartitionCount = accountRangePartition };
         return new(new MemDb(), syncConfig, new StateSyncPivot(blockTree, syncConfig, LimboLogs.Instance), LimboLogs.Instance);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -113,7 +113,7 @@ public class RecreateStateFromAccountRangesTests
         byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
         byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -132,7 +132,7 @@ public class RecreateStateFromAccountRangesTests
         byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
         byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -148,7 +148,7 @@ public class RecreateStateFromAccountRangesTests
     {
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -165,7 +165,7 @@ public class RecreateStateFromAccountRangesTests
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
         // output state
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -201,7 +201,7 @@ public class RecreateStateFromAccountRangesTests
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
         // output state
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -234,7 +234,7 @@ public class RecreateStateFromAccountRangesTests
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
         // output state
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -267,7 +267,7 @@ public class RecreateStateFromAccountRangesTests
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
         // output state
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 
@@ -390,7 +390,7 @@ public class RecreateStateFromAccountRangesTests
         Hash256 rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
         // output state
-        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+        using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
         IDb db = container.ResolveKeyed<IDb>(DbNames.State);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             var proof = accountProofCollector.BuildResult();
 
-            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             var result = snapProvider.AddStorageRange(1, _pathWithAccount, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
@@ -68,7 +68,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             var proof = accountProofCollector.BuildResult();
 
-            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             var result = snapProvider.AddStorageRange(1, _pathWithAccount, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
@@ -81,7 +81,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
         {
             Hash256 rootHash = _inputStorageTree!.RootHash;   // "..."
 
-            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             var result = snapProvider.AddStorageRange(1, _pathWithAccount, rootHash, TestItem.Tree.SlotsWithPaths[0].Path, TestItem.Tree.SlotsWithPaths);
@@ -95,7 +95,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Hash256 rootHash = _inputStorageTree!.RootHash;   // "..."
 
             // output state
-            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });
@@ -127,7 +127,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Hash256 rootHash = _inputStorageTree!.RootHash;   // "..."
 
             // output state
-            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new SyncConfig())).Build();
+            using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -37,7 +37,7 @@ public class SnapProviderTests
     public void AddAccountRange_AccountListIsEmpty_ThrowArgumentException()
     {
         using IContainer container = new ContainerBuilder()
-            .AddModule(new TestSynchronizerModule(new SyncConfig()))
+            .AddModule(new TestSynchronizerModule(new TestSyncConfig()))
             .Build();
 
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
@@ -55,7 +55,7 @@ public class SnapProviderTests
     public void AddAccountRange_ResponseHasEmptyListOfAccountsAndOneProof_ReturnsExpiredRootHash()
     {
         using IContainer container = new ContainerBuilder()
-            .AddModule(new TestSynchronizerModule(new SyncConfig()))
+            .AddModule(new TestSynchronizerModule(new TestSyncConfig()))
             .Build();
 
         SnapProvider snapProvider = container.Resolve<SnapProvider>();
@@ -85,7 +85,7 @@ public class SnapProviderTests
         (SnapServer ss, Hash256 root) = BuildSnapServerFromEntries(entries);
 
         using IContainer container = new ContainerBuilder()
-            .AddModule(new TestSynchronizerModule(new SyncConfig()
+            .AddModule(new TestSynchronizerModule(new TestSyncConfig()
             {
                 SnapSyncAccountRangePartitionCount = 1
             }))
@@ -127,7 +127,7 @@ public class SnapProviderTests
         (SnapServer ss, Hash256 root) = BuildSnapServerFromEntries(entries);
 
         using IContainer container = new ContainerBuilder()
-            .AddModule(new TestSynchronizerModule(new SyncConfig()
+            .AddModule(new TestSynchronizerModule(new TestSyncConfig()
             {
                 SnapSyncAccountRangePartitionCount = 2
             }))

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -41,7 +41,7 @@ public class SnapServerTest
         SnapServer server = new(store.AsReadOnly(), codeDbServer, stateRootTracker ?? CreateConstantStateRootTracker(true), LimboLogs.Instance);
 
         MemDb clientStateDb = new();
-        using ProgressTracker progressTracker = new(clientStateDb, new SyncConfig(), new StateSyncPivot(null!, new SyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(clientStateDb, new TestSyncConfig(), new StateSyncPivot(null!, new TestSyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
 
         INodeStorage nodeStorage = new NodeStorage(clientStateDb);
 
@@ -263,7 +263,7 @@ public class SnapServerTest
         dbProviderClient.RegisterDb(DbNames.State, new MemDb());
         dbProviderClient.RegisterDb(DbNames.Code, new MemDb());
 
-        using ProgressTracker progressTracker = new(dbProviderClient.StateDb, new SyncConfig(), new StateSyncPivot(null!, new SyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(dbProviderClient.StateDb, new TestSyncConfig(), new StateSyncPivot(null!, new TestSyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
         SnapProvider snapProvider = new(progressTracker, dbProviderClient.CodeDb, new NodeStorage(dbProviderClient.StateDb), LimboLogs.Instance);
 
         (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]> proofs) =
@@ -299,7 +299,7 @@ public class SnapServerTest
         dbProviderClient.RegisterDb(DbNames.State, new MemDb());
         dbProviderClient.RegisterDb(DbNames.Code, new MemDb());
 
-        using ProgressTracker progressTracker = new(dbProviderClient.StateDb, new SyncConfig(), new StateSyncPivot(null!, new SyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(dbProviderClient.StateDb, new TestSyncConfig(), new StateSyncPivot(null!, new TestSyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
         SnapProvider snapProvider = new(progressTracker, dbProviderClient.CodeDb, new NodeStorage(dbProviderClient.StateDb), LimboLogs.Instance);
 
         Hash256 startRange = Keccak.Zero;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
@@ -30,7 +30,7 @@ public class StateSyncPivotTest
             .Returns((ci) => Build.A.BlockHeader.WithNumber((long)ci[0]).TestObject);
 
         Synchronization.FastSync.StateSyncPivot stateSyncPivot = new Synchronization.FastSync.StateSyncPivot(blockTree,
-            new SyncConfig()
+            new TestSyncConfig()
             {
                 StateMinDistanceFromHead = minDistance,
                 StateMaxDistanceFromHead = maxDistance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -99,7 +99,7 @@ public class SyncServerTests
             sealValidator,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -141,7 +141,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -178,7 +178,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             staticSelector,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -211,7 +211,7 @@ public class SyncServerTests
             {
                 TerminalTotalDifficulty = $"{testSpecProvider.TerminalTotalDifficulty}"
             },
-            new SyncConfig(),
+            new TestSyncConfig(),
             new MemDb(),
             localBlockTree,
             testSpecProvider,
@@ -246,7 +246,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             testSpecProvider,
             LimboLogs.Instance);
@@ -420,7 +420,7 @@ public class SyncServerTests
             {
                 TerminalTotalDifficulty = $"{ttd}"
             },
-            new SyncConfig(),
+            new TestSyncConfig(),
             new MemDb(),
             localBlockTree,
             testSpecProvider,
@@ -469,7 +469,7 @@ public class SyncServerTests
             sealEngine,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             testSpecProvider,
             LimboLogs.Instance);
@@ -509,7 +509,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -541,7 +541,7 @@ public class SyncServerTests
             sealValidator,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -568,7 +568,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -604,7 +604,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -645,7 +645,7 @@ public class SyncServerTests
             Always.Valid,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -683,7 +683,7 @@ public class SyncServerTests
             sealValidator,
             ctx.PeerPool,
             StaticSelector.Full,
-            new SyncConfig(),
+            new TestSyncConfig(),
             Policy.FullGossip,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
@@ -723,7 +723,7 @@ public class SyncServerTests
                 Always.Valid,
                 PeerPool,
                 selector,
-                new SyncConfig(),
+                new TestSyncConfig(),
                 Policy.FullGossip,
                 MainnetSpecProvider.Instance,
                 LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
@@ -29,7 +29,7 @@ public class SynchronizerModuleTests
         IBlockProcessingQueue blockQueue = Substitute.For<IBlockProcessingQueue>();
 
         return new ContainerBuilder()
-            .AddModule(new SynchronizerModule(new SyncConfig()
+            .AddModule(new SynchronizerModule(new TestSyncConfig()
             {
                 FastSync = true,
                 VerifyTrieOnStateSyncFinished = true

--- a/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
@@ -9,7 +9,7 @@ public class TestSyncConfig : SyncConfig
 {
     public TestSyncConfig()
     {
-        GCOnStateSyncFinished = false;
+        GCOnFeedFinished = false;
         MultiSyncModeSelectorLoopTimerMs = 1;
         SyncDispatcherEmptyRequestDelayMs = 1;
         SyncDispatcherAllocateTimeoutMs = 1;

--- a/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Synchronization;
+
+namespace Nethermind.Synchronization.Test;
+
+public class TestSyncConfig : SyncConfig
+{
+    public TestSyncConfig()
+    {
+        GCOnStateSyncFinished = false;
+        MultiSyncModeSelectorLoopTimerMs = 1;
+        SyncDispatcherEmptyRequestDelayMs = 1;
+        SyncDispatcherAllocateTimeoutMs = 1;
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
@@ -44,7 +44,6 @@ namespace Nethermind.Synchronization.ParallelSync
         public virtual void Finish()
         {
             ChangeState(SyncFeedState.Finished);
-            GC.Collect(2, GCCollectionMode.Aggressive, true, true);
         }
         public Task FeedTask => _taskCompletionSource?.Task ?? Task.CompletedTask;
         public abstract void SyncModeSelectorOnChanged(SyncMode current);

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncModeChangedEventArgs.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncModeChangedEventArgs.cs
@@ -15,5 +15,10 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public SyncMode Previous { get; }
         public SyncMode Current { get; }
+
+        public bool WasModeFinished(SyncMode mode)
+        {
+            return (Previous & mode) != 0 && (Current & mode) == 0;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
@@ -13,12 +13,12 @@ namespace Nethermind.Synchronization.Peers
 {
     public class SyncPeerAllocation
     {
-        public static SyncPeerAllocation FailedAllocation = new(NullStrategy.Instance, AllocationContexts.None);
+        public static SyncPeerAllocation FailedAllocation = new(NullStrategy.Instance, AllocationContexts.None, null);
 
         /// <summary>
         /// this should be used whenever we change IsAllocated property on PeerInfo-
         /// </summary>
-        private static readonly Lock _allocationLock = new();
+        private readonly Lock? _allocationLock;
 
         private readonly IPeerAllocationStrategy _peerAllocationStrategy;
         public AllocationContexts Contexts { get; }
@@ -29,14 +29,15 @@ namespace Nethermind.Synchronization.Peers
         public bool HasPeer => Current is not null;
 
         public SyncPeerAllocation(PeerInfo peerInfo, AllocationContexts contexts)
-            : this(new StaticStrategy(peerInfo), contexts)
+            : this(new StaticStrategy(peerInfo), contexts, null)
         {
         }
 
-        public SyncPeerAllocation(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts contexts)
+        public SyncPeerAllocation(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts contexts, Lock? allocationLock)
         {
             _peerAllocationStrategy = peerAllocationStrategy;
             Contexts = contexts;
+            _allocationLock = allocationLock ?? new Lock();
         }
 
         public void AllocateBestPeer(

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -328,7 +328,7 @@ namespace Nethermind.Synchronization.Peers
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _refreshLoopCancellation.Token);
 
-            SyncPeerAllocation allocation = new(peerAllocationStrategy, allocationContexts);
+            SyncPeerAllocation allocation = new(peerAllocationStrategy, allocationContexts, _isAllocatedChecks);
             while (true)
             {
                 if (TryAllocateOnce(peerAllocationStrategy, allocationContexts, allocation))

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -90,8 +90,22 @@ namespace Nethermind.Synchronization
 
             SyncModeSelector.Changed += syncReport.SyncModeSelectorOnChanged;
 
+            if (syncConfig.GCOnStateSyncFinished)
+            {
+                SyncModeSelector.Changed += GCOnStateSyncFinished;
+            }
+
             // Make unit test faster.
             SyncModeSelector.Update();
+        }
+
+        private void GCOnStateSyncFinished(object? sender, SyncModeChangedEventArgs e)
+        {
+            // State nodes finished
+            if ((e.Previous & SyncMode.StateNodes) != 0 && (e.Current & SyncMode.StateNodes) == 0)
+            {
+                GC.Collect(2, GCCollectionMode.Aggressive, true, true);
+            }
         }
 
         private void StartFullSyncComponents()

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -90,19 +90,18 @@ namespace Nethermind.Synchronization
 
             SyncModeSelector.Changed += syncReport.SyncModeSelectorOnChanged;
 
-            if (syncConfig.GCOnStateSyncFinished)
+            if (syncConfig.GCOnFeedFinished)
             {
-                SyncModeSelector.Changed += GCOnStateSyncFinished;
+                SyncModeSelector.Changed += GCOnFeedFinished;
             }
 
             // Make unit test faster.
             SyncModeSelector.Update();
         }
 
-        private void GCOnStateSyncFinished(object? sender, SyncModeChangedEventArgs e)
+        private void GCOnFeedFinished(object? sender, SyncModeChangedEventArgs e)
         {
-            // State nodes finished
-            if ((e.Previous & SyncMode.StateNodes) != 0 && (e.Current & SyncMode.StateNodes) == 0)
+            if (e.WasModeFinished(SyncMode.StateNodes) || e.WasModeFinished(SyncMode.FastReceipts) || e.WasModeFinished(SyncMode.FastBlocks))
             {
                 GC.Collect(2, GCCollectionMode.Aggressive, true, true);
             }


### PR DESCRIPTION
- Faster I say! _Faster_!
- Turns out most of the slowdown is in `SyncFeed.Finish` that calls GC. This PR changes that so that it is only called on state sync finished.
- Also remove global lock in peer allocation.
- Also create a cached block tree builder that caches blocktree at db level.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Mainnet sync ok. Confirmed gc called once.
