### PR TITLE
Feature/disable nodedata on halfpath

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -404,6 +404,10 @@ public class InitializeNetwork : IStep
         {
             _api.ProtocolsManager!.AddSupportedCapability(new Capability(Protocol.Snap, 1));
         }
+        if (!_api.WorldStateManager!.SupportHashLookup)
+        {
+            _api.ProtocolsManager!.RemoveSupportedCapability(new Capability(Protocol.NodeData, 1));
+        }
 
         _api.ProtocolValidator = protocolValidator;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -84,9 +84,16 @@ namespace Nethermind.Network.Test.P2P
         public void On_init_sends_a_hello_message_with_capabilities()
         {
             P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            string[] expectedCapabilities = ["eth66", "eth67", "eth68", "nodedata1"];
+
+            // These are called by ProtocolsManager.
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 66));
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 67));
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 68));
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.NodeData, 1));
+
             p2PProtocolHandler.Init();
 
-            string[] expectedCapabilities = ["eth66", "eth67", "eth68", "nodedata1"];
             _session.Received(1).DeliverMessage(
                 Arg.Is<HelloMessage>(m => m.Capabilities.Select(c => c.ToString()).SequenceEqual(expectedCapabilities)));
         }

--- a/src/Nethermind/Nethermind.Network/P2P/P2PProtocolInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/P2PProtocolInfoProvider.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.P2P
         public static int GetHighestVersionOfEthProtocol()
         {
             int highestVersion = 0;
-            foreach (Capability ethProtocol in P2PProtocolHandler.DefaultCapabilities)
+            foreach (Capability ethProtocol in ProtocolsManager.DefaultCapabilities)
             {
                 if (ethProtocol.ProtocolCode == Protocol.Eth && highestVersion < ethProtocol.Version)
                     highestVersion = ethProtocol.Version;
@@ -25,7 +25,7 @@ namespace Nethermind.Network.P2P
 
         public static string DefaultCapabilitiesToString()
         {
-            IEnumerable<string> capabilities = P2PProtocolHandler.DefaultCapabilities
+            IEnumerable<string> capabilities = ProtocolsManager.DefaultCapabilities
                 .OrderBy(x => x.ProtocolCode).ThenByDescending(x => x.Version)
                 .Select(x => $"{x.ProtocolCode}/{x.Version}");
             return string.Join(",", capabilities);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -49,17 +49,9 @@ public class P2PProtocolHandler(
 
     protected override TimeSpan InitTimeout => Timeouts.P2PHello;
 
-    public static readonly IEnumerable<Capability> DefaultCapabilities = new Capability[]
-    {
-        new(Protocol.Eth, 66),
-        new(Protocol.Eth, 67),
-        new(Protocol.Eth, 68),
-        new(Protocol.NodeData, 1)
-    };
-
     public IReadOnlyList<Capability> AgreedCapabilities { get { return _agreedCapabilities; } }
     public IReadOnlyList<Capability> AvailableCapabilities { get { return _availableCapabilities; } }
-    private readonly List<Capability> _supportedCapabilities = DefaultCapabilities.ToList();
+    private readonly List<Capability> _supportedCapabilities = new List<Capability>();
 
     public int ListenPort { get; } = session.LocalPort;
     public PublicKey LocalNodeId { get; } = localNodeId;

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -420,17 +420,7 @@ namespace Nethermind.Network
         {
             if (_capabilities.Remove(capability))
             {
-                Console.Error.WriteLine($"|NetworkTrace| {capability} is removed from the discovery");
                 if (_logger.IsDebug) _logger.Debug($"Removed supported capability: {capability}");
-            }
-            else
-            {
-                Console.Error.WriteLine($"|NetworkTrace| {capability} is not removed from the discovery");
-
-                foreach (Capability capability1 in _capabilities)
-                {
-                    Console.Error.WriteLine($"Its {capability1}");
-                }
             }
         }
 

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -38,4 +38,19 @@ public class WorldStateManagerTests
 
         gotEvent.Should().BeTrue();
     }
+
+    [TestCase(INodeStorage.KeyScheme.Hash, true)]
+    [TestCase(INodeStorage.KeyScheme.HalfPath, false)]
+    public void ShouldNotSupportHashLookupOnHalfpath(INodeStorage.KeyScheme keyScheme, bool hashSupported)
+    {
+        IWorldState worldState = Substitute.For<IWorldState>();
+        ITrieStore trieStore = Substitute.For<ITrieStore>();
+        IReadOnlyTrieStore readOnlyTrieStore = Substitute.For<IReadOnlyTrieStore>();
+        trieStore.AsReadOnly().Returns(readOnlyTrieStore);
+        readOnlyTrieStore.Scheme.Returns(keyScheme);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = new WorldStateManager(worldState, trieStore, dbProvider, LimboLogs.Instance);
+
+        worldStateManager.SupportHashLookup.Should().Be(hashSupported);
+    }
 }

--- a/src/Nethermind/Nethermind.State/IWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateManager.cs
@@ -11,6 +11,7 @@ public interface IWorldStateManager
     IWorldState GlobalWorldState { get; }
     IStateReader GlobalStateReader { get; }
     IReadOnlyTrieStore TrieStore { get; }
+    bool SupportHashLookup { get; }
 
     /// <summary>
     /// Used by read only tasks that need to execute blocks.

--- a/src/Nethermind/Nethermind.State/OverlayWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/OverlayWorldStateManager.cs
@@ -26,6 +26,7 @@ public class OverlayWorldStateManager(
     public IStateReader GlobalStateReader => _reader;
 
     public IReadOnlyTrieStore TrieStore { get; } = overlayTrieStore.AsReadOnly();
+    public bool SupportHashLookup => overlayTrieStore.Scheme == INodeStorage.KeyScheme.Hash;
 
     public IWorldState CreateResettableWorldState(IWorldState? forWarmup = null)
     {

--- a/src/Nethermind/Nethermind.State/OverridableWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/OverridableWorldStateManager.cs
@@ -31,6 +31,7 @@ public class OverridableWorldStateManager : IWorldStateManager
     public IWorldState GlobalWorldState => _state;
     public IStateReader GlobalStateReader => _reader;
     public IReadOnlyTrieStore TrieStore => _overlayTrieStore.AsReadOnly();
+    public bool SupportHashLookup => _overlayTrieStore.Scheme == INodeStorage.KeyScheme.Hash;
 
     public IWorldState CreateResettableWorldState(IWorldState? forWarmup = null)
     {

--- a/src/Nethermind/Nethermind.State/ReadOnlyWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/ReadOnlyWorldStateManager.cs
@@ -37,6 +37,7 @@ public class ReadOnlyWorldStateManager : IWorldStateManager
     public IStateReader GlobalStateReader { get; }
 
     public IReadOnlyTrieStore TrieStore => _readOnlyTrieStore;
+    public bool SupportHashLookup => _readOnlyTrieStore.Scheme == INodeStorage.KeyScheme.Hash;
 
     public IWorldState CreateResettableWorldState(IWorldState? forWarmup = null)
     {


### PR DESCRIPTION
- Disable nodedata protocol on halfpath as it cannot serve it.
- This prevent other nethermind node from trying.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested by logging at hello message.