### PR TITLE
Secp256r1 precompile: switch to BoringSSL

### DIFF
--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -16,9 +16,11 @@
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />
+    <Project Path="Nethermind.Init\Nethermind.Init.csproj" />
     <Project Path="Nethermind.JsonRpc/Nethermind.JsonRpc.csproj" />
     <Project Path="Nethermind.KeyStore/Nethermind.KeyStore.csproj" />
     <Project Path="Nethermind.Logging/Nethermind.Logging.csproj" />
+    <Project Path="Nethermind.Merge.Plugin\Nethermind.Merge.Plugin.csproj" />
     <Project Path="Nethermind.Monitoring/Nethermind.Monitoring.csproj" />
     <Project Path="Nethermind.Network.Contract/Nethermind.Network.Contract.csproj" />
     <Project Path="Nethermind.Network.Discovery/Nethermind.Network.Discovery.csproj" />

--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -51,6 +51,7 @@
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.5" />
     <PackageVersion Include="Nethermind.Crypto.Pairings" Version="1.1.1" />
     <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.4.0" />
+    <PackageVersion Include="Nethermind.Crypto.SecP256r1" Version="1.0.0-preview.6" />
     <PackageVersion Include="Nethermind.DotNetty.Buffers" Version="1.0.1" />
     <PackageVersion Include="Nethermind.DotNetty.Handlers" Version="1.0.1" />
     <PackageVersion Include="Nethermind.DotNetty.Transport" Version="1.0.1" />

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Evm.Benchmark
             _stateProvider.Reset();
         }
 
-        [Benchmark(Baseline = true)]
+        [Benchmark]
         public void No_machine_running()
         {
             _stateProvider.Reset();

--- a/src/Nethermind/Nethermind.Evm.Test/Secp256r1PrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Secp256r1PrecompileTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Specs.Forks;
@@ -13,6 +14,8 @@ namespace Nethermind.Evm.Test
     [TestFixture]
     public class Secp256r1PrecompileTests : PrecompileTests<Secp256r1PrecompileTests>, IPrecompileTests
     {
+        private static readonly byte[] ValidResult = new byte[] { 1 }.PadLeft(32);
+
         public static IEnumerable<string> TestFiles()
         {
             yield return "p256Verify.json";
@@ -33,12 +36,41 @@ namespace Nethermind.Evm.Test
         public void Produces_Empty_Output_On_Invalid_Input(string input)
         {
             var bytes = Bytes.FromHexString(input);
-            (ReadOnlyMemory<byte> output, var success) = Secp256r1Precompile.Instance.Run(bytes, Prague.Instance);
+            (ReadOnlyMemory<byte> output, var success) = Precompile().Run(bytes, Prague.Instance);
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(success, Is.True);
                 Assert.That(output.ToArray(), Is.EquivalentTo(Array.Empty<byte>()));
+            }
+        }
+
+        [TestCaseSource(nameof(RandomECDsaInputs))]
+        public void Verifies_random_valid_signature(byte[] input)
+        {
+            (ReadOnlyMemory<byte> output, var success) = Secp256r1Precompile.Instance.Run(input, Prague.Instance);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(success, Is.True);
+                Assert.That(output.ToArray(), Is.EquivalentTo(ValidResult));
+            }
+        }
+
+        public static IEnumerable<TestCaseData> RandomECDsaInputs()
+        {
+            var rng = RandomNumberGenerator.Create();
+            var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+            for (var i = 0; i < 100; i++)
+            {
+                var hash = new byte[32];
+                rng.GetBytes(hash);
+
+                ECParameters pub = ecdsa.ExportParameters(false);
+                byte[] sig = ecdsa.SignHash(hash, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+                byte[] input = [.. hash, .. sig, .. pub.Q.X, .. pub.Q.Y];
+
+                yield return new TestCaseData(input).SetName(Convert.ToHexString(input));
             }
         }
     }

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" />
     <PackageReference Include="Nethermind.Crypto.Pairings" />
     <PackageReference Include="Nethermind.Crypto.Bls" />
+    <PackageReference Include="Nethermind.Crypto.SecP256r1" />
     <PackageReference Include="Nethermind.Gmp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Evm/Precompiles/Secp256r1Precompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/Secp256r1Precompile.cs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Security.Cryptography;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 
 namespace Nethermind.Evm.Precompiles;
 
@@ -19,37 +19,13 @@ public class Secp256r1Precompile : IPrecompile<Secp256r1Precompile>
     public long BaseGasCost(IReleaseSpec releaseSpec) => 3450L;
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0L;
 
-    // TODO can be optimized - Go implementation is 2-6 times faster depending on the platform. Options:
-    // - Try to replicate Go version in C#
-    // - Compile Go code into a library and call it via P/Invoke
     public (byte[], bool) Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
     {
-        if (inputData.Length != 160)
-            return (null, true);
-
-        ReadOnlySpan<byte> bytes = inputData.Span;
-        ReadOnlySpan<byte> hash = bytes[..32], sig = bytes[32..96];
-        ReadOnlySpan<byte> x = bytes[96..128], y = bytes[128..160];
-
-        ECDsa ecdsa;
-        try
-        {
-            ecdsa = ECDsa.Create(new ECParameters
-            {
-                Curve = ECCurve.NamedCurves.nistP256,
-                Q = new() { X = x.ToArray(), Y = y.ToArray() }
-            });
-        }
-        catch
-        {
-            // Invalid x/y parameters
-            return (null, true);
-        }
-
-        var isValid = ecdsa.VerifyHash(hash, sig);
-
         Metrics.Secp256r1Precompile++;
 
-        return (isValid ? ValidResult : null, true);
+        return (
+            Secp256r1.VerifySignature(inputData) ? ValidResult : null,
+            true
+        );
     }
 }

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/PrecompileBenchmarkBase.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/PrecompileBenchmarkBase.cs
@@ -43,7 +43,9 @@ namespace Nethermind.Precompiles.Benchmark
                 foreach (IPrecompile precompile in Precompiles)
                 {
                     List<Param> inputs = [];
-                    foreach (string file in Directory.GetFiles($"{InputsDirectory}/current", "*.csv", SearchOption.TopDirectoryOnly))
+                    var inputsDir = Path.Combine(AppContext.BaseDirectory, InputsDirectory, "current");
+
+                    foreach (string file in Directory.GetFiles(inputsDir, "*.csv", SearchOption.TopDirectoryOnly))
                     {
                         // take only first line from each file
                         inputs.AddRange(File.ReadAllLines(file)
@@ -51,7 +53,7 @@ namespace Nethermind.Precompiles.Benchmark
                             .Select(i => new Param(precompile, file, i, null)));
                     }
 
-                    foreach (string file in Directory.GetFiles($"{InputsDirectory}/current", "*.json", SearchOption.TopDirectoryOnly))
+                    foreach (string file in Directory.GetFiles(inputsDir, "*.json", SearchOption.TopDirectoryOnly))
                     {
                         EthereumJsonSerializer jsonSerializer = new();
                         JsonInput[] jsonInputs = jsonSerializer.Deserialize<JsonInput[]>(File.ReadAllText(file));


### PR DESCRIPTION
## Changes

- Switches to the [secp256r1 package](https://github.com/NethermindEth/secp256r1-bindings) using BoringSSL for signature verification (see https://github.com/NethermindEth/secp256r1-bindings/pull/6)
- Adds a bunch of random test cases
- Small fixes for Benchmarks solution:
  - Broken build because of missing projects
  - Precompile benchmarks runnable only from specific directory
  - 2 baseline methods in single benchmark

Related:
- https://github.com/NethermindEth/nethermind/pull/8252

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
