### PR TITLE
Fix full pruning crash on hash.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -248,7 +248,14 @@ public class FullPrunerTests
                     FullPruningMaxDegreeOfParallelism = degreeOfParallelism,
                     FullPruningMemoryBudgetMb = fullScanMemoryBudgetMb,
                     FullPruningCompletionBehavior = completionBehavior
-                }, BlockTree, StateReader, ProcessExitSource, _chainEstimations, DriveInfo, Substitute.For<IPruningTrieStore>(), LimboLogs.Instance);
+                },
+                BlockTree,
+                StateReader,
+                ProcessExitSource,
+                _chainEstimations,
+                DriveInfo,
+                new TrieStore(NodeStorage, LimboLogs.Instance),
+                LimboLogs.Instance);
         }
 
         public async Task RunFullPruning()

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -1004,13 +1004,13 @@ public class TrieStore : ITrieStore, IPruningTrieStore
             // need existing node will have to read back from db causing copy-on-read mechanism to copy the node.
             void ClearCommitSetQueue()
             {
-                while (_commitSetQueue.TryPeek(out BlockCommitSet commitSet) && commitSet.IsSealed)
+                while (CommitSetQueue.TryPeek(out BlockCommitSet commitSet) && commitSet.IsSealed)
                 {
-                    if (!_commitSetQueue.TryDequeue(out commitSet)) break;
+                    if (!CommitSetQueue.TryDequeue(out commitSet)) break;
                     if (!commitSet.IsSealed)
                     {
                         // Oops
-                        _commitSetQueue.Enqueue(commitSet);
+                        CommitSetQueue.Enqueue(commitSet);
                         break;
                     }
 
@@ -1019,7 +1019,7 @@ public class TrieStore : ITrieStore, IPruningTrieStore
                 }
             }
 
-            if (!(_commitSetQueue?.IsEmpty ?? true))
+            if (!CommitSetQueue.IsEmpty)
             {
                 // We persist outside of lock first.
                 ClearCommitSetQueue();

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -406,7 +406,7 @@ internal class TrieStoreDirtyNodesCache
 
     public void ClearLivePruningTracking()
     {
-        _persistedLastSeen.Clear();
+        _persistedLastSeen?.Clear();
         _pastPathHash?.Clear();
     }
 


### PR DESCRIPTION
- Full pruning tests uses nsubstitue triestore so its not detected at first.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing
