### PR TITLE
Add Holocene timestamps for OP and Base (mainnet)

### DIFF
--- a/src/Nethermind/Chains/op-mainnet.json
+++ b/src/Nethermind/Chains/op-mainnet.json
@@ -10,6 +10,7 @@
         "ecotoneTimestamp": "0x65f23e01",
         "fjordTimestamp": "0x668eb001",
         "graniteTimestamp": "0x66e1be81",
+        "holoceneTimestamp": "0x67800ea1",
         "l1FeeRecipient": "0x420000000000000000000000000000000000001A",
         "l1BlockAddress": "0x4200000000000000000000000000000000000015",
         "canyonBaseFeeChangeDenominator": "250",
@@ -76,6 +77,7 @@
 
     "rip7212TransitionTimestamp": "0x668eb001",
     "opGraniteTransitionTimestamp": "0x66e1be81",
+    "opHoloceneTransitionTimestamp": "0x67800ea1",
 
     "terminalTotalDifficulty": "210470125"
   },


### PR DESCRIPTION
## Changes

- Adds Holocene timestamps for both OP and Base (mainnet) according to https://github.com/ethereum-optimism/superchain-registry/pull/726

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

We'll see how mainnet transitions on `Thu 09 Jan 2025 18:00:01 UTC`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

This config update is required to run OP or Base nodes in mainnet.

## Remarks

I don't know if it's currently possible but operators could potentially pass these timestamps as flags instead of updating Nethermind to a new version which contains this updated config.
