### PR TITLE
Make TxPool pending thread safe

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -239,14 +239,14 @@ namespace Nethermind.TxPool
 
             try
             {
-                if (++_headsQueueCount == 1)
+                if (Interlocked.Increment(ref _headsQueueCount) == 1)
                 {
                     _headBlocksResetEvent.Reset();
                 }
 
                 if (!_headBlocksChannel.Writer.TryWrite(e))
                 {
-                    _headsQueueCount--;
+                    Interlocked.Decrement(ref _headsQueueCount);
                     _headBlocksResetEvent.Set();
                 }
             }
@@ -305,7 +305,7 @@ namespace Nethermind.TxPool
                         }
                         finally
                         {
-                            if (--_headsQueueCount == 0)
+                            if (Interlocked.Decrement(ref _headsQueueCount) == 0)
                             {
                                 _headBlocksResetEvent.Set();
                             }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -283,6 +283,7 @@ namespace Nethermind.TxPool
                                 // Sequential block, just remove changed accounts from cache
                                 _accountCache.RemoveAccounts(accountChanges);
                             }
+
                             args.Block.AccountChanges = null;
                             accountChanges?.Dispose();
 
@@ -295,14 +296,19 @@ namespace Nethermind.TxPool
                             TxPoolHeadChanged?.Invoke(this, args.Block);
                             Metrics.TransactionCount = _transactions.Count;
                             Metrics.BlobTransactionCount = _blobTransactions.Count;
+                        }
+                        catch (Exception e)
+                        {
+                            if (_logger.IsDebug)
+                                _logger.Debug(
+                                    $"TxPool failed to update after block {args.Block.ToString(Block.Format.FullHashAndNumber)} with exception {e}");
+                        }
+                        finally
+                        {
                             if (--_headsQueueCount == 0)
                             {
                                 _headBlocksResetEvent.Set();
                             }
-                        }
-                        catch (Exception e)
-                        {
-                            if (_logger.IsDebug) _logger.Debug($"TxPool failed to update after block {args.Block.ToString(Block.Format.FullHashAndNumber)} with exception {e}");
                         }
                     }
                 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -57,7 +57,9 @@ namespace Nethermind.TxPool
 
         private readonly ILogger _logger;
 
-        private readonly Channel<BlockReplacementEventArgs> _headBlocksChannel = Channel.CreateUnbounded<BlockReplacementEventArgs>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
+        private readonly Channel<BlockReplacementEventArgs> _headBlocksChannel = Channel.CreateUnbounded<BlockReplacementEventArgs>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+        private int _headsQueueCount = 0;
+        private readonly ManualResetEventSlim _headBlocksResetEvent = new(true);
 
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
@@ -179,23 +181,48 @@ namespace Nethermind.TxPool
             ProcessNewHeads();
         }
 
-        public Transaction[] GetPendingTransactions() => _transactionSnapshot ??= _transactions.GetSnapshot();
+        public Transaction[] GetPendingTransactions()
+        {
+            _headBlocksResetEvent.Wait();
+            return _transactionSnapshot ??= _transactions.GetSnapshot();
+        }
 
-        public int GetPendingTransactionsCount() => _transactions.Count;
+        public int GetPendingTransactionsCount()
+        {
+            _headBlocksResetEvent.Wait();
+            return _transactions.Count;
+        }
 
-        public IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender() =>
-            _transactions.GetBucketSnapshot();
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender()
+        {
+            _headBlocksResetEvent.Wait();
+            return _transactions.GetBucketSnapshot();
+        }
 
-        public IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender() =>
-            _blobTransactions.GetBucketSnapshot();
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender()
+        {
+            _headBlocksResetEvent.Wait();
+            return _blobTransactions.GetBucketSnapshot();
+        }
 
