### PR TITLE
StorageRange request refactoring for parallel execution

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -168,11 +168,16 @@ public class ProgressTrackerTests
     {
         using ProgressTracker progressTracker = CreateProgressTracker();
 
-        var startHash = new ValueHash256(start);
         var lastProcessedHash = new ValueHash256(lastProcessed);
         ValueHash256? limitHash = limit is null ? (ValueHash256?)null : new ValueHash256(limit);
 
-        progressTracker.EnqueueStorageRange(TestItem.Tree.AccountsWithPaths[0], startHash, lastProcessedHash, limitHash);
+        StorageRange storageRange = new StorageRange()
+        {
+            Accounts = new ArrayPoolList<PathWithAccount>(1) { TestItem.Tree.AccountsWithPaths[0] },
+            StartingHash = new ValueHash256(start),
+            LimitHash = limitHash
+        };
+        progressTracker.EnqueueStorageRange(storageRange, 0, lastProcessedHash);
 
         //ignore account range
         bool isFinished = progressTracker.IsFinished(out _);
@@ -200,11 +205,16 @@ public class ProgressTrackerTests
     {
         using ProgressTracker progressTracker = CreateProgressTracker();
 
-        var startHash = new ValueHash256(start);
         var lastProcessedHash = new ValueHash256(lastProcessed);
         ValueHash256? limitHash = limit is null ? (ValueHash256?)null : new ValueHash256(limit);
 
-        progressTracker.EnqueueStorageRange(TestItem.Tree.AccountsWithPaths[0], startHash, lastProcessedHash, limitHash);
+        StorageRange storageRange = new StorageRange()
+        {
+            Accounts = new ArrayPoolList<PathWithAccount>(1) { TestItem.Tree.AccountsWithPaths[0] },
+            StartingHash = new ValueHash256(start),
+            LimitHash = limitHash
+        };
+        progressTracker.EnqueueStorageRange(storageRange, 0, lastProcessedHash);
 
         //ignore account range
         bool isFinished = progressTracker.IsFinished(out _);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -31,8 +31,6 @@ namespace Nethermind.Synchronization.Test.SnapSync
         private StorageTree _inputStorageTree;
         private Hash256 _storage;
 
-        private readonly PathWithAccount _pathWithAccount = new PathWithAccount(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero));
-
         [OneTimeSetUp]
         public void Setup()
         {
@@ -55,11 +53,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
-            StorageRange storageRange = new StorageRange()
-            {
-                StartingHash = Keccak.Zero,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new PathWithAccount(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            var storageRange = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
             var result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
@@ -77,11 +71,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
-            StorageRange storageRange = new StorageRange()
-            {
-                StartingHash = Keccak.Zero,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new PathWithAccount(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            var storageRange = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
             var result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
@@ -95,11 +85,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             using IContainer container = new ContainerBuilder().AddModule(new TestSynchronizerModule(new TestSyncConfig())).Build();
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
-            StorageRange storageRange = new StorageRange()
-            {
-                StartingHash = TestItem.Tree.SlotsWithPaths[0].Path,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new PathWithAccount(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            var storageRange = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[0].Path);
             var result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths);
 
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
@@ -118,33 +104,21 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             var proof = accountProofCollector.BuildResult();
 
-            var storageRangeRequest = new StorageRange()
-            {
-                StartingHash = Keccak.Zero,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
-            var result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0,TestItem.Tree.SlotsWithPaths[0..2], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
+            var storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
+            var result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
-            storageRangeRequest = new StorageRange()
-            {
-                StartingHash = TestItem.Tree.SlotsWithPaths[2].Path,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
             var result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[2..4], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
-            storageRangeRequest = new StorageRange()
-            {
-                StartingHash = TestItem.Tree.SlotsWithPaths[4].Path,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);
             var result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             Assert.That(result1, Is.EqualTo(AddRangeResult.OK));
@@ -165,38 +139,35 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             var proof = accountProofCollector.BuildResult();
 
-            var storageRangeRequest = new StorageRange()
-            {
-                StartingHash = Keccak.Zero,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            var storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
             var result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
-            accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path });
+            accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
-            storageRangeRequest = new StorageRange()
-            {
-                StartingHash = TestItem.Tree.SlotsWithPaths[2].Path,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
             var result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[3..4], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
-            accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path });
+            accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
-            storageRangeRequest = new StorageRange()
-            {
-                StartingHash = TestItem.Tree.SlotsWithPaths[4].Path,
-                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountAddress0.ValueHash256, new Account(UInt256.Zero).WithChangedStorageRoot(rootHash)) }
-            };
+            storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);
             var result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
             Assert.That(result1, Is.EqualTo(AddRangeResult.OK));
             Assert.That(result2, Is.EqualTo(AddRangeResult.DifferentRootHash));
             Assert.That(result3, Is.EqualTo(AddRangeResult.OK));
+        }
+
+        private static StorageRange PrepareStorageRequest(ValueHash256 accountPath, Hash256 storageRoot, ValueHash256 startingHash)
+        {
+            return new StorageRange()
+            {
+                StartingHash = startingHash,
+                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(accountPath, new Account(UInt256.Zero).WithChangedStorageRoot(storageRoot)) }
+            };
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -10,6 +10,8 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.Libp2p.Core.Enums;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Snap;
@@ -272,8 +274,12 @@ public class SnapServerTest
 
         try
         {
-            AddRangeResult result = snapProvider.AddStorageRange(TestItem.Tree.AccountsWithPaths[0], inputStorageTree.RootHash, Keccak.Zero,
-                storageSlots[0], proofs);
+            var storageRangeRequest = new StorageRange()
+            {
+                StartingHash = Keccak.Zero,
+                Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountsWithPaths[0].Path, new Account(UInt256.Zero).WithChangedStorageRoot(inputStorageTree.RootHash)) }
+            };
+            AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, storageSlots[0], proofs);
 
             result.Should().Be(AddRangeResult.OK);
         }
