### PR TITLE
Change/use persisted pointer for fast header

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1139,7 +1139,7 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime), TestCaseSource(nameof(SourceOfBSearchTestCases))]
-    public void Loads_lowest_inserted_header_correctly(long beginIndex, long insertedBlocks)
+    public void When_lowestInsertedHeaderWasNotPersisted_useBinarySearchToLoadLowestInsertedHeader(long beginIndex, long insertedBlocks)
     {
         long? expectedResult = insertedBlocks == 0L ? null : beginIndex - insertedBlocks + 1L;
 
@@ -1161,13 +1161,48 @@ public class BlockTreeTests
             tree.Insert(Build.A.BlockHeader.WithNumber(i).WithTotalDifficulty(i).TestObject);
         }
 
+        tree.RecalculateTreeLevels();
+
+        Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(expectedResult), "tree");
+    }
+
+    [Test]
+    public void When_lowestInsertedHeaderWasPersisted_doNot_useBinarySearchToLoadLowestInsertedHeader()
+    {
+        SyncConfig syncConfig = new()
+        {
+            FastSync = true,
+            PivotNumber = "105",
+        };
+
+        BlockTreeBuilder builder = Build.A
+            .BlockTree()
+            .WithSyncConfig(syncConfig);
+        BlockTree tree = builder.TestObject;
+        tree.SuggestBlock(Build.A.Block.Genesis.TestObject);
+        tree.RecalculateTreeLevels();
+
+        for (int i = 1; i < 100; i++)
+        {
+            tree.Insert(Build.A.BlockHeader.WithNumber(i).WithParent(tree.FindHeader(i-1, BlockTreeLookupOptions.None)!).TestObject);
+        }
+
         BlockTree loadedTree = Build.A.BlockTree()
             .WithDatabaseFrom(builder)
             .WithSyncConfig(syncConfig)
             .TestObject;
 
-        Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(expectedResult), "tree");
-        Assert.That(loadedTree.LowestInsertedHeader?.Number, Is.EqualTo(expectedResult), "loaded tree");
+        Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(null));
+        Assert.That(loadedTree.LowestInsertedHeader?.Number, Is.EqualTo(null));
+
+        loadedTree.LowestInsertedHeader = tree.FindHeader(50, BlockTreeLookupOptions.None);
+
+        loadedTree = Build.A.BlockTree()
+            .WithDatabaseFrom(builder)
+            .WithSyncConfig(syncConfig)
+            .TestObject;
+
+        Assert.That(loadedTree.LowestInsertedHeader?.Number, Is.EqualTo(50));
     }
 
     [TestCase(5, 10)]
@@ -1352,7 +1387,6 @@ public class BlockTreeTests
             .TestObject;
 
         Assert.That(tree.BestKnownNumber, Is.EqualTo(pivotNumber + 1), "tree");
-        Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(1), "loaded tree - lowest header");
         Assert.That(loadedTree.BestKnownNumber, Is.EqualTo(pivotNumber + 1), "loaded tree");
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1161,7 +1161,12 @@ public class BlockTreeTests
             tree.Insert(Build.A.BlockHeader.WithNumber(i).WithTotalDifficulty(i).TestObject);
         }
 
-        tree.RecalculateTreeLevels();
+        builder.MetadataDb.Delete(MetadataDbKeys.LowestInsertedFastHeaderHash);
+
+        tree = Build.A.BlockTree()
+            .WithDatabaseFrom(builder)
+            .WithSyncConfig(syncConfig)
+            .TestObject;
 
         Assert.That(tree.LowestInsertedHeader?.Number, Is.EqualTo(expectedResult), "tree");
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1184,7 +1184,7 @@ public class BlockTreeTests
 
         for (int i = 1; i < 100; i++)
         {
-            tree.Insert(Build.A.BlockHeader.WithNumber(i).WithParent(tree.FindHeader(i-1, BlockTreeLookupOptions.None)!).TestObject);
+            tree.Insert(Build.A.BlockHeader.WithNumber(i).WithParent(tree.FindHeader(i - 1, BlockTreeLookupOptions.None)!).TestObject);
         }
 
         BlockTree loadedTree = Build.A.BlockTree()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -134,10 +134,20 @@ public partial class BlockTree
 
     private void LoadLowestInsertedHeader()
     {
-        long left = 1L;
-        long right = _syncConfig.PivotNumberParsed;
+        if (_metadataDb.KeyExists(MetadataDbKeys.LowestInsertedFastHeaderHash))
+        {
+            Hash256? headerHash = _metadataDb.Get(MetadataDbKeys.LowestInsertedFastHeaderHash)?
+                .AsRlpStream().DecodeKeccak();
+            _lowestInsertedHeader = FindHeader(headerHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+        }
+        else
+        {
+            // Old style binary search.
+            long left = 1L;
+            long right = _syncConfig.PivotNumberParsed;
 
-        LowestInsertedHeader = BinarySearchBlockHeader(left, right, LevelExists, BinarySearchDirection.Down);
+            LowestInsertedHeader = BinarySearchBlockHeader(left, right, LevelExists, BinarySearchDirection.Down);
+        }
     }
 
     private void LoadBestKnown()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -140,6 +140,8 @@ public partial class BlockTree
 
             LowestInsertedHeader = BinarySearchBlockHeader(left, right, LevelExists, BinarySearchDirection.Down);
         }