-        public Transaction[] GetPendingTransactionsBySender(Address address) =>
-            _transactions.GetBucketSnapshot(address);
+        public Transaction[] GetPendingTransactionsBySender(Address address)
+        {
+            _headBlocksResetEvent.Wait();
+            return _transactions.GetBucketSnapshot(address);
+        }
 
         // only for testing reasons
-        internal Transaction[] GetOwnPendingTransactions() => _broadcaster.GetSnapshot();
+        internal Transaction[] GetOwnPendingTransactions()
+        {
+            _headBlocksResetEvent.Wait();
+            return _broadcaster.GetSnapshot();
+        }
 
-        public int GetPendingBlobTransactionsCount() => _blobTransactions.Count;
+        public int GetPendingBlobTransactionsCount()
+        {
+            _headBlocksResetEvent.Wait();
+            return _blobTransactions.Count;
+        }
 
         public bool TryGetBlobAndProof(byte[] blobVersionedHash,
             [NotNullWhen(true)] out byte[]? blob,
@@ -212,7 +239,16 @@ namespace Nethermind.TxPool
 
             try
             {
-                _headBlocksChannel.Writer.TryWrite(e);
+                if (++_headsQueueCount == 1)
+                {
+                    _headBlocksResetEvent.Reset();
+                }
+
+                if (!_headBlocksChannel.Writer.TryWrite(e))
+                {
+                    _headsQueueCount--;
+                    _headBlocksResetEvent.Set();
+                }
             }
             catch (Exception exception)
             {
@@ -259,6 +295,10 @@ namespace Nethermind.TxPool
                             TxPoolHeadChanged?.Invoke(this, args.Block);
                             Metrics.TransactionCount = _transactions.Count;
                             Metrics.BlobTransactionCount = _blobTransactions.Count;
+                            if (--_headsQueueCount == 0)
+                            {
+                                _headBlocksResetEvent.Set();
+                            }
                         }
                         catch (Exception e)
                         {
@@ -734,13 +774,19 @@ namespace Nethermind.TxPool
             ? _blobTransactions.ContainsKey(hash)
             : _transactions.ContainsKey(hash) || _broadcaster.ContainsTx(hash);
 
-        public bool TryGetPendingTransaction(Hash256 hash, [NotNullWhen(true)] out Transaction? transaction) =>
-            _transactions.TryGetValue(hash, out transaction)
-            || _blobTransactions.TryGetValue(hash, out transaction)
-            || _broadcaster.TryGetPersistentTx(hash, out transaction);
+        public bool TryGetPendingTransaction(Hash256 hash, [NotNullWhen(true)] out Transaction? transaction)
+        {
+            _headBlocksResetEvent.Wait();
+            return _transactions.TryGetValue(hash, out transaction)
+                   || _blobTransactions.TryGetValue(hash, out transaction)
+                   || _broadcaster.TryGetPersistentTx(hash, out transaction);
+        }
 
-        public bool TryGetPendingBlobTransaction(Hash256 hash, [NotNullWhen(true)] out Transaction? blobTransaction) =>
-            _blobTransactions.TryGetValue(hash, out blobTransaction);
+        public bool TryGetPendingBlobTransaction(Hash256 hash, [NotNullWhen(true)] out Transaction? blobTransaction)
+        {
+            _headBlocksResetEvent.Wait();
+            return _blobTransactions.TryGetValue(hash, out blobTransaction);
+        }
 
         // only for tests - to test sorting
         internal void TryGetBlobTxSortingEquivalent(Hash256 hash, out Transaction? transaction)
@@ -750,6 +796,8 @@ namespace Nethermind.TxPool
         // maybe it should use NonceManager, as it already has info about local txs?
         public UInt256 GetLatestPendingNonce(Address address)
         {
+            _headBlocksResetEvent.Wait();
+
             UInt256 maxPendingNonce = _accounts.GetNonce(address);
 
             bool hasPendingTxs = _transactions.GetBucketCount(address) > 0;


### PR DESCRIPTION
## Changes

- Waits till Tx pool gets updated from background thread before giving pending information

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: thread safety consistency

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No