### PR TITLE
OP Holocene - Proper EIP-1559 parameters handling

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismHeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismHeaderValidatorTests.cs
@@ -36,6 +36,7 @@ public class OptimismHeaderValidatorTests
         yield return ("0xff0000000100000001", false);
         yield return ("0x000000000000000000", false);
         yield return ("0x000000000000000001", false);
+        yield return ("0x00ffffffff000001bc00", false);
     }
 
     [TestCaseSource(nameof(EIP1559ParametersExtraData))]

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismHeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismHeaderValidatorTests.cs
@@ -23,7 +23,6 @@ public class OptimismHeaderValidatorTests
     private static IEnumerable<(string, bool)> EIP1559ParametersExtraData()
     {
         // Valid
-        yield return ("0x000000000000000000", true);
         yield return ("0x000000000100000000", true);
         yield return ("0x0000000001000001bc", true);
         yield return ("0x0000000001ffffffff", true);
@@ -35,6 +34,7 @@ public class OptimismHeaderValidatorTests
         yield return ("0xffffaaaa", false);
         yield return ("0x01ffffffff00000000", false);
         yield return ("0xff0000000100000001", false);
+        yield return ("0x000000000000000000", false);
         yield return ("0x000000000000000001", false);
     }
 

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
@@ -32,8 +32,7 @@ public class OptimismPayloadPreparationServiceTests
 {
     private static IEnumerable<(OptimismPayloadAttributes, EIP1559Parameters?)> TestCases()
     {
-        bool[] trueFalse = [true, false];
-        foreach (var noTxPool in trueFalse)
+        foreach (var noTxPool in (bool[])[true, false])
         {
             yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 8, 0, 0, 0, 2], NoTxPool = noTxPool }, new EIP1559Parameters(0, 8, 2));
             yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 2, 0, 0, 0, 2], NoTxPool = noTxPool }, new EIP1559Parameters(0, 2, 2));

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
@@ -1,27 +1,28 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core.Test.Builders;
-using NUnit.Framework;
-using FluentAssertions;
-using System;
-using NSubstitute;
-using Nethermind.Core.Specs;
-using Nethermind.Merge.Plugin.BlockProduction;
-using Nethermind.Core.Timers;
-using Nethermind.Logging;
-using Nethermind.Optimism.Rpc;
-using Nethermind.Consensus.Transactions;
-using Nethermind.Consensus.Processing;
-using Nethermind.Blockchain;
-using Nethermind.State;
-using Nethermind.Consensus;
-using Nethermind.Core;
-using Nethermind.Config;
-using Nethermind.Core.Crypto;
-using Nethermind.Evm.Tracing;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System;
+using NUnit.Framework;
+using NSubstitute;
+using Nethermind.State;
+using Nethermind.Optimism.Rpc;
+using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Logging;
+using Nethermind.Int256;
+using Nethermind.Evm.Tracing;
+using Nethermind.Core.Timers;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Crypto;
+using Nethermind.Core;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus;
+using Nethermind.Config;
+using Nethermind.Blockchain;
+using FluentAssertions;
 
 namespace Nethermind.Optimism.Test;
 
@@ -36,7 +37,7 @@ public class OptimismPayloadPreparationServiceTests
             yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 8, 0, 0, 0, 2], NoTxPool = noTxPool }, new EIP1559Parameters(0, 8, 2));
             yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 2, 0, 0, 0, 2], NoTxPool = noTxPool }, new EIP1559Parameters(0, 2, 2));
             yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 2, 0, 0, 0, 10], NoTxPool = noTxPool }, new EIP1559Parameters(0, 2, 10));
-            // yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 0, 0, 0, 0, 0], NoTxPool = true }, new EIP1559Parameters(0, 250, 6));
+            yield return (new OptimismPayloadAttributes { EIP1559Params = [0, 0, 0, 0, 0, 0, 0, 0], NoTxPool = noTxPool }, new EIP1559Parameters(0, 250, 6));
         }
     }
     [TestCaseSource(nameof(TestCases))]
@@ -46,6 +47,8 @@ public class OptimismPayloadPreparationServiceTests
 
         var releaseSpec = Substitute.For<IReleaseSpec>();
         releaseSpec.IsOpHoloceneEnabled.Returns(true);
+        releaseSpec.BaseFeeMaxChangeDenominator.Returns((UInt256)250);
+        releaseSpec.ElasticityMultiplier.Returns(6);
         var specProvider = Substitute.For<ISpecProvider>();
         specProvider.GetSpec(parent).Returns(releaseSpec);
 

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismPayloadPreparationServiceTests.cs
@@ -23,6 +23,7 @@ using Nethermind.Consensus;
 using Nethermind.Config;
 using Nethermind.Blockchain;
 using FluentAssertions;
+using Nethermind.Crypto;
 
 namespace Nethermind.Optimism.Test;
 
@@ -91,5 +92,6 @@ public class OptimismPayloadPreparationServiceTests
         currentBestBlock.Should().Be(block);
         currentBestBlock.Header.TryDecodeEIP1559Parameters(out var parameters, out _).Should().BeTrue();
         parameters.Should().BeEquivalentTo(testCase.ExpectedEIP1559Parameters);
+        currentBestBlock.Header.Hash.Should().BeEquivalentTo(currentBestBlock.Header.CalculateHash());
     }
 }

--- a/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
@@ -31,8 +31,8 @@ public sealed class OptimismBaseFeeCalculator(
             spec = eip1559Params.IsZero()
                 ? new OverridableEip1559Spec(specFor1559)
                 {
-                    ElasticityMultiplier = Eip1559Constants.DefaultElasticityMultiplier,
-                    BaseFeeMaxChangeDenominator = Eip1559Constants.DefaultBaseFeeMaxChangeDenominator
+                    ElasticityMultiplier = spec.ElasticityMultiplier,
+                    BaseFeeMaxChangeDenominator = spec.BaseFeeMaxChangeDenominator
                 }
                 : new OverridableEip1559Spec(specFor1559)
                 {

--- a/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
@@ -23,9 +23,9 @@ public sealed class OptimismBaseFeeCalculator(
         if (parent.Timestamp >= holoceneTimestamp)
         {
             // NOTE: This operation should never fail since headers should be valid at this point.
-            if (!parent.TryDecodeEIP1559Parameters(out EIP1559Parameters eip1559Params, out _))
+            if (!parent.TryDecodeEIP1559Parameters(out EIP1559Parameters eip1559Params, out var error))
             {
-                throw new InvalidOperationException($"{nameof(BlockHeader)} was not properly validated: missing {nameof(EIP1559Parameters)}");
+                throw new InvalidOperationException($"{nameof(BlockHeader)} was not properly validated: {error}");
             }
 
             spec = new OverridableEip1559Spec(specFor1559)

--- a/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBaseFeeCalculator.cs
@@ -28,17 +28,11 @@ public sealed class OptimismBaseFeeCalculator(
                 throw new InvalidOperationException($"{nameof(BlockHeader)} was not properly validated: missing {nameof(EIP1559Parameters)}");
             }
 
-            spec = eip1559Params.IsZero()
-                ? new OverridableEip1559Spec(specFor1559)
-                {
-                    ElasticityMultiplier = spec.ElasticityMultiplier,
-                    BaseFeeMaxChangeDenominator = spec.BaseFeeMaxChangeDenominator
-                }
-                : new OverridableEip1559Spec(specFor1559)
-                {
-                    ElasticityMultiplier = eip1559Params.Elasticity,
-                    BaseFeeMaxChangeDenominator = eip1559Params.Denominator
-                };
+            spec = new OverridableEip1559Spec(specFor1559)
+            {
+                ElasticityMultiplier = eip1559Params.Elasticity,
+                BaseFeeMaxChangeDenominator = eip1559Params.Denominator
+            };
         }
 
         return baseFeeCalculator.Calculate(parent, spec);

--- a/src/Nethermind/Nethermind.Optimism/OptimismHeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismHeaderValidator.cs
@@ -41,9 +41,15 @@ public class OptimismHeaderValidator(
         IReleaseSpec spec = _specProvider.GetSpec(header);
         if (spec.IsOpHoloceneEnabled)
         {
-            if (!header.TryDecodeEIP1559Parameters(out _, out var decodeError))
+            if (!header.TryDecodeEIP1559Parameters(out var parameters, out var decodeError))
             {
                 error = decodeError;
+                return false;
+            }
+
+            if (parameters.IsZero())
+            {
+                error = $"{nameof(EIP1559Parameters)} is zero";
                 return false;
             }
         }

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -6,6 +6,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Timers;
+using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
@@ -62,6 +63,9 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
 
                 currentBestBlock.Header.ExtraData = new byte[EIP1559Parameters.ByteLength];
                 eip1559Parameters.WriteTo(currentBestBlock.Header.ExtraData);
+
+                // NOTE: Since we updated the `Header` we need to recalculate the hash.
+                currentBestBlock.Header.Hash = currentBestBlock.Header.CalculateHash();
             }
         }
 

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -55,6 +55,11 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
                     throw new InvalidOperationException($"{nameof(OptimismPayloadAttributes)} was not properly validated: invalid {nameof(OptimismPayloadAttributes.EIP1559Params)}");
                 }
 
+                if (eip1559Parameters.IsZero())
+                {
+                    eip1559Parameters = new EIP1559Parameters(eip1559Parameters.Version, (UInt32)spec.BaseFeeMaxChangeDenominator, (UInt32)spec.ElasticityMultiplier);
+                }
+
                 currentBestBlock.Header.ExtraData = new byte[EIP1559Parameters.ByteLength];
                 eip1559Parameters.WriteTo(currentBestBlock.Header.ExtraData);
             }

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -51,9 +51,10 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
             var spec = _specProvider.GetSpec(currentBestBlock.Header);
             if (spec.IsOpHoloceneEnabled)
             {
+                // NOTE: This operation should never fail since headers should be valid at this point.
                 if (!optimismPayload.TryDecodeEIP1559Parameters(out EIP1559Parameters eip1559Parameters, out var error))
                 {
-                    throw new InvalidOperationException($"{nameof(OptimismPayloadAttributes)} was not properly validated: invalid {nameof(OptimismPayloadAttributes.EIP1559Params)}");
+                    throw new InvalidOperationException($"{nameof(BlockHeader)} was not properly validated: {error}");
                 }
 
                 if (eip1559Parameters.IsZero())

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismPayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismPayloadAttributes.cs
@@ -35,7 +35,6 @@ public class OptimismPayloadAttributes : PayloadAttributes
     /// See <see href="https://specs.optimism.io/protocol/holocene/exec-engine.html#eip-1559-parameters-in-payloadattributesv3"/>
     /// </remarks>
     public byte[]? EIP1559Params { get; set; }
-    private const int EIP1559ParamsLength = 8;
 
     private int TransactionsLength => Transactions?.Length ?? 0;
 
@@ -121,9 +120,9 @@ public class OptimismPayloadAttributes : PayloadAttributes
             error = $"{nameof(EIP1559Params)} should be null before Holocene";
             return PayloadAttributesValidationResult.InvalidPayloadAttributes;
         }
