### PR TITLE
Regression test for BLS precompile caching consensus issue

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/BlsG2AddPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlsG2AddPrecompileTests.cs
@@ -26,6 +26,25 @@ public class BlsG2AddPrecompileTests
         }
     }
 
+    // regression test for consensus issue
+    // precompile cache modified input causing add to zero to return wrong value
+    [Test]
+    public void Modifying_input_should_not_affect_output()
+    {
+        byte[] input = new byte[512];
+
+        G2AddPrecompile precompile = G2AddPrecompile.Instance;
+        (ReadOnlyMemory<byte> output, bool success) = precompile.Run(input, Prague.Instance);
+
+        input[511] = 0xFF;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output.ToArray(), Is.All.EqualTo(0));
+            Assert.That(success, Is.True);
+        });
+    }
+
     /// <summary>
     /// https://github.com/matter-labs/eip1962/tree/master/src/test/test_vectors/eip2537
     /// </summary>


### PR DESCRIPTION
Fixed in https://github.com/NethermindEth/nethermind/pull/8138

## Changes

- Added regression test

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
