### PR TITLE
Increase hot code in PruneCache

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -97,8 +97,15 @@ namespace Nethermind.Core.Crypto
         public static bool operator >=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) >= 0;
         public static bool operator <=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) <= 0;
         public static explicit operator Hash256(in ValueHash256 keccak) => new(keccak);
+        
+        public static bool operator ==(Hash256? a, in ValueHash256 b) => a is null ? b.IsZero : a.ValueHash256._bytes == b._bytes;
+        public static bool operator ==(in ValueHash256 a, Hash256? b) => b is null ? a.IsZero : b.ValueHash256._bytes == a._bytes;
+        public static bool operator !=(Hash256? a, in ValueHash256 b) => !(a == b);
+        public static bool operator !=(in ValueHash256 a, Hash256? b) => !(a == b);
 
         public UInt256 ToUInt256(bool isBigEndian = true) => new UInt256(Bytes, isBigEndian: isBigEndian);
+
+        private bool IsZero => _bytes == default;
     }
 
     public readonly struct Hash256AsKey(Hash256 key) : IEquatable<Hash256AsKey>

--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -98,7 +98,7 @@ namespace Nethermind.Core.Crypto
         public static bool operator <=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) <= 0;
         public static explicit operator Hash256(in ValueHash256 keccak) => new(keccak);
         public static bool operator ==(Hash256? a, in ValueHash256 b) => a is null ? b.IsZero : a.ValueHash256._bytes == b._bytes;
-        public static bool operator ==(in ValueHash256 a, Hash256? b) => b is null ? a.IsZero : b.ValueHash256._bytes == a._bytes;
+        public static bool operator ==(in ValueHash256 a, Hash256? b) => b == a;
         public static bool operator !=(Hash256? a, in ValueHash256 b) => !(a == b);
         public static bool operator !=(in ValueHash256 a, Hash256? b) => !(a == b);
 

--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -97,7 +97,6 @@ namespace Nethermind.Core.Crypto
         public static bool operator >=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) >= 0;
         public static bool operator <=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) <= 0;
         public static explicit operator Hash256(in ValueHash256 keccak) => new(keccak);
-        
         public static bool operator ==(Hash256? a, in ValueHash256 b) => a is null ? b.IsZero : a.ValueHash256._bytes == b._bytes;
         public static bool operator ==(in ValueHash256 a, Hash256? b) => b is null ? a.IsZero : b.ValueHash256._bytes == a._bytes;
         public static bool operator !=(Hash256? a, in ValueHash256 b) => !(a == b);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -246,8 +246,8 @@ internal class TrieStoreDirtyNodesCache
     private (long totalMemory, long dirtyMemory, long totalNode, long dirtyNode) PruneCacheUnlocked(
         bool prunePersisted,
         bool forceRemovePersistedNodes,
-        ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes,
-        ConcurrentNodeWriteBatcher writeBatcher)
+        ConcurrentDictionary<HashAndTinyPath, Hash256?>? persistedHashes,
+        ConcurrentNodeWriteBatcher? writeBatcher)
     {
         long totalMemory = 0;
         long dirtyMemory = 0;
@@ -352,11 +352,11 @@ internal class TrieStoreDirtyNodesCache
             => throw new InvalidOperationException($"Persisted {node} {key} != {keccak}");
     }
 
-    private void Delete(Key key, INodeStorage.IWriteBatch writeBatch)
+    private void Delete(Key key, ConcurrentNodeWriteBatcher? writeBatch)
     {
         Metrics.RemovedNodeCount++;
         Remove(key);
-        writeBatch.Set(key.Address, key.Path, key.Keccak, default, WriteFlags.DisableWAL);
+        writeBatch?.Set(key.Address, key.Path, key.Keccak, default, WriteFlags.DisableWAL);
     }
 
     bool CanDelete(in Key key, Hash256? currentlyPersistingKeccak)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Utils;
