### PR TITLE
Code fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 COPY src/Nethermind src/Nethermind
 
 RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
-    dotnet publish src/Nethermind/Nethermind.Runner -c $BUILD_CONFIG -a $arch -o /publish --sc false \
+    dotnet publish src/Nethermind/Nethermind.Runner -c "$BUILD_CONFIG" -a "$arch" -o /publish --sc false \
       -p:BuildTimestamp=$BUILD_TIMESTAMP -p:Commit=$COMMIT_HASH
 
 # A temporary symlink to support the old executable name


### PR DESCRIPTION
# Fix: Surround variables with double quotes in Dockerfile

## Changes
- Updated the `dotnet publish` command to quote variables.

  - **Before:**
    ```dockerfile
    dotnet publish src/Nethermind/Nethermind.Runner -c $BUILD_CONFIG -a $arch -o /publish --sc false \
    ```

  - **After:**
    ```dockerfile
    dotnet publish src/Nethermind/Nethermind.Runner -c "$BUILD_CONFIG" -a "$arch" -o /publish --sc false \
    ```

## Purpose
- Prevents errors caused by spaces or special characters in variables.
- Follows shell scripting best practices.
