### PR TITLE
Checkpoint of the world state should be moved by FCU

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -113,6 +113,10 @@ public class BlockchainProcessorTests
                 }
             }
 
+            public void UpdateCheckpoint(long blockNumber, Hash256 stateRootCheckpoint)
+            {
+            }
+
             public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing;
 
             public event EventHandler<BlockEventArgs>? BlockProcessing;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -276,7 +276,7 @@ public partial class BlockProcessor(
 
     public void UpdateCheckpoint(long blockNumber, Hash256 stateRootCheckpoint)
     {
-        if (_logger.IsInfo) _logger.Info($"Updating checkpoint to {stateRootCheckpoint} at block {blockNumber}");
+        if (_logger.IsTrace) _logger.Trace($"Updating checkpoint to {stateRootCheckpoint} at block {blockNumber}");
         _checkpoint = stateRootCheckpoint;
     }
 
@@ -290,10 +290,10 @@ public partial class BlockProcessor(
     // TODO: move to branch processor
     private void RestoreBranch(Hash256 branchingPointStateRoot)
     {
-        if (_logger.IsInfo) _logger.Info($"Restoring the branch checkpoint - {branchingPointStateRoot}");
+        if (_logger.IsTrace) _logger.Trace($"Restoring the branch checkpoint - {branchingPointStateRoot}");
         _stateProvider.Reset();
         _stateProvider.StateRoot = branchingPointStateRoot;
-        if (_logger.IsInfo) _logger.Info($"Restored the branch checkpoint - {branchingPointStateRoot} | {_stateProvider.StateRoot}");
+        if (_logger.IsTrace) _logger.Trace($"Restored the branch checkpoint - {branchingPointStateRoot} | {_stateProvider.StateRoot}");
     }
 
     // TODO: block processor pipeline

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -270,10 +270,10 @@ public partial class BlockProcessor(
     // TODO: move to branch processor
     private void RestoreBranch(Hash256 branchingPointStateRoot)
     {
-        if (_logger.IsTrace) _logger.Trace($"Restoring the branch checkpoint - {branchingPointStateRoot}");
+        if (_logger.IsInfo) _logger.Info($"Restoring the branch checkpoint - {branchingPointStateRoot}");
         _stateProvider.Reset();
         _stateProvider.StateRoot = branchingPointStateRoot;
-        if (_logger.IsTrace) _logger.Trace($"Restored the branch checkpoint - {branchingPointStateRoot} | {_stateProvider.StateRoot}");
+        if (_logger.IsInfo) _logger.Info($"Restored the branch checkpoint - {branchingPointStateRoot} | {_stateProvider.StateRoot}");
     }
 
     // TODO: block processor pipeline

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -168,7 +168,7 @@ public partial class BlockProcessor(
                 if (isCommitPoint && notReadOnly)
                 {
                     if (_logger.IsInfo) _logger.Info($"Commit part of a long blocks branch {i}/{blocksCount}");
-                    previousBranchStateRoot = CreateCheckpoint(true);
+                    previousBranchStateRoot = CreateCheckpoint(captureCurrentStateRoot: true);
                     Hash256? newStateRoot = suggestedBlock.StateRoot;
                     InitBranch(newStateRoot, false);
                 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing;
+using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing
 {
@@ -25,6 +26,15 @@ namespace Nethermind.Consensus.Processing
             List<Block> suggestedBlocks,
             ProcessingOptions processingOptions,
             IBlockTracer blockTracer);
+
+        /// <summary>
+        /// Updates the checkpoint to which the block processor should revert to.
+        /// </summary>
+        /// <remarks>
+        /// The root hash of the <see cref="IWorldStateManager.GlobalWorldState"/> could be changed manually.
+        /// This would break the contract though that the global world state should be used only by <see cref="IBlockProcessor"/>.
+        /// </remarks>
+        void UpdateCheckpoint(long blockNumber, Hash256 stateRootCheckpoint);
 
         /// <summary>
         /// Fired when a branch is being processed.

--- a/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
@@ -20,6 +20,10 @@ namespace Nethermind.Consensus.Processing
             return suggestedBlocks.ToArray();
         }
 
+        public void UpdateCheckpoint(long blockNumber, Hash256 stateRootCheckpoint)
+        {
+        }
+
         public event EventHandler<BlocksProcessingEventArgs> BlocksProcessing
         {
             add { }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -323,6 +323,11 @@ public class TestBlockProcessorInterceptor : IBlockProcessor
         return _blockProcessorImplementation.Process(newBranchStateRoot, suggestedBlocks, processingOptions, blockTracer);
     }
 
+    public void UpdateCheckpoint(long blockNumber, Hash256 stateRootCheckpoint)
+    {
+        _blockProcessorImplementation.UpdateCheckpoint(blockNumber, stateRootCheckpoint);
+    }
+
     public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
     {
         add => _blockProcessorImplementation.BlocksProcessing += value;


### PR DESCRIPTION
This PR changes the behavior of `MergePlugin.MergeEnabled` chains so that once a given block is considered final (`FCU` comes in), the checkpoint of the main block processor is moved to the last finalized state root hash. This ensures that the root hash of the world state touched by the main processor always progresses according to FCU. The global world state should not reference any ancient blocks.

### Before

Currently, the pair of calls `.CreateCheckpoint` & `.RestoreBranch` in `BlockProcessor` never moves the current state forward. The state is captured and then rolled back to with each execution of the `NewPayload`. This means, that after the state is set when a node is initialized, it will be switched between an old initial hash root and the current branch hash root. You can see it in enhanced (via 54865e4) logs below. No matter how far, the checkpoint is the same and will be continuously restored to. 

```
31 Jan 2025 08:34:49.302 Received ForkChoice: 21743051 (0xcae62e...091005), Safe: 21743003 (0x940ec8...fb4fc9), Finalized: 21742971 (0x2c8827...04665e)
31 Jan 2025 08:34:49.073  Block throughput      213.35 MGas/s  |    1,962.7 tps |             9.72 Blk/s | exec code  from cache   2,431 | new      1
31 Jan 2025 08:34:49.073  Block mev 0.0282 ETH   21.96 MGas    |      202   txs | calls      1,122 ( 30) | sload   3,581 | sstore  1,253 | create   2
31 Jan 2025 08:34:49.073 Processed            21743051         |      102.9 ms  | slot         13,382 ms |⛽ Gas gwei: 1.49 .. 1.53 (3.04) .. 45.00
31 Jan 2025 08:34:49.073 Restored the branch checkpoint - 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd | 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd
31 Jan 2025 08:34:49.073 Restoring the branch checkpoint - 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd 
```

and 8 hours earlier

```
30 Jan 2025 23:59:43.710 Received ForkChoice: 21740492 (0xa012c9...aafe4c), Safe: 21740460 (0xa486fb...ff9373), Finalized: 21740428 (0x167a8e...a236c3)
30 Jan 2025 23:59:37.159  Block throughput      255.48 MGas/s  |    2,870.2 tps |             8.52 Blk/s | exec code  from cache   3,979 | new      9
30 Jan 2025 23:59:37.159 Block mev 0.0523 ETH   30.00 MGas    |      337   txs | calls      1,862 ( 53) | sload   6,334 | sstore  1,901 | create   3
30 Jan 2025 23:59:37.159 Processed            21740492         |      117.4 ms  | slot         13,408 ms |⛽ Gas gwei: 2.45 .. 2.45 (4.02) .. 69.77
30 Jan 2025 23:59:37.159 Restored the branch checkpoint - 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd | 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd
30 Jan 2025 23:59:37.159 Restoring the branch checkpoint - 0x2c2465a5d17ae367dea6033203a24536d060265234b153c2ef9ecc97ccd615bd 
```

### After

The checkpoint that StateRoot is reset to is properly updated. See the log outputs taken in different times

```
31 Jan 2025 14:19:49.518 Updating checkpoint to 0xe885162f5858ed9c9f245d803da9090abb5c02c89c7171c39403f3e6b36cd7ee at block 21744687
31 Jan 2025 14:19:49.518 Received ForkChoice: 21744764 (0x397e92...1390df), Safe: 21744719 (0x1ac1a3...c6e21e), Finalized: 21744687 (0x62a6dc...046d7f)
31 Jan 2025 14:19:49.293  Block throughput      223.01 MGas/s  |    2,841.4 tps |            20.15 Blk/s | exec code  from cache   1,391 | new      0
31 Jan 2025 14:19:49.293  Block mev 0.0774 ETH   11.07 MGas    |      141   txs | calls        638 ( 23) | sload   2,072 | sstore    673 | create   0
31 Jan 2025 14:19:49.293 Processed            21744764         |       49.6 ms  | slot         12,186 ms |⛽ Gas gwei: 4.51 .. 5.61 (9.54) .. 240.08
31 Jan 2025 14:19:49.293 Restored the branch checkpoint - 0xe885162f5858ed9c9f245d803da9090abb5c02c89c7171c39403f3e6b36cd7ee | 0xe885162f5858ed9c9f245d803da9090abb5c02c89c7171c39403f3e6b36cd7ee
31 Jan 2025 14:19:49.293 Restoring the branch checkpoint - 0xe885162f5858ed9c9f245d803da9090abb5c02c89c7171c39403f3e6b36cd7ee 
```

vs

```
31 Jan 2025 13:51:13.210 Synced Chain Head to 21744621 (0x04fb6c...ee9988)
31 Jan 2025 13:51:13.210 Updating checkpoint to 0x6b27f8e2062dc999b5ba1b8379702d6bd3c88b0a1307a4cda71c812e1adb806f at block 21744527
31 Jan 2025 13:51:13.210 Received ForkChoice: 21744621 (0x04fb6c...ee9988), Safe: 21744559 (0xca69e2...f5cbb9), Finalized: 21744527 (0x3f1824...8a246a)
31 Jan 2025 13:51:12.975  Block throughput      168.70 MGas/s  |    2,684.2 tps |            20.18 Blk/s | exec code  from cache     900 | new      0
31 Jan 2025 13:51:12.975  Block     0.0082 ETH    8.36 MGas    |      133   txs | calls        379 ( 40) | sload   1,462 | sstore    395 | create   0
31 Jan 2025 13:51:12.975 Processed            21744621         |       49.5 ms  | slot         11,420 ms |⛽ Gas gwei: 3.70 .. 3.70 (5.07) .. 13.78
31 Jan 2025 13:51:12.975 Restored the branch checkpoint - 0x6b27f8e2062dc999b5ba1b8379702d6bd3c88b0a1307a4cda71c812e1adb806f | 0x6b27f8e2062dc999b5ba1b8379702d6bd3c88b0a1307a4cda71c812e1adb806f
31 Jan 2025 13:51:12.975 Restoring the branch checkpoint - 0x6b27f8e2062dc999b5ba1b8379702d6bd3c88b0a1307a4cda71c812e1adb806f
```


## Changes

- enhancement of the `MergePlugin` to inform the main block processor about the checkpoint
- fix the `BlockProcessor` so that it takes into consideration the provided checkpoint instead always falling back to the checkpoint  captured at the node startup

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Probably we should test `MergeEnabled` and others as well

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No