### PR TITLE
Change FCU update head message to be less confusing

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -284,7 +284,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         if (shouldUpdateHead)
         {
             _poSSwitcher.ForkchoiceUpdated(newHeadBlock.Header, finalizedBlockHash);
-            if (_logger.IsInfo) _logger.Info($"Synced Chain Head to {newHeadBlock.ToString(Block.Format.Short)}");
+            if (_logger.IsInfo) _logger.Info($"Updated Chain Head to {newHeadBlock.ToString(Block.Format.Short)}");
         }
 
         return null;

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -42,7 +42,7 @@
       <highlight-word regex="(Disposing|Stopping|SyncDispatcher`1) .*" foregroundColor="Gray" wholeWords="true" />
       <!-- Important events at start of line -->
       <highlight-word regex="(?&lt;=\| )(Received ForkChoice)" foregroundColor="DarkGreen" wholeWords="true" />
-      <highlight-word regex="(?&lt;=\| )(Valid|Synced Chain Head)" foregroundColor="Green" wholeWords="true" />
+      <highlight-word regex="(?&lt;=\| )(Valid|Updated Chain Head)" foregroundColor="Green" wholeWords="true" />
       <highlight-word regex="(?&lt;=\| )(candidates cleanup|BeaconChain|Old Headers|Old Bodies|Old Receipts|Snap|Using pivot|Closing|Waiting for Forkchoice message from Consensus Layer|State Sync)" foregroundColor="Cyan" wholeWords="true" />
       <!-- Semi-important events at start of line -->
       <highlight-word regex="(?&lt;=\| )(Received)" foregroundColor="Blue" wholeWords="true" />


### PR DESCRIPTION
## Changes

- Rename `Synced Chain Head` -> `Updated Chain Head` to not confuse users that we are still syncing. User was confused his node is not yet synced.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: logs

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No