### PR TITLE
Fix/block improvement test inconsistencies

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -119,13 +119,13 @@ namespace Nethermind.AuRa.Test
             }
         }
 
-        [Test, Retry(6)]
+        [Test]
         public async Task Produces_block()
         {
             (await StartStop(new Context())).ShouldProduceBlocks(Quantity.AtLeastOne());
         }
 
-        [Test, Retry(15)]
+        [Test]
         public async Task Can_produce_first_block_when_private_chains_allowed()
         {
             Context context = new();

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -218,7 +218,7 @@ namespace Nethermind.AuRa.Test
             (await StartStop(new Context(), true, true)).ShouldProduceBlocks(Quantity.None());
         }
 
-        private async Task<TestResult> StartStop(Context context, bool processingQueueEmpty = true, bool newBestSuggestedBlock = false, int stepDelayMultiplier = 100)
+        private async Task<TestResult> StartStop(Context context, bool processingQueueEmpty = true, bool newBestSuggestedBlock = false)
         {
             AutoResetEvent processedEvent = new(false);
             context.BlockTree.SuggestBlock(Arg.Any<Block>(), Arg.Any<BlockTreeSuggestOptions>())
@@ -229,7 +229,7 @@ namespace Nethermind.AuRa.Test
                 });
 
             context.BlockProducerRunner.Start();
-            await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 20, CancellationToken.None);
+            await processedEvent.WaitOneAsync(context.StepDelay * 20, CancellationToken.None);
             context.BlockTree.ClearReceivedCalls();
             await Task.Delay(context.StepDelay * 2);
             processedEvent.Reset();
@@ -248,7 +248,7 @@ namespace Nethermind.AuRa.Test
                     processedEvent.Reset();
                 }
 
-                await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 20, CancellationToken.None);
+                await processedEvent.WaitOneAsync(context.StepDelay * 20, CancellationToken.None);
 
             }
             finally

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -227,9 +227,9 @@ public class TxPermissionFilterTest
         {
             foreach (ITransactionPermissionContract.TxPermissions txType in TxPermissionsTypes)
             {
-                Task<TestTxPermissionsBlockchain> chainTask = TestContractBlockchain.ForTest<TestTxPermissionsBlockchain, TxPermissionFilterTest>(testsName);
                 async Task<TestTxPermissionsBlockchain> testFactory()
                 {
+                    Task<TestTxPermissionsBlockchain> chainTask = TestContractBlockchain.ForTest<TestTxPermissionsBlockchain, TxPermissionFilterTest>(testsName);
                     TestTxPermissionsBlockchain chain = await chainTask;
                     chain.TxPermissionFilterCache.Permissions.Clear();
                     chain.TransactionPermissionContractVersions.Clear();
@@ -269,13 +269,6 @@ public class TxPermissionFilterTest
         {
             TransactionPermissionContractVersions =
                 new LruCache<ValueHash256, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize, nameof(TransactionPermissionContract));
-
-            IReadOnlyTrieStore trieStore = new TrieStore(DbProvider.StateDb, LimboLogs.Instance).AsReadOnly();
-            IReadOnlyTxProcessorSource txProcessorSource = new ReadOnlyTxProcessingEnv(
-                WorldStateManager,
-                BlockTree.AsReadOnly(),
-                SpecProvider,
-                LimboLogs.Instance);
 
             VersionedTransactionPermissionContract transactionPermissionContract = new(AbiEncoder.Instance, _contractAddress, 1,
                 new ReadOnlyTxProcessingEnv(WorldStateManager, BlockTree.AsReadOnly(), SpecProvider, LimboLogs.Instance), TransactionPermissionContractVersions, LimboLogs.Instance, SpecProvider);

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
@@ -96,9 +97,13 @@ public class FullPruningDiskTest
 
         protected override Task AddBlocksOnStart() => Task.CompletedTask;
 
-        public static async Task<PruningTestBlockchain> Create(IPruningConfig? pruningConfig = null)
+        public static async Task<PruningTestBlockchain> Create(IPruningConfig? pruningConfig = null, long testTimeoutMs = 10000)
         {
-            PruningTestBlockchain chain = new() { PruningConfig = pruningConfig ?? new PruningConfig() };
+            PruningTestBlockchain chain = new()
+            {
+                PruningConfig = pruningConfig ?? new PruningConfig(),
+                TestTimout = testTimeoutMs,
+            };
             await chain.Build();
             return chain;
         }
@@ -135,7 +140,7 @@ public class FullPruningDiskTest
     [Test, MaxTime(Timeout.LongTestTime)]
     public async Task prune_on_disk_multiple_times()
     {
-        using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 0 });
+        using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 0 }, testTimeoutMs: Timeout.LongTestTime);
         for (int i = 0; i < 3; i++)
         {
             await RunPruning(chain, i, false);
@@ -174,7 +179,7 @@ public class FullPruningDiskTest
         if (args.Status != PruningStatus.Starting) return;
         for (int i = 0; i < Reorganization.MaxDepth + 2; i++)
         {
-            await chain.AddBlock(true);
+            await chain.AddBlock();
         }
 
         HashSet<byte[]> allItems = chain.DbProvider.StateDb.GetAllValues().ToHashSet(Bytes.EqualityComparer);
@@ -182,7 +187,7 @@ public class FullPruningDiskTest
         for (int i = 0; i < 100 && !pruningFinished; i++)
         {
             pruningFinished = chain.FullPruner.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(100));
-            await chain.AddBlock(true);
+            await chain.AddBlockDoNotWaitForHead();
         }
 
         if (!onlyFirstRuns || time == 0)

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -84,6 +84,7 @@ public class StartupTreeFixerTests
         tree.BestKnownNumber.Should().Be(2);
     }
 
