### PR TITLE
CliqueBlockProducer to Channels

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -258,8 +258,8 @@ public class CliqueBlockProducerRunner : ICliqueBlockProducerRunner, IDisposable
     {
         _blockTree.NewHeadBlock -= BlockTreeOnNewHeadBlock;
         _cancellationTokenSource?.Cancel();
-        _signalsQueue.Writer.TryComplete();
         await (_producerTask ?? Task.CompletedTask);
+        _signalsQueue.Writer.TryComplete();
     }
 
     bool IBlockProducerRunner.IsProducingBlocks(ulong? maxProducingInterval)


### PR DESCRIPTION
## Changes

- Wrapping a `ConcurrentQueue` in a `BlockingCollection` burns a ton of CPU spinning; whereas its a pattern ideally suited to `Channel`s; and using true `async`

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No

