### PR TITLE
Fix Typos in README Files

### DIFF
--- a/tools/Nethermind.Tools.Kute/README.md
+++ b/tools/Nethermind.Tools.Kute/README.md
@@ -18,7 +18,7 @@ To get real JSON-RPC messages, run the Nethermind Client using the `RpcRecorderS
 
 > We'll assume that the JWT secret used by the Nethermind Client is stored in `keystore/jwt-secret`.
 
-Kute includes a built in help that can be accessed by the options `-h | --help`.
+Kute includes a built-in help that can be accessed by the options `-h | --help`.
 
 Some typical usages are as follows:
 

--- a/tools/SendBlobs/README.md
+++ b/tools/SendBlobs/README.md
@@ -17,7 +17,7 @@ Options:
   --rpcurl <rpcUrl>                      Url of the Json RPC.
   --bloboptions <blobOptions>            Options in format '10x1-2', '2x5-5' etc. for the blobs.
   --privatekey <privateKey>              The key to use for sending blobs.
-  --keyfile <keyFile>                    File containing private keys that each blob tx will be send from.
+  --keyfile <keyFile>                    File containing private keys that each blob tx will be sent from.
   --receiveraddress <receiverAddress>    Receiver address of the blobs.
   --maxfeeperblobgas <maxFeePerBlobGas>  (Optional) Set the maximum fee per blob data.
   --feemultiplier <feeMultiplier>        (Optional) A multiplier to use for gas fees.

--- a/tools/SendBlobs/README.md
+++ b/tools/SendBlobs/README.md
@@ -65,7 +65,7 @@ sh
                                              0x0000000000000000000000000000000000000000000000000000000000000000 \
                                              0x000000000000000000000000000000000000f1c1 10000 4
 
-# send several transactions with 1 blob, with 6 blobs and than with 2 blobs
+# send several transactions with 1 blob, with 6 blobs and then with 2 blobs
 ./SendBlobs --rpcurl http://localhost:8545
             --bloboptions 10x1,10x6,10x2 \
             --privatekey  0x0000000000000000000000000000000000000000000000000000000000000000 \


### PR DESCRIPTION
This PR addresses and fixes several typos in the documentation of the following tools:  

1. **`tools/Nethermind.Tools.Kute/README.md`:**  
   - Corrected "built in" to "built-in" to reflect proper adjective usage.  

2. **`tools/SendBlobs/README.md`:**  
   - Fixed "be send" to "be sent" for proper verb form.  
   - Replaced "and than" with "and then" to ensure correct sequencing expression.  

## Types of Changes  
- [x] Documentation update  
