### PR TITLE
Reduce guard checks and interface calls when using ArrayPoolList

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -30,11 +30,6 @@ namespace Nethermind.Crypto
             _keccakHash.Update(bytesToWrite);
         }
 
-        public override void Write(IReadOnlyList<byte> bytesToWrite)
-        {
-            _keccakHash.Update(bytesToWrite.ToArray());
-        }
-
         public override void WriteByte(byte byteToWrite)
         {
             _keccakHash.Update(MemoryMarshal.CreateSpan(ref byteToWrite, 1));

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -254,10 +254,11 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 : txs.Select(static tx => tx.GasLimit));
 
             List<RewardInfo> rewardInfos = new(txs.Length);
+            Span<long> gasUsedSpan = gasUsed.AsSpan();
             for (int i = 0; i < txs.Length; i++)
             {
                 txs[i].TryCalculatePremiumPerGas(block.BaseFeePerGas, out UInt256 premiumPerGas);
-                rewardInfos.Add(new RewardInfo(gasUsed[i], premiumPerGas));
+                rewardInfos.Add(new RewardInfo(gasUsedSpan[i], premiumPerGas));
             }
 
             rewardInfos.Sort(static (i1, i2) => i1.PremiumPerGas.CompareTo(i2.PremiumPerGas));

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SerializerTester.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SerializerTester.cs
@@ -50,6 +50,7 @@ namespace Nethermind.Network.Test.P2P
             {
                 buffer.Release();
                 buffer2.Release();
+                message.TryDispose();
             }
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -10,6 +10,7 @@ using DotNetty.Buffers;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -196,7 +197,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             HandleIncomingStatusMessage();
             HandleZeroMessage(msg, Eth65MessageCode.NewPooledTransactionHashes);
 
-            _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactions(Arg.Any<Action<GetPooledTransactionsMessage>>(), Arg.Any<IReadOnlyList<Hash256>>());
+            _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactions(Arg.Any<Action<GetPooledTransactionsMessage>>(), Arg.Any<IOwnedReadOnlyList<Hash256>>());
         }
 
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         private readonly Action<GetPooledTransactionsMessage> _doNothing = static msg => msg.Dispose();
         private IPooledTxsRequestor _requestor;
         private ArrayPoolList<Hash256> _response;
