### PR TITLE
Recovering trie node message should be less severe

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Trie/TrieNodeRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/TrieNodeRecovery.cs
@@ -106,6 +106,10 @@ public abstract class TrieNodeRecovery<TRequest> : ITrieNodeRecovery<TRequest>
         {
             if (_logger.IsTrace) _logger.Trace($"Cancelled recovering RLP {rlpHash} from peer {peer}");
         }
+        catch (TimeoutException)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Timeout recovering RLP {rlpHash} from peer {peer}");
+        }
         catch (Exception e)
         {
             if (_logger.IsWarn) _logger.Warn($"Could not recover RLP {rlpHash} from {peer}");

--- a/src/Nethermind/Nethermind.Synchronization/Trie/TrieNodeRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/TrieNodeRecovery.cs
@@ -104,11 +104,12 @@ public abstract class TrieNodeRecovery<TRequest> : ITrieNodeRecovery<TRequest>
         }
         catch (OperationCanceledException)
         {
-            if (_logger.IsTrace) _logger.Trace($"Cancelled recovering RLP from peer {peer}");
+            if (_logger.IsTrace) _logger.Trace($"Cancelled recovering RLP {rlpHash} from peer {peer}");
         }
         catch (Exception e)
         {
-            if (_logger.IsError) _logger.Error($"Could not recover from {peer}", e);
+            if (_logger.IsWarn) _logger.Warn($"Could not recover RLP {rlpHash} from {peer}");
+            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Could not recover RLP {rlpHash} from {peer}", e);
         }
 
         return (recovery, null);


### PR DESCRIPTION
## Changes

- It tries multiple peers and don't need full stack trace; the recovery itself isn't an error
- Also add Timeout exception to the skipped

