### PR TITLE
Trie visitor adjustment

### DIFF
--- a/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
+++ b/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
@@ -7,7 +7,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Trie;
 
 namespace Nethermind.Analytics
@@ -81,24 +80,15 @@ namespace Nethermind.Analytics
 
         public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
+        }
+
+        public void VisitAccount(in OldStyleTrieVisitContext _, TrieNode node, in AccountStruct account)
+        {
             _nodesVisited++;
-
-            if (trieVisitContext.IsStorage)
-            {
-                return;
-            }
-
-            AccountDecoder accountDecoder = new AccountDecoder();
-            Account account = accountDecoder.Decode(node.Value.AsRlpStream());
             Balance += account.Balance;
             _accountsVisited++;
 
             _logger.Info($"Balance after visiting {_accountsVisited} accounts and {_nodesVisited} nodes: {Balance}");
-        }
-
-        public void VisitCode(in OldStyleTrieVisitContext _, Hash256 codeHash)
-        {
-            _nodesVisited++;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
+++ b/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Analytics
             }
         }
 
-        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             _nodesVisited++;
 

--- a/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
+++ b/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
@@ -12,7 +12,7 @@ using Nethermind.Trie;
 
 namespace Nethermind.Analytics
 {
-    public class SupplyVerifier : ITreeVisitor<EmptyContext>
+    public class SupplyVerifier : ITreeVisitor<OldStyleTrieVisitContext>
     {
         private readonly ILogger _logger;
         private readonly HashSet<Hash256> _ignoreThisOne = new HashSet<Hash256>();
@@ -28,7 +28,7 @@ namespace Nethermind.Analytics
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
+        public bool ShouldVisit(in OldStyleTrieVisitContext _, Hash256 nextNode)
         {
             if (_ignoreThisOne.Count > 16)
             {
@@ -43,16 +43,16 @@ namespace Nethermind.Analytics
             return true;
         }
 
-        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in OldStyleTrieVisitContext _, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in OldStyleTrieVisitContext _, Hash256 nodeHash)
         {
             _logger.Warn($"Missing node {nodeHash}");
         }
 
-        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             _logger.Info($"Balance after visiting {_accountsVisited} accounts and {_nodesVisited} nodes: {Balance}");
             _nodesVisited++;
@@ -70,7 +70,7 @@ namespace Nethermind.Analytics
             }
         }
 
-        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             _nodesVisited++;
             if (trieVisitContext.IsStorage)
@@ -79,7 +79,7 @@ namespace Nethermind.Analytics
             }
         }
 
-        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node, ReadOnlySpan<byte> value)
         {
             _nodesVisited++;
 
@@ -96,7 +96,7 @@ namespace Nethermind.Analytics
             _logger.Info($"Balance after visiting {_accountsVisited} accounts and {_nodesVisited} nodes: {Balance}");
         }
 
-        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in OldStyleTrieVisitContext _, Hash256 codeHash)
         {
             _nodesVisited++;
         }

--- a/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
+++ b/src/Nethermind/Nethermind.Analytics/SupplyVerifier.cs
@@ -12,7 +12,7 @@ using Nethermind.Trie;
 
 namespace Nethermind.Analytics
 {
-    public class SupplyVerifier : ITreeVisitor
+    public class SupplyVerifier : ITreeVisitor<EmptyContext>
     {
         private readonly ILogger _logger;
         private readonly HashSet<Hash256> _ignoreThisOne = new HashSet<Hash256>();
@@ -28,7 +28,7 @@ namespace Nethermind.Analytics
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(Hash256 nextNode)
+        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
         {
             if (_ignoreThisOne.Count > 16)
             {
@@ -43,16 +43,16 @@ namespace Nethermind.Analytics
             return true;
         }
 
-        public void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
         {
         }
 
-        public void VisitMissingNode(Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
         {
             _logger.Warn($"Missing node {nodeHash}");
         }
 
-        public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             _logger.Info($"Balance after visiting {_accountsVisited} accounts and {_nodesVisited} nodes: {Balance}");
             _nodesVisited++;
@@ -70,7 +70,7 @@ namespace Nethermind.Analytics
             }
         }
 
-        public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             _nodesVisited++;
             if (trieVisitContext.IsStorage)
@@ -79,7 +79,7 @@ namespace Nethermind.Analytics
             }
         }
 
-        public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             _nodesVisited++;
 
@@ -96,7 +96,7 @@ namespace Nethermind.Analytics
             _logger.Info($"Balance after visiting {_accountsVisited} accounts and {_nodesVisited} nodes: {Balance}");
         }
 
-        public void VisitCode(Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
         {
             _nodesVisited++;
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -43,16 +43,6 @@ public class BlockchainProcessorTests
             public BlockProcessorMock(ILogManager logManager, IStateReader stateReader)
             {
                 _logger = logManager.GetClassLogger();
-                stateReader.When(it =>
-                        it.RunTreeVisitor(Arg.Any<ITreeVisitor>(), Arg.Any<Hash256>(), Arg.Any<VisitingOptions>()))
-                    .Do((info =>
-                    {
-                        // Simulate state root check
-                        ITreeVisitor visitor = (ITreeVisitor)info[0];
-                        Hash256 stateRoot = (Hash256)info[1];
-                        if (!_rootProcessed.Contains(stateRoot)) visitor.VisitMissingNode(stateRoot, new TrieVisitContext());
-                    }));
-
                 stateReader.HasStateForRoot(Arg.Any<Hash256>()).Returns(x => _rootProcessed.Contains(x[0]));
             }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -472,7 +472,7 @@ public class FullPrunerTests
             CheckNode(ctx.Storage, ctx.Path, node);
         }
 
-        public void VisitCode(in TreePathContextWithStorage ctx, Hash256 codeHash)
+        public void VisitAccount(in TreePathContextWithStorage ctx, TrieNode node, in AccountStruct account)
         {
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -449,30 +449,30 @@ public class FullPrunerTests
         public bool IsFullDbScan => true;
         public bool ShouldVisit(in TreePathContextWithStorage ctx, Hash256 nextNode) => true;
 
-        public void VisitTree(in TreePathContextWithStorage ctx, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in TreePathContextWithStorage ctx, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in TreePathContextWithStorage ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in TreePathContextWithStorage ctx, Hash256 nodeHash)
         {
         }
 
-        public void VisitBranch(in TreePathContextWithStorage ctx, TrieNode node, TrieVisitContext trieVisitContext)
-        {
-            CheckNode(ctx.Storage, ctx.Path, node);
-        }
-
-        public void VisitExtension(in TreePathContextWithStorage ctx, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in TreePathContextWithStorage ctx, TrieNode node)
         {
             CheckNode(ctx.Storage, ctx.Path, node);
         }
 
-        public void VisitLeaf(in TreePathContextWithStorage ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitExtension(in TreePathContextWithStorage ctx, TrieNode node)
         {
             CheckNode(ctx.Storage, ctx.Path, node);
         }
 
-        public void VisitCode(in TreePathContextWithStorage ctx, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitLeaf(in TreePathContextWithStorage ctx, TrieNode node, ReadOnlySpan<byte> value)
+        {
+            CheckNode(ctx.Storage, ctx.Path, node);
+        }
+
+        public void VisitCode(in TreePathContextWithStorage ctx, Hash256 codeHash)
         {
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -467,7 +467,7 @@ public class FullPrunerTests
             CheckNode(ctx.Storage, ctx.Path, node);
         }
 
-        public void VisitLeaf(in TreePathContextWithStorage ctx, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in TreePathContextWithStorage ctx, TrieNode node)
         {
             CheckNode(ctx.Storage, ctx.Path, node);
         }

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Blockchain.FullPruning
 
         public void VisitLeaf(in TContext ctx, TrieNode node) => PersistNode(ctx.Storage, ctx.Path, node);
 
-        public void VisitCode(in TContext ctx, Hash256 codeHash) { }
+        public void VisitAccount(in TContext ctx, TrieNode node, in AccountStruct account) { }
 
         private void PersistNode(Hash256 storage, in TreePath path, TrieNode node)
         {

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Blockchain.FullPruning
 
         public bool ShouldVisit(in TContext context, Hash256 nextNode) => !_cancellationToken.IsCancellationRequested;
 
-        public void VisitTree(in TContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in TContext nodeContext, Hash256 rootHash)
         {
             _stopwatch.Start();
             if (_logger.IsInfo) _logger.Info($"Full Pruning Started on root hash {rootHash}: do not close the node until finished or progress will be lost.");
@@ -58,24 +58,24 @@ namespace Nethermind.Blockchain.FullPruning
 
         [DoesNotReturn]
         [StackTraceHidden]
-        public void VisitMissingNode(in TContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in TContext ctx, Hash256 nodeHash)
         {
             if (_logger.IsWarn)
             {
-                _logger.Warn($"Full Pruning Failed: Missing node {nodeHash} at level {trieVisitContext.Level}.");
+                _logger.Warn($"Full Pruning Failed: Missing node {nodeHash} at level {ctx.Storage}:{ctx.Path}.");
             }
 
             // if nodes are missing then state trie is not valid and we need to stop copying it
             throw new TrieException($"Trie {nodeHash} missing");
         }
 
-        public void VisitBranch(in TContext ctx, TrieNode node, TrieVisitContext trieVisitContext) => PersistNode(ctx.Storage, ctx.Path, node);
+        public void VisitBranch(in TContext ctx, TrieNode node) => PersistNode(ctx.Storage, ctx.Path, node);
 
-        public void VisitExtension(in TContext ctx, TrieNode node, TrieVisitContext trieVisitContext) => PersistNode(ctx.Storage, ctx.Path, node);
+        public void VisitExtension(in TContext ctx, TrieNode node) => PersistNode(ctx.Storage, ctx.Path, node);
 
-        public void VisitLeaf(in TContext ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value) => PersistNode(ctx.Storage, ctx.Path, node);
+        public void VisitLeaf(in TContext ctx, TrieNode node, ReadOnlySpan<byte> value) => PersistNode(ctx.Storage, ctx.Path, node);
 
-        public void VisitCode(in TContext ctx, Hash256 codeHash, TrieVisitContext trieVisitContext) { }
+        public void VisitCode(in TContext ctx, Hash256 codeHash) { }
 
         private void PersistNode(Hash256 storage, in TreePath path, TrieNode node)
         {

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Blockchain.FullPruning
 
         public void VisitExtension(in TContext ctx, TrieNode node) => PersistNode(ctx.Storage, ctx.Path, node);
 
-        public void VisitLeaf(in TContext ctx, TrieNode node, ReadOnlySpan<byte> value) => PersistNode(ctx.Storage, ctx.Path, node);
+        public void VisitLeaf(in TContext ctx, TrieNode node) => PersistNode(ctx.Storage, ctx.Path, node);
 
         public void VisitCode(in TContext ctx, Hash256 codeHash) { }
 

--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Blockchain
         public byte[]? GetCode(Hash256 codeHash) => _stateReader.GetCode(codeHash);
         public byte[]? GetCode(ValueHash256 codeHash) => _stateReader.GetCode(codeHash);
 
-        public void Accept(ITreeVisitor visitor, Hash256 stateRoot, VisitingOptions? visitingOptions)
+        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot, VisitingOptions? visitingOptions) where TCtx : struct, INodeContext<TCtx>
         {
             _stateReader.RunTreeVisitor(visitor, stateRoot, visitingOptions);
         }

--- a/src/Nethermind/Nethermind.Consensus/Tracing/ITracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/ITracer.cs
@@ -27,6 +27,6 @@ namespace Nethermind.Consensus.Tracing
         /// <param name="tracer">Trace to act on block processing events.</param>
         void Execute(Block block, IBlockTracer tracer);
 
-        void Accept(ITreeVisitor visitor, Hash256 stateRoot);
+        void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Tracing/Tracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/Tracer.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Consensus.Tracing
 
         public void Execute(Block block, IBlockTracer tracer) => Process(block, tracer, _executeProcessor, _executeOptions);
 
-        public void Accept(ITreeVisitor visitor, Hash256 stateRoot)
+        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>
         {
             ArgumentNullException.ThrowIfNull(visitor);
             ArgumentNullException.ThrowIfNull(stateRoot);

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -413,7 +413,7 @@ namespace Nethermind.Facade
 
         public Address? RecoverTxSender(Transaction tx) => _ecdsa.RecoverAddress(tx);
 
-        public void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot)
+        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>
         {
             _stateReader.RunTreeVisitor(treeVisitor, stateRoot);
         }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -51,7 +51,7 @@ namespace Nethermind.Facade
         IEnumerable<FilterLog> GetLogs(BlockParameter fromBlock, BlockParameter toBlock, object? address = null, IEnumerable<object>? topics = null, CancellationToken cancellationToken = default);
 
         bool TryGetLogs(int filterId, out IEnumerable<FilterLog> filterLogs, CancellationToken cancellationToken = default);
-        void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot);
+        void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>;
         bool HasStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
@@ -25,7 +25,7 @@ namespace Nethermind.State
         /// <param name="visitor">Visitor to run.</param>
         /// <param name="stateRoot">Root to run on.</param>
         /// <param name="visitingOptions">Options to run visitor.</param>
-        void Accept(ITreeVisitor visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null);
+        void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>;
 
         bool AccountExists(Address address);
 

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -15,7 +15,6 @@ namespace Nethermind.State
         ReadOnlySpan<byte> GetStorage(Hash256 stateRoot, Address address, in UInt256 index);
         byte[]? GetCode(Hash256 codeHash);
         byte[]? GetCode(in ValueHash256 codeHash);
-        void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) => RunTreeVisitor(new ContextNotAwareTreeVisitor(treeVisitor), stateRoot, visitingOptions);
         void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>;
         bool HasStateForRoot(Hash256 stateRoot);
     }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -17,7 +17,7 @@ namespace Nethermind.State.Proofs
     /// <summary>
     /// EIP-1186 style proof collector
     /// </summary>
-    public class AccountProofCollector : ITreeVisitor<EmptyContext>
+    public class AccountProofCollector : ITreeVisitor<OldStyleTrieVisitContext>
     {
         private int _pathTraversalIndex;
         private readonly Address _address = Address.Zero;
@@ -146,7 +146,7 @@ namespace Nethermind.State.Proofs
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
+        public bool ShouldVisit(in OldStyleTrieVisitContext _, Hash256 nextNode)
         {
             if (_storageNodeInfos.TryGetValue(nextNode, out StorageNodeInfo value))
             {
@@ -156,15 +156,15 @@ namespace Nethermind.State.Proofs
             return _nodeToVisitFilter.Contains(nextNode);
         }
 
-        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in OldStyleTrieVisitContext _, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in OldStyleTrieVisitContext _, Hash256 nodeHash)
         {
         }
 
-        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -203,7 +203,7 @@ namespace Nethermind.State.Proofs
             _pathTraversalIndex++;
         }
 
-        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -232,7 +232,7 @@ namespace Nethermind.State.Proofs
             }
         }
 
-        private void AddProofItem(TrieNode node, TrieVisitContext trieVisitContext)
+        private void AddProofItem(TrieNode node, OldStyleTrieVisitContext trieVisitContext)
         {
             if (trieVisitContext.IsStorage)
             {
@@ -250,7 +250,7 @@ namespace Nethermind.State.Proofs
             }
         }
 
-        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node, ReadOnlySpan<byte> value)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -311,7 +311,7 @@ namespace Nethermind.State.Proofs
 
         private readonly AccountDecoder _accountDecoder = new();
 