+
+        if (_logger.IsDebug) _logger.Debug($"Lowest inserted header set to {LowestInsertedHeader?.Number.ToString() ?? "null"}");
     }
 
     private void LoadBestKnown()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -134,6 +134,9 @@ namespace Nethermind.Blockchain
                 DeleteBlocks(new Hash256(deletePointer));
             }
 
+            // Need to be here because it still need to run even if there are no genesis to store the null entry.
+            LoadLowestInsertedHeader();
+
             ChainLevelInfo? genesisLevel = LoadLevel(0);
             if (genesisLevel is not null)
             {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -62,7 +62,18 @@ namespace Nethermind.Blockchain
         public BlockHeader? BestSuggestedHeader { get; private set; }
 
         public Block? BestSuggestedBody { get; private set; }
-        public BlockHeader? LowestInsertedHeader { get; private set; }
+        public BlockHeader? LowestInsertedHeader
+        {
+            get => _lowestInsertedHeader;
+            set
+            {
+                _lowestInsertedHeader = value;
+                _metadataDb.Set(MetadataDbKeys.LowestInsertedFastHeaderHash, Rlp.Encode(value?.Hash ?? value?.CalculateHash()).Bytes);
+            }
+        }
+
+        private BlockHeader? _lowestInsertedHeader;
+
         public BlockHeader? BestSuggestedBeaconHeader { get; private set; }
 
         public Block? BestSuggestedBeaconBody { get; private set; }

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -226,11 +226,6 @@ namespace Nethermind.Blockchain
             bool isOnMainChain = (headerOptions & BlockTreeInsertHeaderOptions.NotOnMainChain) == 0;
             BlockInfo blockInfo = new(header.Hash, header.TotalDifficulty ?? 0);
 
-            if (header.Number < (LowestInsertedHeader?.Number ?? long.MaxValue))
-            {
-                LowestInsertedHeader = header;
-            }
-
             bool beaconInsert = (headerOptions & BlockTreeInsertHeaderOptions.BeaconHeaderMetadata) != 0;
             if (!beaconInsert)
             {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -30,7 +30,11 @@ public class BlockTreeOverlay : IBlockTree
     public BlockHeader? BestSuggestedHeader => _overlayTree.BestSuggestedHeader ?? _baseTree.BestSuggestedHeader;
     public Block? BestSuggestedBody => _overlayTree.BestSuggestedBody ?? _baseTree.BestSuggestedBody;
     public BlockHeader? BestSuggestedBeaconHeader => _overlayTree.BestSuggestedBeaconHeader ?? _baseTree.BestSuggestedBeaconHeader;
-    public BlockHeader? LowestInsertedHeader => _overlayTree.LowestInsertedHeader ?? _baseTree.LowestInsertedHeader;
+    public BlockHeader? LowestInsertedHeader
+    {
+        get => _overlayTree.LowestInsertedHeader ?? _baseTree.LowestInsertedHeader;
+        set => _overlayTree.LowestInsertedHeader = value;
+    }
 
     public long? LowestInsertedBodyNumber
     {

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Blockchain
         /// <summary>
         /// Lowest header added in reverse fast sync insert
         /// </summary>
-        BlockHeader? LowestInsertedHeader { get; }
+        BlockHeader? LowestInsertedHeader { get; set; }
 
         /// <summary>
         /// Lowest body added in reverse fast sync insert

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -30,7 +30,11 @@ namespace Nethermind.Blockchain
         public BlockHeader Genesis => _wrapped.Genesis;
         public BlockHeader BestSuggestedHeader => _wrapped.BestSuggestedHeader;
         public BlockHeader BestSuggestedBeaconHeader => _wrapped.BestSuggestedBeaconHeader;
-        public BlockHeader LowestInsertedHeader => _wrapped.LowestInsertedHeader;
+        public BlockHeader? LowestInsertedHeader
+        {
+            get => _wrapped.LowestInsertedHeader;
+            set {}
+        }
 
         public long? LowestInsertedBodyNumber
         {

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Blockchain
         public BlockHeader? LowestInsertedHeader
         {
             get => _wrapped.LowestInsertedHeader;
-            set {}
+            set { }
         }
 
         public long? BestPersistedState

--- a/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
+++ b/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
@@ -16,5 +16,6 @@ namespace Nethermind.Db
         public const int UpdatedPivotData = 9;
         public const int ReceiptsBarrierWhenStarted = 10;
         public const int BodiesBarrierWhenStarted = 11;
+        public const int LowestInsertedFastHeaderHash = 12;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -67,7 +67,6 @@ public partial class EngineModuleTests
             BestSuggestedHeader = chain.BlockTree.Genesis!,
             BestSuggestedBody = chain.BlockTree.FindBlock(0)!,
             BestKnownBeaconBlock = 0,
-            LowestInsertedHeader = null,
             LowestInsertedBeaconHeader = null
         };
         AssertBlockTreePointers(chain.BlockTree, pointers);
@@ -86,7 +85,6 @@ public partial class EngineModuleTests
         block.Header.TotalDifficulty = 0;
         pointers.LowestInsertedBeaconHeader = block.Header;
         pointers.BestKnownBeaconBlock = block.Number;
-        pointers.LowestInsertedHeader = block.Header;
         AssertBlockTreePointers(chain.BlockTree, pointers);
         AssertExecutionStatusNotChangedV1(chain.BlockFinder, block.Hash!, startingHead, startingHead);
     }
@@ -237,7 +235,6 @@ public partial class EngineModuleTests
             BestSuggestedHeader = chain.BlockTree.Genesis!,
             BestSuggestedBody = chain.BlockTree.FindBlock(0)!,
             BestKnownBeaconBlock = 0,
-            LowestInsertedHeader = null,
             LowestInsertedBeaconHeader = null
         };
         AssertBlockTreePointers(chain.BlockTree, pointers);
@@ -256,7 +253,6 @@ public partial class EngineModuleTests
         block.Header.TotalDifficulty = 0;
         pointers.LowestInsertedBeaconHeader = block.Header;
         pointers.BestKnownBeaconBlock = block.Number;
-        pointers.LowestInsertedHeader = block.Header;
 
         AssertBlockTreePointers(chain.BlockTree, pointers);
 
@@ -762,7 +758,6 @@ public partial class EngineModuleTests
             BestSuggestedHeader = chain.BlockTree.Genesis!,
             BestSuggestedBody = chain.BlockTree.FindBlock(0)!,
             BestKnownBeaconBlock = 0,
-            LowestInsertedHeader = null,
             LowestInsertedBeaconHeader = null
         };
         AssertBlockTreePointers(chain.BlockTree, pointers);
