### PR TITLE
Optimism post-bedrock Legacy transaction validation

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
@@ -18,6 +19,7 @@ public class RlpDecoderTests
     {
         _decoder = TxDecoder.Instance;
         _decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+        _decoder.RegisterDecoder(new OptimismLegacyTxDecoder());
     }
 
     [Test]
@@ -48,5 +50,21 @@ public class RlpDecoderTests
         Transaction? decodedTx = Rlp.Decode<Transaction?>(rlpStream);
 
         decodedTx.Should().NotBeNull();
+    }
+
+    [Test]
+    public void Can_decode_Legacy_Empty_Signature()
+    {
+        _decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+
+        // See: https://github.com/NethermindEth/nethermind/issues/7880
+        var hexBytes =
+            "f901c9830571188083030d4094420000000000000000000000000000000000000780b901a4cbd4ece9000000000000000000000000420000000000000000000000000000000000001000000000000000000000000099c9fc46f92e8a1c0dec1b1747d010903e884be10000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000005711800000000000000000000000000000000000000000000000000000000000000e4662a633a000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000094b008aa00579c1307b0ef2c499ad98a8ce58e58000000000000000000000000117274dde02bc94006185af87d78beab28ceae06000000000000000000000000117274dde02bc94006185af87d78beab28ceae06000000000000000000000000000000000000000000000000000000000c3d8b8000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000808080";
+        var bytes = Bytes.FromHexString(hexBytes);
+        var context = bytes.AsRlpValueContext();
+
+        var transaction = _decoder.Decode(ref context);
+
+        transaction.Should().NotBeNull();
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
@@ -11,19 +11,25 @@ namespace Nethermind.Optimism.Test;
 
 public class RlpDecoderTests
 {
+    private TxDecoder _decoder = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _decoder = TxDecoder.Instance;
+        _decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+    }
+
     [Test]
     public void Can_decode_non_null_Transaction()
     {
-        TxDecoder decoder = TxDecoder.Instance;
-        decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
-
         Transaction tx = Build.A.Transaction.WithType(TxType.DepositTx).TestObject;
 
-        RlpStream rlpStream = new(decoder.GetLength(tx, RlpBehaviors.None));
-        decoder.Encode(rlpStream, tx);
+        RlpStream rlpStream = new(_decoder.GetLength(tx, RlpBehaviors.None));
+        _decoder.Encode(rlpStream, tx);
         rlpStream.Reset();
 
-        Transaction? decodedTx = decoder.Decode(rlpStream);
+        Transaction? decodedTx = _decoder.Decode(rlpStream);
 
         decodedTx.Should().NotBeNull();
     }
@@ -31,13 +37,12 @@ public class RlpDecoderTests
     [Test]
     public void Can_decode_non_null_Transaction_through_Rlp()
     {
-        TxDecoder decoder = TxDecoder.Instance;
-        decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+        _decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
 
         Transaction tx = Build.A.Transaction.WithType(TxType.DepositTx).TestObject;
 
-        RlpStream rlpStream = new(decoder.GetLength(tx, RlpBehaviors.None));
-        decoder.Encode(rlpStream, tx);
+        RlpStream rlpStream = new(_decoder.GetLength(tx, RlpBehaviors.None));
+        _decoder.Encode(rlpStream, tx);
         rlpStream.Reset();
 
         Transaction? decodedTx = Rlp.Decode<Transaction?>(rlpStream);

--- a/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
+++ b/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
@@ -38,7 +38,7 @@ public class InitializeBlockchainOptimism(OptimismNethermindApi api) : Initializ
         await base.InitBlockchain();
 
         api.RegisterTxType<OptimismTransactionForRpc>(new OptimismTxDecoder<Transaction>(), Always.Valid);
-        api.RegisterTxType<LegacyTransactionForRpc>(new OptimismLegacyTxDecoder(), new OptimismLegacyTxValidator());
+        api.RegisterTxType<LegacyTransactionForRpc>(new OptimismLegacyTxDecoder(), new OptimismLegacyTxValidator(api.SpecProvider!.ChainId));
     }
 
     protected override ITransactionProcessor CreateTransactionProcessor(CodeInfoRepository codeInfoRepository, VirtualMachine virtualMachine)

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -86,7 +86,7 @@ public class OptimismPlugin : IConsensusPlugin, ISynchronizationPlugin, IInitial
         if (ShouldRunSteps(api))
         {
             api.RegisterTxType<OptimismTransactionForRpc>(new OptimismTxDecoder<Transaction>(), Always.Valid);
-            api.RegisterTxType<LegacyTransactionForRpc>(new OptimismLegacyTxDecoder(), new OptimismLegacyTxValidator());
+            api.RegisterTxType<LegacyTransactionForRpc>(new OptimismLegacyTxDecoder(), new OptimismLegacyTxValidator(api.SpecProvider!.ChainId));
             Rlp.RegisterDecoders(typeof(OptimismReceiptMessageDecoder).Assembly, true);
         }
     }


### PR DESCRIPTION
Partially addresses #7880

## Changes

- Ensure post-Bedrock Legacy transactions are validated normally.
- Add tests for RLP decoding the original problematic transaction.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added a test for the problematic transaction that initially caused the snapshot to not work.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No