### PR TITLE
Fix persist cache remove node

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Consensus.Processing
             ISpecProvider specProvider,
             ILogManager logManager,
             IWorldState worldStateToWarmUp
-            ) : this(worldStateManager.GlobalStateReader, worldStateManager.CreateResettableWorldState(worldStateToWarmUp), new CodeInfoRepository((worldStateToWarmUp as IPreBlockCaches)?.Caches.PrecompileCache), readOnlyBlockTree, specProvider, logManager)
+            ) : this(worldStateManager.GlobalStateReader, worldStateManager.CreateWorldStateForWarmingUp(worldStateToWarmUp), new CodeInfoRepository((worldStateToWarmUp as IPreBlockCaches)?.Caches.PrecompileCache), readOnlyBlockTree, specProvider, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.State/IWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateManager.cs
@@ -20,9 +20,15 @@ public interface IWorldStateManager
     /// <summary>
     /// Used by read only tasks that need to execute blocks.
     /// </summary>
+    /// <returns></returns>
+    IWorldState CreateResettableWorldState();
+
+    /// <summary>
+    /// Create a read only world state to warm up another world state
+    /// </summary>
     /// <param name="forWarmup">Specify a world state to warm up by the returned world state.</param>
     /// <returns></returns>
-    IWorldState CreateResettableWorldState(IWorldState? forWarmup = null);
+    IWorldState CreateWorldStateForWarmingUp(IWorldState forWarmup);
 
     event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State.Healing;
-using Nethermind.State.Snap;
 using Nethermind.State.SnapServer;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -78,7 +75,15 @@ public class WorldStateManager : IWorldStateManager
 
     public ISnapServer? SnapServer => _trieStore.Scheme == INodeStorage.KeyScheme.Hash ? null : new SnapServer.SnapServer(_readOnlyTrieStore, _readaOnlyCodeCb, GlobalStateReader, _logManager, _lastNStateRootTracker);
 
-    public IWorldState CreateResettableWorldState(IWorldState? forWarmup = null)
+    public IWorldState CreateResettableWorldState()
+    {
+        return new WorldState(
+            _readOnlyTrieStore,
+            _readaOnlyCodeCb,
+            _logManager);
+    }
+
+    public IWorldState CreateWorldStateForWarmingUp(IWorldState forWarmup)
     {
         PreBlockCaches? preBlockCaches = (forWarmup as IPreBlockCaches)?.Caches;
         return preBlockCaches is not null
@@ -87,10 +92,7 @@ public class WorldStateManager : IWorldStateManager
                 _readaOnlyCodeCb,
                 _logManager,
                 preBlockCaches)
-            : new WorldState(
-                _readOnlyTrieStore,
-                _readaOnlyCodeCb,
-                _logManager);
+            : CreateResettableWorldState();
     }
 
     public IOverridableWorldScope CreateOverridableWorldScope()

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1085,7 +1085,8 @@ namespace Nethermind.Trie.Test.Pruning
 
             return;
 
-            (Hash256, Hash256) SetupStartingState() {
+            (Hash256, Hash256) SetupStartingState()
+            {
                 WorldState worldState = new WorldState(new TrieStore(nodeStorage, LimboLogs.Instance), memDbProvider.CodeDb, LimboLogs.Instance);
                 worldState.StateRoot = Keccak.EmptyTreeHash;
                 worldState.CreateAccountIfNotExists(address, UInt256.One);

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -11,8 +11,10 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 using NSubstitute;
@@ -1046,6 +1048,56 @@ namespace Nethermind.Trie.Test.Pruning
             }
 
             memDb.Count.Should().Be(4);
+        }
+
+        [Test]
+        public void When_SomeKindOfNonResolvedNotInMainWorldState_OnPrune_DoNotDeleteNode()
+        {
+            IDbProvider memDbProvider = TestMemDbProvider.Init();
+            Address address = TestItem.AddressA;
+            UInt256 slot = 1;
+
+            INodeStorage nodeStorage = new NodeStorage(memDbProvider.StateDb, _scheme);
+            (Hash256 stateRoot, Hash256 storageRoot) = SetupStartingState();
+            nodeStorage.Get(address.ToAccountPath, TreePath.Empty, storageRoot).Should().NotBeNull();
+
+            using TrieStore fullTrieStore = CreateTrieStore(
+                kvStore: memDbProvider.StateDb,
+                pruningStrategy: new TestPruningStrategy(true, true, 2, 100000),
+                persistenceStrategy: No.Persistence);
+
+            WorldState worldState = new WorldState(
+                fullTrieStore,
+                memDbProvider.CodeDb,
+                LimboLogs.Instance);
+
+            // Simulate some kind of cache access which causes unresolved node to remain.
+            IScopedTrieStore storageTrieStore = fullTrieStore.GetTrieStore(address.ToAccountPath);
+            storageTrieStore.FindCachedOrUnknown(TreePath.Empty, storageRoot);
+
+            worldState.StateRoot = stateRoot;
+            worldState.IncrementNonce(address, 1);
+            worldState.Commit(MainnetSpecProvider.Instance.GenesisSpec);
+            worldState.CommitTree(2);
+
+            fullTrieStore.PersistCache(default);
+            nodeStorage.Get(address.ToAccountPath, TreePath.Empty, storageRoot).Should().NotBeNull();
+
+            return;
+
+            (Hash256, Hash256) SetupStartingState() {
+                WorldState worldState = new WorldState(new TrieStore(nodeStorage, LimboLogs.Instance), memDbProvider.CodeDb, LimboLogs.Instance);
+                worldState.StateRoot = Keccak.EmptyTreeHash;
+                worldState.CreateAccountIfNotExists(address, UInt256.One);
+                worldState.Set(new StorageCell(address, slot), TestItem.KeccakB.BytesToArray());
+                worldState.Commit(MainnetSpecProvider.Instance.GenesisSpec);
+                worldState.CommitTree(1);
+
+                ValueHash256 storageRoot = worldState.GetStorageRoot(address);
+                Hash256 stateRoot = worldState.StateRoot;
+                return (stateRoot, storageRoot);
+            }
+
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -347,6 +347,7 @@ internal class TrieStoreDirtyNodesCache
         void PersistNode(TrieNode n, Hash256? address, TreePath path)
         {
             if (n.Keccak is null) return;
+            if (n.NodeType == NodeType.Unknown) return;
             Key key = new Key(address, path, n.Keccak);
             if (wasPersisted.TryAdd(key, true))
             {


### PR DESCRIPTION
- Fix persist cache remove unresolved node at start of full pruning likely due to some kind of caching at world state level which causes the storage root to load but never used and therefore resolved.

## Changes

- Check if nodetype is unknown.
- Split `CreateResettableWorldState` for prewarming to its own method.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested to work together with #8221 . #8221 have a fix for when storage root is missed under high thread count use.