### PR TITLE
IWithdrawalValidator externalized and separated from IBlockValidator

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -44,6 +44,8 @@ namespace Nethermind.Api
         IFilterManager? FilterManager { get; set; }
         IUnclesValidator? UnclesValidator { get; set; }
         IHeaderValidator? HeaderValidator { get; set; }
+        IWithdrawalValidator? WithdrawalValidator { get; set; }
+
         IManualBlockProductionTrigger ManualBlockProductionTrigger { get; }
         IRewardCalculatorSource? RewardCalculatorSource { get; set; }
         /// <summary>

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -135,6 +135,7 @@ namespace Nethermind.Api
         public IFilterStore? FilterStore { get; set; }
         public IFilterManager? FilterManager { get; set; }
         public IUnclesValidator? UnclesValidator { get; set; }
+        public IWithdrawalValidator? WithdrawalValidator { get; set; }
         public IGrpcServer? GrpcServer { get; set; }
         public IHeaderValidator? HeaderValidator { get; set; }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
@@ -27,11 +27,13 @@ public class BlockValidatorTests
         releaseSpec.MaximumUncleCount = 0;
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, releaseSpec));
 
-        BlockValidator blockValidator = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
         bool noiseRemoved = blockValidator.ValidateSuggestedBlock(Build.A.Block.TestObject);
         Assert.That(noiseRemoved, Is.True);
 
-        bool result = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithUncles(Build.A.BlockHeader.TestObject).TestObject);
+        bool result =
+            blockValidator.ValidateSuggestedBlock(Build.A.Block.WithUncles(Build.A.BlockHeader.TestObject).TestObject);
         Assert.That(result, Is.False);
     }
 
@@ -96,7 +98,8 @@ public class BlockValidatorTests
     {
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
         Block suggestedBlock = Build.A.Block.TestObject;
         Block processedBlock = Build.A.Block.TestObject;
 
@@ -111,7 +114,8 @@ public class BlockValidatorTests
     {
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
         Block suggestedBlock = Build.A.Block.TestObject;
         Block processedBlock = Build.A.Block.TestObject;
         string? error;
@@ -129,7 +133,8 @@ public class BlockValidatorTests
     {
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
         Block suggestedBlock = Build.A.Block.TestObject;
         Block processedBlock = Build.A.Block.WithStateRoot(Keccak.Zero).TestObject;
 
@@ -144,7 +149,8 @@ public class BlockValidatorTests
     {
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
         Block suggestedBlock = Build.A.Block.TestObject;
         Block processedBlock = Build.A.Block.WithStateRoot(Keccak.Zero).TestObject;
         string? error;
@@ -162,38 +168,38 @@ public class BlockValidatorTests
         KzgPolynomialCommitments.InitializeAsync().Wait();
 
         yield return new TestCaseData(
-        Build.A.Block.WithHeader(Build.A.BlockHeader.WithUnclesHash(Keccak.Zero).TestObject).TestObject,
-        Substitute.For<ISpecProvider>(),
-        "InvalidUnclesHash");
+            Build.A.Block.WithHeader(Build.A.BlockHeader.WithUnclesHash(Keccak.Zero).TestObject).TestObject,
+            Substitute.For<ISpecProvider>(),
+            "InvalidUnclesHash");
 
         yield return new TestCaseData(
-        Build.A.Block.WithHeader(Build.A.BlockHeader.WithTransactionsRoot(Keccak.Zero).TestObject).TestObject,
-        Substitute.For<ISpecProvider>(),
-        "InvalidTxRoot");
+            Build.A.Block.WithHeader(Build.A.BlockHeader.WithTransactionsRoot(Keccak.Zero).TestObject).TestObject,
+            Substitute.For<ISpecProvider>(),
+            "InvalidTxRoot");
 
         yield return new TestCaseData(
-        Build.A.Block.WithBlobGasUsed(131072)
-        .WithExcessBlobGas(1)
-        .WithTransactions(
-            Build.A.Transaction.WithShardBlobTxTypeAndFields(1)
-            .WithMaxFeePerBlobGas(0)
-            .WithMaxFeePerGas(1000000)
-            .Signed()
-            .TestObject)
-        .TestObject,
-        new CustomSpecProvider(((ForkActivation)0, Cancun.Instance)),
-        "InsufficientMaxFeePerBlobGas");
+            Build.A.Block.WithBlobGasUsed(131072)
+                .WithExcessBlobGas(1)
+                .WithTransactions(
+                    Build.A.Transaction.WithShardBlobTxTypeAndFields(1)
+                        .WithMaxFeePerBlobGas(0)
+                        .WithMaxFeePerGas(1000000)
+                        .Signed()
+                        .TestObject)
+                .TestObject,
+            new CustomSpecProvider(((ForkActivation)0, Cancun.Instance)),
+            "InsufficientMaxFeePerBlobGas");
     }
 
     [TestCaseSource(nameof(BadSuggestedBlocks))]
