### PR TITLE
Deactivate RIP-7212 for Prague

### DIFF
--- a/src/Nethermind/Nethermind.Specs/Forks/18_Prague.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/18_Prague.cs
@@ -20,7 +20,6 @@ public class Prague : Cancun
         IsEip6110Enabled = true;
         IsEip7002Enabled = true;
         IsEip7251Enabled = true;
-        IsRip7212Enabled = true;
         Eip2935ContractAddress = Eip2935Constants.BlockHashHistoryAddress;
     }
 


### PR DESCRIPTION
p256Verify was removed from Prague, but the precompile is still activated, impacting things such like warm address calculations as well as intentional calls.

## Changes

- Remove p256verify activation from prague

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