+    [Retry(30)]
     [MaxTime(Timeout.MaxTestTime * 4)]
     [TestCase(0)]
     [TestCase(1)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -94,7 +94,7 @@ public class StartupTreeFixerTests
     [TestCase(65)]
     public async Task Suggesting_blocks_works_correctly_after_processor_restart(int suggestedBlocksAmount)
     {
-        TestRpcBlockchain testRpc = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).Build();
+        TestRpcBlockchain testRpc = await TestRpcBlockchain.ForTest(SealEngineType.NethDev, testTimeout: Timeout.MaxTestTime * 4).Build();
         await testRpc.BlockchainProcessor.StopAsync();
         IBlockTree tree = testRpc.BlockTree;
         long startingBlockNumber = tree.Head!.Number;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -108,20 +109,15 @@ public class StartupTreeFixerTests
         newBlockchainProcessor.Start();
         testRpc.BlockchainProcessor = newBlockchainProcessor;
 
+        Task waitTask = suggestedBlocksAmount != 0
+            ? testRpc.WaitForNewHeadWhere(b => b.Number == startingBlockNumber + suggestedBlocksAmount)
+            : Task.CompletedTask;
         // fixing after restart
         StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, testRpc.StateReader, LimboNoErrorLogger.Instance, 5);
+        await tree.Accept(fixer, CancellationToken.None);
 
         // waiting for N new heads
-        Task waitHeadTask = Task.Run(async () =>
-        {
-            for (int i = 0; i < suggestedBlocksAmount; ++i)
-            {
-                await testRpc.WaitForNewHead();
-            }
-        });
-
-        await tree.Accept(fixer, CancellationToken.None);
-        await waitHeadTask;
+        await waitTask;
 
         // add a new block at the end
         await testRpc.AddBlock();

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -797,6 +797,7 @@ public class CliqueBlockProducerTests
     }
 
     [Test]
