### PR TITLE
Peers ignore self and recent ips

### DIFF
--- a/src/Nethermind/Nethermind.Config/NetworkNode.cs
+++ b/src/Nethermind/Nethermind.Config/NetworkNode.cs
@@ -63,6 +63,7 @@ namespace Nethermind.Config
 
         public PublicKey NodeId => _enode.PublicKey;
         public string Host => _enode.HostIp.ToString();
+        public IPAddress HostIp => _enode.HostIp;
         public int Port => _enode.Port;
         public long Reputation { get; set; }
     }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Network.Discovery.Test
             _nodes = new[] { new Node(TestItem.PublicKeyA, "192.168.1.18", 1), new Node(TestItem.PublicKeyB, "192.168.1.19", 2) };
 
             IFullDb nodeDb = new SimpleFilePublicKeyDb("Test", "test_db", logManager);
-            _discoveryManager = new DiscoveryManager(lifecycleFactory, _nodeTable, new NetworkStorage(nodeDb, logManager), discoveryConfig, logManager);
+            _discoveryManager = new DiscoveryManager(lifecycleFactory, _nodeTable, new NetworkStorage(nodeDb, logManager), discoveryConfig, null, logManager);
             _discoveryManager.MsgSender = _msgSender;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
@@ -44,6 +44,7 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
 
         INetworkConfig networkConfig = configProvider.GetConfig<INetworkConfig>();
         int port = AssignDiscoveryPort();
+        networkConfig.LocalIp = networkConfig.ExternalIp = $"192.168.2.{AssignDiscoveryIp()}";
         networkConfig.DiscoveryPort = port;
         networkConfig.P2PPort = port;
 
@@ -60,6 +61,11 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
     private int AssignDiscoveryPort()
     {
         return Interlocked.Increment(ref _discoveryPort);
+    }
+    int _discoveryIp = 1;
+    private int AssignDiscoveryIp()
+    {
+        return Interlocked.Increment(ref _discoveryIp);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
@@ -82,7 +82,7 @@ public class NodeLifecycleManagerTests
         IMsgSender udpClient = Substitute.For<IMsgSender>();
 
         SimpleFilePublicKeyDb discoveryDb = new("Test", "test", logManager);
-        _discoveryManager = new DiscoveryManager(lifecycleFactory, _nodeTable, new NetworkStorage(discoveryDb, logManager), discoveryConfig, logManager);
+        _discoveryManager = new DiscoveryManager(lifecycleFactory, _nodeTable, new NetworkStorage(discoveryDb, logManager), discoveryConfig, null, logManager);
         _discoveryManager.MsgSender = udpClient;
 
         _discoveryManagerMock = Substitute.For<IDiscoveryManager>();

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodesLocatorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodesLocatorTests.cs
@@ -55,6 +55,7 @@ namespace Nethermind.Network.Discovery.Test
                 _nodeTable,
                 new NetworkStorage(new MemDb(), LimboLogs.Instance),
                 config,
+                null,
                 LimboLogs.Instance);
             _nodesLocator = new NodesLocator(_nodeTable, manager, config, LimboLogs.Instance);
         }

--- a/src/Nethermind/Nethermind.Network.Discovery/CompositeDiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/CompositeDiscoveryApp.cs
@@ -179,6 +179,7 @@ public class CompositeDiscoveryApp : IDiscoveryApp
             nodeTable,
             discoveryStorage,
             discoveryConfig,
+            _networkConfig,
             _logManager
         );
 

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -240,6 +240,12 @@ public class DiscoveryApp : IDiscoveryApp
                 break;
             }
 
+            if (!_discoveryManager.NodesFilter.Set(networkNode.HostIp))
+            {
+                // Already seen this node ip recently
+                continue;
+            }
+
             Node node;
             try
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -52,7 +52,7 @@ public class DiscoveryManager : IDiscoveryManager
         _createNodeLifecycleManager = GetLifecycleManagerFunc(isPersisted: false);
         _createNodeLifecycleManagerPersisted = GetLifecycleManagerFunc(isPersisted: true);
 
-        NodesFilter = new(networkConfig?.MaxActivePeers ?? 256);
+        NodesFilter = new((networkConfig?.MaxActivePeers * 4) ?? 200);
     }
 
     public NodeRecord SelfNodeRecord => _nodeLifecycleManagerFactory.SelfNodeRecord;

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 using Nethermind.Network.Discovery.Lifecycle;
 using Nethermind.Network.Discovery.Messages;
 using Nethermind.Network.Discovery.RoutingTable;
@@ -26,8 +27,7 @@ public class DiscoveryManager : IDiscoveryManager
     private readonly ConcurrentDictionary<Hash256, INodeLifecycleManager> _nodeLifecycleManagers = new();
     private readonly INodeTable _nodeTable;
     private readonly INetworkStorage _discoveryStorage;
-    // Size not too large that don't retry; but not too small that we retry too often
-    public ClockKeyCache<IDiscoveryManager.IpAddressAsKey> NodesFilter { get; } = new(256);
+    public ClockKeyCache<IDiscoveryManager.IpAddressAsKey> NodesFilter { get; }
 
     private readonly ConcurrentDictionary<MessageTypeKey, TaskCompletionSource<DiscoveryMsg>> _waitingEvents = new();
     private readonly Func<Hash256, Node, INodeLifecycleManager> _createNodeLifecycleManager;