-    public void ValidateSuggestedBlock_SuggestedBlockIsInvalid_CorrectErrorIsSet(Block suggestedBlock, ISpecProvider specProvider, string expectedError)
+    public void ValidateSuggestedBlock_SuggestedBlockIsInvalid_CorrectErrorIsSet(Block suggestedBlock,
+        ISpecProvider specProvider, string expectedError)
     {
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
-        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
-        string? error;
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, Always.Valid, specProvider,
+            LimboLogs.Instance);
 
-        sut.ValidateSuggestedBlock(
-            suggestedBlock, out error);
+        sut.ValidateSuggestedBlock(suggestedBlock, out var error);
 
         Assert.That(error, Does.StartWith(expectedError));
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/ShardBlobBlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/ShardBlobBlockValidatorTests.cs
@@ -22,7 +22,7 @@ public class ShardBlobBlockValidatorTests
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, spec));
         HeaderValidator headerValidator = new(Substitute.For<IBlockTree>(), Always.Valid, specProvider, TestLogManager.Instance);
-        BlockValidator blockValidator = new(Always.Valid, headerValidator, Always.Valid, specProvider, TestLogManager.Instance);
+        BlockValidator blockValidator = new(Always.Valid, headerValidator, Always.Valid, Always.Valid, specProvider, TestLogManager.Instance);
         return blockValidator.ValidateSuggestedBlock(Build.A.Block
             .WithBlobGasUsed(blobGasUsed)
             .WithExcessBlobGas(excessBlobGas)
@@ -36,7 +36,7 @@ public class ShardBlobBlockValidatorTests
     public bool Blobs_per_block_count_is_valid(IReleaseSpec spec, ulong blobGasUsed)
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, spec));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, TestLogManager.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, Always.Valid, specProvider, TestLogManager.Instance);
         return blockValidator.ValidateSuggestedBlock(
             Build.A.Block
                 .WithWithdrawalsRoot(TestItem.KeccakA)

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
@@ -78,6 +78,11 @@ public class TestBlockValidator : IBlockValidator
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
 
+    public bool ValidateBody(Block block)
+    {
+        return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
+    }
+
     public bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error)
     {
         error = null;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
@@ -20,7 +20,7 @@ public class WithdrawalValidatorTests
     public void Not_null_withdrawals_are_invalid_pre_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, London.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(new Withdrawal[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth }).TestObject);
         Assert.That(isValid, Is.False);
     }
@@ -29,7 +29,7 @@ public class WithdrawalValidatorTests
     public void Null_withdrawals_are_invalid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.TestObject);
         Assert.That(isValid, Is.False);
     }
@@ -38,7 +38,7 @@ public class WithdrawalValidatorTests
     public void Withdrawals_with_incorrect_withdrawals_root_are_invalid()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(TestItem.KeccakD).TestObject);
         Assert.That(isValid, Is.False);
@@ -48,7 +48,7 @@ public class WithdrawalValidatorTests
     public void Empty_withdrawals_are_valid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);
@@ -59,10 +59,12 @@ public class WithdrawalValidatorTests
     public void Correct_withdrawals_block_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);
         Assert.That(isValid, Is.True);
     }
+
+    private static WithdrawalValidator CreateWithdrawalValidator() => new(LimboLogs.Instance);
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
@@ -20,7 +20,7 @@ public class WithdrawalValidatorTests
     public void Not_null_withdrawals_are_invalid_pre_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, London.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, new WithdrawalValidator(LimboLogs.Instance), specProvider, LimboLogs.Instance);
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(new Withdrawal[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth }).TestObject);
         Assert.That(isValid, Is.False);
     }
