### PR TITLE
Use taiko txexecutor

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/RegisterAuRaRpcModules.cs
@@ -244,7 +244,7 @@ public class RegisterAuRaRpcModules : RegisterRpcModules
             badBlockStore, fileSystem, logManager)
     {
         protected override ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(IReadOnlyTxProcessingScope scope,
-            OverridableWorldStateManager worldStateManager, BlockProcessor.BlockValidationTransactionsExecutor transactionsExecutor)
+            OverridableWorldStateManager worldStateManager, IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor)
         {
             return new AuRaReadOnlyChainProcessingEnv(
                 scope,

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -234,19 +234,8 @@ public class DbConfig : IDbConfig
 
         "";
     public string? StateDbAdditionalRocksDbOptions { get; set; }
-    
-    public string L1OriginDbRocksDbOptions { get; set; } =
-        "write_buffer_size=4000000;" +
-        "block_based_table_factory.block_cache=16000000;" +
-        "optimize_filters_for_hits=false;" +
-        "prefix_extractor=capped:8;" +
-        "block_based_table_factory.index_type=kHashSearch;" +
-        "block_based_table_factory.block_size=4096;" +
-        "memtable=prefix_hash:1000000;" +
-        // Bloom crash with kHashSearch index
-        "block_based_table_factory.filter_policy=null;" +
-        "allow_concurrent_memtable_write=false;";
+
+    public string L1OriginDbRocksDbOptions { get; set; } = "";
 
     public string? L1OriginDbAdditionalRocksDbOptions { get; set; }
-
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -42,7 +42,7 @@ public class PerTableDbConfig
             string prefixed = string.Concat(prefix, propertyName);
             if (type.GetProperty(prefixed, BindingFlags.Public | BindingFlags.Instance) is null)
             {
-                //throw new InvalidConfigurationException($"Configuration {propertyName} not available with prefix {prefix}. Add {prefix}{propertyName} to {nameof(IDbConfig)}.", -1);
+                throw new InvalidConfigurationException($"Configuration {propertyName} not available with prefix {prefix}. Add {prefix}{propertyName} to {nameof(IDbConfig)}.", -1);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ChangeableTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ChangeableTransactionProcessorAdapter.cs
@@ -22,12 +22,6 @@ namespace Nethermind.Evm.TransactionProcessing
             TransactionProcessor = transactionProcessor;
         }
 
-        public ChangeableTransactionProcessorAdapter(ITransactionProcessor transactionProcessor, ITransactionProcessorAdapter transactionProcessorAdapter)
-            : this(transactionProcessorAdapter)
-        {
-            TransactionProcessor = transactionProcessor;
-        }
-
         public TransactionResult Execute(Transaction transaction, in BlockExecutionContext blkCtx, ITxTracer txTracer) =>
             CurrentAdapter.Execute(transaction, in blkCtx, txTracer);
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ChangeableTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ChangeableTransactionProcessorAdapter.cs
@@ -22,6 +22,12 @@ namespace Nethermind.Evm.TransactionProcessing
             TransactionProcessor = transactionProcessor;
         }
 
+        public ChangeableTransactionProcessorAdapter(ITransactionProcessor transactionProcessor, ITransactionProcessorAdapter transactionProcessorAdapter)
+            : this(transactionProcessorAdapter)
+        {
+            TransactionProcessor = transactionProcessor;
+        }
+
         public TransactionResult Execute(Transaction transaction, in BlockExecutionContext blkCtx, ITxTracer txTracer) =>
             CurrentAdapter.Execute(transaction, in blkCtx, txTracer);
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
@@ -6,13 +6,8 @@ using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Evm.TransactionProcessing;
 
-public interface ITransactionProcessor
+public interface ITransactionProcessor : ITransactionProcessorAdapter
 {
-    /// <summary>
-    /// Execute transaction, commit state
-    /// </summary>
-    TransactionResult Execute(Transaction transaction, in BlockExecutionContext blCtx, ITxTracer txTracer);
-
     /// <summary>
     /// Call transaction, rollback state
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
@@ -8,6 +8,9 @@ namespace Nethermind.Evm.TransactionProcessing
 {
     public interface ITransactionProcessorAdapter
     {
+        /// <summary>
+        /// Execute transaction, commit state
+        /// </summary>
         TransactionResult Execute(Transaction transaction, in BlockExecutionContext blkCtx, ITxTracer txTracer);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -24,18 +24,19 @@ namespace Nethermind.JsonRpc.Modules.DebugModule;
 
 public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
 {
-    private readonly IReadOnlyTrieStore _trieStore;
-    private readonly IJsonRpcConfig _jsonRpcConfig;
-    private readonly IBlockValidator _blockValidator;
-    protected readonly IRewardCalculatorSource _rewardCalculatorSource;
-    protected readonly IReceiptStorage _receiptStorage;
-    private readonly IReceiptsMigration _receiptsMigration;
-    private readonly IConfigProvider _configProvider;
+    protected readonly IReadOnlyDbProvider _dbProvider;
     protected readonly ISpecProvider _specProvider;
     protected readonly ILogManager _logManager;
     protected readonly IBlockPreprocessorStep _recoveryStep;
-    private readonly IReadOnlyDbProvider _dbProvider;
     protected readonly IReadOnlyBlockTree _blockTree;
+    protected readonly IRewardCalculatorSource _rewardCalculatorSource;
+    protected readonly IReceiptStorage _receiptStorage;
+    protected readonly IBlockValidator _blockValidator;
+
+    private readonly IReadOnlyTrieStore _trieStore;
+    private readonly IJsonRpcConfig _jsonRpcConfig;
+    private readonly IReceiptsMigration _receiptsMigration;
+    private readonly IConfigProvider _configProvider;
     private readonly ISyncModeSelector _syncModeSelector;
     private readonly IBadBlockStore _badBlockStore;
     private readonly IFileSystem _fileSystem;
@@ -110,8 +111,10 @@ public class DebugModuleFactory : ModuleFactoryBase<IDebugRpcModule>
         return new DebugRpcModule(_logManager, debugBridge, _jsonRpcConfig, _specProvider);
     }
 
-    protected virtual ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(IReadOnlyTxProcessingScope scope,
-        OverridableWorldStateManager worldStateManager, BlockProcessor.BlockValidationTransactionsExecutor transactionsExecutor)
+    protected virtual ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(
+        IReadOnlyTxProcessingScope scope,
+        OverridableWorldStateManager worldStateManager,
+        IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor)
     {
         return new ReadOnlyChainProcessingEnv(
             scope,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
@@ -55,6 +55,15 @@ public class TraceModuleFactory(
                 _logManager,
                 transactionsExecutor);
 
+    protected virtual IBlockProcessor.IBlockTransactionsExecutor CreateBlockTransactionsExecutorForTrace(ITransactionProcessor transactionProcessor, IWorldState worldState)
+    {
+        return new RpcBlockTransactionsExecutor(transactionProcessor, worldState);
+    }
+    protected virtual IBlockProcessor.IBlockTransactionsExecutor CreateBlockTransactionsExecutor(ITransactionProcessor transactionProcessor, IWorldState worldState)
+    {
+        return new BlockProcessor.BlockValidationTransactionsExecutor(transactionProcessor, worldState);
+    }
+
     public override ITraceRpcModule Create()
     {
         OverridableWorldStateManager worldStateManager = new(dbProvider, _trieStore, logManager);
@@ -65,8 +74,8 @@ public class TraceModuleFactory(
             new MergeRpcRewardCalculator(_rewardCalculatorSource.Get(scope.TransactionProcessor),
                 _poSSwitcher);
 
-        RpcBlockTransactionsExecutor rpcBlockTransactionsExecutor = new(scope.TransactionProcessor, scope.WorldState);
-        BlockProcessor.BlockValidationTransactionsExecutor executeBlockTransactionsExecutor = new(scope.TransactionProcessor, scope.WorldState);
+        IBlockProcessor.IBlockTransactionsExecutor rpcBlockTransactionsExecutor = CreateBlockTransactionsExecutorForTrace(scope.TransactionProcessor, scope.WorldState);
+        IBlockProcessor.IBlockTransactionsExecutor executeBlockTransactionsExecutor = CreateBlockTransactionsExecutor(scope.TransactionProcessor, scope.WorldState);
 
         ReadOnlyChainProcessingEnv traceProcessingEnv = CreateChainProcessingEnv(worldStateManager, rpcBlockTransactionsExecutor, scope, rewardCalculator);
         ReadOnlyChainProcessingEnv executeProcessingEnv = CreateChainProcessingEnv(worldStateManager, executeBlockTransactionsExecutor, scope, rewardCalculator);

--- a/src/Nethermind/Nethermind.Runner/Properties/launchSettings.json
+++ b/src/Nethermind/Nethermind.Runner/Properties/launchSettings.json
@@ -100,7 +100,7 @@
     },
     "Taiko Hekla": {
       "commandName": "Project",
-      "commandLineArgs": "--config none --init-genesishash 0xbeced3738f1246571cccabc82a1e6cbd9ed9d5f7ed2b6c7ded28f9722317bd9e --init-chainspecpath C:/ethereum/taiko/chainspec.json --data-dir C:/ethereum/taiko/ --jsonrpc-jwtsecretfile C:/ethereum/taiko/jwtsecret --jsonrpc-enabled true --jsonrpc-engineport 8551 --jsonrpc-host 0.0.0.0 --jsonrpc-enginehost 0.0.0.0",
+      "commandLineArgs": "-c taiko-hekla --data-dir .data",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Nethermind/Nethermind.Taiko/Rpc/RegisterTaikoRpcModules.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/RegisterTaikoRpcModules.cs
@@ -6,8 +6,10 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Init.Steps;
+using Nethermind.Init.Steps.Migrations;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 using Nethermind.Logging;
 using System;
@@ -95,5 +97,39 @@ public class RegisterTaikoRpcModules : RegisterRpcModules
             _api.LogManager);
 
         rpcModuleProvider.RegisterBoundedByCpuCount(traceModuleFactory, _jsonRpcConfig.Timeout);
+    }
+
+    protected override void RegisterDebugRpcModule(IRpcModuleProvider rpcModuleProvider)
+    {
+        StepDependencyException.ThrowIfNull(_api.DbProvider);
+        StepDependencyException.ThrowIfNull(_api.BlockPreprocessor);
+        StepDependencyException.ThrowIfNull(_api.BlockValidator);
+        StepDependencyException.ThrowIfNull(_api.RewardCalculatorSource);
+        StepDependencyException.ThrowIfNull(_api.KeyStore);
+        StepDependencyException.ThrowIfNull(_api.PeerPool);
+        StepDependencyException.ThrowIfNull(_api.BadBlocksStore);
+        StepDependencyException.ThrowIfNull(_api.WorldStateManager);
+        StepDependencyException.ThrowIfNull(_api.BlockTree);
+        StepDependencyException.ThrowIfNull(_api.ReceiptStorage);
+        StepDependencyException.ThrowIfNull(_api.SpecProvider);
+
+        TaikoDebugModuleFactory debugModuleFactory = new(
+            _api.WorldStateManager.TrieStore,
+            _api.DbProvider,
+            _api.BlockTree,
+            _jsonRpcConfig,
+            _api.BlockValidator,
+            _api.BlockPreprocessor,
+            _api.RewardCalculatorSource,
+            _api.ReceiptStorage,
+            new ReceiptMigration(_api),
+            _api.ConfigProvider,
+            _api.SpecProvider,
+            _api.SyncModeSelector,
+            _api.BadBlocksStore,
+            _api.FileSystem,
+            _api.LogManager);
+
+        rpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, _jsonRpcConfig.Timeout);
     }
 }

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoDebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoDebugModuleFactory.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Tracing;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Db;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules.DebugModule;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Trie.Pruning;
+using System.IO.Abstractions;
+
+namespace Nethermind.Taiko.Rpc;
+
+class TaikoDebugModuleFactory :
+    DebugModuleFactory
+{
+    public TaikoDebugModuleFactory(
+        IReadOnlyTrieStore trieStore,
+        IDbProvider dbProvider,
+        IBlockTree blockTree,
+        IJsonRpcConfig jsonRpcConfig,
+        IBlockValidator blockValidator,
+        IBlockPreprocessorStep recoveryStep,
+        IRewardCalculatorSource rewardCalculator,
+        IReceiptStorage receiptStorage,
+        IReceiptsMigration receiptsMigration,
+        IConfigProvider configProvider,
+        ISpecProvider specProvider,
+        ISyncModeSelector syncModeSelector,
+        IBadBlockStore badBlockStore,
+        IFileSystem fileSystem,
+        ILogManager logManager) : base(trieStore, dbProvider, blockTree, jsonRpcConfig, blockValidator, recoveryStep, rewardCalculator, receiptStorage, receiptsMigration, configProvider, specProvider, syncModeSelector, badBlockStore, fileSystem, logManager)
+    {
+    }
+
+    protected override ReadOnlyChainProcessingEnv CreateReadOnlyChainProcessingEnv(
+    IReadOnlyTxProcessingScope scope,
+    OverridableWorldStateManager worldStateManager,
+    IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor)
+    {
+        return new ReadOnlyChainProcessingEnv(
+            scope,
+            _blockValidator,
+            _recoveryStep,
+            _rewardCalculatorSource.Get(scope.TransactionProcessor),
+            _receiptStorage,
+            _specProvider,
+            _blockTree,
+            worldStateManager.GlobalStateReader,
+            _logManager,
+            new BlockInvalidTxExecutor(scope.TransactionProcessor, scope.WorldState));
+    }
+}

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoTraceModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoTraceModuleFactory.cs
@@ -8,6 +8,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.Logging;
@@ -23,4 +24,13 @@ class TaikoTraceModuleFactory(
     TraceModuleFactory(trieStore, dbProvider, blockTree, jsonRpcConfig, recoveryStep, rewardCalculatorSource, receiptFinder, specProvider, poSSwitcher, logManager)
 {
     protected override OverridableTxProcessingEnv CreateTxProcessingEnv(OverridableWorldStateManager worldStateManager) => new TaikoReadOnlyTxProcessingEnv(worldStateManager, _blockTree, _specProvider, _logManager);
+
+    protected override IBlockProcessor.IBlockTransactionsExecutor CreateBlockTransactionsExecutorForTrace(ITransactionProcessor transactionProcessor, IWorldState worldState)
+    {
+        return new BlockInvalidTxExecutor(new TraceTransactionProcessorAdapter(transactionProcessor), worldState);
+    }
+    protected override IBlockProcessor.IBlockTransactionsExecutor CreateBlockTransactionsExecutor(ITransactionProcessor transactionProcessor, IWorldState worldState)
+    {
+        return new BlockInvalidTxExecutor(transactionProcessor, worldState);
+    }
 }


### PR DESCRIPTION
Added BlockInvalidTxExecutor and added default db options that is expected. 

Ended up with virtualizing two methods for creating `IBlockProcessor.IBlockTransactionsExecutor`, which is needed because `ReadOnlyChainProcessingEnv` wants to have one for trace and without. 

Tell me what you think.