### PR TITLE
Limit task count in tests

### DIFF
--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -24,6 +24,7 @@ namespace Nethermind.Config
         public ulong SecondsPerSlot { get; set; } = 12;
 
         public bool PreWarmStateOnBlockProcessing { get; set; } = true;
+        public int PreWarmStateConcurrency { get; set; } = 0;
 
         public int BlockProductionTimeoutMs { get; set; } = 4_000;
 

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -37,6 +37,9 @@ public interface IBlocksConfig : IConfig
     [ConfigItem(Description = "Whether to pre-warm the state when processing blocks. This can lead to an up to 2x speed-up in the main loop block processing.", DefaultValue = "True")]
     bool PreWarmStateOnBlockProcessing { get; set; }
 
+    [ConfigItem(Description = "Specify pre-warm state concurrency. Default is logical processor - 1.", DefaultValue = "0", HiddenFromDocs = true)]
+    int PreWarmStateConcurrency { get; set; }
+
     [ConfigItem(Description = "The block production timeout, in milliseconds.", DefaultValue = "4000")]
     int BlockProductionTimeoutMs { get; set; }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -48,8 +48,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         {
             // Optimize for single reader concurrency
             SingleReader = true,
-            // Share thread with request, if waiting
-            AllowSynchronousContinuations = true
         });
 
     private readonly Channel<BlockRef> _blockQueue = Channel.CreateBounded<BlockRef>(
@@ -59,8 +57,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             SingleReader = true,
             // Optimize for single writer concurrency (recovery queue)
             SingleWriter = true,
-            // Share thread with request, if waiting
-            AllowSynchronousContinuations = true
         });
 
     private bool _recoveryComplete = false;

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -396,7 +396,7 @@ public class TestBlockchain : IDisposable
 
 
     protected virtual IBlockCachePreWarmer CreateBlockCachePreWarmer() =>