-        if (releaseSpec.IsOpHoloceneEnabled && EIP1559Params?.Length != EIP1559ParamsLength)
+        if (releaseSpec.IsOpHoloceneEnabled && !this.TryDecodeEIP1559Parameters(out _, out var decodeError))
         {
-            error = $"{nameof(EIP1559Params)} should be {EIP1559ParamsLength} bytes long";
+            error = decodeError;
             return PayloadAttributesValidationResult.InvalidPayloadAttributes;
         }
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -142,6 +142,7 @@ public class ChainSpecLoader(IJsonSerializer serializer) : IChainSpecLoader
             Eip6780TransitionTimestamp = chainSpecJson.Params.Eip6780TransitionTimestamp,
             Rip7212TransitionTimestamp = chainSpecJson.Params.Rip7212TransitionTimestamp,
             OpGraniteTransitionTimestamp = chainSpecJson.Params.OpGraniteTransitionTimestamp,
+            OpHoloceneTransitionTimestamp = chainSpecJson.Params.OpHoloceneTransitionTimestamp,
             Eip4788TransitionTimestamp = chainSpecJson.Params.Eip4788TransitionTimestamp,
             Eip7702TransitionTimestamp = chainSpecJson.Params.Eip7702TransitionTimestamp,
             Eip4788ContractAddress = chainSpecJson.Params.Eip4788ContractAddress ?? Eip4788Constants.BeaconRootsAddress,


### PR DESCRIPTION
Fixes #7903

## Changes

- Properly set up the Holocene timestamp.
- Always store EIP-1559 parameters in `ExtraData`, even when dealing with defaults.
- Ensure Block Header hash is recalculated when needed.
- Use defaults from Chainspec rather than from constants.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Unit tests were extended to include cases where `NoTxPool = true` which were missing from the original PR.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This PR fixes several issues that were found after running some integration tests leveraging Kurtosis and the [optimism-package](https://github.com/ethpandaops/optimism-package). More details will be provided as discussion comments.
