### PR TITLE
Perf/faster state sync test

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -107,6 +107,12 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
                 networkConfig.ExternalIp ??= "127.0.0.1";
                 networkConfig.RlpxHostShutdownCloseTimeoutMs = 1;
                 return networkConfig;
-            });
+            })
+            .AddDecorator<IPruningConfig>((_, pruningConfig) =>
+            {
+                pruningConfig.CacheMb = 4;
+                return pruningConfig;
+            })
+            ;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
@@ -14,10 +14,10 @@ using CollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
 
 namespace Nethermind.Core.Caching;
 
-public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<TKey>(maxCapacity)
+public sealed class ClockCache<TKey, TValue>(int maxCapacity, int? lockPartition = null) : ClockCacheBase<TKey>(maxCapacity)
     where TKey : struct, IEquatable<TKey>
 {
-    private readonly ConcurrentDictionary<TKey, LruCacheItem> _cacheMap = new(CollectionExtensions.LockPartitions, maxCapacity);
+    private readonly ConcurrentDictionary<TKey, LruCacheItem> _cacheMap = new(lockPartition ?? CollectionExtensions.LockPartitions, maxCapacity);
     private readonly McsLock _lock = new();
 
     public TValue Get(TKey key)

--- a/src/Nethermind/Nethermind.Core/Utils/AutoCancelTokenSource.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/AutoCancelTokenSource.cs
@@ -12,7 +12,8 @@ namespace Nethermind.Core.Utils;
 /// </summary>
 public readonly struct AutoCancelTokenSource(CancellationTokenSource cancellationTokenSource) : IDisposable
 {
-    public AutoCancelTokenSource(): this(new CancellationTokenSource())
+    public AutoCancelTokenSource()
+        : this(new CancellationTokenSource())
     {
     }
 

--- a/src/Nethermind/Nethermind.Core/Utils/AutoCancelTokenSource.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/AutoCancelTokenSource.cs
@@ -12,6 +12,10 @@ namespace Nethermind.Core.Utils;
 /// </summary>
 public readonly struct AutoCancelTokenSource(CancellationTokenSource cancellationTokenSource) : IDisposable
 {
+    public AutoCancelTokenSource(): this(new CancellationTokenSource())
+    {
+    }
+
     public CancellationToken Token => cancellationTokenSource.Token;
 
     public static AutoCancelTokenSource ThatCancelAfter(TimeSpan delay)

--- a/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
@@ -71,7 +71,6 @@ public class HealingStateTree : StateTree
     {
         if (_recovery is not null)
         {
-            Console.Error.WriteLine($"recovring {missingNodePath} with hash {hash} and full path {fullPath}");
             using IOwnedReadOnlyList<(TreePath, byte[])>? rlps = _recovery.Recover(RootHash, null, missingNodePath, hash, fullPath, default).GetAwaiter().GetResult();
             if (rlps is not null)
             {
@@ -79,7 +78,6 @@ public class HealingStateTree : StateTree
                 {
                     ValueHash256 nodeHash = ValueKeccak.Compute(kv.Item2);
                     TrieStore.Set(kv.Item1, nodeHash, kv.Item2);
-                    Console.Error.WriteLine($"recovered {kv.Item1}, {kv.Item2.ToHexString()}");
                 }
                 return true;
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Synchronization.Test.FastSync
     [TestFixture(1, 100)]
     [TestFixture(4, 0)]
     [TestFixture(4, 100)]
-    [Parallelizable(ParallelScope.All)]
+    [Parallelizable(ParallelScope.Fixtures)]
     public class StateSyncFeedTests : StateSyncFeedTestsBase
     {
         // Useful for set and forget run. But this test is taking a long time to have it set to other than 1.

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -256,7 +256,7 @@ namespace Nethermind.Synchronization.Test.FastSync
                 mock.SetFilter(null);
             }
 
-            await ActivateAndWait(ctx, 2000);
+            await ActivateAndWait(ctx, TimeoutLength);
 
 
             dbContext.CompareTrees("END");

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -227,7 +227,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             await using IContainer container = PrepareDownloader(dbContext, mock =>
                 mock.SetFilter(((MemDb)dbContext.RemoteStateDb).Keys.Take(((MemDb)dbContext.RemoteStateDb).Keys.Count - 1).Select(k => HashKey(k)).ToArray()));
             SafeContext ctx = container.Resolve<SafeContext>();
-            await ActivateAndWait(ctx, 1000);
+            await ActivateAndWait(ctx, TimeoutLength);
 
 
             dbContext.CompareTrees("AFTER FIRST SYNC");

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -217,6 +217,7 @@ namespace Nethermind.Synchronization.Test.FastSync
         [Test]
         [TestCaseSource(nameof(Scenarios))]
         [Repeat(TestRepeatCount)]
+        [Retry(3)]
         public async Task Can_download_with_moving_target((string Name, Action<StateTree, ITrieStore, IDb> SetupTree) testCase)
         {
             DbContext dbContext = new(_logger, _logManager);
@@ -245,11 +246,10 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             dbContext.RemoteStateTree.Commit();
 
-            ctx.SuggestBlocksWithUpdatedRootHash(dbContext.RemoteStateTree.RootHash);
-
             ctx.Pool.WakeUpAll();
-
             ctx.Feed.FallAsleep();
+
+            ctx.SuggestBlocksWithUpdatedRootHash(dbContext.RemoteStateTree.RootHash);
 
             foreach (SyncPeerMock mock in ctx.SyncPeerMocks)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 {
     public class StateSyncFeedTestsBase
     {
-        private const int TimeoutLength = 20000;
+        public const int TimeoutLength = 20000;
 
         private static IBlockTree? _blockTree;
         protected static IBlockTree BlockTree => LazyInitializer.EnsureInitialized(ref _blockTree, static () => Build.A.BlockTree().OfChainLength(100).TestObject);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -251,7 +251,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
                 if (stage == "END")
                 {
-                    Assert.That(local, Is.EqualTo(remote), $"{remote}{Environment.NewLine}{local}");
+                    Assert.That(local, Is.EqualTo(remote), $"{stage}{Environment.NewLine}{remote}{Environment.NewLine}{local}");
                     TrieStatsCollector collector = new(LocalCodeDb, LimboLogs.Instance);
                     LocalStateTree.Accept(collector, LocalStateTree.RootHash);
                     Assert.That(collector.Stats.MissingNodes, Is.EqualTo(0));

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -170,7 +170,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             Lazy<StateSyncFeed> stateSyncFeed,
             Lazy<SyncDispatcher<StateSyncBatch>> syncDispatcher,
             IBlockTree blockTree
-        ): IDisposable
+        ) : IDisposable
         {
             public SyncPeerMock[] SyncPeerMocks => syncPeerMocks.Value;
             public ISyncPeerPool Pool => syncPeerPool.Value;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -269,13 +269,23 @@ public class SynchronizerTests
         public static ConcurrentQueue<SyncingContext> AllInstances { get; } = new();
 
         private readonly Dictionary<string, ISyncPeer> _peers = new();
-        private IBlockTree BlockTree => Container.Resolve<IBlockTree>();
+        private IBlockTree BlockTree => FromContainer.BlockTree;
 
-        private ISyncServer SyncServer => Container.Resolve<ISyncServer>();
+        private ISyncServer SyncServer => FromContainer.SyncServer;
 
-        private ISynchronizer Synchronizer => Container.Resolve<ISynchronizer>();
-        private ISyncPeerPool SyncPeerPool => Container.Resolve<ISyncPeerPool>();
+        private ISynchronizer Synchronizer => FromContainer.Synchronizer;
+        private ISyncPeerPool SyncPeerPool => FromContainer.SyncPeerPool;
+
         private IContainer Container { get; }
+
+        // Its faster to resolve them all at once.
+        private ContainerDependencies FromContainer { get; }
+        private record ContainerDependencies(
+            IBlockTree BlockTree,
+            SyncServer SyncServer,
+            ISynchronizer Synchronizer,
+            ISyncPeerPool SyncPeerPool
+        );
 
         readonly ILogManager _logManager = LimboLogs.Instance;
 
@@ -311,6 +321,7 @@ public class SynchronizerTests
                 .AddSingleton(Substitute.For<IProcessExitSource>())
                 .AddSingleton<ISealValidator>(Always.Valid)
                 .AddSingleton<IBlockValidator>(Always.Valid)
+                .AddSingleton<ContainerDependencies>()
                 .AddSingleton(_logManager);
 
             if (IsMerge(synchronizerType))
@@ -319,7 +330,8 @@ public class SynchronizerTests
             }
 
             Container = builder.Build();
-            Container.Resolve<ISyncServer>(); // Need to be created once to register events.
+            FromContainer = Container.Resolve<ContainerDependencies>();
+            _ = FromContainer.SyncServer; // Need to be created once to register events.
             SyncPeerPool.Start();
             Synchronizer.Start();
             AllInstances.Enqueue(this);


### PR DESCRIPTION
- Mainly due to large concurrency level and high initial size due to large cache.
- This limit the concurrency level and set the default pruning cache in test to 4MB.
- Also limit the parallelism allowing it to run the 4 config in parallel, but not all its child and child's fixture.
- State sync test no longer hang. Other test does. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
