### PR TITLE
Remove Flashbots from Holesky config

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/holesky.json
+++ b/src/Nethermind/Nethermind.Runner/configs/holesky.json
@@ -29,9 +29,6 @@
     "EnginePort": 8551,
     "EngineEnabledModules": "net,eth,subscribe,engine,web3,client,flashbots"
   },
-  "Flasbots": {
-    "Enabled": true
-  },
   "Merge": {
     "Enabled": true
   }


### PR DESCRIPTION
Removes invalid configuration (typo) from Holesky config.
Also seems like it should not be enabled by default at all in this config.

Introduced in #7335 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No