### PR TITLE
update ring buffer size for eip-2935

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
@@ -16,5 +16,5 @@ public static class Eip2935Constants
     /// <summary>
     /// The <c>HISTORY_SERVE_WINDOW</c> parameter.
     /// </summary>
-    public static readonly long RingBufferSize = 8192;
+    public static readonly long RingBufferSize = 8191;
 }


### PR DESCRIPTION
Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- update the ring buffer size for eip-2935  as per https://github.com/ethereum/EIPs/pull/9144

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
