### PR TITLE
Fix Fast Sync settings in "Update OP Superchain chains" worflow

### DIFF
--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -29,12 +29,12 @@ jobs:
           pip install emoji
       - name: Generate Chainspec and config files
         run: python3 scripts/superchain.py -v -o /tmp/superchain
-      - name: Update fast sync settings
-        run: python3 scripts/syncSettings.py --superchain
       - name: Copy generated files
         run: |
           cp -r /tmp/superchain/chainspec/* ./src/Nethermind/Chains
           cp -r /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
+      - name: Update fast sync settings
+        run: python3 scripts/syncSettings.py --superchain
       - name: Create GitHub app token
         id: gh-app
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -33,8 +33,8 @@ jobs:
         run: python3 scripts/syncSettings.py --superchain
       - name: Copy generated files
         run:
-          cp /tmp/superchain/chainspec/* ./src/Nethermind/Chains
-          cp /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
+          cp -r /tmp/superchain/chainspec/* ./src/Nethermind/Chains
+          cp -r /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
       - name: Create GitHub app token
         id: gh-app
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Update fast sync settings
         run: python3 scripts/syncSettings.py --superchain
       - name: Copy generated files
-        run:
+        run: |
           cp -r /tmp/superchain/chainspec/* ./src/Nethermind/Chains
           cp -r /tmp/superchain/runner/* ./src/Nethermind/Nethermind.Runner/configs
       - name: Create GitHub app token


### PR DESCRIPTION
## Changes

- Adjust order of steps in workflow.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

I wish we could just run the workflows locally.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The workflow had the wrong steps order thus it was removing fast sync settings (Pivot number, hash, etc.) from officially supported chains (OP, Base, Worldchain).