### PR TITLE
Trigger Sync tests less frequently

### DIFF
--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -3,9 +3,13 @@ name: Sync Supported Chains
 on:
   workflow_run:
     workflows: ["Publish Docker image"]
-    branches: [master, release/*]
+    branches: [release/*]
     types:
       - completed
+
+  schedule:
+    - cron: "0 0 * * *"
+    
   workflow_dispatch:
     inputs:
       nethermind_image:


### PR DESCRIPTION
Currently we trigger sync tests on each master commit.
It has one big advantage - it is very easy to narrow down which exact commit breaks sync.

Also a big disadvantage - if there are known issues or for longer period of time everything works well - it is quite costly.

Noticed recently that during 5 days we managed to merge 25 commits - each triggered 15 machines so in total 375 VMs (various ones).
With this change we will trigger 5 times and total of 75 VMs - 5 times smaller cost and only disadvantage will be that we will know on which exact day something get broken.

For now it feels fine to do sth like this as it will be good enough to analyze if we are in good shape for a release cutoff - on release we will keep it on every new commit appearing.

In future I may adjust that action to have a "light mode" - sync only mainnets for example - and this one could be a merge_queue condition once we will figure out why it wasn't working before.

Few times less frequent execution combined with much cheaper machines used recently (applied on #7863) is a significant cost reduction.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
- 
## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [ ] Yes
- [X] No