@@ -792,7 +787,6 @@ public partial class EngineModuleTests
         chain.BeaconSync.IsBeaconSyncFinished(pivotBlock.Header).Should().BeFalse();
         AssertBeaconPivotValues(chain.BeaconPivot!, pivotBlock.Header);
         pointers.LowestInsertedBeaconHeader = missingBlocks[^filledNum].Header;
-        pointers.LowestInsertedHeader = missingBlocks[^filledNum].Header;
         pointers.BestKnownBeaconBlock = 9;
         AssertBlockTreePointers(chain.BlockTree, pointers);
         // finish rest of headers sync
@@ -803,7 +797,6 @@ public partial class EngineModuleTests
 
         // headers sync should be finished but not forwards beacon sync
         pointers.LowestInsertedBeaconHeader = missingBlocks[0].Header;
-        pointers.LowestInsertedHeader = missingBlocks[0].Header;
         AssertBlockTreePointers(chain.BlockTree, pointers);
         chain.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
         chain.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeTrue();
@@ -913,7 +906,6 @@ public partial class EngineModuleTests
             BestSuggestedHeader = chain.BlockTree.Genesis!,
             BestSuggestedBody = chain.BlockTree.FindBlock(0)!,
             BestKnownBeaconBlock = 0,
-            LowestInsertedHeader = null,
             LowestInsertedBeaconHeader = null
         };
         AssertBlockTreePointers(chain.BlockTree, pointers);
@@ -940,7 +932,6 @@ public partial class EngineModuleTests
         // verify correct pointers
         requests[0].TryGetBlock(out Block? destinationBlock);
         pointers.LowestInsertedBeaconHeader = destinationBlock!.Header;
-        pointers.LowestInsertedHeader = destinationBlock.Header;
         pointers.BestKnownBeaconBlock = 13;
         AssertBlockTreePointers(chain.BlockTree, pointers);
         chain.BeaconSync!.ShouldBeInBeaconHeaders().Should().BeFalse();
@@ -1061,7 +1052,6 @@ public partial class EngineModuleTests
         blockTree.BestSuggestedBody.Should().Be(pointers.BestSuggestedBody);
         // TODO: post merge sync change to best beacon block
         (blockTree.BestSuggestedBeaconHeader?.Number ?? 0).Should().Be(pointers.BestKnownBeaconBlock);
-        blockTree.LowestInsertedHeader.Should().BeEquivalentTo(pointers.LowestInsertedHeader);
         blockTree.LowestInsertedBeaconHeader.Should().BeEquivalentTo(pointers.LowestInsertedBeaconHeader);
     }
 
@@ -1079,7 +1069,6 @@ public partial class EngineModuleTests
         public BlockHeader? BestSuggestedHeader;
         public Block? BestSuggestedBody;
         public long BestKnownBeaconBlock;
-        public BlockHeader? LowestInsertedHeader;
         public BlockHeader? LowestInsertedBeaconHeader;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -36,7 +36,12 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     protected override bool AllHeadersDownloaded => (_blockTree.LowestInsertedBeaconHeader?.Number ?? long.MaxValue) <=
                                                     _pivot.PivotDestinationNumber || _chainMerged;
 
-    protected override BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedBeaconHeader;
+    protected override BlockHeader? LowestInsertedBlockHeader
+    {
+        get => _blockTree.LowestInsertedBeaconHeader;
+        set => _blockTree.LowestInsertedBeaconHeader = value;
+    }
+
     protected override MeasuredProgress HeadersSyncProgressReport => _syncReport.BeaconHeaders;
 
     protected override MeasuredProgress HeadersSyncQueueReport => _syncReport.BeaconHeadersInQueue;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -43,7 +43,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         {
             // LowestInsertedBeaconHeader is set in blocktree when BeaconHeaderInsert is set.
             // TODO: Probably should move that logic here so that `LowestInsertedBeaconHeader` is set only once per batch.
-v        }
+        }
     }
 
     protected override MeasuredProgress HeadersSyncProgressReport => _syncReport.BeaconHeaders;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -138,6 +138,10 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         return base.InsertHeaders(batch);
     }
 
+    protected override void OnLowestInsertedHeaderInBatch(BlockHeader lowestInsertedHeader)
+    {
+    }
+
     private void ConnectHeaderChainInInvalidChainTracker(IReadOnlyList<BlockHeader?> batchResponse)
     {
         // Sometimes multiple consecutive block failed validation, but engine api need to know the earliest valid hash.

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -143,10 +143,6 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         return base.InsertHeaders(batch);
     }
 
