### PR TITLE
Remove redundant `authorizationTuple.Nonce == ulong.MaxValue` check

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -260,16 +260,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 StackAccessTracker accessTracker,
                 [NotNullWhen(false)] out string? error)
             {
-                UInt256 s = new(authorizationTuple.AuthoritySignature.SAsSpan, isBigEndian: true);
-                if (authorizationTuple.Authority is null
-                    || s > Secp256K1Curve.HalfN
-                    //V minus the offset can only be 1 or 0 since eip-155 does not apply to Setcode signatures
-                    || authorizationTuple.AuthoritySignature.V - Signature.VOffset > 1)
-                {
-                    error = "Bad signature.";
-                    return false;
-                }
-
                 if (authorizationTuple.ChainId != 0 && SpecProvider.ChainId != authorizationTuple.ChainId)
                 {
                     error = $"Chain id ({authorizationTuple.ChainId}) does not match.";
@@ -279,6 +269,16 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (authorizationTuple.Nonce == ulong.MaxValue)
                 {
                     error = $"Nonce ({authorizationTuple.Nonce}) must be less than 2**64 - 1.";
+                    return false;
+                }
+
+                UInt256 s = new(authorizationTuple.AuthoritySignature.SAsSpan, isBigEndian: true);
+                if (authorizationTuple.Authority is null
+                    || s > Secp256K1Curve.HalfN
+                    //V minus the offset can only be 1 or 0 since eip-155 does not apply to Setcode signatures
+                    || authorizationTuple.AuthoritySignature.V - Signature.VOffset > 1)
+                {
+                    error = "Bad signature.";
                     return false;
                 }
 
@@ -295,6 +295,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
                     return false;
                 }
+
                 UInt256 authNonce = WorldState.GetNonce(authorizationTuple.Authority);
                 if (authNonce != authorizationTuple.Nonce)
                 {


### PR DESCRIPTION
## Changes

- We have this check right above: https://github.com/NethermindEth/nethermind/pull/8340/files#diff-b8ea3d5dd4a8bedda3ec0900ae86bf6c3352c28fcec738e3064511be8c9c52e7R279-R283

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No