### PR TITLE
Improve Clarity by Fixing Method Name Typo

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -143,7 +143,7 @@ internal static class SetupCli
         return returnRemainder ? line[(i + 1)..] : line[..i];
     }
 
-    public static void SetupDistributeCommand(CliCommand root)
+    public static void DitributeFunds(CliCommand root)
     {
         CliCommand command = new("distribute")
         {


### PR DESCRIPTION
Fixing the typo in the method name from "DitributeFunds" to "DistributeFunds" improves code clarity and maintainability, helping developers quickly understand and trust the code.