@@ -29,7 +29,7 @@ public class WithdrawalValidatorTests
     public void Null_withdrawals_are_invalid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, new WithdrawalValidator(LimboLogs.Instance), specProvider, LimboLogs.Instance);
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.TestObject);
         Assert.That(isValid, Is.False);
     }
@@ -38,7 +38,7 @@ public class WithdrawalValidatorTests
     public void Withdrawals_with_incorrect_withdrawals_root_are_invalid()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, new WithdrawalValidator(LimboLogs.Instance), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(TestItem.KeccakD).TestObject);
         Assert.That(isValid, Is.False);
@@ -48,7 +48,7 @@ public class WithdrawalValidatorTests
     public void Empty_withdrawals_are_valid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, new WithdrawalValidator(LimboLogs.Instance), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);
@@ -59,12 +59,10 @@ public class WithdrawalValidatorTests
     public void Correct_withdrawals_block_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, new WithdrawalValidator(LimboLogs.Instance), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);
         Assert.That(isValid, Is.True);
     }
-
-    private static WithdrawalValidator CreateWithdrawalValidator() => new(LimboLogs.Instance);
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/WithdrawalValidatorTests.cs
@@ -29,7 +29,7 @@ public class WithdrawalValidatorTests
     public void Null_withdrawals_are_invalid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.TestObject);
         Assert.That(isValid, Is.False);
     }
@@ -38,7 +38,7 @@ public class WithdrawalValidatorTests
     public void Withdrawals_with_incorrect_withdrawals_root_are_invalid()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(TestItem.KeccakD).TestObject);
         Assert.That(isValid, Is.False);
@@ -48,7 +48,7 @@ public class WithdrawalValidatorTests
     public void Empty_withdrawals_are_valid_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);
@@ -59,7 +59,7 @@ public class WithdrawalValidatorTests
     public void Correct_withdrawals_block_post_shanghai()
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Shanghai.Instance));
-        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(),specProvider, LimboLogs.Instance);
+        BlockValidator blockValidator = new(Always.Valid, Always.Valid, Always.Valid, CreateWithdrawalValidator(), specProvider, LimboLogs.Instance);
         Withdrawal[] withdrawals = [TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth];
         Hash256 withdrawalRoot = new WithdrawalTrie(withdrawals).RootHash;
         bool isValid = blockValidator.ValidateSuggestedBlock(Build.A.Block.WithWithdrawals(withdrawals).WithWithdrawalsRoot(withdrawalRoot).TestObject);

--- a/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
@@ -8,7 +8,7 @@ using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.Validators;
 
-public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxValidator
+public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxValidator, IWithdrawalValidator
 {
     private readonly bool _result;
     private readonly ValidationResult _validationResult;
@@ -110,4 +110,9 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
         return _result;
     }
 
+    public bool ValidateWithdrawals(Block block, IReleaseSpec spec, out string? error)
+    {
+        error = null;
+        return _result;
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
@@ -92,6 +92,11 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
         return _result;
     }
 
