### PR TITLE
Reintroduce missing 4844 RPC fields (GasPrice and V)

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
@@ -27,12 +27,6 @@ public class BlobTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction<
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public byte[][]? Blobs { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    public override UInt256? GasPrice { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    public override UInt256? V { get; set; }
-
     [JsonConstructor]
     public BlobTransactionForRpc() { }
 

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
@@ -17,14 +17,6 @@ public class SetCodeTransactionForRpc : EIP1559TransactionForRpc, IFromTransacti
     [JsonDiscriminator]
     public AuthorizationListForRpc AuthorizationList { get; set; }
 
-    #region Deprecated fields
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    public override UInt256? GasPrice { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    public override UInt256? V { get; set; }
-    #endregion
-
     [JsonConstructor]
     public SetCodeTransactionForRpc() { }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/BlobTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/BlobTransactionForRpcTests.cs
@@ -122,7 +122,7 @@ public static class BlobTransactionForRpcTests
         json.GetProperty("yParity").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
         json.GetProperty("r").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
         json.GetProperty("s").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
-        
+
         // Assert deserialization-only are not serialized
         json.TryGetProperty("blobs", out _).Should().BeFalse();
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/BlobTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/BlobTransactionForRpcTests.cs
@@ -122,11 +122,7 @@ public static class BlobTransactionForRpcTests
         json.GetProperty("yParity").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
         json.GetProperty("r").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
         json.GetProperty("s").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
-
-        // Assert deprecated fields are no longer serialized
-        json.TryGetProperty("v", out _).Should().BeFalse();
-        json.TryGetProperty("gasPrice", out _).Should().BeFalse();
-
+        
         // Assert deserialization-only are not serialized
         json.TryGetProperty("blobs", out _).Should().BeFalse();
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/SetCodeTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/SetCodeTransactionForRpcTests.cs
@@ -129,9 +129,5 @@ public static class SetCodeTransactionForRpcTests
             tuple.GetProperty("r").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
             tuple.GetProperty("s").GetString().Should().MatchRegex("^0x([1-9a-f]+[0-9a-f]*|0)$");
         });
-
-        // Assert deprecated fields are no longer serialized
-        json.TryGetProperty("gasPrice", out _).Should().BeFalse();
-        json.TryGetProperty("v", out _).Should().BeFalse();
     }
 }


### PR DESCRIPTION
Fixes #8230 introduced in #7483

## Changes

- Reintroduce missing 4844 RPC fields (GasPrice and V)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Potentially hotfix release?
