### PR TITLE
Fix workflow flags for "Update OP Superchain chains"

### DIFF
--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -33,8 +33,8 @@ jobs:
         run: python3 scripts/syncSettings.py --superchain
       - name: Copy generated files
         run:
-          cp /tmp/superchain/chainspec/* ./src/Nethermind/Chains
-          cp /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
+          cp -r /tmp/superchain/chainspec/* ./src/Nethermind/Chains
+          cp -r /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
       - name: Create GitHub app token
         id: gh-app
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Update fast sync settings
         run: python3 scripts/syncSettings.py --superchain
       - name: Copy generated files
-        run:
+        run: |
           cp -r /tmp/superchain/chainspec/* ./src/Nethermind/Chains
           cp -r /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
       - name: Create GitHub app token


### PR DESCRIPTION
## Changes

- Fix the workflow script to properly copy the autogenerated files

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The original script didn't include the required `-r` flag to copy the generated files.