-        
+
         [TearDown]
         public void TearDown()
         {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
@@ -12,6 +12,9 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
+using System.Runtime.InteropServices;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
 {
@@ -20,74 +23,79 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         private readonly ITxPool _txPool = Substitute.For<ITxPool>();
         private readonly Action<GetPooledTransactionsMessage> _doNothing = static msg => msg.Dispose();
         private IPooledTxsRequestor _requestor;
-        private IReadOnlyList<Hash256> _request;
-        private IList<Hash256> _expected;
-        private IReadOnlyList<Hash256> _response;
-
+        private ArrayPoolList<Hash256> _response;
+        
+        [TearDown]
+        public void TearDown()
+        {
+            _response?.Dispose();
+        }
 
         [Test]
         public void filter_properly_newPooledTxHashes()
         {
-            _response = new List<Hash256>();
             _requestor = new PooledTxsRequestor(_txPool, new TxPoolConfig());
-            _requestor.RequestTransactions(_doNothing, new List<Hash256> { TestItem.KeccakA, TestItem.KeccakD });
+            using var skipped = new ArrayPoolList<Hash256>(2) { TestItem.KeccakA, TestItem.KeccakD };
+            _requestor.RequestTransactions(_doNothing, skipped);
 
-            _request = new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
-            _expected = new List<Hash256> { TestItem.KeccakB, TestItem.KeccakC };
-            _requestor.RequestTransactions(Send, _request);
-            _response.Should().BeEquivalentTo(_expected);
+            using var request = new ArrayPoolList<Hash256>(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+            using var expected = new ArrayPoolList<Hash256>(3) { TestItem.KeccakB, TestItem.KeccakC };
+            _requestor.RequestTransactions(Send, request);
+            _response.Should().BeEquivalentTo(expected);
         }
 
         [Test]
         public void filter_properly_already_pending_hashes()
         {
-            _response = new List<Hash256>();
             _requestor = new PooledTxsRequestor(_txPool, new TxPoolConfig());
-            _requestor.RequestTransactions(_doNothing, new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC });
+            using var skipped = new ArrayPoolList<Hash256>(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+            _requestor.RequestTransactions(_doNothing, skipped);
 
-            _request = new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
-            _requestor.RequestTransactions(Send, _request);
+            using var request = new ArrayPoolList<Hash256>(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+            _requestor.RequestTransactions(Send, request);
             _response.Should().BeEmpty();
         }
 
         [Test]
         public void filter_properly_discovered_hashes()
         {
-            _response = new List<Hash256>();
             _requestor = new PooledTxsRequestor(_txPool, new TxPoolConfig());
 
-            _request = new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
-            _expected = new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
-            _requestor.RequestTransactions(Send, _request);
-            _response.Should().BeEquivalentTo(_expected);
+            using var request = new ArrayPoolList<Hash256>(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+            using var expected = new ArrayPoolList<Hash256>(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+            _requestor.RequestTransactions(Send, request);
+            _response.Should().BeEquivalentTo(expected);
         }
 
         [Test]
         public void can_handle_empty_argument()
         {
-            _response = new List<Hash256>();
             _requestor = new PooledTxsRequestor(_txPool, new TxPoolConfig());
-            _requestor.RequestTransactions(Send, new List<Hash256>());
+            using var skipped = new ArrayPoolList<Hash256>(0);
+            _requestor.RequestTransactions(Send, skipped);
             _response.Should().BeEmpty();
         }
 
         [Test]
         public void filter_properly_hashes_present_in_hashCache()
         {
-            _response = new List<Hash256>();
             ITxPool txPool = Substitute.For<ITxPool>();
             txPool.IsKnown(Arg.Any<Hash256>()).Returns(true);
             _requestor = new PooledTxsRequestor(txPool, new TxPoolConfig());
 
-            _request = new List<Hash256> { TestItem.KeccakA, TestItem.KeccakB };
-            _expected = new List<Hash256> { };
-            _requestor.RequestTransactions(Send, _request);
-            _response.Should().BeEquivalentTo(_expected);
+            using var request = new ArrayPoolList<Hash256>(2) { TestItem.KeccakA, TestItem.KeccakB };
+            using var expected = new ArrayPoolList<Hash256>(0) { };
+            _requestor.RequestTransactions(Send, request);
+            _response.Should().BeEquivalentTo(expected);
         }
 
         private void Send(GetPooledTransactionsMessage msg)
         {
-            using (msg) _response = msg.Hashes.ToList();
+            _response?.Dispose();
+            using (msg)
+            {
+                _response = msg.Hashes.ToPooledList();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -125,7 +125,7 @@ public class Eth68ProtocolHandlerTests
         HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
 
         _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactionsEth68(Arg.Any<Action<GetPooledTransactionsMessage>>(),
-            Arg.Any<IReadOnlyList<Hash256>>(), Arg.Any<IReadOnlyList<int>>(), Arg.Any<IReadOnlyList<byte>>());
+            Arg.Any<IOwnedReadOnlyList<Hash256>>(), Arg.Any<IOwnedReadOnlyList<int>>(), Arg.Any<IOwnedReadOnlyList<byte>>());
     }
 
     [TestCase(true)]
@@ -163,7 +163,7 @@ public class Eth68ProtocolHandlerTests
         HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
 
         _pooledTxsRequestor.Received(1).RequestTransactionsEth68(Arg.Any<Action<GetPooledTransactionsMessage>>(),
-            Arg.Any<IReadOnlyList<Hash256>>(), Arg.Any<IReadOnlyList<int>>(), Arg.Any<IReadOnlyList<byte>>());
+            Arg.Any<IOwnedReadOnlyList<Hash256>>(), Arg.Any<IOwnedReadOnlyList<int>>(), Arg.Any<IOwnedReadOnlyList<byte>>());
     }
 
     [TestCase(1)]
@@ -255,7 +255,19 @@ public class Eth68ProtocolHandlerTests
         HandleIncomingStatusMessage();
         HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
 
-        _session.Received(messagesCount).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg || m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg));
+        //_session.Received(messagesCount).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(
+        //    m => m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg || m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg
+        //));
+        Console.WriteLine($"messagesCount {messagesCount}");
+        _session.Received(messagesCount).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(
+            m => GetResult(m, maxNumberOfTxsInOneMsg, numberOfTransactions)
+        ));
+    }
+
+    private bool GetResult(GetPooledTransactionsMessage m, int maxNumberOfTxsInOneMsg, int numberOfTransactions)
+    {
+        Console.WriteLine($"Result {m.EthMessage.Hashes.Count} {maxNumberOfTxsInOneMsg} {numberOfTransactions}");
+        return true;// m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg || m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg;
     }
 
     private void HandleIncomingStatusMessage()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/NodeData/GetNodeDataMessageTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/NodeData/GetNodeDataMessageTests.cs