-        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in OldStyleTrieVisitContext _, Hash256 codeHash)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -311,7 +311,7 @@ namespace Nethermind.State.Proofs
 
         private readonly AccountDecoder _accountDecoder = new();
 
-        public void VisitCode(in OldStyleTrieVisitContext _, Hash256 codeHash)
+        public void VisitAccount(in OldStyleTrieVisitContext _, TrieNode node, in AccountStruct account)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -17,7 +17,7 @@ namespace Nethermind.State.Proofs
     /// <summary>
     /// EIP-1186 style proof collector
     /// </summary>
-    public class AccountProofCollector : ITreeVisitor
+    public class AccountProofCollector : ITreeVisitor<EmptyContext>
     {
         private int _pathTraversalIndex;
         private readonly Address _address = Address.Zero;
@@ -146,7 +146,7 @@ namespace Nethermind.State.Proofs
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(Hash256 nextNode)
+        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
         {
             if (_storageNodeInfos.TryGetValue(nextNode, out StorageNodeInfo value))
             {
@@ -156,15 +156,15 @@ namespace Nethermind.State.Proofs
             return _nodeToVisitFilter.Contains(nextNode);
         }
 
-        public void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
         {
         }
 
-        public void VisitMissingNode(Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
         {
         }
 
-        public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -203,7 +203,7 @@ namespace Nethermind.State.Proofs
             _pathTraversalIndex++;
         }
 
-        public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -250,7 +250,7 @@ namespace Nethermind.State.Proofs
             }
         }
 
-        public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);
@@ -311,7 +311,7 @@ namespace Nethermind.State.Proofs
 
         private readonly AccountDecoder _accountDecoder = new();
 
-        public void VisitCode(Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -250,7 +250,7 @@ namespace Nethermind.State.Proofs
             }
         }
 
-        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
         {
             AddProofItem(node, trieVisitContext);
             _nodeToVisitFilter.Remove(node.Keccak);

--- a/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
@@ -48,7 +48,7 @@ public abstract class PatriciaTrie<T> : PatriciaTree
 
         var proofCollector = new ProofCollector(Rlp.Encode(index).Bytes);
 
-        Accept(proofCollector, RootHash, new() { ExpectAccounts = false });
+        Accept(proofCollector, RootHash, new());
 
         return proofCollector.BuildResult();
     }

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -11,7 +11,7 @@ namespace Nethermind.State.Proofs
     /// <summary>
     /// EIP-1186 style proof collector
     /// </summary>
-    public class ProofCollector : ITreeVisitor
+    public class ProofCollector : ITreeVisitor<EmptyContext>
     {
         private int _pathIndex;
 
@@ -33,17 +33,17 @@ namespace Nethermind.State.Proofs
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(Hash256 nextNode) => _visitingFilter.Contains(nextNode);
+        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode) => _visitingFilter.Contains(nextNode);
 
-        public void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
         {
         }
 
-        public void VisitMissingNode(Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
         {
         }
 
-        public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
@@ -52,7 +52,7 @@ namespace Nethermind.State.Proofs
             _pathIndex++;
         }
 
-        public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
@@ -68,14 +68,14 @@ namespace Nethermind.State.Proofs
             _proofBits.Add(node.FullRlp.ToArray());
         }
 
-        public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
             _pathIndex = 0;
         }
 
-        public void VisitCode(Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -36,15 +36,15 @@ namespace Nethermind.State.Proofs
 
         public bool ShouldVisit(in EmptyContext _, Hash256 nextNode) => _visitingFilter.Contains(nextNode);
 
-        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in EmptyContext _, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash)
         {
         }
 
-        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
@@ -53,7 +53,7 @@ namespace Nethermind.State.Proofs
             _pathIndex++;
         }
 
-        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
@@ -69,14 +69,14 @@ namespace Nethermind.State.Proofs
             _proofBits.Add(node.FullRlp.ToArray());
         }
 
-        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node, ReadOnlySpan<byte> value)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);
             _pathIndex = 0;
         }
 
-        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in EmptyContext _, Hash256 codeHash)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
 
@@ -76,7 +77,7 @@ namespace Nethermind.State.Proofs
             _pathIndex = 0;
         }
 
-        public void VisitCode(in EmptyContext _, Hash256 codeHash)
+        public void VisitAccount(in EmptyContext _, TrieNode node, in AccountStruct account)
         {
             throw new InvalidOperationException($"{nameof(AccountProofCollector)} does never expect to visit code");
         }

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -69,7 +69,7 @@ namespace Nethermind.State.Proofs
             _proofBits.Add(node.FullRlp.ToArray());
         }
 
-        public void VisitLeaf(in EmptyContext _, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
             _visitingFilter.Remove(node.Keccak);

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -32,6 +32,7 @@ namespace Nethermind.State.Proofs
         public byte[][] BuildResult() => _proofBits.ToArray();
 
         public bool IsFullDbScan => false;
+        public bool ExpectAccounts => false;
 
         public bool ShouldVisit(in EmptyContext _, Hash256 nextNode) => _visitingFilter.Contains(nextNode);
 

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -268,7 +268,7 @@ public class SnapServer : ISnapServer
     {
         PatriciaTree tree = new(_store, _logManager);
         using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
-        VisitingOptions opt = new() { ExpectAccounts = false };
+        VisitingOptions opt = new();
         tree.Accept(visitor, rootHash.ToCommitment(), opt, storageAddr: storage?.ToCommitment(), storageRoot: storageRoot?.ToCommitment());
 
         ArrayPoolList<byte[]> proofs = startingHash != Keccak.Zero || visitor.StoppedEarly ? visitor.GetProofs() : ArrayPoolList<byte[]>.Empty();

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -62,15 +62,7 @@ namespace Nethermind.State
             };
         }
 
-        public void Accept(ITreeVisitor? visitor, Hash256? stateRoot, VisitingOptions? visitingOptions = null)
-        {
-            ArgumentNullException.ThrowIfNull(visitor);
-            ArgumentNullException.ThrowIfNull(stateRoot);
-
-            _tree.Accept(visitor, stateRoot, visitingOptions);
-        }
-
-        public void Accept<TCtx>(ITreeVisitor<TCtx>? visitor, Hash256? stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>
+        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256? stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>
         {
             ArgumentNullException.ThrowIfNull(visitor);
             ArgumentNullException.ThrowIfNull(stateRoot);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -201,11 +201,6 @@ namespace Nethermind.State
             return _stateProvider.GetCodeHash(address);
         }
 
-        public void Accept(ITreeVisitor visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null)
-        {
-            _stateProvider.Accept(visitor, stateRoot, visitingOptions);
-        }
-
         public void Accept<TContext>(ITreeVisitor<TContext> visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TContext : struct, INodeContext<TContext>
         {
             _stateProvider.Accept(visitor, stateRoot, visitingOptions);

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsDecorator.cs
@@ -120,7 +120,7 @@ public class WorldStateMetricsDecorator(IWorldState innerState) : IWorldState
 
     public bool IsContract(Address address) => innerState.IsContract(address);
 
-    public void Accept(ITreeVisitor visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) =>
+    public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx> =>
         innerState.Accept(visitor, stateRoot, visitingOptions);
 
     public bool AccountExists(Address address) => innerState.AccountExists(address);

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -110,7 +110,7 @@ public class RangeQueryVisitorTests
         act.Should().NotThrow();
     }
 
-    private static VisitingOptions CreateVisitingOptions() => new() { ExpectAccounts = false };
+    private static VisitingOptions CreateVisitingOptions() => new() {};
 
     [Test]
     public void RangeFetchPartialLimit()

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -335,7 +335,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitExtension(new EmptyContext(), node, context);
+        visitor.Received().VisitExtension(new EmptyContext(), node);
     }
 
     [Test]
@@ -348,7 +348,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak, context);
+        visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak);
     }
 
     [Test]
@@ -363,7 +363,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitLeafReceived[(TreePath.Empty, node, context, node.Value.ToArray())].Should().Be(1);
+        visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
 
     [Test]
@@ -378,7 +378,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitLeafReceived[(TreePath.Empty, node, context, node.Value.ToArray())].Should().Be(1);
+        visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
 
     [Test]
@@ -393,7 +393,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitLeafReceived[(TreePath.Empty, node, context, node.Value.ToArray())].Should().Be(1);
+        visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
 
     [Test]
@@ -408,7 +408,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitLeafReceived[(TreePath.Empty, node, context, node.Value.ToArray())].Should().Be(1);
+        visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
 
     [Test]
