### PR TITLE
fix s and r values in AuthorizationListForRpc

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
@@ -56,8 +56,8 @@ public class AuthorizationListForRpc
                     tuple.Nonce,
                     tuple.CodeAddress,
                     tuple.AuthoritySignature.RecoveryId,
-                    new UInt256(tuple.AuthoritySignature.S.Span),
-                    new UInt256(tuple.AuthoritySignature.R.Span))));
+                    new UInt256(tuple.AuthoritySignature.S.Span, true),
+                    new UInt256(tuple.AuthoritySignature.R.Span, true))));
 
     public AuthorizationTuple[] ToAuthorizationList() => _tuples
         .Select(static tuple => new AuthorizationTuple(


### PR DESCRIPTION
## Changes

- fix s and r values in AuthorizationListForRpc to be treated as big endian

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

@ak88 to add tests

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No