### PR TITLE
Skip SLOAD and SSTORE lookups on empty storage

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -370,11 +370,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
         if (!exists)
         {
             Hash256 storageRoot = _stateProvider.GetStorageRoot(address);
-            if (storageRoot == Keccak.EmptyTreeHash)
-            {
-                // We know all lookups will be empty against this tree
-                isEmpty = true;
-            }
+            isEmpty = storageRoot == Keccak.EmptyTreeHash; // We know all lookups will be empty against this tree
             value = _storageTreeFactory.Create(address, _trieStore.GetTrieStore(address.ToAccountPath), storageRoot, StateRoot, _logManager);
         }
 


### PR DESCRIPTION
## Changes

- If an account's storage is empty; then we can skip db reads for all slots for `SLOAD` and `SSTORE` (extending the self-destruct approach)
    - New contract creates, set code, etc

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No