### PR TITLE
fix tracing posdao blocks

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
@@ -1,0 +1,300 @@
+﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using Nethermind.Api;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Config;
+using Nethermind.Consensus.AuRa.Config;
+using Nethermind.Consensus.AuRa.Contracts;
+using Nethermind.Consensus.AuRa.Transactions;
+using Nethermind.Consensus.AuRa.Validators;
+using Nethermind.Consensus.ExecutionRequests;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Validators;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Db;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Init.Steps;
+using Nethermind.Init.Steps.Migrations;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.JsonRpc.Modules.DebugModule;
+using Nethermind.JsonRpc.Modules.Trace;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Consensus.AuRa.InitializationSteps;
+
+public class RegisterAuRaRpcModules : RegisterRpcModules
+{
+    public RegisterAuRaRpcModules(AuRaNethermindApi api) : base(api)
+    {
+        _api = api;
+        _parameters = _api.ChainSpec.EngineChainSpecParametersProvider
+            .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
+        _auraConfig = _api.Config<IAuraConfig>();
+        _factory = CreateFactory();
+    }
+
+    private static AuRaNethermindApi _api = null!;
+    private static AuRaChainSpecEngineParameters _parameters = null!;
+    private static IAuraConfig _auraConfig = null!;
+    private readonly IAuRaBlockProcessorFactory _factory;
+
+    protected virtual IAuRaBlockProcessorFactory CreateFactory() => new AuRaBlockProcessorFactory();
+
+    protected override void RegisterTraceRpcModule(IRpcModuleProvider rpcModuleProvider)
+    {
+        StepDependencyException.ThrowIfNull(_api.WorldStateManager);
+        StepDependencyException.ThrowIfNull(_api.DbProvider);
+        StepDependencyException.ThrowIfNull(_api.BlockTree);
+        StepDependencyException.ThrowIfNull(_api.RewardCalculatorSource);
+        StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
+        StepDependencyException.ThrowIfNull(_api.SpecProvider);
+
+        AuRaTraceModuleFactory traceModuleFactory = new(
+            _api.WorldStateManager.TrieStore,
+            _api.DbProvider,
+            _api.BlockTree,
+            _jsonRpcConfig,
+            _api.BlockPreprocessor,
+            _api.RewardCalculatorSource,
+            _api.ReceiptStorage,
+            _api.SpecProvider,
+            _api.PoSSwitcher,
+            _api.LogManager,
+            _factory);
+
+        rpcModuleProvider.RegisterBoundedByCpuCount(traceModuleFactory, _jsonRpcConfig.Timeout);
+    }
+
+    protected class AuRaTraceModuleFactory(
+        IReadOnlyTrieStore trieStore,
+        IDbProvider dbProvider,
+        IBlockTree blockTree,
+        IJsonRpcConfig jsonRpcConfig,
+        IBlockPreprocessorStep recoveryStep,
+        IRewardCalculatorSource rewardCalculatorSource,
+        IReceiptStorage receiptFinder,
+        ISpecProvider specProvider,
+        IPoSSwitcher poSSwitcher,
+        ILogManager logManager,
+        IAuRaBlockProcessorFactory factory)
+        : TraceModuleFactory(trieStore, dbProvider, blockTree, jsonRpcConfig, recoveryStep, rewardCalculatorSource,
+            receiptFinder, specProvider, poSSwitcher, logManager)
+    {
+        protected override ReadOnlyChainProcessingEnv CreateChainProcessingEnv(OverridableWorldStateManager worldStateManager,
+            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor, IReadOnlyTxProcessingScope scope,
+            IRewardCalculator rewardCalculator)
+        {
+            return new AuRaReadOnlyChainProcessingEnv(
+                scope,
+                Always.Valid,
+                _recoveryStep,
+                rewardCalculator,
+                _receiptStorage,
+                _specProvider,
+                _blockTree,
+                worldStateManager.GlobalStateReader,
+                _logManager,
+                transactionsExecutor,
+                factory);
+        }
+    }
+
+    protected class AuRaReadOnlyChainProcessingEnv(
+        IReadOnlyTxProcessingScope scope,
+        IBlockValidator blockValidator,
+        IBlockPreprocessorStep recoveryStep,
+        IRewardCalculator rewardCalculator,
+        IReceiptStorage receiptStorage,
+        ISpecProvider specProvider,
+        IBlockTree blockTree,
+        IStateReader stateReader,
+        ILogManager logManager,
+        IBlockProcessor.IBlockTransactionsExecutor? blockTransactionsExecutor,
+        IAuRaBlockProcessorFactory factory)
+        : ReadOnlyChainProcessingEnv(scope, blockValidator, recoveryStep, rewardCalculator, receiptStorage,
+            specProvider, blockTree, stateReader, logManager, blockTransactionsExecutor)
+    {
+        protected override IBlockProcessor CreateBlockProcessor(IReadOnlyTxProcessingScope scope, IBlockTree blockTree,
+            IBlockValidator blockValidator, IRewardCalculator rewardCalculator, IReceiptStorage receiptStorage,
+            ISpecProvider specProvider, ILogManager logManager, IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor)
+        {
+            ITxFilter auRaTxFilter = new ServiceTxFilter(specProvider);
+
+            var chainSpecAuRa = _api.ChainSpec.EngineChainSpecParametersProvider.GetChainSpecParameters<AuRaChainSpecEngineParameters>();
+            IDictionary<long, IDictionary<Address, byte[]>> rewriteBytecode = chainSpecAuRa.RewriteBytecode;
+            ContractRewriter? contractRewriter = rewriteBytecode?.Count > 0 ? new ContractRewriter(rewriteBytecode) : null;
+
+            return factory.Create(
+                specProvider!,
+                blockValidator!,
+                rewardCalculator,
+                transactionsExecutor,
+                scope.WorldState,
+                receiptStorage,
+                new BeaconBlockRootHandler(scope.TransactionProcessor, scope.WorldState),
+                logManager,
+                blockTree,
+                NullWithdrawalProcessor.Instance,
+                scope.TransactionProcessor,
+                auRaValidator: null,
+                auRaTxFilter,
+                GetGasLimitCalculator(),
+                contractRewriter
+            );
+        }
+
+        private AuRaContractGasLimitOverride? GetGasLimitCalculator()
+        {
+            if (_api.ChainSpec is null) throw new StepDependencyException(nameof(_api.ChainSpec));
+            var blockGasLimitContractTransitions = _parameters.BlockGasLimitContractTransitions;
+
+            if (blockGasLimitContractTransitions?.Any() == true)
+            {
+                AuRaContractGasLimitOverride gasLimitCalculator = new(
+                    blockGasLimitContractTransitions.Select(blockGasLimitContractTransition =>
+                            new BlockGasLimitContract(
+                                _api.AbiEncoder,
+                                blockGasLimitContractTransition.Value,
+                                blockGasLimitContractTransition.Key,
+                                _api.CreateReadOnlyTransactionProcessorSource()))
+                        .ToArray<IBlockGasLimitContract>(),
+                    _api.GasLimitCalculatorCache,
+                    _auraConfig.Minimum2MlnGasPerBlockWhenUsingBlockGasLimitContract,
+                    new TargetAdjustedGasLimitCalculator(_api.SpecProvider, _api.Config<IBlocksConfig>()),
+                    _api.LogManager);
+
+                return gasLimitCalculator;
+            }
+
+            // do not return target gas limit calculator here - this is used for validation to check if the override should have been used
+            return null;
+        }
+    }
+
+    protected override void RegisterDebugRpcModule(IRpcModuleProvider rpcModuleProvider)
+    {
+        StepDependencyException.ThrowIfNull(_api.DbProvider);
+        StepDependencyException.ThrowIfNull(_api.BlockPreprocessor);
+        StepDependencyException.ThrowIfNull(_api.BlockValidator);
+        StepDependencyException.ThrowIfNull(_api.RewardCalculatorSource);
+        StepDependencyException.ThrowIfNull(_api.KeyStore);
+        StepDependencyException.ThrowIfNull(_api.PeerPool);
+        StepDependencyException.ThrowIfNull(_api.BadBlocksStore);
+        StepDependencyException.ThrowIfNull(_api.WorldStateManager);
+        StepDependencyException.ThrowIfNull(_api.BlockTree);
+        StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
+        StepDependencyException.ThrowIfNull(_api.SpecProvider);
+
+        AuRaDebugModuleFactory debugModuleFactory = new(
+            _api.WorldStateManager.TrieStore,
+            _api.DbProvider,
+            _api.BlockTree,
+            _jsonRpcConfig,
+            _api.BlockValidator,
+            _api.BlockPreprocessor,
+            _api.RewardCalculatorSource,
+            _api.ReceiptStorage,
+            new ReceiptMigration(_api),
+            _api.ConfigProvider,
+            _api.SpecProvider,
+            _api.SyncModeSelector,
+            _api.BadBlocksStore,
+            _api.FileSystem,
+            _api.LogManager,
+            _factory);
+
+        rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
+    }
+
+    protected class AuRaDebugModuleFactory(
+        IReadOnlyTrieStore trieStore,
+        IDbProvider dbProvider,
+        IBlockTree blockTree,
+        IJsonRpcConfig jsonRpcConfig,
+        IBlockValidator blockValidator,
+        IBlockPreprocessorStep recoveryStep,
+        IRewardCalculatorSource rewardCalculator,
+        IReceiptStorage receiptStorage,
+        IReceiptsMigration receiptsMigration,
+        IConfigProvider configProvider,
+        ISpecProvider specProvider,
+        ISyncModeSelector syncModeSelector,
+        IBadBlockStore badBlockStore,
+        IFileSystem fileSystem,
+        ILogManager logManager,
+        IAuRaBlockProcessorFactory factory)
+        : DebugModuleFactory(trieStore, dbProvider, blockTree, jsonRpcConfig, blockValidator, recoveryStep,
+            rewardCalculator, receiptStorage, receiptsMigration, configProvider, specProvider, syncModeSelector,
+            badBlockStore, fileSystem, logManager)
+    {
+        protected override ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(IReadOnlyTxProcessingScope scope,
+            OverridableWorldStateManager worldStateManager, BlockProcessor.BlockValidationTransactionsExecutor transactionsExecutor)
+        {
+            return new AuRaReadOnlyChainProcessingEnv(
+                scope,
+                Always.Valid,
+                _recoveryStep,
+                _rewardCalculatorSource.Get(scope.TransactionProcessor),
+                _receiptStorage,
+                _specProvider,
+                _blockTree,
+                worldStateManager.GlobalStateReader,
+                _logManager,
+                transactionsExecutor,
+                factory);
+        }
+    }
+
+    protected interface IAuRaBlockProcessorFactory
+    {
+        public AuRaBlockProcessor Create(
+            ISpecProvider specProvider,
+            IBlockValidator blockValidator,
+            IRewardCalculator rewardCalculator,
+            IBlockProcessor.IBlockTransactionsExecutor blockTransactionsExecutor,
+            IWorldState stateProvider,
+            IReceiptStorage receiptStorage,
+            IBeaconBlockRootHandler beaconBlockRootHandler,
+            ILogManager logManager,
+            IBlockFinder blockTree,
+            IWithdrawalProcessor withdrawalProcessor,
+            ITransactionProcessor transactionProcessor,
+            IAuRaValidator? auRaValidator,
+            ITxFilter? txFilter = null,
+            AuRaContractGasLimitOverride? gasLimitOverride = null,
+            ContractRewriter? contractRewriter = null,
+            IBlockCachePreWarmer? preWarmer = null,
+            IExecutionRequestsProcessor? executionRequestsProcessor = null);
+    }
+
+    private class AuRaBlockProcessorFactory : IAuRaBlockProcessorFactory
+    {
+        public AuRaBlockProcessor Create(ISpecProvider specProvider, IBlockValidator blockValidator,
+            IRewardCalculator rewardCalculator, IBlockProcessor.IBlockTransactionsExecutor blockTransactionsExecutor, IWorldState stateProvider,
+            IReceiptStorage receiptStorage, IBeaconBlockRootHandler beaconBlockRootHandler, ILogManager logManager,
+            IBlockFinder blockTree, IWithdrawalProcessor withdrawalProcessor, ITransactionProcessor transactionProcessor,
+            IAuRaValidator? auRaValidator, ITxFilter? txFilter = null, AuRaContractGasLimitOverride? gasLimitOverride = null,
+            ContractRewriter? contractRewriter = null, IBlockCachePreWarmer? preWarmer = null,
+            IExecutionRequestsProcessor? executionRequestsProcessor = null) =>
+            new(specProvider, blockValidator, rewardCalculator, blockTransactionsExecutor,
+                stateProvider, receiptStorage, beaconBlockRootHandler, logManager, blockTree, withdrawalProcessor,
+                transactionProcessor, auRaValidator, txFilter, gasLimitOverride, contractRewriter, preWarmer,
+                executionRequestsProcessor);
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Init.Steps;
 public class RegisterRpcModules : IStep
 {
     private readonly INethermindApi _api;
-    private readonly IJsonRpcConfig _jsonRpcConfig;
+    protected readonly IJsonRpcConfig _jsonRpcConfig;
 
     public RegisterRpcModules(INethermindApi api)
     {
@@ -108,23 +108,7 @@ public class RegisterRpcModules : IStep
         ProofModuleFactory proofModuleFactory = new(_api.WorldStateManager, _api.BlockTree, _api.BlockPreprocessor, _api.ReceiptFinder, _api.SpecProvider, _api.LogManager);
         rpcModuleProvider.RegisterBounded(proofModuleFactory, 2, _jsonRpcConfig.Timeout);
 
-        DebugModuleFactory debugModuleFactory = new(
-            _api.WorldStateManager.TrieStore,
-            _api.DbProvider,
-            _api.BlockTree,
-            _jsonRpcConfig,
-            _api.BlockValidator,
-            _api.BlockPreprocessor,
-            _api.RewardCalculatorSource,
-            _api.ReceiptStorage,
-            new ReceiptMigration(_api),
-            _api.ConfigProvider,
-            _api.SpecProvider,
-            _api.SyncModeSelector,
-            _api.BadBlocksStore,
-            _api.FileSystem,
-            _api.LogManager);
-        rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
+        RegisterDebugRpcModule(rpcModuleProvider);
 
         RegisterTraceRpcModule(rpcModuleProvider);
 
@@ -213,6 +197,39 @@ public class RegisterRpcModules : IStep
         ThisNodeInfo.AddInfo("RPC modules  :", $"{string.Join(", ", rpcModuleProvider.Enabled.OrderBy(x => x))}");
 
         await Task.CompletedTask;
+    }
+
+    protected virtual void RegisterDebugRpcModule(IRpcModuleProvider rpcModuleProvider)
+    {
+        StepDependencyException.ThrowIfNull(_api.DbProvider);
+        StepDependencyException.ThrowIfNull(_api.BlockPreprocessor);
+        StepDependencyException.ThrowIfNull(_api.BlockValidator);
+        StepDependencyException.ThrowIfNull(_api.RewardCalculatorSource);
+        StepDependencyException.ThrowIfNull(_api.KeyStore);
+        StepDependencyException.ThrowIfNull(_api.PeerPool);
+        StepDependencyException.ThrowIfNull(_api.BadBlocksStore);
+        StepDependencyException.ThrowIfNull(_api.WorldStateManager);
+        StepDependencyException.ThrowIfNull(_api.BlockTree);
+        StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
+        StepDependencyException.ThrowIfNull(_api.SpecProvider);
+
+        DebugModuleFactory debugModuleFactory = new(
+            _api.WorldStateManager.TrieStore,
+            _api.DbProvider,
+            _api.BlockTree,
+            _jsonRpcConfig,
+            _api.BlockValidator,
+            _api.BlockPreprocessor,
+            _api.RewardCalculatorSource,
+            _api.ReceiptStorage,
+            new ReceiptMigration(_api),
+            _api.ConfigProvider,
+            _api.SpecProvider,
+            _api.SyncModeSelector,
+            _api.BadBlocksStore,
+            _api.FileSystem,
+            _api.LogManager);
+        rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
     }
 
     protected ModuleFactoryBase<IEthRpcModule> CreateEthModuleFactory()

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.Validators;
@@ -30,7 +31,7 @@ public class AuRaMergeBlockProcessor(
     IReceiptStorage receiptStorage,
     IBeaconBlockRootHandler beaconBlockRootHandler,
     ILogManager logManager,
-    IBlockTree blockTree,
+    IBlockFinder blockTree,
     IWithdrawalProcessor withdrawalProcessor,
     ITransactionProcessor transactionProcessor,
     IAuRaValidator? validator,

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/RegisterAuRaMergeRpcModules.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/RegisterAuRaMergeRpcModules.cs
@@ -1,0 +1,46 @@
+﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus.AuRa;
+using Nethermind.Consensus.AuRa.InitializationSteps;
+using Nethermind.Consensus.AuRa.Validators;
+using Nethermind.Consensus.ExecutionRequests;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Validators;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+using Nethermind.State;
+
+namespace Nethermind.Merge.AuRa.InitializationSteps;
+
+public class RegisterAuRaMergeRpcModules(AuRaNethermindApi api) : RegisterAuRaRpcModules(api)
+{
+    protected override IAuRaBlockProcessorFactory CreateFactory()
+    {
+        return new AuRaMergeBlockProcessorFactory();
+    }
+
+    private class AuRaMergeBlockProcessorFactory : IAuRaBlockProcessorFactory
+    {
+        public AuRaBlockProcessor Create(ISpecProvider specProvider, IBlockValidator blockValidator,
+            IRewardCalculator rewardCalculator, IBlockProcessor.IBlockTransactionsExecutor blockTransactionsExecutor, IWorldState stateProvider,
+            IReceiptStorage receiptStorage, IBeaconBlockRootHandler beaconBlockRootHandler, ILogManager logManager,
+            IBlockFinder blockTree, IWithdrawalProcessor withdrawalProcessor, ITransactionProcessor transactionProcessor,
+            IAuRaValidator? auRaValidator, ITxFilter? txFilter = null, AuRaContractGasLimitOverride? gasLimitOverride = null,
+            ContractRewriter? contractRewriter = null, IBlockCachePreWarmer? preWarmer = null,
+            IExecutionRequestsProcessor? executionRequestsProcessor = null)
+        {
+            return new AuRaMergeBlockProcessor(specProvider, blockValidator, rewardCalculator, blockTransactionsExecutor,
+                stateProvider, receiptStorage, beaconBlockRootHandler, logManager, blockTree, withdrawalProcessor,
+                transactionProcessor, auRaValidator, txFilter, gasLimitOverride, contractRewriter, preWarmer,
+                executionRequestsProcessor);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/RegisterAuRaMergeRpcModules.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/RegisterAuRaMergeRpcModules.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Blockchain.BeaconBlockRoot;

--- a/src/Nethermind/Nethermind.Optimism/Rpc/RegisterOptimismRpcModules.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/RegisterOptimismRpcModules.cs
@@ -22,14 +22,12 @@ public class RegisterOptimismRpcModules : RegisterRpcModules
     private readonly OptimismNethermindApi _api;
     private readonly ILogger _logger;
     private readonly IOptimismConfig _config;
-    private readonly IJsonRpcConfig _jsonRpcConfig;
 
     public RegisterOptimismRpcModules(INethermindApi api) : base(api)
     {
         _api = (OptimismNethermindApi)api;
         _config = _api.Config<IOptimismConfig>();
         _logger = _api.LogManager.GetClassLogger();
-        _jsonRpcConfig = _api.Config<IJsonRpcConfig>();
     }
 
     protected override void RegisterEthRpcModule(IRpcModuleProvider rpcModuleProvider)

--- a/src/Nethermind/Nethermind.Taiko/Rpc/RegisterTaikoRpcModules.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/RegisterTaikoRpcModules.cs
@@ -18,13 +18,11 @@ public class RegisterTaikoRpcModules : RegisterRpcModules
 {
     private readonly TaikoNethermindApi _api;
     private readonly ILogger _logger;
-    private readonly IJsonRpcConfig _jsonRpcConfig;
 
     public RegisterTaikoRpcModules(INethermindApi api) : base(api)
     {
         _api = (TaikoNethermindApi)api;
         _logger = api.LogManager.GetClassLogger();
-        _jsonRpcConfig = _api.Config<IJsonRpcConfig>();
     }
 
     protected override void RegisterEthRpcModule(IRpcModuleProvider rpcModuleProvider)


### PR DESCRIPTION
## Changes

- Fixes tracing in posdao by using correct `AuraBlockProcessor`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Remarks

@emlautarom1 @deffrian @flcl42 I see very similar approach in Optimism and Taiko plugins. I think we should unify and refactor it in a way that would allow us to inject `BlockProcessor` type into the traces (`ReadOnlyEnvironment`) better. WDYT?
