### PR TITLE
Fix/random debug rpc module test failure

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/AuRaContractGasLimitOverrideTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/AuRaContractGasLimitOverrideTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Logging;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.AuRa.Test.Contract;
@@ -81,7 +82,7 @@ public class AuRaContractGasLimitOverrideTests
         public IGasLimitCalculator GasLimitCalculator { get; private set; }
         public AuRaContractGasLimitOverride.Cache GasLimitOverrideCache { get; private set; }
 
-        protected override BlockProcessor CreateBlockProcessor()
+        protected override BlockProcessor CreateBlockProcessor(IWorldState worldState)
         {
             KeyValuePair<long, Address> blockGasLimitContractTransition = ChainSpec.EngineChainSpecParametersProvider
                 .GetChainSpecParameters<AuRaChainSpecEngineParameters>().BlockGasLimitContractTransitions
@@ -99,10 +100,10 @@ public class AuRaContractGasLimitOverrideTests
                 SpecProvider,
                 Always.Valid,
                 new RewardCalculator(SpecProvider),
-                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
-                State,
+                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, worldState),
+                worldState,
                 ReceiptStorage,
-                new BeaconBlockRootHandler(TxProcessor, State),
+                new BeaconBlockRootHandler(TxProcessor, worldState),
                 LimboLogs.Instance,
                 BlockTree,
                 NullWithdrawalProcessor.Instance,
@@ -117,13 +118,13 @@ public class AuRaContractGasLimitOverrideTests
 
     public class TestGasLimitContractBlockchainLateBlockGasLimit : TestGasLimitContractBlockchain
     {
-        protected override BlockProcessor CreateBlockProcessor()
+        protected override BlockProcessor CreateBlockProcessor(IWorldState worldState)
         {
             var parameters = ChainSpec.EngineChainSpecParametersProvider
                 .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
             KeyValuePair<long, Address> blockGasLimitContractTransition = parameters.BlockGasLimitContractTransitions.First();
             parameters.BlockGasLimitContractTransitions = new Dictionary<long, Address>() { { 10, blockGasLimitContractTransition.Value } };
-            return base.CreateBlockProcessor();
+            return base.CreateBlockProcessor(worldState);
         }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/TestContractBlockchain.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/TestContractBlockchain.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 
 namespace Nethermind.AuRa.Test.Contract
 {
@@ -38,11 +39,11 @@ namespace Nethermind.AuRa.Test.Contract
             return (TTest)await test.Build(provider.SpecProvider);
         }
 
-        protected override Block GetGenesisBlock() =>
+        protected override Block GetGenesisBlock(IWorldState worldState) =>
             new GenesisLoader(
                     ChainSpec,
                     SpecProvider,
-                    State,
+                    worldState,
                     TxProcessor)
                 .Load();
     }

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxCertifierFilterTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxCertifierFilterTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
+using Nethermind.State;
 using Nethermind.TxPool;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -134,7 +135,7 @@ public class TxCertifierFilterTests
         public RegisterContract RegisterContract { get; private set; }
         public CertifierContract CertifierContract { get; private set; }
 
-        protected override BlockProcessor CreateBlockProcessor()
+        protected override BlockProcessor CreateBlockProcessor(IWorldState worldState)
         {
             AbiEncoder abiEncoder = AbiEncoder.Instance;
             ReadOnlyTransactionProcessorSource = new ReadOnlyTxProcessingEnv(
@@ -151,10 +152,10 @@ public class TxCertifierFilterTests
                 SpecProvider,
                 Always.Valid,
                 new RewardCalculator(SpecProvider),
-                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
-                State,
+                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, worldState),
+                worldState,
                 ReceiptStorage,
-                new BeaconBlockRootHandler(TxProcessor, State),
+                new BeaconBlockRootHandler(TxProcessor, worldState),
                 LimboLogs.Instance,
                 BlockTree,
                 NullWithdrawalProcessor.Instance,

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -27,6 +27,7 @@ using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
+using Nethermind.State;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 using NSubstitute;
@@ -264,7 +265,7 @@ public class TxPermissionFilterTest
 
         public LruCache<ValueHash256, UInt256> TransactionPermissionContractVersions { get; private set; }
 
-        protected override BlockProcessor CreateBlockProcessor()
+        protected override BlockProcessor CreateBlockProcessor(IWorldState worldState)
         {
             TransactionPermissionContractVersions =
                 new LruCache<ValueHash256, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize, nameof(TransactionPermissionContract));
@@ -286,10 +287,10 @@ public class TxPermissionFilterTest
                 SpecProvider,
                 Always.Valid,
                 new RewardCalculator(SpecProvider),
-                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
-                State,
+                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, worldState),
+                worldState,
                 ReceiptStorage,
