### PR TITLE
Add Triekey to reduce allocations

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -81,7 +81,7 @@ public class HealingTreeTests
         ITrieStore trieStore = Substitute.For<ITrieStore>();
         trieStore.FindCachedOrUnknown(null, TreePath.Empty, _key).Returns(
             k => throw new MissingTrieNodeException("", new TrieNodeException("", _key), path, 1),
-            k => new TrieNode(NodeType.Leaf) { Key = path });
+            k => new TrieNode(NodeType.Leaf, key: path));
         trieStore.GetTrieStore(Arg.Any<Hash256?>())
             .Returns((callInfo) => new ScopedTrieStore(trieStore, (Hash256?)callInfo[0]));
         TestMemDb db = new();

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -617,10 +617,9 @@ namespace Nethermind.Trie.Test.Pruning
             TreePath emptyPath = TreePath.Empty;
             storage1.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
-            TrieNode a = new(NodeType.Leaf);
+            TrieNode a = new(NodeType.Leaf, key: Nibbles.BytesToNibbleBytes(TestItem.KeccakA.BytesToArray()));
             Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
-            a.Key = Nibbles.BytesToNibbleBytes(TestItem.KeccakA.BytesToArray());
             a.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
             MemDb memDb = new();
@@ -667,10 +666,9 @@ namespace Nethermind.Trie.Test.Pruning
             TreePath emptyPath = TreePath.Empty;
             storage1.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
-            TrieNode a = new(NodeType.Leaf);
+            TrieNode a = new(NodeType.Leaf, key: Bytes.FromHexString("abc"));
             Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
-            a.Key = Bytes.FromHexString("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
             TrieNode b = new(NodeType.Leaf, new byte[1]);
@@ -729,19 +727,17 @@ namespace Nethermind.Trie.Test.Pruning
             TreePath emptyPath = TreePath.Empty;
             storage1.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
-            TrieNode a = new(NodeType.Leaf);
+            TrieNode a = new(NodeType.Leaf, key: storage1Nib[1..]);
             Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
-            a.Key = storage1Nib[1..];
             a.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
             TrieNode storage2 = new(NodeType.Leaf, new byte[32]);
             storage2.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
-            TrieNode b = new(NodeType.Leaf);
+            TrieNode b = new(NodeType.Leaf, key: storage2Nib[1..]);
             Account accountB = new(2, 1, storage2.Keccak, Keccak.OfAnEmptyString);
             b.Value = _accountDecoder.Encode(accountB).Bytes;
-            b.Key = storage2Nib[1..];
             b.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
             TrieNode branch = new(NodeType.Branch);
@@ -861,10 +857,9 @@ namespace Nethermind.Trie.Test.Pruning
         [TestCase(false)]
         public void ReadOnly_store_returns_copies(bool pruning)
         {
-            TrieNode node = new(NodeType.Leaf);
+            TrieNode node = new(NodeType.Leaf, key: Nibbles.BytesToNibbleBytes(TestItem.KeccakA.BytesToArray()));
             Account account = new(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
             node.Value = _accountDecoder.Encode(account).Bytes;
-            node.Key = Nibbles.BytesToNibbleBytes(TestItem.KeccakA.BytesToArray());
             TreePath emptyPath = TreePath.Empty;
             node.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath, true);
 
@@ -890,7 +885,7 @@ namespace Nethermind.Trie.Test.Pruning
             var readOnlyRlp = readOnlyNode.FullRlp;
             readOnlyRlp.Should().BeEquivalentTo(origRlp);
 
-            readOnlyNode.Key?.ToString().Should().Be(originalNode.Key?.ToString());
+            readOnlyNode.Key.ToString().Should().Be(originalNode.Key.ToString());
         }
 
         private long ExpectedPerNodeKeyMemorySize => _scheme == INodeStorage.KeyScheme.Hash ? 0 : TrieStoreDirtyNodesCache.Key.MemoryUsage;

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Trie.Test.Pruning
             long startSize = trieStore.MemoryUsedByDirtyCache;
             trieStore.FindCachedOrUnknown(null, TreePath.Empty, TestItem.KeccakA);
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
-            long oneKeccakSize = trieNode.GetMemorySize(false) + ExpectedPerNodeKeyMemorySize - MemorySizes.SmallObjectOverhead;
+            long oneKeccakSize = trieNode.GetMemorySize(false) + ExpectedPerNodeKeyMemorySize - MemorySizes.SmallObjectOverhead - MemorySizes.RefSize - MemorySizes.RefSize;
             Assert.That(trieStore.MemoryUsedByDirtyCache, Is.EqualTo(startSize + oneKeccakSize));
             trieStore.FindCachedOrUnknown(null, TreePath.Empty, TestItem.KeccakB);
             Assert.That(trieStore.MemoryUsedByDirtyCache, Is.EqualTo(2 * oneKeccakSize + startSize));
@@ -253,7 +253,7 @@ namespace Nethermind.Trie.Test.Pruning
                 tree.Commit();
             }
 
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 540560L : 610708L);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 556672L : 626820L);
             fullTrieStore.CommittedNodesCount.Should().Be(1349);
         }
 
@@ -1012,7 +1012,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             memDb.Count.Should().Be(61);
             fullTrieStore.Prune();
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 552 : 708);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 600 : 756);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TreePathTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TreePathTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using NUnit.Framework;
+using System;
 
 namespace Nethermind.Trie.Test;
 
