### PR TITLE
Build more profitable blocks and improve production logs

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockExtensions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockExtensions.cs
@@ -48,7 +48,7 @@ namespace Nethermind.Consensus.Processing
             if (data is null || data.Length == 0)
             {
                 // If no extra data just show GasBeneficiary address
-                return $"Address: {(block.Header.GasBeneficiary?.ToString() ?? "0x")}";
+                return $"Address: {(block.Header.GasBeneficiary?.ToShortString() ?? "0x")}";
             }
 
             // Ideally we'd prefer to show text; so convert invalid unicode

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -348,7 +348,7 @@ namespace Nethermind.Consensus.Processing
                 var recoveryQueue = Metrics.RecoveryQueueSize;
                 var processingQueue = Metrics.ProcessingQueueSize;
 
-                _logger.Info($" Block{(chunkBlocks > 1 ? $"s  x{chunkBlocks,-9:N0}  " : $"{(isMev ? " mev" : "    ")} {rewards.ToDecimal(null) / weiToEth,5:N4}{BlocksConfig.GasTokenTicker,4}")}{(chunkBlocks == 1 ? mgasColor : "")} {chunkMGas,7:F2}{resetColor} MGas    | {chunkTx,8:N0}   txs | calls {callsColor}{chunkCalls,10:N0}{resetColor} {darkGreyText}({chunkEmptyCalls,3:N0}){resetColor} | sload {chunkSload,7:N0} | sstore {sstoreColor}{chunkSstore,6:N0}{resetColor} | create {createsColor}{chunkCreates,3:N0}{resetColor}{(chunkSelfDestructs > 0 ? $"{darkGreyText}({-chunkSelfDestructs,3:N0}){resetColor}" : "")}");
+                _logger.Info($" Block{(chunkBlocks > 1 ? $"s  x{chunkBlocks,-9:N0} " : $"{(isMev ? " mev" : "    ")} {rewards.ToDecimal(null) / weiToEth,5:N3}{BlocksConfig.GasTokenTicker,4}")}{(chunkBlocks == 1 ? mgasColor : "")} {chunkMGas,8:F2}{resetColor} MGas    | {chunkTx,8:N0}   txs | calls {callsColor}{chunkCalls,10:N0}{resetColor} {darkGreyText}({chunkEmptyCalls,3:N0}){resetColor} | sload {chunkSload,7:N0} | sstore {sstoreColor}{chunkSstore,6:N0}{resetColor} | create {createsColor}{chunkCreates,3:N0}{resetColor}{(chunkSelfDestructs > 0 ? $"{darkGreyText}({-chunkSelfDestructs,3:N0}){resetColor}" : "")}");
                 string blobsOrBlocksPerSec = _showBlobs switch
                 {
                     true => $" blobs {blobs,10:N0}       ",

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -148,8 +148,8 @@ namespace Nethermind.Consensus.Producers
                             {
                                 if (t.Result is not null)
                                 {
-                                    if (Logger.IsInfo)
-                                        Logger.Info($"Produced block {t.Result.ToString(Block.Format.HashNumberDiffAndTx)}");
+                                    if (Logger.IsDebug)
+                                        Logger.Debug($"Produced block {t.Result.ToString(Block.Format.HashNumberDiffAndTx)}");
                                     Metrics.BlocksSealed++;
                                     return t.Result;
                                 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/IBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/IBlockImprovementContextFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Int256;
 
 namespace Nethermind.Consensus.Producers;
 
@@ -12,5 +13,6 @@ public interface IBlockImprovementContextFactory
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime);
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees);
 }

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -196,6 +196,12 @@ namespace Nethermind.Core
         /// <returns></returns>
         public string ToString(bool withZeroX, bool withEip55Checksum) => Bytes.ToHexString(withZeroX, false, withEip55Checksum);
 