+    public bool ValidateBody(Block block)
+    {
+        return _result;
+    }
+
     public bool ValidateOrphanedBlock(Block block, out string? error)
     {
         error = null;

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -242,6 +242,16 @@ public class BlockValidator(
         return _withdrawalValidator.ValidateWithdrawals(block, _specProvider.GetSpec(block.Header), out error);
     }
 
+    public bool ValidateBody(Block block)
+    {
+        _specProvider.GetSpec(block.Header);
+
+        return
+            ValidateTxRootMatchesTxs(block, out _) &&
+            ValidateUnclesHashMatches(block, out _) &&
+            _withdrawalValidator.ValidateWithdrawals(block, _specProvider.GetSpec(block.Header), out _);
+    }
+
     protected virtual bool ValidateTransactions(Block block, IReleaseSpec spec, out string? errorMessage)
     {
         Transaction[] transactions = block.Transactions;
@@ -331,13 +341,13 @@ public class BlockValidator(
     public static bool ValidateTxRootMatchesTxs(Block block, out Hash256 txRoot) =>
         ValidateTxRootMatchesTxs(block.Header, block.Body, out txRoot);
 
-    public static bool ValidateTxRootMatchesTxs(BlockHeader header, BlockBody body, out Hash256 txRoot) =>
+    private static bool ValidateTxRootMatchesTxs(BlockHeader header, BlockBody body, out Hash256 txRoot) =>
         (txRoot = TxTrie.CalculateRoot(body.Transactions)) == header.TxRoot;
 
     public static bool ValidateUnclesHashMatches(Block block, out Hash256 unclesHash) =>
         ValidateUnclesHashMatches(block.Header, block.Body, out unclesHash);
 
-    public static bool ValidateUnclesHashMatches(BlockHeader header, BlockBody body, out Hash256 unclesHash) =>
+    private static bool ValidateUnclesHashMatches(BlockHeader header, BlockBody body, out Hash256 unclesHash) =>
         (unclesHash = UnclesHash.Calculate(body.Uncles)) == header.UnclesHash;
 
     private static string Invalid(Block block) =>

--- a/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
@@ -17,21 +17,12 @@ public interface IBlockValidator : IHeaderValidator
     /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
     /// </summary>
     /// <param name="block">The block to validate.</param>
-    /// <returns>
-    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
-    /// otherwise, <c>false</c>.
-    /// </returns>
-    bool ValidateWithdrawals(Block block) => ValidateWithdrawals(block, out _);
-
-    /// <summary>
-    /// Validates the block specified for withdrawals against
-    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
-    /// </summary>
-    /// <param name="block">The block to validate.</param>
     /// <param name="error">The validation error message if any.</param>
     /// <returns>
     /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
     /// otherwise, <c>false</c>.
     /// </returns>
     bool ValidateWithdrawals(Block block, out string? error);
+
+    bool ValidateBody(Block block);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
@@ -13,15 +13,11 @@ public interface IBlockValidator : IHeaderValidator
     bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error);
 
     /// <summary>
-    /// Validates the block specified for withdrawals against
-    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
+    /// Validates the specified block against the underlying <see cref="IWithdrawalValidator"/>.
     /// </summary>
     /// <param name="block">The block to validate.</param>
     /// <param name="error">The validation error message if any.</param>
-    /// <returns>
-    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
-    /// otherwise, <c>false</c>.
-    /// </returns>
+    /// <returns>Whether the block has valid withdrawals.</returns>
     bool ValidateWithdrawals(Block block, out string? error);
 
     bool ValidateBody(Block block);

--- a/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
@@ -6,9 +6,32 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Consensus.Validators;
 
-public interface IBlockValidator : IHeaderValidator, IWithdrawalValidator
+public interface IBlockValidator : IHeaderValidator
 {
     bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error);
     bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error, bool validateHashes = true);
     bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error);
+
+    /// <summary>
+    /// Validates the block specified for withdrawals against
+    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
+    /// </summary>
+    /// <param name="block">The block to validate.</param>
+    /// <returns>
+    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
+    /// otherwise, <c>false</c>.
+    /// </returns>
+    bool ValidateWithdrawals(Block block) => ValidateWithdrawals(block, out _);
+
+    /// <summary>
+    /// Validates the block specified for withdrawals against
+    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
+    /// </summary>
+    /// <param name="block">The block to validate.</param>
+    /// <param name="error">The validation error message if any.</param>
+    /// <returns>
+    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
+    /// otherwise, <c>false</c>.
+    /// </returns>
+    bool ValidateWithdrawals(Block block, out string? error);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IWithdrawalValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IWithdrawalValidator.cs
@@ -9,15 +9,11 @@ namespace Nethermind.Consensus.Validators;
 public interface IWithdrawalValidator
 {
     /// <summary>
-    /// Validates the block specified for withdrawals against
-    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
+    /// Validates the specified block for withdrawals, if they are available at <paramref name="spec"/>.
     /// </summary>
     /// <param name="block">The block to validate.</param>
-    /// <param name="spec"></param>
+    /// <param name="spec">The current spec.</param>
     /// <param name="error">The validation error message if any.</param>
-    /// <returns>
-    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
-    /// otherwise, <c>false</c>.
-    /// </returns>
+    /// <returns>Whether withdrawals are valid. </returns>
     bool ValidateWithdrawals(Block block, IReleaseSpec spec, out string? error);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IWithdrawalValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IWithdrawalValidator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 
 namespace Nethermind.Consensus.Validators;
 
@@ -12,21 +13,11 @@ public interface IWithdrawalValidator
     /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
     /// </summary>
     /// <param name="block">The block to validate.</param>
-    /// <returns>
-    /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
-    /// otherwise, <c>false</c>.
-    /// </returns>
-    bool ValidateWithdrawals(Block block) => ValidateWithdrawals(block, out _);
-
-    /// <summary>
-    /// Validates the block specified for withdrawals against
-    /// the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
-    /// </summary>
-    /// <param name="block">The block to validate.</param>
+    /// <param name="spec"></param>
     /// <param name="error">The validation error message if any.</param>
     /// <returns>
     /// <c>true</c> if <see cref="Block.Withdrawals"/> are not <c>null</c> when EIP-4895 is activated;
     /// otherwise, <c>false</c>.
     /// </returns>
-    bool ValidateWithdrawals(Block block, out string? error);
+    bool ValidateWithdrawals(Block block, IReleaseSpec spec, out string? error);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
@@ -49,6 +49,11 @@ namespace Nethermind.Consensus.Validators
             return false;
         }
 
