### PR TITLE
Reuse thread state when prewarming addresses in parallel

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -275,8 +275,9 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
                     block.Transactions.Length,
                     parallelOptions,
                     baseState.InitThreadState,
-                static (i, state) =>
+                static (i, nullableState) =>
                 {
+                    AddressWarmingState state = nullableState.GetValueOrDefault();
                     Transaction tx = state.Block.Transactions[i];
                     Address? sender = tx.SenderAddress;
 
@@ -303,7 +304,7 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
 
     private readonly struct AddressWarmingState(ObjectPool<IReadOnlyTxProcessorSource> envPool, Block block, Hash256 stateRoot) : IDisposable
     {
-        public static Action<AddressWarmingState> FinallyAction { get; } = DisposeThreadState;
+        public static Action<AddressWarmingState?> FinallyAction { get; } = DisposeThreadState;
 
         public readonly ObjectPool<IReadOnlyTxProcessorSource> EnvPool = envPool;
         public readonly Block Block = block;
@@ -317,7 +318,7 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
             Scope = scope;
         }
 
-        public AddressWarmingState InitThreadState()
+        public AddressWarmingState? InitThreadState()
         {
             IReadOnlyTxProcessorSource env = EnvPool.Get();
             return new(EnvPool, Block, StateRoot, env, scope: env.Build(StateRoot));
@@ -329,7 +330,7 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
             EnvPool.Return(Env);
         }
 
-        private static void DisposeThreadState(AddressWarmingState state) => state.Dispose();
+        private static void DisposeThreadState(AddressWarmingState? state) => state?.Dispose();
     }
 
     private class ReadOnlyTxProcessingEnvPooledObjectPolicy(ReadOnlyTxProcessingEnvFactory envFactory) : IPooledObjectPolicy<IReadOnlyTxProcessorSource>

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -55,6 +55,8 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         {
             data.Event.Wait();
         }
+
+        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <summary>
@@ -142,7 +144,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             int i = _data.Index.GetNext();
             while (i < _data.ToExclusive)
             {
-                _data.CancellationToken.ThrowIfCancellationRequested();
+                if (_data.CancellationToken.IsCancellationRequested) return;
                 _data.Action(i);
                 // Get the next index
                 i = _data.Index.GetNext();
@@ -277,6 +279,8 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             {
                 data.Event.Wait();
             }
+
+            parallelOptions.CancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>
@@ -296,7 +300,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
                 int i = _data.Index.GetNext();
                 while (i < _data.ToExclusive)
                 {
-                    _data.CancellationToken.ThrowIfCancellationRequested();
+                    if (_data.CancellationToken.IsCancellationRequested) return;
                     value = _data.Action(i, value);
                     i = _data.Index.GetNext();
                 }

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -334,7 +334,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             /// Initializes the thread-local data.
             /// </summary>
             /// <returns>The initialized thread-local data.</returns>
-            public TValue Init() => initValue ?? (init is not null ? init.Invoke() : default)!;
+            public TValue Init() => init is not null ? init.Invoke() : initValue!;
 
             /// <summary>
             /// Finalizes the thread-local data.


### PR DESCRIPTION
## Changes

- When prewarming addresses no state is changed, so the state can be reused for all prewarming that happens on the parallel thread and doesn't need to go via reset and pool.
- Also plumb through CancellationToken to complete early if block finishes before prewarming.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No