### PR TITLE
Change ValueRlpStream to be Span based

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
@@ -19,7 +19,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
     private int _position = 0;
 
     internal readonly string Description =>
-        Data[..Math.Min(Rlp.DebugMessageContentLength, Length)].ToHexString() ?? "0x";
+        Data[..Math.Min(Rlp.DebugMessageContentLength, Data.Length)].ToHexString() ?? "0x";
 
     public int Position
     {
@@ -33,9 +33,9 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
 
     public int PeekNumberOfItemsRemaining(int? beforePosition = null, int maxSearch = int.MaxValue)
     {
-        int positionStored = Position;
+        int positionStored = _position;
         int numberOfItems = 0;
-        while (Position < (beforePosition ?? Length))
+        while (_position < (beforePosition ?? Data.Length))
         {
             int prefix = ReadByte();
             if (prefix <= 128)
@@ -59,7 +59,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
             }
             else
             {
-                Position--;
+                _position--;
                 int sequenceLength = ReadSequenceLength();
                 SkipBytes(sequenceLength);
             }
@@ -71,7 +71,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
             }
         }
 
-        Position = positionStored;
+        _position = positionStored;
         return numberOfItems;
     }
 
@@ -155,7 +155,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         if (prefix < 192)
         {
             throw new RlpException(
-                $"Expected a sequence prefix to be in the range of <192, 255> and got {prefix} at position {Position} in the message of length {Length} starting with {Description}");
+                $"Expected a sequence prefix to be in the range of <192, 255> and got {prefix} at position {_position} in the message of length {Data.Length} starting with {Description}");
         }
 
         if (prefix <= 247)
@@ -300,7 +300,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         if (prefix != 128 + 32)
         {
             throw new RlpException(
-                $"Unexpected prefix of {prefix} when decoding {nameof(Hash256)} at position {Position} in the message of length {Length} starting with {Description}");
+                $"Unexpected prefix of {prefix} when decoding {nameof(Hash256)} at position {_position} in the message of length {Data.Length} starting with {Description}");
         }
 
         ReadOnlySpan<byte> keccakSpan = Read(32);
@@ -329,7 +329,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         if (prefix != 128 + 32)
         {
             throw new RlpException(
-                $"Unexpected prefix of {prefix} when decoding {nameof(Hash256)} at position {Position} in the message of length {Length} starting with {Description}");
+                $"Unexpected prefix of {prefix} when decoding {nameof(Hash256)} at position {_position} in the message of length {Data.Length} starting with {Description}");
         }
 
         ReadOnlySpan<byte> keccakSpan = Read(32);
@@ -448,7 +448,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
 
     public void Reset()
     {
-        Position = 0;
+        _position = 0;
     }
 
     private const byte EmptyArrayByte = 128;
@@ -457,6 +457,6 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
 
     public override readonly string ToString()
     {
-        return $"[{nameof(RlpStream)}|{Position}/{Length}]";
+        return $"[{nameof(RlpStream)}|{_position}/{Data.Length}]";
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -368,7 +368,7 @@ namespace Nethermind.Trie
                     if (data is null)
                     {
                         int length = rlpStream.PeekNextRlpLength();
-                        Span<byte> nextItem = rlpStream.Data.AsSpan(rlpStream.Position, length);
+                        ReadOnlySpan<byte> nextItem = rlpStream.Data.Slice(rlpStream.Position, length);
                         nextItem.CopyTo(destination.Slice(position, nextItem.Length));
                         position += nextItem.Length;
                         rlpStream.SkipBytes(length);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1242,7 +1242,7 @@ namespace Nethermind.Trie
                         default:
                             {
                                 rlpStream.Position--;
-                                Span<byte> fullRlp = rlpStream.PeekNextItem();
+                                ReadOnlySpan<byte> fullRlp = rlpStream.PeekNextItem();
                                 TrieNode child = new(NodeType.Unknown, fullRlp.ToArray());
                                 data = childOrRef = child;
                                 break;
@@ -1309,7 +1309,7 @@ namespace Nethermind.Trie
                         }
                     default:
                         {
-                            Span<byte> fullRlp = rlpStream.PeekNextItem();
+                            ReadOnlySpan<byte> fullRlp = rlpStream.PeekNextItem();
                             TrieNode child = new(NodeType.Unknown, fullRlp.ToArray());
                             rlpStream.SkipItem();
                             output[i] = child;


### PR DESCRIPTION
## Changes

- Use Span as backing data type rather than CappedArray (converting in constructor)

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No
