### PR TITLE
Fix/TrieException after full pruning

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -1028,6 +1028,8 @@ public class TrieStore : ITrieStore, IPruningTrieStore
             ClearCommitSetQueue();
             if (cancellationToken.IsCancellationRequested) return;
 
+            // All persisted node including recommitted nodes between head and reorg depth must be removed so that
+            // it will be re-persisted or at least re-read in order to be cloned.
             // This should clear most nodes. For some reason, not all.
             PruneCache(skipRecalculateMemory: true, forceRemovePersistedNodes: true);
             if (cancellationToken.IsCancellationRequested) return;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -203,7 +203,7 @@ internal class TrieStoreDirtyNodesCache
     /// removing ones that are either no longer referenced or already persisted.
     /// </summary>
     /// <exception cref="InvalidOperationException"></exception>
-    public long PruneCache(bool skipRecalculateMemory = false)
+    public long PruneCache(bool skipRecalculateMemory = false, bool forceRemovePersistedNodes = false)
     {
         bool shouldTrackPersistedNode = _pastPathHash is not null && !_trieStore.IsCurrentlyFullPruning;
         long newMemory = 0;
@@ -214,7 +214,7 @@ internal class TrieStoreDirtyNodesCache
             {
                 // If its persisted and has last seen meaning it was recommitted,
                 // we keep it to prevent key removal from removing it from DB.
-                if (node.IsPersisted && node.LastSeen == -1)
+                if (node.IsPersisted && (node.LastSeen == -1 || forceRemovePersistedNodes))
                 {
                     if (_logger.IsTrace) _logger.Trace($"Removing persisted {node} from memory.");
 


### PR DESCRIPTION
- Fix triexception after full pruning due to persisted node not being removed on `PersistCache`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Four consecutive mainnet full prune