### PR TITLE
Reduce per tx execution allocations

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Evm.Benchmark
                 inputData: default
             );
 
-            _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
+            _evmState = EvmState.RentTopLevel(long.MaxValue, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), _environment, new StackAccessTracker());
         }
 
         [Benchmark]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Evm.Benchmark
                 inputData: default
             );
 
-            _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot());
+            _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
         }
 
         [Benchmark]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -91,7 +91,7 @@ public class MultipleUnsignedOperations
             inputData: default
         );
 
-        _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
+        _evmState = EvmState.RentTopLevel(100_000_000L, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), _environment, new StackAccessTracker());
     }
 
     [Benchmark]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -91,7 +91,7 @@ public class MultipleUnsignedOperations
             inputData: default
         );
 
-        _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot());
+        _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
     }
 
     [Benchmark]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Evm.Benchmark
                 inputData: default
             );
 
-            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
+            _evmState = EvmState.RentTopLevel(100_000_000L, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), _environment, new StackAccessTracker());
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Evm.Benchmark
                 inputData: default
             );
 
-            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot());
+            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.TRANSACTION, _stateProvider.TakeSnapshot(), new StackAccessTracker());
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
@@ -222,20 +222,20 @@ namespace Nethermind.Evm.Test
 
         private static EvmState CreateEvmState(EvmState parentEvmState = null, bool isContinuation = false) =>
             parentEvmState is null
-                ? new EvmState(10000,
-                    new ExecutionEnvironment(),
+                ? EvmState.RentTopLevel(10000,
                     ExecutionType.CALL,
                     Snapshot.Empty,
+                    new ExecutionEnvironment(),
                     new StackAccessTracker())
-                : new EvmState(10000,
-                    new ExecutionEnvironment(),
+                : EvmState.RentFrame(10000,
+                    0,
+                    0,
                     ExecutionType.CALL,
-                    Snapshot.Empty,
-                    0,
-                    0,
                     false,
-                    parentEvmState.AccessTracker,
-                    false);
+                    false,
+                    Snapshot.Empty,
+                    new ExecutionEnvironment(),
+                    parentEvmState.AccessTracker);
 
         public class Context { }
     }

--- a/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
@@ -225,7 +225,8 @@ namespace Nethermind.Evm.Test
                 ? new EvmState(10000,
                     new ExecutionEnvironment(),
                     ExecutionType.CALL,
-                    Snapshot.Empty)
+                    Snapshot.Empty,
+                    new StackAccessTracker())
                 : new EvmState(10000,
                     new ExecutionEnvironment(),
                     ExecutionType.CALL,

--- a/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStateTests.cs
@@ -216,7 +216,7 @@ namespace Nethermind.Evm.Test
         public void Can_dispose_after_init()
         {
             EvmState evmState = CreateEvmState();
-            evmState.InitStacks();
+            evmState.InitializeStacks();
             evmState.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -183,7 +183,11 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
             DataStack = null;
             ReturnStack = null;
         }
-        Restore(); // we are trying to restore when disposing
+        if (_canRestore)
+        {
+             // if we didn't commit and we are not top level, then we need to restore and drop the changes done in this call
+            _accessTracker.Restore();
+        }
         _memory.Dispose();
         // Blank refs to not hold against GC
         _memory = default;
@@ -210,15 +214,5 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
 
         parentState.Refund += Refund;
         _canRestore = false; // we can't restore if we committed
-    }
-
-    private void Restore()
-    {
-        ObjectDisposedException.ThrowIf(_isDisposed, this);
-
-        if (_canRestore) // if we didn't commit and we are not top level, then we need to restore and drop the changes done in this call
-        {
-            _accessTracker.Restore();
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -44,7 +44,7 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
     private Snapshot _snapshot;
     private ExecutionEnvironment _env;
     private StackAccessTracker _accessTracker;
-        
+
 #if DEBUG
     private StackTrace? _creationStackTrace;
 #endif
@@ -147,7 +147,7 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
         }
         // Mark revived
         _isDisposed = false;
-            
+
 #if DEBUG
         _creationStackTrace = new();
 #endif

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -39,32 +39,32 @@ namespace Nethermind.Evm
             in StackAccessTracker accessedItems) : this(gasAvailable,
                                     env,
                                     executionType,
-                                    true,
+                                    isTopLevel: true,
                                     snapshot,
-                                    0L,
-                                    0L,
-                                    false,
+                                    outputDestination: 0L,
+                                    outputLength: 0L,
+                                    isStatic: false,
                                     accessedItems,
-                                    false)
+                                    isCreateOnPreExistingAccount: false)
         {
         }
         /// <summary>