@@ -45,7 +46,7 @@ public class TreePathTests
     [Test]
     public void TestAppendArray()
     {
-        byte[] nibbles = new byte[64];
+        Span<byte> nibbles = new byte[64];
         for (int i = 0; i < 64; i++)
         {
             nibbles[i] = (byte)(i % 16);
@@ -66,7 +67,7 @@ public class TreePathTests
     [TestCase(41)]
     public void TestAppendArrayDivided(int partition)
     {
-        byte[] nibbles = new byte[64];
+        Span<byte> nibbles = new byte[64];
         for (int i = 0; i < 64; i++)
         {
             nibbles[i] = (byte)(i % 16);
@@ -156,12 +157,12 @@ public class TreePathTests
     {
         TreePath path = TreePath.Empty;
 
-        using (path.ScopedAppend(new byte[] { 1, 2, 3, 4 }))
+        using (path.ScopedAppend(new Span<byte>([1, 2, 3, 4])))
         {
             path.Length.Should().Be(4);
             path.Path.ToString().Should().Be("0x1234000000000000000000000000000000000000000000000000000000000000");
 
-            using (path.ScopedAppend(new byte[] { 5, 6, 7 }))
+            using (path.ScopedAppend(new Span<byte>([5, 6, 7])))
             {
                 path.Length.Should().Be(7);
                 path.Path.ToString().Should().Be("0x1234567000000000000000000000000000000000000000000000000000000000");
@@ -178,7 +179,7 @@ public class TreePathTests
         TreePath path = new TreePath();
         for (int i = 0; i < 64; i++)
         {
-            path = path.Append((byte)(i % 16));
+            path = path.Append((int)(i % 16));
         }
 
         return path;

--- a/src/Nethermind/Nethermind.Trie.Test/TrieKeyMultiPartTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieKeyMultiPartTests.cs
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+[TestFixture]
+public class TrieKeyMultiPartTests
+{
+    // For brevity, some tests may re-verify functionality that also
+    // appears in simpler single-part tests. Here we specifically
+    // focus on multi-part cases and edge scenarios.
+
+    [Test]
+    public void CreateTwoPartKey_WithDifferentSizedArrays_ShouldStoreAllBytes()
+    {
+        // part0 is length 2, part1 is length 5
+        byte[] part0 = [0x01, 0x02];
+        byte[] part1 = [0x03, 0x04, 0x05, 0x06, 0x07];
+
+        // Act
+        TrieKey multiPartKey = new TrieKey(part0, part1);
+
+        // Assert
+        multiPartKey.Length.Should().Be(7);
+        multiPartKey.ToArray().Should().Equal(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07);
+    }
+
+    [Test]
+    public void Indexer_ShouldCorrectlyAddressBytesInMultiPartKey()
+    {
+        // part0 is length 3, part1 is length 3
+        byte[] part0 = [10, 11, 12];
+        byte[] part1 = [20, 21, 22];
+        TrieKey multiPartKey = new TrieKey(part0, part1);
+
+        // Act & Assert
+        multiPartKey[0].Should().Be(10);
+        multiPartKey[1].Should().Be(11);
+        multiPartKey[2].Should().Be(12);
+        multiPartKey[3].Should().Be(20);
+        multiPartKey[4].Should().Be(21);
+        multiPartKey[5].Should().Be(22);
+
+        // Confirm the total length
+        multiPartKey.Length.Should().Be(6);
+    }
+
+    [Test]
+    public void Slice_WithStartAndLengthWithinFirstPartOnly_ShouldReturnCorrectKey()
+    {
+        // part0 is length 4, part1 is length 2
+        byte[] part0 = [1, 2, 3, 4];
+        byte[] part1 = [5, 6];
+        TrieKey multiPartKey = new(part0, part1);
+
+        // Slice wholly in part0 => from index 1 to index 3 => bytes {2,3,4}
+        TrieKey sliced = multiPartKey.Slice(1, 3);
+
+        sliced.Length.Should().Be(3);
+        sliced.ToArray().Should().Equal(2, 3, 4);
+    }
+
+    [Test]
+    public void Slice_WithStartAndLengthWithinSecondPartOnly_ShouldReturnCorrectKey()
+    {
+        // part0 is length 2, part1 is length 4
+        byte[] part0 = [10, 11];
+        byte[] part1 = [20, 21, 22, 23];
+        TrieKey multiPartKey = new(part0, part1);
+
+        // Slice wholly in part1 => start at index=2 (where part1 begins),
+        // length=3 => bytes {20,21,22}
+        TrieKey sliced = multiPartKey.Slice(2, 3);
+
+        sliced.Length.Should().Be(3);
+        sliced.ToArray().Should().Equal(20, 21, 22);
+    }
+
+    [Test]
+    public void Slice_SpanningBothParts_ShouldReturnCorrectKey()
+    {
+        // part0 is length 3, part1 is length 3
+        byte[] part0 = [0xAA, 0xBB, 0xCC];
+        byte[] part1 = [0xDD, 0xEE, 0xFF];
+        TrieKey multiPartKey = new(part0, part1);
+
+        // Slice from index=1 in part0 -> 4 bytes total => {0xBB,0xCC,0xDD,0xEE}
+        TrieKey sliced = multiPartKey.Slice(1, 4);
+
+        sliced.Length.Should().Be(4);
+        sliced.ToArray().Should().Equal(0xBB, 0xCC, 0xDD, 0xEE);
+    }
+
+    [Test]
+    public void CommonPrefixLength_WithKeysSpanningParts_ShouldHandlePartialOverlap()
+    {
+        // Arrange
+        // multiPartKey1 => part0 {1,2}, part1 {3,4,5}
+        byte[] key1Part0 = [1, 2];
+        byte[] key1Part1 = [3, 4, 5];
+        TrieKey multiPartKey1 = new(key1Part0, key1Part1);
+
+        // multiPartKey2 => part0 {1}, part1 {2,3,9}
+        byte[] key2Part0 = [1];
+        byte[] key2Part1 = [2, 3, 9];
+        TrieKey multiPartKey2 = new(key2Part0, key2Part1);
+
+        // Act
+        // Both keys are {1,2,3,...} for the first three bytes, except the second key has a '9' after that
+        // so the prefix should be 3.
+        int prefixLength = multiPartKey1.CommonPrefixLength(multiPartKey2);
+
+        // Assert
+        prefixLength.Should().Be(3);
+    }
+
+    [Test]
+    public void Equality_WithSameBytesButDifferentPartSplits_ShouldBeEqual()
+    {
+        // part0 is length 2, part1 is length 2
+        // effectively the combined array is {1,2,3,4}
+        byte[] keyA1 = [1, 2];
+        byte[] keyA2 = [3, 4];
+        TrieKey multiPartKeyA = new(keyA1, keyA2);
+
+        // Single part array is exactly {1,2,3,4}
+        byte[] singleArray = [1, 2, 3, 4];
+        TrieKey singlePartKey = new(singleArray);
+
+        // part0 is length 3, part1 is length 1 => effectively also {1,2,3,4}
+        byte[] keyB1 = [1, 2, 3];
+        byte[] keyB2 = [4];
+        TrieKey multiPartKeyB = new(keyB1, keyB2);
+
+        // Act & Assert
+        multiPartKeyA.Should().Be(singlePartKey);
+        multiPartKeyA.Should().Be(multiPartKeyB);
+        singlePartKey.Should().Be(multiPartKeyB);
+
+        (multiPartKeyA == singlePartKey).Should().BeTrue();
+        (multiPartKeyA == multiPartKeyB).Should().BeTrue();
+        (singlePartKey == multiPartKeyB).Should().BeTrue();
+    }
+
+    [Test]
+    public void Equality_WithDifferentBytesAndDifferentPartSplits_ShouldBeFalse()
+    {
+        // keyX => {1,2,3,4}
+        byte[] xPart0 = [1, 2];
+        byte[] xPart1 = [3, 4];
+        TrieKey keyX = new(xPart0, xPart1);
+
+        // keyY => {1,2,5,4} (different in the third byte)
+        byte[] yPart0 = [1, 2];
+        byte[] yPart1 = [5, 4];
+        TrieKey keyY = new(yPart0, yPart1);
+
+        // Act & Assert
+        keyX.Should().NotBe(keyY);
+        (keyX == keyY).Should().BeFalse();
+    }
+
+    [Test]
+    public void PrependByte_WithMultiPartKey_ShouldProduceCorrectResult()
+    {
+        // baseKey => {2,3,4,5}, stored in two parts
+        byte[] basePart0 = [2, 3];
+        byte[] basePart1 = [4, 5];
+        TrieKey baseKey = new(basePart0, basePart1);
+
+        // Prepend byte = 1 => new key => {1,2,3,4,5}
+        TrieKey prepended = new(0x01, baseKey);
+
+        prepended.Length.Should().Be(5);
+        prepended.ToArray().Should().Equal(1, 2, 3, 4, 5);
+    }
+
+    [Test]
+    public void TwoPartConcatenation_WithOtherTwoPartKey_ShouldCombineAllBytes()
+    {
+        // Key1 => part0: {1,2}, part1: {3}
+        TrieKey key1 = new([1, 2], [3]);
+
+        // Key2 => part0: {4}, part1: {5,6}
+        TrieKey key2 = new([4], [5, 6]);
+
+        // Act
+        TrieKey concatenated = new(key1, key2);
+
+        // combined => {1,2,3,4,5,6}
+        concatenated.Length.Should().Be(6);
+        concatenated.ToArray().Should().Equal(1, 2, 3, 4, 5, 6);
+    }
+
+    [Test]
+    public void Slice_WhenSpanningPart0AndPart1Entirely_ShouldReturnTheWholeKey()
+    {
+        // Key => part0: {10,20}, part1: {30,40}
+        TrieKey key = new([10, 20], [30, 40]);
+        // total length => 4
+
+        // Act - slicing from 0 to the entire length
+        TrieKey entireSlice = key.Slice(0, 4);
+
+        // Assert
+        entireSlice.Length.Should().Be(4);
+        entireSlice.ToArray().Should().Equal(10, 20, 30, 40);
+        entireSlice.Should().Be(key);
+    }
+
+    [Test]
+    public void Slice_WhenItExactlyCutsAfterPart0_ShouldReturnPart1()
+    {
+        // Key => part0: {1,2,3}, part1: {4,5}
+        TrieKey key = new([1, 2, 3], [4, 5]);
+        // length => 5
+
+        // Act - slice that starts where part1 begins => index 3, length 2 => {4,5}
+        TrieKey slice = key.Slice(3, 2);
+
+        // Assert
+        slice.Length.Should().Be(2);
+        slice.ToArray().Should().Equal(4, 5);
+    }
+
+    [Test]
+    public void CommonPrefixLength_WithKeysWhollyInPart1_ShouldCompareCorrectly()
+    {
+        // Key1 => part0:{}, part1:{10,20,30}
+        TrieKey key1 = new(Array.Empty<byte>(), [10, 20, 30]);
+
+        // Key2 => part0:{10}, part1:{20,99}
+        // effectively => {10,20,99}
+        TrieKey key2 = new([10], [20, 99]);
+
+        // First key => [10,20,30]
+        // Second key => [10,20,99]
+        // They match on the first two bytes => prefix = 2
+        int prefixLength = key1.CommonPrefixLength(key2);
+
+        prefixLength.Should().Be(2);
+    }
+
+    [Test]
+    public void ToArray_ShouldCorrectlyCombineMultiPartKeyWithDifferingLengths()
+    {
+        // part0 is length 5, part1 is length 1
+        byte[] part0 = [0xA1, 0xA2, 0xA3, 0xA4, 0xA5];
+        byte[] part1 = [0xFF];
+        TrieKey key = new(part0, part1);
+
+        byte[] array = key.ToArray();
+        array.Should().Equal(0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xFF);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie.Test/TrieKeyTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieKeyTests.cs
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+[TestFixture]
+public class TrieKeyTests
+{
+    [Test]
+    public void Empty_ShouldHaveLengthZero_AndBeEquivalentToEmptyArray()
+    {
+        // Arrange & Act
+        TrieKey emptyKey = TrieKey.Empty;
+
+        // Assert
+        emptyKey.Length.Should().Be(0);
+        emptyKey.ToArray().Should().BeEmpty();
+    }
+
+    [Test]
+    public void CreateFromByte_ShouldBeSingleByteKey()
+    {
+        // Arrange
+        byte singleByte = 5;
+
+        // Act
+        TrieKey trieKey = singleByte; // Implicit operator
+
+        // Assert
+        trieKey.Length.Should().Be(1);
+        trieKey[0].Should().Be(singleByte);
+        trieKey.ToArray().Should().Equal(new byte[] { singleByte });
+    }
+
+    [Test]
+    public void CreateFromByteArray_ShouldStoreAllBytes()
+    {
+        // Arrange
+        byte[] bytes = new byte[] { 10, 11, 12 };
+
+        // Act
+        TrieKey trieKey = bytes; // Implicit operator from byte[]
+
+        // Assert
+        trieKey.Length.Should().Be(3);
+        trieKey.ToArray().Should().Equal(bytes);
+        trieKey[0].Should().Be(10);
+        trieKey[1].Should().Be(11);
+        trieKey[2].Should().Be(12);
+    }
+
+    [Test]
+    public void CreateFromSingleByteAndTrieKey_ShouldPrependByte()
+    {
+        // Arrange
+        byte prependByte = 4;
+        TrieKey baseKey = new byte[] { 5, 6 };
+
+        // Act
+        TrieKey combined = new(prependByte, baseKey);
+
+        // Assert
+        combined.Length.Should().Be(3);
+        combined.ToArray().Should().Equal(new byte[] { 4, 5, 6 });
+    }
+
+    [Test]
+    public void CreateFromTwoTrieKeys_ShouldConcatenate()
+    {
+        // Arrange
+        TrieKey leftKey = new byte[] { 1, 2, 3 };
+        TrieKey rightKey = new byte[] { 4, 5 };
+
+        // Act
+        TrieKey concatenated = new(leftKey, rightKey);
+
+        // Assert
+        concatenated.Length.Should().Be(5);
+        concatenated.ToArray().Should().Equal(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Test]
+    public void Indexer_ShouldThrowIfIndexOutOfRange()
+    {
+        // Arrange
+        TrieKey key = new byte[] { 1, 2, 3 };
+
+        // Act
+        Action action1 = () => { var _ = key[-1]; };
+        Action action2 = () => { var _ = key[3]; };
+
+        // Assert
+        action1.Should().Throw<ArgumentOutOfRangeException>();
+        action2.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void CommonPrefixLength_ShouldReturnCorrectValue_WhenKeysSharePrefix()
+    {
+        // Arrange
+        TrieKey key1 = new byte[] { 1, 2, 3, 4 };
+        TrieKey key2 = new byte[] { 1, 2, 7, 8 };
+
+        // Act
+        int prefixLength = key1.CommonPrefixLength(key2);
+
+        // Assert
+        prefixLength.Should().Be(2, "the first two bytes match (1, 2)");
+    }
+
+    [Test]
+    public void CommonPrefixLength_ShouldReturnZero_WhenNoSharedPrefix()
+    {
+        // Arrange
+        TrieKey key1 = new byte[] { 0xAA };
+        TrieKey key2 = new byte[] { 0xBB };
+
+        // Act
+        int prefixLength = key1.CommonPrefixLength(key2);
+
+        // Assert
+        prefixLength.Should().Be(0);
+    }
+
+    [Test]
+    public void Slice_ShouldReturnCorrectSubset_WhenWithinSinglePart()
+    {
+        // Arrange
+        TrieKey key = new byte[] { 1, 2, 3, 4, 5 };
+
+        // Act
+        TrieKey slice = key.Slice(1, 3);
+
+        // Assert
+        slice.Length.Should().Be(3);
+        slice.ToArray().Should().Equal(2, 3, 4);
+    }
+
+    [Test]
+    public void Slice_ShouldReturnCorrectSubset_WhenSpanningTwoParts()
+    {
+        // Arrange
+        // Constructing a key with two parts by manually using the two-array constructor:
+        var part0 = new byte[] { 1, 2, 3 };
+        var part1 = new byte[] { 4, 5, 6, 7 };
+        TrieKey key = new(part0, part1);
+
+        // Act
+        // Span from index 2 (in part0) to index 4 overall
+        // That means the slice should include {3, 4, 5}.
+        TrieKey slice = key.Slice(2, 3);
+
+        // Assert
+        slice.Length.Should().Be(3);
+        slice.ToArray().Should().Equal(3, 4, 5);
+    }
+
+    [Test]
+    public void Slice_ShouldReturnEmpty_WhenLengthIsZero()
+    {
+        // Arrange
+        TrieKey key = new byte[] { 1, 2, 3 };
+
+        // Act
+        TrieKey slice = key.Slice(2, 0);
+
+        // Assert
+        slice.Should().BeEquivalentTo(TrieKey.Empty);
+        slice.Length.Should().Be(0);
+    }
+
+    [Test]
+    public void Slice_ShouldThrow_WhenInvalidStartOrLength()
+    {
+        // Arrange
+        TrieKey key = new byte[] { 1, 2, 3 };
+
+        // Act
+        Action negativeStart = () => key.Slice(-1, 1);
+        Action negativeLength = () => key.Slice(0, -1);
+        Action outOfRangeSlice = () => key.Slice(1, 10);
+
+        // Assert
+        negativeStart.Should().Throw<ArgumentOutOfRangeException>();
+        negativeLength.Should().Throw<ArgumentOutOfRangeException>();
+        outOfRangeSlice.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void EqualityOperator_ShouldReturnTrue_WhenKeysAreIdentical()
+    {
+        // Arrange
+        TrieKey key1 = new byte[] { 10, 20, 30 };
+        TrieKey key2 = new byte[] { 10, 20, 30 };
+
+        // Act & Assert
+        (key1 == key2).Should().BeTrue();
+        (key1 != key2).Should().BeFalse();
+        key1.Equals(key2).Should().BeTrue();
+    }
+
+    [Test]
+    public void EqualityOperator_ShouldReturnFalse_WhenKeysDiffer()
+    {
+        // Arrange
+        TrieKey key1 = new byte[] { 10, 20, 30 };
+        TrieKey key2 = new byte[] { 10, 20, 31 };
+
+        // Act & Assert
+        (key1 == key2).Should().BeFalse();
+        (key1 != key2).Should().BeTrue();
+        key1.Equals(key2).Should().BeFalse();
+    }
+
+    [Test]
+    public void ToArray_ShouldReturnCombinedBytes()
+    {
+        // Arrange
+        TrieKey key1 = new byte[] { 1, 2 };
+        TrieKey key2 = new byte[] { 3, 4 };
+        TrieKey combined = new(key1, key2);
+
+        // Act
+        byte[] result = combined.ToArray();
+
+        // Assert
+        result.Should().Equal(1, 2, 3, 4);
+    }
+
+    [Test]
+    public void GetHashCode_ShouldThrowNotImplementedException_ByDefault()
+    {
+        // Arrange
+        TrieKey key = new byte[] { 1, 2, 3 };
+
+        // Act
+        Action act = () => _ = key.GetHashCode();
+
+        // Assert
+        act.Should().Throw<NotImplementedException>();
+    }
+
+    [Test]
+    public void ZeroLengthConcatenation_ShouldYieldOtherKey()
+    {
+        // Arrange
+        TrieKey key1 = TrieKey.Empty;
+        TrieKey key2 = new byte[] { 4, 5, 6 };
+
+        // Act
+        TrieKey concatenated1 = new(key1, key2);
+        TrieKey concatenated2 = new(key2, key1);
+
+        // Assert
+        concatenated1.ToArray().Should().Equal(4, 5, 6);
+        concatenated2.ToArray().Should().Equal(4, 5, 6);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -192,7 +192,7 @@ public class TrieNodeTests
         decodedTiniest.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 
         Assert.That(decodedTiniest.Value.ToArray(), Is.EqualTo(ctx.TiniestLeaf.Value.ToArray()), "value");
-        Assert.That(HexPrefix.ToBytes(decodedTiniest.Key!, true), Is.EqualTo(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true)), "key");
+        Assert.That(HexPrefix.ToBytes(decodedTiniest.Key.ToArray(), true), Is.EqualTo(HexPrefix.ToBytes(ctx.TiniestLeaf.Key.ToArray(), true)), "key");
     }
 
     [Test]
@@ -229,7 +229,7 @@ public class TrieNodeTests
         decodedTiniest?.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 
         Assert.That(decodedTiniest.Value.ToArray(), Is.EqualTo(ctx.TiniestLeaf.Value.ToArray()), "value");
-        Assert.That(HexPrefix.ToBytes(decodedTiniest.Key!, true), Is.EqualTo(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true)),
+        Assert.That(HexPrefix.ToBytes(decodedTiniest.Key.ToArray(), true), Is.EqualTo(HexPrefix.ToBytes(ctx.TiniestLeaf.Key.ToArray(), true)),
             "key");
     }
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -533,14 +533,14 @@ public class TrieNodeTests
     public void Size_of_a_heavy_leaf_is_correct()
     {
         Context ctx = new();
-        Assert.That(ctx.HeavyLeaf.GetMemorySize(false), Is.EqualTo(208));
+        Assert.That(ctx.HeavyLeaf.GetMemorySize(false), Is.EqualTo(224));
     }
 
     [Test]
     public void Size_of_a_tiny_leaf_is_correct()
     {
         Context ctx = new();
-        Assert.That(ctx.TiniestLeaf.GetMemorySize(false), Is.EqualTo(136));
+        Assert.That(ctx.TiniestLeaf.GetMemorySize(false), Is.EqualTo(152));
     }
 
     [Test]
@@ -553,7 +553,7 @@ public class TrieNodeTests
             node.SetChild(i, ctx.AccountLeaf);
         }
 
-        Assert.That(node.GetMemorySize(true), Is.EqualTo(3376));
+        Assert.That(node.GetMemorySize(true), Is.EqualTo(3632));
         Assert.That(node.GetMemorySize(false), Is.EqualTo(176));
     }
 
@@ -564,7 +564,7 @@ public class TrieNodeTests
         TrieNode trieNode = new(NodeType.Extension, key: new byte[] { 1 });
         trieNode.SetChild(0, ctx.TiniestLeaf);
 
-        Assert.That(trieNode.GetMemorySize(false), Is.EqualTo(96));
+        Assert.That(trieNode.GetMemorySize(false), Is.EqualTo(112));
     }
 
     [Test]
@@ -574,8 +574,8 @@ public class TrieNodeTests
         TrieNode trieNode = new(NodeType.Extension, key: new byte[] { 1 });
         trieNode.SetChild(0, ctx.TiniestLeaf);
 
-        Assert.That(trieNode.GetMemorySize(true), Is.EqualTo(232));
-        Assert.That(trieNode.GetMemorySize(false), Is.EqualTo(96));
+        Assert.That(trieNode.GetMemorySize(true), Is.EqualTo(264));
+        Assert.That(trieNode.GetMemorySize(false), Is.EqualTo(112));
     }
 
     [Test]
@@ -597,7 +597,7 @@ public class TrieNodeTests
     {
         TrieNode trieNode = new(NodeType.Extension);
         trieNode.SetChild(0, null);
-        trieNode.GetMemorySize(false).Should().Be(64);
+        trieNode.GetMemorySize(false).Should().Be(80);
     }
 
     [Test]
@@ -613,7 +613,7 @@ public class TrieNodeTests
     {
         TrieNode trieNode = new(NodeType.Leaf);
         trieNode.Value = new byte[7];
-        trieNode.GetMemorySize(false).Should().Be(104);
+        trieNode.GetMemorySize(false).Should().Be(120);
     }
 
     [Test]
@@ -711,7 +711,7 @@ public class TrieNodeTests
         trieNode.SetChild(0, child);
 
         trieNode.PrunePersistedRecursively(1);
-        trieNode.GetMemorySize(false).Should().Be(112);
+        trieNode.GetMemorySize(false).Should().Be(128);
     }
 
     [Test]
@@ -724,7 +724,7 @@ public class TrieNodeTests
         trieNode.PrunePersistedRecursively(1);
         TrieNode cloned = trieNode.Clone();
 
-        cloned.GetMemorySize(false).Should().Be(112);
+        cloned.GetMemorySize(false).Should().Be(128);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -145,14 +145,14 @@ public class VisitingTests
         yield return new TestCaseData(new VisitingOptions
         {
             ExpectAccounts = expectAccounts
-        }).SetName("Default");
+        }).SetName($"Default(expectAccounts: {expectAccounts})");
 
         yield return new TestCaseData(new VisitingOptions
         {
             MaxDegreeOfParallelism = Environment.ProcessorCount,
             FullScanMemoryBudget = 1.MiB(),
             ExpectAccounts = expectAccounts
-        }).SetName("Parallel");
+        }).SetName($"Parallel(expectAccounts: {expectAccounts})");
     }
 
     public class AppendingVisitor : ITreeVisitor<AppendingVisitor.PathGatheringContext>
@@ -179,6 +179,15 @@ public class VisitingTests
                 var @new = new byte[Nibbles.Length + 1];
                 Nibbles.CopyTo(@new, 0);
                 @new[Nibbles.Length] = nibble;
+
+                return new PathGatheringContext(@new);
+            }
+
+            public readonly PathGatheringContext Add(TrieNodeKey nibble)
+            {
+                var @new = new byte[Nibbles.Length + 1];
+                Nibbles.CopyTo(@new, 0);
+                @new[Nibbles.Length] = nibble[0];
 
                 return new PathGatheringContext(@new);
             }
@@ -213,7 +222,7 @@ public class VisitingTests
 
         public void VisitLeaf(in PathGatheringContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
-            PathGatheringContext context = nodeContext.Add(node.Key!);
+            PathGatheringContext context = nodeContext.Add(node.Key);
             _paths.Enqueue(context.Nibbles);
         }
 

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -183,7 +183,7 @@ public class VisitingTests
                 return new PathGatheringContext(@new);
             }
 