@@ -39,6 +39,7 @@ public class DiscoveryManager : IDiscoveryManager
         INodeTable? nodeTable,
         INetworkStorage? discoveryStorage,
         IDiscoveryConfig? discoveryConfig,
+        INetworkConfig? networkConfig,
         ILogManager? logManager)
     {
         _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
@@ -50,6 +51,8 @@ public class DiscoveryManager : IDiscoveryManager
         _outgoingMessageRateLimiter = new RateLimiter(discoveryConfig.MaxOutgoingMessagePerSecond);
         _createNodeLifecycleManager = GetLifecycleManagerFunc(isPersisted: false);
         _createNodeLifecycleManagerPersisted = GetLifecycleManagerFunc(isPersisted: true);
+
+        NodesFilter = new(networkConfig?.MaxActivePeers ?? 256);
     }
 
     public NodeRecord SelfNodeRecord => _nodeLifecycleManagerFactory.SelfNodeRecord;

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -27,7 +27,7 @@ public class DiscoveryManager : IDiscoveryManager
     private readonly INodeTable _nodeTable;
     private readonly INetworkStorage _discoveryStorage;
     // Size not too large that don't retry; but not too small that we retry too often
-    public ClockKeyCache<IDiscoveryManager.IpAddressAsKey> NodesFilter { get; } = new(1024);
+    public ClockKeyCache<IDiscoveryManager.IpAddressAsKey> NodesFilter { get; } = new(256);
 
     private readonly ConcurrentDictionary<MessageTypeKey, TaskCompletionSource<DiscoveryMsg>> _waitingEvents = new();
     private readonly Func<Hash256, Node, INodeLifecycleManager> _createNodeLifecycleManager;

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Net;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Network.Discovery.Lifecycle;
 using Nethermind.Network.Discovery.Messages;
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Discovery;
@@ -19,4 +22,15 @@ public interface IDiscoveryManager : IDiscoveryMsgListener
 
     IReadOnlyCollection<INodeLifecycleManager> GetNodeLifecycleManagers();
     IReadOnlyCollection<INodeLifecycleManager> GetOrAddNodeLifecycleManagers(Func<INodeLifecycleManager, bool> query);
+    ClockKeyCache<IpAddressAsKey> NodesFilter { get; }
+    NodeRecord SelfNodeRecord { get; }
+
+    public readonly struct IpAddressAsKey(IPAddress ipAddress) : IEquatable<IpAddressAsKey>
+    {
+        private readonly IPAddress _ipAddress = ipAddress;
+        public static implicit operator IpAddressAsKey(IPAddress ip) => new(ip);
+        public bool Equals(IpAddressAsKey other) => _ipAddress.Equals(other._ipAddress);
+        public override bool Equals(object? obj) => obj is IpAddressAsKey ip && _ipAddress.Equals(ip._ipAddress);
+        public override int GetHashCode() => _ipAddress.GetHashCode();
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/INodeLifecycleManagerFactory.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/INodeLifecycleManagerFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Discovery.Lifecycle;
@@ -9,4 +10,5 @@ public interface INodeLifecycleManagerFactory
 {
     INodeLifecycleManager CreateNodeLifecycleManager(Node node);
     IDiscoveryManager DiscoveryManager { set; }
+    NodeRecord SelfNodeRecord { get; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -190,6 +190,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
         NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryNeighboursIn);
         RefreshNodeContactTime();
 
+        IPAddress? externalIp = _discoveryManager.SelfNodeRecord?.GetObj<IPAddress>(EnrContentKey.Ip);
         foreach (Node node in msg.Nodes)
         {
             if (node.Address.Address == _localhost)
@@ -198,7 +199,18 @@ public class NodeLifecycleManager : INodeLifecycleManager
                     _logger.Trace($"Received localhost as node address from: {msg.FarPublicKey}, node: {node}");
                 continue;
             }
-
+            if (node.Address.Address == externalIp)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"Received self as node address from: {msg.FarPublicKey}, node: {node}");
+                // Ignore self
+                continue;
+            }
+            else if (!_discoveryManager.NodesFilter.Set(node.Address.Address))
+            {
+                // Already seen this node ip recently
+                continue;
+            }
             //If node is new it will create a new nodeLifecycleManager and will update state to New, which will trigger Ping
             _discoveryManager.GetNodeLifecycleManager(node);
         }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
@@ -38,6 +38,7 @@ public class NodeLifecycleManagerFactory : INodeLifecycleManagerFactory
     }
 
     public IDiscoveryManager? DiscoveryManager { private get; set; }
+    public NodeRecord SelfNodeRecord => _selfNodeRecord;
 
     public INodeLifecycleManager CreateNodeLifecycleManager(Node node)
     {


### PR DESCRIPTION
Resolves #2157

Simpler https://github.com/NethermindEth/nethermind/pull/7026

## Changes

- Disfavour nodes with same ip addresses of nodes tried recently
- Don't connect to self even with external ip

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes - changed existing to use different ips