-        /// Constructor for a top level <see cref="EvmState"/>.
+        /// Constructor for a top level <see cref="EvmState"/>, used by tests.
         /// </summary>
-        public EvmState(
+        internal EvmState(
             long gasAvailable,
             ExecutionEnvironment env,
             ExecutionType executionType,
             Snapshot snapshot) : this(gasAvailable,
                                     env,
                                     executionType,
-                                    true,
+                                    isTopLevel: true,
                                     snapshot,
-                                    0L,
-                                    0L,
-                                    false,
+                                    outputDestination: 0L,
+                                    outputLength: 0L,
+                                    isStatic: false,
                                     new StackAccessTracker(),
-                                    false)
+                                    isCreateOnPreExistingAccount: false)
         {
         }
         /// <summary>
@@ -84,7 +84,7 @@ namespace Nethermind.Evm
                 gasAvailable,
                 env,
                 executionType,
-                false,
+                isTopLevel: false,
                 snapshot,
                 outputDestination,
                 outputLength,

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -185,7 +185,7 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
         }
         if (_canRestore)
         {
-             // if we didn't commit and we are not top level, then we need to restore and drop the changes done in this call
+            // if we didn't commit and we are not top level, then we need to restore and drop the changes done in this call
             _accessTracker.Restore();
         }
         _memory.Dispose();

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -100,14 +100,7 @@ public class EvmState : IDisposable // TODO: rename to CallState
         return state;
     }
 
-    private static EvmState Rent()
-    {
-        if (_statePool.TryDequeue(out EvmState state))
-        {
-            return state;
-        }
-        return new EvmState();
-    }
+    private static EvmState Rent() => _statePool.TryDequeue(out EvmState state) ? state : new EvmState();
 
     private void Initialize(
         long gasAvailable,
@@ -145,18 +138,13 @@ public class EvmState : IDisposable // TODO: rename to CallState
         _isDisposed = false;
     }
 
-    public Address From
+    public Address From => ExecutionType switch
     {
-        get
-        {
-            return ExecutionType switch
-            {
-                ExecutionType.STATICCALL or ExecutionType.CALL or ExecutionType.CALLCODE or ExecutionType.CREATE or ExecutionType.CREATE2 or ExecutionType.TRANSACTION => Env.Caller,
-                ExecutionType.DELEGATECALL => Env.ExecutingAccount,
-                _ => throw new ArgumentOutOfRangeException(),
-            };
-        }
-    }
+        ExecutionType.STATICCALL or ExecutionType.CALL or ExecutionType.CALLCODE or ExecutionType.CREATE
+            or ExecutionType.CREATE2 or ExecutionType.TRANSACTION => Env.Caller,
+        ExecutionType.DELEGATECALL => Env.ExecutingAccount,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
 
     public Address To => Env.CodeSource ?? Env.ExecutingAccount;
     internal bool IsPrecompile => Env.CodeInfo.IsPrecompile;

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -99,7 +99,7 @@ public struct StackAccessTracker : IDisposable
 
     private class TrackingState
     {
-        private readonly static ConcurrentQueue<TrackingState> _trackerPool = new();
+        private static readonly ConcurrentQueue<TrackingState> _trackerPool = new();
         public static TrackingState RentState() => _trackerPool.TryDequeue(out TrackingState tracker) ? tracker : new TrackingState();
 
         public static void ResetAndReturn(TrackingState state)

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -114,7 +114,7 @@ public struct StackAccessTracker : IDisposable
         public JournalSet<Address> DestroyList { get; } = new();
         public HashSet<AddressAsKey> CreateList { get; } = new();
 
-        public void Clear()
+        private void Clear()
         {
             AccessedAddresses.Clear();
             AccessedStorageCells.Clear();

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -158,7 +158,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitStorageRoots: false);
 
-            StackAccessTracker accessTracker = new();
+            // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method
+            using StackAccessTracker accessTracker = new();
+
             int delegationRefunds = ProcessDelegations(tx, spec, accessTracker);
 
             ExecutionEnvironment env = BuildExecutionEnvironment(tx, in blCtx, spec, effectiveGasPrice, _codeInfoRepository, accessTracker);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -620,11 +620,11 @@ namespace Nethermind.Evm.TransactionProcessing
                     }
                 }
 