-            public readonly PathGatheringContext Add(TrieKey nibble)
+            public readonly PathGatheringContext Add(in TrieKey nibble)
             {
                 var @new = new byte[Nibbles.Length + 1];
                 Nibbles.CopyTo(@new, 0);

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -183,7 +183,7 @@ public class VisitingTests
                 return new PathGatheringContext(@new);
             }
 
-            public readonly PathGatheringContext Add(TrieNodeKey nibble)
+            public readonly PathGatheringContext Add(TrieKey nibble)
             {
                 var @new = new byte[Nibbles.Length + 1];
                 Nibbles.CopyTo(@new, 0);

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -137,22 +137,22 @@ public class VisitingTests
         }
     }
 
-    public static IEnumerable<TestCaseData> GetAccountOptions() => GetOptions(false);
-    public static IEnumerable<TestCaseData> GetStorageOptions() => GetOptions(true);
+    private static IEnumerable<TestCaseData> GetAccountOptions() => GetOptions(false);
+    private static IEnumerable<TestCaseData> GetStorageOptions() => GetOptions(true);
 
     private static IEnumerable<TestCaseData> GetOptions(bool expectAccounts)
     {
         yield return new TestCaseData(new VisitingOptions
         {
             ExpectAccounts = expectAccounts
-        }).SetName($"Default(expectAccounts: {expectAccounts})");
+        });
 
         yield return new TestCaseData(new VisitingOptions
         {
             MaxDegreeOfParallelism = Environment.ProcessorCount,
             FullScanMemoryBudget = 1.MiB(),
             ExpectAccounts = expectAccounts
-        }).SetName($"Parallel(expectAccounts: {expectAccounts})");
+        });
     }
 
     public class AppendingVisitor : ITreeVisitor<AppendingVisitor.PathGatheringContext>
@@ -183,11 +183,11 @@ public class VisitingTests
                 return new PathGatheringContext(@new);
             }
 
-            public readonly PathGatheringContext Add(in TrieKey nibble)
+            public readonly PathGatheringContext Add(in TrieKey nibblePath)
             {
-                var @new = new byte[Nibbles.Length + 1];
+                var @new = new byte[Nibbles.Length + nibblePath.Length];
                 Nibbles.CopyTo(@new, 0);
-                @new[Nibbles.Length] = nibble[0];
+                nibblePath.CopyTo(@new.AsSpan(Nibbles.Length));
 
                 return new PathGatheringContext(@new);
             }

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -390,7 +390,7 @@ public readonly struct EmptyContext : INodeContext<EmptyContext>
 {
     public EmptyContext Add(ReadOnlySpan<byte> nibblePath) => this;
     public EmptyContext Add(byte nibble) => this;
-    public EmptyContext Add(TrieKey nibble) => this;
+    public EmptyContext Add(in TrieKey nibble) => this;
     public EmptyContext AddStorage(in ValueHash256 storage) => this;
 }
 
@@ -418,7 +418,7 @@ public struct TreePathContext : INodeContext<TreePathContext>
         };
     }
 
-    public TreePathContext Add(TrieKey nibble)
+    public TreePathContext Add(in TrieKey nibble)
     {
         return new TreePathContext()
         {
@@ -465,7 +465,7 @@ public readonly struct TreePathContextWithStorage : ITreePathContextWithStorage,
         };
     }
 
-    public TreePathContextWithStorage Add(TrieKey nibble)
+    public TreePathContextWithStorage Add(in TrieKey nibble)
     {
         return new TreePathContextWithStorage()
         {
@@ -500,7 +500,7 @@ public struct NoopTreePathContextWithStorage : ITreePathContextWithStorage, INod
         return this;
     }
 
-    public readonly NoopTreePathContextWithStorage Add(TrieKey nibble)
+    public readonly NoopTreePathContextWithStorage Add(in TrieKey nibble)
     {
         return this;
     }
@@ -523,6 +523,6 @@ public interface INodeContext<out TNodeContext>
 
     TNodeContext Add(byte nibble);
 
-    TNodeContext Add(TrieKey nibble);
+    TNodeContext Add(in TrieKey nibble);
     TNodeContext AddStorage(in ValueHash256 storage);
 }

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -418,11 +418,11 @@ public struct TreePathContext : INodeContext<TreePathContext>
         };
     }
 
-    public TreePathContext Add(in TrieKey nibble)
+    public TreePathContext Add(in TrieKey nibblePath)
     {
         return new TreePathContext()
         {
-            Path = Path.Append(nibble)
+            Path = Path.Append(nibblePath)
         };
     }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -390,6 +390,7 @@ public readonly struct EmptyContext : INodeContext<EmptyContext>
 {
     public EmptyContext Add(ReadOnlySpan<byte> nibblePath) => this;
     public EmptyContext Add(byte nibble) => this;
+    public EmptyContext Add(TrieNodeKey nibble) => this;
     public EmptyContext AddStorage(in ValueHash256 storage) => this;
 }
 
@@ -410,6 +411,14 @@ public struct TreePathContext : INodeContext<TreePathContext>
     }
 
     public TreePathContext Add(byte nibble)
+    {
+        return new TreePathContext()
+        {
+            Path = Path.Append((int)nibble)
+        };
+    }
+
+    public TreePathContext Add(TrieNodeKey nibble)
     {
         return new TreePathContext()
         {
@@ -451,6 +460,15 @@ public readonly struct TreePathContextWithStorage : ITreePathContextWithStorage,
     {
         return new TreePathContextWithStorage()
         {
+            Path = Path.Append((int)nibble),
+            Storage = Storage
+        };
+    }
+
+    public TreePathContextWithStorage Add(TrieNodeKey nibble)
+    {
+        return new TreePathContextWithStorage()
+        {
             Path = Path.Append(nibble),
             Storage = Storage
         };
@@ -482,6 +500,11 @@ public struct NoopTreePathContextWithStorage : ITreePathContextWithStorage, INod
         return this;
     }
 
+    public readonly NoopTreePathContextWithStorage Add(TrieNodeKey nibble)
+    {
+        return this;
+    }
+
     public readonly NoopTreePathContextWithStorage AddStorage(in ValueHash256 storage)
     {
         return this;
@@ -499,5 +522,7 @@ public interface INodeContext<out TNodeContext>
     TNodeContext Add(ReadOnlySpan<byte> nibblePath);
 
     TNodeContext Add(byte nibble);
+
+    TNodeContext Add(TrieNodeKey nibble);
     TNodeContext AddStorage(in ValueHash256 storage);
 }

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -390,7 +390,7 @@ public readonly struct EmptyContext : INodeContext<EmptyContext>
 {
     public EmptyContext Add(ReadOnlySpan<byte> nibblePath) => this;
     public EmptyContext Add(byte nibble) => this;
-    public EmptyContext Add(TrieNodeKey nibble) => this;
+    public EmptyContext Add(TrieKey nibble) => this;
     public EmptyContext AddStorage(in ValueHash256 storage) => this;
 }
 
@@ -418,7 +418,7 @@ public struct TreePathContext : INodeContext<TreePathContext>
         };
     }
 
-    public TreePathContext Add(TrieNodeKey nibble)
+    public TreePathContext Add(TrieKey nibble)
     {
         return new TreePathContext()
         {
@@ -465,7 +465,7 @@ public readonly struct TreePathContextWithStorage : ITreePathContextWithStorage,
         };
     }
 
-    public TreePathContextWithStorage Add(TrieNodeKey nibble)
+    public TreePathContextWithStorage Add(TrieKey nibble)
     {
         return new TreePathContextWithStorage()
         {
@@ -500,7 +500,7 @@ public struct NoopTreePathContextWithStorage : ITreePathContextWithStorage, INod
         return this;
     }
 
-    public readonly NoopTreePathContextWithStorage Add(TrieNodeKey nibble)
+    public readonly NoopTreePathContextWithStorage Add(TrieKey nibble)
     {
         return this;
     }
@@ -523,6 +523,6 @@ public interface INodeContext<out TNodeContext>
 
     TNodeContext Add(byte nibble);
 
-    TNodeContext Add(TrieNodeKey nibble);
+    TNodeContext Add(TrieKey nibble);
     TNodeContext AddStorage(in ValueHash256 storage);
 }

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Trie
     public static class HexPrefix
     {
         public static int ByteLength(byte[] path) => path.Length / 2 + 1;
-        public static int ByteLength(TrieNodeKey path) => path.Length / 2 + 1;
+        public static int ByteLength(TrieKey path) => path.Length / 2 + 1;
 
         public static void CopyToSpan(byte[] path, bool isLeaf, Span<byte> output)
         {
@@ -31,7 +31,7 @@ namespace Nethermind.Trie
                         : (byte)(16 * path[i + 1] + path[i + 2]);
             }
         }