e.g. it currently outputs:
```
03 Jan 18:56:14 | Missing trie node 0xb99865a61902b36805cd8b8a2525bfdf322c747c78d044be48dc83bbdadabccd, trying to recover from network
03 Jan 18:56:14 | Failed to recover missing trie node
03 Jan 18:56:14 | Missing trie node Account: 13, trying to recover from network
03 Jan 18:56:21 | Processing queue wasn't empty added to queue New Block:  21545884 (0x855b2f...a37d12).
03 Jan 18:56:21 | Received ForkChoice: 21545884 (0x855b2f...a37d12), Safe: 21545855 (0xd0165d...695c63), Finalized: 21545791 (0xd89a89...222316)
03 Jan 18:56:21 | Processing 1 blocks, Request: ForkChoice: 21545884 (0x855b2f...a37d12), Safe: 21545855 (0xd0165d...695c63), Finalized: 21545791 (0xd89a89...222316)
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545690|  95.217.150.56:31932| Out] System.TimeoutException: [Session|Out|Disconnected|30303->95.217.150.56:31932] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545701| 80.239.221.204:| Out] System.TimeoutException: [Session|Out|Disconnected|30303->80.239.221.204:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545679|   34.116.83.11:| Out] System.TimeoutException: [Session|Out|Initialized|30303->34.116.83.11:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545873|   148.113.9.40:| Out] System.TimeoutException: [Session|Out|Disconnected|30303->148.113.9.40:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545758|   148.113.8.11:| Out] System.TimeoutException: [Session|Out|Disconnected|30303->148.113.8.11:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545685|  217.97.69.224:| Out] System.TimeoutException: [Session|Out|Disconnected|30303->217.97.69.224:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545679| 35.247.131.197:| Out] System.TimeoutException: [Session|Out|Initialized|30303->35.247.131.197:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545679| 34.124.219.210:| Out] System.TimeoutException: [Session|Out|Initialized|30303->34.124.219.210:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Could not recover from [Peer|eth68|21545680|  34.159.60.150:| Out] System.TimeoutException: [Session|Out|Initialized|30303->34.159.60.150:30303] Request timeout in Nethermind.Network.P2P.Subprotocols.Snap.Messages.GetTrieNodesMessage
   at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponse[TRequest,TResponse](Request`2 request, TransferSpeedType speedType, Func`2 describeRequestFunc, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\ProtocolHandlers\ZeroProtocolHandlerBase.cs:line 79
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.SendRequest[TIn,TOut](TIn msg, MessageDictionary`2 messageDictionary, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 353
   at Nethermind.Core.LatencyBasedRequestSizer.<>c__DisplayClass4_0`1.<<MeasureLatency>b__0>d.MoveNext() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 41
--- End of stack trace from previous location ---
   at Nethermind.Core.AdaptiveRequestSizer.Run[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\AdaptiveRequestSizer.cs:line 51
   at Nethermind.Core.LatencyBasedRequestSizer.MeasureLatency[TResponse](Func`2 func) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Core\RequestSizer\LatencyBasedRequestSizer.cs:line 38
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(ValueHash256 rootHash, IOwnedReadOnlyList`1 groups, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 322
   at Nethermind.Network.P2P.Subprotocols.Snap.SnapProtocolHandler.GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Network\P2P\Subprotocols\Snap\SnapProtocolHandler.cs:line 317
   at Nethermind.Synchronization.Trie.SnapTrieNodeRecovery.RecoverRlpFromPeerBase(ValueHash256 rlpHash, ISyncPeer peer, GetTrieNodesRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\SnapTrieNodeRecovery.cs:line 48
   at Nethermind.Synchronization.Trie.TrieNodeRecovery`1.RecoverRlpFromPeer(ValueHash256 rlpHash, Recovery recovery, TRequest request, CancellationTokenSource cts) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\TrieNodeRecovery.cs:line 103
03 Jan 18:56:24 | Failed to recover missing trie node
03 Jan 18:56:24 | Processing loop threw an exception. Block: 21545884 (0x855b2f...a37d12), Exception: Nethermind.Trie.MissingTrieNodeException: Node 0xb99865a61902b36805cd8b8a2525bfdf322c747c78d044be48dc83bbdadabccd is missing from the DB
 ---> Nethermind.Trie.TrieNodeException: Failed to load root hash 0xb99865a61902b36805cd8b8a2525bfdf322c747c78d044be48dc83bbdadabccd while loading key 37d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42.
Node 0xb99865a61902b36805cd8b8a2525bfdf322c747c78d044be48dc83bbdadabccd is missing from the DB
   at Nethermind.Synchronization.Trie.HealingTrieStore.LoadRlp(Hash256 address, TreePath& path, Hash256 keccak, ReadFlags readFlags) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\HealingTrieStore.cs:line 40
   at Nethermind.Trie.PreCachedTrieStore.<.ctor>b__4_0(NodeKey key) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PreCachedTrieStore.cs:line 27
   at Nethermind.Trie.PatriciaTree.ResolveNode(TrieNode node, TraverseContext& traverseContext, TreePath& path) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 569
   --- End of inner exception stack trace ---
   at Nethermind.Trie.PatriciaTree.ResolveNode(TrieNode node, TraverseContext& traverseContext, TreePath& path) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 581
   at Nethermind.Trie.PatriciaTree.Get(ReadOnlySpan`1 rawKey, Hash256 rootHash) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 335
   at Nethermind.Synchronization.Trie.HealingStateTree.Get(ReadOnlySpan`1 rawKey, Hash256 rootHash) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Synchronization\Trie\HealingStateTree.cs:line 35
   at Nethermind.State.StateProvider.<.ctor>b__49_0(AddressAsKey address) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 645
   at Nethermind.State.StateProvider.GetStateReadPreWarmCache(AddressAsKey addressAsKey) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 688
   at Nethermind.State.StateProvider.GetAndAddToCache(Address address) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 711
   at Nethermind.Blockchain.BeaconBlockRoot.BeaconBlockRootHandler.BeaconRootsAccessList(Block block, IReleaseSpec spec, Boolean includeStorageCells) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Blockchain\BeaconBlockRoot\BeaconBlockRootHandler.cs:line 32
   at Nethermind.Consensus.Processing.BlockCachePreWarmer.PreWarmCaches(Block suggestedBlock, Hash256 parentStateRoot, IReleaseSpec spec, CancellationToken cancellationToken, ReadOnlySpan`1 systemAccessLists)
   at Nethermind.Consensus.Processing.BlockProcessor.Process(Hash256 newBranchStateRoot, List`1 suggestedBlocks, ProcessingOptions options, IBlockTracer blockTracer) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Consensus\Processing\BlockProcessor.cs:line 97
   at Nethermind.Consensus.Processing.BlockchainProcessor.ProcessBranch(ProcessingBranch& processingBranch, ProcessingOptions options, IBlockTracer tracer, String& error)
   at Nethermind.Consensus.Processing.BlockchainProcessor.Process(Block suggestedBlock, ProcessingOptions options, IBlockTracer tracer, String& error) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Consensus\Processing\BlockchainProcessor.cs:line 366
   at Nethermind.Consensus.Processing.BlockchainProcessor.RunProcessingLoop() in D:\GitHub\nethermind\src\Nethermind\Nethermind.Consensus\Processing\BlockchainProcessor.cs:line 286
03 Jan 18:56:26 | Received New Block:  21545885 (0xaeebee...dc349b)      | limit    30,000,000 👇 | Extra Data: beaverbuild.org
03 Jan 18:56:26 | BeaconPivot was null. Setting beacon pivot to 21545885 (0xaeebee2b0ed07818f5454560e7eee59348bc89c42c5be354a6d46fbaefdc349b)
03 Jan 18:56:26 | New beacon pivot: 21545885 (0xaeebee2b0ed07818f5454560e7eee59348bc89c42c5be354a6d46fbaefdc349b)
03 Jan 18:56:26 | Syncing... Inserting block 21545885 (0xaeebee...dc349b).
03 Jan 18:56:26 | Received ForkChoice: 21545885 (0xaeebee...dc349b), Safe: 21545855 (0xd0165d...695c63), Finalized: 21545823 (0x9aa566...482aa0)
03 Jan 18:56:27 | Processed      21545884... 21545885   |       39.1 ms  | slot         26,300 ms |⛽ Gas gwei: 21.74 .. 21.74 (23.97) .. 73.00
03 Jan 18:56:27 |  Blocks  x2             17.85 MGas    |      258   txs | calls      1,331 ( 69) | sload   5,465 | sstore  1,646 | create   1
03 Jan 18:56:27 |  Block throughput      456.20 MGas/s  |    6,595.6 tps |            51.13 Blk/s | exec code  from cache   3,006 | new      0
03 Jan 18:56:37 | Received New Block:  21545886 (0x686f16...d5e103)      | limit    30,000,000    | Extra Data: ؃ geth go1.22.6 linux
03 Jan 18:56:37 | Removing beacon pivot, previous pivot: Hash: 0xaeebee2b0ed07818f5454560e7eee59348bc89c42c5be354a6d46fbaefdc349b
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No