### PR TITLE
Fix case when new release commit pushed but still master used for sync

### DIFF
--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -367,5 +367,5 @@ jobs:
           ref: "main"
           token: "${{ steps.gh-app.outputs.token }}"
           inputs: '{
-            "nethermind_branch": "${{ github.ref}}"
+            "nethermind_branch": "${{ github.event.workflow_run.head_branch }}"
           }'

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: nethermind
+          ref: ${{ github.event.workflow_run.head_branch || github.ref_name || 'master' }}
       - name: Set Matrix
         id: set-matrix
         run: |
@@ -100,6 +101,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+          ref: ${{ github.event.workflow_run.head_branch || github.ref_name || 'master' }}
           
       - name: Checkout tests repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Noticed that we have an issue that when action is triggered via new docker image publish for release branch we still keep using master image for sync tests.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No