### PR TITLE
Fix wrong parent block due to reorg

### DIFF
--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -17,6 +17,8 @@ namespace Nethermind.Core
             BlockInfos = blockInfos;
         }
 
+        private const int NotFound = -1;
+
         public bool HasNonBeaconBlocks => BlockInfos.Any(static b => (b.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody)) == 0);
         public bool HasBeaconBlocks => BlockInfos.Any(static b => (b.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody)) != 0);
         public bool HasBlockOnMainChain { get; set; }
@@ -82,7 +84,7 @@ namespace Nethermind.Core
                 }
             }
 
-            return -1;
+            return NotFound;
         }
 
         public BlockInfo? FindBlockInfo(Hash256 blockHash)

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -17,8 +17,6 @@ namespace Nethermind.Core
             BlockInfos = blockInfos;
         }
 
-        private const int NotFound = -1;
-
         public bool HasNonBeaconBlocks => BlockInfos.Any(static b => (b.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody)) == 0);
         public bool HasBeaconBlocks => BlockInfos.Any(static b => (b.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody)) != 0);
         public bool HasBlockOnMainChain { get; set; }
@@ -74,7 +72,7 @@ namespace Nethermind.Core
             return null;
         }
 
-        public int FindBeaconMainChainIndex()
+        private int? FindBeaconMainChainIndex()
         {
             for (int i = 0; i < BlockInfos.Length; i++)
             {
@@ -84,7 +82,7 @@ namespace Nethermind.Core
                 }
             }
 
-            return NotFound;
+            return null;
         }
 
         public BlockInfo? FindBlockInfo(Hash256 blockHash)
@@ -112,7 +110,7 @@ namespace Nethermind.Core
             }
 
             int index = foundIndex ?? blockInfos.Length - 1;
-            int beaconMainChainIndex;
+            int? beaconMainChainIndex;
 
             if (setAsMain)
             {
@@ -120,10 +118,10 @@ namespace Nethermind.Core
                 blockInfos[0] = blockInfo;
             }
             // prioritise new beacon info from beacon sync over old fcu
-            else if (blockInfo.IsBeaconMainChain && (beaconMainChainIndex = FindBeaconMainChainIndex()) != NotFound)
+            else if (blockInfo.IsBeaconMainChain && (beaconMainChainIndex = FindBeaconMainChainIndex()) is not null)
             {
-                blockInfos[index] = blockInfos[beaconMainChainIndex];
-                blockInfos[beaconMainChainIndex] = blockInfo;
+                blockInfos[index] = blockInfos[beaconMainChainIndex.Value];
+                blockInfos[beaconMainChainIndex.Value] = blockInfo;
             }
             else
             {

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -110,6 +110,7 @@ namespace Nethermind.Core
             }
 
             int index = foundIndex ?? blockInfos.Length - 1;
+            int beaconMainChainIndex;
 
             if (setAsMain)
             {
@@ -117,14 +118,10 @@ namespace Nethermind.Core
                 blockInfos[0] = blockInfo;
             }
             // prioritise new beacon info from beacon sync over old fcu
-            else if (blockInfo.IsBeaconMainChain)
+            else if (blockInfo.IsBeaconMainChain && (beaconMainChainIndex = FindBeaconMainChainIndex()) != -1)
             {
-                int beaconMainChainIndex = FindBeaconMainChainIndex();
-                if (beaconMainChainIndex != -1)
-                {
-                    blockInfos[index] = blockInfos[beaconMainChainIndex];
-                    blockInfos[beaconMainChainIndex] = blockInfo;
-                }
+                blockInfos[index] = blockInfos[beaconMainChainIndex];
+                blockInfos[beaconMainChainIndex] = blockInfo;
             }
             else
             {

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -72,6 +72,19 @@ namespace Nethermind.Core
             return null;
         }
 
