### PR TITLE
fix txValidator for State test, fix PragueGnosis spec

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
+++ b/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -8,8 +10,11 @@ using Nethermind.Specs.GnosisForks;
 
 namespace Ethereum.Test.Base;
 
-public class ChainUtils
+public static class ChainUtils
 {
+    private static readonly TxValidator MainnetTxValidator = new(MainnetSpecProvider.Instance.ChainId);
+    private static readonly TxValidator GnosisTxValidator = new(GnosisSpecProvider.Instance.ChainId);
+
     public static IReleaseSpec? ResolveSpec(IReleaseSpec? spec, ulong chainId)
     {
         if (chainId != GnosisSpecProvider.Instance.ChainId)
@@ -27,5 +32,11 @@ public class ChainUtils
         }
 
         return spec;
+    }
+
+    public static ValidationResult ValidateTransaction(Transaction transaction, IReleaseSpec spec)
+    {
+        return transaction.ChainId == GnosisSpecProvider.Instance.ChainId ?
+            GnosisTxValidator.IsWellFormed(transaction, spec) : MainnetTxValidator.IsWellFormed(transaction, spec);
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
+++ b/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus.Validators;
-using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -12,31 +10,12 @@ namespace Ethereum.Test.Base;
 
 public static class ChainUtils
 {
-    private static readonly TxValidator MainnetTxValidator = new(MainnetSpecProvider.Instance.ChainId);
-    private static readonly TxValidator GnosisTxValidator = new(GnosisSpecProvider.Instance.ChainId);
-
     public static IReleaseSpec? ResolveSpec(IReleaseSpec? spec, ulong chainId)
     {
-        if (chainId != GnosisSpecProvider.Instance.ChainId)
-        {
-            return spec;
-        }
-
-        if (spec == Cancun.Instance)
-        {
-            return CancunGnosis.Instance;
-        }
-        if (spec == Prague.Instance)
-        {
-            return PragueGnosis.Instance;
-        }
-
-        return spec;
-    }
-
-    public static ValidationResult ValidateTransaction(Transaction transaction, IReleaseSpec spec)
-    {
-        return transaction.ChainId == GnosisSpecProvider.Instance.ChainId ?
-            GnosisTxValidator.IsWellFormed(transaction, spec) : MainnetTxValidator.IsWellFormed(transaction, spec);
+        return chainId == GnosisSpecProvider.Instance.ChainId
+            ? spec == Cancun.Instance ? CancunGnosis.Instance
+            : spec == Prague.Instance ? PragueGnosis.Instance
+            : spec
+            : spec;
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
+++ b/src/Nethermind/Ethereum.Test.Base/ChainUtils.cs
@@ -13,7 +13,8 @@ public static class ChainUtils
     public static IReleaseSpec? ResolveSpec(IReleaseSpec? spec, ulong chainId)
     {
         return chainId == GnosisSpecProvider.Instance.ChainId
-            ? spec == Cancun.Instance ? CancunGnosis.Instance
+            ? spec == London.Instance ? LondonGnosis.Instance
+            : spec == Cancun.Instance ? CancunGnosis.Instance
             : spec == Prague.Instance ? PragueGnosis.Instance
             : spec
             : spec;

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -4,14 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
-using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
@@ -21,15 +18,11 @@ using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using Nethermind.State;
-using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Config;
-using Nethermind.Consensus.AuRa.InitializationSteps;
-using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
-using Nethermind.Specs.GnosisForks;
 
 namespace Ethereum.Test.Base
 {
@@ -38,7 +31,6 @@ namespace Ethereum.Test.Base
         private static ILogger _logger = new(new ConsoleAsyncLogger(LogLevel.Info));
         private static ILogManager _logManager = LimboLogs.Instance;
         private static readonly UInt256 _defaultBaseFeeForStateTest = 0xA;
-        private readonly TxValidator _txValidator = new(MainnetSpecProvider.Instance.ChainId);
 
         [SetUp]
         public void Setup()
@@ -134,7 +126,7 @@ namespace Ethereum.Test.Base
                 header.ExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(parent, spec);
             }
 
-            ValidationResult txIsValid = _txValidator.IsWellFormed(test.Transaction, spec);
+            ValidationResult txIsValid = ChainUtils.ValidateTransaction(test.Transaction, test.Fork);
             TransactionResult? txResult = null;
             if (txIsValid)
             {

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -126,7 +126,7 @@ namespace Ethereum.Test.Base
                 header.ExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(parent, spec);
             }
 
-            ValidationResult txIsValid = ChainUtils.ValidateTransaction(test.Transaction, test.Fork);
+            ValidationResult txIsValid = new TxValidator(test.ChainId).ValidateTransaction(test.Transaction, spec);
             TransactionResult? txResult = null;
             if (txIsValid)
             {

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Config;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core.Test.Modules;
 
 namespace Ethereum.Test.Base
@@ -126,7 +127,7 @@ namespace Ethereum.Test.Base
                 header.ExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(parent, spec);
             }
 
-            ValidationResult txIsValid = new TxValidator(test.ChainId).ValidateTransaction(test.Transaction, spec);
+            ValidationResult txIsValid = new TxValidator(test.ChainId).IsWellFormed(test.Transaction, spec);
             TransactionResult? txResult = null;
             if (txIsValid)
             {

--- a/src/Nethermind/Nethermind.Specs/GnosisForks/12_LondonGnosis.cs
+++ b/src/Nethermind/Nethermind.Specs/GnosisForks/12_LondonGnosis.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading;

--- a/src/Nethermind/Nethermind.Specs/GnosisForks/12_LondonGnosis.cs
+++ b/src/Nethermind/Nethermind.Specs/GnosisForks/12_LondonGnosis.cs
@@ -1,0 +1,25 @@
+﻿// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using Nethermind.Core.Specs;
+using Nethermind.Specs.Forks;
+
+namespace Nethermind.Specs.GnosisForks;
+
+public class LondonGnosis : London
+{
+    private static IReleaseSpec? _instance;
+
+    private LondonGnosis()
+    {
+        SetGnosis(this);
+    }
+
+    public new static IReleaseSpec Instance => LazyInitializer.EnsureInitialized(ref _instance, static () => new LondonGnosis());
+
+    public static void SetGnosis(London spec)
+    {
+        spec.FeeCollector = GnosisSpecProvider.FeeCollector;
+    }
+}

--- a/src/Nethermind/Nethermind.Specs/GnosisForks/17_CancunGnosis.cs
+++ b/src/Nethermind/Nethermind.Specs/GnosisForks/17_CancunGnosis.cs
@@ -3,18 +3,25 @@
 
 using System.Threading;
 using Nethermind.Core.Specs;
+using Nethermind.Specs.Forks;
 
 namespace Nethermind.Specs.GnosisForks;
 
-public class CancunGnosis : Forks.Cancun
+public class CancunGnosis : Cancun
 {
+    private static IReleaseSpec? _instance;
 
-    private static IReleaseSpec _instance;
-    protected CancunGnosis() : base()
+    private CancunGnosis()
     {
-        MaxBlobCount = 2;
-        TargetBlobCount = 1;
-        BlobBaseFeeUpdateFraction = 1112826;
+        SetGnosis(this);
+    }
+
+    public static void SetGnosis(Cancun spec)
+    {
+        LondonGnosis.SetGnosis(spec);
+        spec.MaxBlobCount = 2;
+        spec.TargetBlobCount = 1;
+        spec.BlobBaseFeeUpdateFraction = 1112826;
     }
 
     public new static IReleaseSpec Instance => LazyInitializer.EnsureInitialized(ref _instance, static () => new CancunGnosis());

--- a/src/Nethermind/Nethermind.Specs/GnosisForks/18_PragueGnosis.cs
+++ b/src/Nethermind/Nethermind.Specs/GnosisForks/18_PragueGnosis.cs
@@ -16,6 +16,7 @@ public class PragueGnosis : Forks.Prague
         BlobBaseFeeUpdateFraction = 0x10fafa;
         TargetBlobCount = 1;
         MaxBlobCount = 2;
+        FeeCollector = GnosisSpecProvider.FeeCollector;
     }
 
     public new static IReleaseSpec Instance => LazyInitializer.EnsureInitialized(ref _instance, static () => new PragueGnosis());

--- a/src/Nethermind/Nethermind.Specs/GnosisForks/18_PragueGnosis.cs
+++ b/src/Nethermind/Nethermind.Specs/GnosisForks/18_PragueGnosis.cs
@@ -3,20 +3,26 @@
 
 using System.Threading;
 using Nethermind.Core.Specs;
+using Nethermind.Specs.Forks;
 
 namespace Nethermind.Specs.GnosisForks;
 
-public class PragueGnosis : Forks.Prague
+public class PragueGnosis : Prague
 {
     private static IReleaseSpec _instance;
 
-    protected PragueGnosis() : base()
+    private PragueGnosis()
     {
-        IsEip4844FeeCollectorEnabled = true;
-        BlobBaseFeeUpdateFraction = 0x10fafa;
-        TargetBlobCount = 1;
-        MaxBlobCount = 2;
-        FeeCollector = GnosisSpecProvider.FeeCollector;
+        SetGnosis(this);
+    }
+
+    public static void SetGnosis(Forks.Prague spec)
+    {
+        CancunGnosis.SetGnosis(spec);
+        spec.IsEip4844FeeCollectorEnabled = true;
+        spec.BlobBaseFeeUpdateFraction = 0x10fafa;
+        spec.TargetBlobCount = 1;
+        spec.MaxBlobCount = 2;
     }
 
     public new static IReleaseSpec Instance => LazyInitializer.EnsureInitialized(ref _instance, static () => new PragueGnosis());


### PR DESCRIPTION
Before GeneralTestBase was using TxValidator for Mainnet, which is incorrect for Gnosis
## Changes

- fix GeneralTestBase: choose appropriate chainId for TxValidator
- Add FeeCollector to PragueGnosis

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