@@ -225,100 +225,14 @@ internal class TrieStoreDirtyNodesCache
         ConcurrentDictionary<HashAndTinyPath, Hash256?>? persistedHashes = null,
         INodeStorage? nodeStorage = null)
     {
-        long totalMemory = 0;
-        long dirtyMemory = 0;
-        long totalNode = 0;
-        long dirtyNode = 0;
 
         ConcurrentNodeWriteBatcher? writeBatcher = nodeStorage is not null
             ? new ConcurrentNodeWriteBatcher(nodeStorage, 256) : null;
 
+        long totalMemory, dirtyMemory, totalNode, dirtyNode;
         using (AcquireMapLock())
         {
-            foreach ((Key key, TrieNode node) in AllNodes)
-            {
-                if (node.IsPersisted)
-                {
-                    // Remove persisted node based on `persistedHashes` if available.
-                    if (persistedHashes is not null && key.Path.Length <= TinyTreePath.MaxNibbleLength)
-                    {
-                        HashAndTinyPath tinyKey = new HashAndTinyPath(key.Address, new TinyTreePath(key.Path));
-                        if (persistedHashes.TryGetValue(tinyKey, out Hash256? lastPersistedHash))
-                        {
-                            if (CanDelete(key.Address, key.Path, key.Keccak, lastPersistedHash))
-                            {
-                                Delete(key, writeBatcher);
-                                continue;
-                            }
-                        }
-                    }
-
-                    if (prunePersisted)
-                    {
-                        // If its persisted and has last seen meaning it was recommitted,
-                        // we keep it to prevent key removal from removing it from DB.
-                        if (node.LastSeen == -1 || forceRemovePersistedNodes)
-                        {
-                            if (_logger.IsTrace) _logger.Trace($"Removing persisted {node} from memory.");
-
-                            Hash256? keccak = node.Keccak;
-                            if (keccak is null)
-                            {
-                                TreePath path2 = key.Path;
-                                keccak = node.GenerateKey(_trieStore.GetTrieStore(key.Address), ref path2, isRoot: true);
-                                if (keccak != key.Keccak)
-                                {
-                                    throw new InvalidOperationException($"Persisted {node} {key} != {keccak}");
-                                }
-
-                                node.Keccak = keccak;
-                            }
-                            Remove(key);
-
-                            Metrics.PrunedPersistedNodesCount++;
-                            continue;
-                        }
-
-                        if (_trieStore.IsNoLongerNeeded(node))
-                        {
-                            if (_logger.IsTrace) _logger.Trace($"Removing {node} from memory (no longer referenced).");
-                            if (node.Keccak is null)
-                            {
-                                throw new InvalidOperationException($"Removed {node}");
-                            }
-
-                            Metrics.PrunedPersistedNodesCount++;
-
-                            Remove(key);
-                            continue;
-                        }
-                    }
-                }
-                else if (_trieStore.IsNoLongerNeeded(node))
-                {
-                    if (_logger.IsTrace) _logger.Trace($"Removing {node} from memory (no longer referenced).");
-                    if (node.Keccak is null)
-                    {
-                        throw new InvalidOperationException($"Removed {node}");
-                    }
-
-                    Metrics.PrunedTransientNodesCount++;
-
-                    Remove(key);
-                    continue;
-                }
-
-                node.PrunePersistedRecursively(1);
-                long memory = node.GetMemorySize(false) + KeyMemoryUsage;
-                totalMemory += memory;
-                totalNode++;
-
-                if (!node.IsPersisted)
-                {
-                    dirtyMemory += memory;
-                    dirtyNode++;
-                }
-            }
+            (totalMemory, dirtyMemory, totalNode, dirtyNode) = PruneCacheUnlocked(prunePersisted, forceRemovePersistedNodes, persistedHashes, writeBatcher);
         }
 
         writeBatcher?.Dispose();
@@ -329,6 +243,115 @@ internal class TrieStoreDirtyNodesCache
         _totalDirtyMemory = dirtyMemory;
     }
 
