### PR TITLE
Shrink Netty page size 16MB => 8MB

### DIFF
--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -202,10 +202,11 @@ namespace Nethermind.Init
         {
             ValidateCpuCount(cpuCount);
 
-            NettyMemory = Math.Min(512.MB(), (long)(0.2 * _remainingMemory));
+            NettyMemory = Math.Min(256.MB(), (long)(0.2 * _remainingMemory));
 
             uint arenaCount = (uint)Math.Min(cpuCount * 2, networkConfig.MaxNettyArenaCount);
 
+            NettyMemoryEstimator.SetPageSize();
             long estimate = NettyMemoryEstimator.Estimate(arenaCount, networkConfig.NettyArenaOrder);
 
             /* first of all we assume that the mainnet will be heavier than any other chain on the side */

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -6,12 +6,10 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
-using Nethermind.Blockchain.Utils;
 using Nethermind.Core;
 using Nethermind.Crypto;
 using Nethermind.Db;
@@ -29,11 +27,9 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Rlpx.Handshake;
 using Nethermind.Network.StaticNodes;
-using Nethermind.State.SnapServer;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
-using Nethermind.Synchronization.SnapSync;
 using Nethermind.Synchronization.Trie;
 using Nethermind.TxPool;
 
@@ -41,8 +37,13 @@ namespace Nethermind.Init.Steps;
 
 public static class NettyMemoryEstimator
 {
-    // Environment.SetEnvironmentVariable("io.netty.allocator.pageSize", "8192");
     private const uint PageSize = 8192;
+
+    public static void SetPageSize()
+    {
+        // For some reason needs to be half page size to get page size
+        Environment.SetEnvironmentVariable("io.netty.allocator.pageSize", (PageSize / 2).ToString((IFormatProvider?)null));
+    }
 
     public static long Estimate(uint arenaCount, int arenaOrder)
     {


### PR DESCRIPTION
## Changes

- We decreased peers from 200 to 50; but kept the large pool sizes

This means most of the arenas are wasted space (fill rate); don't want to go too much smaller as are used during receipts and body sync

Before
<img width="400" src="https://github.com/user-attachments/assets/761acbd3-9c23-4e46-892f-db665f7dffd4" />

<img width="600" src="https://github.com/user-attachments/assets/fbd13148-6f2c-4ed9-945e-617d1c32db30" />

After
<img width="400" src="https://github.com/user-attachments/assets/8249e06b-03c7-4fb8-9911-162f48dc25f3" />

<img width="600" src="https://github.com/user-attachments/assets/ed8766b8-ca23-4eab-989e-91735d2e731a" />

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
