### PR TITLE
add Gnosis test runner

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTest.cs
@@ -28,6 +28,7 @@ namespace Ethereum.Test.Base
         public Hash256? PostStateRoot { get; set; }
         public bool SealEngineUsed { get; set; }
         public string? LoadFailure { get; set; }
+        public ulong ChainId { get; set; }
 
         public override string? ToString()
         {

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -79,17 +79,17 @@ public abstract class BlockchainTestBase
         Assert.That(test.LoadFailure, Is.Null, "test data loading failure");
 
         List<(ForkActivation Activation, IReleaseSpec Spec)> transitions =
-            [((ForkActivation)0, Frontier.Instance), ((ForkActivation)1, test.Network)];
+            [((ForkActivation)0, Frontier.Instance), ((ForkActivation)1, test.Network)]; // TODO: this thing took a lot of time to find after it was removed!, genesis block is always initialized with Frontier
         if (test.NetworkAfterTransition is not null)
         {
-               transitions.Add((test.TransitionForkActivation!.Value, test.NetworkAfterTransition));
+            transitions.Add((test.TransitionForkActivation!.Value, test.NetworkAfterTransition));
         }
 
         ISpecProvider specProvider = test.ChainId == GnosisSpecProvider.Instance.ChainId
             ? GnosisSpecProvider.Instance
             : new CustomSpecProvider(transitions.ToArray());
 
-        if (specProvider.GenesisSpec != Frontier.Instance)
+        if (test.ChainId != GnosisSpecProvider.Instance.ChainId && specProvider.GenesisSpec != Frontier.Instance)
         {
             Assert.Fail("Expected genesis spec to be Frontier for blockchain tests");
         }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -27,6 +27,7 @@ using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using Nethermind.State;
@@ -77,20 +78,16 @@ public abstract class BlockchainTestBase
             TestContext.Out.WriteLine($"Network after transition: [{test.NetworkAfterTransition.Name}] at {test.TransitionForkActivation}");
         Assert.That(test.LoadFailure, Is.Null, "test data loading failure");
 
-        ISpecProvider specProvider;
+        List<(ForkActivation Activation, IReleaseSpec Spec)> transitions =
+            [((ForkActivation)0, Frontier.Instance), ((ForkActivation)1, test.Network)];
         if (test.NetworkAfterTransition is not null)
         {
-            specProvider = new CustomSpecProvider(
-                ((ForkActivation)0, Frontier.Instance),
-                ((ForkActivation)1, test.Network),
-                (test.TransitionForkActivation!.Value, test.NetworkAfterTransition));
+               transitions.Add((test.TransitionForkActivation!.Value, test.NetworkAfterTransition));
         }
-        else
-        {
-            specProvider = new CustomSpecProvider(
-                ((ForkActivation)0, Frontier.Instance), // TODO: this thing took a lot of time to find after it was removed!, genesis block is always initialized with Frontier
-                ((ForkActivation)1, test.Network));
-        }
+
+        ISpecProvider specProvider = test.ChainId == GnosisSpecProvider.Instance.ChainId
+            ? GnosisSpecProvider.Instance
+            : new CustomSpecProvider(transitions.ToArray());
 
         if (specProvider.GenesisSpec != Frontier.Instance)
         {

--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTest.cs
@@ -36,6 +36,7 @@ namespace Ethereum.Test.Base
         public ulong? CurrentExcessBlobGas { get; set; }
         public UInt256? ParentBlobGasUsed { get; set; }
         public UInt256? ParentExcessBlobGas { get; set; }
+        public ulong ChainId { get; set; }
 
         public Hash256? RequestsHash { get; set; }
 

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -62,11 +62,13 @@ namespace Ethereum.Test.Base
             TestContext.Out.Write($"Running {test.Name} at {DateTime.UtcNow:HH:mm:ss.ffffff}");
             Assert.That(test.LoadFailure, Is.Null, "test data loading failure");
 
-            ISpecProvider specProvider = new CustomSpecProvider(
-                ((ForkActivation)0, Frontier.Instance), // TODO: this thing took a lot of time to find after it was removed!, genesis block is always initialized with Frontier
-                ((ForkActivation)1, test.Fork));
+            ISpecProvider specProvider = test.ChainId == GnosisSpecProvider.Instance.ChainId
+                ? GnosisSpecProvider.Instance
+                : new CustomSpecProvider(
+                    ((ForkActivation)0, Frontier.Instance), // TODO: this thing took a lot of time to find after it was removed!, genesis block is always initialized with Frontier
+                    ((ForkActivation)1, test.Fork));
 
-            if (specProvider.GenesisSpec != Frontier.Instance)
+            if (test.ChainId != GnosisSpecProvider.Instance.ChainId && specProvider.GenesisSpec != Frontier.Instance)
             {
                 Assert.Fail("Expected genesis spec to be Frontier for blockchain tests");
             }

--- a/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
@@ -16,12 +16,14 @@ public class BlockchainTestsRunner : BlockchainTestBase, IBlockchainTestRunner
     private readonly ConsoleColor _defaultColour;
     private readonly ITestSourceLoader _testsSource;
     private readonly string? _filter;
+    private readonly ulong _chainId;
 
-    public BlockchainTestsRunner(ITestSourceLoader testsSource, string? filter)
+    public BlockchainTestsRunner(ITestSourceLoader testsSource, string? filter, ulong chainId)
     {
         _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
         _defaultColour = Console.ForegroundColor;
         _filter = filter;
+        _chainId = chainId;
     }
 
     public async Task<IEnumerable<EthereumTestResult>> RunTestsAsync()
@@ -42,6 +44,7 @@ public class BlockchainTestsRunner : BlockchainTestBase, IBlockchainTestRunner
             }
             else
             {
+                test.ChainId = _chainId;
                 EthereumTestResult result = await RunTest(test);
                 testResults.Add(result);
                 if (result.Pass)

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -41,6 +41,9 @@ internal class Program
 
         public static CliOption<bool> Stdin { get; } =
             new("--stdin", "-x") { Description = "If stdin is used, the state runner will read inputs (filenames) from stdin, and continue executing until empty line is read." };
+
+        public static CliOption<bool> GnosisTest { get; } =
+            new("--gnosisTest", "-g") { Description = "Set test as gnosisTest. if not, it will be by default assumed a mainnet test." };
     }
 
     public static async Task<int> Main(params string[] args)
@@ -78,15 +81,18 @@ internal class Program
 
         if (parseResult.GetValue(Options.Stdin))
             input = Console.ReadLine();
+        ulong chainId = parseResult.GetValue(Options.GnosisTest) ? 100ul : 1ul;
+
 
         while (!string.IsNullOrWhiteSpace(input))
         {
             if (parseResult.GetValue(Options.BlockTest))
-                await RunBlockTest(input, source => new BlockchainTestsRunner(source, parseResult.GetValue(Options.Filter)));
+                await RunBlockTest(input, source => new BlockchainTestsRunner(source, parseResult.GetValue(Options.Filter), chainId));
             else
                 RunStateTest(input, source => new StateTestsRunner(source, whenTrace,
                     !parseResult.GetValue(Options.ExcludeMemory),
                     !parseResult.GetValue(Options.ExcludeStack),
+                    chainId,
                     parseResult.GetValue(Options.Filter)));
 
             if (!parseResult.GetValue(Options.Stdin))

--- a/src/Nethermind/Nethermind.Test.Runner/Properties/launchSettings.json
+++ b/src/Nethermind/Nethermind.Test.Runner/Properties/launchSettings.json
@@ -4,9 +4,17 @@
       "commandName": "Project",
       "commandLineArgs": "-i statetest1.json"
     },
+    "Gnosis State Test": {
+      "commandName": "Project",
+      "commandLineArgs": "-g -i gnosisStateTest1.json"
+    },
     "Blockchain Test": {
       "commandName": "Project",
       "commandLineArgs": "-b -i blockchainTest1.json"
+    },
+    "Gnosis Blockchain Test": {
+      "commandName": "Project",
+      "commandLineArgs": "-g -b -i gnosisBlockchainTest1.json"
     },
     "Regex State Test": {
       "commandName": "Project",

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -29,15 +29,17 @@ namespace Nethermind.Test.Runner
         private readonly bool _traceMemory;
         private readonly bool _traceStack;
         private readonly string? _filter;
+        private readonly ulong _chainId;
         private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
 
-        public StateTestsRunner(ITestSourceLoader testsSource, WhenTrace whenTrace, bool traceMemory, bool traceStack, string? filter = null)
+        public StateTestsRunner(ITestSourceLoader testsSource, WhenTrace whenTrace, bool traceMemory, bool traceStack, ulong chainId, string? filter = null)
         {
             _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
             _whenTrace = whenTrace;
             _traceMemory = traceMemory;
             _traceStack = traceStack;
             _filter = filter;
+            _chainId = chainId;
             Setup(null);
         }
 
@@ -65,6 +67,7 @@ namespace Nethermind.Test.Runner
             {
                 if (_filter is not null && !Regex.Match(test.Name, $"^({_filter})").Success)
                     continue;
+                test.ChainId = _chainId;
 
                 EthereumTestResult result = null;
                 if (_whenTrace != WhenTrace.Always)


### PR DESCRIPTION
Fixes Closes Resolves #

Currently Nethermind BlockchainTestRunner and StateTestRunner does not support running gnosis tests. These changes supports running gnosis tests

## Changes

-  add new flag `-g (gnosisTest)` flag to Nethermind.Test.Runner,
- if -g flag exists then `chainId = 100` for gnosis
- add GnosisSpecProvider

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
