### PR TITLE
Prevent file logging before configuration initialization

### DIFF
--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -20,6 +20,11 @@ namespace Nethermind.Logging.NLog
         private const string DefaultFileTargetName = "file-async_wrapped";
         private const string DefaultFolder = "logs";
 
+        /// <summary>
+        /// The constructor to use when the configuration is not yet initialized.
+        /// </summary>
+        public NLogManager() { /* Log in temp dir? */ }
+
         public NLogManager(string logFileName, string logDirectory = null, string logRules = null)
         {
             Setup(logFileName, logDirectory, logRules);

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -348,7 +348,7 @@ void ConfigureLogger(ParseResult parseResult)
         return;
     }
 
-    using NLogManager logManager = new("nethermind.log");
+    using NLogManager logManager = new();
 
     logger = logManager.GetClassLogger();
 


### PR DESCRIPTION
## Changes

This PR prevents file logging before configuration initialization. The reason is that now Nethermind uses the log rules at the very beginning to avoid having sudden log style changes after loading the configuration. However, on some user configurations, the Nethermind directory is inaccessible for the Nethermind process, and that causes an error.

Another approach might be writing that part of the logs in the user's temp directory. But till now, that logs were missing, and perhaps having them in the file somewhere is not that useful.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually.
