### PR TITLE
Fix missed bloom filter

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -160,6 +160,12 @@ public class DbConfig : IDbConfig
         "write_buffer_size=4000000;" +
         "block_based_table_factory.block_cache=16000000;" +
         "optimize_filters_for_hits=false;" +
+        "prefix_extractor=capped:8;" +
+        "block_based_table_factory.index_type=kHashSearch;" +
+        "block_based_table_factory.block_size=4096;" +
+        "memtable=prefix_hash:1000000;" +
+        // Bloom crash with kHashSearch index
+        "block_based_table_factory.filter_policy=null;" +
         "allow_concurrent_memtable_write=false;";
     public string? CodeDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -74,7 +74,7 @@ public class DbConfig : IDbConfig
         "block_based_table_factory.partition_filters=true;" +
         "block_based_table_factory.metadata_block_size=4096;" +
 
-        "block_based_table_factory.filter_policy=bloom_filter:10;" +
+        "block_based_table_factory.filter_policy=bloomfilter:10;" +
         "";
     public string? AdditionalRocksDbOptions { get; set; }
 
@@ -124,6 +124,7 @@ public class DbConfig : IDbConfig
         "write_buffer_size=8000000;" +
         "block_based_table_factory.block_cache=32000000;" +
         "compaction_pri=kOldestLargestSeqFirst;" +
+        "optimize_filters_for_hits=false;" +
         "block_based_table_factory.block_size=32000;" +
         "max_bytes_for_level_base=128000000;" +
         "";
@@ -132,9 +133,10 @@ public class DbConfig : IDbConfig
     public ulong? BlockNumbersDbRowCacheSize { get; set; } = (ulong)16.MiB();
     public string BlockNumbersDbRocksDbOptions { get; set; } =
         "write_buffer_size=8000000;" +
+        "max_bytes_for_level_base=16000000;" +
         "block_based_table_factory.block_cache=16000000;" +
         "block_based_table_factory.block_size=4096;" +
-        "max_bytes_for_level_base=16000000;" +
+        "optimize_filters_for_hits=false;" +
         "memtable=prefix_hash:1000000;" +
         "allow_concurrent_memtable_write=false;" +
         "";
@@ -142,7 +144,10 @@ public class DbConfig : IDbConfig
 
     public string BlockInfosDbRocksDbOptions { get; set; } =
         "write_buffer_size=4000000;" +
+        "max_bytes_for_level_base=32000000;" +
+        "optimize_filters_for_hits=false;" +
         "block_based_table_factory.block_cache=16000000;" +
+        "block_based_table_factory.block_size=32000;" +
         "compaction_pri=kOldestLargestSeqFirst;";
     public string? BlockInfosDbAdditionalRocksDbOptions { get; set; } = "";
 
@@ -154,10 +159,7 @@ public class DbConfig : IDbConfig
     public string CodeDbRocksDbOptions { get; set; } =
         "write_buffer_size=4000000;" +
         "block_based_table_factory.block_cache=16000000;" +
-        "prefix_extractor=capped:16;" +
-        "block_based_table_factory.index_type=kHashSearch;" +
-        "block_based_table_factory.block_size=4096;" +
-        "memtable=prefix_hash:1000000;" +
+        "optimize_filters_for_hits=false;" +
         "allow_concurrent_memtable_write=false;";
     public string? CodeDbAdditionalRocksDbOptions { get; set; }
 
@@ -214,7 +216,7 @@ public class DbConfig : IDbConfig
 
         "block_based_table_factory.block_size=32000;" +
 
-        "block_based_table_factory.filter_policy=bloom_filter:15;" +
+        "block_based_table_factory.filter_policy=bloomfilter:15;" +
         "";
     public string? StateDbAdditionalRocksDbOptions { get; set; }
 }


### PR DESCRIPTION
- It seems that rocksdb does not crash when bloom filter config is invalid unlike other parameter key. This can be verified by looking into rockdb log directly which have the filter set  to null.
- With `optimize_filters_for_hits` being true by default, the bloom filter is only set for non-last level of the LSM tree which allow a reads to skip the first two level (in case of state) of LSM while saving disk space by not having it on the last level. With cache/prewarming/compaction priority, its unclear if the impact is significant or not except for maybe state sync.
- Also disable `optimize_filters_for_hits` for block info, headers and code, to make sync faster maybe as it will not hit a lot during sync.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Checked log manually.