### PR TITLE
Add single block receipt migration functionality

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsMigration.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsMigration.cs
@@ -7,6 +7,6 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptsMigration
     {
-        Task<bool> Run(long blockNumber);
+        Task<bool> Run(long blockNumber, bool migrateSingleBlock = false);
     }
 }

--- a/src/Nethermind/Nethermind.Cli/Modules/DebugCliModule.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/DebugCliModule.cs
@@ -93,9 +93,9 @@ namespace Nethermind.Cli.Modules
         }
 
         [CliFunction("debug", "migrateReceipts")]
-        public bool MigrateReceipts(long number)
+        public bool MigrateReceipts(long number, bool migrateSingleBlock = false)
         {
-            return NodeManager.Post<bool>("debug_migrateReceipts", number).Result;
+            return NodeManager.Post<bool>("debug_migrateReceipts", number, migrateSingleBlock).Result;
         }
 
         public DebugCliModule(ICliEngine cliEngine, INodeManager nodeManager) : base(cliEngine, nodeManager)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -389,12 +389,13 @@ public class DebugModuleTests
         debugTraceCall.Should().BeEquivalentTo(expected);
     }
 
-    [Test]
-    public async Task Migrate_receipts()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Migrate_receipts(bool migrateSingleBlock)
     {
         debugBridge.MigrateReceipts(Arg.Any<long>()).Returns(true);
         IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
-        string response = await RpcTest.TestSerializedRequest(rpcModule, "debug_migrateReceipts", 100);
+        string response = await RpcTest.TestSerializedRequest(rpcModule, "debug_migrateReceipts", 100, migrateSingleBlock);
         Assert.That(response, Is.Not.Null);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -91,8 +91,13 @@ public class DebugBridge : IDebugBridge
 
     public void UpdateHeadBlock(Hash256 blockHash) => _blockTree.UpdateHeadBlock(blockHash);
 
-    public Task<bool> MigrateReceipts(long blockNumber)
-        => _receiptsMigration.Run(blockNumber + 1); // add 1 to make go from inclusive (better for API) to exclusive (better for internal)
+    public Task<bool> MigrateReceipts(long blockNumber, bool migrateSingleBlock = false)
+    {
+        if (migrateSingleBlock)
+            return _receiptsMigration.Run(blockNumber);
+        else
+            return _receiptsMigration.Run(blockNumber + 1); // add 1 to make go from inclusive (better for API) to exclusive (better for internal)
+    }
 
     public void InsertReceipts(BlockParameter blockParameter, TxReceipt[] txReceipts)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -94,7 +94,7 @@ public class DebugBridge : IDebugBridge
     public Task<bool> MigrateReceipts(long blockNumber, bool migrateSingleBlock = false)
     {
         if (migrateSingleBlock)
-            return _receiptsMigration.Run(blockNumber);
+            return _receiptsMigration.Run(blockNumber, migrateSingleBlock);
         else
             return _receiptsMigration.Run(blockNumber + 1); // add 1 to make go from inclusive (better for API) to exclusive (better for internal)
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -147,8 +147,8 @@ public class DebugRpcModule : IDebugRpcModule
         return ResultWrapper<GethLikeTxTrace>.Success(transactionTrace);
     }
 
-    public async Task<ResultWrapper<bool>> debug_migrateReceipts(long blockNumber) =>
-        ResultWrapper<bool>.Success(await _debugBridge.MigrateReceipts(blockNumber));
+    public async Task<ResultWrapper<bool>> debug_migrateReceipts(long blockNumber, bool migrateSingleBlock = false) =>
+        ResultWrapper<bool>.Success(await _debugBridge.MigrateReceipts(blockNumber, migrateSingleBlock));
 
     public Task<ResultWrapper<bool>> debug_insertReceipts(BlockParameter blockParameter, ReceiptForRpc[] receiptForRpc)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -31,7 +31,7 @@ public interface IDebugBridge
     ChainLevelInfo GetLevelInfo(long number);
     int DeleteChainSlice(long startNumber, bool force = false);
     void UpdateHeadBlock(Hash256 blockHash);
-    Task<bool> MigrateReceipts(long blockNumber);
+    Task<bool> MigrateReceipts(long blockNumber, bool migrateSingleBlock = false);
     void InsertReceipts(BlockParameter blockParameter, TxReceipt[] receipts);
     SyncReportSymmary GetCurrentSyncStage();
     IEnumerable<string> TraceBlockToFile(Hash256 blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -85,7 +85,7 @@ public interface IDebugRpcModule : IRpcModule
     ResultWrapper<GethLikeTxTrace> debug_traceTransactionInBlockByIndex(byte[] blockRlp, int txIndex, GethTraceOptions options = null);
 
     [JsonRpcMethod(Description = "Sets the block number up to which receipts will be migrated to (Nethermind specific).")]
-    Task<ResultWrapper<bool>> debug_migrateReceipts(long blockNumber);
+    Task<ResultWrapper<bool>> debug_migrateReceipts(long blockNumber, bool migrateSingleBlock = false);
 
     [JsonRpcMethod(Description = "Insert receipts for the block after verifying receipts root correctness.")]
     Task<ResultWrapper<bool>> debug_insertReceipts(BlockParameter blockParameter, ReceiptForRpc[] receiptForRpc);

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -117,6 +117,68 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             }
         }
 
