### PR TITLE
BLS fix: don't return 1 because of infinity point

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Precompiles/Bls/PairingCheckPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/Bls/PairingCheckPrecompile.cs
@@ -46,7 +46,6 @@ public class PairingCheckPrecompile : IPrecompile<PairingCheckPrecompile>
         var acc = GT.One(buf.AsSpan());
         GT p = new(buf.AsSpan()[GT.Sz..]);
 
-        bool hasInf = false;
         for (int i = 0; i < inputData.Length / PairSize; i++)
         {
             int offset = i * PairSize;
@@ -62,7 +61,6 @@ public class PairingCheckPrecompile : IPrecompile<PairingCheckPrecompile>
             // x == inf || y == inf -> e(x, y) = 1
             if (x.IsInf() || y.IsInf())
             {
-                hasInf = true;
                 continue;
             }
 
@@ -70,9 +68,8 @@ public class PairingCheckPrecompile : IPrecompile<PairingCheckPrecompile>
             acc.Mul(p);
         }
 
-        bool verified = hasInf || acc.FinalExp().IsOne();
         byte[] res = new byte[32];
-        if (verified)
+        if (acc.FinalExp().IsOne())
         {
             res[31] = 1;
         }


### PR DESCRIPTION
## Changes

- Instead of returning 1 when infinity point is encountered, should just skip this point
- note: this is preemptive fix, the original spec may be correct

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No