### PR TITLE
Feature/detailed metric

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Metrics.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Metrics.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using Nethermind.Core.Attributes;
+using Nethermind.Core.Metric;
 using Nethermind.Int256;
 // ReSharper disable InconsistentNaming
 
@@ -94,5 +95,16 @@ namespace Nethermind.Blockchain
         [GaugeMetric]
         [Description("State root calculation time")]
         public static double StateMerkleizationTime { get; set; }
+
+        [DetailedMetric]
+        [ExponentialPowerHistogramMetric(Start = 10, Factor = 1.2, Count = 30)]
+        [Description("Histogram of block MGas per second")]
+        public static IMetricObserver BlockMGasPerSec { get; set; } = new NoopMetricObserver();
+
+        [DetailedMetric]
+        [ExponentialPowerHistogramMetric(Start = 100, Factor = 1.25, Count = 50)]
+        [Description("Histogram of block prorcessing time")]
+        public static IMetricObserver BlockProcessingTimeMicros { get; set; } = new NoopMetricObserver();
+
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -159,6 +159,12 @@ namespace Nethermind.Consensus.Processing
             _lastBlockNumber = blockNumber;
             double chunkMGas = (_chunkMGas += block.GasUsed / 1_000_000.0);
 
+            // We want the rate here
+            double mgas = block.GasUsed / 1_000_000.0;
+            double timeSec = data.ProcessingMicroseconds / 1_000_000.0;
+            Metrics.BlockMGasPerSec.Observe(mgas / timeSec);
+            Metrics.BlockProcessingTimeMicros.Observe(data.ProcessingMicroseconds);
+
             Metrics.Mgas += block.GasUsed / 1_000_000.0;
             Transaction[] txs = block.Transactions;
             double chunkMicroseconds = (_chunkProcessingMicroseconds += data.ProcessingMicroseconds);

--- a/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
+++ b/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
@@ -31,6 +31,7 @@ public sealed class KeyIsLabelAttribute : Attribute
     }
 }
 
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class SummaryMetricAttribute : Attribute
 {
     public string[] LabelNames { get; set; } = [];
@@ -38,4 +39,12 @@ public sealed class SummaryMetricAttribute : Attribute
     // Summary objective in quantile-epsilon pair
     public double[] ObjectiveQuantile { get; set; } = [];
     public double[] ObjectiveEpsilon { get; set; } = [];
+}
+
+/// <summary>
+/// Mark a metric as detailed
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class DetailedMetricAttribute : Attribute
+{
 }

--- a/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
+++ b/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
@@ -41,6 +41,15 @@ public sealed class SummaryMetricAttribute : Attribute
     public double[] ObjectiveEpsilon { get; set; } = [];
 }
 
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class ExponentialPowerHistogramMetric : Attribute
+{
+    public string[] LabelNames { get; } = [];
+    public double Start { get; set; }
+    public double Factor { get; set; }
+    public int Count { get; set; }
+}
+
 /// <summary>
 /// Mark a metric as detailed
 /// </summary>

--- a/src/Nethermind/Nethermind.Core/Metric/IMetricObserver.cs
+++ b/src/Nethermind/Nethermind.Core/Metric/IMetricObserver.cs
@@ -6,4 +6,5 @@ namespace Nethermind.Core.Metric;
 public interface IMetricObserver
 {
     public void Observe(IMetricLabels labels, double value);
+    public void Observe(double value);
 }

--- a/src/Nethermind/Nethermind.Core/Metric/NoopMetricObserver.cs
+++ b/src/Nethermind/Nethermind.Core/Metric/NoopMetricObserver.cs
@@ -3,12 +3,15 @@
 
 namespace Nethermind.Core.Metric;
 
-public class NoopMetricObserver
-    : IMetricObserver
+public class NoopMetricObserver : IMetricObserver
 {
     public static NoopMetricObserver Instance = new();
 
     public void Observe(IMetricLabels labels, double value)
+    {
+    }
+
+    public void Observe(double value)
     {
     }
 }

--- a/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
@@ -43,6 +43,9 @@ public class MetricsTests
         [SummaryMetric]
         public static IMetricObserver SomeObservation { get; set; } = NoopMetricObserver.Instance;
 
+        [System.ComponentModel.Description("A test description")]
+        [DetailedMetric]
+        public static long DetailedMetric { get; set; }
     }
 
     public enum SomeEnum
@@ -103,6 +106,24 @@ public class MetricsTests
         Assert.That((updater[keyDictionary2] as MetricsController.KeyIsLabelGaugeMetricUpdater).Gauge.WithLabels("1", "11", "111").Value, Is.EqualTo(1111));
         Assert.That((updater[keyOldDictionary] as MetricsController.GaugePerKeyMetricUpdater).Gauges[keyOldDictionary0].Value, Is.EqualTo(4));
         Assert.That((updater[keyOldDictionary] as MetricsController.GaugePerKeyMetricUpdater).Gauges[keyOldDictionary1].Value, Is.EqualTo(5));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Load_DetailedMetric(bool enableDetailedMetric)