@@ -422,8 +422,8 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitExtensionReceived[(TreePath.Empty, node, context)].Should().Be(1);
-        visitor.VisitLeafReceived[(new(new(Bytes.FromHexString("0xa000000000000000000000000000000000000000000000000000000000000000")), 1), ctx.AccountLeaf, context, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
+        visitor.VisitExtensionReceived[(TreePath.Empty, node)].Should().Be(1);
+        visitor.VisitLeafReceived[(new(new(Bytes.FromHexString("0xa000000000000000000000000000000000000000000000000000000000000000")), 1), ctx.AccountLeaf, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
     }
 
     [Test]
@@ -442,11 +442,11 @@ public class TrieNodeTests
         node.ResolveKey(NullTrieStore.Instance, ref emptyPath, true);
         node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.VisitBranchReceived[(TreePath.Empty, node, context)].Should().Be(1);
+        visitor.VisitBranchReceived[(TreePath.Empty, node)].Should().Be(1);
         for (byte i = 0; i < 16; i++)
         {
             var hex = "0x" + i.ToString("x2")[1] + "000000000000000000000000000000000000000000000000000000000000000";
-            visitor.VisitLeafReceived[(new(new(Bytes.FromHexString(hex)), 1), ctx.AccountLeaf, context, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
+            visitor.VisitLeafReceived[(new(new(Bytes.FromHexString(hex)), 1), ctx.AccountLeaf, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
         }
     }
 
@@ -464,7 +464,7 @@ public class TrieNodeTests
         TreePath emptyPath = TreePath.Empty;
         node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitBranch(new EmptyContext(), node, context);
+        visitor.Received().VisitBranch(new EmptyContext(), node);
     }
 
     [Test]
@@ -1016,48 +1016,48 @@ public class TrieNodeTests
 
     private class TreeVisitorMock : ITreeVisitor<TreePathContext>
     {
-        public readonly Dictionary<(TreePath path, TrieNode, TrieVisitContext), int> VisitExtensionReceived = new();
-        public readonly Dictionary<(TreePath path, TrieNode, TrieVisitContext), int> VisitBranchReceived = new();
-        public readonly Dictionary<(TreePath path, TrieNode, TrieVisitContext, byte[]), int> VisitLeafReceived = new(new LeafComparer());
+        public readonly Dictionary<(TreePath path, TrieNode), int> VisitExtensionReceived = new();
+        public readonly Dictionary<(TreePath path, TrieNode), int> VisitBranchReceived = new();
+        public readonly Dictionary<(TreePath path, TrieNode, byte[]), int> VisitLeafReceived = new(new LeafComparer());
 
         public bool IsFullDbScan => false;
 
         public bool ShouldVisit(in TreePathContext nodeContext, Hash256 nextNode) => true;
 
-        public void VisitTree(in TreePathContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in TreePathContext nodeContext, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in TreePathContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in TreePathContext ctx, Hash256 nodeHash)
         {
         }
 
-        public void VisitBranch(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in TreePathContext ctx, TrieNode node)
         {
-            CollectionsMarshal.GetValueRefOrAddDefault(VisitBranchReceived, (ctx.Path, node, trieVisitContext), out _) += 1;
+            CollectionsMarshal.GetValueRefOrAddDefault(VisitBranchReceived, (ctx.Path, node), out _) += 1;
         }
 
-        public void VisitExtension(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in TreePathContext ctx, TrieNode node)
         {
-            CollectionsMarshal.GetValueRefOrAddDefault(VisitExtensionReceived, (ctx.Path, node, trieVisitContext), out _) += 1;
+            CollectionsMarshal.GetValueRefOrAddDefault(VisitExtensionReceived, (ctx.Path, node), out _) += 1;
         }
 
-        public void VisitLeaf(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in TreePathContext ctx, TrieNode node, ReadOnlySpan<byte> value)
         {
-            CollectionsMarshal.GetValueRefOrAddDefault(VisitLeafReceived, (ctx.Path, node, trieVisitContext, value.ToArray()), out _) += 1;
+            CollectionsMarshal.GetValueRefOrAddDefault(VisitLeafReceived, (ctx.Path, node, value.ToArray()), out _) += 1;
         }
 
-        public void VisitCode(in TreePathContext ctx, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in TreePathContext ctx, Hash256 codeHash)
         {
         }
 
-        private class LeafComparer : IEqualityComparer<(TreePath, TrieNode, TrieVisitContext, byte[])>
+        private class LeafComparer : IEqualityComparer<(TreePath, TrieNode, byte[])>
         {
-            public bool Equals((TreePath, TrieNode, TrieVisitContext, byte[]) x, (TreePath, TrieNode, TrieVisitContext, byte[]) y) =>
-                Equals(x.Item1, y.Item1) && Equals(x.Item2, y.Item2) && Equals(x.Item3, y.Item3) && Bytes.EqualityComparer.Equals(x.Item4, y.Item4);
+            public bool Equals((TreePath, TrieNode, byte[]) x, (TreePath, TrieNode, byte[]) y) =>
+                Equals(x.Item1, y.Item1) && Equals(x.Item2, y.Item2) && Bytes.EqualityComparer.Equals(x.Item3, y.Item3);
 
-            public int GetHashCode((TreePath, TrieNode, TrieVisitContext, byte[]) obj) =>
-                HashCode.Combine(obj.Item1, obj.Item2, obj.Item3, Bytes.EqualityComparer.GetHashCode(obj.Item4));
+            public int GetHashCode((TreePath, TrieNode, byte[]) obj) =>
+                HashCode.Combine(obj.Item1, obj.Item2, Bytes.EqualityComparer.GetHashCode(obj.Item3));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -1047,7 +1047,7 @@ public class TrieNodeTests
             CollectionsMarshal.GetValueRefOrAddDefault(VisitLeafReceived, (ctx.Path, node, node.Value.ToArray()), out _) += 1;
         }
 
-        public void VisitCode(in TreePathContext ctx, Hash256 codeHash)
+        public void VisitAccount(in TreePathContext ctx, TrieNode node, in AccountStruct account)
         {
         }
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -333,7 +333,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ignore);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.Received().VisitExtension(new EmptyContext(), node);
     }
@@ -346,7 +346,7 @@ public class TrieNodeTests
         TrieNode node = new(NodeType.Unknown);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak);
     }
@@ -361,7 +361,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -376,7 +376,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -391,7 +391,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -406,7 +406,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -420,7 +420,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ctx.AccountLeaf);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitExtensionReceived[(TreePath.Empty, node)].Should().Be(1);
         visitor.VisitLeafReceived[(new(new(Bytes.FromHexString("0xa000000000000000000000000000000000000000000000000000000000000000")), 1), ctx.AccountLeaf, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
@@ -440,7 +440,7 @@ public class TrieNodeTests
 
         TreePath emptyPath = TreePath.Empty;
         node.ResolveKey(NullTrieStore.Instance, ref emptyPath, true);
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.VisitBranchReceived[(TreePath.Empty, node)].Should().Be(1);
         for (byte i = 0; i < 16; i++)
@@ -462,7 +462,7 @@ public class TrieNodeTests
         }
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
         visitor.Received().VisitBranch(new EmptyContext(), node);
     }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -327,28 +327,28 @@ public class TrieNodeTests
     [Test]
     public void Extension_can_accept_visitors()
     {
-        ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
+        ITreeVisitor<EmptyContext> visitor = Substitute.For<ITreeVisitor<EmptyContext>>();
         TrieVisitContext context = new();
         TrieNode ignore = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("ccc"), Array.Empty<byte>());
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ignore);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitExtension(node, context);
+        visitor.Received().VisitExtension(new EmptyContext(), node, context);
     }
 
     [Test]
     public void Unknown_node_with_missing_data_can_accept_visitor()
     {
-        ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
+        ITreeVisitor<EmptyContext> visitor = Substitute.For<ITreeVisitor<EmptyContext>>();
         TrieVisitContext context = new();
         TrieNode node = new(NodeType.Unknown);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitMissingNode(node.Keccak, context);
+        visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak, context);
     }
 
     [Test]
@@ -453,7 +453,7 @@ public class TrieNodeTests
     [Test]
     public void Branch_can_accept_visitors()
     {
-        ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
+        ITreeVisitor<EmptyContext> visitor = Substitute.For<ITreeVisitor<EmptyContext>>();
         TrieVisitContext context = new();
         TrieNode node = new(NodeType.Branch);
         for (int i = 0; i < 16; i++)
@@ -462,9 +462,9 @@ public class TrieNodeTests
         }
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
 
-        visitor.Received().VisitBranch(node, context);
+        visitor.Received().VisitBranch(new EmptyContext(), node, context);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -333,7 +333,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ignore);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.Received().VisitExtension(new EmptyContext(), node);
     }
@@ -346,7 +346,7 @@ public class TrieNodeTests
         TrieNode node = new(NodeType.Unknown);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak);
     }
@@ -361,7 +361,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -376,7 +376,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -391,7 +391,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -406,7 +406,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -420,7 +420,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ctx.AccountLeaf);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitExtensionReceived[(TreePath.Empty, node)].Should().Be(1);
         visitor.VisitLeafReceived[(new(new(Bytes.FromHexString("0xa000000000000000000000000000000000000000000000000000000000000000")), 1), ctx.AccountLeaf, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
@@ -440,7 +440,7 @@ public class TrieNodeTests
 
         TreePath emptyPath = TreePath.Empty;
         node.ResolveKey(NullTrieStore.Instance, ref emptyPath, true);
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.VisitBranchReceived[(TreePath.Empty, node)].Should().Be(1);
         for (byte i = 0; i < 16; i++)
@@ -462,7 +462,7 @@ public class TrieNodeTests
         }
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context, long.MaxValue);
 
         visitor.Received().VisitBranch(new EmptyContext(), node);
     }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -1042,9 +1042,9 @@ public class TrieNodeTests
             CollectionsMarshal.GetValueRefOrAddDefault(VisitExtensionReceived, (ctx.Path, node), out _) += 1;
         }
 
-        public void VisitLeaf(in TreePathContext ctx, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in TreePathContext ctx, TrieNode node)
         {
-            CollectionsMarshal.GetValueRefOrAddDefault(VisitLeafReceived, (ctx.Path, node, value.ToArray()), out _) += 1;
+            CollectionsMarshal.GetValueRefOrAddDefault(VisitLeafReceived, (ctx.Path, node, node.Value.ToArray()), out _) += 1;
         }
 
         public void VisitCode(in TreePathContext ctx, Hash256 codeHash)

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -206,7 +206,7 @@ public class VisitingTests
         {
         }
 
-        public void VisitLeaf(in PathGatheringContext nodeContext, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in PathGatheringContext nodeContext, TrieNode node)
         {
             PathGatheringContext context = nodeContext.Add(node.Key!);
             _paths.Enqueue(context.Nibbles);

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -212,7 +212,7 @@ public class VisitingTests
             _paths.Enqueue(context.Nibbles);
         }
 
-        public void VisitCode(in PathGatheringContext nodeContext, Hash256 codeHash)
+        public void VisitAccount(in PathGatheringContext nodeContext, TrieNode node, in AccountStruct account)
         {
         }
     }

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -189,31 +189,30 @@ public class VisitingTests
 
         public bool ShouldVisit(in PathGatheringContext nodeContext, Hash256 nextNode) => true;
 
-        public void VisitTree(in PathGatheringContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in PathGatheringContext nodeContext, Hash256 rootHash)
         {
         }
 
-        public void VisitMissingNode(in PathGatheringContext nodeContext, Hash256 nodeHash,
-            TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in PathGatheringContext nodeContext, Hash256 nodeHash)
         {
             throw new System.Exception("Should not happen");
         }
 
-        public void VisitBranch(in PathGatheringContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in PathGatheringContext nodeContext, TrieNode node)
         {
         }
 
-        public void VisitExtension(in PathGatheringContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in PathGatheringContext nodeContext, TrieNode node)
         {
         }
 
-        public void VisitLeaf(in PathGatheringContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in PathGatheringContext nodeContext, TrieNode node, ReadOnlySpan<byte> value)
         {
             PathGatheringContext context = nodeContext.Add(node.Key!);
             _paths.Enqueue(context.Nibbles);
         }
 
