### PR TITLE
JsonRpc modules cancellation only on Debugger detached

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfigExtension.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfigExtension.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 
 namespace Nethermind.JsonRpc
 {
@@ -16,6 +18,15 @@ namespace Nethermind.JsonRpc
                 enabledModules.Add(modules[i]);
             }
             config.EnabledModules = enabledModules.ToArray();
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="CancellationTokenSource"/> that timeouts after <see cref="IJsonRpcConfig.Timeout"/>
+        /// if <see cref="Debugger.IsAttached"/> is false.
+        /// </summary>
+        public static CancellationTokenSource BuildTimeoutCancellationToken(this IJsonRpcConfig config)
+        {
+            return Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(config.Timeout);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -135,7 +135,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
         reader = await RecordRequest(reader);
         long startTime = Stopwatch.GetTimestamp();
-        CancellationTokenSource timeoutSource = new(_jsonRpcConfig.Timeout);
+        using CancellationTokenSource timeoutSource = _jsonRpcConfig.BuildTimeoutCancellationToken();
 
         // Handles general exceptions during parsing and validation.
         // Sends an error response and stops the stopwatch.

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -563,8 +563,8 @@ public partial class EthRpcModule(
 
     public ResultWrapper<IEnumerable<FilterLog>> eth_getFilterLogs(UInt256 filterId)
     {
-        CancellationTokenSource cancellationTokenSource = new(_rpcConfig.Timeout);
-        CancellationToken cancellationToken = cancellationTokenSource.Token;
+        CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
+        CancellationToken cancellationToken = timeout.Token;
 
         try
         {
@@ -572,17 +572,17 @@ public partial class EthRpcModule(
             bool filterFound = _blockchainBridge.TryGetLogs(id, out IEnumerable<FilterLog> filterLogs, cancellationToken);
             if (id < 0 || !filterFound)
             {
-                cancellationTokenSource.Dispose();
+                timeout.Dispose();
                 return ResultWrapper<IEnumerable<FilterLog>>.Fail($"Filter with id: {filterId} does not exist.");
             }
             else
             {
-                return ResultWrapper<IEnumerable<FilterLog>>.Success(GetLogs(filterLogs, cancellationTokenSource));
+                return ResultWrapper<IEnumerable<FilterLog>>.Success(GetLogs(filterLogs, timeout));
             }
         }
         catch (ResourceNotFoundException exception)
         {
-            cancellationTokenSource.Dispose();
+            timeout.Dispose();
             return GetFailureResult<IEnumerable<FilterLog>>(exception, _ethSyncingInfo.SyncMode.HaveNotSyncedReceiptsYet());
         }
     }
@@ -590,8 +590,8 @@ public partial class EthRpcModule(
     public ResultWrapper<IEnumerable<FilterLog>> eth_getLogs(Filter filter)
     {
         // because of lazy evaluation of enumerable, we need to do the validation here first
-        CancellationTokenSource cancellationTokenSource = new(_rpcConfig.Timeout);
-        CancellationToken cancellationToken = cancellationTokenSource.Token;
+        CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
+        CancellationToken cancellationToken = timeout.Token;
 
         SearchResult<BlockHeader> fromBlockResult;
         SearchResult<BlockHeader> toBlockResult;
@@ -606,7 +606,7 @@ public partial class EthRpcModule(
 
             if (toBlockResult.IsError)
             {
-                cancellationTokenSource.Dispose();
+                timeout.Dispose();
                 return GetFailureResult<IEnumerable<FilterLog>, BlockHeader>(toBlockResult, _ethSyncingInfo.SyncMode.HaveNotSyncedHeadersYet());
             }
 
@@ -616,7 +616,7 @@ public partial class EthRpcModule(
 
         if (fromBlockResult.IsError)
         {
-            cancellationTokenSource.Dispose();
+            timeout.Dispose();
             return GetFailureResult<IEnumerable<FilterLog>, BlockHeader>(fromBlockResult, _ethSyncingInfo.SyncMode.HaveNotSyncedHeadersYet());
         }
 
@@ -630,7 +630,7 @@ public partial class EthRpcModule(
 
         if (fromBlockNumber > toBlockNumber && toBlockNumber != 0)
         {
-            cancellationTokenSource.Dispose();
+            timeout.Dispose();
 
             return ResultWrapper<IEnumerable<FilterLog>>.Fail($"From block {fromBlockNumber} is later than to block {toBlockNumber}.", ErrorCodes.InvalidParams);
         }
@@ -643,7 +643,7 @@ public partial class EthRpcModule(
 
             ArrayPoolList<FilterLog> logs = new(_rpcConfig.MaxLogsPerResponse);
 
-            using (cancellationTokenSource)
+            using (timeout)
             {
                 foreach (FilterLog log in filterLogs)
                 {
@@ -755,9 +755,11 @@ public partial class EthRpcModule(
         return ResultWrapper<ReceiptForRpc>.Success(new(txHash, receipt, gasInfo.Value, logIndexStart));
     }
 
-
     public ResultWrapper<ReceiptForRpc[]?> eth_getBlockReceipts(BlockParameter blockParameter)
     {
         return _receiptFinder.GetBlockReceipts(blockParameter, _blockFinder, _specProvider);
     }
+
+    private CancellationTokenSource BuildTimeoutCancellationTokenSource() =>
+        _rpcConfig.BuildTimeoutCancellationToken();
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
@@ -36,9 +36,9 @@ public abstract class ExecutorBase<TResult, TRequest, TProcessing>
             return ResultWrapper<TResult>.Fail($"No state available for block {header.Hash}",
                 ErrorCodes.ResourceUnavailable);
 
-        using CancellationTokenSource cancellationTokenSource = new(_rpcConfig.Timeout);
+        using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
         TProcessing? toProcess = Prepare(call);
-        return Execute(header.Clone(), toProcess, stateOverride, cancellationTokenSource.Token);
+        return Execute(header.Clone(), toProcess, stateOverride, timeout.Token);
     }
 
     protected abstract TProcessing Prepare(TRequest call);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -207,9 +207,9 @@ public class SimulateTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder
             call.BlockStateCalls.Sort((b1, b2) => b1.BlockOverrides!.Number!.Value.CompareTo(b2.BlockOverrides!.Number!.Value));
         }
 
-        using CancellationTokenSource cancellationTokenSource = new(_rpcConfig.Timeout); //TODO remove!
+        using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
         SimulatePayload<TransactionWithSourceDetails> toProcess = Prepare(call);
-        return Execute(header.Clone(), toProcess, stateOverride, cancellationTokenSource.Token);
+        return Execute(header.Clone(), toProcess, stateOverride, timeout.Token);
     }
 
     protected override ResultWrapper<IReadOnlyList<SimulateBlockResult>> Execute(BlockHeader header,


### PR DESCRIPTION
When debugging JsonRpc modules, including tests, the default configuration causes a timeout after 20s. This PR proposes to not timeout when a debugger is attached. This is done by providing an extension method for `IJsonRpcConfig` and then using it instead of building `CancellationTokenSource` from the `.Timeout` property. All call-sites that are amendable (no `BoundedModule`) are refactored.

## Changes

- extraction of a timeout method

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Ease debugging of hive tests & other that depend on the timeout

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
