### PR TITLE
Add EOF tracing fields

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -242,7 +242,7 @@ public class MyTracer : ITxTracer, IDisposable
     {
     }
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
     }
 

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -127,6 +127,7 @@ public sealed class EvmState : IDisposable // TODO: rename to CallState
         ReturnStackHead = 0;
         ExecutionType = executionType;
         ProgramCounter = 0;
+        FunctionIndex = 0;
         IsTopLevel = isTopLevel;
         _canRestore = !isTopLevel;
         IsStatic = isStatic;

--- a/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
@@ -48,7 +48,7 @@ public class AlwaysCancelTxTracer : ITxTracer
 
     public void MarkAsFailed(Address recipient, GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null) => throw new OperationCanceledException(ErrorMessage);
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env) => throw new OperationCanceledException(ErrorMessage);
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0) => throw new OperationCanceledException(ErrorMessage);
 
     public void ReportOperationError(EvmExceptionType error) => throw new OperationCanceledException(ErrorMessage);
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
@@ -96,8 +96,8 @@ public class BlockReceiptsTracer : IBlockTracer, ITxTracer, IJournal<int>, ITxTr
         return txReceipt;
     }
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env) =>
-        _currentTxTracer.StartOperation(pc, opcode, gas, env);
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0) =>
+        _currentTxTracer.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
 
     public void ReportOperationError(EvmExceptionType error) =>
         _currentTxTracer.ReportOperationError(error);

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -190,12 +190,12 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
         }
     }
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         token.ThrowIfCancellationRequested();
         if (innerTracer.IsTracingInstructions)
         {
-            innerTracer.StartOperation(pc, opcode, gas, env);
+            innerTracer.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -151,14 +151,14 @@ public class CompositeTxTracer : ITxTracer
         }
     }
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         for (int index = 0; index < _txTracers.Count; index++)
         {
             ITxTracer innerTracer = _txTracers[index];
             if (innerTracer.IsTracingInstructions)
             {
-                innerTracer.StartOperation(pc, opcode, gas, env);
+                innerTracer.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
@@ -194,8 +194,8 @@ public class DebugTracer : ITxTracer, ITxTracerWrapper, IDisposable
     public void MarkAsFailed(Address recipient, GasConsumed gasSpent, byte[] output, string error, Hash256? stateRoot = null)
         => InnerTracer.MarkAsFailed(recipient, gasSpent, output, error, stateRoot);
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
-        => InnerTracer.StartOperation(pc, opcode, gas, env);
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
+        => InnerTracer.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
 
     public void ReportOperationError(EvmExceptionType error)
         => InnerTracer.ReportOperationError(error);

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
@@ -100,7 +100,7 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer, ITxTracer
             : new Log.Contract(from, to, value, isAnyCreate ? null : input);
     }
 
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         _log.pc = pc + env.CodeInfo.PcOffset();
         _log.op = new Log.Opcode(opcode);
@@ -108,6 +108,8 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer, ITxTracer
         _log.depth = env.GetGethTraceDepth();
         _log.error = null;
         _log.gasCost = null;
+        // skip codeSection
+        // skip functionDepth
     }
 
     public override void ReportOperationRemainingGas(long gas)

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
@@ -59,7 +59,7 @@ public sealed class Native4ByteTracer : GethLikeNativeTxTracer
         }
     }
 
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         _op = opcode;
     }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -88,9 +88,9 @@ public sealed class NativePrestateTracer : GethLikeNativeTxTracer
             ProcessDiffState();
     }
 
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
-        base.StartOperation(pc, opcode, gas, env);
+        base.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
 
         if (_error is not null) return;
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
@@ -35,12 +35,12 @@ public class GethLikeTxMemoryTracer : GethLikeTxTracer<GethTxMemoryTraceEntry>
             .ToHexString(false);
     }
 
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         var previousTraceEntry = CurrentTraceEntry;
         var previousDepth = CurrentTraceEntry?.Depth ?? 0;
 
