### PR TITLE
JsonRpc standardization: change MinerPremiumNegative error to FeeCapTooLow

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/TransactionPermissionContractV3.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/TransactionPermissionContractV3.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Consensus.AuRa.Contracts
 
             long number = (parentHeader?.Number ?? 0) + 1;
             bool isEip1559Enabled = _specProvider.GetSpecFor1559(number).IsEip1559Enabled;
-            UInt256 gasPrice = isEip1559Enabled && tx.Supports1559 ? tx.MaxFeePerGas : tx.GasPrice;
+            UInt256 gasPrice = tx.GetGasFeeCap(isEip1559Enabled);
 
             return new object[]
             {

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -249,6 +249,11 @@ namespace Nethermind.Core
 
         public bool MayHaveNetworkForm => Type is TxType.Blob;
 
+        public UInt256 GetGasFeeCap(bool isEip1559Enabled = true)
+        {
+            return isEip1559Enabled && Supports1559 ? MaxFeePerGas : GasPrice;
+        }
+
         public class PoolPolicy : IPooledObjectPolicy<Transaction>
         {
             public Transaction Create()

--- a/src/Nethermind/Nethermind.Core/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionExtensions.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Core
         public static bool TryCalculatePremiumPerGas(this Transaction tx, in UInt256 baseFeePerGas, out UInt256 premiumPerGas)
         {
             bool freeTransaction = tx.IsFree();
-            UInt256 feeCap = tx.Supports1559 ? tx.MaxFeePerGas : tx.GasPrice;
+            UInt256 feeCap = tx.GetGasFeeCap();
             if (baseFeePerGas > feeCap)
             {
                 premiumPerGas = UInt256.Zero;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -462,7 +462,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (!tx.TryCalculatePremiumPerGas(header.BaseFeePerGas, out premiumPerGas))
                 {
                     TraceLogInvalidTx(tx, "MINER_PREMIUM_IS_NEGATIVE");
-                    return TransactionResult.MinerPremiumNegative;
+                    return TransactionResult.FeeCapTooLow(tx, header.BaseFeePerGas);
                 }
 
                 UInt256 senderBalance = WorldState.GetBalance(tx.SenderAddress!);
@@ -819,7 +819,7 @@ namespace Nethermind.Evm.TransactionProcessing
         public static readonly TransactionResult InsufficientMaxFeePerGasForSenderBalance = "insufficient MaxFeePerGas for sender balance";
         public static readonly TransactionResult InsufficientSenderBalance = "insufficient sender balance";
         public static readonly TransactionResult MalformedTransaction = "malformed";
-        public static readonly TransactionResult MinerPremiumNegative = "miner premium is negative";
+        public static TransactionResult FeeCapTooLow(Transaction tx, UInt256 baseFee) => $"err: max fee per gas less than block base fee: address {tx.SenderAddress}, maxFeePerGas: {tx.GetGasFeeCap()}, baseFee: {baseFee} (supplied gas {tx.GasLimit})";
         public static readonly TransactionResult NonceOverflow = "nonce overflow";
         public static readonly TransactionResult SenderHasDeployedCode = "sender has deployed code";
         public static readonly TransactionResult SenderNotSpecified = "sender not specified";

--- a/src/Nethermind/Nethermind.Optimism/OptimismTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismTransactionProcessor.cs
@@ -84,7 +84,7 @@ public sealed class OptimismTransactionProcessor(
             if (!tx.TryCalculatePremiumPerGas(header.BaseFeePerGas, out premiumPerGas))
             {
                 TraceLogInvalidTx(tx, "MINER_PREMIUM_IS_NEGATIVE");
-                return TransactionResult.MinerPremiumNegative;
+                return TransactionResult.FeeCapTooLow(tx, header.BaseFeePerGas);
             }
 
             if (UInt256.SubtractUnderflow(senderBalance, tx.Value, out UInt256 balanceLeft))


### PR DESCRIPTION
Currently `eth_call`, `eth_simulateV1`, `eth_estimateGas`, `eth_sendRawTransaction`, `eth_sendTransaction` returns in Geth and Nethermind different error message for the same error:

Geth [link to code](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L368):
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32000,
        "message": "err: max fee per gas less than block base fee: address 0xD3b2Bd4b38360057644C60b1ae7a568D219525b4, maxFeePerGas: 0, baseFee: 0 (supplied gas 50000000)"
    }
}
```

Nethermind:
```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32000,
        "message": "miner premium is negative"
    },
    "id": 1
}
```

## Changes

- replaced MinerPremiumNegative with FeeCapTooLow

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