-        public void VisitCode(in PathGatheringContext nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in PathGatheringContext nodeContext, Hash256 codeHash)
         {
         }
     }

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,6 +16,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Trie;
@@ -43,6 +46,7 @@ public class BatchedTrieVisitor<TNodeContext>
 {
     // Not using shared pool so GC can reclaim them later.
     private readonly ArrayPool<Job> _jobArrayPool = ArrayPool<Job>.Create();
+    private static readonly AccountDecoder _accountDecoder = new();
 
     private readonly ArrayPool<(TrieNode, TNodeContext, SmallTrieVisitContext)> _trieNodePool =
         ArrayPool<(TrieNode, TNodeContext, SmallTrieVisitContext)>.Create();
@@ -266,7 +270,7 @@ public class BatchedTrieVisitor<TNodeContext>
                 using ArrayPoolList<(TrieNode, TNodeContext, SmallTrieVisitContext)> recursiveResult = new(1);
                 trieNode.ResolveNode(_resolver, emptyPath);
                 Interlocked.Increment(ref _activeJobs);
-                trieNode.AcceptResolvedNode(_visitor, nodeContext, _resolver, ctx, recursiveResult);
+                AcceptResolvedNode(trieNode, nodeContext, _resolver, ctx, recursiveResult);
                 QueueNextNodes(recursiveResult);
                 continue;
             }
@@ -354,7 +358,7 @@ public class BatchedTrieVisitor<TNodeContext>
                     return; // missing node
                 }
 
-                nodeToResolve.AcceptResolvedNode(_visitor, nodeContext, _resolver, ctx, nextToProcesses);
+                AcceptResolvedNode(nodeToResolve, nodeContext, _resolver, ctx, nextToProcesses);
                 QueueNextNodes(nextToProcesses);
             }
 
@@ -367,6 +371,104 @@ public class BatchedTrieVisitor<TNodeContext>
         {
             throw new TrieException(
                 $"Unable to resolve node without Keccak. ctx: {ctx.Level}, {ctx.ExpectAccounts}, {ctx.IsStorage}");
+        }
+    }
+
+    /// <summary>
+    /// Like `Accept`, but does not execute its children. Instead it return the next trie to visit in the list
+    /// `nextToVisit`. Also, it assume the node is already resolved.
+    /// </summary>
+    internal void AcceptResolvedNode(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, SmallTrieVisitContext trieVisitContext, IList<(TrieNode, TNodeContext, SmallTrieVisitContext)> nextToVisit)
+    {
+        // Note: The path is not maintained here, its just for a placeholder. This code is only used for BatchedTrieVisitor
+        // which should only be used with hash keys.
+        TreePath emptyPath = TreePath.Empty;
+        switch (node.NodeType)
+        {
+            case NodeType.Branch:
+            {
+                _visitor.VisitBranch(nodeContext, node);
+                trieVisitContext.Level++;
+
+                for (int i = 0; i < TrieNode.BranchesCount; i++)
+                {
+                    TrieNode child = node.GetChild(nodeResolver, ref emptyPath, i);
+                    if (child is not null)
+                    {
+                        child.ResolveKey(nodeResolver, ref emptyPath, false);
+                        TNodeContext childContext = nodeContext.Add((byte)i);
+
+                        if (_visitor.ShouldVisit(childContext, child.Keccak!))
+                        {
+                            SmallTrieVisitContext childCtx = trieVisitContext; // Copy
+                            nextToVisit.Add((child, childContext, childCtx));
+                        }
+
+                        if (child.IsPersisted)
+                        {
+                            node.UnresolveChild(i);
+                        }
+                    }
+                }
+
+                break;
+            }
+            case NodeType.Extension:
+            {
+                _visitor.VisitExtension(nodeContext, node);
+                TrieNode child = node.GetChild(nodeResolver, ref emptyPath, 0) ?? throw new InvalidDataException($"Child of an extension {node.Key} should not be null.");
+                child.ResolveKey(nodeResolver, ref emptyPath, false);
+                TNodeContext childContext = nodeContext.Add(node.Key!);
+                if (_visitor.ShouldVisit(childContext, child.Keccak!))
+                {
+                    trieVisitContext.Level++;
+
+
+                    nextToVisit.Add((child, childContext, trieVisitContext));
+                }
+
+                break;
+            }
+
+            case NodeType.Leaf:
+            {
+                _visitor.VisitLeaf(nodeContext, node);
+
+                if (!trieVisitContext.IsStorage && trieVisitContext.ExpectAccounts) // can combine these conditions
+                {
+                    TNodeContext childContext = nodeContext.Add(node.Key!);
+
+                    Rlp.ValueDecoderContext decoderContext = new Rlp.ValueDecoderContext(node.Value.AsSpan());
+                    if (!_accountDecoder.TryDecodeStruct(ref decoderContext, out AccountStruct account))
+                    {
+                        throw new InvalidDataException("Non storage leaf should be an account");
+                    }
+                    _visitor.VisitAccount(childContext, node, account);
+
+                    if (account.HasStorage && _visitor.ShouldVisit(childContext, account.StorageRoot))
+                    {
+                        trieVisitContext.IsStorage = true;
+                        TNodeContext storageContext = childContext.AddStorage(account.StorageRoot);
+                        trieVisitContext.Level++;
+
+                        if (node.TryResolveStorageRoot(nodeResolver, ref emptyPath, out TrieNode? storageRoot))
+                        {
+                            nextToVisit.Add((storageRoot!, storageContext, trieVisitContext));
+                        }
+                        else
+                        {
+                            _visitor.VisitMissingNode(storageContext, account.StorageRoot);
+                        }
+
+                        trieVisitContext.IsStorage = false;
+                    }
+                }
+
+                break;
+            }
+
+            default:
+                throw new TrieException($"An attempt was made to visit a node {node.Keccak} of type {node.NodeType}");
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -366,7 +366,7 @@ public class BatchedTrieVisitor<TNodeContext>
         static void ThrowUnableToResolve(in SmallTrieVisitContext ctx)
         {
             throw new TrieException(
-                $"Unable to resolve node without Keccak. ctx: {ctx.Level}, {ctx.ExpectAccounts}, {ctx.IsStorage}, {ctx.BranchChildIndex}");
+                $"Unable to resolve node without Keccak. ctx: {ctx.Level}, {ctx.ExpectAccounts}, {ctx.IsStorage}");
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -337,7 +337,7 @@ public class BatchedTrieVisitor<TNodeContext>
                 }
                 catch (TrieException)
                 {
-                    _visitor.VisitMissingNode(nodeContext, nodeToResolve.Keccak, ctx.ToVisitContext());
+                    _visitor.VisitMissingNode(nodeContext, nodeToResolve.Keccak);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -15,9 +15,21 @@ namespace Nethermind.Trie
         /// </summary>
         public bool IsFullDbScan { get; }
 
+        /// <summary>
+        /// Used by snap sync, specify that a range of nodes in increasing order will be traversed. This turn on
+        /// some optimization for this specific scenario.
+        /// </summary>
         public bool IsRangeScan => IsFullDbScan;
+
+        /// <summary>
+        /// Specify that the account will be decoded and code and storage will get traversed.
+        /// </summary>
         public bool ExpectAccounts => true;
 
+        /// <summary>
+        /// Extra read flags for passing to triestore. Used to optimize snap sync's gettrie so that it won't effect
+        /// block processing.
+        /// </summary>
         ReadFlags ExtraReadFlag => ReadFlags.None;
 
         bool ShouldVisit(in TNodeContext nodeContext, Hash256 nextNode);
@@ -30,7 +42,7 @@ namespace Nethermind.Trie
 
         void VisitExtension(in TNodeContext nodeContext, TrieNode node);
 
-        void VisitLeaf(in TNodeContext nodeContext, TrieNode node, ReadOnlySpan<byte> value);
+        void VisitLeaf(in TNodeContext nodeContext, TrieNode node);
 
         void VisitCode(in TNodeContext nodeContext, Hash256 codeHash);
     }

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -16,6 +16,7 @@ namespace Nethermind.Trie
         public bool IsFullDbScan { get; }
 
         public bool IsRangeScan => IsFullDbScan;
+        public bool ExpectAccounts => true;
 
         ReadFlags ExtraReadFlag => ReadFlags.None;
 

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -22,16 +22,16 @@ namespace Nethermind.Trie
 
         bool ShouldVisit(in TNodeContext nodeContext, Hash256 nextNode);
 
-        void VisitTree(in TNodeContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext);
+        void VisitTree(in TNodeContext nodeContext, Hash256 rootHash);
 
-        void VisitMissingNode(in TNodeContext nodeContext, Hash256 nodeHash, TrieVisitContext trieVisitContext);
+        void VisitMissingNode(in TNodeContext nodeContext, Hash256 nodeHash);
 
-        void VisitBranch(in TNodeContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext);
+        void VisitBranch(in TNodeContext nodeContext, TrieNode node);
 
-        void VisitExtension(in TNodeContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext);
+        void VisitExtension(in TNodeContext nodeContext, TrieNode node);
 
-        void VisitLeaf(in TNodeContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value);
+        void VisitLeaf(in TNodeContext nodeContext, TrieNode node, ReadOnlySpan<byte> value);
 
-        void VisitCode(in TNodeContext nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext);
+        void VisitCode(in TNodeContext nodeContext, Hash256 codeHash);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -44,6 +44,11 @@ namespace Nethermind.Trie
 
         void VisitLeaf(in TNodeContext nodeContext, TrieNode node);
 
-        void VisitCode(in TNodeContext nodeContext, Hash256 codeHash);
+        /// <summary>
+        /// Called right after VisitLeaf when `ExpectAccounts` is true.
+        /// The visitor need to decode account to traverse storage. So if you need the account instead of decoding from
+        /// `VisitLeaf` you might as well get it here.
+        /// </summary>
+        void VisitAccount(in TNodeContext nodeContext, TrieNode node, in AccountStruct account);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -7,30 +7,6 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie
 {
-    public interface ITreeVisitor
-    {
-        /// <summary>
-        /// Specify that this is a full table scan and should optimize for it.
-        /// </summary>
-        public bool IsFullDbScan { get; }
-
-        ReadFlags ExtraReadFlag => ReadFlags.None;
-
-        bool ShouldVisit(Hash256 nodeHash);
-
-        void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext);
-
-        void VisitMissingNode(Hash256 nodeHash, TrieVisitContext trieVisitContext);
-
-        void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext);
-
-        void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext);
-
-        void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value);
-
-        void VisitCode(Hash256 codeHash, TrieVisitContext trieVisitContext);
-    }
-
     public interface ITreeVisitor<TNodeContext>
         where TNodeContext : struct, INodeContext<TNodeContext>
     {
@@ -56,51 +32,5 @@ namespace Nethermind.Trie
         void VisitLeaf(in TNodeContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value);
 
         void VisitCode(in TNodeContext nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext);
-    }
-
-    public class ContextNotAwareTreeVisitor : ITreeVisitor<EmptyContext>
-    {
-        private readonly ITreeVisitor _wrapped;
-
-        public ContextNotAwareTreeVisitor(ITreeVisitor wrapped)
-        {
-            _wrapped = wrapped;
-        }
-
-        public bool IsFullDbScan => _wrapped.IsFullDbScan;
-
-        public ReadFlags ExtraReadFlag => _wrapped.ExtraReadFlag;
-
-        public bool ShouldVisit(in EmptyContext nodeContext, Hash256 nextNode) => _wrapped.ShouldVisit(nextNode);
-
-        public void VisitTree(in EmptyContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
-        {
-            _wrapped.VisitTree(rootHash, trieVisitContext);
-        }
-
-        public void VisitMissingNode(in EmptyContext nodeContext, Hash256 nodeHash, TrieVisitContext trieVisitContext)
-        {
-            _wrapped.VisitMissingNode(nodeHash, trieVisitContext);
-        }
-
-        public void VisitBranch(in EmptyContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
-        {
-            _wrapped.VisitBranch(node, trieVisitContext);
-        }
-
-        public void VisitExtension(in EmptyContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
-        {
-            _wrapped.VisitExtension(node, trieVisitContext);
-        }
-
-        public void VisitLeaf(in EmptyContext nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
-        {
-            _wrapped.VisitLeaf(node, trieVisitContext, value);
-        }
-
-        public void VisitCode(in EmptyContext nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext)
-        {
-            _wrapped.VisitCode(codeHash, trieVisitContext);
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1344,7 +1344,7 @@ namespace Nethermind.Trie
                 if (TryGetRootRef(out TrieNode rootRef))
                 {
                     TreePath emptyPath = TreePath.Empty;
-                    rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext, long.MaxValue);
+                    rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
                 }
             }
             // Full db scan
@@ -1358,7 +1358,7 @@ namespace Nethermind.Trie
             {
                 TreePath emptyPath = TreePath.Empty;
                 visitor.VisitTree(default, rootHash);
-                long? total = rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext, long.MaxValue);
+                long? total = rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1358,7 +1358,7 @@ namespace Nethermind.Trie
             {
                 TreePath emptyPath = TreePath.Empty;
                 visitor.VisitTree(default, rootHash);
-                long? total = rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
+                rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1344,7 +1344,7 @@ namespace Nethermind.Trie
                 if (TryGetRootRef(out TrieNode rootRef))
                 {
                     TreePath emptyPath = TreePath.Empty;
-                    rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
+                    rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext, long.MaxValue);
                 }
             }
             // Full db scan
@@ -1358,7 +1358,7 @@ namespace Nethermind.Trie
             {
                 TreePath emptyPath = TreePath.Empty;
                 visitor.VisitTree(default, rootHash);
-                rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
+                long? total = rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext, long.MaxValue);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1258,9 +1258,6 @@ namespace Nethermind.Trie
             }
         }
 
-        public void Accept(ITreeVisitor visitor, Hash256 rootHash, VisitingOptions? visitingOptions = null, Hash256? storageAddr = null) =>
-            Accept(new ContextNotAwareTreeVisitor(visitor), rootHash, visitingOptions, storageAddr);
-
         /// <summary>
         /// Run tree visitor
         /// </summary>

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1330,7 +1330,7 @@ namespace Nethermind.Trie
                     rootRef = RootHash == rootHash ? RootRef : resolver.FindCachedOrUnknown(emptyPath, rootHash);
                     if (!rootRef!.TryResolveNode(resolver, ref emptyPath))
                     {
-                        visitor.VisitMissingNode(default, rootHash, trieVisitContext);
+                        visitor.VisitMissingNode(default, rootHash);
                         return false;
                     }
                 }
