### PR TITLE
Change/Dont BinarySearch before SyncPivot to initialize numbers.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1210,6 +1210,37 @@ public class BlockTreeTests
         Assert.That(loadedTree.LowestInsertedBodyNumber, Is.EqualTo(1), "loaded tree");
     }
 
+    [TestCase(5, 10)]
+    [TestCase(10, 10)]
+    [TestCase(12, 0)]
+    public void Does_not_load_bestKnownNumber_before_syncPivot(long syncPivot, long expectedBestKnownNumber)
+    {
+        SyncConfig syncConfig = new()
+        {
+            FastSync = true,
+            PivotNumber = $"{syncPivot}"
+        };
+
+        MemDb blockInfosDb = new MemDb();
+        MemDb headersDb = new MemDb();
+        MemDb blockDb = new MemDb();
+
+        _ = Build.A.BlockTree()
+            .WithHeadersDb(headersDb)
+            .WithBlockInfoDb(blockInfosDb)
+            .WithBlocksDb(blockDb)
+            .OfChainLength(11)
+            .TestObject;
+
+        BlockTree tree = Build.A.BlockTree()
+            .WithSyncConfig(syncConfig)
+            .WithHeadersDb(headersDb)
+            .WithBlockInfoDb(blockInfosDb)
+            .WithBlocksDb(blockDb)
+            .TestObject;
+
+        Assert.That(tree.BestKnownNumber, Is.EqualTo(expectedBestKnownNumber));
+    }
 
     private static readonly object[] SourceOfBSearchTestCases =
     {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -148,30 +148,15 @@ public partial class BlockTree
 
         long right = Math.Max(0, left) + BestKnownSearchLimit;
 
-        long bestKnownNumberFound =
-            BinarySearchBlockNumber(1, left, LevelExists) ?? 0;
-        long bestKnownNumberAlternative =
-            BinarySearchBlockNumber(left, right, LevelExists) ?? 0;
-
-        long bestSuggestedHeaderNumber =
-            BinarySearchBlockNumber(1, left, HeaderExists) ?? 0;
-        long bestSuggestedHeaderNumberAlternative
-            = BinarySearchBlockNumber(left, right, HeaderExists) ?? 0;
-
-        long bestSuggestedBodyNumber
-            = BinarySearchBlockNumber(1, left, BodyExists) ?? 0;
-        long bestSuggestedBodyNumberAlternative
-            = BinarySearchBlockNumber(left, right, BodyExists) ?? 0;
+        long bestKnownNumberFound = BinarySearchBlockNumber(left, right, LevelExists) ?? 0;
+        long bestSuggestedHeaderNumber = BinarySearchBlockNumber(left, right, HeaderExists) ?? 0;
+        long bestSuggestedBodyNumber = BinarySearchBlockNumber(left, right, BodyExists) ?? 0;
 
         if (_logger.IsInfo)
             _logger.Info("Numbers resolved, " +
-                         $"level = Max({bestKnownNumberFound}, {bestKnownNumberAlternative}), " +
-                         $"header = Max({bestSuggestedHeaderNumber}, {bestSuggestedHeaderNumberAlternative}), " +
-                         $"body = Max({bestSuggestedBodyNumber}, {bestSuggestedBodyNumberAlternative})");
-
-        bestKnownNumberFound = Math.Max(bestKnownNumberFound, bestKnownNumberAlternative);
-        bestSuggestedHeaderNumber = Math.Max(bestSuggestedHeaderNumber, bestSuggestedHeaderNumberAlternative);
-        bestSuggestedBodyNumber = Math.Max(bestSuggestedBodyNumber, bestSuggestedBodyNumberAlternative);
+                         $"level = {bestKnownNumberFound}, " +
+                         $"header = {bestSuggestedHeaderNumber}, " +
+                         $"body = {bestSuggestedBodyNumber}");
 
         if (bestKnownNumberFound < 0 ||
             bestSuggestedHeaderNumber < 0 ||
@@ -195,7 +180,7 @@ public partial class BlockTree
             }
         }
 
-        BestKnownNumber = Math.Max(bestKnownNumberFound, bestKnownNumberAlternative);
+        BestKnownNumber = bestKnownNumberFound;
         BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None);
         BlockHeader? bestSuggestedBodyHeader = FindHeader(bestSuggestedBodyNumber, BlockTreeLookupOptions.None);
         BestSuggestedBody = bestSuggestedBodyHeader is null

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -28,6 +28,7 @@ using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using Nethermind.JsonRpc.Data;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 using Newtonsoft.Json.Linq;
 
 namespace Nethermind.JsonRpc.Test.Modules;
@@ -45,6 +46,7 @@ public class TraceRpcModuleTests
             await Blockchain.AddFunds(TestItem.AddressB, 1000.Ether());
             await Blockchain.AddFunds(TestItem.AddressC, 1000.Ether());
 
+            Hash256 stateRoot = Blockchain.State.StateRoot;
             for (int i = 1; i < 10; i++)
             {
                 List<Transaction> transactions = new();
@@ -52,10 +54,12 @@ public class TraceRpcModuleTests
                 {
                     transactions.Add(Core.Test.Builders.Build.A.Transaction
                         .WithTo(Address.Zero)
-                        .WithNonce(Blockchain.State.GetNonce(TestItem.AddressB) + (UInt256)j)
+                        .WithNonce(Blockchain.StateReader.GetNonce(stateRoot, TestItem.AddressB) + (UInt256)j)
                         .SignedAndResolved(Blockchain.EthereumEcdsa, TestItem.PrivateKeyB).TestObject);
                 }
                 await Blockchain.AddBlock(transactions.ToArray());
+
+                stateRoot = Blockchain.State.StateRoot;
             }
 
             Factory = new(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -46,7 +46,7 @@ public class TraceRpcModuleTests
             await Blockchain.AddFunds(TestItem.AddressB, 1000.Ether());
             await Blockchain.AddFunds(TestItem.AddressC, 1000.Ether());
 
-            Hash256 stateRoot = Blockchain.State.StateRoot;
+            Hash256 stateRoot = Blockchain.BlockTree.Head!.StateRoot!;
             for (int i = 1; i < 10; i++)
             {
                 List<Transaction> transactions = new();
@@ -59,7 +59,7 @@ public class TraceRpcModuleTests
                 }
                 await Blockchain.AddBlock(transactions.ToArray());
 
-                stateRoot = Blockchain.State.StateRoot;
+                stateRoot = Blockchain.BlockTree.Head!.StateRoot!;
             }
 
             Factory = new(


### PR DESCRIPTION
- Currently blocktree initializer will binary search before and after sync pivot to initialize pointers.
- This is incompatible with era and portal as blocks may get inserted before sync pivot, but not up to sync pivot. This situation will cause best known number to be resolved before sync pivot which causes forward sync to hang.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Testing