+        public string ToShortString(bool withZeroX = true)
+        {
+            string address = Bytes.ToHexString(withZeroX);
+            return $"{address[..(withZeroX ? 8 : 6)]}...{address[^6..]}";
+        }
+
         public override bool Equals(object? obj)
         {
             if (obj is null)

--- a/src/Nethermind/Nethermind.Core/Block.cs
+++ b/src/Nethermind/Nethermind.Core/Block.cs
@@ -135,7 +135,8 @@ public class Block
         Format.HashNumberAndTx => Hash is null
             ? $"{Number} null, tx count: {Body.Transactions.Length}"
             : $"{Number} {TimestampDate:HH:mm:ss} ({Hash?.ToShortString()}), tx count: {Body.Transactions.Length}",
-        Format.HashNumberDiffAndTx => $"{ToShortHashAndNumber()}, diff: {Difficulty}, tx count: {Body.Transactions.Length}",
+        Format.HashNumberDiffAndTx => $"{ToShortHashAndNumber()}  diff {Difficulty} | txs {Body.Transactions.Length,9:N0}",
+        Format.HashNumberMGasAndTx => $"{ToShortHashAndNumber()}  {GasUsed / 1_000_000.0,7:N2} MGas | {Body.Transactions.Length,9:N0} txs",
         _ => ToShortHashAndNumber()
     };
 
@@ -184,6 +185,7 @@ public class Block
         FullHashNumberAndExtraData,
         HashNumberAndTx,
         HashNumberDiffAndTx,
+        HashNumberMGasAndTx,
         Short
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -28,7 +28,8 @@ public partial class EngineModuleTests
             _delay = delay;
         }
 
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime) =>
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime,
+        UInt256 currentBlockFees) =>
             new DelayBlockImprovementContext(currentBestBlock, _blockProducer, _timeout, parentHeader, payloadAttributes, _delay, startDateTime);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
@@ -13,7 +13,8 @@ public partial class EngineModuleTests
 {
     private class MockBlockImprovementContextFactory : IBlockImprovementContextFactory
     {
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime) =>
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime,
+        UInt256 currentBlockFees) =>
             new MockBlockImprovementContext(currentBestBlock, startDateTime);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -637,7 +637,6 @@ public partial class EngineModuleTests
             TimerFactory.Default,
             chain.LogManager,
             timePerSlot,
-            improvementDelay: delay,
-            minTimeForProduction: delay);
+            improvementDelay: delay);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Int256;
 
 namespace Nethermind.Merge.Plugin.Test;
 
@@ -23,9 +24,9 @@ public partial class EngineModuleTests
             _blockImprovementContextFactory = blockImprovementContextFactory;
         }
 
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime)
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime, UInt256 currentBlockFees)
         {
-            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime);
+            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime, currentBlockFees);
             CreatedContexts.Add(blockImprovementContext);
             Task.Run(() => ImprovementStarted?.Invoke(this, new ImprovementStartedEventArgs(blockImprovementContext)));
             return blockImprovementContext;

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -30,9 +30,12 @@ public class BlockImprovementContext : IBlockImprovementContext
         CurrentBestBlock = currentBestBlock;
         BlockFees = currentBlockFees;
         StartDateTime = startDateTime;
-        ImprovementTask = blockProducer
-            .BuildBlock(parentHeader, _feesTracer, payloadAttributes, _cancellationTokenSource.Token)
-            .ContinueWith(SetCurrentBestBlock, _cancellationTokenSource.Token);
+
+        CancellationToken ct = _cancellationTokenSource.Token;
+        // Task.Run so doesn't block FCU response while first block is being produced
+        ImprovementTask = Task.Run(() => blockProducer
+            .BuildBlock(parentHeader, _feesTracer, payloadAttributes, ct)
+            .ContinueWith(SetCurrentBestBlock, ct), ct);
     }
 
     public Task<Block?> ImprovementTask { get; }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -23,10 +23,12 @@ public class BlockImprovementContext : IBlockImprovementContext
         TimeSpan timeout,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime)
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees)
     {
         _cancellationTokenSource = new CancellationTokenSource(timeout);
         CurrentBestBlock = currentBestBlock;
+        BlockFees = currentBlockFees;
         StartDateTime = startDateTime;
         ImprovementTask = blockProducer
             .BuildBlock(parentHeader, _feesTracer, payloadAttributes, _cancellationTokenSource.Token)
@@ -42,14 +44,22 @@ public class BlockImprovementContext : IBlockImprovementContext
     {
         if (task.IsCompletedSuccessfully)
         {
-            if (task.Result is not null)
+            Block? block = task.Result;
+            if (block is not null)
             {
-                CurrentBestBlock = task.Result;
-                BlockFees = _feesTracer.Fees;
+                UInt256 fees = _feesTracer.Fees;
+                if (CurrentBestBlock is null ||
+                    fees > BlockFees ||
+                    (fees == BlockFees && block.GasUsed > CurrentBestBlock.GasUsed))
+                {
+                    // Only update block if block has actually improved.
+                    CurrentBestBlock = block;
+                    BlockFees = fees;
+                }
             }
         }
 
-        return task.Result;
+        return CurrentBestBlock;
     }
 
     public bool Disposed { get; private set; }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Int256;
 
 namespace Nethermind.Merge.Plugin.BlockProduction;
 
@@ -23,6 +24,7 @@ public class BlockImprovementContextFactory : IBlockImprovementContextFactory
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime) =>
-        new BlockImprovementContext(currentBestBlock, _blockProducer, _timeout, parentHeader, payloadAttributes, startDateTime);
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees) =>
+        new BlockImprovementContext(currentBestBlock, _blockProducer, _timeout, parentHeader, payloadAttributes, startDateTime, currentBlockFees);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Int256;
 using Nethermind.State;
 
 namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