+    {
+        MetricsConfig metricsConfig = new()
+        {
+            Enabled = true,
+            EnableDetailedMetric = enableDetailedMetric
+        };
+        MetricsController metricsController = new(metricsConfig);
+        metricsController.RegisterMetrics(typeof(TestMetrics));
+        metricsController.UpdateAllMetrics();
+
+        var updater = metricsController._individualUpdater;
+        var metricName = "TestMetrics.DetailedMetric";
+        Assert.That(updater.ContainsKey(metricName), Is.EqualTo(enableDetailedMetric));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
 using FluentAssertions;
 using Nethermind.Core;
@@ -42,6 +43,10 @@ public class MetricsTests
         [System.ComponentModel.Description("summary metric")]
         [SummaryMetric]
         public static IMetricObserver SomeObservation { get; set; } = NoopMetricObserver.Instance;
+
+        [System.ComponentModel.Description("Histograrm metric")]
+        [ExponentialPowerHistogramMetric(Start = 1, Factor = 2, Count = 10)]
+        public static IMetricObserver HistogramObservation { get; set; } = NoopMetricObserver.Instance;
 
         [System.ComponentModel.Description("A test description")]
         [DetailedMetric]
@@ -87,6 +92,7 @@ public class MetricsTests
         var keyOldDictionary0 = $"{nameof(TestMetrics.OldDictionaryMetrics)}.metrics0";
         var keyOldDictionary1 = $"{nameof(TestMetrics.OldDictionaryMetrics)}.metrics1";
         var keySummary = $"{nameof(TestMetrics)}.{nameof(TestMetrics.SomeObservation)}";
+        var keyHistogram = $"{nameof(TestMetrics)}.{nameof(TestMetrics.HistogramObservation)}";
 
         Assert.That(updater.Keys, Has.Member(keyDefault));
         Assert.That(updater.Keys, Has.Member(keySpecial));
@@ -96,8 +102,10 @@ public class MetricsTests
         Assert.That((updater[keyDictionary] as MetricsController.KeyIsLabelGaugeMetricUpdater).Gauge.Name, Is.EqualTo("nethermind_with_labelled_dictionary"));
         Assert.That((updater[keyOldDictionary] as MetricsController.GaugePerKeyMetricUpdater).Gauges[keyOldDictionary0].Name, Is.EqualTo("nethermind_metrics0"));
         Assert.That((updater[keyOldDictionary] as MetricsController.GaugePerKeyMetricUpdater).Gauges[keyOldDictionary1].Name, Is.EqualTo("nethermind_metrics1"));
-        Assert.That(updater[keySummary], Is.TypeOf<MetricsController.MetricUpdater>());
-        Assert.That(TestMetrics.SomeObservation, Is.TypeOf<MetricsController.MetricUpdater>());
+        Assert.That(updater[keySummary], Is.TypeOf<MetricsController.SummaryMetricUpdater>());
+        Assert.That(updater[keyHistogram], Is.TypeOf<MetricsController.HistogramMetricUpdater>());
+        Assert.That(TestMetrics.SomeObservation, Is.TypeOf<MetricsController.SummaryMetricUpdater>());
+        Assert.That(TestMetrics.HistogramObservation, Is.TypeOf<MetricsController.HistogramMetricUpdater>());
 
         Assert.That((updater[keyDefault] as MetricsController.GaugeMetricUpdater).Gauge.Value, Is.EqualTo(123));
         Assert.That((updater[keySpecial] as MetricsController.GaugeMetricUpdater).Gauge.Value, Is.EqualTo(1234));

--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -37,4 +37,7 @@ public interface IMetricsConfig : IConfig
 
     [ConfigItem(Description = "The Prometheus metrics job name.", DefaultValue = "nethermind")]
     string MonitoringJob { get; }
+
+    [ConfigItem(Description = "Enable detailed metric", DefaultValue = "nethermind")]
+    bool EnableDetailedMetric { get; }
 }

--- a/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
@@ -15,4 +15,5 @@ public class MetricsConfig : IMetricsConfig
     public bool EnableDbSizeMetrics { get; set; } = true;
     public string MonitoringGroup { get; set; } = "nethermind";
     public string MonitoringJob { get; set; } = "nethermind";
+    public bool EnableDetailedMetric { get; set; } = false;
 }


### PR DESCRIPTION
- Add `DetailedMetricAttribute` and  `--Metric.EnableDetailedMetric` which are only published when set.
  - Some candidate include any metric heavy number that is not really important for non dev such as time in sync dispatcher, time for each message, size of each message time, etc.
- Should this be leveled instead of only "detail"? I don't know. Maybe. Tags I guess? Separate config for specific use case?
- Add `ExponentialPowerHistogramMetric` and set to block processing time and mgas per sec per block.
- Fix index out of bound exception on some labelled metric.
- Note: With histogram you need to specify the buckets of value. So the ballpark figure need to be known ahead of time. Additionally, the value resolution depends on the number of bucket and each bucket appears as a separate tag in prometheus. This means it is kinda heavy on the metric server side.

![Screenshot_2025-03-07_07-59-18](https://github.com/user-attachments/assets/45ba9118-e8a2-4ca0-b6ac-29bb215883c5)
![Screenshot_2025-03-07_07-55-17](https://github.com/user-attachments/assets/ee426565-39f1-4fb5-a9e0-e9005896684f)

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Seems to work.