+    [Retry(3)]
     public async Task Can_reorganize_when_receiving_in_turn_blocks()
     {
         On goerli = On.FastGoerli;

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -564,6 +564,7 @@ public class CliqueBlockProducerTests
     private static readonly int _timeout = 5000; // this has to cover block period of second + wiggle of up to 500ms * (signers - 1) + 100ms delay of the block readiness check
 
     [Test]
+    [Retry(3)]
     public async Task Can_produce_block_with_transactions()
     {
         await On.Goerli

--- a/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
@@ -59,6 +59,7 @@ public class CensorshipDetectorTests
 
     // Address Censorship is given to be false here since censorship is not being detected for any address.
     [Test]
+    [Retry(3)]
     public void Censorship_when_address_censorship_is_false_and_high_paying_tx_censorship_is_true_for_all_blocks_in_main_cache()
     {
         _txPool = CreatePool();

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -5,8 +5,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
@@ -44,7 +42,6 @@ using Nethermind.State.Repositories;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
-using ZstdSharp.Unsafe;
 
 namespace Nethermind.Core.Test.Blockchain;
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -22,6 +22,7 @@ using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Events;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
@@ -382,6 +383,15 @@ public class TestBlockchain : IDisposable
     public async Task WaitForNewHead()
     {
         await BlockTree.WaitForNewBlock(_cts.Token);
+    }
+
+    public Task WaitForNewHeadWhere(Func<Block, bool> predicate)
+    {
+        return Wait.ForEventCondition<BlockReplacementEventArgs>(
+            _cts.Token,
+            (h) => BlockTree.BlockAddedToMain += h,
+            (h) => BlockTree.BlockAddedToMain -= h,
+            (e) => predicate(e.Block));
     }
 
     public async Task AddBlock(params Transaction[] transactions)

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core.Events;
+using Nethermind.Core.Test.Builders;
+using Nethermind.TxPool;
+
+namespace Nethermind.Core.Test.Blockchain;
+
+public class TestBlockchainUtil(
+    IBlockProducerRunner blockProducerRunner,
+    IManualBlockProductionTrigger blockProductionTrigger,
+    ManualTimestamper timestamper,
+    IBlockTree blockTree,
+    ITxPool txPool
+)
+{
+    private Task _previousAddBlock = Task.CompletedTask;
+
+    public async Task<AcceptTxResult[]> AddBlockDoNotWaitForHead(CancellationToken cancellationToken, params Transaction[] transactions)
+    {
+        await WaitAsync(_previousAddBlock, "Multiple block produced at once.").ConfigureAwait(false);
+        TaskCompletionSource tcs = new TaskCompletionSource();
+        _previousAddBlock = tcs.Task;
+
+        Task waitForNewBlock = WaitAsync(WaitForBlockProducerBlockProduced(cancellationToken), "timeout waiting for block producer");
+
+        AcceptTxResult[] txResults = transactions.Select(t => txPool.SubmitTx(t, TxHandlingOptions.None)).ToArray();
+        timestamper.Add(TimeSpan.FromSeconds(1));
+        await blockProductionTrigger.BuildBlock().ConfigureAwait(false);
+
+        await waitForNewBlock.ConfigureAwait(false);
+
+        tcs.TrySetResult();
+        return txResults;
+    }
+
+    public async Task AddBlockAndWaitForHead(CancellationToken cancellationToken, params Transaction[] transactions)
+    {
+        Task waitforHead = WaitAsync(blockTree.WaitForNewBlock(cancellationToken), "timeout waiting for new head");
+
+        await AddBlockDoNotWaitForHead(cancellationToken, transactions);
+
+        await waitforHead;
+    }
+
+    private Task WaitForBlockProducerBlockProduced(CancellationToken cancellationToken = default)
+    {
+        return Wait.ForEventCondition<BlockEventArgs>(cancellationToken,
+            e => blockProducerRunner.BlockProduced += e,
+            e => blockProducerRunner.BlockProduced -= e,
+            b => true);
+    }
+
+    private async Task WaitAsync(Task task, string error)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            throw new InvalidOperationException(error);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
@@ -110,7 +110,7 @@ public class EthRpcSimulateTestsBase
 
         code?.Should().Be(AcceptTxResult.Accepted);
         Transaction[] txs = chain.TxPool.GetPendingTransactions();
-        await chain.AddBlock(true, txs);
+        await chain.AddBlock(txs);
 
         TxReceipt? createContractTxReceipt = null;
         while (createContractTxReceipt is null)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -138,7 +138,7 @@ public class EthSimulateTestsBlocksAndTransactions
 
         //Test that transfer tx works on mainchain
         UInt256 before = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
-        await chain.AddBlock(true, txMainnetAtoB);
+        await chain.AddBlock(txMainnetAtoB);
         UInt256 after = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         Assert.That(after, Is.LessThan(before));
 
@@ -222,7 +222,7 @@ public class EthSimulateTestsBlocksAndTransactions
 
         //Test that transfer tx works on mainchain
         UInt256 before = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
-        await chain.AddBlock(true, txMainnetAtoB);
+        await chain.AddBlock(txMainnetAtoB);
         UInt256 after = chain.ReadOnlyState.GetBalance(TestItem.AddressA);
         Assert.That(after, Is.LessThan(before));
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -56,10 +56,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                 LimboLogs.Instance);
 
         public IFeeHistoryOracle? FeeHistoryOracle { get; private set; }
-        public static Builder<TestRpcBlockchain> ForTest(string sealEngineType) => ForTest<TestRpcBlockchain>(sealEngineType);
+        public static Builder<TestRpcBlockchain> ForTest(string sealEngineType, long? testTimeout = null) => ForTest<TestRpcBlockchain>(sealEngineType, testTimeout);
 
-        public static Builder<T> ForTest<T>(string sealEngineType) where T : TestRpcBlockchain, new() =>
-            new(new T { SealEngineType = sealEngineType });
+        public static Builder<T> ForTest<T>(string sealEngineType, long? testTimout = null) where T : TestRpcBlockchain, new() =>
+            new(new T { SealEngineType = sealEngineType, TestTimout = testTimout ?? DefaultTimeout });
 
         public static Builder<T> ForTest<T>(T blockchain) where T : TestRpcBlockchain =>
             new(blockchain);

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -207,7 +207,7 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             PostMergeBlockProducer = postMergeBlockProducer;
             PayloadPreparationService ??= new PayloadPreparationService(
                 postMergeBlockProducer,
-                CreateBlockImprovementContextFactory(PostMergeBlockProducer),
+                StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(CreateBlockImprovementContextFactory(PostMergeBlockProducer)),
                 TimerFactory.Default,
                 LogManager,
                 TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -234,7 +234,7 @@ public class BaseEngineModuleTests
 
         public Task WaitForImprovedBlocck(Hash256? parentHash = null)
         {
-            return Wait.ForEventCondition<BlockEventArgs>(default,
+            return Wait.ForEventCondition<BlockEventArgs>(_cts.Token,
                 e => PayloadPreparationService!.BlockImproved += e,
                 e => PayloadPreparationService!.BlockImproved -= e,
                 b =>

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -51,7 +51,7 @@ using NUnit.Framework;
 
 namespace Nethermind.Merge.Plugin.Test;
 
-public class BaseEngineModuleTests
+public partial class BaseEngineModuleTests
 {
     [SetUp]
     public Task Setup()
@@ -231,17 +231,16 @@ public class BaseEngineModuleTests
         public PostMergeBlockProducer? PostMergeBlockProducer { get; set; }
 
         public IPayloadPreparationService? PayloadPreparationService { get; set; }
+        public StoringBlockImprovementContextFactory? StoringBlockImprovementContextFactory { get; set; }
 
-        public Task WaitForImprovedBlocck(Hash256? parentHash = null)
+        public Task WaitForImprovedBlock(Hash256? parentHash = null)
         {
-            return Wait.ForEventCondition<BlockEventArgs>(_cts.Token,
-                e => PayloadPreparationService!.BlockImproved += e,
-                e => PayloadPreparationService!.BlockImproved -= e,
-                b =>
-                {
-                    if (parentHash is null) return true;
-                    return b.Block.ParentHash == parentHash;
-                });
+            return StoringBlockImprovementContextFactory!.WaitForImprovedBlock(_cts.Token, parentHash);
+        }
+
+        public Task WaitForImprovedBlockWithCondition(Func<Block, bool> predicate)
+        {
+            return StoringBlockImprovementContextFactory!.WaitForImprovedBlockWithCondition(_cts.Token, predicate);
         }
 
         public ISealValidator? SealValidator { get; set; }
@@ -317,9 +316,10 @@ public class BaseEngineModuleTests
             BlockProducerEnv blockProducerEnv = blockProducerEnvFactory.Create();
             PostMergeBlockProducer? postMergeBlockProducer = blockProducerFactory.Create(blockProducerEnv);
             PostMergeBlockProducer = postMergeBlockProducer;
+            BlockImprovementContextFactory ??= new BlockImprovementContextFactory(PostMergeBlockProducer, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot));
             PayloadPreparationService ??= new PayloadPreparationService(
                 postMergeBlockProducer,
-                new BlockImprovementContextFactory(PostMergeBlockProducer, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot)),
+                BlockImprovementContextFactory,
                 TimerFactory.Default,
                 LogManager,
                 TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot),
@@ -368,7 +368,15 @@ public class BaseEngineModuleTests
         }
 
         public IManualBlockFinalizationManager BlockFinalizationManager { get; } = new ManualBlockFinalizationManager();
-        public IBlockImprovementContextFactory BlockImprovementContextFactory { get; set; } = null!;
+
+        public IBlockImprovementContextFactory BlockImprovementContextFactory
+        {
+            get => StoringBlockImprovementContextFactory!;
+            set
+            {
+                StoringBlockImprovementContextFactory = value as StoringBlockImprovementContextFactory ?? new StoringBlockImprovementContextFactory(value);
+            }
+        }
 
         protected override async Task<TestBlockchain> Build(ISpecProvider? specProvider = null, UInt256? initialValues = null, bool addBlockOnStart = true)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -235,7 +235,11 @@ public partial class BaseEngineModuleTests
 
         public Task WaitForImprovedBlock(Hash256? parentHash = null)
         {
-            return StoringBlockImprovementContextFactory!.WaitForImprovedBlock(_cts.Token, parentHash);
+            if (parentHash == null)
+            {
+                return StoringBlockImprovementContextFactory!.WaitForImprovedBlockWithCondition(_cts.Token, b => true);
+            }
+            return StoringBlockImprovementContextFactory!.WaitForImprovedBlockWithCondition(_cts.Token, b => b.Header.ParentHash == parentHash);
         }
 
         public Task WaitForImprovedBlockWithCondition(Func<Block, bool> predicate)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -417,10 +416,7 @@ public partial class EngineModuleTests
                 return true;
             });
 
-        lock (improvementContextFactory.CreatedContexts)
-        {
-            improvementContextFactory.CreatedContexts.Should().HaveCount(2);
-        }
+        improvementContextFactory.CreatedContexts.Should().HaveCount(2);
 
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -96,7 +96,7 @@ public partial class EngineModuleTests
         PrivateKey sender = TestItem.PrivateKeyB;
         Transaction[] transactions = BuildTransactions(chain, startingHead, sender, recipient, count, value, out _, out _);
         chain.AddTransactions(transactions);
-        chain.PayloadPreparationService!.BlockImproved += (_, _) => { blockImprovementLock.Release(1); };
+        chain.StoringBlockImprovementContextFactory!.BlockImproved += (_, _) => { blockImprovementLock.Release(1); };
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 new PayloadAttributes() { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
@@ -270,7 +270,7 @@ public partial class EngineModuleTests
         using MergeTestBlockchain chain = await CreateBlockchainWithImprovementContext(
             static chain => new StoringBlockImprovementContextFactory(new MockBlockImprovementContextFactory()),
             timePerSlot, mergeConfig, delay);
-        StoringBlockImprovementContextFactory improvementContextFactory = (StoringBlockImprovementContextFactory)chain.BlockImprovementContextFactory;
+        StoringBlockImprovementContextFactory improvementContextFactory = chain.StoringBlockImprovementContextFactory!;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;
@@ -302,7 +302,7 @@ public partial class EngineModuleTests
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;
-        Task improvementWaitTask = chain.WaitForImprovedBlocck();
+        Task improvementWaitTask = chain.WaitForImprovedBlock();
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyB, TestItem.AddressF, 3, 10, out _, out _));
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
@@ -310,11 +310,11 @@ public partial class EngineModuleTests
             .Result.Data.PayloadId!;
         await improvementWaitTask;
 
-        improvementWaitTask = chain.WaitForImprovedBlocck();
+        improvementWaitTask = chain.WaitForImprovedBlock();
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
         await improvementWaitTask;
 
-        improvementWaitTask = chain.WaitForImprovedBlocck();
+        improvementWaitTask = chain.WaitForImprovedBlock();
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyA, TestItem.AddressC, 5, 10, out _, out _));
         await improvementWaitTask;
 
