### PR TITLE
Fix missing tx index on reorg

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -360,32 +360,7 @@ public class PersistentReceiptStorageTests
     }
 
     [Test]
-    public void When_NewHeadBlock_Remove_TxIndex_OfRemovedBlock()
-    {
-        CreateStorage();
-        (Block block, TxReceipt[] receipts) = InsertBlock();
-
-        if (_receiptConfig.CompactTxIndex)
-        {
-            _receiptsDb.GetColumnDb(ReceiptsColumns.Transactions)[receipts[0].TxHash!.Bytes].Should().BeEquivalentTo(Rlp.Encode(block.Number).Bytes);
-        }
-        else
-        {
-            _receiptsDb.GetColumnDb(ReceiptsColumns.Transactions)[receipts[0].TxHash!.Bytes].Should().NotBeNull();
-        }
-
-        Block newHead = Build.A.Block.WithNumber(1).TestObject;
-        _blockTree.FindBestSuggestedHeader().Returns(newHead.Header);
-        _blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(newHead, block));
-
-        Assert.That(
-            () => _receiptsDb.GetColumnDb(ReceiptsColumns.Transactions)[receipts[0].TxHash!.Bytes],
-            Is.Null.After(1000, 100)
-            );
-    }
-
-    [Test]
-    public void When_NewHeadBlock_Remove_TxIndex_OfRemovedBlock_UnlessTxIsInOtherBlockNumber()
+    public void When_NewHeadBlock_DoNotRemove_TxIndex_WhenTxIsInOtherBlockNumber()
     {
         CreateStorage();
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -376,6 +376,16 @@ namespace Nethermind.Blockchain.Receipts
                 // If the tx is contained in another block, don't remove it. Used for reorg where the same tx
                 // is contained in the new block
                 if (newTxs?.Contains(tx.Hash) == true) continue;
+
+                // Check if the tx is of a different block number, that means that the tx could be a reorg in another
+                // block, so we don't remove it.
+                byte[] txIndexData = _transactionDb.Get(tx.Hash);
+                if (txIndexData is not null && txIndexData.Length != Hash256.Size)
+                {
+                    long blockNumber = new RlpStream(txIndexData).DecodeLong();
+                    if (blockNumber != block.Number) continue;
+                }
+
                 writeBatch[tx.Hash.Bytes] = null;
             }
         }


### PR DESCRIPTION
Fix #6560 

- The tx index is removed on second block after reorg to another second block but the canonical tx is in the first block when going to the second block branch.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Reproducable with unit tests.
