### PR TITLE
Move `Test` projects to proper solution folder

### DIFF
--- a/src/Nethermind/Nethermind.sln
+++ b/src/Nethermind/Nethermind.sln
@@ -212,23 +212,23 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Optimism.Test", "Nethermind.Optimism.Test\Nethermind.Optimism.Test.csproj", "{2438958D-46EA-4A7E-B89F-29E069DA0CCA}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Signer", "Signer", "{89311B58-AF36-4956-883D-54531BC1D5A3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.ExternalSigner.Plugin", "Nethermind.ExternalSigner.Plugin\Nethermind.ExternalSigner.Plugin.csproj", "{6528010D-7DCE-4935-9785-5270FF515F3E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Taiko", "Nethermind.Taiko\Nethermind.Taiko.csproj", "{B4070433-328E-40E6-B89A-6554F015694C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Taiko.Test", "Nethermind.Taiko.Test\Nethermind.Taiko.Test.csproj", "{3E097797-F8D5-4BB5-B544-C78FF0A14986}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Shutter", "Nethermind.Shutter\Nethermind.Shutter.csproj", "{F38037D2-98EA-4263-887A-4B383635F605}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Shutter.Test", "Nethermind.Shutter.Test\Nethermind.Shutter.Test.csproj", "{CEA1C413-A96C-4339-AC1C-839B603DECC8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.SszGenerator", "Nethermind.Serialization.SszGenerator\Nethermind.Serialization.SszGenerator.csproj", "{F2F02874-8DF2-4434-A5F7-3418F24E1E56}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.SszGenerator.Test", "Nethermind.Serialization.SszGenerator.Test\Nethermind.Serialization.SszGenerator.Test.csproj", "{E11DA65F-7F52-40DA-BBF4-E6E90932EB68}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Taiko.Test", "Nethermind.Taiko.Test\Nethermind.Taiko.Test.csproj", "{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Shutter.Test", "Nethermind.Shutter.Test\Nethermind.Shutter.Test.csproj", "{B068C72F-8B77-474E-A58C-5B929096FEF3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Optimism.Test", "Nethermind.Optimism.Test\Nethermind.Optimism.Test.csproj", "{DC983CEF-BA18-45DE-9AEB-AB9B459655BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -604,10 +604,6 @@ Global
 		{AD09FBCB-5496-499B-9129-B6D139A65B6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD09FBCB-5496-499B-9129-B6D139A65B6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD09FBCB-5496-499B-9129-B6D139A65B6F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2438958D-46EA-4A7E-B89F-29E069DA0CCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2438958D-46EA-4A7E-B89F-29E069DA0CCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2438958D-46EA-4A7E-B89F-29E069DA0CCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2438958D-46EA-4A7E-B89F-29E069DA0CCA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6528010D-7DCE-4935-9785-5270FF515F3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6528010D-7DCE-4935-9785-5270FF515F3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6528010D-7DCE-4935-9785-5270FF515F3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -616,18 +612,10 @@ Global
 		{B4070433-328E-40E6-B89A-6554F015694C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4070433-328E-40E6-B89A-6554F015694C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4070433-328E-40E6-B89A-6554F015694C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3E097797-F8D5-4BB5-B544-C78FF0A14986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3E097797-F8D5-4BB5-B544-C78FF0A14986}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3E097797-F8D5-4BB5-B544-C78FF0A14986}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3E097797-F8D5-4BB5-B544-C78FF0A14986}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F38037D2-98EA-4263-887A-4B383635F605}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F38037D2-98EA-4263-887A-4B383635F605}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F38037D2-98EA-4263-887A-4B383635F605}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F38037D2-98EA-4263-887A-4B383635F605}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CEA1C413-A96C-4339-AC1C-839B603DECC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CEA1C413-A96C-4339-AC1C-839B603DECC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CEA1C413-A96C-4339-AC1C-839B603DECC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CEA1C413-A96C-4339-AC1C-839B603DECC8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F2F02874-8DF2-4434-A5F7-3418F24E1E56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F2F02874-8DF2-4434-A5F7-3418F24E1E56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2F02874-8DF2-4434-A5F7-3418F24E1E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -636,6 +624,18 @@ Global
 		{E11DA65F-7F52-40DA-BBF4-E6E90932EB68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E11DA65F-7F52-40DA-BBF4-E6E90932EB68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E11DA65F-7F52-40DA-BBF4-E6E90932EB68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B068C72F-8B77-474E-A58C-5B929096FEF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B068C72F-8B77-474E-A58C-5B929096FEF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B068C72F-8B77-474E-A58C-5B929096FEF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B068C72F-8B77-474E-A58C-5B929096FEF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC983CEF-BA18-45DE-9AEB-AB9B459655BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC983CEF-BA18-45DE-9AEB-AB9B459655BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC983CEF-BA18-45DE-9AEB-AB9B459655BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC983CEF-BA18-45DE-9AEB-AB9B459655BC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -697,6 +697,9 @@ Global
 		{89311B58-AF36-4956-883D-54531BC1D5A3} = {78BED57D-720E-4E6C-ABA2-397B73B494F9}
 		{6528010D-7DCE-4935-9785-5270FF515F3E} = {89311B58-AF36-4956-883D-54531BC1D5A3}
 		{E11DA65F-7F52-40DA-BBF4-E6E90932EB68} = {4019B82F-1104-4D2C-9F96-05FD7D3575E8}
+		{B1CE6CBC-D85B-4631-A9F3-437ADB1FB049} = {4019B82F-1104-4D2C-9F96-05FD7D3575E8}
+		{B068C72F-8B77-474E-A58C-5B929096FEF3} = {4019B82F-1104-4D2C-9F96-05FD7D3575E8}
+		{DC983CEF-BA18-45DE-9AEB-AB9B459655BC} = {4019B82F-1104-4D2C-9F96-05FD7D3575E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {092CA5E3-6180-4ED7-A3CB-9B57FAC2AA85}


### PR DESCRIPTION
## Changes

- Reorder `Nethermind.sln` so test projects are in the proper folder

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

A very small PR that moves a couple of `Test` projects to the appropriate Solution folder, making them part of the `Tests` subfolder so that they're listed alongside other tests suites. This makes them look like the following in the test explorer:

![image](https://github.com/user-attachments/assets/4d0b4363-6515-4bd3-bf19-cd6075cd4e75)

The benefit is that you can now run the entire `Tests` folder without missing any tests.