### PR TITLE
Cleanup/remove last seen map

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -941,11 +941,11 @@ namespace Nethermind.Trie.Test.Pruning
 
             if (_scheme == INodeStorage.KeyScheme.Hash)
             {
-                memDb.Count.Should().NotBe(1);
+                memDb.Count.Should().NotBe(2);
             }
             else
             {
-                memDb.Count.Should().Be(1);
+                memDb.Count.Should().Be(2);
             }
         }
 
@@ -1017,7 +1017,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             memDb.Count.Should().Be(61);
             fullTrieStore.Prune();
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 552 : 708);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 736 : 944);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -782,7 +782,7 @@ namespace Nethermind.Trie.Test
 
             for (int i = 0; i < 256; i++)
             {
-                ctx.VerifyNodeInCache(stateRoots[i], i >= 255 - maxDepth);
+                ctx.VerifyNodeInCache(stateRoots[i], i >= 255 - maxDepth - 1);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -586,14 +586,6 @@ public class TrieStore : ITrieStore, IPruningTrieStore
             AnnounceReorgBoundaries();
             deleteTask.Wait();
 
-            if (_livePruningEnabled)
-            {
-                foreach (TrieStoreDirtyNodesCache dirtyNode in _dirtyNodes)
-                {
-                    dirtyNode.CleanObsoletePersistedLastSeen();
-                }
-            }
-
             if (candidateSets.Count > 0)
             {
                 return true;


### PR DESCRIPTION
- The `_persistedLastSeen` map is used to keep track of recommitted persisted trie node so that it is not removed from DB which is then later not re-added causing trie exception.
- A simpler way is to simply not prune the persisted node from the cache if it is still needed which is also checked if a node was recommited. This remove the `_persistedLastSeen` map and the code related to it. This keep slightly more node in cached which has the benifit of slightly better cache hit rate at expense of more prune cycle.
- The effect is negligable in every way, but it cut code, so that is nice.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization?
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Can replay blocks from era of several weeks worth of blocks.