### PR TITLE
Lookup TxDecoder once per block

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -190,15 +190,23 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
         IRlpStreamDecoder<Transaction>? rlpDecoder = Rlp.GetStreamDecoder<Transaction>() ??
             throw new RlpException($"{nameof(Transaction)} decoder is not registered");
 
-        byte[][] txData = Transactions;
-        Transaction[] transactions = new Transaction[txData.Length];
-
-        for (int i = 0; i < transactions.Length; i++)
+        int i = 0;
+        try
         {
-            transactions[i] = Rlp.Decode(txData[i].AsRlpStream(), rlpDecoder, RlpBehaviors.SkipTypedWrapping);
-        }
+            byte[][] txData = Transactions;
+            Transaction[] transactions = new Transaction[txData.Length];
 
-        return (_transactions = transactions);
+            for (i = 0; i < transactions.Length; i++)
+            {
+                transactions[i] = Rlp.Decode(txData[i].AsRlpStream(), rlpDecoder, RlpBehaviors.SkipTypedWrapping);
+            }
+
+            return (_transactions = transactions);
+        }
+        catch (RlpException e)
+        {
+            throw new RlpException($"Transaction {i} is not valid", e);
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -41,11 +41,11 @@ public class ExecutionPayloadParams(byte[][]? executionRequests = null)
             }
 
             // verification of the requests
