### PR TITLE
Fix `logIndex` in filter changes

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -238,6 +238,35 @@ public class FilterManagerTests
                 .WithLogs(Build.A.LogEntry.WithAddress(TestItem.AddressA)
                     .WithTopics(TestItem.KeccakB, TestItem.KeccakC).TestObject));
 
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    [TestCase(1, 1)]
+    [TestCase(5, 3)]
+    public void logs_should_have_correct_log_indexes(int filtersCount, int logsPerTx)
+    {
+        const int txCount = 10;
+
+        Assert(
+            filterBuilder: (builder, _) => builder
+                .FromBlock(1L)
+                .ToBlock(10L)
+                .WithAddresses(TestItem.AddressA, TestItem.AddressB)
+                .WithTopicExpressions(TestTopicExpressions.Or(
+                    TestTopicExpressions.Specific(TestItem.KeccakB),
+                    TestTopicExpressions.Specific(TestItem.KeccakD)
+                )),
+            filterCount: filtersCount,
+            receiptBuilder: (builder, _) => builder
+                .WithBlockNumber(6L)
+                .WithLogs(Enumerable.Range(0, logsPerTx).Select(_ =>
+                    Build.A.LogEntry
+                        .WithAddress(TestItem.AddressA)
+                        .WithTopics(TestItem.KeccakB, TestItem.KeccakC).TestObject
+                ).ToArray()),
+            receiptCount: txCount,
+            logsAssertion: logs => logs.Select(l => l.LogIndex).Should().BeEquivalentTo(Enumerable.Range(0, txCount * logsPerTx))
+        );
+    }
+
 
     private void LogsShouldNotBeEmpty(Action<FilterBuilder> filterBuilder,
         Action<ReceiptBuilder> receiptBuilder)
@@ -254,6 +283,15 @@ public class FilterManagerTests
     private void LogsShouldBeEmpty(IEnumerable<Action<FilterBuilder>> filterBuilders,
         IEnumerable<Action<ReceiptBuilder>> receiptBuilders)
         => Assert(filterBuilders, receiptBuilders, logs => logs.Should().BeEmpty());
+
+    private void Assert(Action<FilterBuilder, int> filterBuilder, int filterCount,
+        Action<ReceiptBuilder, int> receiptBuilder, int receiptCount,
+        Action<IEnumerable<FilterLog>> logsAssertion)
+        => Assert(
+            Enumerable.Range(0, filterCount).Select<int, Action<FilterBuilder>>(i => builder => filterBuilder(builder, i)),
+            Enumerable.Range(0, receiptCount).Select<int, Action<ReceiptBuilder>>(i => builder => receiptBuilder(builder, i)),
+            logsAssertion
+        );
 
     private void Assert(IEnumerable<Action<FilterBuilder>> filterBuilders,
         IEnumerable<Action<ReceiptBuilder>> receiptBuilders,

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -163,8 +163,10 @@ namespace Nethermind.Blockchain.Filters
             IEnumerable<LogFilter> filters = _filterStore.GetFilters<LogFilter>();
             foreach (LogFilter filter in filters)
             {
-                StoreLogs(filter, txReceipt, ref _logIndex);
+                StoreLogs(filter, txReceipt, _logIndex);
             }
+
+            _logIndex += txReceipt.Logs?.Length ?? 0;
         }
 
         private void AddBlock(Block block)
@@ -191,7 +193,7 @@ namespace Nethermind.Blockchain.Filters
             if (_logger.IsDebug) _logger.Debug($"Filter with id: {filter.Id} contains {blocks.Count} blocks.");
         }
 
-        private void StoreLogs(LogFilter filter, TxReceipt txReceipt, ref long logIndex)
+        private void StoreLogs(LogFilter filter, TxReceipt txReceipt, long logIndex)
         {
             if (txReceipt.Logs is null || txReceipt.Logs.Length == 0)
             {


### PR DESCRIPTION
Fixes #7751 

## Changes

- Fixes incorrect `logIndex` calculation when multiple filters are added

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes