### PR TITLE
Fix flashbots prewarmer not wired correctly

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -23,13 +23,13 @@ using Nethermind.Trie;
 
 namespace Nethermind.Consensus.Processing;
 
-public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpecProvider specProvider, int concurrency, ILogManager logManager, PreBlockCaches? preBlockCaches = null) : IBlockCachePreWarmer
+public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, IWorldState worldStateToWarmup, ISpecProvider specProvider, int concurrency, ILogManager logManager, PreBlockCaches? preBlockCaches = null) : IBlockCachePreWarmer
 {
     private int _concurrencyLevel = (concurrency == 0 ? RuntimeInformation.PhysicalCoreCount - 1 : concurrency);
-    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory), Environment.ProcessorCount * 2);
+    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory, worldStateToWarmup), Environment.ProcessorCount * 2);
     private readonly ILogger _logger = logManager.GetClassLogger<BlockCachePreWarmer>();
 
-    public BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpecProvider specProvider, IBlocksConfig blocksConfig, ILogManager logManager, PreBlockCaches? preBlockCaches = null) : this(envFactory, specProvider, blocksConfig.PreWarmStateConcurrency, logManager, preBlockCaches)
+    public BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, IWorldState worldStateToWarmup, ISpecProvider specProvider, IBlocksConfig blocksConfig, ILogManager logManager, PreBlockCaches? preBlockCaches = null) : this(envFactory, worldStateToWarmup, specProvider, blocksConfig.PreWarmStateConcurrency, logManager, preBlockCaches)
     {
     }
 
@@ -346,9 +346,9 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
         private static void DisposeThreadState(AddressWarmingState state) => state.Dispose();
     }
 
-    private class ReadOnlyTxProcessingEnvPooledObjectPolicy(ReadOnlyTxProcessingEnvFactory envFactory) : IPooledObjectPolicy<IReadOnlyTxProcessorSource>
+    private class ReadOnlyTxProcessingEnvPooledObjectPolicy(ReadOnlyTxProcessingEnvFactory envFactory, IWorldState worldStateToWarmUp) : IPooledObjectPolicy<IReadOnlyTxProcessorSource>
     {
-        public IReadOnlyTxProcessorSource Create() => envFactory.Create();
+        public IReadOnlyTxProcessorSource Create() => envFactory.CreateForWarmingUp(worldStateToWarmUp);
         public bool Return(IReadOnlyTxProcessorSource obj) => true;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/IReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IReadOnlyTxProcessingEnvFactory.cs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
 public interface IReadOnlyTxProcessingEnvFactory
 {
     public IReadOnlyTxProcessorSource Create();
+    public IReadOnlyTxProcessorSource CreateForWarmingUp(IWorldState worldState);
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnvFactory.cs
@@ -14,37 +14,33 @@ public class ReadOnlyTxProcessingEnvFactory(
     IWorldStateManager worldStateManager,
     IReadOnlyBlockTree readOnlyBlockTree,
     ISpecProvider specProvider,
-    ILogManager logManager,
-    IWorldState? worldStateToWarmUp = null) : IReadOnlyTxProcessingEnvFactory
+    ILogManager logManager) : IReadOnlyTxProcessingEnvFactory
 {
     public ReadOnlyTxProcessingEnvFactory(
         IWorldStateManager worldStateManager,
         IBlockTree blockTree,
         ISpecProvider specProvider,
-        ILogManager logManager,
-        IWorldState? worldStateToWarmUp = null)
-        : this(worldStateManager, blockTree.AsReadOnly(), specProvider, logManager, worldStateToWarmUp)
+        ILogManager logManager)
+        : this(worldStateManager, blockTree.AsReadOnly(), specProvider, logManager)
     {
     }
 
     public IReadOnlyTxProcessorSource Create()
     {
-        if (worldStateToWarmUp is null)
-        {
-            return new ReadOnlyTxProcessingEnv(
-                worldStateManager,
-                readOnlyBlockTree,
-                specProvider,
-                logManager);
-        }
-        else
-        {
-            return new ReadOnlyTxProcessingEnv(
-                worldStateManager,
-                readOnlyBlockTree,
-                specProvider,
-                logManager,
-                worldStateToWarmUp);
-        }
+        return new ReadOnlyTxProcessingEnv(
+            worldStateManager,
+            readOnlyBlockTree,
+            specProvider,
+            logManager);
+    }
+
+    public IReadOnlyTxProcessorSource CreateForWarmingUp(IWorldState worldStateToWarmUp)
+    {
+        return new ReadOnlyTxProcessingEnv(
+            worldStateManager,
+            readOnlyBlockTree,
+            specProvider,
+            logManager,
+            worldStateToWarmUp);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -400,7 +400,7 @@ public class TestBlockchain : IDisposable
 
 
     protected virtual IBlockCachePreWarmer CreateBlockCachePreWarmer() =>
-        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager, WorldStateManager.GlobalWorldState), SpecProvider, 4, LogManager, PreBlockCaches);
+        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager), WorldStateManager.GlobalWorldState, SpecProvider, 4, LogManager, PreBlockCaches);
 
     public async Task WaitForNewHead()
     {

--- a/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.Setup.cs
@@ -75,7 +75,8 @@ public partial class FlashbotsModuleTests
                 readOnlyTxProcessingEnvFactory,
                 chain.LogManager,
                 chain.SpecProvider,
-                new FlashbotsConfig()
+                new FlashbotsConfig(),
+                chain.EthereumEcdsa
             )
         );
     }

