### PR TITLE
Add missing Discv5 support for archive op/base nodes

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/base-mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/base-mainnet_archive.json
@@ -9,6 +9,9 @@
   "TxPool": {
     "BlobsSupport": "Disabled"
   },
+  "Discovery": {
+    "DiscoveryVersion": "V5"
+  },
   "Pruning": {
     "Mode": "None"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/base-sepolia_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/base-sepolia_archive.json
@@ -9,6 +9,9 @@
   "TxPool": {
     "BlobsSupport": "Disabled"
   },
+  "Discovery": {
+    "DiscoveryVersion": "V5"
+  },
   "Pruning": {
     "Mode": "None"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/op-mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/op-mainnet_archive.json
@@ -14,6 +14,9 @@
     "AncientBodiesBarrier": 105235063,
     "AncientReceiptsBarrier": 105235063
   },
+  "Discovery": {
+    "DiscoveryVersion": "V5"
+  },
   "Pruning": {
     "Mode": "None"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/op-sepolia_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/op-sepolia_archive.json
@@ -9,6 +9,9 @@
   "TxPool": {
     "BlobsSupport": "Disabled"
   },
+  "Discovery": {
+    "DiscoveryVersion": "V5"
+  },
   "Pruning": {
     "Mode": "None"
   },


### PR DESCRIPTION
Add DiscV5 support for archive op/base nodes.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No