### PR TITLE
State unavailability handling for DebugRpcModule

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -19,6 +19,7 @@ using Nethermind.Synchronization;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Sockets;
 using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Facade;
 
 namespace Nethermind.Api
 {
@@ -56,6 +57,7 @@ namespace Nethermind.Api
         ISubscriptionFactory? SubscriptionFactory { get; set; }
 
         IContainer? ApiWithNetworkServiceContainer { get; set; }
+        IBlockchainBridge? BlockchainBridge { get; set; }
 
         public ContainerBuilder ConfigureContainerBuilderFromApiWithNetwork(ContainerBuilder builder)
         {

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -112,6 +112,24 @@ namespace Nethermind.Api
             );
         }
 
+        private IBlockchainBridge? _blockchainBridge;
+
+        public IBlockchainBridge? BlockchainBridge
+        {
+            get
+            {
+                if (_blockchainBridge == null)
+                {
+                    _blockchainBridge = CreateBlockchainBridge();
+                }
+                return _blockchainBridge;
+            }
+            set
+            {
+                _blockchainBridge = value;
+            }
+        }
+
         public IAbiEncoder AbiEncoder { get; } = Nethermind.Abi.AbiEncoder.Instance;
         public IBlobTxStorage? BlobTxStorage { get; set; }
         public IBlockchainProcessor? BlockchainProcessor { get; set; }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
@@ -35,6 +35,7 @@ using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Trie.Pruning;
+using Nethermind.Facade;
 
 namespace Nethermind.Consensus.AuRa.InitializationSteps;
 
@@ -198,6 +199,8 @@ public class RegisterAuRaRpcModules : RegisterRpcModules
         StepDependencyException.ThrowIfNull(_api.BlockTree);
         StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
         StepDependencyException.ThrowIfNull(_api.SpecProvider);
+        StepDependencyException.ThrowIfNull(_api.StateReader);
+        StepDependencyException.ThrowIfNull(_api.BlockchainBridge);
 
         AuRaDebugModuleFactory debugModuleFactory = new(
             _api.WorldStateManager,
@@ -215,6 +218,8 @@ public class RegisterAuRaRpcModules : RegisterRpcModules
             _api.BadBlocksStore,
             _api.FileSystem,
             _api.LogManager,
+            _api.StateReader,
+            _api.BlockchainBridge,
             _factory);
 
         rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
@@ -236,10 +241,12 @@ public class RegisterAuRaRpcModules : RegisterRpcModules
         IBadBlockStore badBlockStore,
         IFileSystem fileSystem,
         ILogManager logManager,
+        IStateReader stateReader,
+        IBlockchainBridge blockchainBridge,
         IAuRaBlockProcessorFactory factory)
         : DebugModuleFactory(worldStateManager, dbProvider, blockTree, jsonRpcConfig, blockValidator, recoveryStep,
             rewardCalculator, receiptStorage, receiptsMigration, configProvider, specProvider, syncModeSelector,
-            badBlockStore, fileSystem, logManager)
+            badBlockStore, fileSystem, logManager, stateReader, blockchainBridge)
     {
         protected override ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(IReadOnlyTxProcessingScope scope,
             IOverridableWorldScope worldStateManager, BlockProcessor.BlockValidationTransactionsExecutor transactionsExecutor)

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -438,5 +438,9 @@ namespace Nethermind.Facade
             if (txResult.Success) return tracerError;
             return txResult.Error is not null ? $"err: {txResult.Error} (supplied gas {gasLimit})" : null;
         }
+        public Block? GetBlock(Hash256 blockHash)
+        {
+            return _blockTree.FindBlock(blockHash, BlockTreeLookupOptions.RequireCanonical);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -53,5 +53,6 @@ namespace Nethermind.Facade
         bool TryGetLogs(int filterId, out IEnumerable<FilterLog> filterLogs, CancellationToken cancellationToken = default);
         void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot);
         bool HasStateForRoot(Hash256 stateRoot);
+        Block? GetBlock(Hash256 blockHash);
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -209,6 +209,9 @@ public class RegisterRpcModules : IStep
         StepDependencyException.ThrowIfNull(_api.BlockTree);
         StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
         StepDependencyException.ThrowIfNull(_api.SpecProvider);
+        StepDependencyException.ThrowIfNull(_api.StateReader);
+        StepDependencyException.ThrowIfNull(_api.BlockchainBridge);
+
 
         DebugModuleFactory debugModuleFactory = new(
             _api.WorldStateManager,
@@ -225,7 +228,9 @@ public class RegisterRpcModules : IStep
             _api.SyncModeSelector,
             _api.BadBlocksStore,
             _api.FileSystem,
-            _api.LogManager);
+            _api.LogManager,
+            _api.StateReader,
+            _api.BlockchainBridge);
         rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -25,6 +25,8 @@ using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
+using Nethermind.Facade;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using NUnit.Framework;
@@ -38,6 +40,8 @@ public class DebugModuleTests
     private readonly IJsonRpcConfig jsonRpcConfig = new JsonRpcConfig();
     private readonly ISpecProvider specProvider = Substitute.For<ISpecProvider>();
     private readonly IDebugBridge debugBridge = Substitute.For<IDebugBridge>();
+    private readonly IStateReader stateReader = Substitute.For<IStateReader>();
+    private readonly IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
     [Test]
@@ -47,7 +51,7 @@ public class DebugModuleTests
         byte[] value = new byte[] { 4, 5, 6 };
         debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns(value);
         _ = Substitute.For<IConfigProvider>();
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response =
             await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as JsonRpcSuccessResponse;
 
@@ -59,7 +63,7 @@ public class DebugModuleTests
     {
         debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns((byte[])null!);
         _ = Substitute.For<IConfigProvider>();
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         byte[] key = new byte[] { 1, 2, 3 };
         using var response =
             await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as
@@ -81,7 +85,7 @@ public class DebugModuleTests
                     new BlockInfo(TestItem.KeccakB, 1001),
                 }));
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getChainLevel", parameter) as JsonRpcSuccessResponse;
         var chainLevel = response?.Result as ChainLevelForRpc;
         Assert.That(chainLevel, Is.Not.Null);
@@ -96,7 +100,7 @@ public class DebugModuleTests
         Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
         debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).Returns(rlp.Bytes);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcSuccessResponse;
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
@@ -109,7 +113,7 @@ public class DebugModuleTests
         Rlp rlp = decoder.Encode(blk.Header);
         debugBridge.GetBlock(new BlockParameter((long)0)).Returns(blk);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawHeader", 0) as JsonRpcSuccessResponse;
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
@@ -122,7 +126,7 @@ public class DebugModuleTests
         Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
         localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, localDebugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, localDebugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", 1) as JsonRpcSuccessResponse;
 
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
@@ -136,7 +140,7 @@ public class DebugModuleTests
         Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
         localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, localDebugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, localDebugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", 1) as JsonRpcSuccessResponse;
 
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
@@ -147,7 +151,7 @@ public class DebugModuleTests
     {
         debugBridge.GetBlockRlp(new BlockParameter(1)).ReturnsNull();
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", 1) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(-32001));
@@ -158,7 +162,7 @@ public class DebugModuleTests
     {
         debugBridge.GetBlockRlp(new BlockParameter(1)).ReturnsNull();
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", 1) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(-32001));
@@ -171,7 +175,7 @@ public class DebugModuleTests
         _ = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
         debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).ReturnsNull();
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(-32001));
@@ -209,7 +213,7 @@ public class DebugModuleTests
 
         debugBridge.GetTransactionTrace(Arg.Any<Hash256>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         string response = await RpcTest.TestSerializedRequest<IDebugRpcModule>(rpcModule, "debug_traceTransaction", TestItem.KeccakA, new object());
 
         Assert.That(response, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":{\"gas\":\"0x0\",\"failed\":false,\"returnValue\":\"0xa2\",\"structLogs\":[{\"pc\":0,\"op\":\"STOP\",\"gas\":22000,\"gasCost\":1,\"depth\":1,\"error\":null,\"stack\":[\"0000000000000000000000000000000000000000000000000000000000000007\",\"0000000000000000000000000000000000000000000000000000000000000008\"],\"memory\":[\"0000000000000000000000000000000000000000000000000000000000000005\",\"0000000000000000000000000000000000000000000000000000000000000006\"],\"storage\":{\"0000000000000000000000000000000000000000000000000000000000000001\":\"0000000000000000000000000000000000000000000000000000000000000002\",\"0000000000000000000000000000000000000000000000000000000000000003\":\"0000000000000000000000000000000000000000000000000000000000000004\"}}]},\"id\":67}"));