--- a/src/Nethermind/Nethermind.Flashbots/Flashbots.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Flashbots.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
-using Nethermind.Flashbots.Handlers;
 using Nethermind.Flashbots.Modules.Flashbots;
 using Nethermind.Consensus.Processing;
 using Nethermind.JsonRpc;
@@ -33,17 +32,17 @@ public class Flashbots(IFlashbotsConfig flashbotsConfig) : INethermindPlugin
             _api.LogManager
         );
 
-        ValidateSubmissionHandler validateSubmissionHandler = new ValidateSubmissionHandler(
-            _api.HeaderValidator ?? throw new ArgumentNullException(nameof(_api.HeaderValidator)),
-            _api.BlockTree ?? throw new ArgumentNullException(nameof(_api.BlockTree)),
-            _api.BlockValidator ?? throw new ArgumentNullException(nameof(_api.BlockValidator)),
+        ModuleFactoryBase<IFlashbotsRpcModule> flashbotsRpcModule = new FlashbotsRpcModuleFactory(
+            _api.HeaderValidator!,
+            _api.BlockTree,
+            _api.BlockValidator!,
             readOnlyTxProcessingEnvFactory,
-            _api.LogManager ?? throw new ArgumentNullException(nameof(_api.LogManager)),
-            _api.SpecProvider ?? throw new ArgumentNullException(nameof(_api.SpecProvider)),
-            flashbotsConfig
+            _api.LogManager,
+            _api.SpecProvider,
+            flashbotsConfig,
+            _api.EthereumEcdsa!
         );
 
-        ModuleFactoryBase<IFlashbotsRpcModule> flashbotsRpcModule = new FlashbotsRpcModuleFactory(validateSubmissionHandler);
         _api.RpcModuleProvider.RegisterBounded(flashbotsRpcModule,
             flashbotsConfig.FlashbotsModuleConcurrentInstances ?? Environment.ProcessorCount, _jsonRpcConfig.Timeout);
 

--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
@@ -36,17 +36,15 @@ public class ValidateSubmissionHandler
          | ProcessingOptions.ForceProcessing
          | ProcessingOptions.StoreReceipts;
 
-    private readonly ReadOnlyTxProcessingEnvFactory _readOnlyTxProcessingEnvFactory;
-
     private readonly IBlockTree _blockTree;
     private readonly IHeaderValidator _headerValidator;
     private readonly IBlockValidator _blockValidator;
     private readonly ILogger _logger;
-
     private readonly IFlashbotsConfig _flashbotsConfig;
-
-    private readonly ILogManager _logManager;
     private readonly ISpecProvider _specProvider;
+    private readonly IEthereumEcdsa _ethereumEcdsa;
+    private readonly IReadOnlyTxProcessingScope _processingScope;
+    private readonly BlockProcessor _blockProcessor;
 
     public ValidateSubmissionHandler(
         IHeaderValidator headerValidator,
@@ -55,16 +53,36 @@ public class ValidateSubmissionHandler
         ReadOnlyTxProcessingEnvFactory readOnlyTxProcessingEnvFactory,
         ILogManager logManager,
         ISpecProvider specProvider,
-        IFlashbotsConfig flashbotsConfig)
+        IFlashbotsConfig flashbotsConfig,
+        IEthereumEcdsa ethereumEcdsa)
     {
-        _headerValidator = headerValidator;
-        _blockValidator = blockValidator;
-        _readOnlyTxProcessingEnvFactory = readOnlyTxProcessingEnvFactory;
-        _specProvider = specProvider;
-        _logManager = logManager;
         _blockTree = blockTree;
-        _logger = logManager!.GetClassLogger();
+        _blockValidator = blockValidator;
+        _ethereumEcdsa = ethereumEcdsa;
         _flashbotsConfig = flashbotsConfig;
+        _headerValidator = headerValidator;
+        _logger = logManager!.GetClassLogger();
+        _specProvider = specProvider;
+
+        _processingScope = readOnlyTxProcessingEnvFactory.Create().Build(Keccak.EmptyTreeHash);
+        var worldState = _processingScope.WorldState;
+        ITransactionProcessor transactionProcessor = _processingScope.TransactionProcessor;
+        IBlockCachePreWarmer preWarmer = new BlockCachePreWarmer(readOnlyTxProcessingEnvFactory, worldState, _specProvider, 0, logManager);
+        _blockProcessor = new BlockProcessor(
+            _specProvider,
+            _blockValidator,
+            new Consensus.Rewards.RewardCalculator(_specProvider),
+            new BlockProcessor.BlockValidationTransactionsExecutor(transactionProcessor, worldState),
+            worldState,
+            NullReceiptStorage.Instance,
+            transactionProcessor,
+            new BeaconBlockRootHandler(transactionProcessor, worldState),
+            new BlockhashStore(_specProvider, worldState),
+            logManager: logManager,
+            withdrawalProcessor: new WithdrawalProcessor(worldState, logManager!),
+            receiptsRootCalculator: new ReceiptsRootCalculator(),
+            preWarmer: preWarmer
+        );
     }
 
     public Task<ResultWrapper<FlashbotsResult>> ValidateSubmission(BuilderBlockValidationRequest request)
@@ -200,20 +218,14 @@ public class ValidateSubmissionHandler
             return false;
         }
 
-        using IReadOnlyTxProcessingScope processingScope = _readOnlyTxProcessingEnvFactory.Create().Build(parentHeader.StateRoot!);
-        IWorldState currentState = processingScope.WorldState;
-        ITransactionProcessor transactionProcessor = processingScope.TransactionProcessor;
-
-        UInt256 feeRecipientBalanceBefore = currentState.HasStateForRoot(currentState.StateRoot) ? (currentState.AccountExists(feeRecipient) ? currentState.GetBalance(feeRecipient) : UInt256.Zero) : UInt256.Zero;
-
-        IBlockCachePreWarmer preWarmer = new BlockCachePreWarmer(_readOnlyTxProcessingEnvFactory, _specProvider, 0, _logManager);
-
-        BlockProcessor blockProcessor = CreateBlockProcessor(currentState, transactionProcessor, _flashbotsConfig.EnablePreWarmer ? preWarmer : null);
-
-        EthereumEcdsa ecdsa = new EthereumEcdsa(_specProvider.ChainId);
+        using var scope = _processingScope;
+        IWorldState worldState = _processingScope.WorldState;
+        Hash256 stateRoot = parentHeader.StateRoot!;
+        worldState.StateRoot = stateRoot;
         IReleaseSpec spec = _specProvider.GetSpec(parentHeader);
 
-        RecoverSenderAddress(block, ecdsa, spec);
+        RecoverSenderAddress(block, spec);
+        UInt256 feeRecipientBalanceBefore = worldState.HasStateForRoot(stateRoot) ? (worldState.AccountExists(feeRecipient) ? worldState.GetBalance(feeRecipient) : UInt256.Zero) : UInt256.Zero;
 
         List<Block> suggestedBlocks = [block];
         BlockReceiptsTracer blockReceiptsTracer = new();
@@ -224,7 +236,7 @@ public class ValidateSubmissionHandler
             {
                 ValidateSubmissionProcessingOptions |= ProcessingOptions.NoValidation;
             }
-            Block processedBlock = blockProcessor.Process(currentState.StateRoot, suggestedBlocks, ValidateSubmissionProcessingOptions, blockReceiptsTracer)[0];
+            _ = _blockProcessor.Process(stateRoot, suggestedBlocks, ValidateSubmissionProcessingOptions, blockReceiptsTracer)[0];
         }
         catch (Exception e)
         {
@@ -232,7 +244,7 @@ public class ValidateSubmissionHandler
             return false;
         }
 