-                using (EvmState state = new EvmState(
+                using (EvmState state = EvmState.RentTopLevel(
                     unspentGas,
-                    env,
                     tx.IsContractCreation ? ExecutionType.CREATE : ExecutionType.TRANSACTION,
                     snapshot,
+                    env,
                     accessedItems))
                 {
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -647,7 +647,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
             goto Empty;
         }
 
-        vmState.InitStacks();
+        vmState.InitializeStacks();
         EvmStack<TTracingInstructions> stack = new(vmState.DataStackHead, _txTracer, vmState.DataStack.AsSpan());
         long gasAvailable = vmState.GasAvailable;
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2229,16 +2229,16 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         }
 
         ExecutionType executionType = GetCallExecutionType(instruction, env.IsPostMerge());
-        returnData = new EvmState(
+        returnData = EvmState.RentFrame(
             gasLimitUl,
-            callEnv,
-            executionType,
-            snapshot,
             outputOffset.ToLong(),
             outputLength.ToLong(),
+            executionType,
             instruction == Instruction.STATICCALL || vmState.IsStatic,
-            vmState.AccessTracker,
-            isCreateOnPreExistingAccount: false);
+            isCreateOnPreExistingAccount: false,
+            snapshot: snapshot,
+            env: callEnv,
+            stateForAccessLists: vmState.AccessTracker);
 
         return EvmExceptionType.None;
 
@@ -2468,16 +2468,16 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
             transferValue: value,
             value: value
         );
-        EvmState callState = new(
+        EvmState callState = EvmState.RentFrame(
             callGas,
-            callEnv,
+            0L,
+            0L,
             instruction == Instruction.CREATE2 ? ExecutionType.CREATE2 : ExecutionType.CREATE,
-            snapshot,
-            0L,
-            0L,
             vmState.IsStatic,
-            vmState.AccessTracker,
-            accountExists);
+            accountExists,
+            snapshot,
+            callEnv,
+            vmState.AccessTracker);
 
         return (EvmExceptionType.None, callState);
     }


### PR DESCRIPTION
## Changes

Saves 8.6MB of allocations per min; reduces worse case from smart contracts that do huge amounts of calls

- Reduce allocations by pooling `StackAccessTracker` collections
- Reduce allocations by pooling `EvmState`
- EvmState, pass large struct via `in`
- Change `StackAccessTracker` and `EvmState` to file level namespaces 
- Rearranged parameters and assignment order to match layout order

EvmState is a super chonky class and currently allocated for every tx and every internal call (and this is after shrinking `StackAccessTracker`)

