### PR TITLE
Back signature by Vector512 rather than byte[]

### DIFF
--- a/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
@@ -50,9 +50,9 @@ namespace Ethereum.Basic.Test
 
             Transaction decodedSigned = Rlp.Decode<Transaction>(test.Signed);
             ethereumEcdsa.Sign(test.PrivateKey, decodedUnsigned, false);
-            Assert.That(decodedUnsigned.Signature.R.SequenceEqual(decodedSigned.Signature.R), "R");
-            BigInteger expectedS = decodedSigned.Signature.S.ToUnsignedBigInteger();
-            BigInteger actualS = decodedUnsigned.Signature.S.ToUnsignedBigInteger();
+            Assert.That(decodedUnsigned.Signature.R.Span.SequenceEqual(decodedSigned.Signature.R.Span), "R");
+            BigInteger expectedS = decodedSigned.Signature.S.Span.ToUnsignedBigInteger();
+            BigInteger actualS = decodedUnsigned.Signature.S.Span.ToUnsignedBigInteger();
             BigInteger otherS = EthereumEcdsa.LowSTransform - actualS;
 
             // test does not use normalized signature
@@ -62,7 +62,7 @@ namespace Ethereum.Basic.Test
             }
 
             ulong vToCompare = decodedUnsigned.Signature.V;
-            if (otherS == decodedSigned.Signature.S.ToUnsignedBigInteger())
+            if (otherS == decodedSigned.Signature.S.Span.ToUnsignedBigInteger())
             {
                 vToCompare = vToCompare == 27ul ? 28ul : 27ul;
             }

--- a/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
@@ -50,7 +50,7 @@ namespace Ethereum.Basic.Test
 
             Transaction decodedSigned = Rlp.Decode<Transaction>(test.Signed);
             ethereumEcdsa.Sign(test.PrivateKey, decodedUnsigned, false);
-            Assert.That(decodedUnsigned.Signature.R, Is.EqualTo(decodedSigned.Signature.R), "R");
+            Assert.That(decodedUnsigned.Signature.R.SequenceEqual(decodedSigned.Signature.R), "R");
             BigInteger expectedS = decodedSigned.Signature.S.ToUnsignedBigInteger();
             BigInteger actualS = decodedUnsigned.Signature.S.ToUnsignedBigInteger();
             BigInteger otherS = EthereumEcdsa.LowSTransform - actualS;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/ClefSignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/ClefSignerTests.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Blockchain.Test.Consensus
 
             var result = sut.Sign(Keccak.Zero);
 
-            Assert.That(new Signature(returnValue).Bytes, Is.EqualTo(result.Bytes));
+            Assert.That(new Signature(returnValue).Bytes.SequenceEqual(result.Bytes));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Blockchain.Test.Consensus
         {
             NullSigner signer = NullSigner.Instance;
             await signer.Sign((Transaction)null!);
-            signer.Sign((Hash256)null!).Bytes.Should().HaveCount(64);
+            signer.Sign((Hash256)null!).Bytes.Length.Should().Be(64);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/SignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/SignerTests.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Blockchain.Test.Consensus
         {
             Signer signer = new(1, TestItem.PrivateKeyA, LimboLogs.Instance);
             await signer.Sign(Build.A.Transaction.TestObject);
-            signer.Sign(Keccak.Zero).Bytes.Should().HaveCount(64);
+            signer.Sign(Keccak.Zero).Bytes.Length.Should().Be(64);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
@@ -77,8 +77,8 @@ namespace Nethermind.Consensus.Clique
             }
 
             // Copy signature bytes (R and S)
-            byte[] signatureBytes = signature.Bytes;
-            Array.Copy(signatureBytes, 0, header.ExtraData, header.ExtraData.Length - Clique.ExtraSealLength, signatureBytes.Length);
+            ReadOnlySpan<byte> signatureBytes = signature.Bytes;
+            signatureBytes.CopyTo(header.ExtraData.AsSpan(header.ExtraData.Length - Clique.ExtraSealLength));
             // Copy signature's recovery id (V)
             byte recoveryId = signature.RecoveryId;
             header.ExtraData[^1] = recoveryId;

--- a/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
@@ -41,7 +41,7 @@ public class SignatureTests
         var signatureObject = new Signature(signatureSlice, recoveryId);
         var keccak = Keccak.Compute(Bytes.Concat(messageType, data));
         Span<byte> publicKey = stackalloc byte[65];
-        bool result = SpanSecP256k1.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
+        bool result = SpanSecP256k1.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes.ToArray(), signatureObject.RecoveryId, false);
         result.Should().BeTrue();
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -346,6 +346,14 @@ namespace Nethermind.Core.Extensions
             return result;
         }
 
