### PR TITLE
fix memory expansion to support up to uint.max instead of int.max

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -300,7 +300,7 @@ public struct EvmPooledMemory : IEvmMemory
             result++;
         }
 
-        if (result > int.MaxValue)
+        if (result > uint.MaxValue)
         {
             outOfGas = true;
             return 0;


### PR DESCRIPTION
After further investigation, this will only be relevant at 8.7TGas which is impossible
## Changes

- fix memory expansion cost to support up to uint.max instead of int.max matching Geth
## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