```
Type layout for 'EvmState'
Size: 368 bytes. Paddings: 10 bytes (%2 of empty space)
|==================================================================================|
| Object Header (8 bytes)                                                          |
|----------------------------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                                       |
|==================================================================================|
|   0-7: Byte[] DataStack (8 bytes)                                                |
|----------------------------------------------------------------------------------|
|  8-15: Int32[] ReturnStack (8 bytes)                                             |
|----------------------------------------------------------------------------------|
| 16-23: Int64 <GasAvailable>k__BackingField (8 bytes)                             |
|----------------------------------------------------------------------------------|
| 24-31: Int64 <OutputDestination>k__BackingField (8 bytes)                        |
|----------------------------------------------------------------------------------|
| 32-39: Int64 <OutputLength>k__BackingField (8 bytes)                             |
|----------------------------------------------------------------------------------|
| 40-47: Int64 <Refund>k__BackingField (8 bytes)                                   |
|----------------------------------------------------------------------------------|
| 48-51: Int32 DataStackHead (4 bytes)                                             |
|----------------------------------------------------------------------------------|
| 52-55: Int32 ReturnStackHead (4 bytes)                                           |
|----------------------------------------------------------------------------------|
| 56-59: ExecutionType <ExecutionType>k__BackingField (4 bytes)                    |
| |================================|                                               |
| |   0-3: Int32 value__ (4 bytes) |                                               |
| |================================|                                               |
|----------------------------------------------------------------------------------|
| 60-63: Int32 <ProgramCounter>k__BackingField (4 bytes)                           |
|----------------------------------------------------------------------------------|
|    64: Boolean <IsTopLevel>k__BackingField (1 byte)                              |
|----------------------------------------------------------------------------------|
|    65: Boolean _canRestore (1 byte)                                              |
|----------------------------------------------------------------------------------|
|    66: Boolean <IsStatic>k__BackingField (1 byte)                                |
|----------------------------------------------------------------------------------|
|    67: Boolean <IsContinuation>k__BackingField (1 byte)                          |
|----------------------------------------------------------------------------------|
|    68: Boolean <IsCreateOnPreExistingAccount>k__BackingField (1 byte)            |
|----------------------------------------------------------------------------------|
|    69: Boolean _isDisposed (1 byte)                                              |
|----------------------------------------------------------------------------------|
| 70-71: padding (2 bytes)                                                         |
|----------------------------------------------------------------------------------|
| 72-103: EvmPooledMemory _memory (32 bytes)                                       |
| |=================================================|                              |
| |   0-7: Byte[] _memory (8 bytes)                 |                              |
| |-------------------------------------------------|                              |
| |  8-15: UInt64 _lastZeroedSize (8 bytes)         |                              |
| |-------------------------------------------------|                              |
| | 16-23: UInt64 <Length>k__BackingField (8 bytes) |                              |
| |-------------------------------------------------|                              |
| | 24-31: UInt64 <Size>k__BackingField (8 bytes)   |                              |
| |=================================================|                              |
|----------------------------------------------------------------------------------|
| 104-115: Snapshot <Snapshot>k__BackingField (12 bytes)                           |
| |=======================================================================|        |
| |   0-3: Int32 <StateSnapshot>k__BackingField (4 bytes)                 |        |
| |-----------------------------------------------------------------------|        |
| |  4-11: Storage <StorageSnapshot>k__BackingField (8 bytes)             |        |
| | |===================================================================| |        |
| | |   0-3: Int32 <PersistentStorageSnapshot>k__BackingField (4 bytes) | |        |
| | |-------------------------------------------------------------------| |        |
| | |   4-7: Int32 <TransientStorageSnapshot>k__BackingField (4 bytes)  | |        |
| | |===================================================================| |        |
| |=======================================================================|        |
|----------------------------------------------------------------------------------|
| 116-119: padding (4 bytes)                                                       |
|----------------------------------------------------------------------------------|
| 120-343: ExecutionEnvironment _env (224 bytes)                                   |
| |==============================================================================| |
| |   0-7: CodeInfo CodeInfo (8 bytes)                                           | |
| |------------------------------------------------------------------------------| |
| |  8-15: Address ExecutingAccount (8 bytes)                                    | |
| |------------------------------------------------------------------------------| |
| | 16-23: Address Caller (8 bytes)                                              | |
| |------------------------------------------------------------------------------| |
| | 24-31: Address CodeSource (8 bytes)                                          | |
| |------------------------------------------------------------------------------| |
| | 32-35: Int32 CallDepth (4 bytes)                                             | |
| |------------------------------------------------------------------------------| |
| | 36-39: padding (4 bytes)                                                     | |
| |------------------------------------------------------------------------------| |
| | 40-55: ReadOnlyMemory`1 InputData (16 bytes)                                 | |
| | |=================================|                                          | |
| | |   0-7: Object _object (8 bytes) |                                          | |
| | |---------------------------------|                                          | |
| | |  8-11: Int32 _index (4 bytes)   |                                          | |
| | |---------------------------------|                                          | |
| | | 12-15: Int32 _length (4 bytes)  |                                          | |
| | |=================================|                                          | |
| |------------------------------------------------------------------------------| |
| | 56-159: TxExecutionContext TxExecutionContext (104 bytes)                    | |
| | |==========================================================================| | |
| | |   0-7: Address <Origin>k__BackingField (8 bytes)                         | | |
| | |--------------------------------------------------------------------------| | |
| | |  8-15: Byte[][] <BlobVersionedHashes>k__BackingField (8 bytes)           | | |
| | |--------------------------------------------------------------------------| | |
| | | 16-23: ICodeInfoRepository <CodeInfoRepository>k__BackingField (8 bytes) | | |
| | |--------------------------------------------------------------------------| | |
| | | 24-71: BlockExecutionContext BlockExecutionContext (48 bytes)            | | |
| | | |===========================================================|            | | |
| | | |   0-7: BlockHeader <Header>k__BackingField (8 bytes)      |            | | |
| | | |-----------------------------------------------------------|            | | |
| | | |  8-47: Nullable`1 <BlobBaseFee>k__BackingField (40 bytes) |            | | |
| | | |===========================================================|            | | |
| | |--------------------------------------------------------------------------| | |
| | | 72-103: UInt256 <GasPrice>k__BackingField (32 bytes)                     | | |
| | | |============================|                                           | | |
| | | |   0-7: UInt64 u0 (8 bytes) |                                           | | |
| | | |----------------------------|                                           | | |
| | | |  8-15: UInt64 u1 (8 bytes) |                                           | | |
| | | |----------------------------|                                           | | |
| | | | 16-23: UInt64 u2 (8 bytes) |                                           | | |
| | | |----------------------------|                                           | | |
| | | | 24-31: UInt64 u3 (8 bytes) |                                           | | |
| | | |============================|                                           | | |
| | |==========================================================================| | |
| |------------------------------------------------------------------------------| |
| | 160-191: UInt256 TransferValue (32 bytes)                                    | |
| | |============================|                                               | |
| | |   0-7: UInt64 u0 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | |  8-15: UInt64 u1 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | | 16-23: UInt64 u2 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | | 24-31: UInt64 u3 (8 bytes) |                                               | |
| | |============================|                                               | |
| |------------------------------------------------------------------------------| |
| | 192-223: UInt256 Value (32 bytes)                                            | |
| | |============================|                                               | |
| | |   0-7: UInt64 u0 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | |  8-15: UInt64 u1 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | | 16-23: UInt64 u2 (8 bytes) |                                               | |
| | |----------------------------|                                               | |
| | | 24-31: UInt64 u3 (8 bytes) |                                               | |
| | |============================|                                               | |
| |==============================================================================| |
|----------------------------------------------------------------------------------|
| 344-367: StackAccessTracker _accessTracker (24 bytes)                            |
| |===============================================|                                |
| |   0-7: TrackingState _trackingState (8 bytes) |                                |
| |-----------------------------------------------|                                |
| |  8-11: Int32 _addressesSnapshots (4 bytes)    |                                |
| |-----------------------------------------------|                                |
| | 12-15: Int32 _storageKeysSnapshots (4 bytes)  |                                |
| |-----------------------------------------------|                                |
| | 16-19: Int32 _destroyListSnapshots (4 bytes)  |                                |
| |-----------------------------------------------|                                |
| | 20-23: Int32 _logsSnapshots (4 bytes)         |                                |
| |===============================================|                                |
|==================================================================================|
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
