### PR TITLE
refactor(sync): Move ProgressTracker initialization to dedicated method

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -64,7 +64,6 @@ namespace Nethermind.Synchronization.SnapSync
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _db = db ?? throw new ArgumentNullException(nameof(db));
-
             _pivot = pivot;
 
             int accountRangePartitionCount = syncConfig.SnapSyncAccountRangePartitionCount;
@@ -72,9 +71,12 @@ namespace Nethermind.Synchronization.SnapSync
                 throw new ArgumentException($"Account range partition must be between 1 to {int.MaxValue}.");
 
             _accountRangePartitionCount = accountRangePartitionCount;
-            SetupAccountRangePartition();
+            Initialize();
+        }
 
-            //TODO: maybe better to move to a init method instead of the constructor
+        private void Initialize()
+        {
+            SetupAccountRangePartition();
             GetSyncProgress();
         }
 


### PR DESCRIPTION
Resolves # N/A

## Changes

- Moved initialization logic from constructor to a dedicated `Initialize()` method in `ProgressTracker`
- Improved code organization by separating initialization concerns
- Removed TODO comment after implementing the suggested improvement

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This refactoring improves code maintainability by following the Single Responsibility Principle. The initialization logic is now encapsulated in a dedicated method, making the code more modular and easier to understand. This change is purely internal and doesn't affect the public API or behavior of the `ProgressTracker` class.