@@ -28,6 +29,7 @@ public class BoostBlockImprovementContextFactory : IBlockImprovementContextFacto
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime) =>
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees) =>
         new BoostBlockImprovementContext(currentBestBlock, _blockProducer, _timeout, parentHeader, payloadAttributes, _boostRelay, _stateReader, startDateTime);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/NoBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/NoBlockImprovementContextFactory.cs
@@ -16,7 +16,8 @@ public class NoBlockImprovementContextFactory : IBlockImprovementContextFactory
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime)
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees)
     {
         return new NoBlockImprovementContext(currentBestBlock, UInt256.Zero, startDateTime);
     }

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -27,8 +27,7 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
         ILogManager logManager,
         TimeSpan timePerSlot,
         int slotsPerOldPayloadCleanup = SlotsPerOldPayloadCleanup,
-        TimeSpan? improvementDelay = null,
-        TimeSpan? minTimeForProduction = null)
+        TimeSpan? improvementDelay = null)
         : base(
             blockProducer,
             blockImprovementContextFactory,
@@ -36,8 +35,7 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
             logManager,
             timePerSlot,
             slotsPerOldPayloadCleanup,
-            improvementDelay,
-            minTimeForProduction)
+            improvementDelay)
     {
         _specProvider = specProvider;
         _logger = logManager.GetClassLogger();

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -44,7 +44,7 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
     }
 
     protected override void ImproveBlock(string payloadId, BlockHeader parentHeader,
-        PayloadAttributes payloadAttributes, Block currentBestBlock, DateTimeOffset startDateTime)
+        PayloadAttributes payloadAttributes, Block currentBestBlock, DateTimeOffset startDateTime, UInt256 currentBlockFees)
     {
         if (payloadAttributes is OptimismPayloadAttributes optimismPayload)
         {
@@ -81,7 +81,7 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
         }
         else
         {
-            base.ImproveBlock(payloadId, parentHeader, payloadAttributes, currentBestBlock, startDateTime);
+            base.ImproveBlock(payloadId, parentHeader, payloadAttributes, currentBestBlock, startDateTime, currentBlockFees);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
@@ -26,7 +26,8 @@ public class ShutterBlockImprovementContextFactory(
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime) =>
+        DateTimeOffset startDateTime,
+        UInt256 currentBlockFees) =>
         new ShutterBlockImprovementContext(blockProducer,
                                            shutterTxSource,
                                            shutterConfig,


### PR DESCRIPTION
## Changes

The less controversial changes from https://github.com/NethermindEth/nethermind/pull/7640

- Improve the block production logs to match rest of logs 

![image](https://github.com/user-attachments/assets/a7f7048a-5559-4eff-9a45-1b316e49ed3e)
(Image also highlighting PR built block vs released Nethermind built block)

- Use previous block production time to inform next, rather than set value (500ms) for remaining time
- Build more frequently (500ms rather than 3000ms)
- Only accept improved block as replacement when it actually improved
- Use shortened address when used instead of extra data (so doesn't spill the logs to new line)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Other: Logs improvement

## Testing

#### Requires testing

- [x] No