### PR TITLE
Skip sstore gas metering read for system tx

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BeaconBlockRootHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BeaconBlockRootHandlerTests.cs
@@ -99,7 +99,7 @@ public class BeaconBlockRootHandlerTests
 
         Assert.That(accessList, Is.Not.Null);
         Assert.That(accessList.Count.AddressesCount, Is.EqualTo(1));
-        Assert.That(accessList.Count.StorageKeysCount, Is.EqualTo(1));
+        Assert.That(accessList.Count.StorageKeysCount, Is.EqualTo(2));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
@@ -72,17 +72,7 @@ public class BeaconBlockRootHandler(ITransactionProcessor processor, IWorldState
             };
 
             transaction.Hash = transaction.CalculateHash();
-
-            // Skip reads in SSTORE for calculating gas cost
-            spec.IsSystemTransaction = true;
-            try
-            {
-                processor.Execute(transaction, header, tracer);
-            }
-            finally
-            {
-                spec.IsSystemTransaction = false;
-            }
+            processor.Execute(transaction, header, tracer);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BeaconBlockRoot/BeaconBlockRootHandler.cs
@@ -43,11 +43,12 @@ public class BeaconBlockRootHandler(ITransactionProcessor processor, IWorldState
         {
             // https://eips.ethereum.org/EIPS/eip-4788
             // Set the storage value at header.timestamp % HISTORY_BUFFER_LENGTH to be header.timestamp
-            UInt256 slotIndex = block.Timestamp % HistoryBufferLength;
-            builder.AddStorage(in slotIndex);
+            ulong slotIndex = header.Timestamp % HistoryBufferLength;
+            UInt256 slot256 = slotIndex;
+            builder.AddStorage(in slot256);
             // Set the storage value at header.timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH to be calldata[0:32]
-            slotIndex += HistoryBufferLength;
-            builder.AddStorage(in slotIndex);
+            slot256 = slotIndex + HistoryBufferLength;
+            builder.AddStorage(in slot256);
         }
 
         return (eip4788ContractAddress, builder.Build());

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -423,6 +423,6 @@ namespace Nethermind.Core.Specs
         /// <summary>
         /// Skip read in SSTORE for calculating gas cost as not charged
         /// </summary>
-        bool IsSystemTransaction { get; set; }
+        bool IsSystemTransaction { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -419,5 +419,10 @@ namespace Nethermind.Core.Specs
         bool IsAuthorizationListEnabled => IsEip7702Enabled;
 
         public bool RequestsEnabled => ConsolidationRequestsEnabled || WithdrawalRequestsEnabled || DepositsEnabled;
+
+        /// <summary>
+        /// Skip read in SSTORE for calculating gas cost as not charged
+        /// </summary>
+        bool IsSystemTransaction { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -133,5 +133,5 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual UInt256? Eip1559BaseFeeMinValue => spec.Eip1559BaseFeeMinValue;
     public virtual bool ValidateReceipts => spec.ValidateReceipts;
 
-    public bool IsSystemTransaction { get => spec.IsSystemTransaction; set => spec.IsSystemTransaction = value; }
+    public virtual bool IsSystemTransaction { get => spec.IsSystemTransaction; }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -132,4 +132,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual Address? FeeCollector => spec.FeeCollector;
     public virtual UInt256? Eip1559BaseFeeMinValue => spec.Eip1559BaseFeeMinValue;
     public virtual bool ValidateReceipts => spec.ValidateReceipts;
+
+    public bool IsSystemTransaction { get => spec.IsSystemTransaction; set => spec.IsSystemTransaction = value; }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -179,5 +179,7 @@ namespace Nethermind.Specs.Test
         public IBaseFeeCalculator BaseFeeCalculator => _spec.BaseFeeCalculator;
         public bool IsEip6110Enabled => _spec.IsEip6110Enabled;
         public Address DepositContractAddress => _spec.DepositContractAddress;
+
+        public bool IsSystemTransaction { get => _spec.IsSystemTransaction; set => _spec.IsSystemTransaction = value; }
     }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -179,7 +179,6 @@ namespace Nethermind.Specs.Test
         public IBaseFeeCalculator BaseFeeCalculator => _spec.BaseFeeCalculator;
         public bool IsEip6110Enabled => _spec.IsEip6110Enabled;
         public Address DepositContractAddress => _spec.DepositContractAddress;
-
-        public bool IsSystemTransaction { get => _spec.IsSystemTransaction; set => _spec.IsSystemTransaction = value; }
+        public bool IsSystemTransaction => _spec.IsSystemTransaction;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -134,6 +134,6 @@ namespace Nethermind.Specs
             set => _eip2935ContractAddress = value;
         }
 
-        public bool IsSystemTransaction { get; set; }
+        public bool IsSystemTransaction => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -133,5 +133,7 @@ namespace Nethermind.Specs
             get => IsEip2935Enabled ? _eip2935ContractAddress : null;
             set => _eip2935ContractAddress = value;
         }
+
+        public bool IsSystemTransaction { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
@@ -8,5 +8,6 @@ namespace Nethermind.Specs
     public class SystemTransactionReleaseSpec(IReleaseSpec spec, bool isAura, bool isGenesis) : ReleaseSpecDecorator(spec)
     {
         public override bool IsEip158Enabled => !isAura && isGenesis && base.IsEip158Enabled;
+        public override bool IsSystemTransaction => true;
     }
 }


### PR DESCRIPTION
## Changes

- Skip read in SSTORE for Beacon Root tx (happens very early in block and prewarming isn't quite fast enough)
- Move prewarming a bit earlier
- Add both Storage slots to Beacon Root access list (trie fill is still needed for the commit)

Before

![image](https://github.com/user-attachments/assets/0419c907-8e25-4219-8b34-f159892a5407)


After
![image](https://github.com/user-attachments/assets/e0b7030f-689a-4805-ac10-0aed2150d189)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
