### PR TITLE
Fix state pivot update on state sync feed not working

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -459,11 +459,5 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             dbContext.CompareTrees("END");
         }
-
-        [Test]
-        public void ShouldForceResetPivot_OnRestart()
-        {
-
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -197,13 +197,11 @@ namespace Nethermind.Synchronization.Test.FastSync
         }
 
         [Test]
-        [Repeat(TestRepeatCount)]
-        public async Task When_saving_root_goes_asleep()
+        public async Task When_saving_root_goes_asleep_and_then_restart_to_new_tree_when_reactivated()
         {
             DbContext dbContext = new(_logger, _logManager);
             dbContext.RemoteStateTree.Set(TestItem.KeccakA, Build.An.Account.TestObject);
             dbContext.RemoteStateTree.Commit();
-
 
             dbContext.CompareTrees("BEGIN");
 
@@ -460,6 +458,12 @@ namespace Nethermind.Synchronization.Test.FastSync
             await ActivateAndWait(ctx);
 
             dbContext.CompareTrees("END");
+        }
+
+        [Test]
+        public void ShouldForceResetPivot_OnRestart()
+        {
+
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -156,7 +156,7 @@ namespace Nethermind.Synchronization.Test.FastSync
                 Task.Delay(timeout));
         }
 
-        protected class SafeContext(ILifetimeScope container, IBlockTree blockTree, StateSyncPivot stateSyncPivot)
+        protected class SafeContext(ILifetimeScope container, IBlockTree blockTree)
         {
             public SyncPeerMock[] SyncPeerMocks => container.Resolve<SyncPeerMock[]>();
             public ISyncPeerPool Pool => container.Resolve<ISyncPeerPool>();
@@ -172,8 +172,6 @@ namespace Nethermind.Synchronization.Test.FastSync
 
                 blockTree.SuggestBlock(newBlock).Should().Be(AddBlockResult.Added);
                 blockTree.UpdateMainChain([newBlock], false, true);
-
-                stateSyncPivot.UpdateHeaderForcefully();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -42,24 +42,12 @@ namespace Nethermind.Synchronization.FastSync
                 TrySetNewBestHeader($"distance from HEAD:{Diff}");
             }
 
-            if (_logger.IsDebug)
-            {
-                if (_bestHeader is not null)
-                {
-                    var currentHeader = _blockTree.FindHeader(_bestHeader.Number);
-                    if (currentHeader.StateRoot != _bestHeader.StateRoot)
-                    {
-                        _logger.Warn($"SNAP - Pivot:{_bestHeader.StateRoot}, Current:{currentHeader.StateRoot}");
-                    }
-                }
-            }
-
             return _bestHeader;
         }
 
         public void UpdateHeaderForcefully()
         {
-            if ((_blockTree.BestSuggestedHeader?.Number + MultiSyncModeSelector.FastSyncLag) > _bestHeader.Number)
+            if (_bestHeader is null || (_blockTree.BestSuggestedHeader?.Number + MultiSyncModeSelector.FastSyncLag) > _bestHeader.Number)
             {
                 TrySetNewBestHeader("too many empty responses");
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -406,6 +406,11 @@ namespace Nethermind.Synchronization.FastSync
 
         public void ResetStateRootToBestSuggested(SyncFeedState currentState)
         {
+            if (currentState == SyncFeedState.Dormant)
+            {
+                _stateSyncPivot.UpdateHeaderForcefully();
+            }
+
             BlockHeader headerForState = _stateSyncPivot.GetPivotHeader();
 
             if (_logger.IsInfo) _logger.Info($"Starting the node data sync from the {headerForState.ToString(BlockHeader.Format.Short)} {headerForState.StateRoot} root");


### PR DESCRIPTION
- In prod, the sync pivot will simply wait until the chain proceed far enough to continue.
- It seems that in the unit tests, there is a manual force update which hide this issue.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Reproducable on #8055 
