### PR TITLE
Change more children derivation on snap sync

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Autofac;
 using FluentAssertions;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -325,19 +324,19 @@ public class RecreateStateFromAccountRangesTests
         }
 
         HasMoreChildren(TestItem.Tree.AccountsWithPaths[1].Path).Should().BeFalse();
-        HasMoreChildren(TestItem.Tree.AccountsWithPaths[2].Path).Should().BeFalse();
+        HasMoreChildren(TestItem.Tree.AccountsWithPaths[2].Path).Should().BeTrue(); //expect leaves exactly at limit path to be included
         HasMoreChildren(TestItem.Tree.AccountsWithPaths[3].Path).Should().BeTrue();
         HasMoreChildren(TestItem.Tree.AccountsWithPaths[4].Path).Should().BeTrue();
 
-        UInt256 between2and3 = new UInt256(TestItem.Tree.AccountsWithPaths[1].Path.Bytes, true);
-        between2and3 += 5;
+        UInt256 between1and2 = new UInt256(TestItem.Tree.AccountsWithPaths[1].Path.Bytes, true);
+        between1and2 += 5;
 
-        HasMoreChildren(new Hash256(between2and3.ToBigEndian())).Should().BeFalse();
+        HasMoreChildren(new Hash256(between1and2.ToBigEndian())).Should().BeFalse();
 
-        between2and3 = new UInt256(TestItem.Tree.AccountsWithPaths[2].Path.Bytes, true);
+        UInt256 between2and3 = new UInt256(TestItem.Tree.AccountsWithPaths[2].Path.Bytes, true);
         between2and3 -= 1;
 
-        HasMoreChildren(new Hash256(between2and3.ToBigEndian())).Should().BeFalse();
+        HasMoreChildren(new Hash256(between2and3.ToBigEndian())).Should().BeTrue();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -229,7 +229,7 @@ namespace Nethermind.Synchronization.SnapSync
                     {
                         bool hasKeccak = node.GetChildHashAsValueKeccak(ci, out ValueHash256 childKeccak);
 
-                        moreChildrenToRight |= hasKeccak && (ci > right && (ci < limit || noLimit));
+                        moreChildrenToRight |= hasKeccak && (ci > right && (ci <= limit || noLimit));
 
                         if (ci >= left && ci <= right)
                         {


### PR DESCRIPTION
## Changes

`moreChildrenToRight` derivation currently excludes nodes exactly at limit path, which I think should be included. When using `limitHash` other than `ValueKeccak.MaxValue` this may lead to missing nodes during sync.
This should also be aligned with snap serve implementation:
https://github.com/NethermindEth/nethermind/blob/7e0c53cd20e51cc83a8cbddfa51302e495b577f5/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs#L180

This change will help to merge this change #7733
Failed scenario on Holesky:
- last path in batch `0x206ef92f1f724813b79366c1d32f79f21e9d6fc3e63ee7dc9bc60178a02329b9`
- limit hash `0x2072ae6853c35cc00b267d072d8e17646d4881488979de114b622413bf369197`
- branch exists at path `206` with child at nibble `f`, child is not present in current batch
- `moreChildrenToRight` is derived to `false` causing nodes between last path and limit hash never to be requested

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No