### PR TITLE
Fix reorg boundary not set on dispose

### DIFF
--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -51,7 +51,6 @@ using Nethermind.Stats;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
-using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
 using Nethermind.Sockets;
@@ -59,7 +58,6 @@ using Nethermind.Trie;
 using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Era1;
 using Nethermind.Facade.Find;
-using Nethermind.Synchronization.FastSync;
 
 namespace Nethermind.Api
 {
@@ -72,6 +70,7 @@ namespace Nethermind.Api
             LogManager = logManager;
             ChainSpec = chainSpec;
             CryptoRandom = new CryptoRandom();
+            DisposeStack = new DisposableStack(logManager);
             DisposeStack.Push(CryptoRandom);
         }
 
@@ -241,7 +240,7 @@ namespace Nethermind.Api
         public ProtectedPrivateKey? OriginalSignerKey { get; set; }
 
         public ChainSpec ChainSpec { get; set; }
-        public DisposableStack DisposeStack { get; } = new();
+        public DisposableStack DisposeStack { get; }
         public IReadOnlyList<INethermindPlugin> Plugins { get; } = new List<INethermindPlugin>();
         public IList<IPublisher> Publishers { get; } = new List<IPublisher>(); // this should be called publishers
         public IProcessExitSource? ProcessExit { get; set; }

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -84,10 +84,6 @@ public class InitializeStateDb : IStep
         // Used by rpc to trigger pruning.
         setApi.PruningTrigger = pruningTrigger;
 
-        // TODO: Don't forget this
-        TrieStoreBoundaryWatcher trieStoreBoundaryWatcher = new(stateManager, _api.BlockTree!, _api.LogManager);
-        getApi.DisposeStack.Push(trieStoreBoundaryWatcher);
-
         setApi.StateReader = stateManager.GlobalStateReader;
         setApi.ChainHeadStateProvider = new ChainHeadReadOnlyStateProvider(getApi.BlockTree, stateManager.GlobalStateReader);
 

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -166,8 +166,6 @@ public class PruningTrieStateFactory(
                 // Main thread should only read from prewarm caches, not spend extra time updating them.
                 populatePreBlockCache: false);
 
-        disposeStack.Push(mainWorldTrieStore);
-
         // Init state if we need system calls before actual processing starts
         worldState.StateRoot = blockTree!.Head?.StateRoot ?? Keccak.EmptyTreeHash;
         if (blockTree!.Head?.StateRoot is not null)
@@ -180,6 +178,13 @@ public class PruningTrieStateFactory(
             trieStore,
             dbProvider,
             logManager);
+
+        // NOTE: Don't forget this! Very important!
+        TrieStoreBoundaryWatcher trieStoreBoundaryWatcher = new(stateManager, blockTree!, logManager);
+        // Must be disposed after main trie store or the final persist on dispose will not set persisted state on blocktree.
+        disposeStack.Push(trieStoreBoundaryWatcher);
+
+        disposeStack.Push(mainWorldTrieStore);
 
         InitializeFullPruning(
             stateManager.GlobalStateReader,

--- a/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
@@ -65,12 +65,7 @@ public class EthereumRunner(INethermindApi api)
             await Stop(async () => await plugin.DisposeAsync(), $"Disposing plugin {plugin.Name}");
         }
 
-        while (_api.DisposeStack.Count != 0)
-        {
-            IAsyncDisposable disposable = _api.DisposeStack.Pop();
-            await Stop(async () => await disposable.DisposeAsync(), $"Disposing {disposable}");
-        }
-
+        await _api.DisposeStack.DisposeAsync();
         Stop(() => _api.DbProvider?.Dispose(), "Closing DBs");
 
         if (_logger.IsInfo)

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -4,21 +4,17 @@
 using Autofac;
 using FluentAssertions;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Logging;
-using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 using NSubstitute;
-using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test;

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -1,12 +1,24 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Autofac;
 using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test;
@@ -59,5 +71,39 @@ public class WorldStateManagerTests
         {
             worldStateManager.HashServer.Should().BeNull();
         }
+    }
+
+    [Test]
+    public void ShouldAnnounceReorgOnDispose()
+    {
+        int lastBlock = 256;
+        int reorgDepth = 128; // Default reorg depth with snap serving
+
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        IConfigProvider configProvider = new ConfigProvider();
+
+        {
+            using IContainer ctx = new ContainerBuilder()
+                .AddModule(new TestNethermindModule(configProvider))
+                .AddSingleton(blockTree)
+                .Build();
+
+            IWorldState worldState = ctx.Resolve<IWorldStateManager>().GlobalWorldState;
+
+            worldState.StateRoot = Keccak.EmptyTreeHash;
+
+            worldState.CreateAccount(TestItem.AddressA, 1, 2);
+            worldState.Commit(Cancun.Instance);
+            worldState.CommitTree(1);
+
+            for (int i = 2; i <= lastBlock; i++)
+            {
+                worldState.IncrementNonce(TestItem.AddressA, 1);
+                worldState.Commit(Cancun.Instance);
+                worldState.CommitTree(i);
+            }
+        }
+
+        blockTree.Received().BestPersistedState = lastBlock - reorgDepth - 1;
     }
 }


### PR DESCRIPTION
- Fix reorg boundary not set on dispose as the reorg boundary setter is dispose before trie store.
  - Fortunately, triestore does not remove old keys on dispose so the only issue on restart is long reorg depending on cache size.
- The default pruning cache should limit the reorg to around 300 block so this should not be very notable normally.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested to no longer have very long reorg on start when using large cache.