### PR TITLE
Address eof-devnet-0 valdation errors

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -341,8 +341,7 @@ namespace Ethereum.Test.Base
                     vector.ContainerKind =
                         ("INITCODE".Equals(vectorJson.ContainerKind)
                             ? ValidationStrategy.ValidateInitCodeMode
-                            : ValidationStrategy.ValidateRuntimeMode)
-                        | ValidationStrategy.ValidateFullBody;
+                            : ValidationStrategy.ValidateRuntimeMode);
 
                     foreach (var result in vectorJson.Results)
                     {

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/EofValidationStrategy.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/EofValidationStrategy.cs
@@ -13,5 +13,4 @@ public enum ValidationStrategy : byte
     AllowTrailingBytes = Validate | 16,
     ExractHeader = 32,
     HasEofMagic = 64,
-
 }


### PR DESCRIPTION
## Changes

* JUMPF is only returning when the target section is returning
* "short data" containers are valid when inside an inticode container. Tweak needed flags to distinguish between a top level runtime container and an embeded container, and adjust "long data" check.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [X] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
