### PR TITLE
Add message with exact error to `AcceptTxResult.Invalid`

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1070,7 +1070,7 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_sendRawTransaction", rawTransaction);
         Transaction tx = Rlp.Decode<Transaction>(Bytes.FromHexString(rawTransaction));
         await txSender.Received().SendTransaction(tx, TxHandlingOptions.PersistentBroadcast);
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"Invalid\"},\"id\":67}"));
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"Invalid, InvalidTxSignature: Signature is invalid.\"},\"id\":67}"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsMalformed++;
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
-                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction: {result}.");
+                if (logger.IsInfo) logger.Info($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction: {result}");
                 return AcceptTxResult.Invalid;
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsMalformed++;
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
-                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction.");
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction: {result}.");
                 return AcceptTxResult.Invalid;
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -24,8 +24,8 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsMalformed++;
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
-                if (logger.IsInfo) logger.Info($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction: {result}");
-                return AcceptTxResult.Invalid;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction: {result}");
+                return AcceptTxResult.Invalid.WithMessage($"{result}");
             }
 
             return AcceptTxResult.Accepted;


### PR DESCRIPTION
## Changes

- adding message with exact error to `AcceptTxResult.Invalid`
so there will be e.g.:
`Invalid, BlobTxGasLimitExceeded: Transaction's totalDataGas=393216 exceeded MaxBlobGas per transaction=262144.`
instead of just:
`Invalid`

We need to ensure that it will be compatible with our RPC users as error code will be changed (extended) now.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No