@@ -222,7 +226,7 @@ public class DebugModuleTests
 
         debugBridge.GetTransactionTrace(Arg.Any<Hash256>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         string response = await RpcTest.TestSerializedRequest<IDebugRpcModule>(rpcModule, "debug_traceTransaction", TestItem.KeccakA, new object());
 
         Assert.That(response, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":{\"customProperty\":1},\"id\":67}"));
@@ -256,7 +260,7 @@ public class DebugModuleTests
 
         debugBridge.GetTransactionTrace(Arg.Any<Hash256>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         string response = await RpcTest.TestSerializedRequest<IDebugRpcModule>(rpcModule, "debug_traceTransaction", TestItem.KeccakA, new { disableStack = true });
 
         Assert.That(response, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":{\"gas\":\"0x0\",\"failed\":false,\"returnValue\":\"0xa2\",\"structLogs\":[{\"pc\":0,\"op\":\"STOP\",\"gas\":22000,\"gasCost\":1,\"depth\":1,\"error\":null,\"stack\":[],\"memory\":[\"0000000000000000000000000000000000000000000000000000000000000005\",\"0000000000000000000000000000000000000000000000000000000000000006\"],\"storage\":{\"0000000000000000000000000000000000000000000000000000000000000001\":\"0000000000000000000000000000000000000000000000000000000000000002\",\"0000000000000000000000000000000000000000000000000000000000000003\":\"0000000000000000000000000000000000000000000000000000000000000004\"}}]},\"id\":67}"));
@@ -295,7 +299,7 @@ public class DebugModuleTests
         AddBlockResult result = blockTree.SuggestBlock(block1);
         Assert.That(result, Is.EqualTo(AddBlockResult.InvalidBlock));
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         ResultWrapper<IEnumerable<BadBlock>> blocks = rpcModule.debug_getBadBlocks();
         Assert.That(blocks.Data.Count, Is.EqualTo(1));
         Assert.That(blocks.Data.ElementAt(0).Hash, Is.EqualTo(block1.Hash));
@@ -308,7 +312,7 @@ public class DebugModuleTests
         GethTraceOptions passedOption = null!;
         debugBridge.GetTransactionTrace(Arg.Any<Hash256>(), Arg.Any<CancellationToken>(), Arg.Do<GethTraceOptions>(arg => passedOption = arg))
             .Returns(new GethLikeTxTrace());
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         await RpcTest.TestSerializedRequest<IDebugRpcModule>(rpcModule, "debug_traceTransaction", TestItem.KeccakA, new { disableStack = true, tracerConfig = new { a = true } });
         passedOption.TracerConfig!.ToString().Should().Be("{\"a\":true}");
     }
