### PR TITLE
EvmStack native endian

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -165,7 +165,7 @@ public ref struct EvmStack<TTracing>
     }
 
     /// <summary>
-    /// Pops an Uint256 written in big endian.
+    /// Pops an <see cref="UInt256"/>.
     /// </summary>
     /// <param name="result">The returned value.</param>
     public bool PopUInt256(out UInt256 result)
@@ -175,6 +175,20 @@ public ref struct EvmStack<TTracing>
         if (Unsafe.IsNullRef(ref v)) return false;
         result = Unsafe.As<Word, UInt256>(ref v);
         return true;
+    }
+
+    /// <summary>
+    /// Peeks a reference to an <see cref="UInt256"/>.
+    /// </summary>
+    public ref UInt256 PeekUInt256Ref()
+    {
+        int head = Head;
+        if (head == 0)
+        {
+            return ref Unsafe.NullRef<UInt256>();
+        }
+
+        return ref Unsafe.As<Word, UInt256>(ref _words[head - 1]);
     }
 
     private static void Reshuffle(ref Word word)
@@ -250,7 +264,7 @@ public ref struct EvmStack<TTracing>
 
         head--;
         Head = head;
-        return ref Unsafe.Add(ref MemoryMarshal.GetReference(_words), head);
+        return ref _words[head];
     }
 
     public Span<byte> PopWord256(out UInt256 destination)

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.Intrinsics;
 using Nethermind.Core;
 using Nethermind.State;
-
+using Word = System.Runtime.Intrinsics.Vector256<byte>;
 namespace Nethermind.Evm;
 
 /// <summary>
@@ -19,7 +21,7 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
     private static readonly ConcurrentQueue<EvmState> _statePool = new();
     private static readonly StackPool _stackPool = new();
 
-    public byte[]? DataStack;
+    public Word[]? DataStack;
     public int[]? ReturnStack;
 
     public long GasAvailable { get; set; }

--- a/src/Nethermind/Nethermind.Evm/StackPool.cs
+++ b/src/Nethermind/Nethermind.Evm/StackPool.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Concurrent;
+using Word = System.Runtime.Intrinsics.Vector256<byte>;
 
 namespace Nethermind.Evm;
 
@@ -9,9 +10,9 @@ internal class StackPool
 {
     // Also have parallel prewarming and Rpc calls
     private const int MaxStacksPooled = VirtualMachine.MaxCallDepth * 2;
-    private readonly struct StackItem(byte[] dataStack, int[] returnStack)
+    private readonly struct StackItem(Word[] dataStack, int[] returnStack)
     {
-        public readonly byte[] DataStack = dataStack;
+        public readonly Word[] DataStack = dataStack;
         public readonly int[] ReturnStack = returnStack;
     }
 
@@ -23,7 +24,7 @@ internal class StackPool
     /// </summary>
     /// <param name="dataStack"></param>
     /// <param name="returnStack"></param>
-    public void ReturnStacks(byte[] dataStack, int[] returnStack)
+    public void ReturnStacks(Word[] dataStack, int[] returnStack)
     {
         if (_stackPool.Count <= MaxStacksPooled)
         {
@@ -31,7 +32,7 @@ internal class StackPool
         }
     }
 
-    public (byte[], int[]) RentStacks()
+    public (Word[], int[]) RentStacks()
     {
         if (_stackPool.TryDequeue(out StackItem result))
         {
@@ -40,7 +41,7 @@ internal class StackPool
 
         return
         (
-            new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 32],
+            new Word[EvmStack.MaxStackSize + EvmStack.RegisterLength],
             new int[EvmStack.ReturnStackSize]
         );
     }

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -219,6 +219,18 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     void ReportStackPush(in ReadOnlySpan<byte> stackItem);
 
     /// <summary>
+    ///
+    /// </summary>
+    /// <param name="value"></param>
+    void ReportStackPush(in UInt256 value)
+    {
+        if (BitConverter.IsLittleEndian)
+        {
+            // The platform is little endian, requires conversion.
+        }
+    }
+
+    /// <summary>
     /// </summary>
     /// <param name="stackItem"></param>
     /// <remarks>Depends on <see cref="IsTracingInstructions"/></remarks>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -744,9 +744,10 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         gasAvailable -= GasCostOf.VeryLow;
 
                         if (!stack.PopUInt256(out b)) goto StackUnderflow;
-                        if (!stack.PopUInt256(out a)) goto StackUnderflow;
-                        UInt256.Add(in a, in b, out result);
-                        stack.PushUInt256(result);
+                        // if (!stack.PopUInt256(out a)) goto StackUnderflow;
+                        ref a = ref stack.PeekRef(out bool);
+
+                        UInt256.Add(in a, in b, out a);
 
                         break;
                     }