@@ -311,8 +317,12 @@ public class SnapServerTest
 
             try
             {
-                AddRangeResult result = snapProvider.AddStorageRange(TestItem.Tree.AccountsWithPaths[0], inputStorageTree.RootHash, startRange,
-                    storageSlots[0], proofs);
+                var storageRangeRequest = new StorageRange()
+                {
+                    StartingHash = startRange,
+                    Accounts = new ArrayPoolList<PathWithAccount>(1) { new(TestItem.Tree.AccountsWithPaths[0].Path, new Account(UInt256.Zero).WithChangedStorageRoot(inputStorageTree.RootHash)) }
+                };
+                AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, storageSlots[0], proofs);
 
                 result.Should().Be(AddRangeResult.OK);
                 if (startRange == storageSlots[0][^1].Path.ToCommitment())

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
@@ -40,6 +40,6 @@ public class StateSyncPivotTest
         stateSyncPivot.GetPivotHeader().Should().NotBeNull();
 
         blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(newBestSuggested).TestObject);
-        stateSyncPivot.GetPivotHeader().Number.Should().Be(newBestHeader);
+        stateSyncPivot.GetPivotHeader()!.Number.Should().Be(newBestHeader);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Synchronization.FastSync
         private void TrySetNewBestHeader(string msg)
         {
             BlockHeader bestSuggestedHeader = blockTree.BestSuggestedHeader;
-            long targetBlockNumber = Math.Max(bestSuggestedHeader?.Number ?? 0 + MultiSyncModeSelector.FastSyncLag - syncConfig.StateMinDistanceFromHead, 0);
+            long targetBlockNumber = Math.Max((bestSuggestedHeader?.Number ?? 0) + MultiSyncModeSelector.FastSyncLag - syncConfig.StateMinDistanceFromHead, 0);
             BlockHeader bestHeader = blockTree.FindHeader(targetBlockNumber);
             if (bestHeader is not null)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Synchronization.SnapSync
         private const int CODES_BATCH_SIZE = 1_000;
         public const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
         private const uint StorageRangeSplitFactor = 2;
-        internal static readonly byte[] ACC_PROGRESS_KEY = Encoding.ASCII.GetBytes("AccountProgressKey");
+        internal static readonly byte[] ACC_PROGRESS_KEY = "AccountProgressKey"u8.ToArray();
 
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely
         // bottlenecked by _syncCommit lock in SnapProviderHelper, which in turns is limited by the IO.
@@ -60,7 +60,7 @@ namespace Nethermind.Synchronization.SnapSync
 
         private readonly FastSync.StateSyncPivot _pivot;
 
-        public ProgressTracker([KeyFilter(DbNames.State)] IDb db, ISyncConfig syncConfig, FastSync.StateSyncPivot pivot, ILogManager logManager)
+        public ProgressTracker([KeyFilter(DbNames.State)] IDb db, ISyncConfig syncConfig, FastSync.StateSyncPivot pivot, ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _db = db ?? throw new ArgumentNullException(nameof(db));
@@ -140,8 +140,8 @@ namespace Nethermind.Synchronization.SnapSync
             Interlocked.Increment(ref _reqCount);
 
             BlockHeader? pivotHeader = _pivot.GetPivotHeader();
-            Hash256 rootHash = pivotHeader.StateRoot!;
-            var blockNumber = pivotHeader.Number;
+            Hash256? rootHash = pivotHeader?.StateRoot ?? Hash256.Zero;
+            long blockNumber = pivotHeader?.Number ?? 0;
 
             if (!AccountsToRefresh.IsEmpty)
             {
@@ -293,11 +293,11 @@ namespace Nethermind.Synchronization.SnapSync
             Interlocked.Decrement(ref _activeCodeRequests);
         }
 
-        public void ReportAccountRefreshFinished(AccountsToRefreshRequest accountsToRefreshRequest = null)
+        public void ReportAccountRefreshFinished(AccountsToRefreshRequest? accountsToRefreshRequest = null)
         {
             if (accountsToRefreshRequest is not null)
             {
-                foreach (var path in accountsToRefreshRequest.Paths)
+                foreach (AccountWithStorageStartingHash path in accountsToRefreshRequest.Paths)
                 {
                     AccountsToRefresh.Enqueue(path);
                 }
@@ -317,7 +317,7 @@ namespace Nethermind.Synchronization.SnapSync
             AccountsToRefresh.Enqueue(new AccountWithStorageStartingHash() { PathAndAccount = pathWithAccount, StorageStartingHash = startingHash.GetValueOrDefault(), StorageHashLimit = hashLimit ?? Keccak.MaxValue });
         }
 
-        public void ReportFullStorageRequestFinished(IEnumerable<PathWithAccount> storages = default)
+        public void ReportFullStorageRequestFinished(IEnumerable<PathWithAccount>? storages = null)
         {
             if (storages is not null)
             {
@@ -330,7 +330,7 @@ namespace Nethermind.Synchronization.SnapSync
             Interlocked.Decrement(ref _activeStorageRequests);
         }
 
-        public void EnqueueStorageRange(StorageRange storageRange)
+        public void EnqueueStorageRange(StorageRange? storageRange)
         {
             if (storageRange is not null)
             {
@@ -340,46 +340,45 @@ namespace Nethermind.Synchronization.SnapSync
 
         public void EnqueueStorageRange(StorageRange parentRequest, int accountIndex, ValueHash256 lastProcessedHash)
         {
-            var startingHash = parentRequest.StartingHash;
-            var limitHash = parentRequest.LimitHash ?? Keccak.MaxValue;
-
+            ValueHash256 limitHash = parentRequest.LimitHash ?? Keccak.MaxValue;
             if (lastProcessedHash > limitHash)
                 return;
 
+            ValueHash256? startingHash = parentRequest.StartingHash;
+            PathWithAccount account = parentRequest.Accounts[accountIndex];
             UInt256 limit = new UInt256(limitHash.Bytes, true);
             UInt256 lastProcessed = new UInt256(lastProcessedHash.Bytes, true);
             UInt256 start = startingHash.HasValue ? new UInt256(startingHash.Value.Bytes, true) : UInt256.Zero;
 
-            var fullRange = limit - start;
+            UInt256 fullRange = limit - start;
 
             if (lastProcessed < fullRange / StorageRangeSplitFactor + start)
             {
-                var halfOfLeft = (limit - lastProcessed) / 2 + lastProcessed;
-                var halfOfLeftHash = new ValueHash256(halfOfLeft);
+                ValueHash256 halfOfLeftHash = new((limit - lastProcessed) / 2 + lastProcessed);
 
-                NextSlotRange.Enqueue(new StorageRange()
+                NextSlotRange.Enqueue(new StorageRange
                 {
-                    Accounts = new ArrayPoolList<PathWithAccount>(1) { parentRequest.Accounts[accountIndex] },
+                    Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
                     StartingHash = lastProcessedHash,
                     LimitHash = halfOfLeftHash
                 });
 
-                NextSlotRange.Enqueue(new StorageRange()
+                NextSlotRange.Enqueue(new StorageRange
                 {
-                    Accounts = new ArrayPoolList<PathWithAccount>(1) { parentRequest.Accounts[accountIndex] },
+                    Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
                     StartingHash = halfOfLeftHash,
                     LimitHash = limitHash
                 });
 
                 if (_logger.IsTrace)
-                    _logger.Trace($"EnqueueStorageRange account {parentRequest.Accounts[accountIndex].Path} start hash: {startingHash} | last processed: {lastProcessedHash} | limit: {limitHash} | split {halfOfLeftHash}");
+                    _logger.Trace($"EnqueueStorageRange account {account.Path} start hash: {startingHash} | last processed: {lastProcessedHash} | limit: {limitHash} | split {halfOfLeftHash}");
             }
             else
             {
                 //default - no split
-                var storageRange = new StorageRange()
+                var storageRange = new StorageRange
                 {
-                    Accounts = new ArrayPoolList<PathWithAccount>(1) { parentRequest.Accounts[accountIndex] },
+                    Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
                     StartingHash = lastProcessedHash,
                     LimitHash = limitHash
                 };
@@ -387,7 +386,7 @@ namespace Nethermind.Synchronization.SnapSync
             }
         }
 
-        public void ReportStorageRangeRequestFinished(StorageRange storageRange = null)
+        public void ReportStorageRangeRequestFinished(StorageRange? storageRange = null)
         {
             EnqueueStorageRange(storageRange);
 
@@ -433,7 +432,7 @@ namespace Nethermind.Synchronization.SnapSync
             byte[] progress = _db.Get(ACC_PROGRESS_KEY);
             if (progress is { Length: 32 })
             {
-                ValueHash256 path = new ValueHash256(progress);
+                ValueHash256 path = new(progress);
 
                 if (path == ValueKeccak.MaxValue)
                 {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -140,8 +140,8 @@ namespace Nethermind.Synchronization.SnapSync
             Interlocked.Increment(ref _reqCount);
 
             BlockHeader? pivotHeader = _pivot.GetPivotHeader();
-            Hash256? rootHash = pivotHeader?.StateRoot ?? Hash256.Zero;
-            long blockNumber = pivotHeader?.Number ?? 0;
+            Hash256 rootHash = pivotHeader!.StateRoot!;
+            long blockNumber = pivotHeader.Number;
 
             if (!AccountsToRefresh.IsEmpty)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -110,11 +110,10 @@ namespace Nethermind.Synchronization.SnapSync
 
         public static (AddRangeResult result, bool moreChildrenToRight) AddStorageRange(
             StorageTree tree,
-            in ValueHash256? startingHash,
-            IReadOnlyList<PathWithStorageSlot> slots,
-            in ValueHash256 expectedRootHash,
-            in ValueHash256? limitHash,
             PathWithAccount account,
+            IReadOnlyList<PathWithStorageSlot> slots,
+            in ValueHash256? startingHash,
+            in ValueHash256? limitHash,
             IReadOnlyList<byte[]>? proofs = null
         )
         {
@@ -123,7 +122,7 @@ namespace Nethermind.Synchronization.SnapSync
             ValueHash256 lastHash = slots[^1].Path;
 
             (AddRangeResult result, List<(TrieNode, TreePath)> sortedBoundaryList, bool moreChildrenToRight) = FillBoundaryTree(
-                tree, startingHash, lastHash, limitHash ?? Keccak.MaxValue, expectedRootHash, proofs);
+                tree, startingHash, lastHash, limitHash ?? Keccak.MaxValue, account.Account.StorageRoot, proofs);
 
             if (result != AddRangeResult.OK)
             {
@@ -139,7 +138,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             tree.UpdateRootHash();
 
-            if (tree.RootHash.ValueHash256 != expectedRootHash)
+            if (tree.RootHash.ValueHash256 != account.Account.StorageRoot)
             {
                 return (AddRangeResult.DifferentRootHash, true);
             }


### PR DESCRIPTION
Refactoring Storage Range requests in snap sync to pass through original request object when spliting accounts storage range for parallel execution. Additional change to #7733 

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