@@ -349,29 +349,32 @@ public partial class EngineModuleTests
 
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 50 * delay;
-        StoringBlockImprovementContextFactory improvementContextFactory = new(new BlockImprovementContextFactory(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)));
+        StoringBlockImprovementContextFactory improvementContextFactory = new(
+            new BlockImprovementContextFactory(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)),
+            skipDuplicatedContext: true
+        );
         ConfigureBlockchainWithImprovementContextFactory(chain, improvementContextFactory, timePerSlot, delay);
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;
         chain.AddTransactions(tx1);
 
-        Task improvedBlockWait = chain.WaitForImprovedBlocck();
+        Task improvedBlockWait = chain.WaitForImprovedBlock();
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 new PayloadAttributes { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
             .Result.Data.PayloadId!;
         await improvedBlockWait;
 
+        improvedBlockWait = chain.WaitForImprovedBlock();
         chain.AddTransactions(tx2);
-        await chain.WaitForImprovedBlocck();
-
-        ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
+        await improvedBlockWait;
 
         List<int?> transactionsLength = improvementContextFactory.CreatedContexts
             .Select(c => c.CurrentBestBlock?.Transactions.Length).ToList();
 
         transactionsLength.Should().Equal(1, 2);
+        ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
         Transaction[] txs = getPayloadResult.GetTransactions();
 
         txs.Should().HaveCount(2);
@@ -391,17 +394,18 @@ public partial class EngineModuleTests
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;
+        Task blockImprovement = chain.WaitForImprovedBlock();
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyB, TestItem.AddressF, 3, 10, out _, out _));
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 new PayloadAttributes { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
             .Result.Data.PayloadId!;
 
-        await chain.WaitForImprovedBlocck();
+        await blockImprovement;
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
 
         IBlockImprovementContext? cancelledContext = null;
-        await Wait.ForEventCondition<ImprovementStartedEventArgs>(default,
+        await Wait.ForEventCondition<ImprovementStartedEventArgs>(chain.CancellationToken,
             e => improvementContextFactory!.ImprovementStarted += e,
             e => improvementContextFactory!.ImprovementStarted -= e,
             e =>
@@ -410,7 +414,10 @@ public partial class EngineModuleTests
                 return true;
             });
 
-        improvementContextFactory.CreatedContexts.Should().HaveCount(2);
+        lock (improvementContextFactory.CreatedContexts)
+        {
+            improvementContextFactory.CreatedContexts.Should().HaveCount(2);
+        }
 
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
@@ -421,8 +428,6 @@ public partial class EngineModuleTests
     [Test]
     public async Task Cannot_build_invalid_block_with_the_branch()
     {
-        using SemaphoreSlim blockImprovementLock = new(0);
-
         using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(London.Instance));
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 4 * delay;
@@ -433,8 +438,8 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // creating chain with 30 blocks
+        Task blockImprovementWait = chain.WaitForImprovedBlock();
         await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true);
