### PR TITLE
Use non-allocating split

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -168,22 +168,24 @@ namespace Nethermind.Serialization.Json
         {
             ArgumentNullException.ThrowIfNullOrEmpty(innerPath);
 
+            ReadOnlySpan<char> pathSpan = innerPath.AsSpan();
             if (innerPath.Contains('.'))
             {
-                string[] parts = innerPath.Split('.');
                 JsonElement currentElement = element;
-                for (int i = 0; i < parts.Length - 1; i++)
+                Range final = default;
+                foreach (Range subPath in pathSpan.Split('.'))
                 {
-                    if (!currentElement.TryGetProperty(parts[i], out currentElement))
+                    if (!currentElement.TryGetProperty(innerPath[subPath], out currentElement))
                     {
                         value = default;
                         return false;
                     }
+                    final = subPath;
                 }
-                return currentElement.TryGetProperty(parts[^1], out value);
+                return currentElement.TryGetProperty(pathSpan[final], out value);
             }
 
-            return element.TryGetProperty(innerPath.AsSpan(), out value);
+            return element.TryGetProperty(pathSpan, out value);
         }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/NethermindEth/nethermind/issues/7361

## Changes

- Use non allocating `span.Split` rather than `string.Split`

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No