-            byte[][] requests = ExecutionRequests;
+            byte[][]? requests = ExecutionRequests;
             int previousTypeId = -1;
             for (int i = 0; i < requests.Length; i++)
             {
-                var request = requests[i];
+                byte[]? request = requests[i];
                 if (request is null || request.Length <= 1)
                 {
                     error = "Execution request data must be longer than 1 byte";

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Serialization.Rlp;
@@ -22,25 +21,17 @@ public interface IExecutionPayloadParams
 
 public enum ValidationResult : byte { Success, Fail, Invalid };
 
-public class ExecutionPayloadParams<TVersionedExecutionPayload>(
-    TVersionedExecutionPayload executionPayload,
-    byte[]?[] blobVersionedHashes,
-    Hash256? parentBeaconBlockRoot,
-    byte[][]? executionRequests = null)
-    : IExecutionPayloadParams where TVersionedExecutionPayload : ExecutionPayload
+public class ExecutionPayloadParams(byte[][]? executionRequests = null)
 {
-    public TVersionedExecutionPayload ExecutionPayload => executionPayload;
-
     /// <summary>
     /// Gets or sets <see cref="ExecutionRequets"/> as defined in
     /// <see href="https://eips.ethereum.org/EIPS/eip-7685">EIP-7685</see>.
     /// </summary>
     public byte[][]? ExecutionRequests { get; set; } = executionRequests;
 
-    ExecutionPayload IExecutionPayloadParams.ExecutionPayload => ExecutionPayload;
-
-    public ValidationResult ValidateParams(IReleaseSpec spec, int version, out string? error)
+    protected ValidationResult ValidateInitialParams(IReleaseSpec spec, out string? error)
     {
+        error = null;
         if (spec.RequestsEnabled)
         {
             if (ExecutionRequests is null)
@@ -50,22 +41,51 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
             }
 
             // verification of the requests
-            for (int i = 0; i < ExecutionRequests.Length; i++)
+            byte[][] requests = ExecutionRequests;
+            int previousTypeId = -1;
+            for (int i = 0; i < requests.Length; i++)
             {
-                if (ExecutionRequests[i] == null || ExecutionRequests[i].Length <= 1)
+                var request = requests[i];
+                if (request is null || request.Length <= 1)
                 {
                     error = "Execution request data must be longer than 1 byte";
                     return ValidationResult.Fail;
                 }
 
-                if (i > 0 && ExecutionRequests[i][0] <= ExecutionRequests[i - 1][0])
+                int requestTypeId = request[0];
+                if (requestTypeId <= previousTypeId)
                 {
                     error = "Execution requests must not contain duplicates and be ordered by request_type in ascending order";
                     return ValidationResult.Fail;
                 }
-            }
 
+                previousTypeId = requestTypeId;
+            }
         }
+
+        return ValidationResult.Success;
+    }
+}
+
+public class ExecutionPayloadParams<TVersionedExecutionPayload>(
+    TVersionedExecutionPayload executionPayload,
+    byte[]?[] blobVersionedHashes,
+    Hash256? parentBeaconBlockRoot,
+    byte[][]? executionRequests = null)
+    : ExecutionPayloadParams(executionRequests), IExecutionPayloadParams where TVersionedExecutionPayload : ExecutionPayload
+{
+    public TVersionedExecutionPayload ExecutionPayload => executionPayload;
+
+    ExecutionPayload IExecutionPayloadParams.ExecutionPayload => ExecutionPayload;
+
+    public ValidationResult ValidateParams(IReleaseSpec spec, int version, out string? error)
+    {
+        ValidationResult result = ValidateInitialParams(spec, out error);
+        if (result != ValidationResult.Success)
+        {
+            return result;
+        }
+
         Transaction[]? transactions;
         try
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -254,9 +254,14 @@ namespace Nethermind.Serialization.Rlp
         public static T Decode<T>(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             IRlpStreamDecoder<T>? rlpDecoder = GetStreamDecoder<T>();
+            return Decode<T>(rlpStream, rlpDecoder, rlpBehaviors);
+        }
+        public static T Decode<T>(RlpStream rlpStream, IRlpStreamDecoder<T> rlpDecoder, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            ArgumentNullException.ThrowIfNull(rlpDecoder, nameof(rlpDecoder));
             bool shouldCheckStream = rlpStream.Position == 0 && (rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes;
             int length = rlpStream.Length;
-            T? result = rlpDecoder is not null ? rlpDecoder.Decode(rlpStream, rlpBehaviors) : throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
+            T? result = rlpDecoder.Decode(rlpStream, rlpBehaviors);
             if (shouldCheckStream)
                 rlpStream.Check(length);
             return result;

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.cs
@@ -13,10 +13,10 @@ namespace Nethermind.Trie;
 /// <summary>
 /// Track every rented CappedArray<byte> and return them all at once
 /// </summary>
-public class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
+public sealed class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
 {
     private readonly List<byte[]> _rentedBuffers;
-    private readonly ArrayPool<byte> _arrayPool;
+    private readonly ArrayPool<byte>? _arrayPool;
 
     public TrackingCappedArrayPool() : this(0)
     {
@@ -25,7 +25,7 @@ public class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
     public TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte> arrayPool = null)
     {
         _rentedBuffers = new List<byte[]>(initialCapacity);
-        _arrayPool = arrayPool ?? ArrayPool<byte>.Shared;
+        _arrayPool = arrayPool;
     }
 
     public CappedArray<byte> Rent(int size)
@@ -35,7 +35,8 @@ public class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
             return CappedArray<byte>.Empty;
         }
 
-        byte[] array = _arrayPool.Rent(size);
+        // Devirtualize shared array pool by referring directly to it
+        byte[] array = _arrayPool?.Rent(size) ?? ArrayPool<byte>.Shared.Rent(size);
         CappedArray<byte> rented = new CappedArray<byte>(array, size);
         array.AsSpan().Clear();
         _rentedBuffers.Add(array);
@@ -48,9 +49,20 @@ public class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
 
     public void Dispose()
     {
-        foreach (byte[] rentedBuffer in CollectionsMarshal.AsSpan(_rentedBuffers))
+        if (_arrayPool is null)
         {
-            _arrayPool.Return(rentedBuffer);
+            foreach (byte[] rentedBuffer in CollectionsMarshal.AsSpan(_rentedBuffers))
+            {
+                // Devirtualize shared array pool by referring directly to it
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
+        }
+        else
+        {
+            foreach (byte[] rentedBuffer in CollectionsMarshal.AsSpan(_rentedBuffers))
+            {
+                _arrayPool.Return(rentedBuffer);
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes

- Only lookup the TxDecoder once per block, rather than for each tx
- Optimize ExecutionPayloadParams.ValidateParams
- Devirtualize shared array pool

Before
![image](https://github.com/user-attachments/assets/c05af758-91a0-414c-b069-c247918cd2db)

After
![image](https://github.com/user-attachments/assets/9b281f3d-37bc-4cf7-b965-964cc492dbda)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
