### PR TITLE
Reduce enumerator boxing in CollectionExtensions

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Core.Collections
 {
@@ -15,13 +16,49 @@ namespace Nethermind.Core.Collections
 
         public static void AddRange<T>(this ICollection<T> list, IEnumerable<T> items)
         {
-            foreach (T item in items)
+            if (items is T[] array)
             {
-                list.Add(item);
+                list.AddRange(array);
+            }
+            else if (items is IList<T> listItems)
+            {
+                list.AddRange(listItems);
+            }
+            else if (items is IReadOnlyList<T> readOnlyList)
+            {
+                list.AddRange(readOnlyList);
+            }
+            else
+            {
+                foreach (T item in items)
+                {
+                    list.Add(item);
+                }
             }
         }
 
-        public static void AddRange<T>(this ICollection<T> list, params T[] items)
+        [OverloadResolutionPriority(2)]
+        public static void AddRange<T>(this ICollection<T> list, IList<T> items)
+        {
+            int count = items.Count;
+            for (int index = 0; index < count; index++)
+            {
+                list.Add(items[index]);
+            }
+        }
+
+        [OverloadResolutionPriority(1)]
+        public static void AddRange<T>(this ICollection<T> list, IReadOnlyList<T> items)
+        {
+            int count = items.Count;
+            for (int index = 0; index < count; index++)
+            {
+                list.Add(items[index]);
+            }
+        }
+
+        [OverloadResolutionPriority(3)]
+        public static void AddRange<T>(this ICollection<T> list, T[] items)
         {
             for (int index = 0; index < items.Length; index++)
             {


### PR DESCRIPTION
## Changes

- Currently boxes the array enumerator

<img width="787" alt="image" src="https://github.com/user-attachments/assets/8f4a63e5-9da3-4274-9343-c04cc80c60eb" />

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
