### PR TITLE
Fix StartMonitoring dependencies

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -16,7 +16,7 @@ using Type = System.Type;
 
 namespace Nethermind.Init.Steps;
 
-[RunnerStepDependencies(typeof(StartMonitoring))]
+[RunnerStepDependencies(typeof(InitializeNetwork))]
 public class StartMonitoring : IStep
 {
     private readonly IApiWithNetwork _api;


### PR DESCRIPTION
Fixes Closes Resolves #
#8100 

## Changes

- StartMonitoring depends on itself

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_