-        UInt256 feeRecipientBalanceAfter = currentState.GetBalance(feeRecipient);
+        UInt256 feeRecipientBalanceAfter = worldState.GetBalance(feeRecipient);
 
         UInt256 amtBeforeOrWithdrawn = feeRecipientBalanceBefore;
 
@@ -263,13 +275,13 @@ public class ValidateSubmissionHandler
         return true;
     }
 
-    private void RecoverSenderAddress(Block block, EthereumEcdsa ecdsa, IReleaseSpec spec)
+    private void RecoverSenderAddress(Block block, IReleaseSpec spec)
     {
         foreach (Transaction tx in block.Transactions)
         {
             if (tx.SenderAddress is null)
             {
-                tx.SenderAddress = ecdsa.RecoverAddress(tx, !spec.ValidateChainId);
+                tx.SenderAddress = _ethereumEcdsa.RecoverAddress(tx, !spec.ValidateChainId);
             }
         }
     }
@@ -405,24 +417,5 @@ public class ValidateSubmissionHandler
 
         error = null;
         return true;
-    }
-
-    private BlockProcessor CreateBlockProcessor(IWorldState stateProvider, ITransactionProcessor transactionProcessor, IBlockCachePreWarmer? preWarmer = null)
-    {
-        return new BlockProcessor(
-            _specProvider,
-            _blockValidator,
-            new Consensus.Rewards.RewardCalculator(_specProvider),
-            new BlockProcessor.BlockValidationTransactionsExecutor(transactionProcessor, stateProvider),
-            stateProvider,
-            NullReceiptStorage.Instance,
-            transactionProcessor,
-            new BeaconBlockRootHandler(transactionProcessor, stateProvider),
-            new BlockhashStore(_specProvider, stateProvider),
-            logManager: _logManager,
-            withdrawalProcessor: new WithdrawalProcessor(stateProvider, _logManager!),
-            receiptsRootCalculator: new ReceiptsRootCalculator(),
-            preWarmer: preWarmer
-        );
     }
 }

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -2,20 +2,43 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 using Nethermind.Flashbots.Handlers;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.Logging;
 
 namespace Nethermind.Flashbots.Modules.Flashbots
 {
     public class FlashbotsRpcModuleFactory(
-        ValidateSubmissionHandler validateSubmissionHandler
+        IHeaderValidator headerValidator,
+        IBlockTree blockTree,
+        IBlockValidator blockValidator,
+        ReadOnlyTxProcessingEnvFactory readOnlyTxProcessingEnvFactory,
+        ILogManager logManager,
+        ISpecProvider specProvider,
+        IFlashbotsConfig flashbotsConfig,
+        IEthereumEcdsa ethereumEcdsa
     ) : ModuleFactoryBase<IFlashbotsRpcModule>
     {
-        private readonly ValidateSubmissionHandler _validateSubmissionHandler = validateSubmissionHandler ?? throw new ArgumentNullException(nameof(validateSubmissionHandler));
 
         public override IFlashbotsRpcModule Create()
         {
-            return new FlashbotsRpcModule(_validateSubmissionHandler);
+            ValidateSubmissionHandler validateSubmissionHandler = new ValidateSubmissionHandler(
+                headerValidator,
+                blockTree,
+                blockValidator,
+                readOnlyTxProcessingEnvFactory,
+                logManager,
+                specProvider,
+                flashbotsConfig,
+                ethereumEcdsa
+            );
+
+            return new FlashbotsRpcModule(validateSubmissionHandler);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -104,10 +104,10 @@ namespace Nethermind.Init.Steps
             BlockCachePreWarmer? preWarmer = blocksConfig.PreWarmStateOnBlockProcessing
                 ? new(new(
                         _api.WorldStateManager!,
-                        _api.BlockTree!,
+                        _api.BlockTree!.AsReadOnly(),
                         _api.SpecProvider,
-                        _api.LogManager,
-                        mainWorldState),
+                        _api.LogManager),
+                    mainWorldState,
                     _api.SpecProvider!,
                     blocksConfig,
                     _api.LogManager,


### PR DESCRIPTION
- Fix flashbots's rpc module prewarmer not wired correctly. Implicitly the read only processing env factory should have the world state to warm up.
- Fix block processor re-created on each call, which make sense for some application, but generally we keep the instance and recycle it.
- Create `ReadOnlyProcessingEnvFactory.CreateForWarmingUp` which require passing the world state to warm up.
- Prewarmer now need the world state to warm up passed in its constructor to make it clear which world state it is warming up instead of implicitly in the instance of `ReadOnlyProcessingEnvFactory`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing