### PR TITLE
Fix empty value handling of configuration options

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -2,24 +2,42 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Config.Test;
 
-[TestFixture]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [Parallelizable(ParallelScope.All)]
 public class ConfigProvider_FindIncorrectSettings_Tests
 {
+    private IEnvironment _env;
+
+    [SetUp]
+    public void Initialize()
+    {
+        _env = Substitute.For<IEnvironment>();
+        _env.GetEnvironmentVariable(Arg.Any<string>())
+            .Returns(call =>
+            {
+                IDictionary vars = _env.GetEnvironmentVariables();
+                var key = call.Arg<string>();
+
+                return vars.Contains(key) ? vars[key] : null;
+            });
+    }
+
     [Test]
     public void CorrectSettingNames_CaseInsensitive()
     {
         JsonConfigSource? jsonSource = new("SampleJson/CorrectSettingNames.json");
 
-        IEnvironment? env = Substitute.For<IEnvironment>();
-        env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT", "500" } });
-        EnvConfigSource? envSource = new(env);
+        Dictionary<string, string> envVars = new() { { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT", "500" } };
+
+        _env.GetEnvironmentVariables().Returns(envVars);
+        EnvConfigSource? envSource = new(_env);
 
         ArgsConfigSource? argsSource = new(new Dictionary<string, string>() {
             { "DiscoveryConfig.BucketSize", "10" },
@@ -33,20 +51,19 @@ public class ConfigProvider_FindIncorrectSettings_Tests
         configProvider.Initialize();
         (_, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
-        Assert.That(Errors.Count, Is.EqualTo(0));
+        Assert.That(Errors, Is.Empty);
     }
 
     [Test]
     public void NoCategorySettings()
     {
-        IEnvironment? env = Substitute.For<IEnvironment>();
-        env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
+        _env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
             { "NETHERMIND_CLI_SWITCH_LOCAL", "http://localhost:80" },
             { "NETHERMIND_CONFIG", "test2.json" },
             { "NETHERMIND_XYZ", "xyz" },    // not existing, should get error
             { "QWER", "qwerty" }    // not Nethermind setting, no error
         });
-        EnvConfigSource? envSource = new(env);
+        EnvConfigSource? envSource = new(_env);
 
         ConfigProvider? configProvider = new();
         configProvider.AddSource(envSource);
@@ -55,10 +72,12 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
-        Assert.That(Errors.Count, Is.EqualTo(1));
-        Assert.That(Errors[0].Name, Is.EqualTo("XYZ"));
-        Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:XYZ"));
-
+        Assert.That(Errors, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Errors[0].Name, Is.EqualTo("XYZ"));
+            Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:XYZ"));
+        });
     }
 
     [Test]
@@ -66,11 +85,10 @@ public class ConfigProvider_FindIncorrectSettings_Tests
     {
         JsonConfigSource? jsonSource = new("SampleJson/ConfigWithTypos.json");
 
-        IEnvironment? env = Substitute.For<IEnvironment>();
-        env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
+        _env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
             { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPERCOUNT", "500" }  // incorrect, should be NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT
         });
-        EnvConfigSource? envSource = new(env);
+        EnvConfigSource? envSource = new(_env);
 
         ConfigProvider? configProvider = new();
         configProvider.AddSource(jsonSource);
@@ -80,21 +98,23 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
-        Assert.That(Errors.Count, Is.EqualTo(3));
-        Assert.That(Errors[0].Name, Is.EqualTo("Concurrenc"));
-        Assert.That(Errors[1].Category, Is.EqualTo("BlomConfig"));
-        Assert.That(Errors[2].Name, Is.EqualTo("MAXCANDIDATEPERCOUNT"));
-        Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:JsonConfigFile|Category:DiscoveRyConfig|Name:Concurrenc{Environment.NewLine}ConfigType:JsonConfigFile|Category:BlomConfig|Name:IndexLevelBucketSizes{Environment.NewLine}ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:NETWORKCONFIG|Name:MAXCANDIDATEPERCOUNT"));
+        Assert.That(Errors, Has.Count.EqualTo(3));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Errors[0].Name, Is.EqualTo("Concurrenc"));
+            Assert.That(Errors[1].Category, Is.EqualTo("BlomConfig"));
+            Assert.That(Errors[2].Name, Is.EqualTo("MAXCANDIDATEPERCOUNT"));
+            Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:JsonConfigFile|Category:DiscoveRyConfig|Name:Concurrenc{Environment.NewLine}ConfigType:JsonConfigFile|Category:BlomConfig|Name:IndexLevelBucketSizes{Environment.NewLine}ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:NETWORKCONFIG|Name:MAXCANDIDATEPERCOUNT"));
+        });
     }
 
     [Test]
     public void IncorrectFormat()
     {
-        IEnvironment? env = Substitute.For<IEnvironment>();
-        env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
+        _env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() {
             { "NETHERMIND_NETWORKCONFIGMAXCANDIDATEPEERCOUNT", "500" }  // incorrect, should be NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT
         });
