### PR TITLE
All projects target same build output

### DIFF
--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -1,15 +1,18 @@
 <Project>
+  <Target Name="EnsureOutputDirectoryExists" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="$(BaseOutputPath)$(Configuration)" />
+  </Target>
 
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <NuGetAuditMode>direct</NuGetAuditMode>
     <TargetFramework>net9.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <BaseOutputPath>$(SolutionDir)\artifacts\</BaseOutputPath>
-    <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <BaseOutputPath>$(SolutionDir)/artifacts/</BaseOutputPath>
+    <OutputPath>$(BaseOutputPath)$(Configuration)/</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Label="ProductInfo">

--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -8,6 +8,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
+    <BaseOutputPath>$(SolutionDir)\artifacts\</BaseOutputPath>
+    <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Label="ProductInfo">


### PR DESCRIPTION
## Changes

- Point all projects to same build output
- Reduces build size 30GB->600MB for each release configuration (debug/release).
- fixes version of c#, so if someone in the future will come back to previous commits he will have guaranteed builds (latest can have backward compatibility issues!)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: build

## Testing

#### Requires testing

- [x] Yes
- [ ] No


#### Notes on testing

Check if release still works fine.
If it is problematic, we can have a separate output for Runner project, which should be compatible with the current release mode.