+        public static byte[] Concat(ReadOnlySpan<byte> bytes, byte suffix)
+        {
+            byte[] result = new byte[bytes.Length + 1];
+            result[^1] = suffix;
+            bytes.CopyTo(result);
+            return result;
+        }
+
         public static byte[] Reverse(byte[] bytes)
         {
             byte[] result = new byte[bytes.Length];

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -231,7 +231,7 @@ namespace Nethermind.Core
             builder.AppendLine($"{indent}Nonce:     {Nonce}");
             builder.AppendLine($"{indent}Value:     {Value}");
             builder.AppendLine($"{indent}Data:      {(Data.AsArray() ?? []).ToHexString()}");
-            builder.AppendLine($"{indent}Signature: {(Signature?.Bytes ?? []).ToHexString()}");
+            builder.AppendLine($"{indent}Signature: {Signature?.Bytes.ToHexString()}");
             builder.AppendLine($"{indent}V:         {Signature?.V}");
             builder.AppendLine($"{indent}ChainId:   {Signature?.ChainId}");
             builder.AppendLine($"{indent}Timestamp: {Timestamp}");

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
@@ -56,8 +56,8 @@ public class AuthorizationListForRpc
                     tuple.Nonce,
                     tuple.CodeAddress,
                     tuple.AuthoritySignature.RecoveryId,
-                    new UInt256(tuple.AuthoritySignature.S),
-                    new UInt256(tuple.AuthoritySignature.R))));
+                    new UInt256(tuple.AuthoritySignature.S.Span),
+                    new UInt256(tuple.AuthoritySignature.R.Span))));
 
     public AuthorizationTuple[] ToAuthorizationList() => _tuples
         .Select(static tuple => new AuthorizationTuple(

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -73,8 +73,8 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         GasPrice = transaction.GasPrice;
         ChainId = transaction.ChainId;
 
-        R = new UInt256(transaction.Signature?.R ?? [], true);
-        S = new UInt256(transaction.Signature?.S ?? [], true);
+        R = new UInt256(transaction.Signature.R, true);
+        S = new UInt256(transaction.Signature.S, true);
         V = transaction.Signature?.V ?? 0;
     }
 

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -73,9 +73,19 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         GasPrice = transaction.GasPrice;
         ChainId = transaction.ChainId;
 
-        R = new UInt256(transaction.Signature.R, true);
-        S = new UInt256(transaction.Signature.S, true);
-        V = transaction.Signature?.V ?? 0;
+        Signature? signature = transaction.Signature;
+        if (signature is null)
+        {
+            R = UInt256.Zero;
+            S = UInt256.Zero;
+            V = 0;
+        }
+        else
+        {
+            R = new UInt256(signature.R, true);
+            S = new UInt256(signature.S, true);
+            V = signature.V;
+        }
     }
 
     public override Transaction ToTransaction()

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -82,8 +82,8 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         }
         else
         {
-            R = new UInt256(signature.R, true);
-            S = new UInt256(signature.S, true);
+            R = new UInt256(signature.R.Span, true);
+            S = new UInt256(signature.S.Span, true);
             V = signature.V;
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
@@ -127,7 +127,7 @@ public class EthRpcSimulateTestsBase
     {
         AbiDefinition call = new AbiDefinitionParser().Parse(GetEcRecoverContractJsonAbi(name));
         AbiEncodingInfo functionInfo = call.GetFunction(name).GetCallInfo();
-        return AbiEncoder.Instance.Encode(functionInfo.EncodingStyle, functionInfo.Signature, keccak, signature.V, signature.R, signature.S);
+        return AbiEncoder.Instance.Encode(functionInfo.EncodingStyle, functionInfo.Signature, keccak, signature.V, signature.R.ToArray(), signature.S.ToArray());
     }
 
     private static Address? ParseEcRecoverAddress(byte[] data, string name = "recover")

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -285,7 +285,7 @@ public partial class EthRpcModule(
         }
 
         if (_logger.IsTrace) _logger.Trace($"eth_sign request {addressData}, {message}, result: {sig}");
-        return ResultWrapper<byte[]>.Success(sig.Bytes);
+        return ResultWrapper<byte[]>.Success(sig.Bytes.ToArray());
     }
 
     public virtual Task<ResultWrapper<Hash256>> eth_sendTransaction(TransactionForRpc rpcTx)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -264,7 +264,7 @@ public partial class EthRpcModule(
                     : []);
     }
 
-    public ResultWrapper<byte[]> eth_sign(Address addressData, byte[] message)
+    public ResultWrapper<Memory<byte>> eth_sign(Address addressData, byte[] message)
     {
         Signature sig;
         try
@@ -277,15 +277,15 @@ public partial class EthRpcModule(
         }
         catch (SecurityException e)
         {
-            return ResultWrapper<byte[]>.Fail(e.Message, ErrorCodes.AccountLocked);
+            return ResultWrapper<Memory<byte>>.Fail(e.Message, ErrorCodes.AccountLocked);
         }
         catch (Exception)
         {
-            return ResultWrapper<byte[]>.Fail($"Unable to sign as {addressData}");
+            return ResultWrapper<Memory<byte>>.Fail($"Unable to sign as {addressData}");
         }
 
         if (_logger.IsTrace) _logger.Trace($"eth_sign request {addressData}, {message}, result: {sig}");
-        return ResultWrapper<byte[]>.Success(sig.Bytes.ToArray());
+        return ResultWrapper<Memory<byte>>.Success(sig.Memory);
     }
 
     public virtual Task<ResultWrapper<Hash256>> eth_sendTransaction(TransactionForRpc rpcTx)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
@@ -132,7 +133,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         ResultWrapper<byte[]> eth_getCode(Address address, BlockParameter? blockParameter = null);
 
         [JsonRpcMethod(IsImplemented = false, Description = "Signs a transaction", IsSharable = true)]
-        ResultWrapper<byte[]> eth_sign(Address addressData, byte[] message);
+        ResultWrapper<Memory<byte>> eth_sign(Address addressData, byte[] message);
 
         [JsonRpcMethod(IsImplemented = true,
             Description = "Send a transaction to the tx pool and broadcasting",

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
@@ -60,8 +60,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
             Input = transaction.Data.AsArray();
             PublicKey = publicKey;
             ChainId = transaction.Signature.ChainId;
-            R = transaction.Signature.R;
-            S = transaction.Signature.S;
+            R = transaction.Signature.R.ToArray();
+            S = transaction.Signature.S.ToArray();
             V = (UInt256)transaction.Signature.V;
             StandardV = transaction.Signature.RecoveryId;
             // TKS: it does not seem to work with CREATE2

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Evm;
-using System.Text.Json.Serialization;
 
 namespace Nethermind.JsonRpc.Modules.Parity
 {
@@ -34,8 +35,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public ulong? ChainId { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public object Condition { get; set; }
-        public byte[] R { get; set; }
-        public byte[] S { get; set; }
+        public Memory<byte> R { get; set; }
+        public Memory<byte> S { get; set; }
         public UInt256 V { get; set; }
         public UInt256 StandardV { get; set; }
 
@@ -60,8 +61,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
             Input = transaction.Data.AsArray();
             PublicKey = publicKey;
             ChainId = transaction.Signature.ChainId;
-            R = transaction.Signature.R.ToArray();
-            S = transaction.Signature.S.ToArray();
+            R = transaction.Signature.R;
+            S = transaction.Signature.S;
             V = (UInt256)transaction.Signature.V;
             StandardV = transaction.Signature.RecoveryId;
             // TKS: it does not seem to work with CREATE2

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/IPersonalRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/IPersonalRpcModule.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -36,6 +37,6 @@ namespace Nethermind.JsonRpc.Modules.Personal
         [JsonRpcMethod(Description = "The sign method calculates an Ethereum specific signature with: sign(keccack256(\"\x19Ethereum Signed Message:\n\" + len(message) + message))).",
             IsImplemented = false,
             ExampleResponse = "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b")]
-        ResultWrapper<byte[]> personal_sign([JsonRpcParameter(ExampleValue = "[\"0xdeadbeaf\", \"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83\"]")] byte[] message, Address address, string passphrase = null);
+        ResultWrapper<Memory<byte>> personal_sign([JsonRpcParameter(ExampleValue = "[\"0xdeadbeaf\", \"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83\"]")] byte[] message, Address address, string passphrase = null);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
@@ -15,7 +15,6 @@ namespace Nethermind.JsonRpc.Modules.Personal
 {
     public class PersonalRpcModule : IPersonalRpcModule
     {
-        private readonly Encoding _messageEncoding = Encoding.UTF8;
         private readonly IEcdsa _ecdsa;
         private readonly IWallet _wallet;
         private readonly IKeyStore _keyStore;
@@ -84,7 +83,7 @@ namespace Nethermind.JsonRpc.Modules.Personal
         }
 
         [RequiresSecurityReview("Consider removing any operations that allow to provide passphrase in JSON RPC")]
-        public ResultWrapper<byte[]> personal_sign(byte[] message, Address address, string passphrase = null)
+        public ResultWrapper<Memory<byte>> personal_sign(byte[] message, Address address, string passphrase = null)
         {
             if (!_wallet.IsUnlocked(address))
             {
@@ -96,7 +95,7 @@ namespace Nethermind.JsonRpc.Modules.Personal
             }
 
             message = ToEthSignedMessage(message);
-            return ResultWrapper<byte[]>.Success(_wallet.Sign(Keccak.Compute(message), address).Bytes.ToArray());
+            return ResultWrapper<Memory<byte>>.Success(_wallet.Sign(Keccak.Compute(message), address).Memory);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
@@ -96,7 +96,7 @@ namespace Nethermind.JsonRpc.Modules.Personal
             }
 
             message = ToEthSignedMessage(message);
-            return ResultWrapper<byte[]>.Success(_wallet.Sign(Keccak.Compute(message), address).Bytes);
+            return ResultWrapper<byte[]>.Success(_wallet.Sign(Keccak.Compute(message), address).Bytes.ToArray());
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Serializers/DiscoveryMsgSerializerBase.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Serializers/DiscoveryMsgSerializerBase.cs
@@ -48,7 +48,7 @@ public abstract class DiscoveryMsgSerializerBase
 
         Signature signature = _ecdsa.Sign(_privateKey, toSign);
         byteBuffer.SetWriterIndex(startWriteIndex + 32);
-        byteBuffer.WriteBytes(signature.Bytes, 0, 64);
+        byteBuffer.WriteBytes(signature.Bytes);
         byteBuffer.WriteByte(signature.RecoveryId);
 
         byteBuffer.SetReaderIndex(startReadIndex + 32);
@@ -76,7 +76,7 @@ public abstract class DiscoveryMsgSerializerBase
 
         Signature signature = _ecdsa.Sign(_privateKey, toSign);
         byteBuffer.SetWriterIndex(startWriteIndex + 32);
-        byteBuffer.WriteBytes(signature.Bytes, 0, 64);
+        byteBuffer.WriteBytes(signature.Bytes);
         byteBuffer.WriteByte(signature.RecoveryId);
 
         byteBuffer.SetWriterIndex(startWriteIndex + length);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
@@ -106,8 +106,8 @@ public class AuthorizationTupleDecoder : IRlpStreamDecoder<AuthorizationTuple>, 
     private static int GetContentLength(AuthorizationTuple tuple) =>
         GetContentLengthWithoutSig(tuple.ChainId, tuple.CodeAddress, tuple.Nonce)
         + Rlp.LengthOf(tuple.AuthoritySignature.V - Signature.VOffset)
-        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.R.AsSpan(), true))
-        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.S.AsSpan(), true));
+        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.R, true))
+        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.S, true));
 
     private static int GetContentLengthWithoutSig(UInt256 chainId, Address codeAddress, ulong nonce) =>
         Rlp.LengthOf(chainId)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
@@ -78,8 +78,8 @@ public class AuthorizationTupleDecoder : IRlpStreamDecoder<AuthorizationTuple>, 
         stream.Encode(item.CodeAddress);
         stream.Encode(item.Nonce);
         stream.Encode(item.AuthoritySignature.V - Signature.VOffset);
-        stream.Encode(new UInt256(item.AuthoritySignature.R, true));
-        stream.Encode(new UInt256(item.AuthoritySignature.S, true));
+        stream.Encode(new UInt256(item.AuthoritySignature.R.Span, true));
+        stream.Encode(new UInt256(item.AuthoritySignature.S.Span, true));
     }
 
     public NettyRlpStream EncodeWithoutSignature(UInt256 chainId, Address codeAddress, ulong nonce)
@@ -106,8 +106,8 @@ public class AuthorizationTupleDecoder : IRlpStreamDecoder<AuthorizationTuple>, 
     private static int GetContentLength(AuthorizationTuple tuple) =>
         GetContentLengthWithoutSig(tuple.ChainId, tuple.CodeAddress, tuple.Nonce)
         + Rlp.LengthOf(tuple.AuthoritySignature.V - Signature.VOffset)
-        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.R, true))
-        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.S, true));
+        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.R.Span, true))
+        + Rlp.LengthOf(new UInt256(tuple.AuthoritySignature.S.Span, true));
 
     private static int GetContentLengthWithoutSig(UInt256 chainId, Address codeAddress, ulong nonce) =>
         Rlp.LengthOf(chainId)


### PR DESCRIPTION
## Changes

- Drops one object reference per sig and `Vector512` is smaller than `byte[]` with one less indirection

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No