### PR TITLE
Increase default gas limit from 30M to 36M

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -346,9 +346,9 @@ public class ConfigFilesTests : ConfigFileTestsBase
 
     [TestCase("chiado", 17_000_000L, 5UL, 3000)]
     [TestCase("gnosis", 17_000_000L, 5UL, 3000)]
-    [TestCase("mainnet", 30_000_000L)]
-    [TestCase("sepolia", 30_000_000L)]
-    [TestCase("holesky", 30_000_000L)]
+    [TestCase("mainnet", 36_000_000L)]
+    [TestCase("sepolia", 36_000_000L)]
+    [TestCase("holesky", 36_000_000L)]
     [TestCase("^chiado ^gnosis ^mainnet ^sepolia ^holesky")]
     public void Blocks_defaults_are_correct(string configWildcard, long? targetBlockGasLimit = null, ulong secondsPerSlot = 12, int blockProductionTimeout = 4000)
     {

--- a/src/Nethermind/Nethermind.Runner/configs/holesky.json
+++ b/src/Nethermind/Nethermind.Runner/configs/holesky.json
@@ -17,7 +17,7 @@
         "NodeName": "Holesky"
     },
     "Blocks": {
-        "TargetBlockGasLimit": 30000000
+        "TargetBlockGasLimit": 36000000
     },
     "JsonRpc": {
         "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/holesky_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/holesky_archive.json
@@ -12,7 +12,7 @@
         "NodeName": "Holesky Archive"
     },
     "Blocks": {
-        "TargetBlockGasLimit": 30000000
+        "TargetBlockGasLimit": 36000000
     },
     "Receipt": {
         "TxLookupLimit": 0

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.json
@@ -21,7 +21,7 @@
     "NodeName": "Mainnet"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
@@ -17,7 +17,7 @@
     "NodeName": "Mainnet Archive"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "Receipt": {
     "TxLookupLimit": 0

--- a/src/Nethermind/Nethermind.Runner/configs/mekong.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mekong.json
@@ -17,7 +17,7 @@
     "UseGethLimitsInFastBlocks": true
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mekong_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mekong_archive.json
@@ -12,7 +12,7 @@
     "NodeName": "Mekong archive"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "Receipt": {
     "TxLookupLimit": 0

--- a/src/Nethermind/Nethermind.Runner/configs/sepolia.json
+++ b/src/Nethermind/Nethermind.Runner/configs/sepolia.json
@@ -23,7 +23,7 @@
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/sepolia_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/sepolia_archive.json
@@ -14,7 +14,7 @@
     "NodeName": "Sepolia Archive"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 30000000
+    "TargetBlockGasLimit": 36000000
   },
   "Receipt": {
     "TxLookupLimit": 0


### PR DESCRIPTION
## Changes

- 36M is the current safe limit for all participants pre-Pectra (EIP-7623) and taking into account an active propagation size limit bug in CL clients.

See also: https://ethresear.ch/t/on-increasing-the-block-gas-limit-technical-considerations-path-forward/21225

Also being done by Erigon: https://github.com/erigontech/erigon/pull/13057

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No
