### PR TITLE
Deserialize JSON of a decimal number > MAX_UINT64

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
@@ -7,6 +7,9 @@ using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 using System.Text.Json;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.RegularExpressions;
 
 namespace Nethermind.Core.Test.Json
 {
@@ -14,7 +17,8 @@ namespace Nethermind.Core.Test.Json
     public class UInt256ConverterTests : ConverterTestBase<UInt256>
     {
         static readonly UInt256Converter converter = new();
-        static readonly JsonSerializerOptions options = new JsonSerializerOptions { Converters = { converter } };
+        static readonly JsonSerializerOptions options = new() { Converters = { converter } };
+        static bool Equals(UInt256 integer, UInt256 bigInteger) => integer.Equals(bigInteger);
 
         [TestCase(NumberConversion.Hex)]
         [TestCase(NumberConversion.Decimal)]
@@ -26,6 +30,56 @@ namespace Nethermind.Core.Test.Json
             TestConverter(UInt256.Zero, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
         }
 
+        [Test]
+        public void Test_Deserialize(
+            [ValueSource(typeof(UInt256ConverterTests), nameof(ValuesCaseSource))] UInt256 item,
+            [ValueSource(typeof(UInt256ConverterTests), nameof(FormatsCaseSource))] string format)
+        {
+            // fix of epic design choice made in BigInteger.ToString method that appends hex of any positive number with zero
+            string asString = new Regex("0x0(.{64})|0x(.+)").Replace(string.Format(format, (BigInteger)item), (s) => $"0x{(s.Groups[1].Success ? s.Groups[1].Value : (s.Groups[2].Success ? s.Groups[2].Value : s.Groups[0].Value))}");
+
+            JsonSerializerOptions options = new() { Converters = { converter } };
+
+            Container? deserialized = JsonSerializer.Deserialize<Container>($"{{ \"Number\" : {asString} }}", options);
+
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(Equals(item, deserialized.Number));
+
+            UInt256? deserializedUint256 = JsonSerializer.Deserialize<UInt256>(asString, options);
+
+            Assert.That(deserializedUint256, Is.Not.Null);
+            Assert.That(Equals(item, deserializedUint256.Value));
+        }
+
+        public static IEnumerable<UInt256> ValuesCaseSource()
+        {
+            yield return UInt256.MaxValue;
+            yield return UInt256.MaxValue - 1;
+            yield return UInt256.MaxValue >> 8;
+            yield return new UInt256(ulong.MaxValue, ulong.MaxValue);
+            yield return new UInt256(ulong.MaxValue, 1);
+            yield return int.MaxValue;
+            yield return UInt256.One;
+            yield return UInt256.Zero;
+        }
+
+        public static IEnumerable<string> FormatsCaseSource()
+        {
+            // lower case hex
+            yield return "\"0x{0:x}\"";
+            // upper case hex
+            yield return "\"0x{0:X}\"";
+            // hex with leading zeros
+            yield return "\"0x{0:X64}\"";
+            // decimal
+            yield return "{0:D}";
+        }
+
+        class Container
+        {
+            public UInt256 Number { get; set; }
+        }
+
         [TestCase((NumberConversion)99)]
         public void Undefined_not_supported(NumberConversion notSupportedConversion)
         {
@@ -33,9 +87,9 @@ namespace Nethermind.Core.Test.Json
 
             UInt256Converter converter = new();
             Assert.Throws<NotSupportedException>(
-                () => TestConverter(int.MaxValue, (integer, bigInteger) => integer.Equals(bigInteger), converter));
+                () => TestConverter(int.MaxValue, Equals, converter));
             Assert.Throws<NotSupportedException>(
-                () => TestConverter(UInt256.One, (integer, bigInteger) => integer.Equals(bigInteger), converter));
+                () => TestConverter(UInt256.One, Equals, converter));
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
         }
