### PR TITLE
Fix: order memdb

### DIFF
--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 
@@ -144,6 +146,30 @@ namespace Nethermind.Db.Test
         {
             MemDb memDb = new();
             memDb.Flush();
+        }
+
+        [Test]
+        public void Can_get_all_ordered()
+        {
+            MemDb memDb = new();
+            
+            memDb.Set(TestItem.KeccakE, _sampleValue);
+            memDb.Set(TestItem.KeccakC, _sampleValue);
+            memDb.Set(TestItem.KeccakA, _sampleValue);
+            memDb.Set(TestItem.KeccakB, _sampleValue);
+            memDb.Set(TestItem.KeccakD, _sampleValue);
+            
+            var orderedItems = memDb.GetAll(true);
+            
+            orderedItems.Should().HaveCount(5);
+            
+            byte[][] keys = [.. orderedItems.Select(kvp => kvp.Key)];
+            
+            for (int i = 0; i < keys.Length - 1; i++)
+            {
+                Bytes.BytesComparer.Compare(keys[i], keys[i + 1]).Should().BeLessThan(0,
+                    $"Keys should be in ascending order at position {i}");
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -152,19 +152,18 @@ namespace Nethermind.Db.Test
         public void Can_get_all_ordered()
         {
             MemDb memDb = new();
-            
+
             memDb.Set(TestItem.KeccakE, _sampleValue);
             memDb.Set(TestItem.KeccakC, _sampleValue);
             memDb.Set(TestItem.KeccakA, _sampleValue);
             memDb.Set(TestItem.KeccakB, _sampleValue);
             memDb.Set(TestItem.KeccakD, _sampleValue);
-            
+
             var orderedItems = memDb.GetAll(true);
-            
+
             orderedItems.Should().HaveCount(5);
-            
+
             byte[][] keys = [.. orderedItems.Select(kvp => kvp.Key)];
-            
             for (int i = 0; i < keys.Length - 1; i++)
             {
                 Bytes.BytesComparer.Compare(keys[i], keys[i + 1]).Should().BeLessThan(0,

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -97,11 +97,11 @@ namespace Nethermind.Db
             _db.Clear();
         }
 
-        public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAll(bool ordered = false) => _db;
+        public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAll(bool ordered = false) => ordered ? OrderedDb : _db;
 
-        public IEnumerable<byte[]> GetAllKeys(bool ordered = false) => Keys;
+        public IEnumerable<byte[]> GetAllKeys(bool ordered = false) => ordered ? OrderedDb.Select(kvp => kvp.Key) : Keys;
 
-        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => Values;
+        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => ordered ? OrderedDb.Select(kvp => kvp.Value) : Values;
 
         public virtual IWriteBatch StartWriteBatch()
         {
@@ -113,10 +113,10 @@ namespace Nethermind.Db
 
         public int Count => _db.Count;
 
-        public long GetSize() => 0;
-        public long GetCacheSize(bool includeCacheSize) => 0;
-        public long GetIndexSize() => 0;
-        public long GetMemtableSize() => 0;
+        public static long GetSize() => 0;
+        public static long GetCacheSize(bool includeCacheSize) => 0;
+        public static long GetIndexSize() => 0;
+        public static long GetMemtableSize() => 0;
 
         public void Dispose()
         {
@@ -167,5 +167,7 @@ namespace Nethermind.Db
                 Size = Count
             };
         }
+
+        private IEnumerable<KeyValuePair<byte[], byte[]?>> OrderedDb => _db.OrderBy(kvp => kvp.Key, Bytes.Comparer);
     }
 }


### PR DESCRIPTION
## Changes

- `MemDb` now respects ordering parameter in `GetAll`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