-        public static void CopyToSpan(TrieNodeKey path, bool isLeaf, Span<byte> output)
+        public static void CopyToSpan(TrieKey path, bool isLeaf, Span<byte> output)
         {
             if (output.Length != ByteLength(path)) throw new ArgumentOutOfRangeException(nameof(output));
 

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -11,8 +11,27 @@ namespace Nethermind.Trie
     public static class HexPrefix
     {
         public static int ByteLength(byte[] path) => path.Length / 2 + 1;
+        public static int ByteLength(TrieNodeKey path) => path.Length / 2 + 1;
 
         public static void CopyToSpan(byte[] path, bool isLeaf, Span<byte> output)
+        {
+            if (output.Length != ByteLength(path)) throw new ArgumentOutOfRangeException(nameof(output));
+
+            output[0] = (byte)(isLeaf ? 0x20 : 0x00);
+            if (path.Length % 2 != 0)
+            {
+                output[0] += (byte)(0x10 + path[0]);
+            }
+
+            for (int i = 0; i < path.Length - 1; i += 2)
+            {
+                output[i / 2 + 1] =
+                    path.Length % 2 == 0
+                        ? (byte)(16 * path[i] + path[i + 1])
+                        : (byte)(16 * path[i + 1] + path[i + 2]);
+            }
+        }
+        public static void CopyToSpan(TrieNodeKey path, bool isLeaf, Span<byte> output)
         {
             if (output.Length != ByteLength(path)) throw new ArgumentOutOfRangeException(nameof(output));
 

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Trie
                         : (byte)(16 * path[i + 1] + path[i + 2]);
             }
         }
-        public static void CopyToSpan(TrieKey path, bool isLeaf, Span<byte> output)
+        public static void CopyToSpan(in TrieKey path, bool isLeaf, Span<byte> output)
         {
             if (output.Length != ByteLength(path)) throw new ArgumentOutOfRangeException(nameof(output));
 

--- a/src/Nethermind/Nethermind.Trie/NodeData.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeData.cs
@@ -7,6 +7,8 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
+using static Nethermind.Trie.Pruning.TrieStoreDirtyNodesCache;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Trie;
 
@@ -21,7 +23,309 @@ public interface INodeData
 
 interface INodeWithKey : INodeData
 {
-    public byte[] Key { get; set; }
+    public TrieNodeKey Key { get; set; }
+}
+
+public class TrieNodeKey : IEquatable<TrieNodeKey>
+{
+    private readonly static byte[][] _singleByteArrays =
+    [
+        [0],
+        [1],
+        [2],
+        [3],
+        [4],
+        [5],
+        [6],
+        [7],
+        [8],
+        [9],
+        [10],
+        [11],
+        [12],
+        [13],
+        [14],
+        [15]
+    ];
+    public static TrieNodeKey Empty { get; } = new(Array.Empty<byte>());
+    private readonly static TrieNodeKey[] _singleByteKeys =
+    [
+        new TrieNodeKey(_singleByteArrays[0]),
+        new TrieNodeKey(_singleByteArrays[1]),
+        new TrieNodeKey(_singleByteArrays[2]),
+        new TrieNodeKey(_singleByteArrays[3]),
+        new TrieNodeKey(_singleByteArrays[4]),
+        new TrieNodeKey(_singleByteArrays[5]),
+        new TrieNodeKey(_singleByteArrays[6]),
+        new TrieNodeKey(_singleByteArrays[7]),
+        new TrieNodeKey(_singleByteArrays[8]),
+        new TrieNodeKey(_singleByteArrays[9]),
+        new TrieNodeKey(_singleByteArrays[10]),
+        new TrieNodeKey(_singleByteArrays[11]),
+        new TrieNodeKey(_singleByteArrays[12]),
+        new TrieNodeKey(_singleByteArrays[13]),
+        new TrieNodeKey(_singleByteArrays[14]),
+        new TrieNodeKey(_singleByteArrays[15])
+    ];
+
+    private readonly byte[] _keyPart0;
+    private readonly byte[]? _keyPart1;
+
+    public TrieNodeKey(byte[] key) => _keyPart0 = key;
+    public TrieNodeKey(byte keyPart0, TrieNodeKey keyPart1)
+    {
+        if (keyPart1.Length == 0)
+        {
+            _keyPart0 = _singleByteArrays[keyPart0];
+        }
+        else if (keyPart1._keyPart1 is null)
+        {
+            _keyPart0 = _singleByteArrays[keyPart0];
+            _keyPart1 = keyPart1._keyPart0;
+        }
+        else
+        {
+            // Often slice off the first byte, so just combine keyPart1 parts
+            _keyPart0 = _singleByteArrays[keyPart0];
+            _keyPart1 = Bytes.Concat(keyPart1._keyPart0, keyPart1._keyPart1);
+        }
+    }
+
+    public TrieNodeKey(TrieNodeKey keyPart0, TrieNodeKey keyPart1)
+    {
+        if (keyPart0.Length == 0 && keyPart1.Length == 0)
+        {
+            // Both parts are empty, return Empty
+            _keyPart0 = Array.Empty<byte>();
+        }
+        else if (keyPart0.Length == 0)
+        {
+            _keyPart0 = keyPart1._keyPart0;
+            _keyPart1 = keyPart1._keyPart1;
+        }
+        else if (keyPart1.Length == 0)
+        {
+            _keyPart0 = keyPart0._keyPart0;
+            _keyPart1 = keyPart0._keyPart1;
+        }
+        else if (keyPart0._keyPart1 is null && keyPart1._keyPart1 is null)
+        {
+            _keyPart0 = keyPart0._keyPart0;
+            _keyPart1 = keyPart1._keyPart0;
+        }
+        else if (keyPart0._keyPart1 is null)
+        {
+            // Combine the keyPart1._keyPart0 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart1
+            if (keyPart0._keyPart0.Length >= keyPart1._keyPart1.Length)
+            {
+                _keyPart0 = keyPart0._keyPart0;
+                int combinedLength = keyPart1._keyPart0.Length + keyPart1._keyPart1.Length;
+                _keyPart1 = new byte[combinedLength];
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
+            }
+            else
+            {
+                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart0.Length;
+                _keyPart0 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart0.Length);
+                _keyPart1 = keyPart1._keyPart1;
+            }
+        }
+        else if (keyPart1._keyPart1 is null)
+        {
+            // Combine the keyPart0._keyPart1 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart0
+            if (keyPart0._keyPart0.Length >= keyPart1._keyPart0.Length)
+            {
+                _keyPart0 = keyPart0._keyPart0;
+                int combinedLength = keyPart0._keyPart1.Length + keyPart1._keyPart1.Length;
+                _keyPart1 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart1, 0, _keyPart1, 0, keyPart0._keyPart1.Length);
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, keyPart0._keyPart1.Length, keyPart1._keyPart0.Length);
+            }
+            else
+            {
+                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart1.Length;
+                _keyPart0 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart1.Length);
+                _keyPart1 = keyPart1._keyPart0;
+            }
+        }
+        else
+        {
+            _keyPart0 = new byte[keyPart0.Length];
+            Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+            Array.Copy(keyPart0._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart0._keyPart1.Length);
+
+            _keyPart1 = new byte[keyPart1.Length];
+            Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
+            Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
+        }
+    }
+
+    public TrieNodeKey(byte[] keyPart0, byte[] keyPart1)
+    {
+        _keyPart0 = keyPart0;
+        _keyPart1 = keyPart1;
+    }
+
+    public static implicit operator TrieNodeKey(byte key) => _singleByteKeys[key];
+    public static implicit operator TrieNodeKey(byte[] key) => new(key);
+
+    public byte this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Index out of range");
+            }
+            return index < (_keyPart0?.Length ?? 0) ? _keyPart0![index] : _keyPart1![index - _keyPart0!.Length];
+        }
+    }
+
+    public int CommonPrefixLength(TrieNodeKey other)
+    {
+        int commonLength = 0;
+        int minLength = Math.Min(Length, other.Length);
+        while (commonLength < minLength && this[commonLength] == other[commonLength])
+        {
+            commonLength++;
+        }
+        return commonLength;
+    }
+
+    public TrieNodeKey Slice(int start) => Slice(start, Length - start);
+
+    public TrieNodeKey Slice(int start, int length)
+    {
+        if (start < 0 || length < 0 || start + length > Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Invalid start or length parameters");
+        }
+
+        if (length == 0)
+        {
+            return Empty;
+        }
+
+        if (length == 1)
+        {
+            return _singleByteKeys[this[start]];
+        }
+
+        int part0Length = _keyPart0?.Length ?? 0;
+
+        // If slice is entirely within first part
+        if (_keyPart1 is null || start + length <= part0Length)
+        {
+            if (start == 0 && length == part0Length)
+            {
+                return _keyPart1 is null ? this : new TrieNodeKey(_keyPart0!);
+            }
+            byte[] newArray = new byte[length];
+            Array.Copy(_keyPart0!, start, newArray, 0, length);
+            return new TrieNodeKey(newArray);
+        }
+
+        // If slice starts in second part
+        if (start >= part0Length)
+        {
+            if (start == part0Length && length == _keyPart1!.Length)
+            {
+                return new TrieNodeKey(_keyPart1);
+            }
+            byte[] newArray = new byte[length];
+            Array.Copy(_keyPart1!, start - part0Length, newArray, 0, length);
+            return new TrieNodeKey(newArray);
+        }
+
+        // Slice spans both parts
+        int lengthInPart0 = part0Length - start;
+        int lengthInPart1 = length - lengthInPart0;
+
+        byte[] newKey = new byte[length];
+        Array.Copy(_keyPart0, start, newKey, 0, lengthInPart0);
+        Array.Copy(_keyPart1, 0, newKey, lengthInPart0, lengthInPart1);
+
+        return new TrieNodeKey(newKey);
+    }
+
+    public byte[] ToArray()
+    {
+        var length = Length;
+        if (length == 0) return Array.Empty<byte>();
+        if (length == 1) return _singleByteArrays[this[0]];
+
+        byte[] result = new byte[length];
+        _keyPart0.CopyTo(result, 0);
+        _keyPart1?.CopyTo(result, _keyPart0.Length);
+        return result;
+    }
+
+    public int Length => _keyPart0.Length + (_keyPart1?.Length ?? 0);
+
+    public static bool operator ==(TrieNodeKey left, TrieNodeKey right)
+    {
+        if (left is null) return right is null;
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(TrieNodeKey left, TrieNodeKey right) => !(left == right);
+
+    public bool Equals(TrieNodeKey? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        if (Length != other.Length) return false;
+
+        ReadOnlySpan<byte> thisSpan0 = _keyPart0;
+        ReadOnlySpan<byte> otherSpan0 = other._keyPart0;
+
+        if (thisSpan0.Length == otherSpan0.Length)
+        {
+            return thisSpan0.SequenceEqual(otherSpan0);
+        }
+
+        ReadOnlySpan<byte> thisSpan1 = _keyPart1 ?? default;
+        ReadOnlySpan<byte> otherSpan1 = other._keyPart1 ?? default;
+
+        int thisIndex = 0;
+        int otherIndex = 0;
+        int totalLength = Length;
+
+        while (thisIndex < totalLength && otherIndex < totalLength)
+        {
+            ReadOnlySpan<byte> thisCurrentSpan = thisIndex < thisSpan0.Length ? thisSpan0 : thisSpan1;
+            int thisCurrentIndex = thisIndex < thisSpan0.Length ? thisIndex : thisIndex - thisSpan0.Length;
+
+            ReadOnlySpan<byte> otherCurrentSpan = otherIndex < otherSpan0.Length ? otherSpan0 : otherSpan1;
+            int otherCurrentIndex = otherIndex < otherSpan0.Length ? otherIndex : otherIndex - otherSpan0.Length;
+
+            int thisRemaining = thisCurrentSpan.Length - thisCurrentIndex;
+            int otherRemaining = otherCurrentSpan.Length - otherCurrentIndex;
+            int compareLength = Math.Min(thisRemaining, otherRemaining);
+
+            if (!thisCurrentSpan.Slice(thisCurrentIndex, compareLength).SequenceEqual(otherCurrentSpan.Slice(otherCurrentIndex, compareLength)))
+            {
+                return false;
+            }
+
+            thisIndex += compareLength;
+            otherIndex += compareLength;
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object obj) => Equals(obj as TrieNodeKey);
+
+    public override int GetHashCode()
+    {
+        throw new NotImplementedException();
+    }
 }
 
 public class BranchData : INodeData
@@ -56,9 +360,9 @@ public class ExtensionData : INodeWithKey
         (_key is not null ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
     public int Length => 2;
 
-    public byte[]? _key;
+    public TrieNodeKey _key;
     public object? _value;
-    public byte[] Key { get => _key; set => _key = value; }
+    public TrieNodeKey Key { get => _key; set => _key = value; }
     public object? Value { get => _value; set => _value = value; }
     public ref object this[int index]
     {
@@ -82,18 +386,18 @@ public class ExtensionData : INodeWithKey
 
     public ExtensionData() { }
 
-    internal ExtensionData(byte[] key)
+    internal ExtensionData(TrieNodeKey key)
     {
         Key = key;
     }
 
-    internal ExtensionData(byte[] key, TrieNode value)
+    internal ExtensionData(TrieNodeKey key, TrieNode value)
     {
         Key = key;
         Value = value;
     }
 
-    private ExtensionData(byte[] key, object? value)
+    private ExtensionData(TrieNodeKey key, object? value)
     {
         Key = key;
         Value = value;
@@ -112,19 +416,19 @@ public class LeafData : INodeWithKey
 
     private readonly CappedArray<byte> _value;
 
-    public byte[] Key { get; set; }
+    public TrieNodeKey Key { get; set; }
     public ref readonly CappedArray<byte> Value => ref _value;
     public TrieNode? StorageRoot { get; set; }
 
     public LeafData() { }
 
-    internal LeafData(byte[] key, in CappedArray<byte> value)
+    internal LeafData(TrieNodeKey key, in CappedArray<byte> value)
     {
         Key = key;
         _value = value;
     }
 
-    private LeafData(byte[] key, in CappedArray<byte> value, TrieNode? storageRoot)
+    private LeafData(TrieNodeKey key, in CappedArray<byte> value, TrieNode? storageRoot)
     {
         Key = key;
         _value = value;

--- a/src/Nethermind/Nethermind.Trie/NodeData.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeData.cs
@@ -54,7 +54,7 @@ public class ExtensionData : INodeWithKey
 {
     public NodeType NodeType => NodeType.Extension;
     public int MemorySize => MemorySizes.RefSize + MemorySizes.RefSize +
-        (Key.Length > 0 ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
+        MemorySizes.RefSize + MemorySizes.RefSize + (Key.Length > 0 ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
     public int Length => 2;
 
     private TrieKey _key;
@@ -109,7 +109,7 @@ public class LeafData : INodeWithKey
     public NodeType NodeType => NodeType.Leaf;
     public int Length => 0;
     public int MemorySize => MemorySizes.RefSize + MemorySizes.RefSize + MemorySizes.RefSize +
-         (Key.Length > 0 ? (int)MemorySizes.Align(Key.Length + MemorySizes.ArrayOverhead) : 0) +
+         MemorySizes.RefSize + MemorySizes.RefSize + (Key.Length > 0 ? (int)MemorySizes.Align(Key.Length + MemorySizes.ArrayOverhead) : 0) +
          (_value.IsNotNull ? (int)MemorySizes.Align(_value.Length + MemorySizes.ArrayOverhead) : 0);
 
     private readonly CappedArray<byte> _value;

--- a/src/Nethermind/Nethermind.Trie/NodeData.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeData.cs
@@ -23,10 +23,10 @@ public interface INodeData
 
 interface INodeWithKey : INodeData
 {
-    public TrieNodeKey Key { get; set; }
+    public TrieKey Key { get; set; }
 }
 
-public class TrieNodeKey : IEquatable<TrieNodeKey>
+public class TrieKey : IEquatable<TrieKey>
 {
     private readonly static byte[][] _singleByteArrays =
     [
@@ -47,32 +47,32 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         [14],
         [15]
     ];
-    public static TrieNodeKey Empty { get; } = new(Array.Empty<byte>());
-    private readonly static TrieNodeKey[] _singleByteKeys =
+    public static TrieKey Empty { get; } = new(Array.Empty<byte>());
+    private readonly static TrieKey[] _singleByteKeys =
     [
-        new TrieNodeKey(_singleByteArrays[0]),
-        new TrieNodeKey(_singleByteArrays[1]),
-        new TrieNodeKey(_singleByteArrays[2]),
-        new TrieNodeKey(_singleByteArrays[3]),
-        new TrieNodeKey(_singleByteArrays[4]),
-        new TrieNodeKey(_singleByteArrays[5]),
-        new TrieNodeKey(_singleByteArrays[6]),
-        new TrieNodeKey(_singleByteArrays[7]),
-        new TrieNodeKey(_singleByteArrays[8]),
-        new TrieNodeKey(_singleByteArrays[9]),
-        new TrieNodeKey(_singleByteArrays[10]),
-        new TrieNodeKey(_singleByteArrays[11]),
-        new TrieNodeKey(_singleByteArrays[12]),
-        new TrieNodeKey(_singleByteArrays[13]),
-        new TrieNodeKey(_singleByteArrays[14]),
-        new TrieNodeKey(_singleByteArrays[15])
+        new TrieKey(_singleByteArrays[0]),
+        new TrieKey(_singleByteArrays[1]),
+        new TrieKey(_singleByteArrays[2]),
+        new TrieKey(_singleByteArrays[3]),
+        new TrieKey(_singleByteArrays[4]),
+        new TrieKey(_singleByteArrays[5]),
+        new TrieKey(_singleByteArrays[6]),
+        new TrieKey(_singleByteArrays[7]),
+        new TrieKey(_singleByteArrays[8]),
+        new TrieKey(_singleByteArrays[9]),
+        new TrieKey(_singleByteArrays[10]),
+        new TrieKey(_singleByteArrays[11]),
+        new TrieKey(_singleByteArrays[12]),
+        new TrieKey(_singleByteArrays[13]),
+        new TrieKey(_singleByteArrays[14]),
+        new TrieKey(_singleByteArrays[15])
     ];
 
     private readonly byte[] _keyPart0;
     private readonly byte[]? _keyPart1;
 
-    public TrieNodeKey(byte[] key) => _keyPart0 = key;
-    public TrieNodeKey(byte keyPart0, TrieNodeKey keyPart1)
+    public TrieKey(byte[] key) => _keyPart0 = key;
+    public TrieKey(byte keyPart0, TrieKey keyPart1)
     {
         if (keyPart1.Length == 0)
         {
@@ -91,7 +91,7 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         }
     }
 
-    public TrieNodeKey(TrieNodeKey keyPart0, TrieNodeKey keyPart1)
+    public TrieKey(TrieKey keyPart0, TrieKey keyPart1)
     {
         if (keyPart0.Length == 0 && keyPart1.Length == 0)
         {
@@ -165,14 +165,14 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         }
     }
 
-    public TrieNodeKey(byte[] keyPart0, byte[] keyPart1)
+    public TrieKey(byte[] keyPart0, byte[] keyPart1)
     {
         _keyPart0 = keyPart0;
         _keyPart1 = keyPart1;
     }
 
-    public static implicit operator TrieNodeKey(byte key) => _singleByteKeys[key];
-    public static implicit operator TrieNodeKey(byte[] key) => new(key);
+    public static implicit operator TrieKey(byte key) => _singleByteKeys[key];
+    public static implicit operator TrieKey(byte[] key) => new(key);
 
     public byte this[int index]
     {
@@ -186,7 +186,7 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         }
     }
 
-    public int CommonPrefixLength(TrieNodeKey other)
+    public int CommonPrefixLength(TrieKey other)
     {
         int commonLength = 0;
         int minLength = Math.Min(Length, other.Length);
@@ -197,9 +197,9 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         return commonLength;
     }
 
-    public TrieNodeKey Slice(int start) => Slice(start, Length - start);
+    public TrieKey Slice(int start) => Slice(start, Length - start);
 
-    public TrieNodeKey Slice(int start, int length)
+    public TrieKey Slice(int start, int length)
     {
         if (start < 0 || length < 0 || start + length > Length)
         {
@@ -223,11 +223,11 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         {
             if (start == 0 && length == part0Length)
             {
-                return _keyPart1 is null ? this : new TrieNodeKey(_keyPart0!);
+                return _keyPart1 is null ? this : new TrieKey(_keyPart0!);
             }
             byte[] newArray = new byte[length];
             Array.Copy(_keyPart0!, start, newArray, 0, length);
-            return new TrieNodeKey(newArray);
+            return new TrieKey(newArray);
         }
 
         // If slice starts in second part
@@ -235,11 +235,11 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         {
             if (start == part0Length && length == _keyPart1!.Length)
             {
-                return new TrieNodeKey(_keyPart1);
+                return new TrieKey(_keyPart1);
             }
             byte[] newArray = new byte[length];
             Array.Copy(_keyPart1!, start - part0Length, newArray, 0, length);
-            return new TrieNodeKey(newArray);
+            return new TrieKey(newArray);
         }
 
         // Slice spans both parts
@@ -250,7 +250,7 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         Array.Copy(_keyPart0, start, newKey, 0, lengthInPart0);
         Array.Copy(_keyPart1, 0, newKey, lengthInPart0, lengthInPart1);
 
-        return new TrieNodeKey(newKey);
+        return new TrieKey(newKey);
     }
 
     public byte[] ToArray()
@@ -267,15 +267,15 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
 
     public int Length => _keyPart0.Length + (_keyPart1?.Length ?? 0);
 
-    public static bool operator ==(TrieNodeKey left, TrieNodeKey right)
+    public static bool operator ==(TrieKey left, TrieKey right)
     {
         if (left is null) return right is null;
         return left.Equals(right);
     }
 
-    public static bool operator !=(TrieNodeKey left, TrieNodeKey right) => !(left == right);
+    public static bool operator !=(TrieKey left, TrieKey right) => !(left == right);
 
-    public bool Equals(TrieNodeKey? other)
+    public bool Equals(TrieKey? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
@@ -320,7 +320,7 @@ public class TrieNodeKey : IEquatable<TrieNodeKey>
         return true;
     }
 
-    public override bool Equals(object obj) => Equals(obj as TrieNodeKey);
+    public override bool Equals(object obj) => Equals(obj as TrieKey);
 
     public override int GetHashCode()
     {
@@ -360,9 +360,9 @@ public class ExtensionData : INodeWithKey
         (_key is not null ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
     public int Length => 2;
 
-    public TrieNodeKey _key;
+    public TrieKey _key;
     public object? _value;
-    public TrieNodeKey Key { get => _key; set => _key = value; }
+    public TrieKey Key { get => _key; set => _key = value; }
     public object? Value { get => _value; set => _value = value; }
     public ref object this[int index]
     {
@@ -386,18 +386,18 @@ public class ExtensionData : INodeWithKey
 
     public ExtensionData() { }
 
-    internal ExtensionData(TrieNodeKey key)
+    internal ExtensionData(TrieKey key)
     {
         Key = key;
     }
 
-    internal ExtensionData(TrieNodeKey key, TrieNode value)
+    internal ExtensionData(TrieKey key, TrieNode value)
     {
         Key = key;
         Value = value;
     }
 
-    private ExtensionData(TrieNodeKey key, object? value)
+    private ExtensionData(TrieKey key, object? value)
     {
         Key = key;
         Value = value;
@@ -416,19 +416,19 @@ public class LeafData : INodeWithKey
 
     private readonly CappedArray<byte> _value;
 
-    public TrieNodeKey Key { get; set; }
+    public TrieKey Key { get; set; }
     public ref readonly CappedArray<byte> Value => ref _value;
     public TrieNode? StorageRoot { get; set; }
 
     public LeafData() { }
 
-    internal LeafData(TrieNodeKey key, in CappedArray<byte> value)
+    internal LeafData(TrieKey key, in CappedArray<byte> value)
     {
         Key = key;
         _value = value;
     }
 
-    private LeafData(TrieNodeKey key, in CappedArray<byte> value, TrieNode? storageRoot)
+    private LeafData(TrieKey key, in CappedArray<byte> value, TrieNode? storageRoot)
     {
         Key = key;
         _value = value;

--- a/src/Nethermind/Nethermind.Trie/NodeData.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeData.cs
@@ -7,8 +7,6 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
-using static Nethermind.Trie.Pruning.TrieStoreDirtyNodesCache;
-using Nethermind.Core.Extensions;
 
 namespace Nethermind.Trie;
 
@@ -24,308 +22,7 @@ public interface INodeData
 interface INodeWithKey : INodeData
 {
     public TrieKey Key { get; set; }
-}
-
-public class TrieKey : IEquatable<TrieKey>
-{
-    private readonly static byte[][] _singleByteArrays =
-    [
-        [0],
-        [1],
-        [2],
-        [3],
-        [4],
-        [5],
-        [6],
-        [7],
-        [8],
-        [9],
-        [10],
-        [11],
-        [12],
-        [13],
-        [14],
-        [15]
-    ];
-    public static TrieKey Empty { get; } = new(Array.Empty<byte>());
-    private readonly static TrieKey[] _singleByteKeys =
-    [
-        new TrieKey(_singleByteArrays[0]),
-        new TrieKey(_singleByteArrays[1]),
-        new TrieKey(_singleByteArrays[2]),
-        new TrieKey(_singleByteArrays[3]),
-        new TrieKey(_singleByteArrays[4]),
-        new TrieKey(_singleByteArrays[5]),
-        new TrieKey(_singleByteArrays[6]),
-        new TrieKey(_singleByteArrays[7]),
-        new TrieKey(_singleByteArrays[8]),
-        new TrieKey(_singleByteArrays[9]),
-        new TrieKey(_singleByteArrays[10]),
-        new TrieKey(_singleByteArrays[11]),
-        new TrieKey(_singleByteArrays[12]),
-        new TrieKey(_singleByteArrays[13]),
-        new TrieKey(_singleByteArrays[14]),
-        new TrieKey(_singleByteArrays[15])
-    ];
-
-    private readonly byte[] _keyPart0;
-    private readonly byte[]? _keyPart1;
-
-    public TrieKey(byte[] key) => _keyPart0 = key;
-    public TrieKey(byte keyPart0, TrieKey keyPart1)
-    {
-        if (keyPart1.Length == 0)
-        {
-            _keyPart0 = _singleByteArrays[keyPart0];
-        }
-        else if (keyPart1._keyPart1 is null)
-        {
-            _keyPart0 = _singleByteArrays[keyPart0];
-            _keyPart1 = keyPart1._keyPart0;
-        }
-        else
-        {
-            // Often slice off the first byte, so just combine keyPart1 parts
-            _keyPart0 = _singleByteArrays[keyPart0];
-            _keyPart1 = Bytes.Concat(keyPart1._keyPart0, keyPart1._keyPart1);
-        }
-    }
-
-    public TrieKey(TrieKey keyPart0, TrieKey keyPart1)
-    {
-        if (keyPart0.Length == 0 && keyPart1.Length == 0)
-        {
-            // Both parts are empty, return Empty
-            _keyPart0 = Array.Empty<byte>();
-        }
-        else if (keyPart0.Length == 0)
-        {
-            _keyPart0 = keyPart1._keyPart0;
-            _keyPart1 = keyPart1._keyPart1;
-        }
-        else if (keyPart1.Length == 0)
-        {
-            _keyPart0 = keyPart0._keyPart0;
-            _keyPart1 = keyPart0._keyPart1;
-        }
-        else if (keyPart0._keyPart1 is null && keyPart1._keyPart1 is null)
-        {
-            _keyPart0 = keyPart0._keyPart0;
-            _keyPart1 = keyPart1._keyPart0;
-        }
-        else if (keyPart0._keyPart1 is null)
-        {
-            // Combine the keyPart1._keyPart0 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart1
-            if (keyPart0._keyPart0.Length >= keyPart1._keyPart1.Length)
-            {
-                _keyPart0 = keyPart0._keyPart0;
-                int combinedLength = keyPart1._keyPart0.Length + keyPart1._keyPart1.Length;
-                _keyPart1 = new byte[combinedLength];
-                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
-                Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
-            }
-            else
-            {
-                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart0.Length;
-                _keyPart0 = new byte[combinedLength];
-                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
-                Array.Copy(keyPart1._keyPart0, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart0.Length);
-                _keyPart1 = keyPart1._keyPart1;
-            }
-        }
-        else if (keyPart1._keyPart1 is null)
-        {
-            // Combine the keyPart0._keyPart1 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart0
-            if (keyPart0._keyPart0.Length >= keyPart1._keyPart0.Length)
-            {
-                _keyPart0 = keyPart0._keyPart0;
-                int combinedLength = keyPart0._keyPart1.Length + keyPart1._keyPart1.Length;
-                _keyPart1 = new byte[combinedLength];
-                Array.Copy(keyPart0._keyPart1, 0, _keyPart1, 0, keyPart0._keyPart1.Length);
-                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, keyPart0._keyPart1.Length, keyPart1._keyPart0.Length);
-            }
-            else
-            {
-                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart1.Length;
-                _keyPart0 = new byte[combinedLength];
-                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
-                Array.Copy(keyPart1._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart1.Length);
-                _keyPart1 = keyPart1._keyPart0;
-            }
-        }
-        else
-        {
-            _keyPart0 = new byte[keyPart0.Length];
-            Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
-            Array.Copy(keyPart0._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart0._keyPart1.Length);
-
-            _keyPart1 = new byte[keyPart1.Length];
-            Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
-            Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
-        }
-    }
-
-    public TrieKey(byte[] keyPart0, byte[] keyPart1)
-    {
-        _keyPart0 = keyPart0;
-        _keyPart1 = keyPart1;
-    }
-
-    public static implicit operator TrieKey(byte key) => _singleByteKeys[key];
-    public static implicit operator TrieKey(byte[] key) => new(key);
-
-    public byte this[int index]
-    {
-        get
-        {
-            if (index < 0 || index >= Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, "Index out of range");
-            }
-            return index < (_keyPart0?.Length ?? 0) ? _keyPart0![index] : _keyPart1![index - _keyPart0!.Length];
-        }
-    }
-
-    public int CommonPrefixLength(TrieKey other)
-    {
-        int commonLength = 0;
-        int minLength = Math.Min(Length, other.Length);
-        while (commonLength < minLength && this[commonLength] == other[commonLength])
-        {
-            commonLength++;
-        }
-        return commonLength;
-    }
-
-    public TrieKey Slice(int start) => Slice(start, Length - start);
-
-    public TrieKey Slice(int start, int length)
-    {
-        if (start < 0 || length < 0 || start + length > Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(start), "Invalid start or length parameters");
-        }
-
-        if (length == 0)
-        {
-            return Empty;
-        }
-
-        if (length == 1)
-        {
-            return _singleByteKeys[this[start]];
-        }
-
-        int part0Length = _keyPart0?.Length ?? 0;
-
-        // If slice is entirely within first part
-        if (_keyPart1 is null || start + length <= part0Length)
-        {
-            if (start == 0 && length == part0Length)
-            {
-                return _keyPart1 is null ? this : new TrieKey(_keyPart0!);
-            }
-            byte[] newArray = new byte[length];
-            Array.Copy(_keyPart0!, start, newArray, 0, length);
-            return new TrieKey(newArray);
-        }
-
-        // If slice starts in second part
-        if (start >= part0Length)
-        {
-            if (start == part0Length && length == _keyPart1!.Length)
-            {
-                return new TrieKey(_keyPart1);
-            }
-            byte[] newArray = new byte[length];
-            Array.Copy(_keyPart1!, start - part0Length, newArray, 0, length);
-            return new TrieKey(newArray);
-        }
-
-        // Slice spans both parts
-        int lengthInPart0 = part0Length - start;
-        int lengthInPart1 = length - lengthInPart0;
-
-        byte[] newKey = new byte[length];
-        Array.Copy(_keyPart0, start, newKey, 0, lengthInPart0);
-        Array.Copy(_keyPart1, 0, newKey, lengthInPart0, lengthInPart1);
-
-        return new TrieKey(newKey);
-    }
-
-    public byte[] ToArray()
-    {
-        var length = Length;
-        if (length == 0) return Array.Empty<byte>();
-        if (length == 1) return _singleByteArrays[this[0]];
-
-        byte[] result = new byte[length];
-        _keyPart0.CopyTo(result, 0);
-        _keyPart1?.CopyTo(result, _keyPart0.Length);
-        return result;
-    }
-
-    public int Length => _keyPart0.Length + (_keyPart1?.Length ?? 0);
-
-    public static bool operator ==(TrieKey left, TrieKey right)
-    {
-        if (left is null) return right is null;
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(TrieKey left, TrieKey right) => !(left == right);
-
-    public bool Equals(TrieKey? other)
-    {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-        if (Length != other.Length) return false;
-
-        ReadOnlySpan<byte> thisSpan0 = _keyPart0;
-        ReadOnlySpan<byte> otherSpan0 = other._keyPart0;
-
-        if (thisSpan0.Length == otherSpan0.Length)
-        {
-            return thisSpan0.SequenceEqual(otherSpan0);
-        }
-
-        ReadOnlySpan<byte> thisSpan1 = _keyPart1 ?? default;
-        ReadOnlySpan<byte> otherSpan1 = other._keyPart1 ?? default;
-
-        int thisIndex = 0;
-        int otherIndex = 0;
-        int totalLength = Length;
-
-        while (thisIndex < totalLength && otherIndex < totalLength)
-        {
-            ReadOnlySpan<byte> thisCurrentSpan = thisIndex < thisSpan0.Length ? thisSpan0 : thisSpan1;
-            int thisCurrentIndex = thisIndex < thisSpan0.Length ? thisIndex : thisIndex - thisSpan0.Length;
-
-            ReadOnlySpan<byte> otherCurrentSpan = otherIndex < otherSpan0.Length ? otherSpan0 : otherSpan1;
-            int otherCurrentIndex = otherIndex < otherSpan0.Length ? otherIndex : otherIndex - otherSpan0.Length;
-
-            int thisRemaining = thisCurrentSpan.Length - thisCurrentIndex;
-            int otherRemaining = otherCurrentSpan.Length - otherCurrentIndex;
-            int compareLength = Math.Min(thisRemaining, otherRemaining);
-
-            if (!thisCurrentSpan.Slice(thisCurrentIndex, compareLength).SequenceEqual(otherCurrentSpan.Slice(otherCurrentIndex, compareLength)))
-            {
-                return false;
-            }
-
-            thisIndex += compareLength;
-            otherIndex += compareLength;
-        }
-
-        return true;
-    }
-
-    public override bool Equals(object obj) => Equals(obj as TrieKey);
-
-    public override int GetHashCode()
-    {
-        throw new NotImplementedException();
-    }
+    public INodeData Clone(in TrieKey newKey);
 }
 
 public class BranchData : INodeData
@@ -357,10 +54,10 @@ public class ExtensionData : INodeWithKey
 {
     public NodeType NodeType => NodeType.Extension;
     public int MemorySize => MemorySizes.RefSize + MemorySizes.RefSize +
-        (_key is not null ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
+        (Key.Length > 0 ? (int)MemorySizes.Align(_key.Length + MemorySizes.ArrayOverhead) : 0);
     public int Length => 2;
 
-    public TrieKey _key;
+    private TrieKey _key;
     public object? _value;
     public TrieKey Key { get => _key; set => _key = value; }
     public object? Value { get => _value; set => _value = value; }
@@ -386,24 +83,25 @@ public class ExtensionData : INodeWithKey
 
     public ExtensionData() { }
 
-    internal ExtensionData(TrieKey key)
+    internal ExtensionData(in TrieKey key)
     {
         Key = key;
     }
 
-    internal ExtensionData(TrieKey key, TrieNode value)
+    internal ExtensionData(in TrieKey key, TrieNode value)
     {
         Key = key;
         Value = value;
     }
 
-    private ExtensionData(TrieKey key, object? value)
+    private ExtensionData(in TrieKey key, object? value)
     {
         Key = key;
         Value = value;
     }
 
     INodeData INodeData.Clone() => new ExtensionData(Key, Value);
+    public INodeData Clone(in TrieKey newKey) => new ExtensionData(newKey, Value);
 }
 
 public class LeafData : INodeWithKey
@@ -411,7 +109,7 @@ public class LeafData : INodeWithKey
     public NodeType NodeType => NodeType.Leaf;
     public int Length => 0;
     public int MemorySize => MemorySizes.RefSize + MemorySizes.RefSize + MemorySizes.RefSize +
-         (Key is not null ? (int)MemorySizes.Align(Key.Length + MemorySizes.ArrayOverhead) : 0) +
+         (Key.Length > 0 ? (int)MemorySizes.Align(Key.Length + MemorySizes.ArrayOverhead) : 0) +
          (_value.IsNotNull ? (int)MemorySizes.Align(_value.Length + MemorySizes.ArrayOverhead) : 0);
 
     private readonly CappedArray<byte> _value;
@@ -422,13 +120,13 @@ public class LeafData : INodeWithKey
 
     public LeafData() { }
 
-    internal LeafData(TrieKey key, in CappedArray<byte> value)
+    internal LeafData(in TrieKey key, in CappedArray<byte> value)
     {
         Key = key;
         _value = value;
     }
 
-    private LeafData(TrieKey key, in CappedArray<byte> value, TrieNode? storageRoot)
+    private LeafData(in TrieKey key, in CappedArray<byte> value, TrieNode? storageRoot)
     {
         Key = key;
         _value = value;
@@ -438,4 +136,5 @@ public class LeafData : INodeWithKey
 
     INodeData INodeData.Clone() => new LeafData(Key, in _value);
     public LeafData CloneWithNewValue(in CappedArray<byte> value) => new LeafData(Key, in value, StorageRoot);
+    public INodeData Clone(in TrieKey newKey) => new LeafData(in newKey, in _value);
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -932,11 +932,6 @@ namespace Nethermind.Trie
 
         private ref readonly CappedArray<byte> TraverseLeaf(TrieNode node, scoped in TraverseContext traverseContext, scoped ref TreePath path)
         {
-            if (node.Key is null)
-            {
-                ThrowMissingPrefixException();
-            }
-
             TrieKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
             TrieKey shorterPath;
             TrieKey longerPath;
@@ -1038,11 +1033,6 @@ namespace Nethermind.Trie
 
         private ref readonly CappedArray<byte> TraverseExtension(TrieNode node, scoped in TraverseContext traverseContext, scoped ref TreePath path)
         {
-            if (node.Key is null)
-            {
-                ThrowMissingPrefixException();
-            }
-
             TrieNode originalNode = node;
             TrieKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
 
@@ -1430,13 +1420,6 @@ namespace Nethermind.Trie
         {
             throw new TrieException(
                 $"Could not find the leaf node to delete: {traverseContext.UpdatePath.ToHexString()}");
-        }
-
-        [DoesNotReturn]
-        [StackTraceHidden]
-        private static void ThrowMissingPrefixException()
-        {
-            throw new InvalidDataException("An attempt to visit a node without a prefix path.");
         }
 
         [DoesNotReturn]

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -690,7 +690,7 @@ namespace Nethermind.Trie
                             // this only happens when we have branches with values
                             // which is not possible in the Ethereum protocol where keys are of equal lengths
                             // (it is possible in the more general trie definition)
-                            TrieNode leafFromBranch = TrieNodeFactory.CreateLeaf(TrieNodeKey.Empty, node.Value);
+                            TrieNode leafFromBranch = TrieNodeFactory.CreateLeaf(TrieKey.Empty, node.Value);
                             if (_logger.IsTrace) _logger.Trace($"Converting {node} into {leafFromBranch}");
                             nextNode = leafFromBranch;
                         }
@@ -768,7 +768,7 @@ namespace Nethermind.Trie
                                    B B B B B B B B B B B B B B B B
                                    L L - - - - - - - - - - - - - - */
 
-                                TrieNodeKey newKey = new((byte)childNodeIndex, childNode.Key);
+                                TrieKey newKey = new((byte)childNodeIndex, childNode.Key);
 
                                 TrieNode extendedExtension = childNode.CloneWithChangedKey(newKey);
                                 if (_logger.IsTrace)
@@ -778,7 +778,7 @@ namespace Nethermind.Trie
                             }
                             else if (childNode.IsLeaf)
                             {
-                                TrieNodeKey newKey = new((byte)childNodeIndex, childNode.Key);
+                                TrieKey newKey = new((byte)childNodeIndex, childNode.Key);
 
                                 TrieNode extendedLeaf = childNode.CloneWithChangedKey(newKey);
                                 if (_logger.IsTrace)
@@ -809,7 +809,7 @@ namespace Nethermind.Trie
 
                     if (nextNode.IsLeaf)
                     {
-                        TrieNodeKey newKey = new(node.Key, nextNode.Key);
+                        TrieKey newKey = new(node.Key, nextNode.Key);
                         TrieNode extendedLeaf = nextNode.CloneWithChangedKey(newKey);
                         if (_logger.IsTrace)
                             _logger.Trace($"Combining {node} and {nextNode} into {extendedLeaf}");
@@ -843,7 +843,7 @@ namespace Nethermind.Trie
                            B B B B B B B B B B B B B B B B
                            L L - - - - - - - - - - - - - - */
 
-                        TrieNodeKey newKey = new(node.Key, nextNode.Key);
+                        TrieKey newKey = new(node.Key, nextNode.Key);
                         TrieNode extendedExtension = nextNode.CloneWithChangedKey(newKey);
                         if (_logger.IsTrace)
                             _logger.Trace($"Combining {node} and {nextNode} into {extendedExtension}");
@@ -937,9 +937,9 @@ namespace Nethermind.Trie
                 ThrowMissingPrefixException();
             }
 
-            TrieNodeKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
-            TrieNodeKey shorterPath;
-            TrieNodeKey longerPath;
+            TrieKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
+            TrieKey shorterPath;
+            TrieKey longerPath;
             if (traverseContext.RemainingUpdatePathLength - node.Key.Length < 0)
             {
                 shorterPath = remaining;
@@ -1009,7 +1009,7 @@ namespace Nethermind.Trie
 
             if (extensionLength != 0)
             {
-                TrieNodeKey extensionPath = longerPath.Slice(0, extensionLength);
+                TrieKey extensionPath = longerPath.Slice(0, extensionLength);
                 TrieNode extension = TrieNodeFactory.CreateExtension(extensionPath);
                 PushToNodeStack(extension, traverseContext.CurrentIndex, 0);
             }
@@ -1021,12 +1021,12 @@ namespace Nethermind.Trie
             }
             else
             {
-                TrieNodeKey shortLeafPath = shorterPath.Slice(extensionLength + 1);
+                TrieKey shortLeafPath = shorterPath.Slice(extensionLength + 1);
                 TrieNode shortLeaf = TrieNodeFactory.CreateLeaf(shortLeafPath.ToArray(), shorterPathValue);
                 branch.SetChild(shorterPath[extensionLength], shortLeaf);
             }
 
-            TrieNodeKey leafPath = longerPath.Slice(extensionLength + 1);
+            TrieKey leafPath = longerPath.Slice(extensionLength + 1);
             TrieNode withUpdatedKeyAndValue = node.CloneWithChangedKeyAndValue(
                 leafPath, longerPathValue);
 
@@ -1044,7 +1044,7 @@ namespace Nethermind.Trie
             }
 
             TrieNode originalNode = node;
-            TrieNodeKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
+            TrieKey remaining = traverseContext.GetRemainingUpdatePath().ToArray();
 
             int extensionLength = remaining.CommonPrefixLength(node.Key);
             if (extensionLength == node.Key.Length)
@@ -1083,10 +1083,10 @@ namespace Nethermind.Trie
                 ThrowMissingLeafException(in traverseContext);
             }
 
-            TrieNodeKey pathBeforeUpdate = node.Key;
+            TrieKey pathBeforeUpdate = node.Key;
             if (extensionLength != 0)
             {
-                TrieNodeKey extensionPath = node.Key.Slice(0, extensionLength);
+                TrieKey extensionPath = node.Key.Slice(0, extensionLength);
                 node = node.CloneWithChangedKey(extensionPath);
                 PushToNodeStack(node, traverseContext.CurrentIndex, 0);
             }
@@ -1099,7 +1099,7 @@ namespace Nethermind.Trie
             }
             else
             {
-                TrieNodeKey remainingPath = remaining.Slice(extensionLength + 1);
+                TrieKey remainingPath = remaining.Slice(extensionLength + 1);
                 TrieNode shortLeaf = TrieNodeFactory.CreateLeaf(remainingPath, in traverseContext.UpdateValue);
                 branch.SetChild(remaining[extensionLength], shortLeaf);
             }
@@ -1112,7 +1112,7 @@ namespace Nethermind.Trie
 
             if (pathBeforeUpdate.Length - extensionLength > 1)
             {
-                TrieNodeKey extensionPath = pathBeforeUpdate.Slice(extensionLength + 1, pathBeforeUpdate.Length - extensionLength - 1);
+                TrieKey extensionPath = pathBeforeUpdate.Slice(extensionLength + 1, pathBeforeUpdate.Length - extensionLength - 1);
                 TrieNode secondExtension
                     = TrieNodeFactory.CreateExtension(extensionPath, originalNodeChild);
                 branch.SetChild(pathBeforeUpdate[extensionLength], secondExtension);
@@ -1145,7 +1145,7 @@ namespace Nethermind.Trie
             }
 
             int currentIndex = traverseContext.CurrentIndex + 1;
-            TrieNodeKey leafPath = traverseContext.UpdatePath[
+            TrieKey leafPath = traverseContext.UpdatePath[
                 currentIndex..].ToArray();
             TrieNode leaf = TrieNodeFactory.CreateLeaf(leafPath, in traverseContext.UpdateValue);
             ConnectNodes(leaf, in traverseContext);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
@@ -94,13 +94,13 @@ public struct TreePath : IEquatable<TreePath>
         return copy;
     }
 
-    public readonly TreePath Append(in TrieKey nibbles)
+    public readonly TreePath Append(in TrieKey nibblePath)
     {
-        if (nibbles.Length == 0) return this;
-        if (nibbles.Length == 1) return Append((int)nibbles[0]);
+        if (nibblePath.Length == 0) return this;
+        if (nibblePath.Length == 1) return Append((int)nibblePath[0]);
 
         TreePath copy = this;
-        copy.AppendMut(nibbles);
+        copy.AppendMut(nibblePath);
         return copy;
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
@@ -7,12 +7,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.Intrinsics;
-
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using System.Numerics;
 
 namespace Nethermind.Trie;
 
@@ -95,9 +94,9 @@ public struct TreePath : IEquatable<TreePath>
         return copy;
     }
 
-    public readonly TreePath Append(TrieKey nibbles)
+    public readonly TreePath Append(in TrieKey nibbles)
     {
-        if ((nibbles?.Length ?? 0) == 0) return this;
+        if (nibbles.Length == 0) return this;
         if (nibbles.Length == 1) return Append((int)nibbles[0]);
 
         TreePath copy = this;
@@ -145,9 +144,9 @@ public struct TreePath : IEquatable<TreePath>
         }
     }
 
-    internal void AppendMut(TrieKey nibbles)
+    internal void AppendMut(in TrieKey nibbles)
     {
-        if ((nibbles?.Length ?? 0) == 0) return;
+        if (nibbles.Length == 0) return;
         if (nibbles.Length == 1)
         {
             AppendMut((int)nibbles[0]);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
@@ -95,7 +95,7 @@ public struct TreePath : IEquatable<TreePath>
         return copy;
     }
 
-    public readonly TreePath Append(TrieNodeKey nibbles)
+    public readonly TreePath Append(TrieKey nibbles)
     {
         if ((nibbles?.Length ?? 0) == 0) return this;
         if (nibbles.Length == 1) return Append((int)nibbles[0]);
@@ -145,7 +145,7 @@ public struct TreePath : IEquatable<TreePath>
         }
     }
 
-    internal void AppendMut(TrieNodeKey nibbles)
+    internal void AppendMut(TrieKey nibbles)
     {
         if ((nibbles?.Length ?? 0) == 0) return;
         if (nibbles.Length == 1)
@@ -453,7 +453,7 @@ public static class TreePathExtensions
         path.AppendMut(nibbles);
         return new TreePath.AppendScope(previousLength, ref path);
     }
-    public static TreePath.AppendScope ScopedAppend(this ref TreePath path, TrieNodeKey nibbles)
+    public static TreePath.AppendScope ScopedAppend(this ref TreePath path, TrieKey nibbles)
     {
         int previousLength = path.Length;
         path.AppendMut(nibbles);

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Trie
 
         public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key.ToArray()).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         private readonly AccountDecoder decoder = new();
@@ -63,7 +63,7 @@ namespace Nethermind.Trie
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key.ToArray()).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             Rlp.ValueDecoderContext valueDecoderContext = new(value);
             if (!trieVisitContext.IsStorage)
             {

--- a/src/Nethermind/Nethermind.Trie/TrieKey.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieKey.cs
@@ -351,7 +351,7 @@ public readonly struct TrieKey
         ReadOnlySpan<byte> otherSpan0 = other._keyPart0;
 
         // If both have the same length in their first array, compare them directly.
-        if (thisSpan0.Length == otherSpan0.Length)
+        if (thisSpan0.Length == otherSpan0.Length && (_keyPart1 is null || _keyPart1.Length == 0))
         {
             return thisSpan0.SequenceEqual(otherSpan0);
         }

--- a/src/Nethermind/Nethermind.Trie/TrieKey.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieKey.cs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Trie;
+
+public readonly struct TrieKey : IEquatable<TrieKey>
+{
+    private readonly static byte[][] _singleBytes = [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15]];
+    private readonly static TrieKey[] _singleByteKeys = [new(_singleBytes[0]), new(_singleBytes[1]), new(_singleBytes[2]), new(_singleBytes[3]), new(_singleBytes[4]), new(_singleBytes[5]), new(_singleBytes[6]), new(_singleBytes[7]), new(_singleBytes[8]), new(_singleBytes[9]), new(_singleBytes[10]), new(_singleBytes[11]), new(_singleBytes[12]), new(_singleBytes[13]), new(_singleBytes[14]), new(_singleBytes[15])];
+    public static TrieKey Empty { get; } = new(Array.Empty<byte>());
+
+    private readonly byte[]? _keyPart0;
+    private readonly byte[]? _keyPart1;
+
+    public TrieKey(byte[] key) => _keyPart0 = key;
+    public TrieKey(byte keyPart0, TrieKey keyPart1)
+    {
+        if (keyPart1.Length == 0)
+        {
+            _keyPart0 = _singleBytes[keyPart0];
+        }
+        else if (keyPart1._keyPart1 is null)
+        {
+            _keyPart0 = _singleBytes[keyPart0];
+            _keyPart1 = keyPart1._keyPart0;
+        }
+        else
+        {
+            // Often slice off the first byte, so just combine keyPart1 parts
+            _keyPart0 = _singleBytes[keyPart0];
+            _keyPart1 = Bytes.Concat(keyPart1._keyPart0, keyPart1._keyPart1);
+        }
+    }
+
+    public TrieKey(TrieKey keyPart0, TrieKey keyPart1)
+    {
+        if (keyPart0.Length == 0 && keyPart1.Length == 0)
+        {
+            // Both parts are empty, return Empty
+            _keyPart0 = Array.Empty<byte>();
+        }
+        else if (keyPart0.Length == 0)
+        {
+            _keyPart0 = keyPart1._keyPart0;
+            _keyPart1 = keyPart1._keyPart1;
+        }
+        else if (keyPart1.Length == 0)
+        {
+            _keyPart0 = keyPart0._keyPart0;
+            _keyPart1 = keyPart0._keyPart1;
+        }
+        else if (keyPart0._keyPart1 is null && keyPart1._keyPart1 is null)
+        {
+            _keyPart0 = keyPart0._keyPart0;
+            _keyPart1 = keyPart1._keyPart0;
+        }
+        else if (keyPart0._keyPart1 is null)
+        {
+            // Combine the keyPart1._keyPart0 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart1
+            if (keyPart0._keyPart0.Length >= keyPart1._keyPart1.Length)
+            {
+                _keyPart0 = keyPart0._keyPart0;
+                int combinedLength = keyPart1._keyPart0.Length + keyPart1._keyPart1.Length;
+                _keyPart1 = new byte[combinedLength];
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
+            }
+            else
+            {
+                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart0.Length;
+                _keyPart0 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart0.Length);
+                _keyPart1 = keyPart1._keyPart1;
+            }
+        }
+        else if (keyPart1._keyPart1 is null)
+        {
+            // Combine the keyPart0._keyPart1 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart0
+            if (keyPart0._keyPart0.Length >= keyPart1._keyPart0.Length)
+            {
+                _keyPart0 = keyPart0._keyPart0;
+                int combinedLength = keyPart0._keyPart1.Length + keyPart1._keyPart1.Length;
+                _keyPart1 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart1, 0, _keyPart1, 0, keyPart0._keyPart1.Length);
+                Array.Copy(keyPart1._keyPart0, 0, _keyPart1, keyPart0._keyPart1.Length, keyPart1._keyPart0.Length);
+            }
+            else
+            {
+                int combinedLength = keyPart0._keyPart0.Length + keyPart1._keyPart1.Length;
+                _keyPart0 = new byte[combinedLength];
+                Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+                Array.Copy(keyPart1._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart1._keyPart1.Length);
+                _keyPart1 = keyPart1._keyPart0;
+            }
+        }
+        else
+        {
+            _keyPart0 = new byte[keyPart0.Length];
+            Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
+            Array.Copy(keyPart0._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart0._keyPart1.Length);
+
+            _keyPart1 = new byte[keyPart1.Length];
+            Array.Copy(keyPart1._keyPart0, 0, _keyPart1, 0, keyPart1._keyPart0.Length);
+            Array.Copy(keyPart1._keyPart1, 0, _keyPart1, keyPart1._keyPart0.Length, keyPart1._keyPart1.Length);
+        }
+    }
+
+    public TrieKey(byte[] keyPart0, byte[] keyPart1)
+    {
+        _keyPart0 = keyPart0;
+        _keyPart1 = keyPart1;
+    }
+
+    public static implicit operator TrieKey(byte key) => _singleByteKeys[key];
+    public static implicit operator TrieKey(byte[] key) => new(key);
+
+    public readonly byte this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Index out of range");
+            }
+            return index < (_keyPart0?.Length ?? 0) ? _keyPart0![index] : _keyPart1![index - _keyPart0!.Length];
+        }
+    }
+
+    public readonly int CommonPrefixLength(TrieKey other)
+    {
+        int commonLength = 0;
+        int minLength = Math.Min(Length, other.Length);
+        while (commonLength < minLength && this[commonLength] == other[commonLength])
+        {
+            commonLength++;
+        }
+        return commonLength;
+    }
+
+    public readonly TrieKey Slice(int start) => Slice(start, Length - start);
+
+    public readonly TrieKey Slice(int start, int length)
+    {
+        if (start < 0 || length < 0 || start + length > Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Invalid start or length parameters");
+        }
+
+        if (length == 0)
+        {
+            return Empty;
+        }
+
+        if (length == 1)
+        {
+            return _singleByteKeys[this[start]];
+        }
+
+        int part0Length = _keyPart0?.Length ?? 0;
+
+        // If slice is entirely within first part
+        if (_keyPart1 is null || start + length <= part0Length)
+        {
+            if (start == 0 && length == part0Length)
+            {
+                return _keyPart1 is null ? this : new TrieKey(_keyPart0!);
+            }
+            byte[] newArray = new byte[length];
+            Array.Copy(_keyPart0!, start, newArray, 0, length);
+            return new TrieKey(newArray);
+        }
+
+        // If slice starts in second part
+        if (start >= part0Length)
+        {
+            if (start == part0Length && length == _keyPart1!.Length)
+            {
+                return new TrieKey(_keyPart1);
+            }
+            byte[] newArray = new byte[length];
+            Array.Copy(_keyPart1!, start - part0Length, newArray, 0, length);
+            return new TrieKey(newArray);
+        }
+
+        // Slice spans both parts
+        int lengthInPart0 = part0Length - start;
+        int lengthInPart1 = length - lengthInPart0;
+
+        byte[] newKey = new byte[length];
+        Array.Copy(_keyPart0, start, newKey, 0, lengthInPart0);
+        Array.Copy(_keyPart1, 0, newKey, lengthInPart0, lengthInPart1);
+
+        return new TrieKey(newKey);
+    }
+
+    public readonly byte[] ToArray()
+    {
+        var length = Length;
+        if (length == 0) return Array.Empty<byte>();
+        if (length == 1) return _singleBytes[this[0]];
+        if (_keyPart0.Length == length) return _keyPart0;
+
+        byte[] result = new byte[length];
+        _keyPart0?.CopyTo(result, 0);
+        _keyPart1?.CopyTo(result, _keyPart0?.Length ?? 0);
+        return result;
+    }
+
+    public readonly int Length => (_keyPart0?.Length ?? 0) + (_keyPart1?.Length ?? 0);
+
+    public static bool operator ==(in TrieKey left, in TrieKey right) => left.Equals(right);
+    public static bool operator !=(TrieKey left, TrieKey right) => !(left == right);
+
+    public readonly bool Equals(TrieKey other)
+    {
+        if (Length != other.Length) return false;
+
+        ReadOnlySpan<byte> thisSpan0 = _keyPart0;
+        ReadOnlySpan<byte> otherSpan0 = other._keyPart0;
+
+        if (thisSpan0.Length == otherSpan0.Length)
+        {
+            return thisSpan0.SequenceEqual(otherSpan0);
+        }
+
+        ReadOnlySpan<byte> thisSpan1 = _keyPart1 ?? default;
+        ReadOnlySpan<byte> otherSpan1 = other._keyPart1 ?? default;
+
+        int thisIndex = 0;
+        int otherIndex = 0;
+        int totalLength = Length;
+
+        while (thisIndex < totalLength && otherIndex < totalLength)
+        {
+            ReadOnlySpan<byte> thisCurrentSpan = thisIndex < thisSpan0.Length ? thisSpan0 : thisSpan1;
+            int thisCurrentIndex = thisIndex < thisSpan0.Length ? thisIndex : thisIndex - thisSpan0.Length;
+
+            ReadOnlySpan<byte> otherCurrentSpan = otherIndex < otherSpan0.Length ? otherSpan0 : otherSpan1;
+            int otherCurrentIndex = otherIndex < otherSpan0.Length ? otherIndex : otherIndex - otherSpan0.Length;
+
+            int thisRemaining = thisCurrentSpan.Length - thisCurrentIndex;
+            int otherRemaining = otherCurrentSpan.Length - otherCurrentIndex;
+            int compareLength = Math.Min(thisRemaining, otherRemaining);
+
+            if (!thisCurrentSpan.Slice(thisCurrentIndex, compareLength).SequenceEqual(otherCurrentSpan.Slice(otherCurrentIndex, compareLength)))
+            {
+                return false;
+            }
+
+            thisIndex += compareLength;
+            otherIndex += compareLength;
+        }
+
+        return true;
+    }
+
+    public readonly override bool Equals(object obj) => obj is TrieKey key && key.Equals(obj);
+    public readonly override int GetHashCode() => throw new NotImplementedException();
+}

--- a/src/Nethermind/Nethermind.Trie/TrieKey.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieKey.cs
@@ -391,6 +391,26 @@ public readonly struct TrieKey
         return true;
     }
 
+    public readonly void CopyTo(Span<byte> destination)
+    {
+        if (destination.Length < Length)
+        {
+            throw new ArgumentException($"Destination span must be at least {Length} bytes long.", nameof(destination));
+        }
+
+        int offset = 0;
+
+        // Copy the first part if not null
+        if (_keyPart0 is not null)
+        {
+            _keyPart0.CopyTo(destination.Slice(offset, _keyPart0.Length));
+            offset += _keyPart0.Length;
+        }
+
+        // Copy the second part if not null
+        _keyPart1?.CopyTo(destination.Slice(offset, _keyPart1.Length));
+    }
+
     public readonly override bool Equals(object obj) => obj is TrieKey key && Equals(in key);
     public readonly override int GetHashCode() => throw new NotImplementedException();
 }

--- a/src/Nethermind/Nethermind.Trie/TrieKey.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieKey.cs
@@ -6,22 +6,47 @@ using Nethermind.Core.Extensions;
 
 namespace Nethermind.Trie;
 
-public readonly struct TrieKey : IEquatable<TrieKey>
+/// <summary>
+/// Represents a key used in a trie data structure. 
+/// This struct can hold a key in one or two byte array parts 
+/// for efficient concatenation and slicing operations.
+/// </summary>
+public readonly struct TrieKey
 {
+    // Predefined array instances for single-byte keys (0..15).
     private readonly static byte[][] _singleBytes = [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15]];
+    // Predefined TrieKey instances for single-byte keys (0..15).
     private readonly static TrieKey[] _singleByteKeys = [new(_singleBytes[0]), new(_singleBytes[1]), new(_singleBytes[2]), new(_singleBytes[3]), new(_singleBytes[4]), new(_singleBytes[5]), new(_singleBytes[6]), new(_singleBytes[7]), new(_singleBytes[8]), new(_singleBytes[9]), new(_singleBytes[10]), new(_singleBytes[11]), new(_singleBytes[12]), new(_singleBytes[13]), new(_singleBytes[14]), new(_singleBytes[15])];
+
+    /// <summary>
+    /// An empty TrieKey instance (no bytes).
+    /// </summary>
     public static TrieKey Empty { get; } = new(Array.Empty<byte>());
 
+    // These two byte arrays together represent the key. 
+    // If _keyPart1 is null, the entire key is in _keyPart0.
     private readonly byte[]? _keyPart0;
     private readonly byte[]? _keyPart1;
 
+    /// <summary>
+    /// Creates a TrieKey from a single byte array.
+    /// </summary>
+    /// <param name="key">The byte array representing the key.</param>
     public TrieKey(byte[] key) => _keyPart0 = key;
+
+    /// <summary>
+    /// Creates a TrieKey by prepending a single byte to another TrieKey.
+    /// </summary>
+    /// <param name="keyPart0">Single byte to prepend.</param>
+    /// <param name="keyPart1">The remaining part of the key as a TrieKey.</param>
     public TrieKey(byte keyPart0, TrieKey keyPart1)
     {
+        // If the second part is empty, just store the single byte in _keyPart0.
         if (keyPart1.Length == 0)
         {
             _keyPart0 = _singleBytes[keyPart0];
         }
+        // If the second part has only _keyPart0, combine single-byte with that.
         else if (keyPart1._keyPart1 is null)
         {
             _keyPart0 = _singleBytes[keyPart0];
@@ -29,37 +54,47 @@ public readonly struct TrieKey : IEquatable<TrieKey>
         }
         else
         {
-            // Often slice off the first byte, so just combine keyPart1 parts
+            // If the second part has two arrays, combine them and prepend the single byte.
+            // We often slice off the first byte, so just combine keyPart1 parts
             _keyPart0 = _singleBytes[keyPart0];
             _keyPart1 = Bytes.Concat(keyPart1._keyPart0, keyPart1._keyPart1);
         }
     }
 
+    /// <summary>
+    /// Creates a TrieKey by concatenating two TrieKeys.
+    /// </summary>
+    /// <param name="keyPart0">The first TrieKey segment.</param>
+    /// <param name="keyPart1">The second TrieKey segment.</param>
     public TrieKey(TrieKey keyPart0, TrieKey keyPart1)
     {
+        // If both parts are empty, this key is empty.
         if (keyPart0.Length == 0 && keyPart1.Length == 0)
         {
-            // Both parts are empty, return Empty
             _keyPart0 = Array.Empty<byte>();
         }
+        // If the first part is empty, just copy the second part's arrays.
         else if (keyPart0.Length == 0)
         {
             _keyPart0 = keyPart1._keyPart0;
             _keyPart1 = keyPart1._keyPart1;
         }
+        // If the second part is empty, just copy the first part's arrays.
         else if (keyPart1.Length == 0)
         {
             _keyPart0 = keyPart0._keyPart0;
             _keyPart1 = keyPart0._keyPart1;
         }
+        // If both parts only have _keyPart0 (no _keyPart1), just set them.
         else if (keyPart0._keyPart1 is null && keyPart1._keyPart1 is null)
         {
             _keyPart0 = keyPart0._keyPart0;
             _keyPart1 = keyPart1._keyPart0;
         }
+        // If only the first part has a single array, handle partial combination carefully.
         else if (keyPart0._keyPart1 is null)
         {
-            // Combine the keyPart1._keyPart0 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart1
+            // Depending on lengths, combine part or all of the second key's arrays.
             if (keyPart0._keyPart0.Length >= keyPart1._keyPart1.Length)
             {
                 _keyPart0 = keyPart0._keyPart0;
@@ -77,9 +112,10 @@ public readonly struct TrieKey : IEquatable<TrieKey>
                 _keyPart1 = keyPart1._keyPart1;
             }
         }
+        // If only the second part has a single array, handle partial combination carefully.
         else if (keyPart1._keyPart1 is null)
         {
-            // Combine the keyPart0._keyPart1 with the shorter part of keyPart0._keyPart0 or keyPart1._keyPart0
+            // Depending on lengths, combine part or all of the first key's arrays.
             if (keyPart0._keyPart0.Length >= keyPart1._keyPart0.Length)
             {
                 _keyPart0 = keyPart0._keyPart0;
@@ -99,6 +135,7 @@ public readonly struct TrieKey : IEquatable<TrieKey>
         }
         else
         {
+            // Both keys have two arrays, so fully concatenate them.
             _keyPart0 = new byte[keyPart0.Length];
             Array.Copy(keyPart0._keyPart0, 0, _keyPart0, 0, keyPart0._keyPart0.Length);
             Array.Copy(keyPart0._keyPart1, 0, _keyPart0, keyPart0._keyPart0.Length, keyPart0._keyPart1.Length);
@@ -109,15 +146,37 @@ public readonly struct TrieKey : IEquatable<TrieKey>
         }
     }
 
+    /// <summary>
+    /// Creates a TrieKey from two separate byte arrays.
+    /// </summary>
+    /// <param name="keyPart0">The first part of the key.</param>
+    /// <param name="keyPart1">The second part of the key.</param>
     public TrieKey(byte[] keyPart0, byte[] keyPart1)
     {
         _keyPart0 = keyPart0;
         _keyPart1 = keyPart1;
     }
 
+    /// <summary>
+    /// Implicitly converts a single byte into a TrieKey.
+    /// </summary>
+    /// <param name="key">A single byte.</param>
     public static implicit operator TrieKey(byte key) => _singleByteKeys[key];
+
+    /// <summary>
+    /// Implicitly converts a byte array into a TrieKey.
+    /// </summary>
+    /// <param name="key">A byte array.</param>
     public static implicit operator TrieKey(byte[] key) => new(key);
 
+    /// <summary>
+    /// Gets the byte at the specified index in this TrieKey.
+    /// </summary>
+    /// <param name="index">Index of the byte to retrieve.</param>
+    /// <returns>The byte at the specified index.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if index is out of range (less than 0 or >= Length).
+    /// </exception>
     public readonly byte this[int index]
     {
         get
@@ -126,14 +185,24 @@ public readonly struct TrieKey : IEquatable<TrieKey>
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, "Index out of range");
             }
-            return index < (_keyPart0?.Length ?? 0) ? _keyPart0![index] : _keyPart1![index - _keyPart0!.Length];
+            // If index is within the first array, return from _keyPart0; otherwise from _keyPart1.
+            return index < (_keyPart0?.Length ?? 0)
+                ? _keyPart0![index]
+                : _keyPart1![index - _keyPart0!.Length];
         }
     }
 
+    /// <summary>
+    /// Calculates the length of the common prefix between this TrieKey and another.
+    /// </summary>
+    /// <param name="other">Another TrieKey to compare.</param>
+    /// <returns>The number of bytes of the shared prefix.</returns>
     public readonly int CommonPrefixLength(TrieKey other)
     {
         int commonLength = 0;
         int minLength = Math.Min(Length, other.Length);
+
+        // Increment while bytes are matching.
         while (commonLength < minLength && this[commonLength] == other[commonLength])
         {
             commonLength++;
@@ -141,8 +210,22 @@ public readonly struct TrieKey : IEquatable<TrieKey>
         return commonLength;
     }
 
+    /// <summary>
+    /// Returns a subset (slice) of this TrieKey starting at a given index through the end.
+    /// </summary>
+    /// <param name="start">Starting index (inclusive).</param>
+    /// <returns>A new TrieKey representing the sliced portion.</returns>
     public readonly TrieKey Slice(int start) => Slice(start, Length - start);
 
+    /// <summary>
+    /// Returns a subset (slice) of this TrieKey with the specified start index and length.
+    /// </summary>
+    /// <param name="start">Starting index (inclusive).</param>
+    /// <param name="length">Number of bytes to include in the slice.</param>
+    /// <returns>A new TrieKey representing the sliced portion.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if the slice parameters are outside this TrieKey's range.
+    /// </exception>
     public readonly TrieKey Slice(int start, int length)
     {
         if (start < 0 || length < 0 || start + length > Length)
@@ -150,11 +233,13 @@ public readonly struct TrieKey : IEquatable<TrieKey>
             throw new ArgumentOutOfRangeException(nameof(start), "Invalid start or length parameters");
         }
 
+        // If we request an empty slice, return Empty.
         if (length == 0)
         {
             return Empty;
         }
 
+        // If the slice is exactly 1 byte, we can return a predefined single-byte key.
         if (length == 1)
         {
             return _singleByteKeys[this[start]];
@@ -162,19 +247,23 @@ public readonly struct TrieKey : IEquatable<TrieKey>
 
         int part0Length = _keyPart0?.Length ?? 0;
 
-        // If slice is entirely within first part
+        // If the entire slice is within the first array:
         if (_keyPart1 is null || start + length <= part0Length)
         {
+            // If the slice covers the entire first array and there's no second array,
+            // or if it effectively covers the entire _keyPart0 portion, return that slice directly.
             if (start == 0 && length == part0Length)
             {
                 return _keyPart1 is null ? this : new TrieKey(_keyPart0!);
             }
+
+            // Otherwise, copy out the relevant portion from _keyPart0.
             byte[] newArray = new byte[length];
             Array.Copy(_keyPart0!, start, newArray, 0, length);
             return new TrieKey(newArray);
         }
 
-        // If slice starts in second part
+        // If the slice is entirely in the second array:
         if (start >= part0Length)
         {
             if (start == part0Length && length == _keyPart1!.Length)
@@ -186,78 +275,122 @@ public readonly struct TrieKey : IEquatable<TrieKey>
             return new TrieKey(newArray);
         }
 
-        // Slice spans both parts
+        // If the slice spans both arrays, copy the relevant parts from each.
         int lengthInPart0 = part0Length - start;
         int lengthInPart1 = length - lengthInPart0;
-
         byte[] newKey = new byte[length];
+
         Array.Copy(_keyPart0, start, newKey, 0, lengthInPart0);
         Array.Copy(_keyPart1, 0, newKey, lengthInPart0, lengthInPart1);
 
         return new TrieKey(newKey);
     }
 
+    /// <summary>
+    /// Converts this TrieKey into a single byte array.
+    /// </summary>
+    /// <returns>A byte array containing the entire key.</returns>
     public readonly byte[] ToArray()
     {
         var length = Length;
-        if (length == 0) return Array.Empty<byte>();
-        if (length == 1) return _singleBytes[this[0]];
-        if (_keyPart0.Length == length) return _keyPart0;
+        if (length == 0)
+        {
+            return Array.Empty<byte>();
+        }
 
+        // If the key is just one byte, we can reference our singleBytes array.
+        if (length == 1)
+        {
+            return _singleBytes[this[0]];
+        }
+
+        // If only _keyPart0 is used and it matches the total length, return it.
+        if (_keyPart0.Length == length)
+        {
+            return _keyPart0;
+        }
+
+        // Otherwise, combine both parts into one array.
         byte[] result = new byte[length];
         _keyPart0?.CopyTo(result, 0);
         _keyPart1?.CopyTo(result, _keyPart0?.Length ?? 0);
         return result;
     }
 
+    /// <summary>
+    /// Gets the total length (in bytes) of this TrieKey.
+    /// </summary>
     public readonly int Length => (_keyPart0?.Length ?? 0) + (_keyPart1?.Length ?? 0);
 
-    public static bool operator ==(in TrieKey left, in TrieKey right) => left.Equals(right);
+    /// <summary>
+    /// Compares two TrieKeys for equality.
+    /// </summary>
+    /// <param name="left">The left TrieKey.</param>
+    /// <param name="right">The right TrieKey.</param>
+    /// <returns>True if they have the same bytes; otherwise false.</returns>
+    public static bool operator ==(in TrieKey left, in TrieKey right) => left.Equals(in right);
+
+    /// <summary>
+    /// Compares two TrieKeys for inequality.
+    /// </summary>
+    /// <param name="left">The left TrieKey.</param>
+    /// <param name="right">The right TrieKey.</param>
+    /// <returns>True if they differ in any byte; otherwise false.</returns>
     public static bool operator !=(TrieKey left, TrieKey right) => !(left == right);
 
-    public readonly bool Equals(TrieKey other)
+    /// <summary>
+    /// Indicates whether this instance and a specified TrieKey have the same bytes.
+    /// </summary>
+    /// <param name="other">The TrieKey to compare with.</param>
+    /// <returns>True if they are byte-identical; otherwise false.</returns>
+    public readonly bool Equals(in TrieKey other)
     {
         if (Length != other.Length) return false;
 
         ReadOnlySpan<byte> thisSpan0 = _keyPart0;
         ReadOnlySpan<byte> otherSpan0 = other._keyPart0;
 
+        // If both have the same length in their first array, compare them directly.
         if (thisSpan0.Length == otherSpan0.Length)
         {
             return thisSpan0.SequenceEqual(otherSpan0);
         }
 
+        // Otherwise, we have to account for part1 segments too.
         ReadOnlySpan<byte> thisSpan1 = _keyPart1 ?? default;
         ReadOnlySpan<byte> otherSpan1 = other._keyPart1 ?? default;
 
-        int thisIndex = 0;
-        int otherIndex = 0;
+        int thisTotalIndex = 0;
+        int otherTotalIndex = 0;
         int totalLength = Length;
 
-        while (thisIndex < totalLength && otherIndex < totalLength)
+        // Compare segment by segment across parts 0 and parts 1.
+        while (thisTotalIndex < totalLength && otherTotalIndex < totalLength)
         {
-            ReadOnlySpan<byte> thisCurrentSpan = thisIndex < thisSpan0.Length ? thisSpan0 : thisSpan1;
-            int thisCurrentIndex = thisIndex < thisSpan0.Length ? thisIndex : thisIndex - thisSpan0.Length;
+            ReadOnlySpan<byte> thisSpan = thisTotalIndex < thisSpan0.Length ? thisSpan0 : thisSpan1;
+            int thisIndex = thisTotalIndex < thisSpan0.Length ? thisTotalIndex : thisTotalIndex - thisSpan0.Length;
 
-            ReadOnlySpan<byte> otherCurrentSpan = otherIndex < otherSpan0.Length ? otherSpan0 : otherSpan1;
-            int otherCurrentIndex = otherIndex < otherSpan0.Length ? otherIndex : otherIndex - otherSpan0.Length;
+            ReadOnlySpan<byte> otherSpan = otherTotalIndex < otherSpan0.Length ? otherSpan0 : otherSpan1;
+            int otherIndex = otherTotalIndex < otherSpan0.Length ? otherTotalIndex : otherTotalIndex - otherSpan0.Length;
 
-            int thisRemaining = thisCurrentSpan.Length - thisCurrentIndex;
-            int otherRemaining = otherCurrentSpan.Length - otherCurrentIndex;
+            int thisRemaining = thisSpan.Length - thisIndex;
+            int otherRemaining = otherSpan.Length - otherIndex;
             int compareLength = Math.Min(thisRemaining, otherRemaining);
 
-            if (!thisCurrentSpan.Slice(thisCurrentIndex, compareLength).SequenceEqual(otherCurrentSpan.Slice(otherCurrentIndex, compareLength)))
+            // Compare slices. If they differ at any point, return false.
+            if (!thisSpan.Slice(thisIndex, compareLength)
+                .SequenceEqual(otherSpan.Slice(otherIndex, compareLength)))
             {
                 return false;
             }
 
-            thisIndex += compareLength;
-            otherIndex += compareLength;
+            thisTotalIndex += compareLength;
+            otherTotalIndex += compareLength;
         }
 
         return true;
     }
 
-    public readonly override bool Equals(object obj) => obj is TrieKey key && key.Equals(obj);
+    public readonly override bool Equals(object obj) => obj is TrieKey key && Equals(in key);
     public readonly override int GetHashCode() => throw new NotImplementedException();
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Trie
                 Debug.Assert(item.Key is not null,
                     "Extension key is null when encoding");
 
-                byte[] hexPrefix = item.Key;
+                TrieNodeKey hexPrefix = item.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)
@@ -95,7 +95,7 @@ namespace Nethermind.Trie
                     ThrowNullKey(node);
                 }
 