@@ -21,7 +21,7 @@ public class GetNodeDataMessageTests
     public void Sets_values_from_constructor_argument()
     {
         Hash256[] keys = { TestItem.KeccakA, TestItem.KeccakB };
-        GetNodeDataMessage message = new(keys.ToPooledList());
+        using GetNodeDataMessage message = new(keys.ToPooledList());
         keys.Should().BeEquivalentTo(message.Hashes);
     }
 
@@ -34,7 +34,7 @@ public class GetNodeDataMessageTests
     [Test]
     public void To_string()
     {
-        GetNodeDataMessage message = new(ArrayPoolList<Hash256>.Empty());
+        using GetNodeDataMessage message = new(ArrayPoolList<Hash256>.Empty());
         _ = message.ToString();
     }
 
@@ -42,7 +42,7 @@ public class GetNodeDataMessageTests
     public void Packet_type_and_protocol_are_correct()
     {
         Hash256[] keys = { TestItem.KeccakA, TestItem.KeccakB };
-        GetNodeDataMessage message = new(keys.ToPooledList());
+        using GetNodeDataMessage message = new(keys.ToPooledList());
 
         message.PacketType.Should().Be(NodeDataMessageCode.GetNodeData);
         message.Protocol.Should().Be(Protocol.NodeData);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializerTests.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             GetStorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                StoragetRange = new()
+                StorageRange = new()
                 {
                     RootHash = TestItem.KeccakA,
                     Accounts = TestItem.Keccaks.Select(static k => new PathWithAccount(k, null)).ToPooledList(TestItem.Keccaks.Length),
@@ -43,7 +43,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             GetStorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                StoragetRange = new()
+                StorageRange = new()
                 {
                     RootHash = Keccak.OfAnEmptyString,
                     Accounts = ArrayPoolList<PathWithAccount>.Empty(),

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializerTests.cs
@@ -98,7 +98,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
 
             GetTrieNodesMessageSerializer serializer = new();
 
-            GetTrieNodesMessage? msg = serializer.Deserialize(data);
+            using GetTrieNodesMessage? msg = serializer.Deserialize(data);
             byte[] recode = serializer.Serialize(msg);
 
             recode.Should().BeEquivalentTo(data);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializerTests.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void Roundtrip()
         {
-            ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
+            using ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
 
             TrieNodesMessage message = new(data);
 
@@ -27,7 +27,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void RoundtripWithCorrectLength()
         {
-            ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
+            using ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
 
             TrieNodesMessage message = new(data);
             message.RequestId = 1;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
@@ -40,9 +40,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);
-            for (int i = 0; i < message.Hashes.Count; i++)
+            foreach (Hash256 hash in message.Hashes.AsSpan())
             {
-                rlpStream.Encode(message.Hashes[i]);
+                rlpStream.Encode(hash);
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/IPooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/IPooledTxsRequestor.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 
@@ -10,8 +10,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 {
     public interface IPooledTxsRequestor
     {
-        void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes);
-        void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes);
-        void RequestTransactionsEth68(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes, IReadOnlyList<int> sizes, IReadOnlyList<byte> types);
+        void RequestTransactions(Action<GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes);
+        void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes);
+        void RequestTransactionsEth68(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes, IOwnedReadOnlyList<int> sizes, IOwnedReadOnlyList<byte> types);
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -27,15 +27,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
         }
 
-        public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
+        public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes)
         {
-            ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes);
+            ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes.AsSpan());
             RequestPooledTransactions(send, discoveredTxHashes);
         }
 
-        public void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
+        public void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes)
         {
-            ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes);
+            ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes.AsSpan());
 
             if (discoveredTxHashes.Count <= MaxNumberOfTxsInOneMsg)
             {
@@ -56,41 +56,44 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             }
         }
 
-        public void RequestTransactionsEth68(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes, IReadOnlyList<int> sizes, IReadOnlyList<byte> types)
+        public void RequestTransactionsEth68(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes, IOwnedReadOnlyList<int> sizes, IOwnedReadOnlyList<byte> types)
         {
-            using ArrayPoolList<(Hash256 Hash, byte Type, int Size)> discoveredTxHashesAndSizes = AddMarkUnknownHashesEth68(hashes, sizes, types);
+            using ArrayPoolList<(Hash256 Hash, byte Type, int Size)> discoveredTxHashesAndSizes = AddMarkUnknownHashesEth68(hashes.AsSpan(), sizes.AsSpan(), types.AsSpan());
             if (discoveredTxHashesAndSizes.Count == 0) return;
 
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
             ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
 
-            for (int i = 0; i < discoveredTxHashesAndSizes.Count; i++)
+            var discoveredCount = discoveredTxHashesAndSizes.Count;
+            var toRequestCount = 0;
+            foreach ((Hash256 hash, byte type, int size) in discoveredTxHashesAndSizes.AsSpan())
             {
-                int txSize = discoveredTxHashesAndSizes[i].Size;
-                TxType txType = (TxType)discoveredTxHashesAndSizes[i].Type;
+                int txSize = size;
+                TxType txType = (TxType)type;
 
-                if (txSize > packetSizeLeft && hashesToRequest.Count > 0)
+                if (txSize > packetSizeLeft && toRequestCount > 0)
                 {
                     RequestPooledTransactionsEth66(send, hashesToRequest);
-                    hashesToRequest = new ArrayPoolList<Hash256>(discoveredTxHashesAndSizes.Count);
+                    hashesToRequest = new ArrayPoolList<Hash256>(discoveredCount);
                     packetSizeLeft = TransactionsMessage.MaxPacketSize;
+                    toRequestCount = 0;
                 }
 
                 if (_blobSupportEnabled || txType != TxType.Blob)
                 {
-                    hashesToRequest.Add(discoveredTxHashesAndSizes[i].Hash);
+                    hashesToRequest.Add(hash);
                     packetSizeLeft -= txSize;
+                    toRequestCount++;
                 }
             }
 
             RequestPooledTransactionsEth66(send, hashesToRequest);
         }
 