-    protected override void OnLowestInsertedHeaderInBatch(BlockHeader lowestInsertedHeader)
-    {
-    }
-
     private void ConnectHeaderChainInInvalidChainTracker(IReadOnlyList<BlockHeader?> batchResponse)
     {
         // Sometimes multiple consecutive block failed validation, but engine api need to know the earliest valid hash.

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -39,7 +39,8 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     protected override BlockHeader? LowestInsertedBlockHeader
     {
         get => _blockTree.LowestInsertedBeaconHeader;
-        set {
+        set
+        {
             // Set in blocktree
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -41,8 +41,9 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         get => _blockTree.LowestInsertedBeaconHeader;
         set
         {
-            // Set in blocktree
-        }
+            // LowestInsertedBeaconHeader is set in blocktree when BeaconHeaderInsert is set.
+            // TODO: Probably should move that logic here so that `LowestInsertedBeaconHeader` is set only once per batch.
+v        }
     }
 
     protected override MeasuredProgress HeadersSyncProgressReport => _syncReport.BeaconHeaders;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -39,7 +39,9 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     protected override BlockHeader? LowestInsertedBlockHeader
     {
         get => _blockTree.LowestInsertedBeaconHeader;
-        set => _blockTree.LowestInsertedBeaconHeader = value;
+        set {
+            // Set in blocktree
+        }
     }
 
     protected override MeasuredProgress HeadersSyncProgressReport => _syncReport.BeaconHeaders;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -28,7 +28,7 @@ using BlockTree = Nethermind.Blockchain.BlockTree;
 
 namespace Nethermind.Synchronization.Test.FastBlocks;
 
-[Parallelizable(ParallelScope.Self)]
+[Parallelizable(ParallelScope.All)]
 public class FastHeadersSyncTests
 {
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncBatch.cs
@@ -9,6 +9,7 @@ namespace Nethermind.Synchronization.FastBlocks
     {
         public BlockInfo?[] Infos { get; } = infos;
         public OwnedBlockBodies? Response { get; set; }
+        public override long? MinNumber => Infos[0].BlockNumber;
 
         public override void Dispose()
         {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -143,7 +143,6 @@ namespace Nethermind.Synchronization.FastBlocks
                 {
                     batch = new BodiesSyncBatch(infos);
                     // Used for peer allocation. It pick peer which have the at least this number
-                    batch.MinNumber = infos[0].BlockNumber;
                     batch.Prioritized = true;
                 }
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksBatch.cs
@@ -83,7 +83,7 @@ namespace Nethermind.Synchronization.FastBlocks
             => (_handlingEndTime ?? _stopwatch.ElapsedMilliseconds) - (_handlingStartTime ?? _stopwatch.ElapsedMilliseconds);
 
         /// Minimum header number for allocation strategy.
-        public virtual long? MinNumber { get; }
+        public abstract long? MinNumber { get; }
         public virtual void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksBatch.cs
@@ -81,7 +81,9 @@ namespace Nethermind.Synchronization.FastBlocks
             => (_handlingStartTime ?? _stopwatch.ElapsedMilliseconds) - (_waitingStartTime ?? _handlingStartTime ?? _stopwatch.ElapsedMilliseconds);
         public double? HandlingTime
             => (_handlingEndTime ?? _stopwatch.ElapsedMilliseconds) - (_handlingStartTime ?? _stopwatch.ElapsedMilliseconds);
-        public long? MinNumber { get; set; }
+
+        /// Minimum header number for allocation strategy.
+        public virtual long? MinNumber { get; }
         public virtual void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -499,7 +499,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
             using ArrayPoolList<BlockHeader> headers = new ArrayPoolList<BlockHeader>(1);
             headers.Add(lastHeader);
-            for (long i = batch.EndNumber -1; i >= batch.StartNumber; i--)
+            for (long i = batch.EndNumber - 1; i >= batch.StartNumber; i--)
             {
                 // Don't worry about fork, `InsertHeaders` will check for fork and retry if it is not on the right fork.
                 BlockHeader nextHeader = _blockTree.FindHeader(lastHeader.ParentHash!, i);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -316,7 +316,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
                 else if (ShouldBuildANewBatch())
                 {
-                    batch = BuildNewBatch();
+                    batch = ProcessPersistedHeadersOrBuildNewBatch();
                     if (_logger.IsTrace) _logger.Trace($"New batch {batch}");
                 }
 
@@ -339,20 +339,23 @@ namespace Nethermind.Synchronization.FastBlocks
             }
         }
 
-        private HeadersSyncBatch? BuildNewBatch()
+        private HeadersSyncBatch? ProcessPersistedHeadersOrBuildNewBatch()
         {
             HeadersSyncBatch? batch = null;
             do
             {
-                batch = new();
-                batch.StartNumber = Math.Max(HeadersDestinationNumber,
-                    _lowestRequestedHeaderNumber - _headersRequestSize);
-                batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber,
-                    _headersRequestSize);
-                _lowestRequestedHeaderNumber = batch.StartNumber;
-
+                batch = BuildNewBatch();
                 batch = ProcessPersistedPortion(batch);
             } while (batch is null && ShouldBuildANewBatch());
+            return batch;
+        }
+
+        private HeadersSyncBatch BuildNewBatch()
+        {
+            HeadersSyncBatch batch = new();
+            batch.StartNumber = Math.Max(HeadersDestinationNumber, _lowestRequestedHeaderNumber - _headersRequestSize);
+            batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber, _headersRequestSize);
+            _lowestRequestedHeaderNumber = batch.StartNumber;
             return batch;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -511,16 +511,12 @@ namespace Nethermind.Synchronization.FastBlocks
                 lastHeader = nextHeader;
             }
 
-            ArrayPoolList<BlockHeader> reversedBatch = new ArrayPoolList<BlockHeader>(headers.Count);
-            foreach (BlockHeader blockHeader in headers.Reverse())
-            {
-                reversedBatch.Add(blockHeader);
-            }
+            headers.AsSpan().Reverse();
 
             using HeadersSyncBatch newBatchToProcess = new HeadersSyncBatch();
             newBatchToProcess.StartNumber = lastHeader.Number;
             newBatchToProcess.RequestSize = headers.Count;
-            newBatchToProcess.Response = reversedBatch;
+            newBatchToProcess.Response = headers;
             if (_logger.IsDebug) _logger.Debug($"Handling header portion {newBatchToProcess.StartNumber} to {newBatchToProcess.EndNumber} with persisted headers.");
             InsertHeaders(newBatchToProcess);
 
@@ -681,6 +677,7 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncQueueReport.Update(HeadersInQueue);
             return added;
 
+            // Well, its the last in the batch, but first processed.
             bool ValidateFirstHeader(BlockHeader header)
             {
                 BlockHeader lowestInserted = LowestInsertedBlockHeader;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -504,8 +504,8 @@ namespace Nethermind.Synchronization.FastBlocks
                 // Don't worry about fork, `InsertHeaders` will check for fork and retry if it is not on the right fork.
                 BlockHeader nextHeader = _blockTree.FindHeader(lastHeader.ParentHash!, i);
                 if (nextHeader is null) break;
+                headers.Add(nextHeader);
                 lastHeader = nextHeader;
-                headers.Add(lastHeader);
             }
 
             ArrayPoolList<BlockHeader> reversedBatch = new ArrayPoolList<BlockHeader>(headers.Count);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -81,7 +81,7 @@ namespace Nethermind.Synchronization.FastBlocks
         protected virtual MeasuredProgress HeadersSyncQueueReport => _syncReport.HeadersInQueue;
 
         protected virtual long HeadersDestinationNumber => 0;
-        protected virtual bool AllHeadersDownloaded => (LowestInsertedBlockHeader?.Number ?? long.MaxValue) == 1;
+        protected virtual bool AllHeadersDownloaded => (LowestInsertedBlockHeader?.Number ?? long.MaxValue) <= 1;
 
         public override bool IsFinished => AllHeadersDownloaded;
         private bool AnyHeaderDownloaded => LowestInsertedBlockHeader is not null;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -626,9 +626,9 @@ namespace Nethermind.Synchronization.FastBlocks
                 throw new Exception($"Added {added} + left {leftFillerSize} + right {rightFillerSize} != request size {batch.RequestSize} in {batch}");
             }
 
-            if (lowestInsertedHeader is not null)
+            if (lowestInsertedHeader is not null && lowestInsertedHeader.Number < (LowestInsertedBlockHeader?.Number ?? long.MaxValue))
             {
-                OnLowestInsertedHeaderInBatch(lowestInsertedHeader);
+                LowestInsertedBlockHeader = lowestInsertedHeader;
             }
 
             added = Math.Max(0, added);
@@ -765,14 +765,6 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
 
                 return true;
-            }
-        }
-
-        protected virtual void OnLowestInsertedHeaderInBatch(BlockHeader lowestInsertedHeader)
-        {
-            if (lowestInsertedHeader.Number < (LowestInsertedBlockHeader?.Number ?? long.MaxValue))
-            {
-                LowestInsertedBlockHeader = lowestInsertedHeader;
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -491,6 +491,9 @@ namespace Nethermind.Synchronization.FastBlocks
         /// <returns></returns>
         private HeadersSyncBatch? ProcessPersistedPortion(HeadersSyncBatch batch)
         {
+            // This only check for the last header though, which is fine as headers are so small, the time it take
+            // to download one is more or less the same as the whole batch. So many small batch is slower than
+            // less large batch.
             BlockHeader? lastHeader = _blockTree.FindHeader(batch.EndNumber, BlockTreeLookupOptions.None);
             if (lastHeader is null) return batch;
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -71,7 +71,11 @@ namespace Nethermind.Synchronization.FastBlocks
         private ulong _memoryEstimate;
         private long _headersEstimate;
 
-        protected virtual BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedHeader;
+        protected virtual BlockHeader? LowestInsertedBlockHeader
+        {
+            get => _blockTree.LowestInsertedHeader;
+            set => _blockTree.LowestInsertedHeader = value;
+        }
 
         protected virtual MeasuredProgress HeadersSyncProgressReport => _syncReport.FastBlocksHeaders;
         protected virtual MeasuredProgress HeadersSyncQueueReport => _syncReport.HeadersInQueue;
@@ -574,7 +578,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 bool isFirst = i == batch.Response.Count - 1 - skippedAtTheEnd;
                 if (isFirst)
                 {
-                    if (ValidateFirstHeader(header)) break;
+                    if (!ValidateFirstHeader(header)) break;
                 }
                 else
                 {
@@ -707,7 +711,7 @@ namespace Nethermind.Synchronization.FastBlocks
                                 "headers - different branch");
                         }
 
-                        return true;
+                        return false;
                     }
 
                     if (header.Number == LowestInsertedBlockHeader?.Number)
@@ -721,7 +725,7 @@ namespace Nethermind.Synchronization.FastBlocks
                                 "headers - different branch");
                         }
 
