### PR TITLE
match on deposit contract log topic v2

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
@@ -141,11 +141,15 @@ public class ExecutionProcessorTests
         Assert.That(block.Header.RequestsHash, Is.EqualTo(
            CalculateHash(_executionDepositRequests, _executionWithdrawalRequests, _executionConsolidationRequests)
        ));
-
-
         static LogEntry CreateLogEntry(byte[][] requestDataParts) =>
             Build.A.LogEntry
                 .WithData(_abiEncoder.Encode(AbiEncodingStyle.None, _depositEventABI, requestDataParts!))
                 .WithAddress(DepositContractAddress).TestObject;
+    }
+
+    [Test]
+    public void ShouldUseCorrectDepositTopic()
+    {
+        Assert.That(ExecutionRequestsProcessor.DepositEventAbi.Hash, Is.EqualTo(new Hash256("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5")));
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
@@ -143,6 +143,7 @@ public class ExecutionProcessorTests
         static LogEntry CreateLogEntry(byte[][] requestDataParts) =>
             Build.A.LogEntry
                 .WithData(_abiEncoder.Encode(AbiEncodingStyle.None, _depositEventABI, requestDataParts!))
+                .WithTopics(ExecutionRequestsProcessor.DepositEventAbi.Hash)
                 .WithAddress(DepositContractAddress).TestObject;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
@@ -25,6 +26,8 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
     private readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
 
     private const long GasLimit = 30_000_000L;
+
+    private Hash256 DepositTopic  = new ("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5");
 
     private readonly ITransactionProcessor _transactionProcessor;
 
@@ -73,7 +76,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                 for (var j = 0; j < logEntries.Length; j++)
                 {
                     LogEntry log = logEntries[j];
-                    if (log.Address == spec.DepositContractAddress)
+                    if (log.Address == spec.DepositContractAddress && log.Topics.Length >= 1 && log.Topics[0] == DepositTopic)
                     {
                         Span<byte> depositRequestBuffer = new byte[ExecutionRequestExtensions.DepositRequestsBytesSize];
                         DecodeDepositRequest(log, depositRequestBuffer);

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
@@ -27,7 +27,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
 
     private const long GasLimit = 30_000_000L;
 
-    private Hash256 DepositTopic  = new ("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5");
+    private Hash256 DepositTopic = new("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5");
 
     private readonly ITransactionProcessor _transactionProcessor;
 

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
@@ -3,12 +3,10 @@
 
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
@@ -22,12 +20,10 @@ namespace Nethermind.Consensus.ExecutionRequests;
 
 public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
 {
-    private readonly AbiSignature _depositEventABI = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
+    public static readonly AbiSignature DepositEventAbi = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
     private readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
 
     private const long GasLimit = 30_000_000L;
-
-    private Hash256 DepositTopic = new("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5");
 
     private readonly ITransactionProcessor _transactionProcessor;
 
@@ -76,7 +72,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                 for (var j = 0; j < logEntries.Length; j++)
                 {
                     LogEntry log = logEntries[j];
-                    if (log.Address == spec.DepositContractAddress && log.Topics.Length >= 1 && log.Topics[0] == DepositTopic)
+                    if (log.Address == spec.DepositContractAddress && log.Topics.Length >= 1 && log.Topics[0] == DepositEventAbi.Hash)
                     {
                         Span<byte> depositRequestBuffer = new byte[ExecutionRequestExtensions.DepositRequestsBytesSize];
                         DecodeDepositRequest(log, depositRequestBuffer);
@@ -92,7 +88,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
 
     private void DecodeDepositRequest(LogEntry log, Span<byte> buffer)
     {
-        object[] result = _abiEncoder.Decode(AbiEncodingStyle.None, _depositEventABI, log.Data);
+        object[] result = _abiEncoder.Decode(AbiEncodingStyle.None, DepositEventAbi, log.Data);
         int offset = 0;
 
         foreach (var item in result)


### PR DESCRIPTION
## Changes

This resolves a situation on the Sepolia testnet, which has a different deposit contract. The contract on that network emits two kinds of logs, instead of only deposit events like the deposit contract on mainnet. So we need to skip events with mismatched topics.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
