### PR TITLE
Use new Json Pipeline overloads

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -143,18 +143,15 @@ namespace Nethermind.Serialization.Json
         public async ValueTask<long> SerializeAsync<T>(Stream stream, T value, bool indented = false, bool leaveOpen = true)
         {
             var writer = GetPipeWriter(stream, leaveOpen);
-            Serialize(writer, value, indented);
+            await JsonSerializer.SerializeAsync(writer, value, indented ? JsonOptionsIndented : _jsonOptions);
             await writer.CompleteAsync();
 
             long outputCount = writer.WrittenCount;
             return outputCount;
         }
 
-        public void Serialize<T>(IBufferWriter<byte> writer, T value, bool indented = false)
-        {
-            using var jsonWriter = new Utf8JsonWriter(writer, CreateWriterOptions(indented));
-            JsonSerializer.Serialize(jsonWriter, value, indented ? JsonOptionsIndented : _jsonOptions);
-        }
+        public Task SerializeAsync<T>(PipeWriter writer, T value, bool indented = false)
+            => JsonSerializer.SerializeAsync(writer, value, indented ? JsonOptionsIndented : _jsonOptions);
 
         public static void SerializeToStream<T>(Stream stream, T value, bool indented = false)
         {

--- a/src/Nethermind/Nethermind.Serialization.Json/IJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/IJsonSerializer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.IO.Pipelines;
 using System.Threading.Tasks;
 
 namespace Nethermind.Serialization.Json
@@ -16,6 +17,6 @@ namespace Nethermind.Serialization.Json
         string Serialize<T>(T value, bool indented = false);
         long Serialize<T>(Stream stream, T value, bool indented = false, bool leaveOpen = true);
         ValueTask<long> SerializeAsync<T>(Stream stream, T value, bool indented = false, bool leaveOpen = true);
-        void Serialize<T>(IBufferWriter<byte> writer, T value, bool indented = false);
+        Task SerializeAsync<T>(PipeWriter writer, T value, bool indented = false);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -53,6 +53,9 @@ public sealed class CountingPipeWriter : CountingWriter
 
     public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
         => _writer.FlushAsync(cancellationToken);
+
+    public override bool CanGetUnflushedBytes => _writer.CanGetUnflushedBytes;
+    public override long UnflushedBytes => _writer.UnflushedBytes;
 }
 
 public sealed class CountingStreamPipeWriter : CountingWriter


### PR DESCRIPTION
## Changes

- Use the new async Json Pipeline overloads introduced in .NET 9.0 https://github.com/dotnet/runtime/pull/101461 to respond better to back pressure on the Json response.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Optimization

## Testing

#### Requires testing

- [x] No
