### PR TITLE
Fix state override accessing state

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/TxPriorityContractTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/TxPriorityContractTests.cs
@@ -59,6 +59,7 @@ namespace Nethermind.AuRa.Test.Contract
         }
 
         [Test]
+        [Retry(3)]
         public async Task whitelist_should_return_correctly()
         {
             using TxPermissionContractBlockchainWithBlocks chain = await TestContractBlockchain.ForTest<TxPermissionContractBlockchainWithBlocks, TxPriorityContractTests>();

--- a/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingEnv.cs
@@ -51,17 +51,12 @@ public class OverridableTxProcessingEnv : IOverridableTxProcessorSource
 
     IOverridableTxProcessingScope IOverridableTxProcessorSource.Build(Hash256 stateRoot) => Build(stateRoot);
 
-    public OverridableTxProcessingScope Build(Hash256 stateRoot)
-    {
-        Hash256 originalStateRoot = StateProvider.StateRoot;
-        StateProvider.StateRoot = stateRoot;
-        return new(CodeInfoRepository, TransactionProcessor, StateProvider, originalStateRoot);
-    }
+    public OverridableTxProcessingScope Build(Hash256 stateRoot) => new(CodeInfoRepository, TransactionProcessor, StateProvider, stateRoot);
 
     IOverridableTxProcessingScope IOverridableTxProcessorSource.BuildAndOverride(BlockHeader header, Dictionary<Address, AccountOverride>? stateOverride)
     {
         OverridableTxProcessingScope scope = Build(header.StateRoot ?? throw new ArgumentException($"Block {header.Hash} state root is null", nameof(header)));
-        if (stateOverride != null)
+        if (stateOverride is not null)
         {
             scope.WorldState.ApplyStateOverrides(scope.CodeInfoRepository, stateOverride, SpecProvider.GetSpec(header), header.Number);
             header.StateRoot = scope.WorldState.StateRoot;

--- a/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingScope.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/OverridableTxProcessingScope.cs
@@ -8,22 +8,34 @@ using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class OverridableTxProcessingScope(
-    IOverridableCodeInfoRepository codeInfoRepository,
-    ITransactionProcessor transactionProcessor,
-    IOverridableWorldState worldState,
-    Hash256 originalStateRoot
-) : IOverridableTxProcessingScope
+public class OverridableTxProcessingScope : IOverridableTxProcessingScope
 {
-    public IOverridableCodeInfoRepository CodeInfoRepository => codeInfoRepository;
-    public ITransactionProcessor TransactionProcessor => transactionProcessor;
-    public IWorldState WorldState => worldState;
+    private readonly IOverridableCodeInfoRepository _codeInfoRepository;
+    private readonly ITransactionProcessor _transactionProcessor;
+    private readonly IOverridableWorldState _worldState;
 
-    public void Dispose()
+    public OverridableTxProcessingScope(IOverridableCodeInfoRepository codeInfoRepository,
+        ITransactionProcessor transactionProcessor,
+        IOverridableWorldState worldState,
+        Hash256 stateRoot)
     {
-        worldState.StateRoot = originalStateRoot;
-        worldState.Reset();
-        worldState.ResetOverrides();
-        codeInfoRepository.ResetOverrides();
+        _codeInfoRepository = codeInfoRepository;
+        _transactionProcessor = transactionProcessor;
+        _worldState = worldState;
+        Reset();
+        _worldState.StateRoot = stateRoot;
+    }
+
+    public IOverridableCodeInfoRepository CodeInfoRepository => _codeInfoRepository;
+    public ITransactionProcessor TransactionProcessor => _transactionProcessor;
+    public IWorldState WorldState => _worldState;
+
+    public void Dispose() => Reset();
+
+    private void Reset()
+    {
+        _worldState.Reset();
+        _worldState.ResetOverrides();
+        _codeInfoRepository.ResetOverrides();
     }
 }

--- a/src/Nethermind/Nethermind.Evm/StateOverridesExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/StateOverridesExtensions.cs
@@ -38,11 +38,12 @@ public static class StateOverridesExtensions
                 state.UpdateCode(overridableCodeInfoRepository, spec, accountOverride, address);
                 state.UpdateState(accountOverride, address);
             }
-
-            state.Commit(spec);
-            state.CommitTree(blockNumber);
-            state.RecalculateStateRoot();
         }
+
+        state.Commit(spec);
+        state.CommitTree(blockNumber);
+        state.RecalculateStateRoot();
+
     }
 
     private static void UpdateState(this IWorldState stateProvider, AccountOverride accountOverride, Address address)

--- a/src/Nethermind/Nethermind.Evm/StateOverridesExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/StateOverridesExtensions.cs
@@ -38,11 +38,11 @@ public static class StateOverridesExtensions
                 state.UpdateCode(overridableCodeInfoRepository, spec, accountOverride, address);
                 state.UpdateState(accountOverride, address);
             }
-        }
 
-        state.Commit(spec);
-        state.CommitTree(blockNumber);
-        state.RecalculateStateRoot();
+            state.Commit(spec);
+            state.CommitTree(blockNumber);
+            state.RecalculateStateRoot();
+        }
     }
 
     private static void UpdateState(this IWorldState stateProvider, AccountOverride accountOverride, Address address)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -394,6 +394,7 @@ namespace Nethermind.Synchronization.Test.FastSync
         }
 
         [Test]
+        [Parallelizable(ParallelScope.None)] // TODO: Investigate why it fails with parralelization
         public async Task When_empty_response_received_with_no_peer_return_not_allocated()
         {
             DbContext dbContext = new(_logger, _logManager);


### PR DESCRIPTION
Fixes #8130 and #7945

## Changes

- Doesn't bother trying to revert state root on json rpc, resets environment before accessing it

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

`eth_call`/`eth_estimateGas`/`eth_simulate`/`debug_traceXXX`/`trace_` fuzzing with state overrides