-        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager, WorldStateManager.GlobalWorldState), SpecProvider, LogManager, PreBlockCaches);
+        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager, WorldStateManager.GlobalWorldState), SpecProvider, 4, LogManager, PreBlockCaches);
 
     public async Task WaitForNewHead()
     {

--- a/src/Nethermind/Nethermind.Core.Test/Caching/ClockKeyCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/ClockKeyCacheTests.cs
@@ -155,7 +155,8 @@ namespace Nethermind.Core.Test.Caching
         public void Beyond_capacity_lru_parallel()
         {
             ClockKeyCache<AddressAsKey> cache = new(Capacity);
-            Parallel.For(0, Environment.ProcessorCount * 8, (s) =>
+            int processorCount = Math.Min(Environment.ProcessorCount, 32);
+            Parallel.For(0, processorCount * 8, (s) =>
             {
                 for (int ii = 0; ii < Capacity; ii++)
                 {

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
@@ -174,7 +174,8 @@ namespace Nethermind.Core.Test.Caching
         public void Beyond_capacity_lru_parallel()
         {
             LruKeyCache<AddressAsKey> cache = new(Capacity, Capacity / 2, "test");
-            Parallel.For(0, Environment.ProcessorCount * 8, (iter) =>
+            int processorCount = Math.Min(Environment.ProcessorCount, 32);
+            Parallel.For(0, processorCount * 8, (iter) =>
             {
                 for (int ii = 0; ii < Capacity; ii++)
                 {
@@ -197,7 +198,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     cache.Get(_addresses[i + Capacity]);
 
-                    if (iter % Environment.ProcessorCount == 0)
+                    if (iter % processorCount == 0)
                     {
                         cache.Clear();
                     }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -91,7 +91,13 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
                 syncConfig.MultiSyncModeSelectorLoopTimerMs = 1;
                 syncConfig.SyncDispatcherEmptyRequestDelayMs = 1;
                 syncConfig.SyncDispatcherAllocateTimeoutMs = 1;
+                syncConfig.MaxProcessingThreads = 4;
                 return syncConfig;
+            })
+            .AddDecorator<IBlocksConfig>((_, blocksConfig) =>
+            {
+                blocksConfig.PreWarmStateConcurrency = 4;
+                return blocksConfig;
             })
             .AddDecorator<INetworkConfig>((_, networkConfig) =>
             {

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Net;
 using Autofac;
 using Nethermind.Blockchain;
@@ -91,12 +92,12 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
                 syncConfig.MultiSyncModeSelectorLoopTimerMs = 1;
                 syncConfig.SyncDispatcherEmptyRequestDelayMs = 1;
                 syncConfig.SyncDispatcherAllocateTimeoutMs = 1;
-                syncConfig.MaxProcessingThreads = 4;
+                syncConfig.MaxProcessingThreads = Math.Min(8, Environment.ProcessorCount);
                 return syncConfig;
             })
             .AddDecorator<IBlocksConfig>((_, blocksConfig) =>
             {
-                blocksConfig.PreWarmStateConcurrency = 4;
+                blocksConfig.PreWarmStateConcurrency = Math.Min(4, Environment.ProcessorCount);
                 return blocksConfig;
             })
             .AddDecorator<INetworkConfig>((_, networkConfig) =>

--- a/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
+++ b/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
@@ -33,8 +33,8 @@ public static class RuntimeInformation
     }
 
     public static int PhysicalCoreCount { get; } = GetCpuInfo()?.PhysicalCoreCount ?? Environment.ProcessorCount;
-    public static ParallelOptions ParallelOptionsPhysicalCores { get; } = new() { MaxDegreeOfParallelism = PhysicalCoreCount };
     public static ParallelOptions ParallelOptionsLogicalCores { get; } = new() { MaxDegreeOfParallelism = Environment.ProcessorCount };
+    public static ParallelOptions ParallelOptionsLogicalCoresUpTo16 { get; } = new() { MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 16) };
 
     public static bool Is64BitPlatform() => IntPtr.Size == 8;
 }

--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
@@ -206,7 +206,7 @@ public class ValidateSubmissionHandler
 
         UInt256 feeRecipientBalanceBefore = currentState.HasStateForRoot(currentState.StateRoot) ? (currentState.AccountExists(feeRecipient) ? currentState.GetBalance(feeRecipient) : UInt256.Zero) : UInt256.Zero;
 
-        IBlockCachePreWarmer preWarmer = new BlockCachePreWarmer(_readOnlyTxProcessingEnvFactory, _specProvider, _logManager);
+        IBlockCachePreWarmer preWarmer = new BlockCachePreWarmer(_readOnlyTxProcessingEnvFactory, _specProvider, 0, _logManager);
 
         BlockProcessor blockProcessor = CreateBlockProcessor(currentState, transactionProcessor, _flashbotsConfig.EnablePreWarmer ? preWarmer : null);
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -107,6 +107,7 @@ namespace Nethermind.Init.Steps
                         _api.LogManager,
                         _api.WorldStateManager!.GlobalWorldState),
                     _api.SpecProvider!,
+                    blocksConfig,
                     _api.LogManager,
                     preBlockCaches)
                 : null;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -366,7 +366,7 @@ public partial class BlockDownloaderTests
         peerAllocation.AllocateBestPeer(new List<PeerInfo>(), Substitute.For<INodeStatsManager>(), ctx.BlockTree);
 
         ctx.PeerPool
-            .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>())
+            .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(peerAllocation));
 
         SyncFeedComponent<BlocksRequest> fastSyncFeedComponent = ctx.FastSyncFeedComponent;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -43,7 +43,7 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization.Test;
 
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Self)]
 public partial class BlockDownloaderTests
 {
     [TestCase(1L, DownloaderOptions.Process, 0)]

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -43,7 +43,7 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization.Test;
 
-[Parallelizable(ParallelScope.Children)]
+[Parallelizable(ParallelScope.All)]
 public partial class BlockDownloaderTests
 {
     [TestCase(1L, DownloaderOptions.Process, 0)]

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -43,7 +43,7 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization.Test;
 
-[Parallelizable(ParallelScope.Self)]
+[Parallelizable(ParallelScope.Children)]
 public partial class BlockDownloaderTests
 {
     [TestCase(1L, DownloaderOptions.Process, 0)]

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Synchronization.Test.FastSync.SnapProtocolTests
 
         public async Task ExecuteDispatch(StateSyncBatch batch, int times)
         {
-            SyncPeerAllocation allocation = await Allocate(batch);
+            SyncPeerAllocation allocation = await Allocate(batch, default);
 
             for (int i = 0; i < times; i++)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -394,7 +394,6 @@ namespace Nethermind.Synchronization.Test.FastSync
         }
 
         [Test]
-        [Parallelizable(ParallelScope.None)] // TODO: Investigate why it fails with parralelization
         public async Task When_empty_response_received_with_no_peer_return_not_allocated()
         {
             DbContext dbContext = new(_logger, _logManager);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -10,6 +10,7 @@ using Autofac;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -111,11 +112,10 @@ namespace Nethermind.Synchronization.Test.FastSync
         protected ContainerBuilder BuildTestContainerBuilder(DbContext dbContext, int syncDispatcherAllocateTimeoutMs = 10)
         {
             ContainerBuilder containerBuilder = new ContainerBuilder()
-                .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, null))
-                .AddModule(new TestSynchronizerModule(new TestSyncConfig()
+                .AddModule(new TestNethermindModule(new ConfigProvider(new SyncConfig()
                 {
                     FastSync = true
-                }))
+                })))
                 .AddDecorator<ISyncConfig>((_, syncConfig) => // Need to be a decorator because `TestEnvironmentModule` override `SyncDispatcherAllocateTimeoutMs` for other tests, but we need specific value.
                 {
                     syncConfig.SyncDispatcherAllocateTimeoutMs = syncDispatcherAllocateTimeoutMs; // there is a test for requested nodes which get affected if allocate timeout

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -297,10 +297,6 @@ public class SynchronizerTests
 
             _logger = _logManager.GetClassLogger();
             ISyncConfig syncConfig = GetSyncConfig();
-            syncConfig.MultiSyncModeSelectorLoopTimerMs = 1;
-            syncConfig.SyncDispatcherEmptyRequestDelayMs = 1;
-            syncConfig.SyncDispatcherAllocateTimeoutMs = 1;
-
             MergeConfig mergeConfig = new();
             if (WithTTD(synchronizerType))
             {
@@ -309,6 +305,7 @@ public class SynchronizerTests
             }
             IConfigProvider configProvider = new ConfigProvider(syncConfig, mergeConfig);
             ContainerBuilder builder = new ContainerBuilder()
+                .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, null))
                 .AddModule(new TestNethermindModule(configProvider))
                 .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
                 .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -305,7 +305,6 @@ public class SynchronizerTests
             }
             IConfigProvider configProvider = new ConfigProvider(syncConfig, mergeConfig);
             ContainerBuilder builder = new ContainerBuilder()
-                .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, null))
                 .AddModule(new TestNethermindModule(configProvider))
                 .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
                 .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)

--- a/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Blockchain.Synchronization;
 
 namespace Nethermind.Synchronization.Test;
@@ -13,6 +14,6 @@ public class TestSyncConfig : SyncConfig
         MultiSyncModeSelectorLoopTimerMs = 1;
         SyncDispatcherEmptyRequestDelayMs = 1;
         SyncDispatcherAllocateTimeoutMs = 1;
-        MaxProcessingThreads = 4;
+        MaxProcessingThreads = Math.Min(Environment.ProcessorCount, 8);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/TestSyncConfig.cs
@@ -13,5 +13,6 @@ public class TestSyncConfig : SyncConfig
         MultiSyncModeSelectorLoopTimerMs = 1;
         SyncDispatcherEmptyRequestDelayMs = 1;
         SyncDispatcherAllocateTimeoutMs = 1;
+        MaxProcessingThreads = 4;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Synchronization.ParallelSync
                             continue;
                         }
 
-                        SyncPeerAllocation allocation = await Allocate(request);
+                        SyncPeerAllocation allocation = await Allocate(request, cancellationToken);
                         PeerInfo? allocatedPeer = allocation.Current;
                         if (Logger.IsTrace) Logger.Trace($"Allocated peer: {allocatedPeer}");
                         if (allocatedPeer is not null)
@@ -243,9 +243,9 @@ namespace Nethermind.Synchronization.ParallelSync
             SyncPeerPool.Free(allocation);
         }
 
-        protected async Task<SyncPeerAllocation> Allocate(T request)
+        protected async Task<SyncPeerAllocation> Allocate(T request, CancellationToken cancellationToken)
         {
-            SyncPeerAllocation allocation = await SyncPeerPool.Allocate(PeerAllocationStrategyFactory.Create(request), Feed.Contexts, _allocateTimeoutMs);
+            SyncPeerAllocation allocation = await SyncPeerPool.Allocate(PeerAllocationStrategyFactory.Create(request), Feed.Contexts, _allocateTimeoutMs, cancellationToken);
             Downloader.OnAllocate(allocation);
             return allocation;
         }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
@@ -28,8 +28,8 @@ namespace Nethermind.Synchronization.Peers
 
         public bool HasPeer => Current is not null;
 
-        public SyncPeerAllocation(PeerInfo peerInfo, AllocationContexts contexts)
-            : this(new StaticStrategy(peerInfo), contexts, null)
+        public SyncPeerAllocation(PeerInfo peerInfo, AllocationContexts contexts, Lock? allocationLock = null)
+            : this(new StaticStrategy(peerInfo), contexts, allocationLock)
         {
         }
 

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -916,6 +916,7 @@ namespace Nethermind.Trie.Test.Pruning
         }
 
         [Test]
+        [Retry(3)]
         public async Task Will_RemovePastKeys_OnSnapshot()
         {
             MemDb memDb = new();

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -166,7 +166,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool bufferPool)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCoresUpTo16,
                     (local: 0, item, tree, bufferPool, rootPath),
                     static (i, state) =>
                     {
@@ -227,7 +227,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCoresUpTo16,
                     (local: 0, item, tree, bufferPool, rootPath),
                     static (i, state) =>
                     {


### PR DESCRIPTION
- Unit tests slows down with high core count machine which seems to be due to the spawing of tasks.
- This PR limits those tasks creation.

## Changes

- Add config to limit prewarming task count.
- Reduce default limit of concurrent task for dispatcher in tests.
- Disable `AllowSynchronousContinuations` as it randomly deadlock tests.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [X] Yes?
- [ ] No

#### Notes on testing

- Seems to be faster but still not passing completely.