### PR TITLE
[Json RPC] Catch Trie exception on eth_getStorage call

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -364,14 +364,14 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
-    public async Task Eth_get_storage_at_trie_exception()
+    public async Task Eth_get_storage_at_missing_trie_node()
     {
         using Context ctx = await Context.Create();
         ctx.Test.StateDb.Clear();
         BlockParameter? blockParameter = null;
         BlockHeader? header = ctx.Test.BlockFinder.FindHeader(blockParameter);
         string serialized = await ctx.Test.TestEthRpc("eth_getStorageAt", TestItem.AddressA.Bytes.ToHexString(true), "0x1");
-        var expected = $"{{\"jsonrpc\":\"2.0\",\"error\":{{\"code\":-32002,\"message\":\"No state available for block {header?.Number} ({header?.Hash})\"}},\"id\":67}}";
+        var expected = $"{{\"jsonrpc\":\"2.0\",\"error\":{{\"code\":-32000,\"message\":\"missing trie node {header?.StateRoot} (path ) state {header?.StateRoot} is not available\"}},\"id\":67}}";
         Assert.That(serialized, Is.EqualTo(expected));
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -364,6 +364,18 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_get_storage_at_trie_exception()
+    {
+        using Context ctx = await Context.Create();
+        ctx.Test.StateDb.Clear();
+        BlockParameter? blockParameter = null;
+        BlockHeader? header = ctx.Test.BlockFinder.FindHeader(blockParameter);
+        string serialized = await ctx.Test.TestEthRpc("eth_getStorageAt", TestItem.AddressA.Bytes.ToHexString(true), "0x1");
+        var expected = $"{{\"jsonrpc\":\"2.0\",\"error\":{{\"code\":-32002,\"message\":\"No state available for block {header?.Number} ({header?.Hash})\"}},\"id\":67}}";
+        Assert.That(serialized, Is.EqualTo(expected));
+    }
+
+    [Test]
     public async Task Eth_get_block_number()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -184,9 +184,10 @@ public partial class EthRpcModule(
             ReadOnlySpan<byte> storage = _stateReader.GetStorage(header!.StateRoot!, address, positionIndex);
             return ResultWrapper<byte[]>.Success(storage.IsEmpty ? Bytes32.Zero.Unwrap() : storage!.PadLeft(32));
         }
-        catch (MissingTrieNodeException)
+        catch (MissingTrieNodeException e)
         {
-            return GetStateFailureResult<byte[]>(header);
+            var hash = e.TrieNodeException.NodeHash;
+            return ResultWrapper<byte[]>.Fail($"missing trie node {hash} (path ) state {hash} is not available", ErrorCodes.InvalidInput);
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -33,6 +33,7 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Trie;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
 using Block = Nethermind.Core.Block;
@@ -178,8 +179,15 @@ public partial class EthRpcModule(
         }
 
         BlockHeader? header = searchResult.Object;
-        ReadOnlySpan<byte> storage = _stateReader.GetStorage(header!.StateRoot!, address, positionIndex);
-        return ResultWrapper<byte[]>.Success(storage.IsEmpty ? Bytes32.Zero.Unwrap() : storage!.PadLeft(32));
+        try
+        {
+            ReadOnlySpan<byte> storage = _stateReader.GetStorage(header!.StateRoot!, address, positionIndex);
+            return ResultWrapper<byte[]>.Success(storage.IsEmpty ? Bytes32.Zero.Unwrap() : storage!.PadLeft(32));
+        }
+        catch (MissingTrieNodeException)
+        {
+            return GetStateFailureResult<byte[]>(header);
+        }
     }
 
     public Task<ResultWrapper<UInt256>> eth_getTransactionCount(Address address, BlockParameter? blockParameter)


### PR DESCRIPTION
When trying to get a missing storage via RPC call, we not handling the missing node well, so we end up returning exception trace into the RPC response. example call & response:

```
curl 172.234.253.190:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc": "2.0", "method": "eth_getStorageAt", "params": ["0x4d9079bb4165aeb4084c526a32695dcfd2f77381", "0x0000000000000000000000000000000000000000000000000000000000000002", "0xda7485"], "id": 662251708906005292}'
  ```
  Response:
  ```
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":"Nethermind.Trie.MissingTrieNodeException: Node 0x7624432bf4159f20277937ee01260167ef485023da8e2814c7e5b6dd2665346f is missing from the DB\n ---> Nethermind.Trie.TrieNodeException: Failed to load root hash 0x7624432bf4159f20277937ee01260167ef485023da8e2814c7e5b6dd2665346f while loading key d2313780e872947b0af5192f9f8a83047a495d8fba883ae44701b43000eb1a32.\nNode 0x7624432bf4159f20277937ee01260167ef485023da8e2814c7e5b6dd2665346f is missing from the DB\n   at Nethermind.Trie.Pruning.ReadOnlyTrieStore.ScopedReadOnlyTrieStore.Nethermind.Trie.Pruning.ITrieNodeResolver.LoadRlp(TreePath& path, Hash256 hash, ReadFlags flags)\n   at Nethermind.Trie.PatriciaTree.ResolveNode(TrieNode node, TraverseContext& traverseContext, TreePath& path) in /src/Nethermind/Nethermind.Trie/PatriciaTree.cs:line 571\n   --- End of inner exception stack trace ---\n   at Nethermind.Trie.PatriciaTree.ResolveNode(TrieNode node, TraverseContext& traverseContext, TreePath& path) in /src/Nethermind/Nethermind.Trie/PatriciaTree.cs:line 579\n   at Nethermind.Trie.PatriciaTree.Get(ReadOnlySpan`1 rawKey, Hash256 rootHash) in /src/Nethermind/Nethermind.Trie/PatriciaTree.cs:line 333\n   at Nethermind.State.StateReader.TryGetState(Hash256 stateRoot, Address address, AccountStruct& account) in /src/Nethermind/Nethermind.State/StateReader.cs:line 70\n   at Nethermind.State.StateReader.GetStorage(Hash256 stateRoot, Address address, UInt256& index) in /src/Nethermind/Nethermind.State/StateReader.cs:line 27\n   at Nethermind.State.StateReader.Nethermind.State.IStateReader.GetStorage(Hash256 stateRoot, Address address, UInt256& index)\n   at Nethermind.JsonRpc.Modules.Eth.EthRpcModule.eth_getStorageAt(Address address, UInt256 positionIndex, BlockParameter blockParameter) in /src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs:line 181\n   at InvokeStub_IEthRpcModule.eth_getStorageAt(Object, Object, Object, Object, Object)\n   at System.Reflection.MethodInvoker.InvokeImpl(Object obj, Object arg1, Object arg2, Object arg3, Object arg4)\n   at System.Reflection.MethodInvoker.Invoke(Object obj, Span`1 arguments)\n   at Nethermind.JsonRpc.JsonRpcService.ExecuteAsync(JsonRpcRequest request, String methodName, ResolvedMethodInfo method, JsonRpcContext context) in /src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs:line 175"},"id":662251708906005292}
```

I went for a most obvious solution, although not sure if it's the best one. 

I've updated the response to match geth implementation (with wrong-ish error code):

```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32000,
        "message": "missing trie node 0x7624432bf4159f20277937ee01260167ef485023da8e2814c7e5b6dd2665346f (path ) state 0x7624432bf4159f20277937ee01260167ef485023da8e2814c7e5b6dd2665346f is not available"
    },
    "id": 662251708906005292
}
```


## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