+        public int FindBeaconMainChainIndex()
+        {
+            for (int i = 0; i < BlockInfos.Length; i++)
+            {
+                if (BlockInfos[i].IsBeaconMainChain)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         public BlockInfo? FindBlockInfo(Hash256 blockHash)
         {
             int? index = FindIndex(blockHash);
@@ -102,6 +115,16 @@ namespace Nethermind.Core
             {
                 blockInfos[index] = blockInfos[0];
                 blockInfos[0] = blockInfo;
+            }
+            // prioritise new beacon info from beacon sync over old fcu
+            else if (blockInfo.IsBeaconMainChain)
+            {
+                int beaconMainChainIndex = FindBeaconMainChainIndex();
+                if (beaconMainChainIndex != -1)
+                {
+                    blockInfos[index] = blockInfos[beaconMainChainIndex];
+                    blockInfos[beaconMainChainIndex] = blockInfo;
+                }
             }
             else
             {

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -118,7 +118,7 @@ namespace Nethermind.Core
                 blockInfos[0] = blockInfo;
             }
             // prioritise new beacon info from beacon sync over old fcu
-            else if (blockInfo.IsBeaconMainChain && (beaconMainChainIndex = FindBeaconMainChainIndex()) != -1)
+            else if (blockInfo.IsBeaconMainChain && (beaconMainChainIndex = FindBeaconMainChainIndex()) != NotFound)
             {
                 blockInfos[index] = blockInfos[beaconMainChainIndex];
                 blockInfos[beaconMainChainIndex] = blockInfo;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -9,11 +9,14 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Evm;
@@ -24,9 +27,13 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.GC;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.Forks;
+using Nethermind.Stats;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Peers.AllocationStrategies;
 using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
@@ -656,6 +663,60 @@ public partial class EngineModuleTests
         }
     }
 
+    [Test]
+    public async Task Sync_proper_chain_when_header_fork_came_from_fcu_and_beacon_sync()
+    {
+        // fork A
+        MergeTestBlockchain chainA = await CreateBlockchain(releaseSpec: Cancun.Instance);
+        IEngineRpcModule rpcModuleA = CreateEngineModule(chainA, null, TimeSpan.FromDays(1));
+        await rpcModuleA.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
+
+        // main fork B
+        MergeTestBlockchain chainB = await CreateBlockchain(releaseSpec: Cancun.Instance);
+        IEngineRpcModule rpcModuleB = CreateEngineModule(chainB, null, TimeSpan.FromDays(1));
+        await rpcModuleB.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
+
+        // syncing chain
+        MergeTestBlockchain chainC = await CreateBlockchain(releaseSpec: Cancun.Instance);
+        IEngineRpcModule rpcModuleC = CreateEngineModule(chainC, null, TimeSpan.FromDays(1));
+        await rpcModuleC.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
+
+        ExecutionPayloadV3 payloadResultA1 = await AddNewBlockV3(rpcModuleA, chainA, 1);
+        ExecutionPayloadV3 payloadResultA2 = await AddNewBlockV3(rpcModuleA, chainA, 1);
+
+        ExecutionPayloadV3 payloadResultB1 = await AddNewBlockV3(rpcModuleB, chainB, 1);
+        // fork
+        ExecutionPayloadV3 payloadResultB2 = await AddNewBlockV3(rpcModuleB, chainB, 2);
+        ExecutionPayloadV3 payloadResultB3 = await AddNewBlockV3(rpcModuleB, chainB, 1);
+
+        SyncPeerMock chainAPeer = new SyncPeerMock(chainA.BlockTree);
+        SyncPeerAllocation alloc = new SyncPeerAllocation(new PeerInfo(chainAPeer), AllocationContexts.All);
+        alloc.AllocateBestPeer(new[] { new PeerInfo(chainAPeer) }, Substitute.For<INodeStatsManager>(), Substitute.For<IBlockTree>());
+        chainC.SyncPeerPool!.Allocate(
+            Arg.Any<IPeerAllocationStrategy>(),
+            Arg.Any<AllocationContexts>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())!.Returns(Task.FromResult(alloc));
+
+
+        await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultA1.BlockHash, chainC.BlockTree.GenesisHash, chainC.BlockTree.GenesisHash), null);
+        await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultA2.BlockHash, chainC.BlockTree.GenesisHash, chainC.BlockTree.GenesisHash), null);
+        await Task.Delay(1000);
+
+        await rpcModuleC.engine_newPayloadV3(payloadResultB2, [], TestItem.KeccakE);
+        await rpcModuleC.engine_newPayloadV3(payloadResultB3, [], TestItem.KeccakE);
+
+        await Task.Delay(1000);
+        AddBlockResult res = chainC.BlockTree.Insert(chainB.BlockTree.FindBlock(2)!.Header, BlockTreeInsertHeaderOptions.BeaconHeaderInsert);
+        await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultB3.BlockHash, chainC.BlockTree.GenesisHash, chainC.BlockTree.GenesisHash), null);
+
+        BlockHeader[]? heads = new ChainLevelHelper(chainC.BlockTree, chainC.BeaconPivot!, new SyncConfig(), chainC.LogManager)
+            .GetNextHeaders(10, 3);
+
+        Assert.That(heads?[2].Hash, Is.EqualTo(payloadResultB2.BlockHash));
+        Assert.That(heads?[3].Hash, Is.EqualTo(payloadResultB3.BlockHash));
+    }
+
     public static IEnumerable<TestCaseData> ForkchoiceUpdatedV3DeclinedTestCaseSource
     {
         get
@@ -808,7 +869,7 @@ public partial class EngineModuleTests
         }
     }
 
