### PR TITLE
Configurable fast sync lag

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -594,7 +594,8 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             }
             catch (OperationCanceledException)
             {
-                if (DisconnectFailure != null) Assert.Fail($"Disconnect detected. {DisconnectFailure}");
+                if (DisconnectFailure == null) throw; // Timeout without disconnect
+                Assert.Fail($"Disconnect detected. {DisconnectFailure}");
             }
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -593,7 +593,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
             syncProgressResolver.FindBestHeader().Returns(Scenario.ChainHead.Number);
             syncProgressResolver.FindBestFullBlock().Returns(Scenario.ChainHead.Number);
-            syncProgressResolver.FindBestFullState().Returns(Scenario.ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+            syncProgressResolver.FindBestFullState().Returns(Scenario.ChainHead.Number - 32);
             syncProgressResolver.FindBestProcessedBlock().Returns(0);
             syncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.FinishedReceipts);
             syncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -24,6 +24,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
         public static class Scenario
         {
             public const long FastSyncCatchUpHeightDelta = 64;
+            public const long FastSyncLag = 32;
 
             public static BlockHeader Pivot { get; } = Build.A.Block
                 .WithDifficulty(1)
@@ -82,7 +83,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             public static BlockHeader SlightlyFutureHeadWithFastSyncLag { get; } = Build.A.Block
                 .WithDifficulty(1)
                 .WithTotalDifficulty(Pivot.TotalDifficulty + 2048 + 4)
-                .WithNumber(ChainHead.Number + MultiSyncModeSelector.FastSyncLag + 1)
+                .WithNumber(ChainHead.Number + FastSyncLag + 1)
                 .TestObject.Header;
 
             public static BlockHeader MaliciousPrePivot { get; } = Build.A.Block
@@ -350,7 +351,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _syncProgressSetups.Add(
                         () =>
                         {
-                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
@@ -367,9 +368,9 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _syncProgressSetups.Add(
                         () =>
                         {
-                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(fastBlocksState);
                             SyncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
@@ -384,9 +385,9 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _syncProgressSetups.Add(
                         () =>
                         {
-                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(fastBlocksState);
                             SyncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
@@ -401,9 +402,9 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _syncProgressSetups.Add(
                         () =>
                         {
-                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag - 7);
+                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncLag - 7);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.FinishedReceipts);
                             SyncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
@@ -420,7 +421,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.FinishedReceipts);
                             SyncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
@@ -435,7 +436,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _syncProgressSetups.Add(
                         () =>
                         {
-                            bestHeader ??= ChainHead.Number - MultiSyncModeSelector.FastSyncLag;
+                            bestHeader ??= ChainHead.Number - FastSyncLag;
                             SyncProgressResolver.FindBestHeader().Returns(bestHeader.Value);
 
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
@@ -452,7 +453,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                 public ScenarioBuilder IfThisNodeJustStartedFullSyncProcessing(FastBlocksState fastBlocksState = FastBlocksState.FinishedReceipts)
                 {
-                    long currentBlock = ChainHead.Number - MultiSyncModeSelector.FastSyncLag + 1;
+                    long currentBlock = ChainHead.Number - FastSyncLag + 1;
                     _syncProgressSetups.Add(
                         () =>
                         {
@@ -470,13 +471,13 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                 public ScenarioBuilder IfThisNodeJustFinishedStateSyncButBehindHeader(FastBlocksState fastBlocksState = FastBlocksState.FinishedReceipts)
                 {
-                    long currentBlock = ChainHead.Number - MultiSyncModeSelector.FastSyncLag;
+                    long currentBlock = ChainHead.Number - FastSyncLag;
                     _syncProgressSetups.Add(
                         () =>
                         {
                             SyncProgressResolver.FindBestHeader().Returns(currentBlock);
                             SyncProgressResolver.FindBestFullBlock().Returns(0); //no full blocks available
-                            SyncProgressResolver.FindBestFullState().Returns(currentBlock - 4); //pivot is set to header, but then header follows the head of the chain 
+                            SyncProgressResolver.FindBestFullState().Returns(currentBlock - 4); //pivot is set to header, but then header follows the head of the chain
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(fastBlocksState);
                             SyncProgressResolver.ChainDifficulty.Returns((UInt256)currentBlock);
@@ -489,7 +490,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                 public ScenarioBuilder IfThisNodeRecentlyStartedFullSyncProcessing(FastBlocksState fastBlocksState = FastBlocksState.FinishedReceipts)
                 {
-                    long currentBlock = ChainHead.Number - MultiSyncModeSelector.FastSyncLag / 2;
+                    long currentBlock = ChainHead.Number - FastSyncLag / 2;
                     _syncProgressSetups.Add(
                         () =>
                         {
@@ -517,10 +518,10 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag + 1);
-                            SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncLag + 1);
+                            SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.FinishedReceipts);
-                            SyncProgressResolver.ChainDifficulty.Returns((UInt256)ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.ChainDifficulty.Returns((UInt256)ChainHead.Number - FastSyncLag);
                             return "recently started full sync on empty clique chain";
                         }
                     );
@@ -817,7 +818,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             BeaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
                             BeaconSyncStrategy.GetTargetBlockHeight().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - FastSyncLag);
                             SyncProgressResolver.IsFastBlocksHeadersFinished().Returns(true);
                             return "beacon process destination with fast sync lag";
                         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
@@ -12,9 +12,9 @@ namespace Nethermind.Synchronization.Test.SnapSync;
 
 public class StateSyncPivotTest
 {
-    [TestCase(1000, 1000, 10, 100, 1022, 0)]
-    [TestCase(900, 1000, 10, 50, 1022, 0)]
-    [TestCase(900, 1000, 10, 100, 1022, 0)]
+    [TestCase(1000, 1000, 10, 100, 1000, 0)]
+    [TestCase(900, 1000, 10, 50, 1000, 0)]
+    [TestCase(900, 1000, 10, 100, 1000, 0)]
     [TestCase(900, 900, 32, 100, 900, 0)]
     [TestCase(0, 300, 32, 100, 301, 300)]
     public void Will_set_new_best_header_some_distance_from_best_suggested(

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/FastSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/FastSyncFeed.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Synchronization.Blocks
         public FastSyncFeed(ISyncConfig syncConfig)
         {
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
-            _blocksRequest = new BlocksRequest(BuildOptions(), MultiSyncModeSelector.FastSyncLag);
+            _blocksRequest = new BlocksRequest(BuildOptions(), syncConfig.StateMinDistanceFromHead);
         }
 
         protected override SyncMode ActivationSyncModes { get; } = SyncMode.FastSync;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Synchronization.FastSync
 
         public BlockHeader? GetPivotHeader()
         {
-            if (_bestHeader is null || (blockTree.BestSuggestedHeader?.Number + MultiSyncModeSelector.FastSyncLag) - _bestHeader.Number >= syncConfig.StateMaxDistanceFromHead)
+            if (_bestHeader is null || (blockTree.BestSuggestedHeader?.Number + syncConfig.StateMinDistanceFromHead) - _bestHeader.Number >= syncConfig.StateMaxDistanceFromHead)
             {
                 TrySetNewBestHeader($"distance from HEAD:{Diff}");
             }
@@ -32,7 +32,7 @@ namespace Nethermind.Synchronization.FastSync
 
         public void UpdateHeaderForcefully()
         {
-            if (_bestHeader is null || (blockTree.BestSuggestedHeader?.Number + MultiSyncModeSelector.FastSyncLag) > _bestHeader.Number)
+            if (_bestHeader is null || (blockTree.BestSuggestedHeader?.Number + syncConfig.StateMinDistanceFromHead) > _bestHeader.Number)
             {
                 TrySetNewBestHeader("too many empty responses");
             }
@@ -40,8 +40,8 @@ namespace Nethermind.Synchronization.FastSync
 
         private void TrySetNewBestHeader(string msg)
         {
-            BlockHeader bestSuggestedHeader = blockTree.BestSuggestedHeader;
-            long targetBlockNumber = (bestSuggestedHeader?.Number ?? 0) + MultiSyncModeSelector.FastSyncLag - syncConfig.StateMinDistanceFromHead;
+            BlockHeader bestSuggestedHeader = blockTree.BestSuggestedHeader; // Note: Best suggested header is always `syncConfig.StateMinDistanceFromHead`. behind from actual head.
+            long targetBlockNumber = (bestSuggestedHeader?.Number ?? 0);
             targetBlockNumber = Math.Max(targetBlockNumber, 0);
             // The new pivot must be at least one block after the sync pivot as the forward downloader does not
             // download the block at the sync pivot which may cause state not found error if state was downloaded

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -35,11 +35,6 @@ namespace Nethermind.Synchronization.ParallelSync
     public class MultiSyncModeSelector : ISyncModeSelector
     {
         /// <summary>
-        /// Number of blocks before the best peer's head when we switch from fast sync to full sync
-        /// </summary>
-        public const int FastSyncLag = 32;
-
-        /// <summary>
         /// How many blocks can fast sync stay behind while state nodes is still syncing
         /// </summary>
         private const int StickyStateNodesDelta = 32;
@@ -61,10 +56,10 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool FastBlocksHeadersFinished => !FastSyncEnabled || _syncProgressResolver.IsFastBlocksHeadersFinished();
         private bool FastBlocksBodiesFinished => !FastBodiesEnabled || _syncProgressResolver.IsFastBlocksBodiesFinished();
         private bool FastBlocksReceiptsFinished => !FastReceiptsEnabled || _syncProgressResolver.IsFastBlocksReceiptsFinished();
-        private long FastSyncCatchUpHeightDelta => _syncConfig.FastSyncCatchUpHeightDelta ?? FastSyncLag;
+        private long FastSyncCatchUpHeightDelta => _syncConfig.FastSyncCatchUpHeightDelta ?? _syncConfig.StateMinDistanceFromHead;
         private bool NotNeedToWaitForHeaders => !_needToWaitForHeaders || FastBlocksHeadersFinished;
         private long? LastBlockThatEnabledFullSync { get; set; }
-        private int TotalSyncLag => FastSyncLag + _syncConfig.HeaderStateDistance;
+        private int TotalSyncLag => _syncConfig.StateMinDistanceFromHead + _syncConfig.HeaderStateDistance;
 
         private readonly CancellationTokenSource _cancellation = new();
 
@@ -90,10 +85,10 @@ namespace Nethermind.Synchronization.ParallelSync
             _syncProgressResolver = syncProgressResolver ?? throw new ArgumentNullException(nameof(syncProgressResolver));
             _needToWaitForHeaders = syncConfig.NeedToWaitForHeader;
 
-            if (syncConfig.FastSyncCatchUpHeightDelta <= FastSyncLag)
+            if (syncConfig.FastSyncCatchUpHeightDelta <= syncConfig.StateMinDistanceFromHead)
             {
                 if (_logger.IsWarn)
-                    _logger.Warn($"'FastSyncCatchUpHeightDelta' parameter is less or equal to {FastSyncLag}, which is a threshold of blocks always downloaded in full sync. 'FastSyncCatchUpHeightDelta' will have no effect.");
+                    _logger.Warn($"'FastSyncCatchUpHeightDelta' parameter is less or equal to {syncConfig.StateMinDistanceFromHead}, which is a threshold of blocks always downloaded in full sync. 'FastSyncCatchUpHeightDelta' will have no effect.");
             }
 
             _isSnapSyncDisabledAfterAnyStateSync = _syncProgressResolver.FindBestFullState() != 0;
@@ -589,7 +584,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool hasAnyPostPivotPeer = AnyPostPivotPeerKnown(best.Peer.Block);
             bool notInFastSync = !best.IsInFastSync;
             bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
-            bool stickyStateNodes = best.TargetBlock - best.Header < (FastSyncLag + StickyStateNodesDelta);
+            bool stickyStateNodes = best.TargetBlock - best.Header < (_syncConfig.StateMinDistanceFromHead + StickyStateNodesDelta);
             bool stateNotDownloadedYet = (best.TargetBlock - best.State > TotalSyncLag ||
                                           best.Header > (best.State + _syncConfig.HeaderStateDistance) && best.Header > best.Block);
             bool notInAStickyFullSync = !IsInAStickyFullSyncMode(best);


### PR DESCRIPTION
- Combine fast sync lag constant with `syncConfig.StateMinDistanceFromHead` which make fast sync lag configurable also.
- Useful in integration tests.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [X] Hive tests still passed