+        [Test]
+        public async Task SingleBlockMigration_RestoresMissingReceipt()
+        {
+            IReceiptConfig receiptConfig = new ReceiptConfig
+            {
+                StoreReceipts = true,
+                ReceiptsMigration = true,
+                CompactReceiptStore = false 
+            };
+
+            var blockTreeBuilder = Core.Test.Builders.Build.A.BlockTree().OfChainLength(3);
+            IBlockTree blockTree = blockTreeBuilder.TestObject;
+            IChainLevelInfoRepository chainLevelInfoRepository = blockTreeBuilder.ChainLevelInfoRepository;
+
+            InMemoryReceiptStorage inMemoryReceiptStorage = new(true);
+            InMemoryReceiptStorage outMemoryReceiptStorage = new(true);
+            inMemoryReceiptStorage.MigratedBlockNumber = 0;
+            outMemoryReceiptStorage.MigratedBlockNumber = 0;
+
+            Block blockToMigrate = blockTree.FindBlock(1);
+            TxReceipt receiptA = Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[0]).TestObject;
+            TxReceipt receiptB = Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[1]).TestObject;
+
+            inMemoryReceiptStorage.Insert(blockToMigrate, new[] { receiptA, receiptB });
+
+            outMemoryReceiptStorage.Insert(blockToMigrate, new[] { receiptA });
+
+            TestMemColumnsDb<ReceiptsColumns> receiptColumnDb = new();
+            TestMemDb blocksDb = (TestMemDb)receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks);
+            TestMemDb txIndexDb = (TestMemDb)receiptColumnDb.GetColumnDb(ReceiptsColumns.Transactions);
+
+            ISyncModeSelector syncModeSelector = Substitute.For<ISyncModeSelector>();
+            syncModeSelector.Current.Returns(SyncMode.WaitingForBlock);
+
+            TestReceiptStorage testStorage = new TestReceiptStorage(inMemoryReceiptStorage, outMemoryReceiptStorage);
+
+            var migration = new ReceiptMigration(
+                testStorage,
+                blockTree,
+                syncModeSelector,
+                chainLevelInfoRepository,
+                receiptConfig,
+                receiptColumnDb,
+                Substitute.For<IReceiptsRecovery>(),
+                LimboLogs.Instance
+            );
+
+            await migration.Run(1, migrateSingleBlock: true);
+            if (migration._migrationTask != null)
+            {
+                await migration._migrationTask;
+            }
+
+            TxReceipt[] outReceipts = outMemoryReceiptStorage.Get(blockToMigrate, recover: false, recoverSender: false);
+            outReceipts.Length.Should().Be(2, "Both receipts (A & B) should be present after migration.");
+
+            outReceipts.Should().Contain(receiptA)
+                       .And.Contain(receiptB);
+
+            outMemoryReceiptStorage.MigratedBlockNumber.Should().BeGreaterThanOrEqualTo(1);
+        }
+
         private class TestReceiptStorage : IReceiptStorage
         {
             private readonly IReceiptStorage _inStorage;


### PR DESCRIPTION
Adds possibility to fix only single block with missing TxHash<---> Receipt connection

Current method goes from 0 to blockNum which is long and annoying if you have missing receipt on block 30mln.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No


#### Requires explanation in Release Notes

- [X] Yes
- [ ] No

New parameter to debug_migrateReceipts added: `migrateSingleBlock`. Default value = false.

When set, combined with blockNumber allows to execute migration only for single block rather entire range which helps fixing TxHash<->Receipt relation quickly.