+        public bool ValidateBody(Block block)
+        {
+            return false;
+        }
+
         public bool ValidateOrphanedBlock(Block block, out string? error)
         {
             error = null;

--- a/src/Nethermind/Nethermind.Consensus/Validators/SimulateBlockValidatorProxy.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/SimulateBlockValidatorProxy.cs
@@ -10,6 +10,8 @@ public class SimulateBlockValidatorProxy(IBlockValidator baseBlockValidator) : I
     public bool ValidateWithdrawals(Block block, out string? error) =>
         baseBlockValidator.ValidateWithdrawals(block, out error);
 
+    public bool ValidateBody(Block block) => baseBlockValidator.ValidateBody(block);
+
     public bool ValidateOrphanedBlock(Block block, out string? error) =>
         baseBlockValidator.ValidateOrphanedBlock(block, out error);
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Consensus.Messages;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Logging;
+using Nethermind.State.Proofs;
+
+namespace Nethermind.Consensus.Validators;
+
+public class WithdrawalValidator : IWithdrawalValidator
+{
+    private readonly ILogger _logger;
+
+    public WithdrawalValidator(ILogManager? logManager)
+    {
+        _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
+    }
+
+    public bool ValidateWithdrawals(Block block, IReleaseSpec spec, out string? error)
+    {
+        if (spec.WithdrawalsEnabled && block.Withdrawals is null)
+        {
+            error = BlockErrorMessages.MissingWithdrawals;
+
+            if (_logger.IsWarn) _logger.Warn($"Withdrawals cannot be null in block {block.Hash} when EIP-4895 activated.");
+
+            return false;
+        }
+
+        if (!spec.WithdrawalsEnabled && block.Withdrawals is not null)
+        {
+            error = BlockErrorMessages.WithdrawalsNotEnabled;
+
+            if (_logger.IsWarn) _logger.Warn($"Withdrawals must be null in block {block.Hash} when EIP-4895 not activated.");
+
+            return false;
+        }
+
+        if (block.Withdrawals is not null)
+        {
+            if (!ValidateWithdrawalsHashMatches(block, out Hash256 withdrawalsRoot))
+            {
+                error = BlockErrorMessages.InvalidWithdrawalsRoot(block.Header.WithdrawalsRoot, withdrawalsRoot);
+                if (_logger.IsWarn) _logger.Warn($"Withdrawals root hash mismatch in block {block.ToString(Block.Format.FullHashAndNumber)}: expected {block.Header.WithdrawalsRoot}, got {withdrawalsRoot}");
+
+                return false;
+            }
+        }
+
+        error = null;
+
+        return true;
+    }
+
+    // TODO: make them private
+    public static bool ValidateWithdrawalsHashMatches(Block block, out Hash256? withdrawalsRoot) =>
+        ValidateWithdrawalsHashMatches(block.Header, block.Body, out withdrawalsRoot);
+
+    public static bool ValidateWithdrawalsHashMatches(BlockHeader header, BlockBody body, out Hash256? withdrawalsRoot)
+    {
+        if (body.Withdrawals is null)
+        {
+            withdrawalsRoot = null;
+            return header.WithdrawalsRoot is null;
+        }
+
+        return (withdrawalsRoot = new WithdrawalTrie(body.Withdrawals).RootHash) == header.WithdrawalsRoot;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
@@ -42,7 +42,7 @@ public class WithdrawalValidator : IWithdrawalValidator
 
         if (block.Withdrawals is not null)
         {
-            if (!ValidateWithdrawalsHashMatches(block, out Hash256 withdrawalsRoot))
+            if (!ValidateWithdrawalsHashMatches(block.Header, block.Body, out var withdrawalsRoot))
             {
                 error = BlockErrorMessages.InvalidWithdrawalsRoot(block.Header.WithdrawalsRoot, withdrawalsRoot);
                 if (_logger.IsWarn) _logger.Warn($"Withdrawals root hash mismatch in block {block.ToString(Block.Format.FullHashAndNumber)}: expected {block.Header.WithdrawalsRoot}, got {withdrawalsRoot}");
@@ -57,9 +57,6 @@ public class WithdrawalValidator : IWithdrawalValidator
     }
 
     // TODO: make them private
-    public static bool ValidateWithdrawalsHashMatches(Block block, out Hash256? withdrawalsRoot) =>
-        ValidateWithdrawalsHashMatches(block.Header, block.Body, out withdrawalsRoot);
-
     public static bool ValidateWithdrawalsHashMatches(BlockHeader header, BlockBody body, out Hash256? withdrawalsRoot)
     {
         if (body.Withdrawals is null)

--- a/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/WithdrawalValidator.cs
@@ -11,6 +11,10 @@ using Nethermind.State.Proofs;
 
 namespace Nethermind.Consensus.Validators;
 
+
+/// <summary>
+/// Validates a block for withdrawals against the <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
+/// </summary>
 public class WithdrawalValidator : IWithdrawalValidator
 {
     private readonly ILogger _logger;

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -107,6 +107,8 @@ public class TestBlockchain : IDisposable
     private TrieStoreBoundaryWatcher _trieStoreWatcher = null!;
     public IHeaderValidator HeaderValidator { get; set; } = null!;
 
+    public IWithdrawalValidator WithdrawalValidator { get; set; } = null!;
+
     private ReceiptCanonicalityMonitor? _canonicalityMonitor;
 
     public IBlockValidator BlockValidator { get; set; } = null!;
@@ -198,6 +200,7 @@ public class TestBlockchain : IDisposable
 
         BlockPreprocessorStep = new RecoverSignatures(EthereumEcdsa, TxPool, SpecProvider, LogManager);
         HeaderValidator = new HeaderValidator(BlockTree, Always.Valid, SpecProvider, LogManager);
+        WithdrawalValidator = new WithdrawalValidator(LogManager);
 
         _canonicalityMonitor ??= new ReceiptCanonicalityMonitor(ReceiptStorage, LogManager);
         BeaconBlockRootHandler = new BeaconBlockRootHandler(TxProcessor, State);
@@ -206,6 +209,7 @@ public class TestBlockchain : IDisposable
             new TxValidator(SpecProvider.ChainId),
             HeaderValidator,
             Always.Valid,
+            WithdrawalValidator,
             SpecProvider,
             LogManager);
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/BlockProcessingModule.cs
@@ -36,6 +36,7 @@ public class BlockProcessingModule : Module
             .AddSingleton<ITxValidator, ISpecProvider>((spec) => new TxValidator(spec.ChainId))
             .AddSingleton<IHeaderValidator, HeaderValidator>()
             .AddSingleton<IUnclesValidator, UnclesValidator>()
+            .AddSingleton<IWithdrawalValidator, WithdrawalValidator>()
             .AddSingleton<IRewardCalculatorSource>(NoBlockRewards.Instance)
             .AddSingleton<ISealValidator>(NullSealEngine.Instance)
             .AddSingleton<ITransactionComparerProvider, TransactionComparerProvider>()

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -98,6 +98,7 @@ public class SimulateReadOnlyBlocksProcessingEnv : IDisposable
             new TxValidator(SpecProvider!.ChainId),
             headerValidator,
             Always.Valid,
+            new WithdrawalValidator(_logManager),
             SpecProvider,
             _logManager);
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -85,6 +85,7 @@ namespace Nethermind.Init.Steps
 
             setApi.HeaderValidator = CreateHeaderValidator();
             setApi.UnclesValidator = CreateUnclesValidator();
+            setApi.WithdrawalValidator = CreateWithdrawalValidator();
             setApi.BlockValidator = CreateBlockValidator();
 
             IChainHeadInfoProvider chainHeadInfoProvider =
@@ -179,6 +180,7 @@ namespace Nethermind.Init.Steps
                 _api.TxValidator,
                 _api.HeaderValidator,
                 _api.UnclesValidator,
+                _api.WithdrawalValidator,
                 _api.SpecProvider,
                 _api.LogManager);
         }
@@ -189,6 +191,11 @@ namespace Nethermind.Init.Steps
                 _api.BlockTree,
                 _api.HeaderValidator,
                 _api.LogManager);
+        }
+
+        protected virtual IWithdrawalValidator CreateWithdrawalValidator()
+        {
+            return new WithdrawalValidator(_api.LogManager);
         }
 
         protected virtual ITransactionProcessor CreateTransactionProcessor(CodeInfoRepository codeInfoRepository, IVirtualMachine virtualMachine, IWorldState worldState)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -284,11 +284,13 @@ public partial class EngineModuleTests
             SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
             HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
             HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);
+            WithdrawalValidator = new WithdrawalValidator(LogManager);
 
             return new BlockValidator(
                 new TxValidator(SpecProvider.ChainId),
                 HeaderValidator,
                 Always.Valid,
+                WithdrawalValidator,
                 SpecProvider,
                 LogManager);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
@@ -44,6 +44,8 @@ public class InvalidBlockInterceptorTest
     {
         Block block = Build.A.Block.TestObject;
         _baseValidator.ValidateSuggestedBlock(block, out _).Returns(baseReturnValue);
+        _baseValidator.ValidateBody(block).Returns(true);
+
         _invalidBlockInterceptor.ValidateSuggestedBlock(block, out _);
 
         _tracker.Received().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
@@ -65,6 +67,7 @@ public class InvalidBlockInterceptorTest
         Block suggestedBlock = Build.A.Block.WithExtraData(new byte[] { 1 }).TestObject;
         TxReceipt[] txs = [];
         _baseValidator.ValidateProcessedBlock(block, txs, suggestedBlock, out _).Returns(baseReturnValue);
+        _baseValidator.ValidateBody(block).Returns(true);
         _invalidBlockInterceptor.ValidateProcessedBlock(block, txs, suggestedBlock);
 
         _tracker.Received().SetChildParent(suggestedBlock.GetOrCalculateHash(), suggestedBlock.ParentHash!);
@@ -126,5 +129,4 @@ public class InvalidBlockInterceptorTest
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
         _tracker.DidNotReceive().OnInvalidBlock(block.GetOrCalculateHash(), block.ParentHash);
     }
