### PR TITLE
Double check pruning cache key memory usage

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -255,7 +255,7 @@ namespace Nethermind.Trie.Test.Pruning
                 tree.Commit();
             }
 
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 540560L : 610708L);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 589124 : 659272L);
             fullTrieStore.CommittedNodesCount.Should().Be(1349);
         }
 
@@ -691,7 +691,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             using (fullTrieStore.BeginBlockCommit(1))
             {
-                using (ICommitter committer = fullTrieStore.GetTrieStore(Hash256.Zero).BeginCommit(storage1))
+                using (ICommitter committer = fullTrieStore.GetTrieStore(null).BeginCommit(storage1))
                 {
                     committer.CommitNode(ref emptyPath, new NodeCommitInfo(a));
                     committer.CommitNode(ref emptyPath, new NodeCommitInfo(storage1));
@@ -895,7 +895,7 @@ namespace Nethermind.Trie.Test.Pruning
             readOnlyNode.Key?.ToString().Should().Be(originalNode.Key?.ToString());
         }
 
-        private long ExpectedPerNodeKeyMemorySize => _scheme == INodeStorage.KeyScheme.Hash ? 0 : TrieStoreDirtyNodesCache.Key.MemoryUsage;
+        private long ExpectedPerNodeKeyMemorySize => (_scheme == INodeStorage.KeyScheme.Hash ? 0 : TrieStoreDirtyNodesCache.Key.MemoryUsage) + MemorySizes.ObjectHeaderMethodTable + MemorySizes.RefSize + 4 + MemorySizes.RefSize;
 
         [Test]
         public void After_commit_should_have_has_root()
@@ -1020,7 +1020,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             memDb.Count.Should().Be(61);
             fullTrieStore.Prune();
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 736 : 944);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 880 : 1088);
         }
 
         [Test]
@@ -1132,7 +1132,7 @@ namespace Nethermind.Trie.Test.Pruning
             }
 
             memDb.Count.Should().Be(0);
-            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 11776 : 15104);
+            fullTrieStore.MemoryUsedByDirtyCache.Should().Be(_scheme == INodeStorage.KeyScheme.Hash ? 14080 : 17408);
 
             fullTrieStore.PersistCache(default);
             memDb.Count.Should().Be(64);

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -886,7 +886,7 @@ namespace Nethermind.Trie.Test
             ctx
                 .AssertThatDirtyNodeCountIs(9)
                 .AssertThatCachedNodeCountIs(951)
-                .AssertThatTotalMemoryUsedIs(819292L);
+                .AssertThatTotalMemoryUsedIs(853528);
         }
 
         [Test]
@@ -916,7 +916,7 @@ namespace Nethermind.Trie.Test
             ctx
                 .AssertThatDirtyNodeCountIs(2)
                 .AssertThatCachedNodeCountIs(3)
-                .AssertThatTotalMemoryUsedIs(1572);
+                .AssertThatTotalMemoryUsedIs(1680);
         }
 
         [Test]
@@ -949,7 +949,7 @@ namespace Nethermind.Trie.Test
 
             ctx
                 .AssertThatDirtyNodeCountIs(9)
-                .AssertThatCachedNodeCountIs(318);
+                .AssertThatCachedNodeCountIs(324);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/HashAndTinyPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/HashAndTinyPath.cs
@@ -10,17 +10,12 @@ namespace Nethermind.Trie.Pruning;
 [StructLayout(LayoutKind.Auto)]
 internal readonly struct HashAndTinyPath : IEquatable<HashAndTinyPath>
 {
-    public readonly ValueHash256 addr;
+    public readonly Hash256? addr;
     public readonly TinyTreePath path;
 
     public HashAndTinyPath(Hash256? hash, in TinyTreePath path)
     {
         addr = hash ?? default;
-        this.path = path;
-    }
-    public HashAndTinyPath(in ValueHash256 hash, in TinyTreePath path)
-    {
-        addr = hash;
         this.path = path;
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -61,8 +61,8 @@ internal class TrieStoreDirtyNodesCache
         KeyMemoryUsage = _storeByHash ? 0 : Key.MemoryUsage; // 0 because previously it was not counted.
 
         // Overhead for each key in concurrent dictionary. The key is stored in a "node" for the hashtable.
-        int concurrentNodeKeyOverhead = MemorySizes.ObjectHeaderMethodTable + MemorySizes.RefSize + 4 + MemorySizes.RefSize;
-        KeyMemoryUsage += concurrentNodeKeyOverhead;
+        // <object header> + <value ref> + <hashcode> + <next node ref>
+        KeyMemoryUsage += MemorySizes.ObjectHeaderMethodTable + MemorySizes.RefSize + 4 + MemorySizes.RefSize;;
 
         if (trackedPastKeyCount > 0 && !storeByHash)
         {


### PR DESCRIPTION
- Fix address should be a ref type as it can be shared between nodes.
- Account for per-key memory overhead of concurrent dictionary.
- Reduce minimum difference between average memory used per node measure from the heap and the metric from 241 byte to 128 byte.
  - Meaasured by replaying blocks until cache size reached 30GB.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Should not affect much function.