@@ -45,7 +99,7 @@ namespace Nethermind.Core.Test.Json
         {
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Raw;
             UInt256Converter converter = new();
-            TestConverter(0, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
+            TestConverter(0, Equals, converter);
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
         }

--- a/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -29,12 +30,13 @@ public class UInt256Converter : JsonConverter<UInt256>
     {
         if (reader.TokenType == JsonTokenType.Number)
         {
-            if (reader.TryGetUInt64(out ulong smallValue))
+            ReadOnlySpan<byte> bytes = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+
+            if (Utf8Parser.TryParse(bytes, out ulong shortValue, out int bytesConsumed) && bytes.Length == bytesConsumed)
             {
-                return smallValue;
+                return new UInt256(shortValue);
             }
 
-            ReadOnlySpan<byte> bytes = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
             Span<char> chars = stackalloc char[bytes.Length + 1];
             Encoding.UTF8.GetChars(bytes, chars);
 

--- a/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
@@ -26,19 +25,42 @@ public class UInt256Converter : JsonConverter<UInt256>
         JsonSerializerOptions options) =>
         ReadInternal(ref reader, JsonTokenType.String);
 
+    // length of UIn256.MaxValue decimal string "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    const int maxLength = 78;
+
+    [SkipLocalsInit]
     private static UInt256 ReadInternal(ref Utf8JsonReader reader, JsonTokenType allowedTokenType)
+    {
+        int length = reader.HasValueSequence ? (int)reader.ValueSequence.Length : reader.ValueSpan.Length;
+
+        if (length is 0 or > maxLength)
+        {
+            ThrowJsonException();
+        }
+
+        if (reader.HasValueSequence)
+        {
+            Span<byte> span = stackalloc byte[length];
+            reader.ValueSequence.CopyTo(span);
+            return ReadNumber(reader, allowedTokenType, span);
+        }
+
+        return ReadNumber(reader, allowedTokenType, reader.ValueSpan);
+    }
+
+    [SkipLocalsInit]
+    private static UInt256 ReadNumber(Utf8JsonReader reader, JsonTokenType allowedTokenType, ReadOnlySpan<byte> span)
     {
         if (reader.TokenType == JsonTokenType.Number)
         {
-            ReadOnlySpan<byte> bytes = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
-
-            if (Utf8Parser.TryParse(bytes, out ulong shortValue, out int bytesConsumed) && bytes.Length == bytesConsumed)
+            if (Utf8Parser.TryParse(span, out ulong shortValue, out int bytesConsumed) && span.Length == bytesConsumed)
             {
                 return new UInt256(shortValue);
             }
 
-            Span<char> chars = stackalloc char[bytes.Length + 1];
-            Encoding.UTF8.GetChars(bytes, chars);
+            Span<char> chars = stackalloc char[span.Length + 1];
+            chars[span.Length] = '\0';
+            Encoding.UTF8.GetChars(span, chars);
 
             return UInt256.Parse(chars, NumberStyles.None);
         }
@@ -48,11 +70,10 @@ public class UInt256Converter : JsonConverter<UInt256>
             ThrowJsonException();
         }
 
-        ReadOnlySpan<byte> hex = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
-        return Read(hex);
+        return ReadHex(span);
     }
 
-    public static UInt256 Read(ReadOnlySpan<byte> hex)
+    public static UInt256 ReadHex(ReadOnlySpan<byte> hex)
     {
         if (hex.SequenceEqual("0x0"u8))
         {

--- a/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
@@ -29,8 +29,18 @@ public class UInt256Converter : JsonConverter<UInt256>
     {
         if (reader.TokenType == JsonTokenType.Number)
         {
-            return reader.GetUInt64();
+            if (reader.TryGetUInt64(out ulong smallValue))
+            {
+                return smallValue;
+            }
+
+            ReadOnlySpan<byte> bytes = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+            Span<char> chars = stackalloc char[bytes.Length + 1];
+            Encoding.UTF8.GetChars(bytes, chars);
+
+            return UInt256.Parse(chars, NumberStyles.None);
         }
+
         if (reader.TokenType != allowedTokenType)
         {
             ThrowJsonException();

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/BlockRewardConverter.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/BlockRewardConverter.cs
@@ -43,7 +43,7 @@ public class BlockRewardConverter : JsonConverter<SortedDictionary<long, UInt256
                 }
 
                 var property =
-                    UInt256Converter.Read(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan);
+                    UInt256Converter.ReadHex(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan);
                 var key = (long)property;
                 reader.Read();
                 if (reader.TokenType != JsonTokenType.String)
@@ -52,7 +52,7 @@ public class BlockRewardConverter : JsonConverter<SortedDictionary<long, UInt256
                 }
 
                 var blockReward =
-                    UInt256Converter.Read(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan);
+                    UInt256Converter.ReadHex(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan);
                 value.Add(key, blockReward);
 
                 reader.Read();


### PR DESCRIPTION
## Changes

- Handle cases of big integers in form of decimal number passed in json

Example:

```
{"jsonrpc":"2.0","id":2,"method":"taikoAuth_txPoolContentWithMinTip","params": ["0x0000000000000000000000000000000000000000", 

15974323677659503371917880, 

10000, 10000, [], 1, 1 ]}
```


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