-                        return true;
+                        return false;
                     }
 
                     if (_dependencies.ContainsKey(header.Number))
@@ -754,18 +758,18 @@ namespace Nethermind.Synchronization.FastBlocks
                     MarkDirty();
                     if (_logger.IsDebug) _logger.Debug($"{batch} -> DEPENDENCY {dependentBatch}");
                     // but we cannot do anything with it yet
-                    return true;
+                    return false;
                 }
 
-                return false;
+                return true;
             }
         }
 
         protected virtual void OnLowestInsertedHeaderInBatch(BlockHeader lowestInsertedHeader)
         {
-            if (lowestInsertedHeader.Number < (_blockTree.LowestInsertedHeader?.Number ?? long.MaxValue))
+            if (lowestInsertedHeader.Number < (LowestInsertedBlockHeader?.Number ?? long.MaxValue))
             {
-                _blockTree.LowestInsertedHeader = lowestInsertedHeader;
+                LowestInsertedBlockHeader = lowestInsertedHeader;
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -12,6 +12,7 @@ using ConcurrentCollections;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
@@ -334,13 +335,20 @@ namespace Nethermind.Synchronization.FastBlocks
             }
         }
 
-        private HeadersSyncBatch BuildNewBatch()
+        private HeadersSyncBatch? BuildNewBatch()
         {
-            HeadersSyncBatch batch = new();
-            batch.MinNumber = _lowestRequestedHeaderNumber - 1;
-            batch.StartNumber = Math.Max(HeadersDestinationNumber, _lowestRequestedHeaderNumber - _headersRequestSize);
-            batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber, _headersRequestSize);
-            _lowestRequestedHeaderNumber = batch.StartNumber;
+            HeadersSyncBatch? batch = null;
+            do
+            {
+                batch = new();
+                batch.StartNumber = Math.Max(HeadersDestinationNumber,
+                    _lowestRequestedHeaderNumber - _headersRequestSize);
+                batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber,
+                    _headersRequestSize);
+                _lowestRequestedHeaderNumber = batch.StartNumber;
+
+                batch = ProcessPersistedPortion(batch);
+            } while (batch is null && ShouldBuildANewBatch());
             return batch;
         }
 
