### PR TITLE
GC: Clear references in ArrayPoolList before returning to pool

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;


### PR DESCRIPTION
## Changes

- Clear object references in ArrayPoolList before returning to pool; otherwise can inadvertently extend object lifetime from reference from array in pool still pointing at large object

![image](https://github.com/user-attachments/assets/4e1704c0-9eb1-40b1-aeaf-b32d88f3dc23)
 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] No