-    private async Task AddNewBlockV3(IEngineRpcModule rpcModule, MergeTestBlockchain chain, int transactionCount = 0)
+    private async Task<ExecutionPayloadV3> AddNewBlockV3(IEngineRpcModule rpcModule, MergeTestBlockchain chain, int transactionCount = 0)
     {
         Transaction[] txs = BuildTransactions(chain, chain.BlockTree.Head!.Hash!, TestItem.PrivateKeyA, TestItem.AddressB, (uint)transactionCount, 0, out _, out _, 0);
         chain.AddTransactions(txs);
@@ -842,6 +903,8 @@ public partial class EngineModuleTests
 
         ForkchoiceStateV1 newForkchoiceState = new(payload.ExecutionPayload.BlockHash, payload.ExecutionPayload.BlockHash, payload.ExecutionPayload.BlockHash);
         await rpcModule.engine_forkchoiceUpdatedV3(newForkchoiceState, null);
+
+        return payload.ExecutionPayload;
     }
 
     private async Task<(IEngineRpcModule, string?, Transaction[], MergeTestBlockchain chain)> BuildAndGetPayloadV3Result(

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -69,7 +68,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             // if we didn't reach the end of the stream, assume we have basefee to decode
-            if (decoderContext.Position != headerCheck)
+            if (decoderContext.Position != headerCheck && decoderContext.PeekPrefixAndContentLength().ContentLength != Hash256.Size)
             {
                 blockHeader.BaseFeePerGas = decoderContext.DecodeUInt256();
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             // if we didn't reach the end of the stream, assume we have basefee to decode
-            if (decoderContext.Position != headerCheck && decoderContext.PeekPrefixAndContentLength().ContentLength != Hash256.Size)
+            if (decoderContext.Position != headerCheck)
             {
                 blockHeader.BaseFeePerGas = decoderContext.DecodeUInt256();
             }


### PR DESCRIPTION
Fixes #8063

Blocks downloader requests next headers, next headers are incorrect, containing headers from different forks:
(forkB is main fork)

N-2: forkB
N-1: forkA
N: forkB

which leads to missing parent state when we process block N. 

Happens when:

forkA FCU N-1
beacon header downloaded in sync for forkB N-1
forkB NP N-1
forkB NP N
forkB FCU **N** (but no forkB FCU for N-1)

## Changes

- Prioritize recently retrieved beacon chain header over previous one

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