-
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
@@ -123,5 +123,5 @@ public class InvalidBlockInterceptor(
         // Body does not match header, but it does not mean the hash that the header point to is invalid.
         !BlockValidator.ValidateTxRootMatchesTxs(block, out _) ||
         !BlockValidator.ValidateUnclesHashMatches(block, out _) ||
-        !BlockValidator.ValidateWithdrawalsHashMatches(block, out _);
+        !WithdrawalValidator.ValidateWithdrawalsHashMatches(block, out _);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -254,7 +254,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
 
             _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
             _api.BlockValidator = new InvalidBlockInterceptor(
-                new BlockValidator(_api.TxValidator, _api.HeaderValidator, _api.UnclesValidator,
+                new BlockValidator(_api.TxValidator, _api.HeaderValidator, _api.UnclesValidator, _api.WithdrawalValidator,
                     _api.SpecProvider, _api.LogManager),
                 _invalidChainTracker,
                 _api.LogManager);
@@ -420,6 +420,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                     _api.TxValidator,
                     _api.HeaderValidator,
                     _api.UnclesValidator,
+                    _api.WithdrawalValidator,
                     _api.SpecProvider,
                     _api.LogManager),
                 _invalidChainTracker,

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -394,6 +394,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
             if (_api.BetterPeerStrategy is null) throw new ArgumentNullException(nameof(_api.BetterPeerStrategy));
             if (_api.SealValidator is null) throw new ArgumentNullException(nameof(_api.SealValidator));
             if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
+            if (_api.WithdrawalValidator is null) throw new ArgumentNullException(nameof(_api.WithdrawalValidator));
             if (_api.NodeStatsManager is null) throw new ArgumentNullException(nameof(_api.NodeStatsManager));
             if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
             if (_api.StateReader is null) throw new ArgumentNullException(nameof(_api.StateReader));

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -109,6 +109,7 @@ namespace Nethermind.Runner.Test.Ethereum
                 HealthHintService = Substitute.For<IHealthHintService>(),
                 TxValidator = new TxValidator(MainnetSpecProvider.Instance.ChainId),
                 UnclesValidator = Substitute.For<IUnclesValidator>(),
+                WithdrawalValidator = Substitute.For<IWithdrawalValidator>(),
                 BlockProductionPolicy = Substitute.For<IBlockProductionPolicy>(),
                 BetterPeerStrategy = Substitute.For<IBetterPeerStrategy>(),
                 ReceiptMonitor = Substitute.For<IReceiptMonitor>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -499,6 +499,12 @@ public partial class BlockDownloaderTests
             return true;
         }
 