@@ -1340,7 +1340,7 @@ namespace Nethermind.Trie
 
             if (!visitor.IsFullDbScan)
             {
-                visitor.VisitTree(default, rootHash, trieVisitContext);
+                visitor.VisitTree(default, rootHash);
                 if (TryGetRootRef(out TrieNode rootRef))
                 {
                     TreePath emptyPath = TreePath.Empty;
@@ -1350,14 +1350,14 @@ namespace Nethermind.Trie
             // Full db scan
             else if (TrieStore.Scheme == INodeStorage.KeyScheme.Hash && visitingOptions.FullScanMemoryBudget != 0)
             {
-                visitor.VisitTree(default, rootHash, trieVisitContext);
+                visitor.VisitTree(default, rootHash);
                 BatchedTrieVisitor<TNodeContext> batchedTrieVisitor = new(visitor, resolver, visitingOptions);
                 batchedTrieVisitor.Start(rootHash, trieVisitContext);
             }
             else if (TryGetRootRef(out TrieNode rootRef))
             {
                 TreePath emptyPath = TreePath.Empty;
-                visitor.VisitTree(default, rootHash, trieVisitContext);
+                visitor.VisitTree(default, rootHash);
                 rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
             }
         }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1281,10 +1281,6 @@ namespace Nethermind.Trie
 
             using TrieVisitContext trieVisitContext = new()
             {
-                // hacky but other solutions are not much better, something nicer would require a bit of thinking
-                // we introduced a notion of an account on the visit context level which should have no knowledge of account really
-                // but we know that we have multiple optimizations and assumptions on trees
-                ExpectAccounts = visitingOptions.ExpectAccounts,
                 MaxDegreeOfParallelism = visitingOptions.MaxDegreeOfParallelism,
                 IsStorage = storageAddr is not null
             };

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -145,29 +145,29 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         }
     }
 
