### PR TITLE
Don't start snap sync unless it's near the tip enough

### DIFF
--- a/src/Nethermind/Chains/taiko-mainnet.json
+++ b/src/Nethermind/Chains/taiko-mainnet.json
@@ -2,7 +2,7 @@
   "name": "Taiko Mainnet",
   "dataDir": "taiko-mainnet",
   "engine": {
-    "Taiko": { }
+    "Taiko": {}
   },
   "params": {
     "chainId": "167000",

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.State.Snap;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Synchronization.ParallelSync
@@ -636,8 +635,7 @@ namespace Nethermind.Synchronization.ParallelSync
             {
                 LogDetailedSyncModeChecks("STATE_NODES",
                     (nameof(isInStateSync), isInStateSync),
-                    (nameof(snapSyncDisabled), snapSyncDisabled),
-                    (nameof(snapRangesFinished), snapRangesFinished));
+                    ($"{nameof(snapSyncDisabled)}||{nameof(snapRangesFinished)}", snapSyncDisabled || snapRangesFinished));
             }
 
             return result;
@@ -646,7 +644,7 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool ShouldBeInSnapRangesPhase(Snapshot best)
         {
             bool isInStateSync = best.IsInStateSync;
-            bool isCloseToHead = best.TargetBlock >= best.Header && (best.TargetBlock - best.Header) < Constants.MaxDistanceFromHead;
+            bool isCloseToHead = best.TargetBlock >= best.Header && (best.TargetBlock - best.Header) <= FastSyncLag;
             bool snapNotFinished = !_syncProgressResolver.IsSnapGetRangesFinished();
 
             if (_logger.IsTrace)


### PR DESCRIPTION
## Changes

- Don't start snap sync unless it's near the tip enough
  Otherwise the following part of of `ShouldBeInStateSyncMode` may be always true
  ```
            bool stateNotDownloadedYet = (best.TargetBlock - best.State > FastSyncLag ||
                                          best.Header > best.State && best.Header > best.Block);
  ```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No