### PR TITLE
Feature/Configurable dirty node shard count

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -110,6 +110,7 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
             {
                 pruningConfig.CacheMb = 8;
                 pruningConfig.DirtyCacheMb = 4;
+                pruningConfig.DirtyNodeShardBit = 1;
                 return pruningConfig;
             })
             ;

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -79,4 +79,7 @@ public interface IPruningConfig : IConfig
 
     [ConfigItem(Description = "The number of past states before the state gets pruned. Used to determine how old of a state to keep from the head.", DefaultValue = "64")]
     int PruningBoundary { get; set; }
+
+    [ConfigItem(Description = "Dirty node shard count", DefaultValue = "256")]
+    int DirtyNodeShardBit { get; set; }
 }

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -80,6 +80,6 @@ public interface IPruningConfig : IConfig
     [ConfigItem(Description = "The number of past states before the state gets pruned. Used to determine how old of a state to keep from the head.", DefaultValue = "64")]
     int PruningBoundary { get; set; }
 
-    [ConfigItem(Description = "Dirty node shard count", DefaultValue = "256")]
+    [ConfigItem(Description = "Dirty node shard count", DefaultValue = "8")]
     int DirtyNodeShardBit { get; set; }
 }

--- a/src/Nethermind/Nethermind.Db/PruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/PruningConfig.cs
@@ -37,5 +37,6 @@ namespace Nethermind.Db
         public bool AvailableSpaceCheckEnabled { get; set; } = true;
         public double TrackedPastKeyCountMemoryRatio { get; set; } = 0.1;
         public int PruningBoundary { get; set; } = 64;
+        public int DirtyNodeShardBit { get; set; } = 8;
     }
 }

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -128,6 +128,7 @@ public class PruningTrieStateFactory(
                 // Use of ratio, as the effectiveness highly correlate with the amount of keys per snapshot save which
                 // depends on CacheMb. 0.05 is the minimum where it can keep track the whole snapshot.. most of the time.
                 .TrackingPastKeys((int)(pruningConfig.CacheMb.MB() * pruningConfig.TrackedPastKeyCountMemoryRatio / 48))
+                .WithDirtyNodeShardCount(pruningConfig.DirtyNodeShardBit)
                 .KeepingLastNState(pruningConfig.PruningBoundary);
         }
         else

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
@@ -10,7 +10,8 @@ namespace Nethermind.Trie.Test.Pruning
         bool pruningEnabled,
         bool shouldPrune = false,
         int? maxDepth = null,
