### PR TITLE
Small refactor to make ExecuteEvmCall error handling clearer.

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -687,11 +687,10 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 statusCode = StatusCode.Success;
             }
-
             gasConsumed = Refund(tx, header, spec, opts, substate, unspentGas,
                 env.TxExecutionContext.GasPrice, delegationRefunds, floorGas);
             goto Complete;
-   
+
         FailContractCreate:
             if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");
             WorldState.Restore(snapshot);


### PR DESCRIPTION
Removes the try/catch from `ExecuteEvmCall`. All EvmException OverFlowExceptions should be caught by the inner try/catch inside the `Run` method. 