-                byte[] hexPrefix = node.Key;
+                TrieNodeKey hexPrefix = node.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Trie
                 Debug.Assert(item.Key is not null,
                     "Extension key is null when encoding");
 
-                TrieNodeKey hexPrefix = item.Key;
+                TrieKey hexPrefix = item.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)
@@ -95,7 +95,7 @@ namespace Nethermind.Trie
                     ThrowNullKey(node);
                 }
 
-                TrieNodeKey hexPrefix = node.Key;
+                TrieKey hexPrefix = node.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -33,8 +33,6 @@ namespace Nethermind.Trie
 
                 Debug.Assert(item.NodeType == NodeType.Extension,
                     $"Node passed to {nameof(EncodeExtension)} is {item.NodeType}");
-                Debug.Assert(item.Key is not null,
-                    "Extension key is null when encoding");
 
                 TrieKey hexPrefix = item.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
@@ -90,11 +88,6 @@ namespace Nethermind.Trie
             {
                 Metrics.TreeNodeRlpEncodings++;
 
-                if (node.Key is null)
-                {
-                    ThrowNullKey(node);
-                }
-
                 TrieKey hexPrefix = node.Key;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
@@ -119,13 +112,6 @@ namespace Nethermind.Trie
                 }
                 rlpStream.Encode(node.Value.AsSpan());
                 return data;
