### PR TITLE
Improved tree visitor parallelism and efficiency.

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Collections/RefList16Tests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/RefList16Tests.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Collections;
+
+public class RefList16Tests
+{
+    [Test]
+    public void CanAddItem()
+    {
+        RefList16<Hash256> pool = new RefList16<Hash256>();
+
+        pool.Count.Should().Be(0);
+
+        pool.Add(TestItem.KeccakA);
+        pool.Count.Should().Be(1);
+
+        pool.Add(TestItem.KeccakB);
+        pool.Count.Should().Be(2);
+
+        pool[0].Should().Be(TestItem.KeccakA);
+        pool[1].Should().Be(TestItem.KeccakB);
+
+        Span<Hash256> span = pool.AsSpan();
+        span.Length.Should().Be(2);
+        span[0].Should().Be(TestItem.KeccakA);
+        span[1].Should().Be(TestItem.KeccakB);
+    }
+
+    [Test]
+    public void WillThrowExceptionWhenTryingToAddMoreThan16Item()
+    {
+        RefList16<Hash256> pool = new RefList16<Hash256>();
+
+        for (int i = 0; i < 16; i++)
+        {
+            pool.Add(Hash256.Zero);
+        }
+        pool.Count.Should().Be(16);
+
+        try
+        {
+            pool.Add(TestItem.KeccakA);
+            Assert.Fail("Should throw `IndexOutOfRangeException`");
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Collections/RefList16.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/RefList16.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Collections;
+
+/// <summary>
+/// Like a list with a capacity of 16. But refstruct and therefore on the stack.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public ref struct RefList16<T>
+{
+    [InlineArray(16)]
+    private struct Inline16
+    {
+        public T? Item;
+    }
+
+    private Inline16 _array;
+    public int Count;
+
+    public RefList16(int initialSize)
+    {
+        Count = initialSize;
+    }
+
+    public T? this[int index] => _array[index];
+
+    public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref Unsafe.As<Inline16, T>(ref _array), Count);
+
+    public void Add(T item)
+    {
+        if (Count == 16) throw new IndexOutOfRangeException("Can only support a maximum of 16 items");
+        _array![Count++] = item;
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -38,7 +38,8 @@ namespace Nethermind.Trie
 
         private int _visitedNodes;
 
-        internal void Start(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path) {
+        internal void Start(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path)
+        {
             _ = Accept(node, nodeContext, nodeResolver, ref path, options.IsStorage, long.MaxValue);
         }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -172,6 +172,7 @@ namespace Nethermind.Trie
                 TNodeContext childContext = nodeContext.Add((byte)i);
                 if (visitor.ShouldVisit(childContext, childNode.Keccak!))
                 {
+                    // Note: Changing the subtreeSizeHint mid iteration is deliberate
                     subtreeSizeHint = Accept(childNode, childContext, trieNodeResolver, ref path, isStorage, subtreeSizeHint);
                     actualSubtreeSize += subtreeSizeHint;
                 }
@@ -204,6 +205,7 @@ namespace Nethermind.Trie
                 TNodeContext childContext = nodeContext.Add((byte)i);
                 if (visitor.ShouldVisit(childContext, child.Keccak!))
                 {
+                    // Note: Changing the subtreeSizeHint mid iteration is deliberate
                     subtreeSizeHint = Accept(child, childContext, nodeResolver, ref path, isStorage, subtreeSizeHint);
                     actualSubtreeSize += subtreeSizeHint;
                 }
@@ -246,6 +248,7 @@ namespace Nethermind.Trie
                     }
                     else
                     {
+                        // Note: Changing the subtreeSizeHint mid iteration is deliberate
                         subtreeSizeHint = Accept(child, childContext, trieNodeResolver, ref path, isStorage, subtreeSizeHint);
                         actualSubtreeSize += subtreeSizeHint;
                     }
@@ -274,7 +277,7 @@ namespace Nethermind.Trie
             int visitedNodes = Interlocked.Increment(ref _visitedNodes);
 
             // TODO: Fine tune interval? Use TrieNode.GetMemorySize(false) to calculate memory usage?
-            if (visitedNodes % 100_000_000 == 0)
+            if (visitedNodes % 20_000_000 == 0)
             {
                 GC.Collect();
             }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -39,8 +39,7 @@ namespace Nethermind.Trie
         private int _visitedNodes;
 
         internal void Start(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path) {
-            long totalSize = Accept(node, nodeContext, nodeResolver, ref path, options.IsStorage, long.MaxValue);
-            Console.Error.WriteLine($"TotalSize: {totalSize}");
+            _ = Accept(node, nodeContext, nodeResolver, ref path, options.IsStorage, long.MaxValue);
         }
 
         internal long Accept(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path, bool isStorage, long subtreeSizeHint)


### PR DESCRIPTION
- Improved tree visitor parallelism by estimating the size of subtree and not spawning new task if the size is lower than a set threshold.
- Use `RefArray16` a refstruct instead of arraypoollist.
- Before, After. Nodes read per sec during verify trie on mainnet. Memory limited to 64GB via systemd-run.
![Screenshot from 2025-02-25 18-54-10](https://github.com/user-attachments/assets/18f85fb2-b89d-4413-af27-5f09a3dd5ddb)
- Single thread does not change much. Perhaps cpu utilization is improved but throughput remain. 
![Screenshot_2025-02-25_19-11-53](https://github.com/user-attachments/assets/870ae3c9-9193-44bc-9c10-9fd6b4de7814)

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