-        chain.PayloadPreparationService!.BlockImproved += (_, _) => { blockImprovementLock.Release(1); };
 
         Block block30 = chain.BlockTree.Head!;
 
@@ -450,7 +455,7 @@ public partial class EngineModuleTests
                 new ForkchoiceStateV1(block30.GetOrCalculateHash(), Keccak.Zero, block30.GetOrCalculateHash()),
                 payloadAttributesBlock31A)
             .Result.Data.PayloadId!;
-        await blockImprovementLock.WaitAsync(delay * 1000);
+        await blockImprovementWait;
 
         ExecutionPayload getPayloadResultBlock31A = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadIdBlock31A))).Data!;
         getPayloadResultBlock31A.Should().NotBeNull();
@@ -479,8 +484,9 @@ public partial class EngineModuleTests
             new ForkchoiceStateV1(block31B.GetOrCalculateHash(), Keccak.Zero, block31B.GetOrCalculateHash())).Result.Data;
 
         // we added same transactions, so if we build on incorrect state root, we will end up with invalid block
+        blockImprovementWait = chain.WaitForImprovedBlock();
         chain.AddTransactions(BuildTransactions(chain, block31A.GetOrCalculateHash(), TestItem.PrivateKeyC, TestItem.AddressF, 3, 10, out _, out _));
-        await blockImprovementLock.WaitAsync(delay * 1000);
+        await blockImprovementWait;
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
         getPayloadResult.Should().NotBeNull();
 
@@ -513,7 +519,7 @@ public partial class EngineModuleTests
         Hash256 blockX = chain.BlockTree.HeadHash;
         chain.AddTransactions(BuildTransactions(chain, blockX, TestItem.PrivateKeyB, TestItem.AddressF, 3, 10, out _, out _));
 