-            }
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            private static void ThrowNullKey(TrieNode node)
-            {
-                throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
             }
 
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -163,7 +163,7 @@ namespace Nethermind.Trie
         public bool IsBranch => NodeType == NodeType.Branch;
         public bool IsExtension => NodeType == NodeType.Extension;
 
-        public byte[]? Key
+        public TrieNodeKey? Key
         {
             get => _nodeData is INodeWithKey node ? node?.Key : null;
             internal set
@@ -175,7 +175,7 @@ namespace Nethermind.Trie
 
                 if (IsSealed)
                 {
-                    if (node.Key.AsSpan().SequenceEqual(value))
+                    if (node.Key == value)
                     {
                         // No change, parallel read
                         return;
@@ -500,11 +500,11 @@ namespace Nethermind.Trie
                     ReadOnlySpan<byte> valueSpan = rlpStream.DecodeByteArraySpan();
                     CappedArray<byte> buffer = bufferPool.SafeRentBuffer(valueSpan.Length);
                     valueSpan.CopyTo(buffer.AsSpan());
-                    _nodeData = new LeafData(key, in buffer);
+                    _nodeData = new LeafData(new(key), in buffer);
                 }
                 else
                 {
-                    _nodeData = new ExtensionData(key);
+                    _nodeData = new ExtensionData(new(key));
                 }
             }
 
@@ -823,7 +823,7 @@ namespace Nethermind.Trie
             return MemorySizes.Align(unaligned);
         }
 