-    public void VisitTree(in TreePathContext nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
+    public void VisitTree(in TreePathContext nodeContext, Hash256 rootHash)
     {
     }
 
 
-    public void VisitMissingNode(in TreePathContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+    public void VisitMissingNode(in TreePathContext ctx, Hash256 nodeHash)
     {
         throw new TrieException($"Missing node {ctx.Path} {nodeHash}");
     }
 
-    public void VisitBranch(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+    public void VisitBranch(in TreePathContext ctx, TrieNode node)
     {
         _leftmostNodes[ctx.Path.Length] ??= node;
         _rightmostNodes[ctx.Path.Length] = node;
     }
 
-    public void VisitExtension(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+    public void VisitExtension(in TreePathContext ctx, TrieNode node)
     {
         _leftmostNodes[ctx.Path.Length] ??= node;
         _rightmostNodes[ctx.Path.Length] = node;
     }
 
-    public void VisitLeaf(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+    public void VisitLeaf(in TreePathContext ctx, TrieNode node, ReadOnlySpan<byte> value)
     {
         _leftmostNodes[ctx.Path.Length] ??= node;
         _rightmostNodes[ctx.Path.Length] = node;
@@ -192,7 +192,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         _skipStarthashComparison = true;
     }
 
-    public void VisitCode(in TreePathContext nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext)
+    public void VisitCode(in TreePathContext nodeContext, Hash256 codeHash)
     {
     }
 

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -192,7 +192,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         _skipStarthashComparison = true;
     }
 
-    public void VisitCode(in TreePathContext nodeContext, Hash256 codeHash)
+    public void VisitAccount(in TreePathContext nodeContext, TrieNode node, in AccountStruct accountStruct)
     {
     }
 

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -47,6 +47,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
     public bool StoppedEarly { get; set; } = false;
     public bool IsFullDbScan => false;
     public bool IsRangeScan => true;
+    public bool ExpectAccounts => false;
     private readonly CancellationToken _cancellationToken;
 
     public ReadFlags ExtraReadFlag { get; }

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -167,7 +167,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         _rightmostNodes[ctx.Path.Length] = node;
     }
 
-    public void VisitLeaf(in TreePathContext ctx, TrieNode node, ReadOnlySpan<byte> value)
+    public void VisitLeaf(in TreePathContext ctx, TrieNode node)
     {
         _leftmostNodes[ctx.Path.Length] ??= node;
         _rightmostNodes[ctx.Path.Length] = node;

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -60,11 +60,11 @@ namespace Nethermind.Trie
 
         private readonly AccountDecoder decoder = new();
 
-        public void VisitLeaf(in OldStyleTrieVisitContext context, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext context, TrieNode node)
         {
             string leafDescription = context.IsStorage ? "LEAF " : "ACCOUNT ";
             _builder.AppendLine($"{GetPrefix(context)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
-            Rlp.ValueDecoderContext valueDecoderContext = new(value);
+            Rlp.ValueDecoderContext valueDecoderContext = new(node.Value);
             if (!context.IsStorage)
             {
                 Account account = decoder.Decode(ref valueDecoderContext);

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -10,7 +10,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Trie
 {
-    public class TreeDumper : ITreeVisitor<EmptyContext>
+    public class TreeDumper : ITreeVisitor<OldTrieVisitContext>
     {
         private readonly StringBuilder _builder = new();
 
@@ -21,12 +21,12 @@ namespace Nethermind.Trie
 
         public bool IsFullDbScan { get; init; } = true;
 
-        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
+        public bool ShouldVisit(in OldTrieVisitContext _, Hash256 nextNode)
         {
             return true;
         }
 
-        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in OldTrieVisitContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
         {
             if (rootHash == Keccak.EmptyTreeHash)
             {
@@ -38,49 +38,49 @@ namespace Nethermind.Trie
             }
         }
 
-        private static string GetPrefix(TrieVisitContext context) => string.Concat($"{GetIndent(context.Level)}", context.IsStorage ? "STORAGE " : string.Empty, $"{GetChildIndex(context)}");
+        private static string GetPrefix(in OldTrieVisitContext ctx, TrieVisitContext context) => string.Concat($"{GetIndent(context.Level)}", context.IsStorage ? "STORAGE " : string.Empty, $"{GetChildIndex(ctx)}");
 
         private static string GetIndent(int level) => new('+', level * 2);
-        private static string GetChildIndex(TrieVisitContext context) => context.BranchChildIndex is null ? string.Empty : $"{context.BranchChildIndex:x2} ";
+        private static string GetChildIndex(in OldTrieVisitContext ctx) => ctx.BranchChildIndex is null ? string.Empty : $"{ctx.BranchChildIndex:x2} ";
 
-        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in OldTrieVisitContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetIndent(trieVisitContext.Level)}{GetChildIndex(trieVisitContext)}MISSING {nodeHash}");
+            _builder.AppendLine($"{GetIndent(trieVisitContext.Level)}{GetChildIndex(ctx)}MISSING {nodeHash}");
         }
 
-        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
         }
 
-        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         private readonly AccountDecoder decoder = new();
 
-        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             Rlp.ValueDecoderContext valueDecoderContext = new(value);
             if (!trieVisitContext.IsStorage)
             {
                 Account account = decoder.Decode(ref valueDecoderContext);
-                _builder.AppendLine($"{GetPrefix(trieVisitContext)}  NONCE: {account.Nonce}");
-                _builder.AppendLine($"{GetPrefix(trieVisitContext)}  BALANCE: {account.Balance}");
-                _builder.AppendLine($"{GetPrefix(trieVisitContext)}  IS_CONTRACT: {account.IsContract}");
+                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  NONCE: {account.Nonce}");
+                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  BALANCE: {account.Balance}");
+                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  IS_CONTRACT: {account.IsContract}");
             }
             else
             {
-                _builder.AppendLine($"{GetPrefix(trieVisitContext)}  VALUE: {valueDecoderContext.DecodeByteArray().ToHexString(true, true)}");
+                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  VALUE: {valueDecoderContext.DecodeByteArray().ToHexString(true, true)}");
             }
         }
 
-        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in OldTrieVisitContext ctx, Hash256 codeHash, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}CODE {codeHash}");
+            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}CODE {codeHash}");
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -58,16 +58,17 @@ namespace Nethermind.Trie
             _builder.AppendLine($"{GetPrefix(context)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
-        private readonly AccountDecoder decoder = new();
-
         public void VisitLeaf(in OldStyleTrieVisitContext context, TrieNode node)
+        {
+        }
+
+        public void VisitAccount(in OldStyleTrieVisitContext context, TrieNode node, in AccountStruct account)
         {
             string leafDescription = context.IsStorage ? "LEAF " : "ACCOUNT ";
             _builder.AppendLine($"{GetPrefix(context)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             Rlp.ValueDecoderContext valueDecoderContext = new(node.Value);
             if (!context.IsStorage)
             {
-                Account account = decoder.Decode(ref valueDecoderContext);
                 _builder.AppendLine($"{GetPrefix(context)}  NONCE: {account.Nonce}");
                 _builder.AppendLine($"{GetPrefix(context)}  BALANCE: {account.Balance}");
                 _builder.AppendLine($"{GetPrefix(context)}  IS_CONTRACT: {account.IsContract}");
@@ -76,11 +77,6 @@ namespace Nethermind.Trie
             {
                 _builder.AppendLine($"{GetPrefix(context)}  VALUE: {valueDecoderContext.DecodeByteArray().ToHexString(true, true)}");
             }
-        }
-
-        public void VisitCode(in OldStyleTrieVisitContext context, Hash256 codeHash)
-        {
-            _builder.AppendLine($"{GetPrefix(context)}CODE {codeHash}");
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -10,7 +10,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Trie
 {
-    public class TreeDumper : ITreeVisitor
+    public class TreeDumper : ITreeVisitor<EmptyContext>
     {
         private readonly StringBuilder _builder = new();
 
@@ -21,12 +21,12 @@ namespace Nethermind.Trie
 
         public bool IsFullDbScan { get; init; } = true;
 
-        public bool ShouldVisit(Hash256 nextNode)
+        public bool ShouldVisit(in EmptyContext _, Hash256 nextNode)
         {
             return true;
         }
 
-        public void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in EmptyContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
         {
             if (rootHash == Keccak.EmptyTreeHash)
             {
@@ -43,24 +43,24 @@ namespace Nethermind.Trie
         private static string GetIndent(int level) => new('+', level * 2);
         private static string GetChildIndex(TrieVisitContext context) => context.BranchChildIndex is null ? string.Empty : $"{context.BranchChildIndex:x2} ";
 
-        public void VisitMissingNode(Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in EmptyContext _, Hash256 nodeHash, TrieVisitContext trieVisitContext)
         {
             _builder.AppendLine($"{GetIndent(trieVisitContext.Level)}{GetChildIndex(trieVisitContext)}MISSING {nodeHash}");
         }
 
-        public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
         }
 
-        public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext)
         {
             _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         private readonly AccountDecoder decoder = new();
 
-        public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in EmptyContext _, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
             _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
@@ -78,7 +78,7 @@ namespace Nethermind.Trie
             }
         }
 
-        public void VisitCode(Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in EmptyContext _, Hash256 codeHash, TrieVisitContext trieVisitContext)
         {
             _builder.AppendLine($"{GetPrefix(trieVisitContext)}CODE {codeHash}");
         }

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -10,7 +10,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Trie
 {
-    public class TreeDumper : ITreeVisitor<OldTrieVisitContext>
+    public class TreeDumper : ITreeVisitor<OldStyleTrieVisitContext>
     {
         private readonly StringBuilder _builder = new();
 
@@ -21,12 +21,12 @@ namespace Nethermind.Trie
 
         public bool IsFullDbScan { get; init; } = true;
 
-        public bool ShouldVisit(in OldTrieVisitContext _, Hash256 nextNode)
+        public bool ShouldVisit(in OldStyleTrieVisitContext _, Hash256 nextNode)
         {
             return true;
         }
 
-        public void VisitTree(in OldTrieVisitContext _, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in OldStyleTrieVisitContext context, Hash256 rootHash)
         {
             if (rootHash == Keccak.EmptyTreeHash)
             {
@@ -34,53 +34,53 @@ namespace Nethermind.Trie
             }
             else
             {
-                _builder.AppendLine(trieVisitContext.IsStorage ? "STORAGE TREE" : "STATE TREE");
+                _builder.AppendLine(context.IsStorage ? "STORAGE TREE" : "STATE TREE");
             }
         }
 
-        private static string GetPrefix(in OldTrieVisitContext ctx, TrieVisitContext context) => string.Concat($"{GetIndent(context.Level)}", context.IsStorage ? "STORAGE " : string.Empty, $"{GetChildIndex(ctx)}");
+        private static string GetPrefix(in OldStyleTrieVisitContext context) => string.Concat($"{GetIndent(context.Level)}", context.IsStorage ? "STORAGE " : string.Empty, $"{GetChildIndex(context)}");
 
         private static string GetIndent(int level) => new('+', level * 2);
-        private static string GetChildIndex(in OldTrieVisitContext ctx) => ctx.BranchChildIndex is null ? string.Empty : $"{ctx.BranchChildIndex:x2} ";
+        private static string GetChildIndex(in OldStyleTrieVisitContext context) => context.BranchChildIndex is null ? string.Empty : $"{context.BranchChildIndex:x2} ";
 
-        public void VisitMissingNode(in OldTrieVisitContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in OldStyleTrieVisitContext context, Hash256 nodeHash)
         {
-            _builder.AppendLine($"{GetIndent(trieVisitContext.Level)}{GetChildIndex(ctx)}MISSING {nodeHash}");
+            _builder.AppendLine($"{GetIndent(context.Level)}{GetChildIndex(context)}MISSING {nodeHash}");
         }
 
-        public void VisitBranch(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in OldStyleTrieVisitContext context, TrieNode node)
         {
-            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(context)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
         }
 
-        public void VisitExtension(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in OldStyleTrieVisitContext context, TrieNode node)
         {
-            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(context)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         private readonly AccountDecoder decoder = new();
 
-        public void VisitLeaf(in OldTrieVisitContext ctx, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in OldStyleTrieVisitContext context, TrieNode node, ReadOnlySpan<byte> value)
         {
-            string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            string leafDescription = context.IsStorage ? "LEAF " : "ACCOUNT ";
+            _builder.AppendLine($"{GetPrefix(context)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             Rlp.ValueDecoderContext valueDecoderContext = new(value);
-            if (!trieVisitContext.IsStorage)
+            if (!context.IsStorage)
             {
                 Account account = decoder.Decode(ref valueDecoderContext);
-                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  NONCE: {account.Nonce}");
-                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  BALANCE: {account.Balance}");
-                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  IS_CONTRACT: {account.IsContract}");
+                _builder.AppendLine($"{GetPrefix(context)}  NONCE: {account.Nonce}");
+                _builder.AppendLine($"{GetPrefix(context)}  BALANCE: {account.Balance}");
+                _builder.AppendLine($"{GetPrefix(context)}  IS_CONTRACT: {account.IsContract}");
             }
             else
             {
-                _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}  VALUE: {valueDecoderContext.DecodeByteArray().ToHexString(true, true)}");
+                _builder.AppendLine($"{GetPrefix(context)}  VALUE: {valueDecoderContext.DecodeByteArray().ToHexString(true, true)}");
             }
         }
 
-        public void VisitCode(in OldTrieVisitContext ctx, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in OldStyleTrieVisitContext context, Hash256 codeHash)
         {
-            _builder.AppendLine($"{GetPrefix(ctx, trieVisitContext)}CODE {codeHash}");
+            _builder.AppendLine($"{GetPrefix(context)}CODE {codeHash}");
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -292,7 +292,7 @@ namespace Nethermind.Trie
 
                         TNodeContext leafContext = nodeContext.Add(Key!);
 
-                        if (!trieVisitContext.IsStorage && trieVisitContext.ExpectAccounts) // can combine these conditions
+                        if (!trieVisitContext.IsStorage && visitor.ExpectAccounts) // can combine these conditions
                         {
                             Account account = _accountDecoder.Decode(Value.AsRlpStream());
                             if (account.HasCode && visitor.ShouldVisit(leafContext, account.CodeHash))

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -80,7 +80,7 @@ namespace Nethermind.Trie
 
                 case NodeType.Leaf:
                     {
-                        visitor.VisitLeaf(nodeContext, this, Value.AsSpan());
+                        visitor.VisitLeaf(nodeContext, this);
 
                         if (!trieVisitContext.IsStorage && trieVisitContext.ExpectAccounts) // can combine these conditions
                         {
@@ -278,7 +278,7 @@ namespace Nethermind.Trie
 
                 case NodeType.Leaf:
                     {
-                        visitor.VisitLeaf(nodeContext, this, Value.AsSpan());
+                        visitor.VisitLeaf(nodeContext, this);
 
                         trieVisitContext.AddVisited();
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -49,7 +49,6 @@ namespace Nethermind.Trie
                                 if (visitor.ShouldVisit(childContext, child.Keccak!))
                                 {
                                     SmallTrieVisitContext childCtx = trieVisitContext; // Copy
-                                    childCtx.BranchChildIndex = (byte?)i;
                                     nextToVisit.Add((child, childContext, childCtx));
                                 }
 
@@ -71,7 +70,6 @@ namespace Nethermind.Trie
                         if (visitor.ShouldVisit(childContext, child.Keccak!))
                         {
                             trieVisitContext.Level++;
-                            trieVisitContext.BranchChildIndex = null;
 
 
                             nextToVisit.Add((child, childContext, trieVisitContext));
@@ -92,7 +90,6 @@ namespace Nethermind.Trie
                             if (account.HasCode && visitor.ShouldVisit(childContext, account.CodeHash))
                             {
                                 trieVisitContext.Level++;
-                                trieVisitContext.BranchChildIndex = null;
                                 visitor.VisitCode(childContext, account.CodeHash, trieVisitContext.ToVisitContext());
                                 trieVisitContext.Level--;
                             }
@@ -102,7 +99,6 @@ namespace Nethermind.Trie
                                 trieVisitContext.IsStorage = true;
                                 TNodeContext storageContext = childContext.AddStorage(account.StorageRoot);
                                 trieVisitContext.Level++;
-                                trieVisitContext.BranchChildIndex = null;
 
                                 if (TryResolveStorageRoot(nodeResolver, ref emptyPath, out TrieNode? storageRoot))
                                 {
@@ -152,7 +148,6 @@ namespace Nethermind.Trie
                             TNodeContext childContext = nodeContext.Add((byte)i);
                             if (v.ShouldVisit(childContext, child.Keccak!))
                             {
-                                context.BranchChildIndex = i;
                                 child.Accept(v, childContext, resolver, ref path, context);
                             }
                             path.TruncateMut(previousPathLength);
@@ -230,7 +225,6 @@ namespace Nethermind.Trie
                                 TNodeContext childContext = nodeContext.Add((byte)i);
                                 if (visitor.ShouldVisit(childContext, child.Keccak!))
                                 {
-                                    visitContext.BranchChildIndex = i;
                                     child.Accept(visitor, childContext, nodeResolver, ref path, visitContext);
                                 }
                             }
@@ -260,7 +254,6 @@ namespace Nethermind.Trie
                         }
 
                         trieVisitContext.Level--;
-                        trieVisitContext.BranchChildIndex = null;
                         break;
                     }
 
@@ -275,7 +268,6 @@ namespace Nethermind.Trie
                         if (visitor.ShouldVisit(childContext, child.Keccak!))
                         {
                             trieVisitContext.Level++;
-                            trieVisitContext.BranchChildIndex = null;
                             child.Accept(visitor, childContext, nodeResolver, ref path, trieVisitContext);
                             trieVisitContext.Level--;
                         }
@@ -298,7 +290,6 @@ namespace Nethermind.Trie
                             if (account.HasCode && visitor.ShouldVisit(leafContext, account.CodeHash))
                             {
                                 trieVisitContext.Level++;
-                                trieVisitContext.BranchChildIndex = null;
                                 visitor.VisitCode(leafContext, account.CodeHash, trieVisitContext);
                                 trieVisitContext.Level--;
                             }
@@ -306,7 +297,6 @@ namespace Nethermind.Trie
                             if (account.HasStorage && visitor.ShouldVisit(leafContext, account.StorageRoot))
                             {
                                 trieVisitContext.Level++;
-                                trieVisitContext.BranchChildIndex = null;
 
                                 if (TryResolveStorageRoot(nodeResolver, ref path, out TrieNode? storageRoot))
                                 {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -125,11 +125,6 @@ namespace Nethermind.Trie
             }
         }
 
-        internal void Accept(ITreeVisitor visitor, ITrieNodeResolver nodeResolver, ref TreePath path, TrieVisitContext trieVisitContext)
-        {
-            Accept(new ContextNotAwareTreeVisitor(visitor), default, nodeResolver, ref path, trieVisitContext);
-        }
-
         internal void Accept<TNodeContext>(ITreeVisitor<TNodeContext> visitor, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path, TrieVisitContext trieVisitContext)
             where TNodeContext : struct, INodeContext<TNodeContext>
         {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Trie
             {
                 case NodeType.Branch:
                     {
-                        visitor.VisitBranch(nodeContext, this, trieVisitContext.ToVisitContext());
+                        visitor.VisitBranch(nodeContext, this);
                         trieVisitContext.Level++;
 
                         for (int i = 0; i < BranchesCount; i++)
@@ -63,7 +63,7 @@ namespace Nethermind.Trie
                     }
                 case NodeType.Extension:
                     {
-                        visitor.VisitExtension(nodeContext, this, trieVisitContext.ToVisitContext());
+                        visitor.VisitExtension(nodeContext, this);
                         TrieNode child = GetChild(nodeResolver, ref emptyPath, 0) ?? throw new InvalidDataException($"Child of an extension {Key} should not be null.");
                         child.ResolveKey(nodeResolver, ref emptyPath, false);
                         TNodeContext childContext = nodeContext.Add(Key!);
@@ -80,7 +80,7 @@ namespace Nethermind.Trie
 
                 case NodeType.Leaf:
                     {
-                        visitor.VisitLeaf(nodeContext, this, trieVisitContext.ToVisitContext(), Value.AsSpan());
+                        visitor.VisitLeaf(nodeContext, this, Value.AsSpan());
 
                         if (!trieVisitContext.IsStorage && trieVisitContext.ExpectAccounts) // can combine these conditions
                         {
@@ -90,7 +90,7 @@ namespace Nethermind.Trie
                             if (account.HasCode && visitor.ShouldVisit(childContext, account.CodeHash))
                             {
                                 trieVisitContext.Level++;
-                                visitor.VisitCode(childContext, account.CodeHash, trieVisitContext.ToVisitContext());
+                                visitor.VisitCode(childContext, account.CodeHash);
                                 trieVisitContext.Level--;
                             }
 
@@ -106,7 +106,7 @@ namespace Nethermind.Trie
                                 }
                                 else
                                 {
-                                    visitor.VisitMissingNode(storageContext, account.StorageRoot, trieVisitContext.ToVisitContext());
+                                    visitor.VisitMissingNode(storageContext, account.StorageRoot);
                                 }
 
                                 trieVisitContext.IsStorage = false;
@@ -130,7 +130,7 @@ namespace Nethermind.Trie
             }
             catch (TrieException)
             {
-                visitor.VisitMissingNode(nodeContext, Keccak, trieVisitContext);
+                visitor.VisitMissingNode(nodeContext, Keccak);
                 return;
             }
 
@@ -231,7 +231,7 @@ namespace Nethermind.Trie
                             path.TruncateOne();
                         }
 
-                        visitor.VisitBranch(nodeContext, this, trieVisitContext);
+                        visitor.VisitBranch(nodeContext, this);
                         trieVisitContext.AddVisited();
                         trieVisitContext.Level++;
 
@@ -259,7 +259,7 @@ namespace Nethermind.Trie
 
                 case NodeType.Extension:
                     {
-                        visitor.VisitExtension(nodeContext, this, trieVisitContext);
+                        visitor.VisitExtension(nodeContext, this);
                         trieVisitContext.AddVisited();
                         TrieNode child = GetChild(nodeResolver, ref path, 0) ?? throw new InvalidDataException($"Child of an extension {Key} should not be null.");
                         int previousPathLength = AppendChildPath(ref path, 0);
@@ -278,7 +278,7 @@ namespace Nethermind.Trie
 
                 case NodeType.Leaf:
                     {
-                        visitor.VisitLeaf(nodeContext, this, trieVisitContext, Value.AsSpan());
+                        visitor.VisitLeaf(nodeContext, this, Value.AsSpan());
 
                         trieVisitContext.AddVisited();
 
@@ -290,7 +290,7 @@ namespace Nethermind.Trie
                             if (account.HasCode && visitor.ShouldVisit(leafContext, account.CodeHash))
                             {
                                 trieVisitContext.Level++;
-                                visitor.VisitCode(leafContext, account.CodeHash, trieVisitContext);
+                                visitor.VisitCode(leafContext, account.CodeHash);
                                 trieVisitContext.Level--;
                             }
 
@@ -316,7 +316,7 @@ namespace Nethermind.Trie
                                 }
                                 else
                                 {
-                                    visitor.VisitMissingNode(leafContext, account.StorageRoot, trieVisitContext);
+                                    visitor.VisitMissingNode(leafContext, account.StorageRoot);
                                 }
 
                                 trieVisitContext.Level--;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -24,12 +24,12 @@ namespace Nethermind.Trie
         internal void Accept<TNodeContext>(ITreeVisitor<TNodeContext> visitor, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver,
             ref TreePath path, TrieVisitContext trieVisitContext) where TNodeContext : struct, INodeContext<TNodeContext>
         {
-            new TrieNodeTraverser<TNodeContext>(visitor, new VisitingOptions())
+            new TrieNodeTraverser<TNodeContext>(visitor, trieVisitContext)
                 .Accept(this, nodeContext, nodeResolver, ref path, trieVisitContext.IsStorage);
         }
     }
 
-    public class TrieNodeTraverser<TNodeContext>(ITreeVisitor<TNodeContext> visitor, VisitingOptions options) where TNodeContext : struct, INodeContext<TNodeContext>
+    public class TrieNodeTraverser<TNodeContext>(ITreeVisitor<TNodeContext> visitor, TrieVisitContext options) where TNodeContext : struct, INodeContext<TNodeContext>
     {
         private static readonly AccountDecoder _accountDecoder = new();
         private int _maxDegreeOfParallelism = options.MaxDegreeOfParallelism;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1134,7 +1134,7 @@ namespace Nethermind.Trie
             // }
         }
 
-        private bool TryResolveStorageRoot(ITrieNodeResolver resolver, ref TreePath currentPath, out TrieNode? storageRoot)
+        internal bool TryResolveStorageRoot(ITrieNodeResolver resolver, ref TreePath currentPath, out TrieNode? storageRoot)
         {
             bool hasStorage = false;
 
@@ -1319,7 +1319,7 @@ namespace Nethermind.Trie
             path.TruncateOne();
         }
 
-        private void UnresolveChild(int i)
+        internal void UnresolveChild(int i)
         {
             ref var data = ref _nodeData[i];
             if (IsPersisted)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1264,7 +1264,7 @@ namespace Nethermind.Trie
         /// <param name="tree"></param>
         /// <param name="path"></param>
         /// <param name="output"></param>
-        private void ResolveAllChildBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode?[] output)
+        internal void ResolveAllChildBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode?[] output)
         {
             RlpFactory rlp = _rlp;
             if (rlp is null)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -149,8 +149,9 @@ namespace Nethermind.Trie
             IncrementLevel(nodeContext);
         }
 
-        public void VisitCode(in Context nodeContext, Hash256 codeHash)
+        public void VisitAccount(in Context nodeContext, TrieNode node, in AccountStruct account)
         {
+            Hash256 codeHash = account.CodeHash;
             ValueHash256 key = new ValueHash256(codeHash.Bytes);
             bool codeExist = _existingCodeHash.TryGet(key, out int codeLength);
             if (!codeExist)

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Trie
             IncrementLevel(nodeContext);
         }
 
-        public void VisitLeaf(in Context nodeContext, TrieNode node, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in Context nodeContext, TrieNode node)
         {
             long lastAccountNodeCount = _lastAccountNodeCount;
             long currentNodeCount = Stats.NodesCount;

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -151,12 +151,12 @@ namespace Nethermind.Trie
 
         public void VisitAccount(in Context nodeContext, TrieNode node, in AccountStruct account)
         {
-            Hash256 codeHash = account.CodeHash;
-            ValueHash256 key = new ValueHash256(codeHash.Bytes);
+            if (!account.HasCode) return;
+            ValueHash256 key = account.CodeHash;
             bool codeExist = _existingCodeHash.TryGet(key, out int codeLength);
             if (!codeExist)
             {
-                byte[] code = _codeKeyValueStore[codeHash.Bytes];
+                byte[] code = _codeKeyValueStore[key.Bytes];
                 codeExist = code is not null;
                 if (codeExist)
                 {
@@ -172,7 +172,7 @@ namespace Nethermind.Trie
             }
             else
             {
-                if (_logger.IsWarn) _logger.Warn($"Missing code. Hash: {codeHash}");
+                if (_logger.IsWarn) _logger.Warn($"Missing code. Hash: {account.CodeHash}");
                 Interlocked.Increment(ref Stats._missingCode);
             }
 

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -10,7 +10,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.Trie
 {
-    public class TrieStatsCollector : ITreeVisitor<TreePathContextWithStorage>
+    public class TrieStatsCollector : ITreeVisitor<TrieStatsCollector.Context>
     {
         private readonly ClockCache<ValueHash256, int> _existingCodeHash = new ClockCache<ValueHash256, int>(1024 * 8);
         private readonly IKeyValueStore _codeKeyValueStore;
@@ -18,6 +18,44 @@ namespace Nethermind.Trie
 
         private readonly ILogger _logger;
         private readonly CancellationToken _cancellationToken;
+
+        public struct Context: INodeContext<Context>
+        {
+            private TreePathContextWithStorage PathContext;
+            private OldStyleTrieVisitContext OldStyleTrieVisitContext;
+
+            public Hash256? Storage => PathContext.Storage;
+            public TreePath Path => PathContext.Path;
+            public bool IsStorage => OldStyleTrieVisitContext.IsStorage;
+            public int Level => OldStyleTrieVisitContext.Level;
+
+            public Context Add(ReadOnlySpan<byte> nibblePath)
+            {
+                return new Context()
+                {
+                    PathContext = PathContext.Add(nibblePath),
+                    OldStyleTrieVisitContext = OldStyleTrieVisitContext.Add(nibblePath)
+                };
+            }
+
+            public Context Add(byte nibble)
+            {
+                return new Context()
+                {
+                    PathContext = PathContext.Add(nibble),
+                    OldStyleTrieVisitContext = OldStyleTrieVisitContext.Add(nibble)
+                };
+            }
+
+            public Context AddStorage(in ValueHash256 storage)
+            {
+                return new Context()
+                {
+                    PathContext = PathContext.AddStorage(storage),
+                    OldStyleTrieVisitContext = OldStyleTrieVisitContext.AddStorage(storage)
+                };
+            }
+        }
 
         public TrieStatsCollector(IKeyValueStore codeKeyValueStore, ILogManager logManager, CancellationToken cancellationToken = default)
         {
@@ -29,18 +67,18 @@ namespace Nethermind.Trie
         public TrieStats Stats { get; } = new();
 
         public bool IsFullDbScan => true;
-        public void VisitTree(in TreePathContextWithStorage nodeContext, Hash256 rootHash, TrieVisitContext trieVisitContext)
+        public void VisitTree(in Context nodeContext, Hash256 rootHash)
         {
         }
 
-        public bool ShouldVisit(in TreePathContextWithStorage nodeContext, Hash256 nextNode)
+        public bool ShouldVisit(in Context nodeContext, Hash256 nextNode)
         {
             return true;
         }
 
-        public void VisitMissingNode(in TreePathContextWithStorage nodeContext, Hash256 nodeHash, TrieVisitContext trieVisitContext)
+        public void VisitMissingNode(in Context nodeContext, Hash256 nodeHash)
         {
-            if (trieVisitContext.IsStorage)
+            if (nodeContext.IsStorage)
             {
                 if (_logger.IsWarn) _logger.Warn($"Missing node. Storage: {nodeContext.Storage} Path: {nodeContext.Path} Hash: {nodeHash}");
                 Interlocked.Increment(ref Stats._missingStorage);
@@ -51,14 +89,14 @@ namespace Nethermind.Trie
                 Interlocked.Increment(ref Stats._missingState);
             }
 
-            IncrementLevel(trieVisitContext);
+            IncrementLevel(nodeContext);
         }
 
-        public void VisitBranch(in TreePathContextWithStorage nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitBranch(in Context nodeContext, TrieNode node)
         {
             _cancellationToken.ThrowIfCancellationRequested();
 
-            if (trieVisitContext.IsStorage)
+            if (nodeContext.IsStorage)
             {
                 Interlocked.Add(ref Stats._storageSize, node.FullRlp.Length);
                 Interlocked.Increment(ref Stats._storageBranchCount);
@@ -69,12 +107,12 @@ namespace Nethermind.Trie
                 Interlocked.Increment(ref Stats._stateBranchCount);
             }
 
-            IncrementLevel(trieVisitContext);
+            IncrementLevel(nodeContext);
         }
 
-        public void VisitExtension(in TreePathContextWithStorage nodeContext, TrieNode node, TrieVisitContext trieVisitContext)
+        public void VisitExtension(in Context nodeContext, TrieNode node)
         {
-            if (trieVisitContext.IsStorage)
+            if (nodeContext.IsStorage)
             {
                 Interlocked.Add(ref Stats._storageSize, node.FullRlp.Length);
                 Interlocked.Increment(ref Stats._storageExtensionCount);
@@ -85,10 +123,10 @@ namespace Nethermind.Trie
                 Interlocked.Increment(ref Stats._stateExtensionCount);
             }
 
-            IncrementLevel(trieVisitContext);
+            IncrementLevel(nodeContext);
         }
 
-        public void VisitLeaf(in TreePathContextWithStorage nodeContext, TrieNode node, TrieVisitContext trieVisitContext, ReadOnlySpan<byte> value)
+        public void VisitLeaf(in Context nodeContext, TrieNode node, ReadOnlySpan<byte> value)
         {
             long lastAccountNodeCount = _lastAccountNodeCount;
             long currentNodeCount = Stats.NodesCount;
@@ -97,7 +135,7 @@ namespace Nethermind.Trie
                 _logger.Warn($"Collected info from {Stats.NodesCount} nodes. Missing CODE {Stats.MissingCode} STATE {Stats.MissingState} STORAGE {Stats.MissingStorage}");
             }
 
-            if (trieVisitContext.IsStorage)
+            if (nodeContext.IsStorage)
             {
                 Interlocked.Add(ref Stats._storageSize, node.FullRlp.Length);
                 Interlocked.Increment(ref Stats._storageLeafCount);
@@ -108,10 +146,10 @@ namespace Nethermind.Trie
                 Interlocked.Increment(ref Stats._accountCount);
             }
 
-            IncrementLevel(trieVisitContext);
+            IncrementLevel(nodeContext);
         }
 
-        public void VisitCode(in TreePathContextWithStorage nodeContext, Hash256 codeHash, TrieVisitContext trieVisitContext)
+        public void VisitCode(in Context nodeContext, Hash256 codeHash)
         {
             ValueHash256 key = new ValueHash256(codeHash.Bytes);
             bool codeExist = _existingCodeHash.TryGet(key, out int codeLength);
@@ -137,18 +175,18 @@ namespace Nethermind.Trie
                 Interlocked.Increment(ref Stats._missingCode);
             }
 
-            IncrementLevel(trieVisitContext, Stats._codeLevels);
+            IncrementLevel(nodeContext, Stats._codeLevels);
         }
 
-        private void IncrementLevel(TrieVisitContext trieVisitContext)
+        private void IncrementLevel(Context context)
         {
-            long[] levels = trieVisitContext.IsStorage ? Stats._storageLevels : Stats._stateLevels;
-            IncrementLevel(trieVisitContext, levels);
+            long[] levels = context.IsStorage ? Stats._storageLevels : Stats._stateLevels;
+            IncrementLevel(context, levels);
         }
 
-        private static void IncrementLevel(TrieVisitContext trieVisitContext, long[] levels)
+        private static void IncrementLevel(Context context, long[] levels)
         {
-            Interlocked.Increment(ref levels[trieVisitContext.Level]);
+            Interlocked.Increment(ref levels[context.Level]);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -19,17 +19,18 @@ namespace Nethermind.Trie
         private readonly ILogger _logger;
         private readonly CancellationToken _cancellationToken;
 
+        // Combine both `TreePathContextWithStorage` and `OldStyleTrieVisitContext`
         public struct Context: INodeContext<Context>
         {
             private TreePathContextWithStorage PathContext;
             private OldStyleTrieVisitContext OldStyleTrieVisitContext;
 
-            public Hash256? Storage => PathContext.Storage;
-            public TreePath Path => PathContext.Path;
-            public bool IsStorage => OldStyleTrieVisitContext.IsStorage;
-            public int Level => OldStyleTrieVisitContext.Level;
+            public readonly Hash256? Storage => PathContext.Storage;
+            public readonly TreePath Path => PathContext.Path;
+            public readonly bool IsStorage => OldStyleTrieVisitContext.IsStorage;
+            public readonly int Level => OldStyleTrieVisitContext.Level;
 
-            public Context Add(ReadOnlySpan<byte> nibblePath)
+            public readonly Context Add(ReadOnlySpan<byte> nibblePath)
             {
                 return new Context()
                 {
@@ -38,7 +39,7 @@ namespace Nethermind.Trie
                 };
             }
 
-            public Context Add(byte nibble)
+            public readonly Context Add(byte nibble)
             {
                 return new Context()
                 {
@@ -47,7 +48,7 @@ namespace Nethermind.Trie
                 };
             }
 
-            public Context AddStorage(in ValueHash256 storage)
+            public readonly Context AddStorage(in ValueHash256 storage)
             {
                 return new Context()
                 {

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -19,7 +19,6 @@ namespace Nethermind.Trie
         public int Level { get; internal set; }
         public bool IsStorage { get; set; }
         public int? BranchChildIndex { get; internal set; }
-        public bool ExpectAccounts { get; init; }
         public int VisitedNodes => _visitedNodes;
 
         public int MaxDegreeOfParallelism
@@ -59,7 +58,6 @@ namespace Nethermind.Trie
             Level = (byte)trieVisitContext.Level;
             IsStorage = trieVisitContext.IsStorage;
             BranchChildIndex = (byte?)trieVisitContext.BranchChildIndex;
-            ExpectAccounts = trieVisitContext.ExpectAccounts;
         }
 
         public byte Level { get; internal set; }
@@ -124,7 +122,6 @@ namespace Nethermind.Trie
                 Level = Level,
                 IsStorage = IsStorage,
                 BranchChildIndex = BranchChildIndex,
-                ExpectAccounts = ExpectAccounts
             };
         }
     }

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -9,34 +9,37 @@ using Nethermind.Core.Threading;
 
 namespace Nethermind.Trie
 {
-    public struct OldTrieVisitContext : INodeContext<OldTrieVisitContext>
+    public struct OldStyleTrieVisitContext : INodeContext<OldStyleTrieVisitContext>
     {
         public int Level;
         public bool IsStorage;
         public int? BranchChildIndex;
 
-        public OldTrieVisitContext Add(ReadOnlySpan<byte> nibblePath)
+        public OldStyleTrieVisitContext Add(ReadOnlySpan<byte> nibblePath)
         {
-            return this;
-        }
-
-        public OldTrieVisitContext Add(byte nibble)
-        {
-            return new OldTrieVisitContext
+            return this with
             {
-                Level = Level,
-                IsStorage = IsStorage,
-                BranchChildIndex = nibble,
+                BranchChildIndex = null,
+                Level = Level + 1,
             };
         }
 
-        public OldTrieVisitContext AddStorage(in ValueHash256 storage)
+        public OldStyleTrieVisitContext Add(byte nibble)
         {
-            return new OldTrieVisitContext
+            return this with
             {
-                Level = Level,
+                BranchChildIndex = nibble,
+                Level = Level + 1,
+            };
+        }
+
+        public OldStyleTrieVisitContext AddStorage(in ValueHash256 storage)
+        {
+            return new OldStyleTrieVisitContext
+            {
+                BranchChildIndex = null,
                 IsStorage = true,
-                BranchChildIndex = BranchChildIndex,
+                Level = Level + 1
             };
         }
     }

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Trie
             int visitedNodes = Interlocked.Increment(ref _visitedNodes);
 
             // TODO: Fine tune interval? Use TrieNode.GetMemorySize(false) to calculate memory usage?
-            if (visitedNodes % 1_000_000 == 0)
+            if (visitedNodes % 10_000_000 == 0)
             {
                 GC.Collect();
             }

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -49,20 +49,17 @@ namespace Nethermind.Trie
         private readonly int _maxDegreeOfParallelism = 1;
         private int _visitedNodes;
 
-        private ConcurrencyController? _threadLimiter = null;
-        public ConcurrencyController ConcurrencyController => _threadLimiter ??= new ConcurrencyController(MaxDegreeOfParallelism);
-
-        public int Level { get; internal set; }
-        public bool IsStorage { get; set; }
         public int MaxDegreeOfParallelism
         {
             get => _maxDegreeOfParallelism;
             internal init
             {
                 _maxDegreeOfParallelism = VisitingOptions.AdjustMaxDegreeOfParallelism(value);
-                _threadLimiter = null;
             }
         }
+
+        public int Level { get; internal set; }
+        public bool IsStorage { get; set; }
 
         public TrieVisitContext Clone() => (TrieVisitContext)MemberwiseClone();
 

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -7,38 +7,25 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie
 {
-    public struct OldStyleTrieVisitContext : INodeContext<OldStyleTrieVisitContext>
+    public readonly struct OldStyleTrieVisitContext(int level, bool isStorage, int? branchChildIndex) : INodeContext<OldStyleTrieVisitContext>
     {
-        public int Level;
-        public bool IsStorage;
-        public int? BranchChildIndex;
+        public readonly int Level = level;
+        public readonly bool IsStorage = isStorage;
+        public readonly int? BranchChildIndex= branchChildIndex;
 
         public OldStyleTrieVisitContext Add(ReadOnlySpan<byte> nibblePath)
         {
-            return this with
-            {
-                BranchChildIndex = null,
-                Level = Level + 1,
-            };
+            return new(Level + 1, IsStorage, null);
         }
 
         public OldStyleTrieVisitContext Add(byte nibble)
         {
-            return this with
-            {
-                BranchChildIndex = nibble,
-                Level = Level + 1,
-            };
+            return new(Level + 1, IsStorage, nibble);
         }
 
         public OldStyleTrieVisitContext AddStorage(in ValueHash256 storage)
         {
-            return new OldStyleTrieVisitContext
-            {
-                BranchChildIndex = null,
-                IsStorage = true,
-                Level = Level + 1
-            };
+            return new (Level + 1, true, null);
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Threading;
 
 namespace Nethermind.Trie
 {
@@ -47,7 +45,6 @@ namespace Nethermind.Trie
     public class TrieVisitContext : IDisposable
     {
         private readonly int _maxDegreeOfParallelism = 1;
-        private int _visitedNodes;
 
         public int MaxDegreeOfParallelism
         {
@@ -58,25 +55,10 @@ namespace Nethermind.Trie
             }
         }
 
-        public int Level { get; internal set; }
         public bool IsStorage { get; set; }
-
-        public TrieVisitContext Clone() => (TrieVisitContext)MemberwiseClone();
 
         public void Dispose()
         {
-        }
-
-        public void AddVisited()
-        {
-            int visitedNodes = Interlocked.Increment(ref _visitedNodes);
-
-            // TODO: Fine tune interval? Use TrieNode.GetMemorySize(false) to calculate memory usage?
-            if (visitedNodes % 100_000_000 == 0)
-            {
-                GC.Collect();
-            }
-
         }
     }
 
@@ -85,7 +67,6 @@ namespace Nethermind.Trie
     {
         public SmallTrieVisitContext(TrieVisitContext trieVisitContext)
         {
-            Level = (byte)trieVisitContext.Level;
             IsStorage = trieVisitContext.IsStorage;
         }
 
@@ -126,15 +107,6 @@ namespace Nethermind.Trie
                     _flags = (byte)(_flags & ~ExpectAccountsFlag);
                 }
             }
-        }
-
-        public readonly TrieVisitContext ToVisitContext()
-        {
-            return new TrieVisitContext()
-            {
-                Level = Level,
-                IsStorage = IsStorage,
-            };
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Trie
             int visitedNodes = Interlocked.Increment(ref _visitedNodes);
 
             // TODO: Fine tune interval? Use TrieNode.GetMemorySize(false) to calculate memory usage?
-            if (visitedNodes % 10_000_000 == 0)
+            if (visitedNodes % 100_000_000 == 0)
             {
                 GC.Collect();
             }

--- a/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
@@ -14,11 +14,6 @@ namespace Nethermind.Trie
         private readonly int _maxDegreeOfParallelism = 1;
 
         /// <summary>
-        /// Should visit accounts.
-        /// </summary>
-        public bool ExpectAccounts { get; init; } = true;
-
-        /// <summary>
         /// Maximum number of threads that will be used to visit the trie.
         /// </summary>
         public int MaxDegreeOfParallelism


### PR DESCRIPTION
Fixes Closes Resolves #

- Convert all `ITrieVisitor` to `ITrieVisitorr<OldStyleTrievisitContext>`
- Remove `TrieVisitContext` from `ITrieVisitor<TCtx>`.
- Fix missed some storage due to concurrent access to `IsStorage` in `TrieVisitContext` by removing `TrieVisitContext` from the main visitor code.
- Encapsulate visitor code to `TrieNodeTraverser`.
- Increase GC threshold from 1Mil to 100Mil nodes.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes?
- [ ] No

#### Notes on testing

- VerifyTrie stats is now consistent.