-        Task improvementTask = chain.WaitForImprovedBlocck(blockX);
+        Task improvementTask = chain.WaitForImprovedBlock(blockX);
 
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(blockX, Keccak.Zero, blockX),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -50,9 +50,10 @@ public partial class EngineModuleTests
 
         BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(10);
+        chain.StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(improvementContextFactory);
         chain.PayloadPreparationService = new PayloadPreparationService(
             chain.PostMergeBlockProducer!,
-            improvementContextFactory,
+            chain.StoringBlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
             timePerSlot);
@@ -67,14 +68,13 @@ public partial class EngineModuleTests
         boostRelay.When(b => b.SendPayload(Arg.Any<BoostExecutionPayloadV1>(), Arg.Any<CancellationToken>()))
             .Do(c => sentItem = c.Arg<BoostExecutionPayloadV1>());
 
-        ManualResetEvent wait = new(false);
-        chain.PayloadPreparationService.BlockImproved += (_, _) => wait.Set();
+        Task blockImprovementWait = chain.WaitForImprovedBlock();
 
         string payloadId = rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 new PayloadAttributes { Timestamp = timestamp, SuggestedFeeRecipient = feeRecipient, PrevRandao = random }).Result.Data
             .PayloadId!;
 
-        await wait.WaitOneAsync(100, CancellationToken.None);
+        await blockImprovementWait;
 
         ResultWrapper<ExecutionPayload?> response = await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId));
 
@@ -153,9 +153,10 @@ public partial class EngineModuleTests
         BoostRelay boostRelay = new(defaultHttpClient, relayUrl);
         BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5000), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(1000);
+        chain.StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(improvementContextFactory);
         chain.PayloadPreparationService = new PayloadPreparationService(
             chain.PostMergeBlockProducer!,
-            improvementContextFactory,
+            chain.StoringBlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
             timePerSlot);
@@ -163,14 +164,13 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;
 
-        ManualResetEvent wait = new(false);
-        chain.PayloadPreparationService.BlockImproved += (_, _) => wait.Set();
+        Task blockImprovementWait = chain.WaitForImprovedBlock();
 
         string payloadId = rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 payloadAttributes).Result.Data
             .PayloadId!;
 
-        await wait.WaitOneAsync(100, CancellationToken.None);
+        await blockImprovementWait;
 
         ResultWrapper<ExecutionPayload?> response = await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId));
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -50,10 +50,10 @@ public partial class EngineModuleTests
 
         BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(10);
-        chain.StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(improvementContextFactory);
+        chain.BlockImprovementContextFactory = improvementContextFactory;
         chain.PayloadPreparationService = new PayloadPreparationService(
             chain.PostMergeBlockProducer!,
-            chain.StoringBlockImprovementContextFactory,
+            chain.BlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
             timePerSlot);
@@ -153,10 +153,10 @@ public partial class EngineModuleTests
         BoostRelay boostRelay = new(defaultHttpClient, relayUrl);
         BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5000), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(1000);
-        chain.StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(improvementContextFactory);
+        chain.BlockImprovementContextFactory = improvementContextFactory;
         chain.PayloadPreparationService = new PayloadPreparationService(
             chain.PostMergeBlockProducer!,
-            chain.StoringBlockImprovementContextFactory,
+            chain.BlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
             timePerSlot);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -32,7 +32,7 @@ public partial class BaseEngineModuleTests
 
         public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime, UInt256 currentBlockFees)
         {
-            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime);
+            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime, currentBlockFees);
             if (_skipDuplicatedContext
                 && CreatedContexts.Count > 0
                 && CreatedContexts[^1].CurrentBestBlock == blockImprovementContext.CurrentBestBlock)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -59,18 +59,6 @@ public partial class BaseEngineModuleTests
             return t.Result;
         }
 
