### PR TITLE
Json Rpc should only handle application/json requests

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -171,7 +171,7 @@ public class Startup
             {
                 await ctx.Response.WriteAsync("Nethermind JSON RPC");
             }
-            else
+            else if (ctx.Request.ContentType?.Contains("application/json") ?? false)
             {
                 if (jsonRpcUrl.MaxRequestBodySize is not null)
                     ctx.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize = jsonRpcUrl.MaxRequestBodySize;


### PR DESCRIPTION
Resolves #8015

## Changes

- Json Rpc should only be trying to parse requests which are `application/json`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
