### PR TITLE
Fix random runner test failure in CI

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1592,6 +1592,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb
         private readonly ColumnFamilyHandle? _cf;
         private readonly ReadOptions? _readOptions;
         private readonly Timer _timer;
+        private bool _isDisposed;
 
         // This is about once every two second maybe at max throughput.
         private const int IteratorUsageLimit = 1000000;
@@ -1607,6 +1608,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb
 
         private void OnTimer(object? state)
         {
+            if (_isDisposed) return;
             _readaheadIterators.ClearIterators();
             _readaheadIterators2.ClearIterators();
             _readaheadIterators3.ClearIterators();
@@ -1614,6 +1616,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb
 
         public void Dispose()
         {
+            if (_isDisposed) return;
+            _isDisposed = true;
             _timer.Dispose();
             _readaheadIterators.DisposeAll();
             _readaheadIterators2.DisposeAll();

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1694,7 +1694,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb
             public void ClearIterators()
             {
                 if (_disposed) return;
-
+                if (Values is null) return;
                 foreach (IteratorHolder iterator in Values)
                 {
                     iterator.Dispose();


### PR DESCRIPTION
- CI seems to catch exception log and fail. This is the log:
```
A total of 1 test files matched the specified pattern.
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Nethermind.Db.Rocks.DbOnTheRocks.IteratorManager.ManagedIterators.ClearIterators() in /_/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs:line 1694
   at Nethermind.Db.Rocks.DbOnTheRocks.IteratorManager.OnTimer(Object state) in /_/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs:line 1610
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```
## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