-        public TrieNode CloneWithChangedKey(byte[] key)
+        public TrieNode CloneWithChangedKey(TrieNodeKey key)
         {
             TrieNode trieNode = Clone();
             trieNode.Key = key;
@@ -857,7 +857,7 @@ namespace Nethermind.Trie
             return trieNode;
         }
 
-        public TrieNode CloneWithChangedKeyAndValue(byte[] key, in CappedArray<byte> changedValue)
+        public TrieNode CloneWithChangedKeyAndValue(TrieNodeKey key, in CappedArray<byte> changedValue)
         {
             TrieNode trieNode = Clone();
             trieNode.Key = key;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -163,7 +163,7 @@ namespace Nethermind.Trie
         public bool IsBranch => NodeType == NodeType.Branch;
         public bool IsExtension => NodeType == NodeType.Extension;
 
-        public TrieNodeKey? Key
+        public TrieKey? Key
         {
             get => _nodeData is INodeWithKey node ? node?.Key : null;
             internal set
@@ -823,7 +823,7 @@ namespace Nethermind.Trie
             return MemorySizes.Align(unaligned);
         }
 
-        public TrieNode CloneWithChangedKey(TrieNodeKey key)
+        public TrieNode CloneWithChangedKey(TrieKey key)
         {
             TrieNode trieNode = Clone();
             trieNode.Key = key;
@@ -857,7 +857,7 @@ namespace Nethermind.Trie
             return trieNode;
         }
 
-        public TrieNode CloneWithChangedKeyAndValue(TrieNodeKey key, in CappedArray<byte> changedValue)
+        public TrieNode CloneWithChangedKeyAndValue(TrieKey key, in CappedArray<byte> changedValue)
         {
             TrieNode trieNode = Clone();
             trieNode.Key = key;

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -12,17 +12,17 @@ namespace Nethermind.Trie
             return new(new BranchData());
         }
 
-        public static TrieNode CreateLeaf(byte[] path, in CappedArray<byte> value)
+        public static TrieNode CreateLeaf(TrieNodeKey path, in CappedArray<byte> value)
         {
             return new(new LeafData(path, in value));
         }
 
-        public static TrieNode CreateExtension(byte[] path)
+        public static TrieNode CreateExtension(TrieNodeKey path)
         {
             return new(new ExtensionData(path));
         }
 
-        public static TrieNode CreateExtension(byte[] path, TrieNode child)
+        public static TrieNode CreateExtension(TrieNodeKey path, TrieNode child)
         {
             return new(new ExtensionData(path, child));
         }

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -12,17 +12,17 @@ namespace Nethermind.Trie
             return new(new BranchData());
         }
 
