### PR TITLE
fix shutter test execute engine tests

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
@@ -21,17 +22,20 @@ using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Db;
-using Nethermind.Evm.Tracing;
 using Nethermind.Facade.Eth;
 using Nethermind.HealthChecks;
 using Nethermind.Int256;
+using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.GC;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Synchronization;
@@ -46,7 +50,7 @@ using NUnit.Framework;
 
 namespace Nethermind.Merge.Plugin.Test;
 
-public partial class EngineModuleTests
+public class BaseEngineModuleTests
 {
     [SetUp]
     public Task Setup()
@@ -148,6 +152,75 @@ public partial class EngineModuleTests
             chain.SpecProvider,
             new GCKeeper(NoGCStrategy.Instance, chain.LogManager),
             chain.LogManager);
+    }
+
+    protected async Task<IReadOnlyList<ExecutionPayload>> ProduceBranchV1(IEngineRpcModule rpc,
+        MergeTestBlockchain chain,
+        int count, ExecutionPayload startingParentBlock, bool setHead, Hash256? random = null,
+        ulong slotLength = 12)
+    {
+        List<ExecutionPayload> blocks = new();
+        ExecutionPayload parentBlock = startingParentBlock;
+        parentBlock.TryGetBlock(out Block? block);
+        UInt256? startingTotalDifficulty = block!.IsGenesis
+            ? block.Difficulty : chain.BlockFinder.FindHeader(block!.Header!.ParentHash!)!.TotalDifficulty;
+        BlockHeader parentHeader = block!.Header;
+        parentHeader.TotalDifficulty = startingTotalDifficulty +
+                                       parentHeader.Difficulty;
+        for (int i = 0; i < count; i++)
+        {
+            ExecutionPayload? getPayloadResult = await BuildAndGetPayloadOnBranch(rpc, chain, parentHeader,
+                parentBlock.Timestamp + slotLength,
+                random ?? TestItem.KeccakA, Address.Zero);
+            PayloadStatusV1 payloadStatusResponse = (await rpc.engine_newPayloadV1(getPayloadResult)).Data;
+            payloadStatusResponse.Status.Should().Be(PayloadStatus.Valid);
+            if (setHead)
+            {
+                Hash256 newHead = getPayloadResult!.BlockHash;
+                ForkchoiceStateV1 forkchoiceStateV1 = new(newHead, newHead, newHead);
+                ResultWrapper<ForkchoiceUpdatedV1Result> setHeadResponse = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
+                setHeadResponse.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+                setHeadResponse.Data.PayloadId.Should().Be(null);
+            }
+
+            blocks.Add((getPayloadResult));
+            parentBlock = getPayloadResult;
+            parentBlock.TryGetBlock(out block!);
+            block.Header.TotalDifficulty = parentHeader.TotalDifficulty + block.Header.Difficulty;
+            parentHeader = block.Header;
+        }
+
+        return blocks;
+    }
+
+    protected async Task<ExecutionPayload> BuildAndGetPayloadOnBranch(
+        IEngineRpcModule rpc, MergeTestBlockchain chain, BlockHeader parentHeader,
+        ulong timestamp, Hash256 random, Address feeRecipient)
+    {
+        PayloadAttributes payloadAttributes =
+            new() { Timestamp = timestamp, PrevRandao = random, SuggestedFeeRecipient = feeRecipient };
+
+        // we're using payloadService directly, because we can't use fcU for branch
+        string payloadId = chain.PayloadPreparationService!.StartPreparingPayload(parentHeader, payloadAttributes)!;
+
+        ResultWrapper<ExecutionPayload?> getPayloadResult =
+            await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId));
+        return getPayloadResult.Data!;
+    }
+
+    protected ExecutionPayload CreateParentBlockRequestOnHead(IBlockTree blockTree)
+    {
+        Block? head = blockTree.Head ?? throw new NotSupportedException();
+        return new ExecutionPayload()
+        {
+            BlockNumber = head.Number,
+            BlockHash = head.Hash!,
+            StateRoot = head.StateRoot!,
+            ReceiptsRoot = head.ReceiptsRoot!,
+            GasLimit = head.GasLimit,
+            Timestamp = head.Timestamp,
+            BaseFeePerGas = head.BaseFeePerGas,
+        };
     }
 
     public class MergeTestBlockchain : TestBlockchain
@@ -304,57 +377,5 @@ public partial class EngineModuleTests
 
         public async Task<MergeTestBlockchain> Build(ISpecProvider? specProvider = null) =>
             (MergeTestBlockchain)await Build(specProvider, null);
