### PR TITLE
remove precompiles

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Precompiles/AddressExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/AddressExtensions.cs
@@ -36,8 +36,6 @@ public static class AddressExtensions
                     0x0f => releaseSpec.Bls381Enabled,
                     0x10 => releaseSpec.Bls381Enabled,
                     0x11 => releaseSpec.Bls381Enabled,
-                    0x12 => releaseSpec.Bls381Enabled,
-                    0x13 => releaseSpec.Bls381Enabled,
                     _ => false
                 },
                 0x01 => (data[4] >>> 24) switch


### PR DESCRIPTION
Two precompiles were removed from EIP2537 here - https://github.com/ethereum/EIPs/pull/8945

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
