### PR TITLE
Back Bloom with inline array rather than byte[]

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/BloomTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BloomTests.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Core.Test
         {
             Bloom bloom = new();
             bloom.Set(Keccak.OfAnEmptyString.Bytes);
-            byte[] bytes = bloom.Bytes;
+            ReadOnlySpan<byte> bytes = bloom.Bytes;
             Bloom bloom2 = new(bytes);
             Assert.That(bloom2.ToString(), Is.EqualTo(bloom.ToString()));
         }

--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
-
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Json;
@@ -17,10 +18,9 @@ namespace Nethermind.Core
         public const int BitLength = 2048;
         public const int ByteLength = BitLength / 8;
 
-        public Bloom()
-        {
-            Bytes = new byte[ByteLength];
-        }
+        private BloomData _bloomData;
+
+        public Bloom() { }
 
         public Bloom(Bloom?[] blooms) : this()
         {
@@ -34,8 +34,6 @@ namespace Nethermind.Core
 
         public Bloom(LogEntry[]? logEntries, Bloom? blockBloom = null)
         {
-            Bytes = new byte[ByteLength];
-
             if (logEntries is null) return;
 
             Add(logEntries, blockBloom);
@@ -43,15 +41,15 @@ namespace Nethermind.Core
 
         public Bloom(byte[] bytes)
         {
-            Bytes = bytes;
+            bytes.CopyTo(Bytes);
         }
 
         public Bloom(ReadOnlySpan<byte> bytes)
         {
-            Bytes = bytes.ToArray();
+            bytes.CopyTo(Bytes);
         }
 
-        public byte[] Bytes { get; }
+        public Span<byte> Bytes => _bloomData.AsSpan();
 
         public void Set(ReadOnlySpan<byte> sequence)
         {
@@ -119,7 +117,7 @@ namespace Nethermind.Core
             return Equals((Bloom)obj);
         }
 
-        public override int GetHashCode() => new ReadOnlySpan<byte>(Bytes).FastHash();
+        public override int GetHashCode() => Bytes.FastHash();
 
         public void Add(LogEntry[] logEntries, Bloom? blockBloom = null)
         {
@@ -144,7 +142,7 @@ namespace Nethermind.Core
                 return;
             }
 
-            Bytes.AsSpan().Or(bloom.Bytes);
+            Bytes.Or(bloom.Bytes);
         }
 
         public bool Matches(LogEntry logEntry)
@@ -223,8 +221,15 @@ namespace Nethermind.Core
         public Bloom Clone()
         {
             Bloom clone = new();
-            Bytes.CopyTo(clone.Bytes, 0);
+            Bytes.CopyTo(clone.Bytes);
             return clone;
+        }
+
+        [InlineArray(ByteLength)]
+        public struct BloomData
+        {
+            private byte _element0;
+            public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element0, ByteLength);
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -173,6 +173,10 @@ namespace Nethermind.Core.Extensions
             return newList;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int FastHash(this Span<byte> input)
+            => FastHash((ReadOnlySpan<byte>)input);
+
         [SkipLocalsInit]
         public static int FastHash(this ReadOnlySpan<byte> input)
         {

--- a/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
@@ -283,7 +283,7 @@ namespace Nethermind.Db.Blooms
                 }
             }
 
-            private static uint CountBits(Bloom bloom) => bloom.Bytes.AsSpan().CountBits();
+            private static uint CountBits(Bloom bloom) => bloom.Bytes.CountBits();
 
             public long GetBucket(long blockNumber) => blockNumber / LevelElementSize;
 


### PR DESCRIPTION
## Changes

- Drops one object reference per Bloom and inline array is smaller than `byte[]` with one less indirection

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