-        EnvConfigSource? envSource = new(env);
+        EnvConfigSource? envSource = new(_env);
 
         ConfigProvider? configProvider = new();
         configProvider.AddSource(envSource);
@@ -103,9 +123,11 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
-        Assert.That(Errors.Count, Is.EqualTo(1));
-        Assert.That(Errors[0].Name, Is.EqualTo("NETWORKCONFIGMAXCANDIDATEPEERCOUNT"));
-        Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:NETWORKCONFIGMAXCANDIDATEPEERCOUNT"));
+        Assert.That(Errors, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Errors[0].Name, Is.EqualTo("NETWORKCONFIGMAXCANDIDATEPEERCOUNT"));
+            Assert.That(ErrorMsg, Is.EqualTo($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:NETWORKCONFIGMAXCANDIDATEPEERCOUNT"));
+        });
     }
-
 }

--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -165,7 +165,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         _env.GetEnvironmentVariables().Returns(envVars);
         EnvConfigSource? envSource = new(_env);
-        
+
         ConfigProvider? configProvider = new();
         configProvider.AddSource(envSource);
 

--- a/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Config
         }
 
         private static bool IsNullString(string valueString) =>
-            string.IsNullOrEmpty(valueString) || valueString.Equals("null", StringComparison.OrdinalIgnoreCase);
+            valueString?.Equals("null", StringComparison.OrdinalIgnoreCase) ?? true;
 
         public static object GetDefault(Type type) => type.IsValueType ? (false, Activator.CreateInstance(type)) : (false, null);
 

--- a/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Config
                     //supports Arrays, e.g int[] and generic IEnumerable<T>, IList<T>
                     var itemType = valueType.IsGenericType ? valueType.GetGenericArguments()[0] : valueType.GetElementType();
 
-                    if (itemType == typeof(byte) && !valueString.AsSpan().TrimStart().StartsWith("["))
+                    if (itemType == typeof(byte) && !valueString.AsSpan().TrimStart().StartsWith('['))
                     {
                         // hex encoded byte array
                         value = Bytes.FromHexString(valueString.Trim());
@@ -105,7 +105,7 @@ namespace Nethermind.Config
 
         private static bool TryFromHex(Type type, string itemValue, out object value)
         {
-            if (!itemValue.StartsWith("0x"))
+            if (!itemValue.StartsWith("0x", StringComparison.Ordinal))
             {
                 value = null;
                 return false;

--- a/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Config
         {
             var variableName = string.IsNullOrEmpty(category) ? $"NETHERMIND_{name.ToUpperInvariant()}" : $"NETHERMIND_{category.ToUpperInvariant()}_{name.ToUpperInvariant()}";
             var variableValueString = _environmentWrapper.GetEnvironmentVariable(variableName);
-            return string.IsNullOrWhiteSpace(variableValueString) ? (false, null) : (true, variableValueString);
+            return (variableValueString is not null, variableValueString);
         }
 
         public IEnumerable<(string Category, string Name)> GetConfigKeys()

--- a/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
@@ -23,6 +23,11 @@ namespace Nethermind.Config
         public (bool IsSet, object Value) GetValue(Type type, string category, string name)
         {
             (bool isSet, string value) = GetRawValue(category, name);
+
+            // Unset blank values for non-string types
+            if (type != typeof(string) && string.IsNullOrWhiteSpace(value))
+                isSet = false;
+
             return (isSet, isSet ? ConfigSourceHelper.ParseValue(type, value, category, name) : ConfigSourceHelper.GetDefault(type));
         }
 


### PR DESCRIPTION
Fixes #7956 #4952

## Changes

- Fixed the bug introduced in #7540 when command line options with empty values of `""` are converted to `null`
- Fixed the handling of empty environment variables not to be treated as undefined _for string types only_

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

## Remarks

This PR sets command line options and env vars on par as, currently, env vars don't support empty values, treating them as null/unset. However, there are a few things to note:

- .NET handling of environment variables has been changed/improved since .NET 9 with the [support of empty values](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/empty-env-variable)
- Support of empty env var depends on the environment; I couldn't make them work in PowerShell
- Setting an empty env var doesn't work with `launchSettings.json`