+        public bool ValidateBody(Block block)
+        {
+            Thread.Sleep(1000);
+            return true;
+        }
+
         public bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error)
         {
             Thread.Sleep(1000);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -236,6 +236,7 @@ public class SyncServerTests
             Always.Valid,
             mergeHeaderValidator,
             Always.Valid,
+            Always.Valid,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
 
@@ -459,6 +460,7 @@ public class SyncServerTests
             Always.Valid,
             headerValidatorWithInterceptor,
             Always.Valid,
+            Always.Valid,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);
 
@@ -498,6 +500,7 @@ public class SyncServerTests
         BlockValidator blockValidator = new(
             Always.Valid,
             headerValidator,
+            Always.Valid,
             Always.Valid,
             MainnetSpecProvider.Instance,
             LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Taiko/InitializeBlockchainTaiko.cs
+++ b/src/Nethermind/Nethermind.Taiko/InitializeBlockchainTaiko.cs
@@ -55,6 +55,7 @@ public class InitializeBlockchainTaiko(TaikoNethermindApi api) : InitializeBlock
         if (_api.TxValidator is null) throw new StepDependencyException(nameof(_api.TxValidator));
         if (_api.HeaderValidator is null) throw new StepDependencyException(nameof(_api.HeaderValidator));
         if (_api.UnclesValidator is null) throw new StepDependencyException(nameof(_api.UnclesValidator));
+        if (_api.WithdrawalValidator is null) throw new StepDependencyException(nameof(_api.WithdrawalValidator));
         if (_api.EthereumEcdsa is null) throw new StepDependencyException(nameof(_api.EthereumEcdsa));
         if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
 
@@ -62,6 +63,7 @@ public class InitializeBlockchainTaiko(TaikoNethermindApi api) : InitializeBlock
             _api.TxValidator,
             _api.HeaderValidator,
             _api.UnclesValidator,
+            _api.WithdrawalValidator,
             _api.SpecProvider,
             _api.EthereumEcdsa,
             _api.LogManager);

--- a/src/Nethermind/Nethermind.Taiko/TaikoBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoBlockValidator.cs
@@ -17,9 +17,10 @@ public class TaikoBlockValidator(
     ITxValidator txValidator,
     IHeaderValidator headerValidator,
     IUnclesValidator unclesValidator,
+    IWithdrawalValidator withdrawalValidator,
     ISpecProvider specProvider,
     IEthereumEcdsa ecdsa,
-    ILogManager logManager) : BlockValidator(txValidator, headerValidator, unclesValidator, specProvider, logManager)
+    ILogManager logManager) : BlockValidator(txValidator, headerValidator, unclesValidator, withdrawalValidator, specProvider, logManager)
 {
     private static readonly byte[] AnchorSelector = Keccak.Compute("anchor(bytes32,bytes32,uint64,uint32)").Bytes[0..4].ToArray();
     private static readonly byte[] AnchorV2Selector = Keccak.Compute("anchorV2(uint64,bytes32,uint32,(uint8,uint8,uint32,uint64,uint32))").Bytes[0..4].ToArray();


### PR DESCRIPTION
This PR introduces an option to override `IWithdrawalValidator` without reimplementing the whole `BlockValidator`. This is done in a preparation of #8235 so that `Optimism` can provide its validator for the withdrawal roots. The separation moves the validating method to the `BlockValidator` while keeping spec-specific one in the newly created `WithdrawalValidator`. The design is aligned with other validating components like, `UncleValidator` etc.

## Changes

- `BlockValidator` no longer implements `IWithdrawalValidator`
- `BlockValidator` keeps its methods for validating withdrawals
- a separate family of components for the withdrawal validation `IWithdrawalValidator` / `WithdrawalValidator` is created

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
