### PR TITLE
Remove redundant check for delegations

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -283,12 +283,6 @@ namespace Nethermind.Evm.TransactionProcessing
                     return false;
                 }
 
-                if (authorizationTuple.AuthoritySignature.ChainId is not null && authorizationTuple.AuthoritySignature.ChainId != authorizationTuple.ChainId)
-                {
-                    error = "Bad signature.";
-                    return false;
-                }
-
                 accessTracker.WarmUp(authorizationTuple.Authority);
 
                 if (WorldState.HasCode(authorizationTuple.Authority) && !_codeInfoRepository.TryGetDelegation(WorldState, authorizationTuple.Authority, out _))


### PR DESCRIPTION
Removes not needed check for `AuthorizationTuple`. Chain id cannot be embedded in V since EIP-155 does not apply to non-tx signatures, and we already have a check for V == 0 || V == 1 in https://github.com/NethermindEth/nethermind/blob/3fa523dab07944f62b79142259a592759579725a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs?plain=1#L280C1-L280C88.

Verified with Geth as having the same check in:
https://github.com/ethereum/go-ethereum/blob/master/core/types/tx_setcode.go#L119