### PR TITLE
Revert removed admin_prune method in interface

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -62,6 +62,12 @@ public interface IAdminRpcModule : IRpcModule
         IsImplemented = false)]
     ResultWrapper<bool> admin_setSolc();
 
+    [JsonRpcMethod(Description = "Runs full pruning if enabled.",
+        EdgeCaseHint = "",
+        ExampleResponse = "\"Starting\"",
+        IsImplemented = true)]
+    ResultWrapper<PruningStatus> admin_prune();
+
     [JsonRpcMethod(Description = "True if state root for the block is available",
         EdgeCaseHint = "",
         ExampleResponse = "\"Starting\"",


### PR DESCRIPTION
Reverting removed pruning method removed by mistake in #7962 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No