-        private ArrayPoolList<Hash256> AddMarkUnknownHashes(IReadOnlyList<Hash256> hashes)
+        private ArrayPoolList<Hash256> AddMarkUnknownHashes(ReadOnlySpan<Hash256> hashes)
         {
-            int count = hashes.Count;
-            ArrayPoolList<Hash256> discoveredTxHashes = new ArrayPoolList<Hash256>(count);
-            for (int i = 0; i < count; i++)
+            ArrayPoolList<Hash256> discoveredTxHashes = new ArrayPoolList<Hash256>(hashes.Length);
+            for (int i = 0; i < hashes.Length; i++)
             {
                 Hash256 hash = hashes[i];
                 if (!_txPool.IsKnown(hash) && _pendingHashes.Set(hash))
@@ -102,11 +105,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             return discoveredTxHashes;
         }
 
-        private ArrayPoolList<(Hash256, byte, int)> AddMarkUnknownHashesEth68(IReadOnlyList<Hash256> hashes, IReadOnlyList<int> sizes, IReadOnlyList<byte> types)
+        private ArrayPoolList<(Hash256, byte, int)> AddMarkUnknownHashesEth68(ReadOnlySpan<Hash256> hashes, ReadOnlySpan<int> sizes, ReadOnlySpan<byte> types)
         {
-            int count = hashes.Count;
-            ArrayPoolList<(Hash256, byte, int)> discoveredTxHashesAndSizes = new(count);
-            for (int i = 0; i < count; i++)
+            ArrayPoolList<(Hash256, byte, int)> discoveredTxHashesAndSizes = new(hashes.Length);
+            for (int i = 0; i < hashes.Length; i++)
             {
                 Hash256 hash = hashes[i];
                 if (!_txPool.IsKnown(hash) && !_txPool.ContainsTx(hash, (TxType)types[i]) && _pendingHashes.Set(hash))
@@ -120,14 +122,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         private static void RequestPooledTransactions(Action<GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashesToRequest)
         {
-            if (hashesToRequest.Count > 0)
-            {
-                send(new(hashesToRequest));
-            }
-            else
-            {
-                hashesToRequest.Dispose();
-            }
+            send(new(hashesToRequest));
         }
 
         private static void RequestPooledTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashesToRequest)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -259,12 +259,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private ValueTask HandleSlow((IOwnedReadOnlyList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
         {
             IOwnedReadOnlyList<Transaction> transactions = request.txs;
+            ReadOnlySpan<Transaction> transactionsSpan = transactions.AsSpan();
             try
             {
                 int startIdx = request.startIndex;
                 bool isTrace = Logger.IsTrace;
-                int count = transactions.Count;
-                for (int i = startIdx; i < count; i++)
+                for (int i = startIdx; i < transactionsSpan.Length; i++)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -273,7 +273,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                         return ValueTask.CompletedTask;
                     }
 
-                    PrepareAndSubmitTransaction(transactions[i], isTrace);
+                    PrepareAndSubmitTransaction(transactionsSpan[i], isTrace);
                 }
 
                 transactions.Dispose();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
@@ -19,9 +19,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
             NettyRlpStream nettyRlpStream = new(byteBuffer);
 
             nettyRlpStream.StartSequence(contentLength);
-            for (int i = 0; i < message.Transactions.Count; i++)
+            foreach (Transaction tx in message.Transactions.AsSpan())
             {
-                nettyRlpStream.Encode(message.Transactions[i], RlpBehaviors.InMempoolForm);
+                nettyRlpStream.Encode(tx, RlpBehaviors.InMempoolForm);
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -130,11 +130,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             ArrayPoolList<Transaction> txsToSend = new(msg.Hashes.Count);
 
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-            for (int i = 0; i < msg.Hashes.Count; i++)
+            foreach (Hash256 hash in msg.Hashes.AsSpan())
             {
                 if (cancellationToken.IsCancellationRequested) break;
 
-                if (_txPool.TryGetPendingTransaction(msg.Hashes[i], out Transaction tx))
+                if (_txPool.TryGetPendingTransaction(hash, out Transaction tx))
                 {
                     int txSize = tx.GetLength();
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessageSerializer68.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessageSerializer68.cs
@@ -24,15 +24,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages
         public void Serialize(IByteBuffer byteBuffer, NewPooledTransactionHashesMessage68 message)
         {
             int sizesLength = 0;
-            for (int i = 0; i < message.Sizes.Count; i++)
+            foreach (int size in message.Sizes.AsSpan())
             {
-                sizesLength += Rlp.LengthOf(message.Sizes[i]);
+                sizesLength += Rlp.LengthOf(size);
             }
 
             int hashesLength = 0;
-            for (int i = 0; i < message.Hashes.Count; i++)
+            foreach (Hash256 hash in message.Hashes.AsSpan())
             {
-                hashesLength += Rlp.LengthOf(message.Hashes[i]);
+                hashesLength += Rlp.LengthOf(hash);
             }
 
             int totalSize = Rlp.LengthOf(message.Types) + Rlp.LengthOfSequence(sizesLength) + Rlp.LengthOfSequence(hashesLength);
@@ -42,18 +42,18 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(totalSize);
-            rlpStream.Encode(message.Types);
+            rlpStream.Encode(message.Types.AsSpan());
 
             rlpStream.StartSequence(sizesLength);
-            for (int i = 0; i < message.Sizes.Count; ++i)
+            foreach (int size in message.Sizes.AsSpan())
             {
-                rlpStream.Encode(message.Sizes[i]);
+                rlpStream.Encode(size);
             }
 
             rlpStream.StartSequence(hashesLength);
-            for (int i = 0; i < message.Hashes.Count; ++i)
+            foreach (Hash256 hash in message.Hashes.AsSpan())
             {
-                rlpStream.Encode(message.Hashes[i]);
+                rlpStream.Encode(hash);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangeMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangeMessage.cs
@@ -9,11 +9,17 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
     {
         public override int PacketType => SnapMessageCode.GetStorageRanges;
 
-        public StorageRange StoragetRange { get; set; }
+        public StorageRange StorageRange { get; set; }
 
         /// <summary>
         /// Soft limit at which to stop returning data
         /// </summary>
         public long ResponseBytes { get; set; }
+
+        public override void Dispose()
+        {
+            StorageRange?.Dispose();
+            base.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
@@ -16,10 +16,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             NettyRlpStream rlpStream = GetRlpStreamAndStartSequence(byteBuffer, message);
 
             rlpStream.Encode(message.RequestId);
-            rlpStream.Encode(message.StoragetRange.RootHash);
-            rlpStream.Encode(message.StoragetRange.Accounts.Select(static a => a.Path).ToArray()); // TODO: optimize this
-            rlpStream.Encode(message.StoragetRange.StartingHash);
-            rlpStream.Encode(message.StoragetRange.LimitHash);
+            rlpStream.Encode(message.StorageRange.RootHash);
+            rlpStream.Encode(message.StorageRange.Accounts.Select(static a => a.Path).ToArray()); // TODO: optimize this
+            rlpStream.Encode(message.StorageRange.StartingHash);
+            rlpStream.Encode(message.StorageRange.LimitHash);
             rlpStream.Encode(message.ResponseBytes);
         }
 
@@ -30,11 +30,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
 
             message.RequestId = rlpStream.DecodeLong();
 
-            message.StoragetRange = new();
-            message.StoragetRange.RootHash = rlpStream.DecodeKeccak();
-            message.StoragetRange.Accounts = rlpStream.DecodeArrayPoolList(DecodePathWithRlpData);
-            message.StoragetRange.StartingHash = rlpStream.DecodeKeccak();
-            message.StoragetRange.LimitHash = rlpStream.DecodeKeccak();
+            message.StorageRange = new();
+            message.StorageRange.RootHash = rlpStream.DecodeKeccak();
+            message.StorageRange.Accounts = rlpStream.DecodeArrayPoolList(DecodePathWithRlpData);
+            message.StorageRange.StartingHash = rlpStream.DecodeKeccak();
+            message.StorageRange.LimitHash = rlpStream.DecodeKeccak();
             message.ResponseBytes = rlpStream.DecodeLong();
 
             return message;
@@ -48,10 +48,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         public override int GetLength(GetStorageRangeMessage message, out int contentLength)
         {
             contentLength = Rlp.LengthOf(message.RequestId);
-            contentLength += Rlp.LengthOf(message.StoragetRange.RootHash);
-            contentLength += Rlp.LengthOf(message.StoragetRange.Accounts.Select(static a => a.Path).ToArray(), true); // TODO: optimize this
-            contentLength += Rlp.LengthOf(message.StoragetRange.StartingHash);
-            contentLength += Rlp.LengthOf(message.StoragetRange.LimitHash);
+            contentLength += Rlp.LengthOf(message.StorageRange.RootHash);
+            contentLength += Rlp.LengthOf(message.StorageRange.Accounts.Select(static a => a.Path).ToArray(), true); // TODO: optimize this
+            contentLength += Rlp.LengthOf(message.StorageRange.StartingHash);
+            contentLength += Rlp.LengthOf(message.StorageRange.LimitHash);
             contentLength += Rlp.LengthOf(message.ResponseBytes);
 
             return Rlp.LengthOfSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -255,7 +255,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
                 Proofs = ArrayPoolList<byte[]>.Empty(),
                 Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
             };
-            StorageRange? storageRange = getStorageRangeMessage.StoragetRange;
+            StorageRange? storageRange = getStorageRangeMessage.StorageRange;
             (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IOwnedReadOnlyList<byte[]> proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
                 storageRange.StartingHash, storageRange.LimitHash, getStorageRangeMessage.ResponseBytes, cancellationToken);
             StorageRangeMessage? response = new() { Proofs = proofs, Slots = ranges };
@@ -286,7 +286,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             StorageRangeMessage response = await _requestSizer.MeasureLatency(bytesLimit =>
                 SendRequest(new GetStorageRangeMessage()
                 {
-                    StoragetRange = range,
+                    StorageRange = range,
                     ResponseBytes = bytesLimit
                 }, _getStorageRangeRequests, token));
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using DotNetty.Buffers;
 using DotNetty.Common.Utilities;
+using Nethermind.Core.Collections;
 
 namespace Nethermind.Serialization.Rlp
 {
@@ -29,20 +30,6 @@ namespace Nethermind.Serialization.Rlp
             bytesToWrite.CopyTo(target);
             int newWriterIndex = _buffer.WriterIndex + bytesToWrite.Length;
 
-            _buffer.SetWriterIndex(newWriterIndex);
-        }
-
-        public override void Write(IReadOnlyList<byte> bytesToWrite)
-        {
-            _buffer.EnsureWritable(bytesToWrite.Count);
-            Span<byte> target =
-                _buffer.Array.AsSpan(_buffer.ArrayOffset + _buffer.WriterIndex, bytesToWrite.Count);
-            for (int i = 0; i < bytesToWrite.Count; ++i)
-            {
-                target[i] = bytesToWrite[i];
-            }
-
-            int newWriterIndex = _buffer.WriterIndex + bytesToWrite.Count;
             _buffer.SetWriterIndex(newWriterIndex);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -183,15 +183,6 @@ namespace Nethermind.Serialization.Rlp
             _position += bytesToWrite.Length;
         }
 
-        public virtual void Write(IReadOnlyList<byte> bytesToWrite)
-        {
-            for (int i = 0; i < bytesToWrite.Count; ++i)
-            {
-                Data[_position + i] = bytesToWrite[i];
-            }
-            Position += bytesToWrite.Count;
-        }
-
         protected virtual string Description =>
             Data.AsSpan(0, Math.Min(Rlp.DebugMessageContentLength, Length)).ToHexString() ?? "0x";
 
@@ -590,32 +581,6 @@ namespace Nethermind.Serialization.Rlp
                 byte prefix = (byte)(183 + lengthOfLength);
                 WriteByte(prefix);
                 WriteEncodedLength(input.Length);
-                Write(input);
-            }
-        }
-
-        public void Encode(IReadOnlyList<byte> input)
-        {
-            if (input.Count == 0)
-            {
-                WriteByte(EmptyArrayByte);
-            }
-            else if (input.Count == 1 && input[0] < 128)
-            {
-                WriteByte(input[0]);
-            }
-            else if (input.Count < 56)
-            {
-                byte smallPrefix = (byte)(input.Count + 128);
-                WriteByte(smallPrefix);
-                Write(input);
-            }
-            else
-            {
-                int lengthOfLength = Rlp.LengthOfLength(input.Count);
-                byte prefix = (byte)(183 + lengthOfLength);
-                WriteByte(prefix);
-                WriteEncodedLength(input.Count);
                 Write(input);
             }
         }


### PR DESCRIPTION
## Changes

- Convert to .Span for usage and iteration to avoid per iteration guard checks and interface calls; as ends up being a huge amount of non-inlinable calls

<img width="607" alt="image" src="https://github.com/user-attachments/assets/9ef34eff-d58a-46c6-b878-684d8c5014b1" />


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No