-        int trackedPastKeyCount = 0)
+        int trackedPastKeyCount = 0,
+        int shardBit = 8)
         : IPruningStrategy
     {
         public bool PruningEnabled => pruningEnabled;
@@ -28,5 +29,6 @@ namespace Nethermind.Trie.Test.Pruning
         public long? WithPersistedMemoryLimit { get; set; }
 
         public int TrackedPastKeyCount => trackedPastKeyCount;
+        public int ShardBit => shardBit;
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -270,6 +270,12 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
+            public PruningContext AssertThatCachedNodeCountMoreThan(long cachedNodeCount)
+            {
+                _trieStore.CachedNodesCount.Should().BeGreaterThan(cachedNodeCount);
+                return this;
+            }
+
             public PruningContext AssertThatDirtyNodeCountIs(long dirtyNodeCount)
             {
                 _trieStore.DirtyCachedNodesCount.Should().Be(dirtyNodeCount);
@@ -949,7 +955,7 @@ namespace Nethermind.Trie.Test
 
             ctx
                 .AssertThatDirtyNodeCountIs(9)
-                .AssertThatCachedNodeCountIs(324);
+                .AssertThatCachedNodeCountMoreThan(280);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ISnapshotStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ISnapshotStrategy.cs
@@ -12,5 +12,6 @@ namespace Nethermind.Trie.Pruning
         double PrunePersistedNodePortion { get; }
         long PrunePersistedNodeMinimumTarget { get; }
         int TrackedPastKeyCount { get; }
+        int ShardBit { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/KeepLastNPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/KeepLastNPruningStrategy.cs
@@ -17,4 +17,5 @@ public class KeepLastNPruningStrategy(IPruningStrategy baseStrategy, int depth) 
     public long PrunePersistedNodeMinimumTarget => baseStrategy.PrunePersistedNodeMinimumTarget;
 
     public int TrackedPastKeyCount => baseStrategy.TrackedPastKeyCount;
+    public int ShardBit => baseStrategy.ShardBit;
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/MemoryLimit.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/MemoryLimit.cs
@@ -16,5 +16,6 @@ namespace Nethermind.Trie.Pruning
         public double PrunePersistedNodePortion => 1.0;
         public long PrunePersistedNodeMinimumTarget => 0;
         public int TrackedPastKeyCount => 0;
+        public int ShardBit => 8;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
@@ -21,5 +21,6 @@ namespace Nethermind.Trie.Pruning
         public long PrunePersistedNodeMinimumTarget => 0;
 
         public int TrackedPastKeyCount => 0;
+        public int ShardBit => 0;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/PersistedMemoryLimit.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/PersistedMemoryLimit.cs
@@ -22,4 +22,5 @@ public class PersistedMemoryLimit(IPruningStrategy baseStrategy, long persistedM
     public long PrunePersistedNodeMinimumTarget => 50.MiB();
 
     public int TrackedPastKeyCount => baseStrategy.TrackedPastKeyCount;
+    public int ShardBit => baseStrategy.ShardBit;
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/Prune.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Prune.cs
@@ -18,5 +18,8 @@ namespace Nethermind.Trie.Pruning
 
         public static IPruningStrategy KeepingLastNState(this IPruningStrategy baseStrategy, int n)
             => new KeepLastNPruningStrategy(baseStrategy, n);
+
+        public static IPruningStrategy WithDirtyNodeShardCount(this IPruningStrategy baseStrategy, int shardCount)
+            => new ShardBitPruningStrategy(baseStrategy, shardCount);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ShardBitPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ShardBitPruningStrategy.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Trie.Pruning;
+
+public class ShardBitPruningStrategy(IPruningStrategy baseStrategy, int shardCount) : IPruningStrategy
+{
+    public bool PruningEnabled => baseStrategy.PruningEnabled;
+
+    public int MaxDepth => baseStrategy.MaxDepth;
+
+    public bool ShouldPruneDirtyNode(in long dirtyNodeMemory)
+    {
+        return baseStrategy.ShouldPruneDirtyNode(in dirtyNodeMemory);
+    }
+
+    public bool ShouldPrunePersistedNode(in long persistedNodeMemory)
+    {
+        return baseStrategy.ShouldPrunePersistedNode(in persistedNodeMemory);
+    }
+
+    public double PrunePersistedNodePortion => baseStrategy.PrunePersistedNodePortion;
+
+    public long PrunePersistedNodeMinimumTarget => baseStrategy.PrunePersistedNodeMinimumTarget;
+
+    public int TrackedPastKeyCount => baseStrategy.TrackedPastKeyCount;
+
+    public int ShardBit => shardCount;
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrackedPastKeyCountStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrackedPastKeyCountStrategy.cs
@@ -16,4 +16,6 @@ public class TrackedPastKeyCountStrategy(IPruningStrategy baseStrategy, int trac
     public long PrunePersistedNodeMinimumTarget => baseStrategy.PrunePersistedNodeMinimumTarget;
 
     public int TrackedPastKeyCount => trackedPastKeyCount;
+
+    public int ShardBit => baseStrategy.ShardBit;
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -80,10 +80,10 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         if (pruningStrategy.PruningEnabled)
         {
             _shardBit = _pruningStrategy.ShardBit;
-            _shardedDirtyNodeCount = 1 << _shardBit;
+            _shardedDirtyNodeCount = 1 << (_shardBit - 1);
 
-            // 30 because of the 1 << 31 become negative
-            if (_shardBit is < 0 or > 30)
+            // 31 because of the 1 << (32 - 1) become negative
+            if (_shardBit is <= 0 or > 31)
             {
                 throw new InvalidOperationException($"Shard bit count must be between 0 and 30.");
             }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -281,13 +281,11 @@ public class TrieStore : ITrieStore, IPruningTrieStore
     {
         // When enabled, the shard have dictionaries for tracking past path hash also.
         // So the same path need to be in the same shard for the remove logic to work.
-        uint baseSize = (uint)(_livePruningEnabled
+        uint hashCode = (uint)(_livePruningEnabled
             ? path.GetHashCode()
             : hash.GetHashCode());
 
-        // Using some early bits so that nodes of similar prefix would get put in the same shard.
-        uint shardIdx = baseSize >> (32 - _shardBit);
-        return (int)shardIdx;
+        return (int)(hashCode % _shardedDirtyNodeCount);
     }
 
     private int GetNodeShardIdx(in TrieStoreDirtyNodesCache.Key key) => GetNodeShardIdx(key.Path, key.Keccak);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -281,9 +281,9 @@ public class TrieStore : ITrieStore, IPruningTrieStore
     {
         // When enabled, the shard have dictionaries for tracking past path hash also.
         // So the same path need to be in the same shard for the remove logic to work.
-        uint baseSize = _livePruningEnabled
-            ? BinaryPrimitives.ReadUInt32BigEndian(path.Path.Bytes[..4])
-            : BinaryPrimitives.ReadUInt32BigEndian(hash.Bytes[..4]);
+        uint baseSize = (uint)_livePruningEnabled
+            ? path..GetHashCode()
+            : hash..GetHashCode();
 
         // Using some early bits so that nodes of similar prefix would get put in the same shard.
         uint shardIdx = baseSize >> (32 - _shardBit);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -282,7 +282,7 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         // When enabled, the shard have dictionaries for tracking past path hash also.
         // So the same path need to be in the same shard for the remove logic to work.
         uint baseSize = (uint)_livePruningEnabled
-            ? path..GetHashCode()
+            ? path.GetHashCode()
             : hash..GetHashCode();
 
         // Using some early bits so that nodes of similar prefix would get put in the same shard.

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -80,10 +80,10 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         if (pruningStrategy.PruningEnabled)
         {
             _shardBit = _pruningStrategy.ShardBit;
-            _shardedDirtyNodeCount = 1 << (_shardBit - 1);
+            _shardedDirtyNodeCount = 1 << _shardBit;
 
-            // 31 because of the 1 << (32 - 1) become negative
-            if (_shardBit is <= 0 or > 31)
+            // 30 because of the 1 << 31 become negative
+            if (_shardBit is <= 0 or > 30)
             {
                 throw new InvalidOperationException($"Shard bit count must be between 0 and 30.");
             }
@@ -287,10 +287,6 @@ public class TrieStore : ITrieStore, IPruningTrieStore
 
         // Using some early bits so that nodes of similar prefix would get put in the same shard.
         uint shardIdx = baseSize >> (32 - _shardBit);
-        if (shardIdx < 0 || shardIdx >= _shardedDirtyNodeCount)
-        {
-            Console.Error.WriteLine($"Its {shardIdx} {baseSize} on {_shardedDirtyNodeCount} anv {_shardBit}");
-        }
         return (int)shardIdx;
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -283,7 +283,7 @@ public class TrieStore : ITrieStore, IPruningTrieStore
         // So the same path need to be in the same shard for the remove logic to work.
         uint baseSize = (uint)_livePruningEnabled
             ? path.GetHashCode()
-            : hash..GetHashCode();
+            : hash.GetHashCode();
 
         // Using some early bits so that nodes of similar prefix would get put in the same shard.
         uint shardIdx = baseSize >> (32 - _shardBit);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -281,9 +281,9 @@ public class TrieStore : ITrieStore, IPruningTrieStore
     {
         // When enabled, the shard have dictionaries for tracking past path hash also.
         // So the same path need to be in the same shard for the remove logic to work.
-        uint baseSize = (uint)_livePruningEnabled
+        uint baseSize = (uint)(_livePruningEnabled
             ? path.GetHashCode()
-            : hash.GetHashCode();
+            : hash.GetHashCode());
 
         // Using some early bits so that nodes of similar prefix would get put in the same shard.
         uint shardIdx = baseSize >> (32 - _shardBit);


### PR DESCRIPTION
- Configurable dirty node shard count.
- So that unit test can run with very little shard and I guess some weird setup with very high core count can have better parallelism during pruning.

## Changes

- Configurable dirty node shard count by configuring shard bit.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Seems to work.