-    }
-}
-
-public class TestBlockProcessorInterceptor : IBlockProcessor
-{
-    private readonly IBlockProcessor _blockProcessorImplementation;
-    public int DelayMs { get; set; }
-    public Exception? ExceptionToThrow { get; set; }
-
-    public TestBlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, int delayMs)
-    {
-        _blockProcessorImplementation = baseBlockProcessor;
-        DelayMs = delayMs;
-    }
-
-    public Block[] Process(Hash256 newBranchStateRoot, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions processingOptions, IBlockTracer blockTracer)
-    {
-        if (DelayMs > 0)
-        {
-            Thread.Sleep(DelayMs);
-        }
-
-        if (ExceptionToThrow is not null)
-        {
-            throw ExceptionToThrow;
-        }
-
-        return _blockProcessorImplementation.Process(newBranchStateRoot, suggestedBlocks, processingOptions, blockTracer);
-    }
-
-    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
-    {
-        add => _blockProcessorImplementation.BlocksProcessing += value;
-        remove => _blockProcessorImplementation.BlocksProcessing -= value;
-    }
-
-    public event EventHandler<BlockEventArgs>? BlockProcessing
-    {
-        add => _blockProcessorImplementation.BlockProcessing += value;
-        remove => _blockProcessorImplementation.BlockProcessing -= value;
-    }
-
-    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed
-    {
-        add => _blockProcessorImplementation.BlockProcessed += value;
-        remove => _blockProcessorImplementation.BlockProcessed -= value;
-    }
-
-    public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
-    {
-        add => _blockProcessorImplementation.TransactionProcessed += value;
-        remove => _blockProcessorImplementation.TransactionProcessed -= value;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -20,7 +20,6 @@ using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
-using Microsoft.CodeAnalysis;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing;
@@ -28,7 +27,7 @@ using Nethermind.Evm.Tracing;
 namespace Nethermind.Merge.Plugin.Test
 {
     [Parallelizable(ParallelScope.All)]
-    public partial class EngineModuleTests: BaseEngineModuleTests
+    public partial class EngineModuleTests : BaseEngineModuleTests
     {
         private static readonly DateTime Timestamp = DateTimeOffset.FromUnixTimeSeconds(1000).UtcDateTime;
         private ITimestamper Timestamper { get; } = new ManualTimestamper(Timestamp);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -28,7 +28,7 @@ using Nethermind.Evm.Tracing;
 namespace Nethermind.Merge.Plugin.Test
 {
     [Parallelizable(ParallelScope.All)]
-    public partial class EngineModuleTests
+    public partial class EngineModuleTests: BaseEngineModuleTests
     {
         private static readonly DateTime Timestamp = DateTimeOffset.FromUnixTimeSeconds(1000).UtcDateTime;
         private ITimestamper Timestamper { get; } = new ManualTimestamper(Timestamp);
@@ -82,21 +82,6 @@ namespace Nethermind.Merge.Plugin.Test
             accountFrom = account;
 
             return Enumerable.Range(0, (int)count).Select(i => BuildTransaction((uint)i, account)).ToArray();
-        }
-
-        protected ExecutionPayload CreateParentBlockRequestOnHead(IBlockTree blockTree)
-        {
-            Block? head = blockTree.Head ?? throw new NotSupportedException();
-            return new ExecutionPayload()
-            {
-                BlockNumber = head.Number,
-                BlockHash = head.Hash!,
-                StateRoot = head.StateRoot!,
-                ReceiptsRoot = head.ReceiptsRoot!,
-                GasLimit = head.GasLimit,
-                Timestamp = head.Timestamp,
-                BaseFeePerGas = head.BaseFeePerGas,
-            };
         }
 
         private static ExecutionPayload CreateBlockRequest(MergeTestBlockchain chain, ExecutionPayload parent, Address miner, Withdrawal[]? withdrawals = null,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/TestBlockProcessorInterceptor.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/TestBlockProcessorInterceptor.Setup.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.Tracing;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+public class TestBlockProcessorInterceptor : IBlockProcessor
+{
+    private readonly IBlockProcessor _blockProcessorImplementation;
+    public int DelayMs { get; set; }
+    public Exception? ExceptionToThrow { get; set; }
+
+    public TestBlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, int delayMs)
+    {
+        _blockProcessorImplementation = baseBlockProcessor;
+        DelayMs = delayMs;
+    }
+
+    public Block[] Process(Hash256 newBranchStateRoot, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions processingOptions, IBlockTracer blockTracer)
+    {
+        if (DelayMs > 0)
+        {
+            Thread.Sleep(DelayMs);
+        }
+
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return _blockProcessorImplementation.Process(newBranchStateRoot, suggestedBlocks, processingOptions, blockTracer);
+    }
+
+    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
+    {
+        add => _blockProcessorImplementation.BlocksProcessing += value;
+        remove => _blockProcessorImplementation.BlocksProcessing -= value;
+    }
+
+    public event EventHandler<BlockEventArgs>? BlockProcessing
+    {
+        add => _blockProcessorImplementation.BlockProcessing += value;
+        remove => _blockProcessorImplementation.BlockProcessing -= value;
+    }
+
+    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed
+    {
+        add => _blockProcessorImplementation.BlockProcessed += value;
+        remove => _blockProcessorImplementation.BlockProcessed -= value;
+    }
+
+    public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
+    {
+        add => _blockProcessorImplementation.TransactionProcessed += value;
+        remove => _blockProcessorImplementation.TransactionProcessed -= value;
+    }
+}

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterBlockHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterBlockHandlerTests.cs
@@ -12,7 +12,7 @@ using Nethermind.Merge.Plugin.Test;
 namespace Nethermind.Shutter.Test;
 
 [TestFixture]
-class ShutterBlockHandlerTests : EngineModuleTests
+class ShutterBlockHandlerTests : BaseEngineModuleTests
 {
     [Test]
     public void Can_wait_for_valid_block()

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterIntegrationTests.cs
@@ -16,7 +16,7 @@ using Nethermind.Merge.Plugin.Test;
 namespace Nethermind.Shutter.Test;
 
 [TestFixture]
-public class ShutterIntegrationTests : EngineModuleTests
+public class ShutterIntegrationTests : BaseEngineModuleTests
 {
     private const int BuildingSlot = (int)ShutterTestsCommon.InitialSlot;
     private const ulong BuildingSlotTimestamp = ShutterTestsCommon.InitialSlotTimestamp;

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterTestsCommon.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterTestsCommon.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.IO.Abstractions;
 using Nethermind.Abi;
 using Nethermind.Blockchain;
@@ -14,12 +13,11 @@ using Nethermind.Crypto;
 using Nethermind.Facade.Find;
 using Nethermind.KeyStore.Config;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Test;
 using Nethermind.Shutter.Config;
 using Nethermind.Specs;
 using Nethermind.State;
 using NSubstitute;
-
-using static Nethermind.Merge.Plugin.Test.EngineModuleTests;
 
 namespace Nethermind.Shutter.Test;
 class ShutterTestsCommon
@@ -63,7 +61,7 @@ class ShutterTestsCommon
         );
     }
 
-    public static ShutterApiSimulator InitApi(Random rnd, MergeTestBlockchain chain, ITimestamper? timestamper = null, ShutterEventSimulator? eventSimulator = null)
+    public static ShutterApiSimulator InitApi(Random rnd, BaseEngineModuleTests.MergeTestBlockchain chain, ITimestamper? timestamper = null, ShutterEventSimulator? eventSimulator = null)
         => new(
             eventSimulator ?? InitEventSimulator(rnd),
             AbiEncoder, chain.BlockTree.AsReadOnly(), chain.EthereumEcdsa, chain.LogFinder, chain.ReceiptStorage,

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterTxLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterTxLoaderTests.cs
@@ -15,7 +15,7 @@ using Nethermind.Merge.Plugin.Test;
 namespace Nethermind.Shutter.Test;
 
 [TestFixture]
-class ShutterTxLoaderTests : EngineModuleTests
+class ShutterTxLoaderTests : BaseEngineModuleTests
 {
     private class ShutterEventSimulatorHalfInvalid(Random rnd, ulong chainId, ulong threshold, ulong slot, IAbiEncoder abiEncoder, Address sequencerContractAddress) : ShutterEventSimulator(rnd, chainId, threshold, slot, abiEncoder, sequencerContractAddress)
     {


### PR DESCRIPTION
- Some shutter test subclasses `EngineModuleTests` without actually changing any behaviour. It just need the rpc factory method and some util function. This causes it to execute some engine module tests also.
- This PR moves those util class ot `BaseEngineModuleTests` so that shutter tests does not execute the engine tests again.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