@@ -347,7 +351,7 @@ public class DebugModuleTests
 
         debugBridge.GetTransactionTrace(Arg.Any<Transaction>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
 
-        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         ResultWrapper<GethLikeTxTrace> debugTraceCall = rpcModule.debug_traceCall(txForRpc, null, gtOptions);
         var expected = ResultWrapper<GethLikeTxTrace>.Success(
             new GethLikeTxTrace()
@@ -393,7 +397,7 @@ public class DebugModuleTests
     public async Task Migrate_receipts()
     {
         debugBridge.MigrateReceipts(Arg.Any<long>(), Arg.Any<long>()).Returns(true);
-        IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         string response = await RpcTest.TestSerializedRequest(rpcModule, "debug_migrateReceipts", 100);
         Assert.That(response, Is.Not.Null);
     }
@@ -402,7 +406,7 @@ public class DebugModuleTests
     public async Task Update_head_block()
     {
         debugBridge.UpdateHeadBlock(Arg.Any<Hash256>());
-        IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         await RpcTest.TestSerializedRequest(rpcModule, "debug_resetHead", TestItem.KeccakA);
         debugBridge.Received().UpdateHeadBlock(TestItem.KeccakA);
     }
@@ -418,7 +422,7 @@ public class DebugModuleTests
             .GetBlockTrace(blockRlp, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(traces);
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlock(blockRlp.Bytes);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
 
@@ -434,7 +438,7 @@ public class DebugModuleTests
             .GetBlockTrace(blockRlp, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(default(GethLikeTxTrace[]));
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlock(blockRlp.Bytes);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for RLP {blockRlp.Bytes.ToHexString()}", ErrorCodes.ResourceNotFound);
 
@@ -453,7 +457,7 @@ public class DebugModuleTests
             .TraceBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_standardTraceBlockToFile(blockHash);
         var expected = ResultWrapper<IEnumerable<string>>.Success(GetFileNames(blockHash));
 
@@ -472,7 +476,7 @@ public class DebugModuleTests
             .TraceBadBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_standardTraceBadBlockToFile(blockHash);
         var expected = ResultWrapper<IEnumerable<string>>.Success(GetFileNames(blockHash));
 
@@ -490,7 +494,7 @@ public class DebugModuleTests
             .GetBlockTrace(new BlockParameter(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(traces);
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlockByHash(blockHash);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
 
@@ -506,7 +510,7 @@ public class DebugModuleTests
             .GetBlockTrace(new BlockParameter(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(default(GethLikeTxTrace[]));
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlockByHash(blockHash);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockHash}", ErrorCodes.ResourceNotFound);
 
@@ -524,7 +528,7 @@ public class DebugModuleTests
             .GetBlockTrace(blockNumber, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(traces);
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlockByNumber(blockNumber);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
 
@@ -540,7 +544,7 @@ public class DebugModuleTests
             .GetBlockTrace(blockNumber, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
             .Returns(default(GethLikeTxTrace[]));
 
-        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider);
+        var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig, specProvider, stateReader, blockchainBridge);
         var actual = rpcModule.debug_traceBlockByNumber(blockNumber);
         var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockNumber}", ErrorCodes.ResourceNotFound);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -24,6 +24,8 @@ using Nethermind.Synchronization.ParallelSync;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
+using Nethermind.State;
+using Nethermind.Facade;
 
 namespace Nethermind.JsonRpc.Test.Modules;
 
@@ -48,6 +50,8 @@ public class DebugRpcModuleTests
             IConfigProvider configProvider = Substitute.For<IConfigProvider>();
             IReceiptsMigration receiptsMigration = Substitute.For<IReceiptsMigration>();
             ISyncModeSelector syncModeSelector = Substitute.For<ISyncModeSelector>();
+            IStateReader stateReader = Substitute.For<IStateReader>();
+            IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
             var factory = new DebugModuleFactory(
                 blockchain.WorldStateManager,
                 blockchain.DbProvider,
@@ -63,7 +67,9 @@ public class DebugRpcModuleTests
                 syncModeSelector,
                 new BadBlockStore(blockchain.BlocksDb, 100),
                 new FileSystem(),
-                blockchain.LogManager
+                blockchain.LogManager,
+                stateReader,
+                blockchainBridge
             );
 
             IDebugRpcModule debugRpcModule = factory.Create();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -19,6 +19,7 @@ using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Trie.Pruning;
+using Nethermind.Facade;
 
 namespace Nethermind.JsonRpc.Modules.DebugModule;
 
@@ -39,6 +40,8 @@ public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
     private readonly IBadBlockStore _badBlockStore;
     private readonly IFileSystem _fileSystem;
     private readonly IWorldStateManager _worldStateManager;
+    private readonly IStateReader _stateReader;
+    private readonly IBlockchainBridge _blockchainBridge;
 
     public DebugModuleFactory(
         IWorldStateManager worldStateManager,
@@ -55,7 +58,9 @@ public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
         ISyncModeSelector syncModeSelector,
         IBadBlockStore badBlockStore,
         IFileSystem fileSystem,
-        ILogManager logManager)
+        ILogManager logManager,
+        IStateReader stateReader,
+        IBlockchainBridge blockchainBridge)
     {
         _worldStateManager = worldStateManager;
         _dbProvider = dbProvider.AsReadOnly(false);
@@ -72,6 +77,8 @@ public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
         _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
         _badBlockStore = badBlockStore;
         _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
+        _blockchainBridge = blockchainBridge ?? throw new ArgumentNullException(nameof(blockchainBridge));
     }
 
     public override IDebugRpcModule Create()
@@ -107,7 +114,7 @@ public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
             _syncModeSelector,
             _badBlockStore);
 
-        return new DebugRpcModule(_logManager, debugBridge, _jsonRpcConfig, _specProvider);
+        return new DebugRpcModule(_logManager, debugBridge, _jsonRpcConfig, _specProvider, _stateReader, _blockchainBridge);
     }
 
     protected virtual ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(IReadOnlyTxProcessingScope scope,


### PR DESCRIPTION
Fixes #8174

## Changes

- Added `try-catch` blocks in both `debug_traceTransaction` and `debug_traceCall` to handle `MissingTrieNodeException`
- Created the helper method `GetStateFailureResult<T>()` to standardize error messages for state unavailability
- Matched error handling approaches with `EthRpcModule` and `TraceRpcModule`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._