-        base.StartOperation(pc, opcode, gas, env);
+        base.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
 
         if (CurrentTraceEntry.Depth > previousDepth)
         {

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -69,7 +69,7 @@ public abstract class GethLikeTxTracer<TEntry> : GethLikeTxTracer where TEntry :
     protected GethLikeTxTracer(GethTraceOptions options) : base(options) { }
     private bool _gasCostAlreadySetForCurrentOp;
 
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         bool isPostMerge = env.IsPostMerge();
         if (CurrentTraceEntry is not null)
@@ -80,6 +80,8 @@ public abstract class GethLikeTxTracer<TEntry> : GethLikeTxTracer where TEntry :
         CurrentTraceEntry.Gas = gas;
         CurrentTraceEntry.Opcode = opcode.GetName(isPostMerge);
         CurrentTraceEntry.ProgramCounter = pc;
+        // skip codeSection
+        // skip functionDepth
         _gasCostAlreadySetForCurrentOp = false;
     }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -179,8 +179,10 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     /// <param name="opcode"></param>
     /// <param name="gas"></param>
     /// <param name="env"></param>
+    /// <param name="codeSection"></param>
+    /// <param name="functionDepth"></param>
     /// <remarks>Depends on <see cref="IsTracingInstructions"/></remarks>
-    void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env);
+    void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0);
 
     /// <summary>
     ///

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -27,7 +27,7 @@ public class NullTxTracer : TxTracer
         => ThrowInvalidOperationException();
     public override void MarkAsFailed(Address recipient, GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
         => ThrowInvalidOperationException();
-    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
         => ThrowInvalidOperationException();
 
     public override void ReportOperationError(EvmExceptionType error)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -217,12 +217,14 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             };
         }
 
-        public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+        public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
         {
             ParityVmOperationTrace operationTrace = new();
             _gasAlreadySetForCurrentOp = false;
             operationTrace.Pc = pc + env.CodeInfo.PcOffset();
             operationTrace.Cost = gas;
+            // skip codeSection
+            // skip functionDepth
             _currentOperation = operationTrace;
             _currentPushList.Clear();
             _currentVmTrace.Ops.Add(operationTrace);

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -53,7 +53,7 @@ public abstract class TxTracer : ITxTracer
     public virtual void ReportStorageRead(in StorageCell storageCell) { }
     public virtual void MarkAsSuccess(Address recipient, GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null) { }
     public virtual void MarkAsFailed(Address recipient, GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null) { }
-    public virtual void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env) { }
+    public virtual void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0) { }
     public virtual void ReportOperationError(EvmExceptionType error) { }
     public virtual void ReportOperationRemainingGas(long gas) { }
     public virtual void ReportLog(LogEntry log) { }

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -50,16 +50,18 @@ public class StateTestTxTracer : ITxTracer, IDisposable
         _trace.Result.GasUsed = gasSpent;
     }
 
-    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env)
+    public void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
         bool isPostMerge = env.IsPostMerge();
         _gasAlreadySetForCurrentOp = false;
         _traceEntry = new StateTestTxTraceEntry();
         _traceEntry.Pc = pc + env.CodeInfo.PcOffset();
+        _traceEntry.Section = codeSection;
         _traceEntry.Operation = (byte)opcode;
         _traceEntry.OperationName = opcode.GetName(isPostMerge);
         _traceEntry.Gas = gas;
         _traceEntry.Depth = env.GetGethTraceDepth();
+        _traceEntry.FunctionDepth = functionDepth;
         _trace.Entries.Add(_traceEntry);
     }
 

--- a/src/Nethermind/Nethermind.Test.Runner/StateTxTraceEntry.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTxTraceEntry.cs
@@ -16,6 +16,10 @@ namespace Nethermind.Test.Runner
         [JsonPropertyName("pc")]
         public int Pc { get; set; }
 
+        [JsonPropertyName("section")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int Section { get; set; }
+
         [JsonPropertyName("op")]
         public byte Operation { get; set; }
 
@@ -37,10 +41,14 @@ namespace Nethermind.Test.Runner
         [JsonPropertyName("depth")]
         public int Depth { get; set; }
 
+        [JsonPropertyName("functionDepth")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int FunctionDepth { get; set; }
+
         [JsonPropertyName("refund")]
         public int Refund { get; set; }
 
-        [JsonPropertyName("opname")]
+        [JsonPropertyName("opName")]
         public string? OperationName { get; set; }
 
         [JsonPropertyName("error")]


### PR DESCRIPTION
## Changes

Add the "section" and "functionDepth" tracing fields to correspond to code section and CALLF depth (respectivly). This required some deep plumbing changes to add the field in the interfaces.


## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

nethermind is being fuzzed via an EOF focused fuzzer. These new fields are needed for the differential fuzzing.

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [ ] Yes
- [X] No