-        public Task WaitForImprovedBlock(CancellationToken cancellationToken, Hash256? parentHash = null)
-        {
-            return Wait.ForEventCondition<BlockEventArgs>(cancellationToken,
-                e => BlockImproved += e,
-                e => BlockImproved -= e,
-                b =>
-                {
-                    if (parentHash is null) return true;
-                    return b.Block.ParentHash == parentHash;
-                });
-        }
-
         public Task WaitForImprovedBlockWithCondition(CancellationToken cancellationToken, Func<Block, bool> cond)
         {
             return Wait.ForEventCondition<BlockEventArgs>(cancellationToken,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -3,36 +3,84 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Events;
 
 namespace Nethermind.Merge.Plugin.Test;
 
-public partial class EngineModuleTests
+public partial class BaseEngineModuleTests
 {
-    private class StoringBlockImprovementContextFactory : IBlockImprovementContextFactory
+    public class StoringBlockImprovementContextFactory : IBlockImprovementContextFactory
     {
         private readonly IBlockImprovementContextFactory _blockImprovementContextFactory;
+        private readonly bool _skipDuplicatedContext;
         public IList<IBlockImprovementContext> CreatedContexts { get; } = new List<IBlockImprovementContext>();
 
         public event EventHandler<ImprovementStartedEventArgs>? ImprovementStarted;
 
-        public StoringBlockImprovementContextFactory(IBlockImprovementContextFactory blockImprovementContextFactory)
+        public event EventHandler<BlockEventArgs>? BlockImproved;
+
+        public StoringBlockImprovementContextFactory(IBlockImprovementContextFactory blockImprovementContextFactory, bool skipDuplicatedContext = false)
         {
             _blockImprovementContextFactory = blockImprovementContextFactory;
+            _skipDuplicatedContext = skipDuplicatedContext;
         }
 
         public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime)
         {
             IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime);
-            CreatedContexts.Add(blockImprovementContext);
+            if (_skipDuplicatedContext
+                && CreatedContexts.Count > 0
+                && CreatedContexts[^1].CurrentBestBlock == blockImprovementContext.CurrentBestBlock)
+            {
+                return blockImprovementContext;
+            }
+
+            lock (CreatedContexts)
+            {
+                CreatedContexts.Add(blockImprovementContext);
+            }
+            blockImprovementContext.ImprovementTask.ContinueWith(LogProductionResult);
             Task.Run(() => ImprovementStarted?.Invoke(this, new ImprovementStartedEventArgs(blockImprovementContext)));
             return blockImprovementContext;
         }
+
+        private Block? LogProductionResult(Task<Block?> t)
+        {
+            if (t.IsCompletedSuccessfully)
+            {
+                BlockImproved?.Invoke(this, new BlockEventArgs(t.Result!));
+            }
+
+            return t.Result;
+        }
+
+        public Task WaitForImprovedBlock(CancellationToken cancellationToken, Hash256? parentHash = null)
+        {
+            return Wait.ForEventCondition<BlockEventArgs>(cancellationToken,
+                e => BlockImproved += e,
+                e => BlockImproved -= e,
+                b =>
+                {
+                    if (parentHash is null) return true;
+                    return b.Block.ParentHash == parentHash;
+                });
+        }
+
+        public Task WaitForImprovedBlockWithCondition(CancellationToken cancellationToken, Func<Block, bool> cond)
+        {
+            return Wait.ForEventCondition<BlockEventArgs>(cancellationToken,
+                e => BlockImproved += e,
+                e => BlockImproved -= e,
+                b => cond(b.Block));
+        }
     }
 
-    private class ImprovementStartedEventArgs : EventArgs
+    public class ImprovementStartedEventArgs : EventArgs
     {
         public IBlockImprovementContext BlockImprovementContext { get; }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -267,7 +267,6 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task getPayloadV2_received_fees_should_be_equal_to_block_value_in_result()
     {
-        using SemaphoreSlim blockImprovementLock = new(0);
         using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
@@ -281,8 +280,7 @@ public partial class EngineModuleTests
         Transaction[] transactions =
             BuildTransactions(chain, startingHead, sender, Address.Zero, count, value, out _, out _);
 
-        chain.AddTransactions(transactions);
-        chain.PayloadPreparationService!.BlockImproved += (_, _) => { blockImprovementLock.Release(1); };
+        Task blockImprovementWait = chain.WaitForImprovedBlock();
 
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
@@ -296,7 +294,7 @@ public partial class EngineModuleTests
 
         UInt256 startingBalance = chain.ReadOnlyState.GetBalance(feeRecipient);
 
-        await blockImprovementLock.WaitAsync(10000);
+        await blockImprovementWait;
         GetPayloadV2Result getPayloadResult = (await rpc.engine_getPayloadV2(Bytes.FromHexString(payloadId))).Data!;
 
         ResultWrapper<PayloadStatusV1> executePayloadResult =
@@ -363,7 +361,7 @@ public partial class EngineModuleTests
         chain.AddTransactions(txs);
 
         await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
-        ExecutionPayload executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
+        ExecutionPayload executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, false, withdrawals);
 
         await rpc.engine_forkchoiceUpdatedV2(new ForkchoiceStateV1(executionPayload2.BlockHash!,
             executionPayload2.BlockHash!, executionPayload2.BlockHash!));
@@ -829,15 +827,9 @@ public partial class EngineModuleTests
         Withdrawal[]? withdrawals,
         bool waitForBlockImprovement = true)
     {
-        using SemaphoreSlim blockImprovementLock = new SemaphoreSlim(0);
-
-        if (waitForBlockImprovement)
-        {
-            chain.PayloadPreparationService!.BlockImproved += (s, e) =>
-            {
-                blockImprovementLock.Release(1);
-            };
-        }
+        Task blockImprovementWait = waitForBlockImprovement
+            ? chain.WaitForImprovedBlock()
+            : Task.CompletedTask;
 
         ForkchoiceStateV1 forkchoiceState = new ForkchoiceStateV1(headBlockHash, finalizedBlockHash, safeBlockHash);
         PayloadAttributes payloadAttributes = new PayloadAttributes
@@ -849,8 +841,7 @@ public partial class EngineModuleTests
         };
         string? payloadId = rpc.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes).Result.Data.PayloadId;
 
-        if (waitForBlockImprovement)
-            await blockImprovementLock.WaitAsync(10000);
+        await blockImprovementWait;
 
         ResultWrapper<ExecutionPayload?> getPayloadResult =
             await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId!));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -885,14 +885,11 @@ public partial class EngineModuleTests
         Hash256 currentHeadHash = chain.BlockTree.HeadHash;
         ForkchoiceStateV1 forkchoiceState = new(currentHeadHash, currentHeadHash, currentHeadHash);
 
