### PR TITLE
TrieStore to Channels

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -12,6 +12,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
@@ -32,7 +33,7 @@ public class TrieStore : ITrieStore, IPruningTrieStore
     private readonly Task[] _dirtyNodesTasks = [];
     private readonly ConcurrentDictionary<HashAndTinyPath, Hash256?>[] _persistedHashes = [];
     private readonly Action<TreePath, Hash256?, TrieNode> _persistedNodeRecorder;
-    private readonly Task[] _disposeTasks = new Task[Environment.ProcessorCount];
+    private readonly Task[] _disposeTasks = new Task[RuntimeInformation.PhysicalCoreCount];
 
     // This seems to attempt prevent multiple block processing at the same time and along with pruning at the same time.
     private readonly object _dirtyNodesLock = new object();

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -790,26 +790,31 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         // However, anything that we are trying to persist here should still be in dirty cache.
         // So parallel read should go there first instead of to the database for these dataset,
         // so it should be fine for these to be non atomic.
-        using BlockingCollection<INodeStorage.WriteBatch> disposeQueue = new BlockingCollection<INodeStorage.WriteBatch>(4);
-
-        for (int index = 0; index < _disposeTasks.Length; index++)
+        Channel<INodeStorage.WriteBatch> disposeQueue = Channel.CreateBounded<INodeStorage.WriteBatch>(4);
+        try
         {
-            _disposeTasks[index] = Task.Run(() =>
+            for (int index = 0; index < _disposeTasks.Length; index++)
             {
-                while (disposeQueue.TryTake(out INodeStorage.WriteBatch disposable, Timeout.Infinite))
+                _disposeTasks[index] = Task.Run(async () =>
                 {
-                    disposable.Dispose();
-                }
-            });
+                    await foreach (var disposable in disposeQueue.Reader.ReadAllAsync())
+                    {
+                        disposable.Dispose();
+                    }
+                });
+            }
+
+            using ArrayPoolList<Task> persistNodeStartingFromTasks = parallelStartNodes.Select(
+                entry => Task.Run(() => PersistNodeStartingFrom(entry.trieNode, entry.address2, entry.path, persistedNodeRecorder, writeFlags, disposeQueue)))
+                .ToPooledList(parallelStartNodes.Count);
+
+            Task.WaitAll(persistNodeStartingFromTasks.AsSpan());
+        }
+        finally
+        {
+            disposeQueue.Writer.Complete();
         }
 
-        using ArrayPoolList<Task> persistNodeStartingFromTasks = parallelStartNodes.Select(
-            entry => Task.Run(() => PersistNodeStartingFrom(entry.trieNode, entry.address2, entry.path, persistedNodeRecorder, writeFlags, disposeQueue)))
-            .ToPooledList(parallelStartNodes.Count);
-
-        Task.WaitAll(persistNodeStartingFromTasks.AsSpan());
-
-        disposeQueue.CompleteAdding();
         Task.WaitAll(_disposeTasks);
 
         // Dispose top level last in case something goes wrong, at least the root won't be stored
@@ -824,14 +829,14 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         LastPersistedBlockNumber = commitSet.BlockNumber;
     }
 
-    private void PersistNodeStartingFrom(TrieNode tn, Hash256 address2, TreePath path,
+    private async Task PersistNodeStartingFrom(TrieNode tn, Hash256 address2, TreePath path,
         Action<TreePath, Hash256?, TrieNode>? persistedNodeRecorder,
-        WriteFlags writeFlags, BlockingCollection<INodeStorage.WriteBatch> disposeQueue)
+        WriteFlags writeFlags, Channel<INodeStorage.WriteBatch> disposeQueue)
     {
         long persistedNodeCount = 0;
         INodeStorage.WriteBatch writeBatch = _nodeStorage.StartWriteBatch();
 
-        void DoPersist(TrieNode node, Hash256? address3, TreePath path2)
+        async ValueTask DoPersist(TrieNode node, Hash256? address3, TreePath path2)
         {
             persistedNodeRecorder?.Invoke(path2, address3, node);
             PersistNode(address3, path2, node, writeBatch, writeFlags);
@@ -839,13 +844,13 @@ public class TrieStore : ITrieStore, IPruningTrieStore
             persistedNodeCount++;
             if (persistedNodeCount % 512 == 0)
             {
-                disposeQueue.Add(writeBatch);
+                await disposeQueue.Writer.WriteAsync(writeBatch);
                 writeBatch = _nodeStorage.StartWriteBatch();
             }
         }
 
-        tn.CallRecursively(DoPersist, address2, ref path, GetTrieStore(address2), true, _logger);
-        disposeQueue.Add(writeBatch);
+        await tn.CallRecursivelyAsync(DoPersist, address2, path, GetTrieStore(address2), true, _logger);
+        await disposeQueue.Writer.WriteAsync(writeBatch);
     }
 
     private void PersistNode(Hash256? address, in TreePath path, TrieNode currentNode, INodeStorage.WriteBatch writeBatch, WriteFlags writeFlags = WriteFlags.None)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -844,14 +844,14 @@ public class TrieStore : ITrieStore, IPruningTrieStore
             PersistNode(address3, path2, node, writeBatch, writeFlags);
 
             persistedNodeCount++;
-            if (persistedNodeCount % 256 == 0)
+            if (persistedNodeCount % 512 == 0)
             {
                 await disposeQueue.Writer.WriteAsync(writeBatch);
                 writeBatch = _nodeStorage.StartWriteBatch();
             }
         }
 
-        await tn.CallRecursivelyAsync(DoPersist, address2, path, GetTrieStore(address2), true, _logger);
+        await tn.CallRecursivelyAsync(DoPersist, address2, ref path, GetTrieStore(address2), _logger);
         await disposeQueue.Writer.WriteAsync(writeBatch);
     }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -935,12 +935,12 @@ namespace Nethermind.Trie
 
             if (!IsLeaf)
             {
-                if (_data is not null)
+                object?[] data = _data;
+                if (data is not null)
                 {
-                    for (int i = 0; i < _data.Length; i++)
+                    for (int i = 0; i < data.Length; i++)
                     {
-                        object o = _data[i];
-                        if (o is TrieNode child)
+                        if (data[i] is TrieNode child)
                         {
                             if (logger.IsTrace) logger.Trace($"Persist recursively on child {i} {child} of {this}");
                             int previousLength = AppendChildPath(ref currentPath, i);
@@ -1001,12 +1001,12 @@ namespace Nethermind.Trie
 
             if (!IsLeaf)
             {
-                if (_data is not null)
+                object?[] data = _data;
+                if (data is not null)
                 {
-                    for (int i = 0; i < _data.Length; i++)
+                    for (int i = 0; i < data.Length; i++)
                     {
-                        object o = _data[i];
-                        if (o is TrieNode child)
+                        if (data[i] is TrieNode child)
                         {
                             if (logger.IsTrace) logger.Trace($"Persist recursively on child {i} {child} of {this}");
                             int previousLength = AppendChildPath(ref currentPath, i);


### PR DESCRIPTION
## Changes

- Wrapping a `ConcurrentQueue` in a `BlockingCollection` burns a ton of CPU spinning; whereas its a pattern ideally suited to `Channel`s; and using true `async`

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No