@@ -888,7 +889,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         Metrics.ExpOpcode++;
 
                         if (!stack.PopUInt256(out a)) goto StackUnderflow;
-                        bytes = stack.PopWord256();
+                        bytes = stack.PopWord256(out b);
 
                         int leadingZeros = bytes.LeadingZerosCount();
                         if (leadingZeros != 32)
@@ -1052,57 +1053,57 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                     {
                         gasAvailable -= GasCostOf.VeryLow;
 
-                        ref byte bytesRef = ref stack.PopBytesByRef();
+                        ref byte bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> aVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        bytesRef = ref stack.PopBytesByRef();
+                        bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> bVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        WriteUnaligned(ref stack.PushBytesRef(), Vector256.BitwiseAnd(aVec, bVec));
+                        WriteUnaligned(ref stack.PushRef(), Vector256.BitwiseAnd(aVec, bVec));
                         break;
                     }
                 case Instruction.OR:
                     {
                         gasAvailable -= GasCostOf.VeryLow;
 
-                        ref byte bytesRef = ref stack.PopBytesByRef();
+                        ref byte bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> aVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        bytesRef = ref stack.PopBytesByRef();
+                        bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> bVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        WriteUnaligned(ref stack.PushBytesRef(), Vector256.BitwiseOr(aVec, bVec));
+                        WriteUnaligned(ref stack.PushRef(), Vector256.BitwiseOr(aVec, bVec));
                         break;
                     }
                 case Instruction.XOR:
                     {
                         gasAvailable -= GasCostOf.VeryLow;
 
-                        ref byte bytesRef = ref stack.PopBytesByRef();
+                        ref byte bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> aVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        bytesRef = ref stack.PopBytesByRef();
+                        bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
                         Vector256<byte> bVec = ReadUnaligned<Vector256<byte>>(ref bytesRef);
 
-                        WriteUnaligned(ref stack.PushBytesRef(), Vector256.Xor(aVec, bVec));
+                        WriteUnaligned(ref stack.PushRef(), Vector256.Xor(aVec, bVec));
                         break;
                     }
                 case Instruction.NOT:
                     {
                         gasAvailable -= GasCostOf.VeryLow;
 
-                        ref byte bytesRef = ref stack.PopBytesByRef();
+                        ref byte bytesRef = ref stack.PopRef();
                         if (IsNullRef(ref bytesRef)) goto StackUnderflow;
 
                         Vector256<byte> negVec = Vector256.OnesComplement(ReadUnaligned<Vector256<byte>>(ref bytesRef));
 
-                        WriteUnaligned(ref stack.PushBytesRef(), negVec);
+                        WriteUnaligned(ref stack.PushRef(), negVec);
                         break;
                     }
                 case Instruction.BYTE:
@@ -1142,7 +1143,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         bytes = vmState.Memory.LoadSpan(in a, b);
 
                         // Compute the KECCAK256 directly to the stack slot
-                        KeccakCache.ComputeTo(bytes, out As<byte, ValueHash256>(ref stack.PushBytesRef()));
+                        KeccakCache.ComputeTo(bytes, out As<byte, ValueHash256>(ref stack.PushRef()));
                         break;
                     }
                 case Instruction.ADDRESS:


### PR DESCRIPTION
This PR changes the endianness of the `EvmStack` to be aligned with the platform it runs on. It means that no endianness conversions should be done when retrieving storing `UInt256`. The penalty though is related to pushing/poping bytes that now require reversing. According to the profiling this should happen much less frequent than regular operations.

Beside the endiannes, this PR add one method that allows to peek a `ref UInt256` to the top of the stack. This allows for any `Instruction` that has push/pop behavior to get a ref to the last parameter and directly set the value on the stack, without performing calculations for pop and push. Instead it will calculated the offset once for getting the `ref` and use it for pop.

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
