### PR TITLE
Refactor/move prewarm out of tx env base

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingEnv.cs
@@ -28,13 +28,12 @@ public class OverridableTxProcessingEnv : ReadOnlyTxProcessingEnvBase, IOverrida
         OverridableWorldStateManager worldStateManager,
         IReadOnlyBlockTree readOnlyBlockTree,
         ISpecProvider specProvider,
-        ILogManager? logManager,
-        IWorldState? worldStateToWarmUp = null
-    ) : base(worldStateManager, readOnlyBlockTree, specProvider, logManager, worldStateToWarmUp)
+        ILogManager? logManager
+    ) : base(worldStateManager.GlobalStateReader, worldStateManager.CreateResettableWorldState(), readOnlyBlockTree, specProvider, logManager)
     {
         WorldStateManager = worldStateManager;
         StateProvider = (OverridableWorldState)base.StateProvider;
-        CodeInfoRepository = new(new CodeInfoRepository((worldStateToWarmUp as IPreBlockCaches)?.Caches.PrecompileCache));
+        CodeInfoRepository = new(new CodeInfoRepository());
         Machine = new VirtualMachine(BlockhashProvider, specProvider, CodeInfoRepository, logManager);
         _transactionProcessorLazy = new(CreateTransactionProcessor);
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Consensus.Processing
         {
         }
 
-        public ReadOnlyTxProcessingEnv(
+        private ReadOnlyTxProcessingEnv(
             IStateReader stateReader,
             IWorldState stateProvider,
             ICodeInfoRepository codeInfoRepository,

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
@@ -30,25 +30,36 @@ namespace Nethermind.Consensus.Processing
         public IVirtualMachine Machine { get; }
 
         public ICodeInfoRepository CodeInfoRepository { get; }
+
         public ReadOnlyTxProcessingEnv(
             IWorldStateManager worldStateManager,
-            IBlockTree blockTree,
-            ISpecProvider? specProvider,
-            ILogManager? logManager,
-            IWorldState? worldStateToWarmUp = null)
-            : this(worldStateManager, blockTree.AsReadOnly(), specProvider, logManager, worldStateToWarmUp)
+            IReadOnlyBlockTree readOnlyBlockTree,
+            ISpecProvider specProvider,
+            ILogManager logManager,
+            IWorldState worldStateToWarmUp
+            ) : this(worldStateManager.GlobalStateReader, worldStateManager.CreateResettableWorldState(worldStateToWarmUp), new CodeInfoRepository((worldStateToWarmUp as IPreBlockCaches)?.Caches.PrecompileCache), readOnlyBlockTree, specProvider, logManager)
         {
         }
 
         public ReadOnlyTxProcessingEnv(
             IWorldStateManager worldStateManager,
             IReadOnlyBlockTree readOnlyBlockTree,
-            ISpecProvider? specProvider,
-            ILogManager? logManager,
-            IWorldState? worldStateToWarmUp = null
-            ) : base(worldStateManager, readOnlyBlockTree, specProvider, logManager, worldStateToWarmUp)
+            ISpecProvider specProvider,
+            ILogManager logManager
+            ) : this(worldStateManager.GlobalStateReader, worldStateManager.CreateResettableWorldState(), new CodeInfoRepository(), readOnlyBlockTree, specProvider, logManager)
         {
-            CodeInfoRepository = new CodeInfoRepository((worldStateToWarmUp as IPreBlockCaches)?.Caches.PrecompileCache);
+        }
+
+        public ReadOnlyTxProcessingEnv(
+            IStateReader stateReader,
+            IWorldState stateProvider,
+            ICodeInfoRepository codeInfoRepository,
+            IReadOnlyBlockTree readOnlyBlockTree,
+            ISpecProvider specProvider,
+            ILogManager logManager
+            ) : base(stateReader, stateProvider, readOnlyBlockTree, specProvider, logManager)
+        {
+            CodeInfoRepository = codeInfoRepository;
             Machine = new VirtualMachine(BlockhashProvider, specProvider, CodeInfoRepository, logManager);
             BlockTree = readOnlyBlockTree ?? throw new ArgumentNullException(nameof(readOnlyBlockTree));
             BlockhashProvider = new BlockhashProvider(BlockTree, specProvider, StateProvider, logManager);

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvBase.cs
@@ -18,22 +18,20 @@ public class ReadOnlyTxProcessingEnvBase
     public IBlockhashProvider BlockhashProvider { get; protected set; }
 
     public ISpecProvider SpecProvider { get; }
-    public ILogManager? LogManager { get; set; }
+    protected ILogManager LogManager { get; }
 
     protected ReadOnlyTxProcessingEnvBase(
-        IWorldStateManager worldStateManager,
+        IStateReader stateReader,
+        IWorldState stateProvider,
         IBlockTree readOnlyBlockTree,
-        ISpecProvider? specProvider,
-        ILogManager? logManager,
-        IWorldState? worldStateToWarmUp = null
+        ISpecProvider specProvider,
+        ILogManager logManager
     )
     {
-        ArgumentNullException.ThrowIfNull(specProvider);
-        ArgumentNullException.ThrowIfNull(worldStateManager);
         SpecProvider = specProvider;
-        StateReader = worldStateManager.GlobalStateReader;
-        StateProvider = worldStateManager.CreateResettableWorldState(worldStateToWarmUp);
-        BlockTree = readOnlyBlockTree ?? throw new ArgumentNullException(nameof(readOnlyBlockTree));
+        StateReader = stateReader;
+        StateProvider = stateProvider;
+        BlockTree = readOnlyBlockTree;
         BlockhashProvider = new BlockhashProvider(BlockTree, specProvider, StateProvider, logManager);
         LogManager = logManager;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
@@ -32,9 +32,7 @@ public class ReadOnlyTxProcessingEnvFactory(
         if (worldStateToWarmUp is null)
         {
             return new ReadOnlyTxProcessingEnv(
-                worldStateManager.GlobalStateReader,
-                worldStateManager.CreateResettableWorldState(),
-                new CodeInfoRepository(),
+                worldStateManager,
                 readOnlyBlockTree,
                 specProvider,
                 logManager);

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Blockchain;
 using Nethermind.Core.Specs;
+using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -12,19 +13,40 @@ namespace Nethermind.Consensus.Processing;
 public class ReadOnlyTxProcessingEnvFactory(
     IWorldStateManager worldStateManager,
     IReadOnlyBlockTree readOnlyBlockTree,
-    ISpecProvider? specProvider,
-    ILogManager? logManager,
+    ISpecProvider specProvider,
+    ILogManager logManager,
     IWorldState? worldStateToWarmUp = null) : IReadOnlyTxProcessingEnvFactory
 {
     public ReadOnlyTxProcessingEnvFactory(
         IWorldStateManager worldStateManager,
         IBlockTree blockTree,
-        ISpecProvider? specProvider,
-        ILogManager? logManager,
+        ISpecProvider specProvider,
+        ILogManager logManager,
         IWorldState? worldStateToWarmUp = null)
         : this(worldStateManager, blockTree.AsReadOnly(), specProvider, logManager, worldStateToWarmUp)
     {
     }
 
-    public IReadOnlyTxProcessorSource Create() => new ReadOnlyTxProcessingEnv(worldStateManager, readOnlyBlockTree, specProvider, logManager, worldStateToWarmUp);
+    public IReadOnlyTxProcessorSource Create()
+    {
+        if (worldStateToWarmUp is null)
+        {
+            return new ReadOnlyTxProcessingEnv(
+                worldStateManager.GlobalStateReader,
+                worldStateManager.CreateResettableWorldState(),
+                new CodeInfoRepository(),
+                readOnlyBlockTree,
+                specProvider,
+                logManager);
+        }
+        else
+        {
+            return new ReadOnlyTxProcessingEnv(
+                worldStateManager,
+                readOnlyBlockTree,
+                specProvider,
+                logManager,
+                worldStateToWarmUp);
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -58,7 +58,7 @@ public class SimulateReadOnlyBlocksProcessingEnv : ReadOnlyTxProcessingEnvBase, 
         ISpecProvider specProvider,
         ILogManager? logManager = null,
         bool validate = false)
-        : base(worldStateManager, blockTree, specProvider, logManager)
+        : base(worldStateManager.GlobalStateReader, worldStateManager.CreateResettableWorldState(), blockTree, specProvider, logManager)
     {
         ReadOnlyBlockTree = baseBlockTree;
         DbProvider = readOnlyDbProvider;

--- a/src/Nethermind/Nethermind.Optimism/OptimismOverridableTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismOverridableTxProcessingEnv.cs
@@ -18,9 +18,8 @@ public class OptimismOverridableTxProcessingEnv(
     ISpecProvider specProvider,
     ILogManager logManager,
     IL1CostHelper l1CostHelper,
-    IOptimismSpecHelper opSpecHelper,
-    IWorldState? worldStateToWarmUp = null)
-    : OverridableTxProcessingEnv(worldStateManager, readOnlyBlockTree, specProvider, logManager, worldStateToWarmUp)
+    IOptimismSpecHelper opSpecHelper)
+    : OverridableTxProcessingEnv(worldStateManager, readOnlyBlockTree, specProvider, logManager)
 {
     protected override ITransactionProcessor CreateTransactionProcessor()
     {

--- a/src/Nethermind/Nethermind.Optimism/OptimismReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismReadOnlyTxProcessingEnv.cs
@@ -18,13 +18,11 @@ public class OptimismReadOnlyTxProcessingEnv(
       ISpecProvider specProvider,
       ILogManager logManager,
       IL1CostHelper l1CostHelper,
-      IOptimismSpecHelper opSpecHelper,
-      IWorldState? worldStateToWarmUp = null) : ReadOnlyTxProcessingEnv(
+      IOptimismSpecHelper opSpecHelper) : ReadOnlyTxProcessingEnv(
       worldStateManager,
       readOnlyBlockTree,
       specProvider,
-      logManager,
-      worldStateToWarmUp
+      logManager
      )
 {
     protected override ITransactionProcessor CreateTransactionProcessor()

--- a/src/Nethermind/Nethermind.Taiko/TaikoReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoReadOnlyTxProcessingEnv.cs
@@ -14,14 +14,12 @@ public class TaikoReadOnlyTxProcessingEnv(
   OverridableWorldStateManager worldStateManager,
   IReadOnlyBlockTree readOnlyBlockTree,
   ISpecProvider specProvider,
-  ILogManager logManager,
-  IWorldState? worldStateToWarmUp = null) : OverridableTxProcessingEnv(
+  ILogManager logManager) : OverridableTxProcessingEnv(
   worldStateManager,
   readOnlyBlockTree,
   specProvider,
-  logManager,
-  worldStateToWarmUp
- )
+  logManager
+)
 {
     protected override ITransactionProcessor CreateTransactionProcessor() =>
         new TaikoTransactionProcessor(SpecProvider, StateProvider, Machine, CodeInfoRepository, LogManager);

--- a/src/Nethermind/Nethermind.Taiko/TaikoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoReadOnlyTxProcessingEnvFactory.cs
@@ -12,8 +12,7 @@ public class TaikoReadOnlyTxProcessingEnvFactory(
     OverridableWorldStateManager worldStateManager,
     IReadOnlyBlockTree readOnlyBlockTree,
     ISpecProvider specProvider,
-    ILogManager logManager,
-    IWorldState? worldStateToWarmUp = null)
+    ILogManager logManager)
 {
-    public TaikoReadOnlyTxProcessingEnv Create() => new(worldStateManager, readOnlyBlockTree, specProvider, logManager, worldStateToWarmUp);
+    public TaikoReadOnlyTxProcessingEnv Create() => new(worldStateManager, readOnlyBlockTree, specProvider, logManager);
 }


### PR DESCRIPTION
- Move worldStateToWarmUp out of `ReadOnlyTxProcessingEnvBase` as other read only tx processing does not need it.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Can run just  fine.