-                new BeaconBlockRootHandler(TxProcessor, State),
+                new BeaconBlockRootHandler(TxProcessor, worldState),
                 LimboLogs.Instance,
                 BlockTree,
                 NullWithdrawalProcessor.Instance,

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.FeeCollector.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.FeeCollector.cs
@@ -33,9 +33,9 @@ public partial class BlockProducerBaseTests
             private async Task<ScenarioBuilder> AssertNewBlockFeeCollectedAsync(UInt256 expectedFeeCollected, params Transaction[] transactions)
             {
                 await ExecuteAntecedentIfNeeded();
-                UInt256 balanceBefore = _testRpcBlockchain.State.GetBalance(_feeCollector);
+                UInt256 balanceBefore = _testRpcBlockchain.ReadOnlyState.GetBalance(_feeCollector);
                 await _testRpcBlockchain.AddBlock(transactions);
-                UInt256 balanceAfter = _testRpcBlockchain.State.GetBalance(_feeCollector);
+                UInt256 balanceAfter = _testRpcBlockchain.ReadOnlyState.GetBalance(_feeCollector);
                 Assert.That(balanceAfter - balanceBefore, Is.EqualTo(expectedFeeCollected));
 
                 return this;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.IsProducingBlocks.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.IsProducingBlocks.cs
@@ -40,7 +40,7 @@ public partial class BlockProducerBaseTests
         DevBlockProducer blockProducer = new(
             Substitute.For<ITxSource>(),
             testRpc.BlockchainProcessor,
-            testRpc.State,
+            testRpc.WorldStateManager.GlobalWorldState,
             testRpc.BlockTree,
             testRpc.Timestamper,
             testRpc.SpecProvider,
@@ -59,7 +59,7 @@ public partial class BlockProducerBaseTests
         TestBlockProducer blockProducer = new(
             Substitute.For<ITxSource>(),
             testRpc.BlockchainProcessor,
-            testRpc.State,
+            testRpc.WorldStateManager.GlobalWorldState,
             Substitute.For<ISealer>(),
             testRpc.BlockTree,
             testRpc.Timestamper,
@@ -81,7 +81,7 @@ public partial class BlockProducerBaseTests
             testRpc.BlockchainProcessor,
             Substitute.For<ISealer>(),
             testRpc.BlockTree,
-            testRpc.State,
+            testRpc.WorldStateManager.GlobalWorldState,
             Substitute.For<IGasLimitCalculator>(),
             testRpc.Timestamper,
             testRpc.SpecProvider,
@@ -123,7 +123,7 @@ public partial class BlockProducerBaseTests
         CliqueBlockProducer blockProducer = new(
             Substitute.For<ITxSource>(),
             testRpc.BlockchainProcessor,
-            testRpc.State,
+            testRpc.WorldStateManager.GlobalWorldState,
             testRpc.Timestamper,
             Substitute.For<ICryptoRandom>(),
             Substitute.For<ISnapshotManager>(),

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeExtensions.cs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
+using Nethermind.Core.Events;
 using Nethermind.Crypto;
 
 namespace Nethermind.Core.Test.Builders
@@ -55,6 +58,15 @@ namespace Nethermind.Core.Test.Builders
         public static void UpdateMainChain(this IBlockTree blockTree, Block block)
         {
             blockTree.UpdateMainChain(new[] { block }, true);
+        }
+
+        public static Task WaitForNewBlock(this IBlockTree blockTree, CancellationToken cancellation)
+        {
+            return Wait.ForEventCondition<BlockReplacementEventArgs>(
+                cancellation,
+                (h) => blockTree.BlockAddedToMain += h,
+                (h) => blockTree.BlockAddedToMain -= h,
+                (e) => true);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
+++ b/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Core.Test.IO;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 using NSubstitute;
 using NUnit.Framework.Constraints;
 
@@ -119,8 +120,9 @@ public class Era1ModuleTests
     public async Task CreateEraAndVerifyAccumulators()
     {
         TestBlockchain testBlockchain = await BasicTestBlockchain.Create();
-        testBlockchain.State.AddToBalance(TestItem.AddressA, 10.Ether(), testBlockchain.SpecProvider.GenesisSpec);
-        testBlockchain.State.RecalculateStateRoot();
+        IWorldState worldState = testBlockchain.WorldStateManager.GlobalWorldState;
+        worldState.AddToBalance(TestItem.AddressA, 10.Ether(), testBlockchain.SpecProvider.GenesisSpec);
+        worldState.RecalculateStateRoot();
 
         using TempPath tmpFile = TempPath.GetTempFile();
         Block genesis = testBlockchain.BlockFinder.FindBlock(0)!;
@@ -209,8 +211,9 @@ public class Era1ModuleTests
     public async Task TestBigBlocksExportImportHistory()
     {
         TestBlockchain testBlockchain = await BasicTestBlockchain.Create();
-        testBlockchain.State.AddToBalance(TestItem.AddressA, 10.Ether(), testBlockchain.SpecProvider.GenesisSpec);
-        testBlockchain.State.RecalculateStateRoot();
+        IWorldState worldState = testBlockchain.WorldStateManager.GlobalWorldState;
+        worldState.AddToBalance(TestItem.AddressA, 10.Ether(), testBlockchain.SpecProvider.GenesisSpec);
+        worldState.RecalculateStateRoot();
 
         using var tmpFile = TempPath.GetTempFile();
         using EraWriter builder = new EraWriter(tmpFile.Path, Substitute.For<ISpecProvider>());

--- a/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
@@ -71,7 +71,7 @@ public partial class FlashbotsModuleTests
     private Block CreateBlock(EngineModuleTests.MergeTestBlockchain chain)
     {
         BlockHeader currentHeader = chain.BlockTree.Head.Header;
-        IWorldState State = chain.State;
+        IWorldState State = chain.WorldStateManager.GlobalWorldState;
         State.CreateAccount(TestKeysAndAddress.TestAddr, TestKeysAndAddress.TestBalance);
         UInt256 nonce = State.GetNonce(TestKeysAndAddress.TestAddr);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceBlock.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceBlock.cs
@@ -85,7 +85,7 @@ public partial class DebugRpcModuleTests
     {
         Func<TestRpcBlockchain, Transaction[]> transactions = b =>
         {
-            var nonce = b.State.GetNonce(TestItem.AddressA);
+            var nonce = b.ReadOnlyState.GetNonce(TestItem.AddressA);
             var contract = Prepare.EvmCode
                 .PushData(0)
                 .PushData(32)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
@@ -111,7 +111,7 @@ public partial class DebugRpcModuleTests
     private static IEnumerable<TestCaseData> TraceTransactionTransferSource()
     {
         var transferTransaction = (TestRpcBlockchain b) => Build.A.Transaction
-            .WithNonce(b.State.GetNonce(TestItem.AddressA))
+            .WithNonce(b.ReadOnlyState.GetNonce(TestItem.AddressA))
             .SignedAndResolved(TestItem.PrivateKeyA)
             .TestObject;
 
@@ -193,7 +193,7 @@ public partial class DebugRpcModuleTests
             .Done;
 
         var contractTransaction = (TestRpcBlockchain b) => Build.A.Transaction
-            .WithNonce(b.State.GetNonce(TestItem.AddressA))
+            .WithNonce(b.ReadOnlyState.GetNonce(TestItem.AddressA))
             .WithCode(code)
             .WithGasLimit(100000)
             .SignedAndResolved(TestItem.PrivateKeyA)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -254,7 +254,7 @@ public partial class EthRpcModuleTests
         {
             To = TestItem.AddressB
         };
-        ctx.Test.State.InsertCode(TestItem.AddressA, "H"u8.ToArray(), London.Instance);
+        ctx.Test.WorldStateManager.GlobalWorldState.InsertCode(TestItem.AddressA, "H"u8.ToArray(), London.Instance);
 
         string serialized =
             await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -118,7 +118,7 @@ public partial class EthRpcModuleTests
         {
             To = TestItem.AddressB
         };
-        ctx.Test.State.InsertCode(TestItem.AddressA, "H"u8.ToArray(), London.Instance);
+        ctx.Test.WorldStateManager.GlobalWorldState.InsertCode(TestItem.AddressA, "H"u8.ToArray(), London.Instance);
 
         string serialized =
             await ctx.Test.TestEthRpc("eth_call", transaction, "latest");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1256,7 +1256,7 @@ public partial class EthRpcModuleTests
 
         Transaction testTx = Build.A.Transaction
           .WithType(TxType.SetCode)
-          .WithNonce(Test.State.GetNonce(TestItem.AddressA))
+          .WithNonce(Test.ReadOnlyState.GetNonce(TestItem.AddressA))
           .WithMaxFeePerGas(9.GWei())
           .WithMaxPriorityFeePerGas(9.GWei())
           .WithGasLimit(GasCostOf.Transaction + GasCostOf.NewAccount)
@@ -1280,22 +1280,22 @@ public partial class EthRpcModuleTests
         TestRpcBlockchain test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).Build(specProvider);
         Transaction setCodeTx = Build.A.Transaction
           .WithType(TxType.SetCode)
-          .WithNonce(test.State.GetNonce(TestItem.AddressB))
+          .WithNonce(test.ReadOnlyState.GetNonce(TestItem.AddressB))
           .WithMaxFeePerGas(9.GWei())
           .WithMaxPriorityFeePerGas(9.GWei())
           .WithGasLimit(GasCostOf.Transaction + GasCostOf.NewAccount)
-          .WithAuthorizationCode(test.EthereumEcdsa.Sign(TestItem.PrivateKeyB, 0, TestItem.AddressC, (ulong)test.State.GetNonce(TestItem.AddressB) + 1))
+          .WithAuthorizationCode(test.EthereumEcdsa.Sign(TestItem.PrivateKeyB, 0, TestItem.AddressC, (ulong)test.ReadOnlyState.GetNonce(TestItem.AddressB) + 1))
           .WithTo(TestItem.AddressA)
           .SignedAndResolved(TestItem.PrivateKeyB).TestObject;
 
         await test.AddBlock(setCodeTx);
 
-        var code = test.State.GetCode(TestItem.AddressB);
+        var code = test.ReadOnlyState.GetCode(TestItem.AddressB);
 
         Assert.That(code!.Slice(0, 3), Is.EquivalentTo(Eip7702Constants.DelegationHeader.ToArray()));
 
         Transaction normalTx = Build.A.Transaction
-          .WithNonce(test.State.GetNonce(TestItem.AddressB))
+          .WithNonce(test.ReadOnlyState.GetNonce(TestItem.AddressB))
           .WithMaxFeePerGas(9.GWei())
           .WithMaxPriorityFeePerGas(9.GWei())
           .WithGasLimit(GasCostOf.Transaction)
@@ -1317,7 +1317,7 @@ public partial class EthRpcModuleTests
         TestRpcBlockchain test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).Build(specProvider);
         Transaction invalidSetCodeTx = Build.A.Transaction
           .WithType(TxType.SetCode)
-          .WithNonce(test.State.GetNonce(TestItem.AddressB))
+          .WithNonce(test.ReadOnlyState.GetNonce(TestItem.AddressB))
           .WithMaxFeePerGas(9.GWei())
           .WithMaxPriorityFeePerGas(9.GWei())
           .WithGasLimit(GasCostOf.Transaction + GasCostOf.NewAccount)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
@@ -140,7 +140,7 @@ public class EthSimulateTestsPrecompilesWithRedirection
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
         Assert.That(headHash != chain.BlockFinder.Head!.Hash!);
-        chain.State.StateRoot = chain.BlockFinder.Head!.StateRoot!;
+        chain.WorldStateManager.GlobalWorldState.StateRoot = chain.BlockFinder.Head!.StateRoot!;
 
         TransactionForRpc transactionForRpc = TransactionForRpc.FromTransaction(new Transaction
         {
@@ -178,7 +178,7 @@ public class EthSimulateTestsPrecompilesWithRedirection
         SimulateTxExecutor executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig());
 
         Debug.Assert(contractAddress is not null, nameof(contractAddress) + " is not null");
-        Assert.That(chain.State.AccountExists(contractAddress), Is.True);
+        Assert.That(chain.ReadOnlyState.AccountExists(contractAddress), Is.True);
 
         ResultWrapper<IReadOnlyList<SimulateBlockResult>> result = executor.Execute(payload, BlockParameter.Latest);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -47,7 +47,7 @@ public class EthSimulateTestsBlocksAndTransactions
     {
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
 
-        UInt256 nonceA = chain.State.GetNonce(TestItem.AddressA);
+        UInt256 nonceA = chain.ReadOnlyState.GetNonce(TestItem.AddressA);
         Transaction txToFail = GetTransferTxData(nonceA, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 10_000_000);
         UInt256 nextNonceA = ++nonceA;
         Transaction tx = GetTransferTxData(nextNonceA, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 4_000_000);
@@ -96,7 +96,7 @@ public class EthSimulateTestsBlocksAndTransactions
     {
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
 
-        UInt256 nonceA = chain.State.GetNonce(TestItem.AddressA);
+        UInt256 nonceA = chain.ReadOnlyState.GetNonce(TestItem.AddressA);
         Transaction txMainnetAtoB = GetTransferTxData(nonceA, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 1);
         Transaction txAtoB1 = GetTransferTxData(nonceA + 1, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 1);
         Transaction txAtoB2 = GetTransferTxData(nonceA + 2, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 1);
@@ -137,9 +137,9 @@ public class EthSimulateTestsBlocksAndTransactions
         };
 
         //Test that transfer tx works on mainchain
-        UInt256 before = chain.State.GetBalance(TestItem.AddressA);
+        UInt256 before = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         await chain.AddBlock(true, txMainnetAtoB);
-        UInt256 after = chain.State.GetBalance(TestItem.AddressA);
+        UInt256 after = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         Assert.That(after, Is.LessThan(before));
 
         chain.Bridge.GetReceipt(txMainnetAtoB.Hash!);
@@ -170,7 +170,7 @@ public class EthSimulateTestsBlocksAndTransactions
     {
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
 
-        UInt256 nonceA = chain.State.GetNonce(TestItem.AddressA);
+        UInt256 nonceA = chain.ReadOnlyState.GetNonce(TestItem.AddressA);
 
         Transaction txMainnetAtoB =
             GetTransferTxData(nonceA, chain.EthereumEcdsa, TestItem.PrivateKeyA, TestItem.AddressB, 1);
@@ -221,9 +221,9 @@ public class EthSimulateTestsBlocksAndTransactions
         };
 
         //Test that transfer tx works on mainchain
-        UInt256 before = chain.State.GetBalance(TestItem.AddressA);
+        UInt256 before = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         await chain.AddBlock(true, txMainnetAtoB);
-        UInt256 after = chain.State.GetBalance(TestItem.AddressA);
+        UInt256 after = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         Assert.That(after, Is.LessThan(before));
 
         chain.Bridge.GetReceipt(txMainnetAtoB.Hash!);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -185,7 +185,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         Transaction transaction = Build.A.Transaction.WithNonce(currentNonceAddressA)
             .WithTo(TestItem.AddressA)
             .SignedAndResolved(blockchain.EthereumEcdsa, TestItem.PrivateKeyA).TestObject;
@@ -205,7 +205,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         Transaction transaction = Build.A.Transaction.WithNonce(currentNonceAddressA)
             .WithTo(TestItem.AddressA)
             .SignedAndResolved(blockchain.EthereumEcdsa, TestItem.PrivateKeyA).TestObject;
@@ -227,8 +227,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         byte[] deployedCode = new byte[3];
         byte[] initCode = Prepare.EvmCode
@@ -273,13 +273,13 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         await context.Blockchain.AddBlock(
             new[]
             {
                 Build.A.Transaction.WithNonce(currentNonceAddressA + 1).WithTo(TestItem.AddressD)
                     .SignedAndResolved(TestItem.PrivateKeyA).TestObject,
-                Build.A.Transaction.WithNonce(blockchain.State.GetNonce(TestItem.AddressB) + 1).WithTo(TestItem.AddressC)
+                Build.A.Transaction.WithNonce(blockchain.ReadOnlyState.GetNonce(TestItem.AddressB) + 1).WithTo(TestItem.AddressC)
                     .SignedAndResolved(TestItem.PrivateKeyB).TestObject,
                 Build.A.Transaction.WithNonce(currentNonceAddressA).WithTo(TestItem.AddressC)
                     .SignedAndResolved(TestItem.PrivateKeyA).TestObject
@@ -309,9 +309,9 @@ public class TraceRpcModuleTests
         traceFilterRequest.ToBlock = BlockParameter.Latest;
         traceFilterRequest.FromAddress = new[] { TestItem.PrivateKeyA.Address, TestItem.PrivateKeyD.Address };
         traceFilterRequest.ToAddress = new[] { TestItem.AddressC, TestItem.AddressA, TestItem.AddressB };
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressC = blockchain.State.GetNonce(TestItem.AddressC);
-        UInt256 currentNonceAddressD = blockchain.State.GetNonce(TestItem.AddressD);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressC = blockchain.ReadOnlyState.GetNonce(TestItem.AddressC);
+        UInt256 currentNonceAddressD = blockchain.ReadOnlyState.GetNonce(TestItem.AddressD);
         // first block skipped: After 3 -> 1
         await blockchain.AddBlock(
             new[]
@@ -391,7 +391,7 @@ public class TraceRpcModuleTests
         traceFilterRequest.ToBlock = BlockParameter.Latest;
         // traceFilterRequest.FromAddress = new[] {TestItem.PrivateKeyA.Address, TestItem.PrivateKeyD.Address};
         // traceFilterRequest.ToAddress = new[] {TestItem.AddressC, TestItem.AddressA, TestItem.AddressB};
-        UInt256 currentNonceAddressC = blockchain.State.GetNonce(TestItem.AddressC);
+        UInt256 currentNonceAddressC = blockchain.ReadOnlyState.GetNonce(TestItem.AddressC);
         await blockchain.AddBlock();
         await blockchain.AddBlock();
         await blockchain.AddBlock(
@@ -411,7 +411,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         Transaction transaction = Build.A.Transaction.WithNonce(currentNonceAddressA++).WithTo(TestItem.AddressC)
             .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
         await blockchain.AddBlock(transaction);
@@ -429,7 +429,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
 
         Transaction transaction = Build.A.Transaction.WithNonce(currentNonceAddressA++).WithTo(TestItem.AddressC)
             .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
@@ -446,8 +446,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         byte[] deployedCode = new byte[3];
         byte[] initCode = Prepare.EvmCode
@@ -492,8 +492,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         byte[] deployedCode = new byte[3];
         byte[] initCode = Prepare.EvmCode
@@ -548,8 +548,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         byte[] deployedCode = new byte[3];
         _ = Prepare.EvmCode
@@ -582,8 +582,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         Address? contractAddress = ContractAddress.From(TestItem.AddressA, currentNonceAddressA);
         byte[] code = Prepare.EvmCode
@@ -613,7 +613,7 @@ public class TraceRpcModuleTests
         TestSpecProvider specProvider = new(releaseSpec);
         await context.Build(specProvider, isAura: true);
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressC = blockchain.State.GetNonce(TestItem.AddressC);
+        UInt256 currentNonceAddressC = blockchain.ReadOnlyState.GetNonce(TestItem.AddressC);
 
         Transaction serviceTransaction = Build.A.Transaction.WithNonce(currentNonceAddressC++)
             .WithTo(TestItem.AddressE)
@@ -632,8 +632,8 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
-        UInt256 currentNonceAddressB = blockchain.State.GetNonce(TestItem.AddressB);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressB = blockchain.ReadOnlyState.GetNonce(TestItem.AddressB);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
 
         Address? contractAddress = ContractAddress.From(TestItem.AddressA, currentNonceAddressA);
@@ -793,7 +793,7 @@ public class TraceRpcModuleTests
         await context.Build();
 
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
 
         Transaction transaction1 = Build.A.Transaction.WithNonce(currentNonceAddressA++).WithTo(TestItem.AddressC)
             .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
@@ -861,7 +861,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
         Address? contractAddress = ContractAddress.From(TestItem.AddressA, currentNonceAddressA);
 
@@ -898,7 +898,7 @@ public class TraceRpcModuleTests
         Context context = new();
         await context.Build();
         TestRpcBlockchain blockchain = context.Blockchain;
-        UInt256 currentNonceAddressA = blockchain.State.GetNonce(TestItem.AddressA);
+        UInt256 currentNonceAddressA = blockchain.ReadOnlyState.GetNonce(TestItem.AddressA);
         await blockchain.AddFunds(TestItem.AddressA, 10000.Ether());
 
         Transaction tx = Build.A.Transaction.WithNonce(currentNonceAddressA++)
@@ -907,9 +907,9 @@ public class TraceRpcModuleTests
             .WithGasLimit(50000)
             .WithGasPrice(10).SignedAndResolved(TestItem.PrivateKeyA).TestObject;
 
-        blockchain.State.TryGetAccount(TestItem.AddressA, out AccountStruct accountA);
-        blockchain.State.TryGetAccount(TestItem.AddressD, out AccountStruct accountD);
-        blockchain.State.TryGetAccount(TestItem.AddressF, out AccountStruct accountF);
+        blockchain.ReadOnlyState.TryGetAccount(TestItem.AddressA, out AccountStruct accountA);
+        blockchain.ReadOnlyState.TryGetAccount(TestItem.AddressD, out AccountStruct accountD);
+        blockchain.ReadOnlyState.TryGetAccount(TestItem.AddressF, out AccountStruct accountF);
 
         string[] traceTypes = ["stateDiff"];
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -42,6 +42,7 @@ using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
+using Nethermind.State;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -328,20 +329,20 @@ public class BaseEngineModuleTests
             return new MergeBlockProducer(preMergeBlockProducer, postMergeBlockProducer, PoSSwitcher);
         }
 
-        protected override IBlockProcessor CreateBlockProcessor()
+        protected override IBlockProcessor CreateBlockProcessor(IWorldState worldState)
         {
             BlockValidator = CreateBlockValidator();
-            WithdrawalProcessor = new WithdrawalProcessor(State, LogManager);
+            WithdrawalProcessor = new WithdrawalProcessor(worldState, LogManager);
             IBlockProcessor processor = new BlockProcessor(
                 SpecProvider,
                 BlockValidator,
                 NoBlockRewards.Instance,
-                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
-                State,
+                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, worldState),
+                worldState,
                 ReceiptStorage,
                 TxProcessor,
-                new BeaconBlockRootHandler(TxProcessor, State),
-                new BlockhashStore(SpecProvider, State),
+                new BeaconBlockRootHandler(TxProcessor, worldState),
+                new BlockhashStore(SpecProvider, worldState),
                 LogManager,
                 WithdrawalProcessor,
                 preWarmer: CreateBlockCachePreWarmer(),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -716,7 +716,7 @@ public partial class EngineModuleTests
         Block? head = chain.BlockTree.Head!;
 
         // make sure AddressA has enough balance to send tx
-        chain.State.GetBalance(TestItem.AddressA).Should().BeGreaterThan(UInt256.One);
+        chain.ReadOnlyState.GetBalance(TestItem.AddressA).Should().BeGreaterThan(UInt256.One);
 
         // block is an invalid block, but it is impossible to detect until we process it.
         // it is invalid because after you processs its transactions, the root of the state trie
@@ -953,7 +953,7 @@ public partial class EngineModuleTests
             result.Data.PayloadId.Should().Be(null);
             testChain.BlockTree.HeadHash.Should().Be(block.BlockHash);
             testChain.BlockTree.Head!.Number.Should().Be(block.BlockNumber);
-            testChain.State.StateRoot.Should().Be(testChain.BlockTree.Head!.StateRoot!);
+            testChain.WorldStateManager.GlobalWorldState.StateRoot.Should().Be(testChain.BlockTree.Head!.StateRoot!);
         }
 
         async Task CanReorganizeToLastBlock(MergeTestBlockchain testChain,
@@ -985,7 +985,7 @@ public partial class EngineModuleTests
             result.Data.PayloadId.Should().Be(null);
             testChain.BlockTree.HeadHash.Should().Be(block.BlockHash);
             testChain.BlockTree.Head!.Number.Should().Be(block.BlockNumber);
-            testChain.State.StateRoot.Should().Be(testChain.BlockTree.Head!.StateRoot!);
+            testChain.WorldStateManager.GlobalWorldState.StateRoot.Should().Be(testChain.BlockTree.Head!.StateRoot!);
         }
 
         IReadOnlyList<ExecutionPayload> branch1 = await ProduceBranchV1(rpc, chain, 10, CreateParentBlockRequestOnHead(chain.BlockTree), true);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -294,7 +294,7 @@ public partial class EngineModuleTests
                 })
             .Result.Data.PayloadId!;
 
-        UInt256 startingBalance = chain.StateReader.GetBalance(chain.State.StateRoot, feeRecipient);
+        UInt256 startingBalance = chain.ReadOnlyState.GetBalance(feeRecipient);
 
         await blockImprovementLock.WaitAsync(10000);
         GetPayloadV2Result getPayloadResult = (await rpc.engine_getPayloadV2(Bytes.FromHexString(payloadId))).Data!;

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -315,11 +315,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     {
         public virtual async Task BuildBlockWithTxs(Transaction[] transactions, CancellationToken cancellation)
         {
-            Task newBlockTask = Wait.ForEventCondition<BlockReplacementEventArgs>(
-                cancellation,
-                (h) => blockTree.BlockAddedToMain += h,
-                (h) => blockTree.BlockAddedToMain -= h,
-                (e) => true);
+            Task newBlockTask = blockTree.WaitForNewBlock(cancellation);
 
             AcceptTxResult[] txResults = transactions.Select(t => txPool.SubmitTx(t, TxHandlingOptions.None)).ToArray();
             foreach (AcceptTxResult acceptTxResult in txResults)
@@ -370,11 +366,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     {
         public async Task BuildBlockWithTxs(Transaction[] transactions, CancellationToken cancellation)
         {
-            Task newBlockTask = Wait.ForEventCondition<BlockReplacementEventArgs>(
-                cancellation,
-                (h) => blockTree.BlockAddedToMain += h,
-                (h) => blockTree.BlockAddedToMain -= h,
-                (e) => true);
+            Task newBlockTask = blockTree.WaitForNewBlock(cancellation);
 
             AcceptTxResult[] txResults = transactions.Select(t => txPool.SubmitTx(t, TxHandlingOptions.None)).ToArray();
             foreach (AcceptTxResult acceptTxResult in txResults)


### PR DESCRIPTION
- Fix random debug rpc failure due to the use of global IWorldState.
- Removed global IWorldState from TestBlockchain, replaced with ReadOnlyState.
- Fix inconsistent block number after add block. Does not seems to fix the test though.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
