### PR TITLE
Use system processor for SkipValidation txs

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private TransactionResult ExecuteCore(Transaction tx, in BlockExecutionContext blCtx, ITxTracer tracer, ExecutionOptions opts)
         {
-            if (tx.IsSystem() || opts.HasFlag(ExecutionOptions.SkipValidation))
+            if (tx.IsSystem() || opts == ExecutionOptions.SkipValidation)
             {
                 _systemTransactionProcessor ??= new SystemTransactionProcessor(SpecProvider, WorldState, VirtualMachine, _codeInfoRepository, _logManager);
                 return _systemTransactionProcessor.Execute(tx, blCtx.Header, tracer, opts);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private TransactionResult ExecuteCore(Transaction tx, in BlockExecutionContext blCtx, ITxTracer tracer, ExecutionOptions opts)
         {
-            if (tx.IsSystem())
+            if (tx.IsSystem() || opts.HasFlag(ExecutionOptions.SkipValidation))
             {
                 _systemTransactionProcessor ??= new SystemTransactionProcessor(SpecProvider, WorldState, VirtualMachine, _codeInfoRepository, _logManager);
                 return _systemTransactionProcessor.Execute(tx, blCtx.Header, tracer, opts);


### PR DESCRIPTION
## Changes

- Change to skip cloning tx to SystemTransaction in https://github.com/NethermindEth/nethermind/pull/7983 meant it can fail to process the full tx due to sender not having enough balance to send value.
   
   This also uses the `ExecutionOptions` to decide whether to run as low validation system tx

![image](https://github.com/user-attachments/assets/b30e011a-2c25-4a8e-856c-4875988ace00)

![image](https://github.com/user-attachments/assets/9a08b911-413b-4f7e-acc9-ac7ec42d16a8)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No