-        public static TrieNode CreateLeaf(TrieNodeKey path, in CappedArray<byte> value)
+        public static TrieNode CreateLeaf(TrieKey path, in CappedArray<byte> value)
         {
             return new(new LeafData(path, in value));
         }
 
-        public static TrieNode CreateExtension(TrieNodeKey path)
+        public static TrieNode CreateExtension(TrieKey path)
         {
             return new(new ExtensionData(path));
         }
 
-        public static TrieNode CreateExtension(TrieNodeKey path, TrieNode child)
+        public static TrieNode CreateExtension(TrieKey path, TrieNode child)
         {
             return new(new ExtensionData(path, child));
         }

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -12,17 +12,17 @@ namespace Nethermind.Trie
             return new(new BranchData());
         }
 
-        public static TrieNode CreateLeaf(TrieKey path, in CappedArray<byte> value)
+        public static TrieNode CreateLeaf(in TrieKey path, in CappedArray<byte> value)
         {
             return new(new LeafData(path, in value));
         }
 
-        public static TrieNode CreateExtension(TrieKey path)
+        public static TrieNode CreateExtension(in TrieKey path)
         {
             return new(new ExtensionData(path));
         }
 
-        public static TrieNode CreateExtension(TrieKey path, TrieNode child)
+        public static TrieNode CreateExtension(in TrieKey path, TrieNode child)
         {
             return new(new ExtensionData(path, child));
         }

--- a/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
@@ -46,5 +46,10 @@ namespace Nethermind.Trie
                 <= -1 => Environment.ProcessorCount,
                 _ => rawMaxDegreeOfParallelism
             };
+
+        public override string ToString()
+        {
+            return $"Accounts: {ExpectAccounts}, {(MaxDegreeOfParallelism > 1 ? "Parallel" : "Serial")}, MemoryBudget: {FullScanMemoryBudget}";
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Add Triekey which can represent a key from two arrays rather than allocating a new one using concatenation
- Horrible

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes