### PR TITLE
secp256r1 improvements

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -51,6 +51,7 @@
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.4" />
     <PackageVersion Include="Nethermind.Crypto.Pairings" Version="1.1.1" />
     <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.4.0" />
+    <PackageVersion Include="Nethermind.Crypto.SecP256r1" Version="1.0.0" />
     <PackageVersion Include="Nethermind.DotNetty.Buffers" Version="1.0.1" />
     <PackageVersion Include="Nethermind.DotNetty.Handlers" Version="1.0.1" />
     <PackageVersion Include="Nethermind.DotNetty.Transport" Version="1.0.1" />

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Nethermind.Crypto.Pairings" />
     <PackageReference Include="Nethermind.Crypto.Bls" />
     <PackageReference Include="Nethermind.Gmp" />
+    <PackageReference Include="Nethermind.Crypto.SecP256r1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Data\JSTracers\*.js">

--- a/src/Nethermind/Nethermind.Evm/Precompiles/Secp256r1Precompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/Secp256r1Precompile.cs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Security.Cryptography;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 
 namespace Nethermind.Evm.Precompiles;
 
@@ -19,24 +19,12 @@ public class Secp256r1Precompile : IPrecompile<Secp256r1Precompile>
     public long BaseGasCost(IReleaseSpec releaseSpec) => 3450L;
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0L;
 
-    // TODO can be optimized - Go implementation is 2-6 times faster depending on the platform. Options:
-    // - Try to replicate Go version in C#
-    // - Compile Go code into a library and call it via P/Invoke
     public (byte[], bool) Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
     {
         if (inputData.Length != 160)
             return (null, true);
 
-        ReadOnlySpan<byte> bytes = inputData.Span;
-        ReadOnlySpan<byte> hash = bytes[..32], sig = bytes[32..96];
-        ReadOnlySpan<byte> x = bytes[96..128], y = bytes[128..160];
-
-        using var ecdsa = ECDsa.Create(new ECParameters
-        {
-            Curve = ECCurve.NamedCurves.nistP256,
-            Q = new() { X = x.ToArray(), Y = y.ToArray() }
-        });
-        var isValid = ecdsa.VerifyHash(hash, sig);
+        var isValid = Secp256r1.VerifySignature(in inputData);
 
         Metrics.Secp256r1Precompile++;
 

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/Secp256r1Benchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/Secp256r1Benchmark.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Evm.Precompiles;
+
+namespace Nethermind.Precompiles.Benchmark;
+
+public class Secp256r1Benchmark: PrecompileBenchmarkBase
+{
+    protected override IEnumerable<IPrecompile> Precompiles => [Secp256r1Precompile.Instance];
+    protected override string InputsDirectory => "secp256r1";
+}


### PR DESCRIPTION
**[WIP] Requires few other PRs to be merged**

Improvements to secp256r1 precompile.

## Changes

- Switches to Go ECDSA using P/Invoke to improve speed
- Adds precompile benchmarks

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
