### PR TITLE
Make EthereumJsonSerializer MaxDepth configurable

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
@@ -11,15 +11,12 @@ public static class DisposableExtensions
 {
     public static void TryDispose<T>(this T item)
     {
-        if (item is IDisposable d)
-        {
-            d.Dispose();
-        }
+        (item as IDisposable)?.Dispose();
     }
 
-    public static void DisposeItems<T>(this IEnumerable<T> item) where T : IDisposable
+    public static void DisposeItems<T>(this IEnumerable<T> items) where T : IDisposable
     {
-        foreach (T disposable in item)
+        foreach (T disposable in items)
         {
             disposable.Dispose();
         }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -25,9 +25,8 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
     private string ExecuteCallTrace(byte[] code, string? tracerConfig = null)
     {
         (_, Transaction tx) = PrepareTx(MainnetSpecProvider.CancunActivation, 100000, code);
-        NativeCallTracer tracer = new(tx, GetGethTraceOptions(tracerConfig));
-
-        GethLikeTxTrace callTrace = Execute(tracer, code, MainnetSpecProvider.CancunActivation).BuildResult();
+        using NativeCallTracer tracer = new(tx, GetGethTraceOptions(tracerConfig));
+        using GethLikeTxTrace callTrace = Execute(tracer, code, MainnetSpecProvider.CancunActivation).BuildResult();
         return JsonSerializer.Serialize(callTrace.CustomTracerResult?.Value, SerializerOptions);
     }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeBlockJavaScriptTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeBlockJavaScriptTracer.cs
@@ -12,23 +12,14 @@ using Nethermind.State;
 
 namespace Nethermind.Evm.Tracing.GethStyle.Custom.JavaScript;
 
-public class GethLikeBlockJavaScriptTracer : BlockTracerBase<GethLikeTxTrace, GethLikeJavaScriptTxTracer>, IDisposable
+public class GethLikeBlockJavaScriptTracer(IWorldState worldState, IReleaseSpec spec, GethTraceOptions options)
+    : BlockTracerBase<GethLikeTxTrace, GethLikeJavaScriptTxTracer>(options.TxHash), IDisposable
 {
-    private readonly IReleaseSpec _spec;
-    private readonly GethTraceOptions _options;
-    private readonly Context _ctx;
-    private readonly Db _db;
+    private readonly Context _ctx = new();
+    private readonly Db _db = new(worldState);
     private int _index;
     private List<IDisposable>? _engines;
     private UInt256 _baseFee;
-
-    public GethLikeBlockJavaScriptTracer(IWorldState worldState, IReleaseSpec spec, GethTraceOptions options) : base(options.TxHash)
-    {
-        _spec = spec;
-        _options = options;
-        _ctx = new Context();
-        _db = new Db(worldState);
-    }
 
     public override void StartNewBlockTrace(Block block)
     {
@@ -42,14 +33,14 @@ public class GethLikeBlockJavaScriptTracer : BlockTracerBase<GethLikeTxTrace, Ge
     protected override GethLikeJavaScriptTxTracer OnStart(Transaction? tx)
     {
         SetTransactionCtx(tx);
-        Engine engine = new(_spec);
+        Engine engine = new(spec);
         _engines?.Add(engine);
-        return new GethLikeJavaScriptTxTracer(this, engine, _db, _ctx, _options);
+        return new GethLikeJavaScriptTxTracer(this, engine, _db, _ctx, options);
     }
 
     private void SetTransactionCtx(Transaction? tx)
     {
-        _ctx.GasPrice = tx!.CalculateEffectiveGasPrice(_spec.IsEip1559Enabled, _baseFee);
+        _ctx.GasPrice = tx!.CalculateEffectiveGasPrice(spec.IsEip1559Enabled, _baseFee);
         _ctx.TxHash = tx.Hash;
         _ctx.txIndex = tx.Hash is not null ? _index++ : null;
         _ctx.gas = tx.GasLimit;

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrame.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrame.cs
@@ -46,12 +46,7 @@ public class NativeCallTracerCallFrame : IDisposable
             Input?.Dispose();
             Output?.Dispose();
             Logs?.Dispose();
-            foreach (NativeCallTracerCallFrame childCallFrame in Calls)
-            {
-                childCallFrame.Dispose();
-            }
-
-            Calls.Dispose();
+            Calls.DisposeRecursive();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrame.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrame.cs
@@ -13,7 +13,9 @@ namespace Nethermind.Evm.Tracing.GethStyle.Custom.Native.Call;
 [JsonConverter(typeof(NativeCallTracerCallFrameConverter))]
 public class NativeCallTracerCallFrame : IDisposable
 {
-    private int _disposed = 0;
+    private const int Alive = 0;
+    private const int Disposed = 1;
+    private int _disposed = Alive;
 
     public Instruction Type { get; set; }
 
@@ -41,7 +43,7 @@ public class NativeCallTracerCallFrame : IDisposable
 
     public void Dispose()
     {
-        if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+        if (Interlocked.CompareExchange(ref _disposed, Disposed, Alive) == Alive)
         {
             Input?.Dispose();
             Output?.Dispose();

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeBlockFileTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeBlockFileTracer.cs
@@ -13,16 +13,16 @@ using System.IO.Abstractions;
 
 namespace Nethermind.Evm.Tracing.GethStyle;
 
-public class GethLikeBlockFileTracer : BlockTracerBase<GethLikeTxTrace, GethLikeTxFileTracer>
+public class GethLikeBlockFileTracer : BlockTracerBase<GethLikeTxTrace, GethLikeTxFileTracer>, IDisposable
 {
-    private const string _alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+    private const string Alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
 
     private readonly Block _block;
-    private Stream _file;
+    private Stream? _file;
     private readonly string _fileNameFormat;
     private readonly List<string> _fileNames = new();
     private readonly IFileSystem _fileSystem;
-    private Utf8JsonWriter _jsonWriter;
+    private Utf8JsonWriter? _jsonWriter;
     private readonly GethTraceOptions _options;
     private readonly JsonSerializerOptions _serializerOptions = new();
 
@@ -99,7 +99,7 @@ public class GethLikeBlockFileTracer : BlockTracerBase<GethLikeTxTrace, GethLike
             static (chars, rand) =>
             {
                 for (var i = 0; i < chars.Length; i++)
-                    chars[i] = _alphabet[rand.Next(0, _alphabet.Length)];
+                    chars[i] = Alphabet[rand.Next(0, Alphabet.Length)];
             });
 
         for (; index < _block.Transactions.Length; index++)
@@ -107,5 +107,10 @@ public class GethLikeBlockFileTracer : BlockTracerBase<GethLikeTxTrace, GethLike
                 break;
 
         return string.Format(_fileNameFormat, index, hash, suffix);
+    }
+
+    public void Dispose()
+    {
+        DisposeFileStreamIfAny();
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeBlockMemoryTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeBlockMemoryTracer.cs
@@ -5,13 +5,10 @@ using Nethermind.Core;
 
 namespace Nethermind.Evm.Tracing.GethStyle;
 
-public class GethLikeBlockMemoryTracer : BlockTracerBase<GethLikeTxTrace, GethLikeTxMemoryTracer>
+public class GethLikeBlockMemoryTracer(GethTraceOptions options)
+    : BlockTracerBase<GethLikeTxTrace, GethLikeTxMemoryTracer>(options.TxHash)
 {
-    private readonly GethTraceOptions _options;
-
-    public GethLikeBlockMemoryTracer(GethTraceOptions options) : base(options.TxHash) => _options = options;
-
-    protected override GethLikeTxMemoryTracer OnStart(Transaction? tx) => new(tx, _options);
+    protected override GethLikeTxMemoryTracer OnStart(Transaction? tx) => new(tx, options);
 
     protected override GethLikeTxTrace OnEnd(GethLikeTxMemoryTracer txTracer) => txTracer.BuildResult();
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTraceCollection.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTraceCollection.cs
@@ -1,18 +1,25 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Evm.Tracing.GethStyle;
 
 [JsonConverter(typeof(GethLikeTxTraceCollectionConverter))]
-public record GethLikeTxTraceCollection(IReadOnlyCollection<GethLikeTxTrace> Traces) : IReadOnlyCollection<GethLikeTxTrace>
+public record GethLikeTxTraceCollection(IReadOnlyCollection<GethLikeTxTrace> Traces) : IReadOnlyCollection<GethLikeTxTrace>, IDisposable
 {
     public IEnumerator<GethLikeTxTrace> GetEnumerator() => Traces.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public int Count => Traces.Count;
+    public void Dispose()
+    {
+        Traces.DisposeItems();
+        Traces.TryDispose();
+    }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -92,7 +92,7 @@ public class RegisterRpcModules : IStep
             _api.SyncModeSelector!,
             _api.SyncProgressResolver!,
             _api.LogManager);
-        _api.RpcModuleProvider = new RpcModuleProvider(_api.FileSystem, _jsonRpcConfig, _api.LogManager);
+        _api.RpcModuleProvider = new RpcModuleProvider(_api.FileSystem, _jsonRpcConfig, _api.EthereumJsonSerializer, _api.LogManager);
 
         IRpcModuleProvider rpcModuleProvider = _api.RpcModuleProvider;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -62,7 +62,7 @@ public class JsonRpcServiceTests
 
     private JsonRpcResponse TestRequestWithPool<T>(IRpcModulePool<T> pool, string method, params object?[]? parameters) where T : IRpcModule
     {
-        RpcModuleProvider moduleProvider = new(new FileSystem(), _configurationProvider.GetConfig<IJsonRpcConfig>(), LimboLogs.Instance);
+        RpcModuleProvider moduleProvider = new(new FileSystem(), _configurationProvider.GetConfig<IJsonRpcConfig>(), new EthereumJsonSerializer(), LimboLogs.Instance);
         moduleProvider.Register(pool);
         _jsonRpcService = new JsonRpcService(moduleProvider, _logManager, _configurationProvider.GetConfig<IJsonRpcConfig>());
         JsonRpcRequest request = RpcTest.BuildJsonRequest(method, parameters);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
@@ -7,6 +7,7 @@ using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Net;
 using Nethermind.JsonRpc.Modules.Proof;
 using Nethermind.Logging;
+using Nethermind.Serialization.Json;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -24,7 +25,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public void Initialize()
         {
             _fileSystem = Substitute.For<IFileSystem>();
-            _moduleProvider = new RpcModuleProvider(_fileSystem, new JsonRpcConfig(), LimboLogs.Instance);
+            _moduleProvider = new RpcModuleProvider(_fileSystem, new JsonRpcConfig(), new EthereumJsonSerializer(), LimboLogs.Instance);
             _context = new JsonRpcContext(RpcEndpoint.Http);
         }
 
@@ -39,7 +40,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             JsonRpcConfig jsonRpcConfig = new();
             jsonRpcConfig.EnabledModules = [];
-            _moduleProvider = new RpcModuleProvider(new FileSystem(), jsonRpcConfig, LimboLogs.Instance);
+            _moduleProvider = new RpcModuleProvider(new FileSystem(), jsonRpcConfig, new EthereumJsonSerializer(), LimboLogs.Instance);
             _moduleProvider.Register(new SingletonModulePool<IProofRpcModule>(Substitute.For<IProofRpcModule>(), false));
             ModuleResolution resolution = _moduleProvider.Check("proof_call", _context);
             Assert.That(resolution, Is.EqualTo(ModuleResolution.Disabled));
@@ -64,7 +65,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             JsonRpcConfig config = new();
             _fileSystem.File.Exists(Arg.Any<string>()).Returns(true);
             _fileSystem.File.ReadLines(Arg.Any<string>()).Returns(new[] { regex });
-            _moduleProvider = new RpcModuleProvider(_fileSystem, config, LimboLogs.Instance);
+            _moduleProvider = new RpcModuleProvider(_fileSystem, config, new EthereumJsonSerializer(), LimboLogs.Instance);
 
             SingletonModulePool<INetRpcModule> pool = new(new NetRpcModule(LimboLogs.Instance, Substitute.For<INetBridge>()), true);
             _moduleProvider.Register(pool);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
@@ -31,7 +31,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public TestRpcModuleProvider(T module)
         {
             _jsonRpcConfig = new JsonRpcConfig();
-            _provider = new RpcModuleProvider(new FileSystem(), _jsonRpcConfig, LimboLogs.Instance);
+            _provider = new RpcModuleProvider(new FileSystem(), _jsonRpcConfig, new EthereumJsonSerializer(), LimboLogs.Instance);
 
             _provider.Register(new SingletonModulePool<INetRpcModule>(new SingletonFactory<INetRpcModule>(typeof(INetRpcModule).IsAssignableFrom(typeof(T)) ? (INetRpcModule)module : Substitute.For<INetRpcModule>()), true));
             _provider.Register(new SingletonModulePool<IEthRpcModule>(new SingletonFactory<IEthRpcModule>(typeof(IEthRpcModule).IsAssignableFrom(typeof(T)) ? (IEthRpcModule)module : Substitute.For<IEthRpcModule>()), true));

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -28,18 +28,18 @@ public static class RpcTest
         IJsonRpcService service = BuildRpcService(module);
         JsonRpcRequest request = BuildJsonRequest(method, parameters);
 
-        JsonRpcContext context = module is IContextAwareRpcModule { Context: not null } contextAwareModule
+        using JsonRpcContext context = module is IContextAwareRpcModule { Context: not null } contextAwareModule
             ? contextAwareModule.Context
             : new JsonRpcContext(RpcEndpoint.Http);
         using JsonRpcResponse response = await service.SendRequestAsync(request, context).ConfigureAwait(false);
 
         EthereumJsonSerializer serializer = new();
 
-        Stream stream = new MemoryStream();
+        await using Stream stream = new MemoryStream();
         long size = await serializer.SerializeAsync(stream, response).ConfigureAwait(false);
 
         // for coverage (and to prove that it does not throw
-        Stream indentedStream = new MemoryStream();
+        await using Stream indentedStream = new MemoryStream();
         await serializer.SerializeAsync(indentedStream, response, true).ConfigureAwait(false);
 
         stream.Seek(0, SeekOrigin.Begin);

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Config;
+using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc;
 
@@ -157,6 +158,9 @@ public interface IJsonRpcConfig : IConfig
 
     [ConfigItem(Description = "The max number of JSON-RPC requests in a batch.", DefaultValue = "1024")]
     int MaxBatchSize { get; set; }
+
+    [ConfigItem(Description = "The maximum depth of JSON response object tree.", DefaultValue = "128")]
+    int JsonSerializationMaxDepth { get; set; }
 
     [ConfigItem(Description = "The max batch size limit for batched JSON-RPC calls.", DefaultValue = "33554432")]
     long? MaxBatchResponseBodySize { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Nethermind.Core.Extensions;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc;
 
@@ -63,6 +64,7 @@ public class JsonRpcConfig : IJsonRpcConfig
     public int? EnginePort { get; set; } = null;
     public string[] EngineEnabledModules { get; set; } = ModuleType.DefaultEngineModules.ToArray();
     public int MaxBatchSize { get; set; } = 1024;
+    public int JsonSerializationMaxDepth { get; set; } = EthereumJsonSerializer.DefaultMaxDepth;
     public long? MaxBatchResponseBodySize { get; set; } = 32.MiB();
     public long? MaxSimulateBlocksCap { get; set; } = 256;
     public int EstimateErrorMargin { get; set; } = 150;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -34,10 +34,10 @@ namespace Nethermind.JsonRpc.Modules
 
         private readonly Lock _updateRegistrationsLock = new();
 
-        public RpcModuleProvider(IFileSystem fileSystem, IJsonRpcConfig jsonRpcConfig, ILogManager logManager)
+        public RpcModuleProvider(IFileSystem fileSystem, IJsonRpcConfig jsonRpcConfig, IJsonSerializer serializer, ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-            Serializer = new EthereumJsonSerializer();
+            Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
             if (fileSystem.File.Exists(_jsonRpcConfig.CallsFilterFilePath))
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -280,7 +280,7 @@ public partial class EngineModuleTests
         MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         JsonRpcConfig jsonRpcConfig = new() { EnabledModules = new[] { ModuleType.Engine } };
-        RpcModuleProvider moduleProvider = new(new FileSystem(), jsonRpcConfig, LimboLogs.Instance);
+        RpcModuleProvider moduleProvider = new(new FileSystem(), jsonRpcConfig, new EthereumJsonSerializer(), LimboLogs.Instance);
         moduleProvider.Register(new SingletonModulePool<IEngineRpcModule>(new SingletonFactory<IEngineRpcModule>(rpcModule), true));
 
         ExecutionPayloadV3 executionPayload = CreateBlockRequestV3(

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -23,6 +23,7 @@ using Nethermind.Network.Config;
 using Nethermind.Runner.Ethereum;
 using Nethermind.Optimism;
 using Nethermind.Runner.Ethereum.Api;
+using Nethermind.Serialization.Json;
 using Nethermind.Taiko;
 using NUnit.Framework;
 
@@ -118,7 +119,7 @@ public class EthereumRunnerTests
             networkConfig.DiscoveryPort = port;
 
             INethermindApi nethermindApi = new ApiBuilder(configProvider, LimboLogs.Instance).Create();
-            nethermindApi.RpcModuleProvider = new RpcModuleProvider(new FileSystem(), new JsonRpcConfig(), LimboLogs.Instance);
+            nethermindApi.RpcModuleProvider = new RpcModuleProvider(new FileSystem(), new JsonRpcConfig(), new EthereumJsonSerializer(), LimboLogs.Instance);
             EthereumRunner runner = new(nethermindApi);
 
             using CancellationTokenSource cts = new();

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Api/ApiBuilder.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Api/ApiBuilder.cs
@@ -10,6 +10,7 @@ using Nethermind.Api.Extensions;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Core;
+using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs.ChainSpecStyle;
@@ -31,7 +32,7 @@ public class ApiBuilder
         _logger = _logManager.GetClassLogger();
         _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
         _initConfig = configProvider.GetConfig<IInitConfig>();
-        _jsonSerializer = new EthereumJsonSerializer();
+        _jsonSerializer = new EthereumJsonSerializer(configProvider.GetConfig<IJsonRpcConfig>().JsonSerializationMaxDepth);
         ChainSpec = LoadChainSpec(_jsonSerializer);
     }
 

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -43,7 +43,6 @@ public class StartRpc(INethermindApi api) : IStep
             IRpcModuleProvider rpcModuleProvider = _api.RpcModuleProvider!;
             JsonRpcService jsonRpcService = new(rpcModuleProvider, _api.LogManager, jsonRpcConfig);
 
-            IJsonSerializer jsonSerializer = new EthereumJsonSerializer();
             IRpcAuthentication auth = jsonRpcConfig.UnsecureDevNoRpcAuthentication || !jsonRpcUrlCollection.Values.Any(u => u.IsAuthenticated)
                 ? NoAuthentication.Instance
                 : JwtAuthentication.FromFile(jsonRpcConfig.JwtSecretFile, _api.Timestamper, logger);
@@ -62,7 +61,7 @@ public class StartRpc(INethermindApi api) : IStep
                     jsonRpcService,
                     _api.JsonRpcLocalStats!,
                     _api.LogManager,
-                    jsonSerializer,
+                    _api.EthereumJsonSerializer,
                     jsonRpcUrlCollection,
                     auth,
                     jsonRpcConfig.MaxBatchResponseBodySize);
@@ -72,7 +71,7 @@ public class StartRpc(INethermindApi api) : IStep
 
             Bootstrap.Instance.JsonRpcService = jsonRpcService;
             Bootstrap.Instance.LogManager = _api.LogManager;
-            Bootstrap.Instance.JsonSerializer = jsonSerializer;
+            Bootstrap.Instance.JsonSerializer = _api.EthereumJsonSerializer;
             Bootstrap.Instance.JsonRpcLocalStats = _api.JsonRpcLocalStats!;
             Bootstrap.Instance.JsonRpcAuthentication = auth;
 
@@ -92,7 +91,7 @@ public class StartRpc(INethermindApi api) : IStep
             }, cancellationToken);
 
             JsonRpcIpcRunner jsonIpcRunner = new(jsonRpcProcessor, _api.ConfigProvider,
-                _api.LogManager, _api.JsonRpcLocalStats!, jsonSerializer, _api.FileSystem);
+                _api.LogManager, _api.JsonRpcLocalStats!, _api.EthereumJsonSerializer, _api.FileSystem);
             jsonIpcRunner.Start(cancellationToken);
 
 #pragma warning disable 4014

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -16,21 +16,20 @@ namespace Nethermind.Serialization.Json
 {
     public class EthereumJsonSerializer : IJsonSerializer
     {
+        public const int DefaultMaxDepth = 128;
         private readonly int? _maxDepth;
         private readonly JsonSerializerOptions _jsonOptions;
 
-        public EthereumJsonSerializer(IEnumerable<JsonConverter> converters, int? maxDepth = null)
+        public EthereumJsonSerializer(IEnumerable<JsonConverter> converters, int maxDepth = DefaultMaxDepth)
         {
             _maxDepth = maxDepth;
-            _jsonOptions = maxDepth.HasValue
-                ? CreateOptions(indented: false, maxDepth: maxDepth.Value, converters: converters)
-                : CreateOptions(indented: false, converters: converters);
+            _jsonOptions = CreateOptions(indented: false, maxDepth: maxDepth, converters: converters);
         }
 
-        public EthereumJsonSerializer(int? maxDepth = null)
+        public EthereumJsonSerializer(int maxDepth = DefaultMaxDepth)
         {
             _maxDepth = maxDepth;
-            _jsonOptions = maxDepth.HasValue ? CreateOptions(indented: false, maxDepth: maxDepth.Value) : JsonOptions;
+            _jsonOptions = maxDepth != DefaultMaxDepth ? CreateOptions(indented: false, maxDepth: maxDepth) : JsonOptions;
         }
 
         public object Deserialize(string json, Type type)
@@ -58,7 +57,7 @@ namespace Nethermind.Serialization.Json
             return JsonSerializer.Serialize<T>(value, indented ? JsonOptionsIndented : _jsonOptions);
         }
 
-        private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter> converters = null, int maxDepth = 64)
+        private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter> converters = null, int maxDepth = DefaultMaxDepth)
         {
             var options = new JsonSerializerOptions
             {


### PR DESCRIPTION
Resolves #8295

## Changes

- Make EthereumJsonSerializer MaxDepth configurable. 
- Increase default to 128.
- Fixes some ArrayPoolList not-disposed issues in tracing

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Remarks

Some traces can get very deep, deeper than 64. For edge cases even 128 might be to low, but lets keep it sane for now. It is configurable if needs to be higher.
