### PR TITLE
Shrink tx hash cache from 512k to 130k

### DIFF
--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Init
 
         private void AssignTxPoolMemory(ITxPoolConfig txPoolConfig)
         {
-            long hashCacheMemory = txPoolConfig.Size / 4L * 1024L * 128L;
+            long hashCacheMemory = txPoolConfig.Size / 1024L * 128L;
             if ((_remainingMemory * 0.05) < hashCacheMemory)
             {
                 hashCacheMemory = Math.Min((long)(_remainingMemory * 0.05), hashCacheMemory);

--- a/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
@@ -5,7 +5,7 @@ namespace Nethermind.TxPool
 {
     public static class MemoryAllowance
     {
-        public static int MemPoolSize { get; set; } = 1 << 11;
-        public static int TxHashCacheSize { get; set; } = 1 << 19;
+        public static int MemPoolSize { get; set; } = 2_048;
+        public static int TxHashCacheSize { get; set; } = 131_072;
     }
 }


### PR DESCRIPTION
## Changes

- From 1 << 19 to 1 << 17

Etherscan shows pending txs are more in that range; and is cache so some mild over processing is ok and we are unlikely to see all the tx available in a block.

Currently we have 2 x 16MB arrays (32MB) for this cache size; this change brings it down to 2 x 4MB (8MB)

https://etherscan.io/chart/pendingtx
<img width="611" alt="image" src="https://github.com/user-attachments/assets/475105e4-0e5a-40ab-ba69-660916c57c3c" />


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
