### PR TITLE
Add admin_removeTrustedPeer RPC endpoint

### DIFF
--- a/src/Nethermind/Nethermind.Cli/Modules/AdminCliModule.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/AdminCliModule.cs
@@ -25,5 +25,7 @@ namespace Nethermind.Cli.Modules
         [CliFunction("admin", "addTrustedPeer", Description = "Adds given node to the trusted nodes")]
         public bool AddTrustedPeer(string enode) => NodeManager.Post<bool>("admin_addTrustedPeer", enode).Result;
 
+        [CliFunction("admin", "removeTrustedPeer", Description = "Removes given node from the trusted nodes")]
+        public bool RemoveTrustedPeer(string enode) => NodeManager.Post<bool>("admin_removeTrustedPeer", enode).Result;
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -152,6 +152,19 @@ public class AdminRpcModule : IAdminRpcModule
         }
     }
 
+    public async Task<ResultWrapper<bool>> admin_removeTrustedPeer(string enode)
+    {
+        Enode enodeObj = new(enode);
+
+        if (await _trustedNodesManager.RemoveAsync(enodeObj, updateFile: true))
+        {
+            return ResultWrapper<bool>.Success(true);
+        }
+        else
+        {
+            return ResultWrapper<bool>.Fail("Failed to remove trusted peer.");
+        }
+    }
 
     public ResultWrapper<PeerInfo[]> admin_peers(bool includeDetails = false)
         => ResultWrapper<PeerInfo[]>.Success(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -118,6 +118,16 @@ public interface IAdminRpcModule : IContextAwareRpcModule
         string enode
 );
 
+    [JsonRpcMethod(Description = "Removes the given node from the trusted peers list.",
+        EdgeCaseHint = "",
+        ResponseDescription = "Boolean indicating success",
+        ExampleResponse = "true",
+        IsImplemented = true)]
+    Task<ResultWrapper<bool>> admin_removeTrustedPeer(
+        [JsonRpcParameter(Description = "Given node", ExampleValue = "\"enode://...\"")]
+        string enode
+);
+
     [JsonRpcMethod(Description = "Subscribes to a particular event over WebSocket. For every event that matches the subscription, a notification with event details and subscription id is sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<string> admin_subscribe(string subscriptionName, string? args = null);
     [JsonRpcMethod(Description = "Unsubscribes from a subscription.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]


### PR DESCRIPTION
Related #7811

## Changes

- Added interface method in IAdminRpcModule
- Implemented admin_removeTrustedPeer in AdminRpcModule
- Added unit test for the new method
- Added corresponding CLI function in AdminCliModule

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
