### PR TITLE
Add prewarm cache to TransactionProcessorTests

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
@@ -53,7 +53,8 @@ public class TransactionProcessorTests
     {
         MemDb stateDb = new();
         TrieStore trieStore = new(stateDb, LimboLogs.Instance);
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        PreBlockCaches preBlockCaches = new();
+        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance, preBlockCaches);
         _stateProvider.CreateAccount(TestItem.AddressA, AccountBalance);
         _stateProvider.Commit(_specProvider.GenesisSpec);
         _stateProvider.CommitTree(0);
@@ -235,7 +236,7 @@ public class TransactionProcessorTests
         Assert.That(result.Success, Is.True);
     }
 
-    [TestCase]
+    [Test]
     public void Balance_is_not_changed_on_call_and_restore()
     {
         long gasLimit = 100000;
@@ -251,7 +252,7 @@ public class TransactionProcessorTests
         _stateProvider.GetBalance(TestItem.PrivateKeyA.Address).Should().Be(1.Ether());
     }
 
-    [TestCase]
+    [Test]
     public void Account_is_not_created_on_call_and_restore()
     {
         long gasLimit = 100000;
@@ -268,7 +269,7 @@ public class TransactionProcessorTests
         _stateProvider.AccountExists(TestItem.PrivateKeyD.Address).Should().BeFalse();
     }
 
-    [TestCase]
+    [Test]
     public void Nonce_is_not_changed_on_call_and_restore()
     {
         long gasLimit = 100000;


### PR DESCRIPTION
## Changes

- Regression test for bug [fixed](https://github.com/NethermindEth/nethermind/pull/7406/files#diff-b8ea3d5dd4a8bedda3ec0900ae86bf6c3352c28fcec738e3064511be8c9c52e7R179) in #7406. Before this change `CallAndRestore` would throw exception due to underflow error when decrementing nonce caused by prewarm cache

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