-        using SemaphoreSlim blockImprovementLock = new(0);
-        EventHandler<BlockEventArgs> onBlockImprovedHandler = (_, _) => blockImprovementLock.Release(1);
-        chain.PayloadPreparationService!.BlockImproved += onBlockImprovedHandler;
+        Task blockImprovementWait = chain.WaitForImprovedBlock();
 
         string payloadId = (await rpcModule.engine_forkchoiceUpdatedV3(forkchoiceState, payloadAttributes)).Data.PayloadId!;
 
-        await blockImprovementLock.WaitAsync(10000);
-        chain.PayloadPreparationService!.BlockImproved -= onBlockImprovedHandler;
+        await blockImprovementWait;
 
         ResultWrapper<GetPayloadV3Result?> payloadResult = await rpcModule.engine_getPayloadV3(Bytes.FromHexString(payloadId));
         Assert.That(payloadResult.Result, Is.EqualTo(Result.Success));
@@ -914,9 +911,9 @@ public partial class EngineModuleTests
         IEngineRpcModule rpcModule = CreateEngineModule(chain, null, TimeSpan.FromDays(1));
         Transaction[] txs = [];
 
-        using SemaphoreSlim blockImprovementLock = new(0);
-        EventHandler<BlockEventArgs> onBlockImprovedHandler = (_, _) => blockImprovementLock.Release(1);
-        chain.PayloadPreparationService!.BlockImproved += onBlockImprovedHandler;
+        Task blockImprovementWait = transactionCount != 0
+            ? chain.WaitForImprovedBlock()
+            : Task.CompletedTask;
 
         Hash256 currentHeadHash = chain.BlockTree.HeadHash;
 
@@ -941,11 +938,7 @@ public partial class EngineModuleTests
             ? rpcModule.engine_forkchoiceUpdatedV3(forkchoiceState, payloadAttributes).Result?.Data?.PayloadId
             : rpcModule.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes).Result?.Data?.PayloadId;
 
-        if (transactionCount is not 0)
-        {
-            await blockImprovementLock.WaitAsync(10000);
-        }
-        chain.PayloadPreparationService!.BlockImproved -= onBlockImprovedHandler;
+        await blockImprovementWait;
 
         return (rpcModule, payloadId, txs, chain);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -352,15 +352,9 @@ public partial class EngineModuleTests
         Withdrawal[]? withdrawals,
         bool waitForBlockImprovement = true)
     {
-        using SemaphoreSlim blockImprovementLock = new SemaphoreSlim(0);
-
-        if (waitForBlockImprovement)
-        {
-            chain.PayloadPreparationService!.BlockImproved += (s, e) =>
-            {
-                blockImprovementLock.Release(1);
-            };
-        }
+        Task blockImprovementWait = waitForBlockImprovement
+            ? chain.WaitForImprovedBlock()
+            : Task.CompletedTask;
 
         ForkchoiceStateV1 forkchoiceState = new ForkchoiceStateV1(headBlockHash, finalizedBlockHash, safeBlockHash);
         PayloadAttributes payloadAttributes = new PayloadAttributes
@@ -375,8 +369,7 @@ public partial class EngineModuleTests
         ResultWrapper<ForkchoiceUpdatedV1Result> result = rpc.engine_forkchoiceUpdatedV3(forkchoiceState, payloadAttributes).Result;
         string? payloadId = result.Data.PayloadId;
 
-        if (waitForBlockImprovement)
-            await blockImprovementLock.WaitAsync(10000);
+        await blockImprovementWait;
 
         ResultWrapper<GetPayloadV4Result?> getPayloadResult =
             await rpc.engine_getPayloadV4(Bytes.FromHexString(payloadId!));

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
@@ -13,7 +13,5 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         string? StartPreparingPayload(BlockHeader parentHeader, PayloadAttributes payloadAttributes);
 
         ValueTask<IBlockProductionContext?> GetPayload(string payloadId);
-
-        event EventHandler<BlockEventArgs>? BlockImproved;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -178,7 +178,6 @@ public class PayloadPreparationService : IPayloadPreparationService
         {
             if (t.Result is not null)
             {
-                BlockImproved?.Invoke(this, new BlockEventArgs(t.Result));
                 if (_logger.IsInfo) _logger.Info($"Improved post-merge block {t.Result.ToString(Block.Format.HashNumberDiffAndTx)}");
             }
             else
@@ -216,6 +215,4 @@ public class PayloadPreparationService : IPayloadPreparationService
 
         return null;
     }
-
-    public event EventHandler<BlockEventArgs>? BlockImproved;
 }


### PR DESCRIPTION
*I have a dream: that one day, every man, woman, children —and even pet— will be able to run all of Nethermind's unit tests and pass all of them on the very first try... I'm still dreaming.*

- Improved consistency in block improvements tests.
- Fixed AuraBlockProducer tests that previously always took at least 40 seconds.
- Move block production wait code to `TestBlockchainUtil`. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- One or two tests still randomly fails.