@@ -437,7 +445,6 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncBatch rightFiller = new();
             rightFiller.StartNumber = batch.EndNumber - rightFillerSize + 1;
             rightFiller.RequestSize = rightFillerSize;
-            rightFiller.MinNumber = batch.MinNumber;
             return rightFiller;
         }
 
@@ -446,7 +453,6 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncBatch leftFiller = new();
             leftFiller.StartNumber = batch.StartNumber;
             leftFiller.RequestSize = leftFillerSize;
-            leftFiller.MinNumber = batch.MinNumber;
             return leftFiller;
         }
 
@@ -456,7 +462,6 @@ namespace Nethermind.Synchronization.FastBlocks
             dependentBatch.StartNumber = addedEarliest;
             int count = (int)(addedLast - addedEarliest + 1);
             dependentBatch.RequestSize = count;
-            dependentBatch.MinNumber = batch.MinNumber;
             dependentBatch.Response = batch.Response!
                 .Skip((int)(addedEarliest - batch.StartNumber))
                 .Take(count).ToPooledList(count);
@@ -466,7 +471,55 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private void EnqueueBatch(HeadersSyncBatch batch)
         {
-            _pending.Enqueue(batch);
+            HeadersSyncBatch? left = ProcessPersistedPortion(batch);
+            if (left is not null)
+            {
+                _pending.Enqueue(batch);
+            }
+        }
+
+        /// <summary>
+        /// Check for portion of header that is already persisted and process them, returning a null batch
+        /// if the whole portion is already persisted and does not require download.
+        /// If only portion of the batch is persisted, then return a new batch that need to be downloaded.
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <returns></returns>
+        private HeadersSyncBatch? ProcessPersistedPortion(HeadersSyncBatch batch)
+        {
+            BlockHeader? lastHeader = _blockTree.FindHeader(batch.EndNumber, BlockTreeLookupOptions.None);
+            if (lastHeader is null) return batch;
+
+            using ArrayPoolList<BlockHeader> headers = new ArrayPoolList<BlockHeader>(1);
+            headers.Add(lastHeader);
+            for (long i = batch.EndNumber -1; i >= batch.StartNumber; i--)
+            {
+                // Don't worry about fork, `InsertHeaders` will check for fork and retry if it is not on the right fork.
+                BlockHeader nextHeader = _blockTree.FindHeader(lastHeader.ParentHash!, i);
+                if (nextHeader is null) break;
+                lastHeader = nextHeader;
+                headers.Add(lastHeader);
+            }
+
+            ArrayPoolList<BlockHeader> reversedBatch = new ArrayPoolList<BlockHeader>(headers.Count);
+            foreach (BlockHeader blockHeader in headers.Reverse())
+            {
+                reversedBatch.Add(blockHeader);
+            }
+
+            using HeadersSyncBatch newBatchToProcess = new HeadersSyncBatch();
+            newBatchToProcess.StartNumber = lastHeader.Number;
+            newBatchToProcess.RequestSize = headers.Count;
+            newBatchToProcess.Response = reversedBatch;
+            if (_logger.IsDebug) _logger.Debug($"Handling header portion {newBatchToProcess.StartNumber} to {newBatchToProcess.EndNumber} with persisted headers.");
+            InsertHeaders(newBatchToProcess);
+
+            int newRequestSize = batch.RequestSize - headers.Count;
+
+            if (newRequestSize == 0) return null;
+
+            batch.RequestSize = newRequestSize;
+            return batch;
         }
 
         protected virtual int InsertHeaders(HeadersSyncBatch batch)
@@ -618,7 +671,7 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncQueueReport.Update(HeadersInQueue);
             return added;
 
-            bool ValidateFirstHeader(BlockHeader? header)
+            bool ValidateFirstHeader(BlockHeader header)
             {
                 BlockHeader lowestInserted = LowestInsertedBlockHeader;
                 // response does not carry expected data

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncBatch.cs
@@ -39,6 +39,8 @@ namespace Nethermind.Synchronization.FastBlocks
             return $"HEADERS {details} [{(Prioritized ? "HIGH" : "LOW")}] [times: S:{SchedulingTime:F0}ms|R:{RequestTime:F0}ms|V:{ValidationTime:F0}ms|W:{WaitingTime:F0}ms|H:{HandlingTime:F0}ms|A:{AgeInMs:F0}ms, retries {Retries}] min#: {MinNumber} {ResponseSourcePeer}";
         }
 
+        public override long? MinNumber => StartNumber + RequestSize;
+
         public override void Dispose()
         {
             base.Dispose();

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncBatch.cs
@@ -16,5 +16,7 @@ namespace Nethermind.Synchronization.FastBlocks
             base.Dispose();
             Response?.Dispose();
         }
+
+        public override long? MinNumber => Infos[0].BlockNumber;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -143,7 +143,6 @@ namespace Nethermind.Synchronization.FastBlocks
                 if (infos[0] is not null)
                 {
                     batch = new ReceiptsSyncBatch(infos);
-                    batch.MinNumber = infos[0].BlockNumber;
                     batch.Prioritized = true;
                 }
 


### PR DESCRIPTION
- Currently unlike oldbodies, orldreceipt or beacon header, the pointer for fast header is initialized via binary search from genesis to sync pivot. 
- This cause a problem with era/portal which may insert header in between arbitrarily.
- This change the pointer to be persisted like beacon header and the pointer is changed manually in fast header instead of on every block/header insert.
- Also don't download already persisted header. This only 2x faster than downloading though.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Mainnet sync work.