+    private (long totalMemory, long dirtyMemory, long totalNode, long dirtyNode) PruneCacheUnlocked(
+        bool prunePersisted,
+        bool forceRemovePersistedNodes,
+        ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes,
+        ConcurrentNodeWriteBatcher writeBatcher)
+    {
+        long totalMemory = 0;
+        long dirtyMemory = 0;
+        long totalNode = 0;
+        long dirtyNode = 0;
+        foreach ((Key key, TrieNode node) in AllNodes)
+        {
+            if (node.IsPersisted)
+            {
+                // Remove persisted node based on `persistedHashes` if available.
+                if (persistedHashes is not null && key.Path.Length <= TinyTreePath.MaxNibbleLength)
+                {
+                    HashAndTinyPath tinyKey = new(key.Address, new TinyTreePath(key.Path));
+                    if (persistedHashes.TryGetValue(tinyKey, out Hash256? lastPersistedHash))
+                    {
+                        if (CanDelete(key, lastPersistedHash))
+                        {
+                            Delete(key, writeBatcher);
+                            continue;
+                        }
+                    }
+                }
+
+                if (prunePersisted)
+                {
+                    // If its persisted and has last seen meaning it was recommitted,
+                    // we keep it to prevent key removal from removing it from DB.
+                    if (node.LastSeen == -1 || forceRemovePersistedNodes)
+                    {
+                        if (_logger.IsTrace) LogPersistedNodeRemoval(node);
+
+                        Hash256? keccak = node.Keccak;
+                        if (keccak is null)
+                        {
+                            TreePath path2 = key.Path;
+                            keccak = node.GenerateKey(_trieStore.GetTrieStore(key.Address), ref path2, isRoot: true);
+                            if (keccak != key.Keccak)
+                            {
+                                ThrowPersistedNodeDoesNotMatch(key, node, keccak);
+                            }
+
+                            node.Keccak = keccak;
+                        }
+
+                        RemoveNodeFromCache(key, node);
+                        continue;
+                    }
+
+                    if (_trieStore.IsNoLongerNeeded(node))
+                    {
+                        RemoveNodeFromCache(key, node);
+                        continue;
+                    }
+                }
+            }
+            else if (_trieStore.IsNoLongerNeeded(node))
+            {
+                RemoveNodeFromCache(key, node);
+                continue;
+            }
+
+            node.PrunePersistedRecursively(1);
+            long memory = node.GetMemorySize(false) + KeyMemoryUsage;
+            totalMemory += memory;
+            totalNode++;
+
+            if (!node.IsPersisted)
+            {
+                dirtyMemory += memory;
+                dirtyNode++;
+            }
+        }
+
+        return (totalMemory, dirtyMemory, totalNode, dirtyNode);
+        
+        void RemoveNodeFromCache(in Key key, TrieNode node)
+        {
+            if (_logger.IsTrace) LogNodeRemoval(node);
+            if (node.Keccak is null)
+            {
+                ThrowKeccakIsNull(node);
+            }
+
+            Metrics.PrunedPersistedNodesCount++;
+
+            Remove(key);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void LogPersistedNodeRemoval(TrieNode node) => _logger.Trace($"Removing persisted {node} from memory.");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void LogNodeRemoval(TrieNode node) => _logger.Trace($"Removing {node} from memory.");
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowKeccakIsNull(TrieNode node) => throw new InvalidOperationException($"Removed {node}");
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowPersistedNodeDoesNotMatch(in Key key, TrieNode node, Hash256 keccak)
+            => throw new InvalidOperationException($"Persisted {node} {key} != {keccak}");
+    }
+
     private void Delete(Key key, INodeStorage.IWriteBatch writeBatch)
     {
         Metrics.RemovedNodeCount++;
@@ -336,16 +359,16 @@ internal class TrieStoreDirtyNodesCache
         writeBatch.Set(key.Address, key.Path, key.Keccak, default, WriteFlags.DisableWAL);
     }
 
-    bool CanDelete(in Hash256? address, in TreePath fullPath, in ValueHash256 keccak, Hash256? currentlyPersistingKeccak)
+    bool CanDelete(in Key key, Hash256? currentlyPersistingKeccak)
     {
         // Multiple current hash that we don't keep track for simplicity. Just ignore this case.
         if (currentlyPersistingKeccak is null) return false;
 
         // The persisted hash is the same as currently persisting hash. Do nothing.
-        if ((ValueHash256)currentlyPersistingKeccak == keccak) return false;
+        if (currentlyPersistingKeccak == key.Keccak) return false;
 
         // We have it in cache and it is still needed.
-        if (TryGetValue(new Key(address, fullPath, keccak.ToCommitment()), out TrieNode node) &&
+        if (TryGetValue(in key, out TrieNode node) &&
             !_trieStore.IsNoLongerNeeded(node)) return false;
 
         return true;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -322,7 +322,7 @@ internal class TrieStoreDirtyNodesCache
         }
 
         return (totalMemory, dirtyMemory, totalNode, dirtyNode);
-        
+
         void RemoveNodeFromCache(in Key key, TrieNode node)
         {
             if (_logger.IsTrace) LogNodeRemoval(node);


### PR DESCRIPTION
## Changes

- Split into two methods, and outer one with `using` and one with hot loop. The presence of `catch`/`finally` alters the quality of surrounding code forcing more to be pushed to stack rather than registers (so it has persistence from a throw). This is worse for methods with loops.
- Move (not hot path) throws and logging to local functions, so their asm doesn't form part of loop code
- Refactor 3 occurrences of same code to `RemoveNodeFromCache` local function
- Pass `Key` into `CanDelete` so `ValueKeccak` doesn't need to allocate via `.ToCommitment()`

It still ends up with a try/finally from the foreach on an interface enumerator; but doesn't have a double try/finally

Before `PruneCache`
```asm
G_M000_IG01:  
...
       mov      rax, 1152                                 ; clear 1kb of stack
       vmovdqa  xmmword ptr [rbp+rax-0x80], xmm4
       vmovdqa  xmmword ptr [rbp+rax-0x70], xmm4
       vmovdqa  xmmword ptr [rbp+rax-0x60], xmm4
       add      rax, 48
       jne      SHORT  -5 instr
       
; Total bytes of code: 4430
```
After `PruneCacheUnlocked`
```asm
G_M000_IG01:
...
       mov      rax, 624                                  ; clear 624 bytes of stack
       vmovdqa  xmmword ptr [rbp+rax-0x60], xmm4
       vmovdqa  xmmword ptr [rbp+rax-0x50], xmm4
       vmovdqa  xmmword ptr [rbp+rax-0x40], xmm4
       add      rax, 48
       jne      SHORT  -5 instr
...

; Total bytes of code: 1685
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No - Existing tests
