### PR TITLE
Disable warmup by default in StateTestRunner

### DIFF
--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -45,6 +45,9 @@ internal class Program
 
         public static CliOption<bool> GnosisTest { get; } =
             new("--gnosisTest", "-g") { Description = "Set test as gnosisTest. if not, it will be by default assumed a mainnet test." };
+
+        public static CliOption<bool> EnableWarmup { get; } =
+        new("--warmup","-wu") {Description = "Enable warmup for benchmarking purposes."};
     }
 
     public static async Task<int> Main(params string[] args)
@@ -61,6 +64,7 @@ internal class Program
             Options.Wait,
             Options.Stdin,
             Options.GnosisTest,
+            Options.EnableWarmup,
         ];
         rootCommand.SetAction(Run);
 
@@ -95,7 +99,9 @@ internal class Program
                     !parseResult.GetValue(Options.ExcludeMemory),
                     !parseResult.GetValue(Options.ExcludeStack),
                     chainId,
-                    parseResult.GetValue(Options.Filter)));
+                    parseResult.GetValue(Options.Filter),
+                    parseResult.GetValue(Options.EnableWarmup)));
+
 
             if (!parseResult.GetValue(Options.Stdin))
                 break;

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -30,6 +30,7 @@ namespace Nethermind.Test.Runner
         private readonly bool _traceStack;
         private readonly string? _filter;
         private readonly ulong _chainId;
+        private readonly bool _enableWarmup;
         private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
 
         public StateTestsRunner(ITestSourceLoader testsSource, WhenTrace whenTrace, bool traceMemory, bool traceStack, ulong chainId, string? filter = null)
@@ -40,6 +41,7 @@ namespace Nethermind.Test.Runner
             _traceStack = traceStack;
             _filter = filter;
             _chainId = chainId;
+            _enableWarmup = enableWarmup;
             Setup(null);
         }
 
@@ -72,7 +74,8 @@ namespace Nethermind.Test.Runner
                 EthereumTestResult result = null;
                 if (_whenTrace != WhenTrace.Always)
                 {
-                    // Warm up
+                    if(_enableWarmup){ // Warm up only when benchmarking
+
                     Parallel.For(0, 30, (i, s) =>
                     {
                         _ = RunTest(test, NullTxTracer.Instance);
@@ -81,6 +84,7 @@ namespace Nethermind.Test.Runner
                     // Give time to Jit optimized version
                     Thread.Sleep(20);
                     GC.Collect(GC.MaxGeneration);
+                    }
                     result = RunTest(test, NullTxTracer.Instance);
                 }
 


### PR DESCRIPTION
Closes #8227

## Changes

- Add --warmup command-line option to enable warmup when needed for benchmarking
- Modify StateTestsRunner to only perform warmup when explicitly enabled
- Default behavior now skips warmup for faster test execution
- Maintain warmup capability for benchmarking scenarios

## Types of changes

- [ ] Optimization

## Testing

- [ ] Yes