### PR TITLE
Perf/More accurate request limit.

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
@@ -61,6 +61,11 @@ public static class ReadOnlyListExtensions
         return new SlicedReadOnlyList<T>(list, start, count);
     }
 
+    public static IReadOnlyList<T> Clamp<T>(this IReadOnlyList<T> list, int limit)
+    {
+        return new SlicedReadOnlyList<T>(list, 0, Math.Min(limit, list.Count));
+    }
+
     // Extension method that slices from the start index to the end of the list
     public static IReadOnlyList<T> Slice<T>(this IReadOnlyList<T> list, int start)
     {

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
@@ -19,6 +19,7 @@ public class LatencyAndMessageSizeBasedRequestSizer
     private readonly TimeSpan _lowerLatencyWatermark;
     private readonly long _maxResponseSize;
     private readonly AdaptiveRequestSizer _requestSizer;
+    public int RequestSize => _requestSizer.RequestSize;
 
     public LatencyAndMessageSizeBasedRequestSizer(
         int minRequestLimit,

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
@@ -44,7 +44,8 @@ public class LatencyAndMessageSizeBasedRequestSizer
 
     /// <summary>
     /// Adjust the request size depending on the latency and response size. Accept a list as request which will be capped.
-    /// If the response size is too large, reduce request size.
+    /// If the response size (byte) is too large, reduce request size.
+    /// If the response size (count) less than request size, reduce request size.
     /// If the latency is above watermark, reduce request size.
     /// If the latency is below watermark and response size is not too large, increase request size.
     /// </summary>
@@ -52,12 +53,14 @@ public class LatencyAndMessageSizeBasedRequestSizer
     /// <param name="func"></param>
     /// <typeparam name="TResponse">response type</typeparam>
     /// <typeparam name="TRequest">request type</typeparam>
+    /// <typeparam name="TResponseItem">response item type</typeparam>
     /// <returns></returns>
-    public async Task<TResponse> Run<TResponse, TRequest>(IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func)
+    public async Task<TResponse> Run<TResponse, TRequest, TResponseItem>(IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem>
     {
         return await _requestSizer.Run(async (adjustedRequestSize) =>
         {
             long startTime = Stopwatch.GetTimestamp();
+            long affectiveRequestSize = Math.Min(adjustedRequestSize, request.Count);
             (TResponse result, long messageSize) = await func(request.Slice(0, Math.Min(adjustedRequestSize, request.Count)));
             TimeSpan duration = Stopwatch.GetElapsedTime(startTime);
             if (messageSize > _maxResponseSize)
@@ -66,6 +69,11 @@ public class LatencyAndMessageSizeBasedRequestSizer
             }
 
             if (duration > _upperLatencyWatermark)
+            {
+                return (result, AdaptiveRequestSizer.Direction.Decrease);
+            }
+
+            if (result.Count < affectiveRequestSize)
             {
                 return (result, AdaptiveRequestSizer.Direction.Decrease);
             }

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
@@ -12,6 +12,7 @@ public class LatencyBasedRequestSizer
     private readonly TimeSpan _upperWatermark;
     private readonly TimeSpan _lowerWatermark;
     private readonly AdaptiveRequestSizer _requestSizer;
+    public int RequestSize => _requestSizer.RequestSize;
 
     public LatencyBasedRequestSizer(
         int minRequestLimit,

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Stats
@@ -32,5 +33,18 @@ namespace Nethermind.Stats
         SyncPeerNodeDetails EthNodeDetails { get; }
         SyncPeerNodeDetails LesNodeDetails { get; }
         CompatibilityValidationType? FailedCompatibilityValidation { get; set; }
+
+        /// <summary>
+        /// Run a request sizer for the specific request type. The function passed in will receive a closure with the
+        /// Original request size clamped down to a calculated limit. Depending on the latency and response size,
+        /// the limit will be adjusted for subsequent calls.
+        /// </summary>
+        Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func);
+
+        /// <summary>
+        /// Run a request sizer for the specific request type. The function passed in will receive a closure with a limit
+        /// Depending on the latency, the limit will be adjusted for subsequent calls.
+        /// </summary>
+        Task<TResponse> RunLatencyRequestSizer<TResponse>(RequestType requestType, Func<int, Task<TResponse>> func);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -46,5 +46,10 @@ namespace Nethermind.Stats
         /// Depending on the latency, the limit will be adjusted for subsequent calls.
         /// </summary>
         Task<TResponse> RunLatencyRequestSizer<TResponse>(RequestType requestType, Func<int, Task<TResponse>> func);
+
+        /// <summary>
+        /// Get the current request limit for the specific request type.
+        /// </summary>
+        int GetCurrentRequestLimit(RequestType requestType);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -39,7 +39,11 @@ namespace Nethermind.Stats
         /// Original request size clamped down to a calculated limit. Depending on the latency and response size,
         /// the limit will be adjusted for subsequent calls.
         /// </summary>
-        Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func);
+        Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest, TResponseItem>(
+            RequestType requestType,
+            IReadOnlyList<TRequest> request,
+            Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func)
+            where TResponse : IReadOnlyList<TResponseItem>;
 
         /// <summary>
         /// Run a request sizer for the specific request type. The function passed in will receive a closure with a limit

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
@@ -34,6 +34,15 @@ namespace Nethermind.Stats
         SnapRanges
     }
 
+    public enum RequestType
+    {
+        NodeData,
+        Headers,
+        Bodies,
+        Receipts,
+        SnapRanges
+    }
+
     public static class NodeStatsManagerExtension
     {
         public static void UpdateCurrentReputation(this INodeStatsManager nodeStatsManager, IEnumerable<Node> nodes)

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
@@ -36,7 +36,6 @@ namespace Nethermind.Stats
 
     public enum RequestType
     {
-        NodeData,
         Headers,
         Bodies,
         Receipts,

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
@@ -22,7 +22,6 @@ namespace Nethermind.Stats
         void ReportSyncEvent(Node node, NodeStatsEventType nodeStatsEvent);
         bool HasFailedValidation(Node node);
         void ReportTransferSpeedEvent(Node node, TransferSpeedType transferSpeedType, long value);
-        int GetCurrentRequestLimit(Node node, RequestType requestType);
     }
 
     public enum TransferSpeedType

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
@@ -22,6 +22,7 @@ namespace Nethermind.Stats
         void ReportSyncEvent(Node node, NodeStatsEventType nodeStatsEvent);
         bool HasFailedValidation(Node node);
         void ReportTransferSpeedEvent(Node node, TransferSpeedType transferSpeedType, long value);
+        int GetCurrentRequestLimit(Node node, RequestType requestType);
     }
 
     public enum TransferSpeedType

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-
+using System.Threading.Tasks;
 using FastEnumUtility;
+using Nethermind.Core;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Stats;
@@ -47,6 +48,47 @@ public class NodeStatsLight : INodeStats
     private static readonly Random Random = new();
 
     private static readonly int _statsLength = FastEnum.GetValues<NodeStatsEventType>().Length;
+
+    private readonly LatencyAndMessageSizeBasedRequestSizer _bodiesRequestSizer = new(
+        minRequestLimit: 1,
+        maxRequestLimit: 128,
+
+        // In addition to the byte limit, we also try to keep the latency of the get block bodies between these two
+        // watermark. This reduce timeout rate, and subsequently disconnection rate.
+        lowerLatencyWatermark: TimeSpan.FromMilliseconds(2000),
+        upperLatencyWatermark: TimeSpan.FromMilliseconds(3000),
+
+        // When the bodies message size exceed this, we try to reduce the maximum number of block for this peer.
+        // This is for BeSU and Reth which does not seems to use the 2MB soft limit, causing them to send 20MB of bodies
+        // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
+        // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
+        maxResponseSize: 3_000_000,
+        initialRequestSize: 4
+    );
+
+    private readonly LatencyAndMessageSizeBasedRequestSizer _receiptsRequestSizer = new(
+        minRequestLimit: 1,
+        maxRequestLimit: 128,
+
+        // In addition to the byte limit, we also try to keep the latency of the get receipts between these two
+        // watermark. This reduce timeout rate, and subsequently disconnection rate.
+        lowerLatencyWatermark: TimeSpan.FromMilliseconds(2000),
+        upperLatencyWatermark: TimeSpan.FromMilliseconds(3000),
+
+        // When the receipts message size exceed this, we try to reduce the maximum number of block for this peer.
+        // This is for BeSU and Reth which does not seems to use the 2MB soft limit, causing them to send 20MB of bodies
+        // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
+        // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
+        maxResponseSize: 3_000_000,
+        initialRequestSize: 8
+    );
+
+    private readonly LatencyBasedRequestSizer _snapRequestSizer = new(
+        minRequestLimit: 50000,
+        maxRequestLimit: 3_000_000,
+        lowerWatermark: TimeSpan.FromMilliseconds(2000),
+        upperWatermark: TimeSpan.FromMilliseconds(3500)
+    );
 
     public NodeStatsLight(Node node, decimal latestSpeedWeight = 0.25m)
     {
@@ -361,5 +403,20 @@ public class NodeStatsLight : INodeStats
         }
 
         return rlpxReputation;
+    }
+
+    public async Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func)
+    {
+        if (requestType == RequestType.Bodies) return await _bodiesRequestSizer.Run(request, func);
+        if (requestType == RequestType.Receipts) return await _receiptsRequestSizer.Run(request, func);
+
+        throw new ArgumentException($"Unsupported request type: {requestType}");
+    }
+
+    public async Task<TResponse> RunLatencyRequestSizer<TResponse>(RequestType requestType, Func<int, Task<TResponse>> func)
+    {
+        if (requestType == RequestType.SnapRanges) return await _snapRequestSizer.MeasureLatency(func);
+
+        throw new ArgumentException($"Unsupported request type: {requestType}");
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -405,10 +405,9 @@ public class NodeStatsLight : INodeStats
         return rlpxReputation;
     }
 
-    public async Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func)
-    {
-        if (requestType == RequestType.Bodies) return await _bodiesRequestSizer.Run(request, func);
-        if (requestType == RequestType.Receipts) return await _receiptsRequestSizer.Run(request, func);
+    public async Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest, TResponseItem>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem> {
+        if (requestType == RequestType.Bodies) return await _bodiesRequestSizer.Run<TResponse, TRequest, TResponseItem>(request, func);
+        if (requestType == RequestType.Receipts) return await _receiptsRequestSizer.Run<TResponse, TRequest, TResponseItem>(request, func);
 
         throw new ArgumentException($"Unsupported request type: {requestType}");
     }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -419,4 +419,13 @@ public class NodeStatsLight : INodeStats
 
         throw new ArgumentException($"Unsupported request type: {requestType}");
     }
+
+    public int GetCurrentRequestLimit(RequestType requestType)
+    {
+        if (requestType == RequestType.Bodies) return _bodiesRequestSizer.RequestSize;
+        if (requestType == RequestType.Receipts) return _receiptsRequestSizer.RequestSize;
+        if (requestType == RequestType.SnapRanges) return _snapRequestSizer.RequestSize;
+
+        throw new ArgumentException($"Unsupported request type: {requestType}");
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -405,7 +405,8 @@ public class NodeStatsLight : INodeStats
         return rlpxReputation;
     }
 
-    public async Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest, TResponseItem>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem> {
+    public async Task<TResponse> RunSizeAndLatencyRequestSizer<TResponse, TRequest, TResponseItem>(RequestType requestType, IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem>
+    {
         if (requestType == RequestType.Bodies) return await _bodiesRequestSizer.Run<TResponse, TRequest, TResponseItem>(request, func);
         if (requestType == RequestType.Receipts) return await _receiptsRequestSizer.Run<TResponse, TRequest, TResponseItem>(request, func);
 

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -425,6 +425,19 @@ public class NodeStatsLight : INodeStats
         if (requestType == RequestType.Bodies) return _bodiesRequestSizer.RequestSize;
         if (requestType == RequestType.Receipts) return _receiptsRequestSizer.RequestSize;
         if (requestType == RequestType.SnapRanges) return _snapRequestSizer.RequestSize;
+        if (requestType == RequestType.Headers)
+        {
+            switch (Node.ClientType)
+            {
+                // TODO: Find out other clients limit
+                case NodeClientType.Nethermind:
+                    return 1024;
+                case NodeClientType.Geth:
+                    return 192;
+                default:
+                    return 192;
+            }
+        }
 
         throw new ArgumentException($"Unsupported request type: {requestType}");
     }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
@@ -171,6 +171,11 @@ namespace Nethermind.Stats
             stats.AddTransferSpeedCaptureEvent(type, value);
         }
 
+        public int GetCurrentRequestLimit(Node node, RequestType requestType)
+        {
+            return GetOrAdd(node).GetCurrentRequestLimit(requestType);
+        }
+
         public void Dispose()
         {
             _cleanupTimer.Dispose();

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
@@ -171,11 +171,6 @@ namespace Nethermind.Stats
             stats.AddTransferSpeedCaptureEvent(type, value);
         }
 
-        public int GetCurrentRequestLimit(Node node, RequestType requestType)
-        {
-            return GetOrAdd(node).GetCurrentRequestLimit(requestType);
-        }
-
         public void Dispose()
         {
             _cleanupTimer.Dispose();

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Test.Builders;
@@ -119,5 +120,18 @@ public class NodeStatsTests
         }
 
         _nodeStats.CurrentNodeReputation().Should().Be(reputation);
+    }
+
+    [Test]
+    public async Task TestRequestLimit()
+    {
+        _nodeStats = new NodeStatsLight(_node);
+        _nodeStats.GetCurrentRequestLimit(RequestType.Bodies).Should().Be(4);
+
+        int[] result = await _nodeStats.RunSizeAndLatencyRequestSizer<int[], int, int>(RequestType.Bodies, [1, 2, 3, 4, 5],
+            (mapped) => Task.FromResult<(int[], long)>((mapped.ToArray(), 1)));
+
+        result.Should().BeEquivalentTo([1, 2, 3, 4]);
+        _nodeStats.GetCurrentRequestLimit(RequestType.Bodies).Should().Be(6);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -414,7 +414,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public async Task Can_LimitGetBlockBodiesRequestSize()
         {
-            using BlockBodiesMessage msg = new(Build.A.Block.TestObjectNTimes(3));
+            using BlockBodiesMessage msg4 = new( Build.A.Block.TestObjectNTimes(4));
             Transaction signedTransaction = Build.A.Transaction.SignedAndResolved().TestObject;
             Block largerBlock = Build.A.Block.WithTransactions(Enumerable.Repeat(signedTransaction, 1000).ToArray()).TestObject;
 
@@ -429,7 +429,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             HandleIncomingStatusMessage();
             Task getTask = ((ISyncPeer)_handler).GetBlockBodies(requests, CancellationToken.None).AddResultTo(_disposables);
-            HandleZeroMessage(msg, Eth62MessageCode.BlockBodies);
+            HandleZeroMessage(msg4, Eth62MessageCode.BlockBodies);
             await getTask;
 
             Assert.That(getMsg.BlockHashes.Count, Is.EqualTo(4));
@@ -441,7 +441,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             Assert.That(getMsg.BlockHashes.Count, Is.EqualTo(6));
 
             getTask = ((ISyncPeer)_handler).GetBlockBodies(requests, CancellationToken.None).AddResultTo(_disposables);
-            HandleZeroMessage(msg, Eth62MessageCode.BlockBodies);
+            HandleZeroMessage(msg4, Eth62MessageCode.BlockBodies);
             await getTask;
 
             Assert.That(getMsg.BlockHashes.Count, Is.EqualTo(4));

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -414,7 +414,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public async Task Can_LimitGetBlockBodiesRequestSize()
         {
-            using BlockBodiesMessage msg4 = new( Build.A.Block.TestObjectNTimes(4));
+            using BlockBodiesMessage msg4 = new(Build.A.Block.TestObjectNTimes(4));
             Transaction signedTransaction = Build.A.Transaction.SignedAndResolved().TestObject;
             Block largerBlock = Build.A.Block.WithTransactions(Enumerable.Repeat(signedTransaction, 1000).ToArray()).TestObject;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -173,10 +173,13 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
                         return _protocolHandler;
                     }
 
+                    var nodeStatsManager = Substitute.For<INodeStatsManager>();
+                    nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns((c) => new NodeStatsLight((Node)c[0]));
+
                     _protocolHandler = new Eth63ProtocolHandler(
                         Session,
                         _serializationService,
-                        Substitute.For<INodeStatsManager>(),
+                        nodeStatsManager,
                         SyncServer,
                         RunImmediatelyScheduler.Instance,
                         Substitute.For<ITxPool>(),

--- a/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.State.Snap;
 using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -47,7 +48,20 @@ public class SnapProtocolHandlerTests
             set => _messageSerializationService = value;
         }
 
-        public INodeStatsManager NodeStatsManager { get; set; } = Substitute.For<INodeStatsManager>();
+        private INodeStatsManager? _nodeStatsManager;
+        public INodeStatsManager NodeStatsManager
+        {
+            get
+            {
+                if (_nodeStatsManager is null)
+                {
+                    _nodeStatsManager = Substitute.For<INodeStatsManager>();
+                    _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns((c) => new NodeStatsLight((Node)c[0]));
+                }
+                return _nodeStatsManager;
+            }
+            set => _nodeStatsManager = value;
+        }
 
 
         private SnapProtocolHandler? _snapProtocolHandler;
@@ -68,6 +82,7 @@ public class SnapProtocolHandlerTests
         public TimeSpan SimulatedLatency { get; set; } = TimeSpan.Zero;
 
         private readonly List<long> _recordedResponseBytesLength = new();
+
         public Context WithResponseBytesRecorder
         {
             get

--- a/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
@@ -130,12 +130,12 @@ public class SnapProtocolHandlerTests
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldIncrease();
 
-        ctx.SimulatedLatency = SnapProtocolHandler.LowerLatencyThreshold + TimeSpan.FromMilliseconds(1);
+        ctx.SimulatedLatency = TimeSpan.FromMilliseconds(2001);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldNotChange();
 
-        ctx.SimulatedLatency = SnapProtocolHandler.UpperLatencyThreshold + TimeSpan.FromMilliseconds(1);
+        ctx.SimulatedLatency = TimeSpan.FromMilliseconds(3501);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldDecrease();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -88,7 +88,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 return new OwnedBlockBodies([]);
             }
 
-            OwnedBlockBodies blocks = await _nodeStats.RunSizeAndLatencyRequestSizer(RequestType.Bodies, blockHashes, async clampedBlockHashes =>
+            OwnedBlockBodies blocks = await _nodeStats.RunSizeAndLatencyRequestSizer<OwnedBlockBodies, Hash256, BlockBody?>(RequestType.Bodies, blockHashes, async clampedBlockHashes =>
                 await SendRequest(new GetBlockBodiesMessage(clampedBlockHashes), token));
 
             return blocks;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -57,23 +57,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected readonly MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader?>> _headersRequests;
         protected readonly MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests;
 
-        private readonly LatencyAndMessageSizeBasedRequestSizer _bodiesRequestSizer = new(
-            minRequestLimit: 1,
-            maxRequestLimit: 128,
-
-            // In addition to the byte limit, we also try to keep the latency of the get block bodies between these two
-            // watermark. This reduce timeout rate, and subsequently disconnection rate.
-            lowerLatencyWatermark: TimeSpan.FromMilliseconds(2000),
-            upperLatencyWatermark: TimeSpan.FromMilliseconds(3000),
-
-            // When the bodies message size exceed this, we try to reduce the maximum number of block for this peer.
-            // This is for BeSU and Reth which does not seems to use the 2MB soft limit, causing them to send 20MB of bodies
-            // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
-            // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
-            maxResponseSize: 3_000_000,
-            initialRequestSize: 4
-        );
-
         protected ClockKeyCache<ValueHash256>? _notifiedTransactions;
         protected ClockKeyCache<ValueHash256> NotifiedTransactions => _notifiedTransactions ??= new(2 * MemoryAllowance.MemPoolSize);
 
@@ -90,7 +73,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             _txDecoder = TxDecoder.Instance;
             _headersRequests = new MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
             _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
-
         }
 
         public void Disconnect(DisconnectReason reason, string details)
@@ -106,7 +88,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 return new OwnedBlockBodies([]);
             }
 
-            OwnedBlockBodies blocks = await _bodiesRequestSizer.Run(blockHashes, async clampedBlockHashes =>
+            OwnedBlockBodies blocks = await _nodeStats.RunSizeAndLatencyRequestSizer(RequestType.Bodies, blockHashes, async clampedBlockHashes =>
                 await SendRequest(new GetBlockBodiesMessage(clampedBlockHashes), token));
 
             return blocks;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
     public abstract class ZeroProtocolHandlerBase(ISession session, INodeStatsManager nodeStats, IMessageSerializationService serializer, ILogManager logManager)
         : ProtocolHandlerBase(session, nodeStats, serializer, logManager), IZeroProtocolHandler
     {
+        protected readonly INodeStats _nodeStats = nodeStats.GetOrAdd(session.Node);
+
         public override void HandleMessage(Packet message)
         {
             ZeroPacket zeroPacket = new(message);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -29,23 +29,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
 
         private readonly MessageQueue<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)> _receiptsRequests;
 
-        private readonly LatencyAndMessageSizeBasedRequestSizer _receiptsRequestSizer = new(
-            minRequestLimit: 1,
-            maxRequestLimit: 128,
-
-            // In addition to the byte limit, we also try to keep the latency of the get receipts between these two
-            // watermark. This reduce timeout rate, and subsequently disconnection rate.
-            lowerLatencyWatermark: TimeSpan.FromMilliseconds(2000),
-            upperLatencyWatermark: TimeSpan.FromMilliseconds(3000),
-
-            // When the receipts message size exceed this, we try to reduce the maximum number of block for this peer.
-            // This is for BeSU and Reth which does not seems to use the 2MB soft limit, causing them to send 20MB of bodies
-            // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
-            // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
-            maxResponseSize: 3_000_000,
-            initialRequestSize: 8
-        );
-
         public Eth63ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
             INodeStatsManager nodeStatsManager,
@@ -151,7 +134,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 return ArrayPoolList<TxReceipt[]>.Empty();
             }
 
-            IOwnedReadOnlyList<TxReceipt[]> txReceipts = await _receiptsRequestSizer.Run(blockHashes, async clampedBlockHashes =>
+            IOwnedReadOnlyList<TxReceipt[]> txReceipts = await _nodeStats.RunSizeAndLatencyRequestSizer(RequestType.Receipts, blockHashes, async clampedBlockHashes =>
                 await SendRequest(new GetReceiptsMessage(clampedBlockHashes.ToPooledList()), token));
 
             return txReceipts;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -134,7 +134,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 return ArrayPoolList<TxReceipt[]>.Empty();
             }
 
-            IOwnedReadOnlyList<TxReceipt[]> txReceipts = await _nodeStats.RunSizeAndLatencyRequestSizer(RequestType.Receipts, blockHashes, async clampedBlockHashes =>
+            IOwnedReadOnlyList<TxReceipt[]> txReceipts = await _nodeStats.RunSizeAndLatencyRequestSizer<IOwnedReadOnlyList<TxReceipt[]>, Hash256, TxReceipt[]>(RequestType.Receipts, blockHashes, async clampedBlockHashes =>
                 await SendRequest(new GetReceiptsMessage(clampedBlockHashes.ToPooledList()), token));
 
             return txReceipts;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -28,16 +28,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 {
     public class SnapProtocolHandler : ZeroProtocolHandlerBase, ISnapSyncPeer
     {
-        public static TimeSpan LowerLatencyThreshold = TimeSpan.FromMilliseconds(2000);
-        public static TimeSpan UpperLatencyThreshold = TimeSpan.FromMilliseconds(3500);
         private static readonly TrieNodesMessage EmptyTrieNodesMessage = new TrieNodesMessage(ArrayPoolList<byte[]>.Empty());
-
-        private readonly LatencyBasedRequestSizer _requestSizer = new(
-            minRequestLimit: 50000,
-            maxRequestLimit: 3_000_000,
-            lowerWatermark: LowerLatencyThreshold,
-            upperWatermark: UpperLatencyThreshold
-        );
 
         private ISnapServer? SyncServer { get; }
         private BackgroundTaskSchedulerWrapper BackgroundTaskScheduler { get; }
@@ -272,7 +263,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         public async Task<AccountsAndProofs> GetAccountRange(AccountRange range, CancellationToken token)
         {
-            AccountRangeMessage response = await _requestSizer.MeasureLatency(bytesLimit =>
+            AccountRangeMessage response = await _nodeStats.RunLatencyRequestSizer(RequestType.SnapRanges, bytesLimit =>
                 SendRequest(new GetAccountRangeMessage()
                 {
                     AccountRange = range,
@@ -284,7 +275,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         public async Task<SlotsAndProofs> GetStorageRange(StorageRange range, CancellationToken token)
         {
-            StorageRangeMessage response = await _requestSizer.MeasureLatency(bytesLimit =>
+            StorageRangeMessage response = await _nodeStats.RunLatencyRequestSizer(RequestType.SnapRanges, bytesLimit =>
                 SendRequest(new GetStorageRangeMessage()
                 {
                     StorageRange = range,
@@ -296,7 +287,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         public async Task<IOwnedReadOnlyList<byte[]>> GetByteCodes(IReadOnlyList<ValueHash256> codeHashes, CancellationToken token)
         {
-            ByteCodesMessage response = await _requestSizer.MeasureLatency(bytesLimit =>
+            ByteCodesMessage response = await _nodeStats.RunLatencyRequestSizer(RequestType.SnapRanges, bytesLimit =>
                 SendRequest(new GetByteCodesMessage
                 {
                     Hashes = codeHashes.ToPooledList(),
@@ -320,7 +311,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         private async Task<IOwnedReadOnlyList<byte[]>> GetTrieNodes(Hash256 rootHash, IOwnedReadOnlyList<PathGroup> groups, CancellationToken token)
         {
-            TrieNodesMessage response = await _requestSizer.MeasureLatency((bytesLimit) =>
+            TrieNodesMessage response = await _nodeStats.RunLatencyRequestSizer(RequestType.SnapRanges, bytesLimit =>
                 SendRequest(new GetTrieNodesMessage
                 {
                     RootHash = rootHash,

--- a/src/Nethermind/Nethermind.Serialization.Rlp/OwnedBlockBodies.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/OwnedBlockBodies.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 
@@ -13,7 +15,7 @@ namespace Nethermind.Core;
 /// BlockBody may contain `Memory<byte>` that is explicitly managed. Reusing `BlockBody` from this object after Dispose
 /// is likely to cause corrupted `BlockBody`.
 /// </summary>
-public class OwnedBlockBodies : IDisposable
+public class OwnedBlockBodies : IDisposable, IReadOnlyList<BlockBody?>
 {
     private readonly BlockBody?[]? _rawBodies = null;
 
@@ -67,4 +69,24 @@ public class OwnedBlockBodies : IDisposable
         _memoryOwner?.Dispose();
         _memoryOwner = null;
     }
+
+    public IEnumerator<BlockBody?> GetEnumerator()
+    {
+        foreach (var blockBody in _rawBodies)
+        {
+            yield return blockBody;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        foreach (var blockBody in _rawBodies)
+        {
+            yield return blockBody;
+        }
+    }
+
+    public int Count => _rawBodies.Length;
+
+    public BlockBody? this[int index] => _rawBodies[index];
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -31,7 +31,6 @@ public class BodiesSyncFeedTests
     private IBlockTree _syncingFromBlockTree = null!;
     private IBlockTree _syncingToBlockTree = null!;
     private TestMemDb _blocksDb = null!;
-    private INodeStatsManager _nodeStatsManager = null!;
     private ISyncPointers _syncPointers = null!;
     private BodiesSyncFeed _feed = null!;
     private ISyncConfig _syncConfig = null!;
@@ -69,14 +68,12 @@ public class BodiesSyncFeedTests
             DownloadBodiesInFastSync = true,
         };
         _syncingToBlockTree.SyncPivot = (_pivotBlock.Number, _pivotBlock.Hash);
-        _nodeStatsManager = Substitute.For<INodeStatsManager>();
 
         _feed = new BodiesSyncFeed(
             MainnetSpecProvider.Instance,
             _syncingToBlockTree,
             _syncPointers,
             Substitute.For<ISyncPeerPool>(),
-            _nodeStatsManager,
             _syncConfig,
             new NullSyncReport(),
             _blocksDb,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
@@ -14,6 +15,8 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Specs;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -28,6 +31,7 @@ public class BodiesSyncFeedTests
     private IBlockTree _syncingFromBlockTree = null!;
     private IBlockTree _syncingToBlockTree = null!;
     private TestMemDb _blocksDb = null!;
+    private INodeStatsManager _nodeStatsManager = null!;
     private ISyncPointers _syncPointers = null!;
     private BodiesSyncFeed _feed = null!;
     private ISyncConfig _syncConfig = null!;
@@ -65,12 +69,14 @@ public class BodiesSyncFeedTests
             DownloadBodiesInFastSync = true,
         };
         _syncingToBlockTree.SyncPivot = (_pivotBlock.Number, _pivotBlock.Hash);
+        _nodeStatsManager = Substitute.For<INodeStatsManager>();
 
         _feed = new BodiesSyncFeed(
             MainnetSpecProvider.Instance,
             _syncingToBlockTree,
             _syncPointers,
             Substitute.For<ISyncPeerPool>(),
+            _nodeStatsManager,
             _syncConfig,
             new NullSyncReport(),
             _blocksDb,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -19,10 +19,12 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.State.Repositories;
+using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Peers.AllocationStrategies;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Synchronization.SyncLimits;
 using NSubstitute;
@@ -807,6 +809,35 @@ public class FastHeadersSyncTests
 
         Action act = () => feed.InitializeFeed();
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Should_Limit_BatchSize_ToEstimate()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+        using HeadersSyncFeed feed = new(
+            blockTree: blockTree,
+            syncPeerPool: syncPeerPool,
+            syncConfig: new TestSyncConfig
+            {
+                FastSync = true,
+                PivotNumber = "1000",
+                PivotHash = TestItem.KeccakA.ToString(),
+                PivotTotalDifficulty = "1000",
+            },
+            syncReport: new NullSyncReport(),
+            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy(),
+            poSSwitcher: Substitute.For<IPoSSwitcher>(),
+            logManager: LimboLogs.Instance);
+        blockTree.SyncPivot.Returns((1000, TestItem.KeccakB));
+
+        syncPeerPool.EstimateRequestLimit(RequestType.Headers, Arg.Any<IPeerAllocationStrategy>(), AllocationContexts.Headers, default)
+            .Returns(Task.FromResult<int?>(5));
+
+        feed.InitializeFeed();
+        HeadersSyncBatch? req = await feed.PrepareRequest(default);
+        req!.RequestSize.Should().Be(5);
     }
 
     private class ResettableHeaderSyncFeed : HeadersSyncFeed

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -75,6 +75,12 @@ public class SyncDispatcherTests
         {
         }
 
+        public Task<int?> EstimateRequestLimit(RequestType bodies, IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts blocks,
+            CancellationToken token)
+        {
+            return Task.FromResult<int?>(null);
+        }
+
         public Task<int?> EstimateRequestLimit(RequestType bodies, FastBlocksAllocationStrategy approximateAllocationStrategy,
             AllocationContexts blocks, CancellationToken token)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
@@ -74,9 +75,10 @@ public class SyncDispatcherTests
         {
         }
 
-        public int GetCurrentRequestLimit(PeerInfo peerInfo, RequestType requestType)
+        public Task<int?> EstimateRequestLimit(RequestType bodies, FastBlocksAllocationStrategy approximateAllocationStrategy,
+            AllocationContexts blocks, CancellationToken token)
         {
-            return 1024;
+            return Task.FromResult<int?>(null);
         }
 
         public void WakeUpAll()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -81,12 +81,6 @@ public class SyncDispatcherTests
             return Task.FromResult<int?>(null);
         }
 
-        public Task<int?> EstimateRequestLimit(RequestType bodies, FastBlocksAllocationStrategy approximateAllocationStrategy,
-            AllocationContexts blocks, CancellationToken token)
-        {
-            return Task.FromResult<int?>(null);
-        }
-
         public void WakeUpAll()
         {
             throw new NotImplementedException();

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -74,6 +74,11 @@ public class SyncDispatcherTests
         {
         }
 
+        public int GetCurrentRequestLimit(PeerInfo peerInfo, RequestType requestType)
+        {
+            return 1024;
+        }
+
         public void WakeUpAll()
         {
             throw new NotImplementedException();

--- a/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
@@ -15,9 +15,11 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Specs;
+using Nethermind.Stats;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Peers.AllocationStrategies;
 using Nethermind.Synchronization.Reporting;
 using NSubstitute;
 using NUnit.Framework;
@@ -33,6 +35,7 @@ public class ReceiptSyncFeedTests
     private Block _pivotBlock = null!;
     private InMemoryReceiptStorage _syncingFromReceiptStore;
     private IReceiptStorage _receiptStorage;
+    private ISyncPeerPool _syncPeerPool = null!;
 
     [SetUp]
     public void Setup()
@@ -66,12 +69,13 @@ public class ReceiptSyncFeedTests
         };
         _syncingToBlockTree.SyncPivot = (_pivotBlock.Number, _pivotBlock.Hash);
 
+        _syncPeerPool = Substitute.For<ISyncPeerPool>();
         _feed = new ReceiptsSyncFeed(
             MainnetSpecProvider.Instance,
             _syncingToBlockTree,
             _receiptStorage,
             new MemorySyncPointers(),
-            Substitute.For<ISyncPeerPool>(),
+            _syncPeerPool,
             _syncConfig,
             new NullSyncReport(),
             new MemDb(),
@@ -83,6 +87,7 @@ public class ReceiptSyncFeedTests
     public void TearDown()
     {
         _feed.Dispose();
+        _syncPeerPool.DisposeAsync();
     }
 
     [Test]
@@ -128,5 +133,15 @@ public class ReceiptSyncFeedTests
                 _pivotBlock.Number - 3,
                 // Skipped
                 _pivotBlock.Number - 5]);
+    }
+
+    [Test]
+    public async Task ShouldLimitBatchSizeToPeerEstimate()
+    {
+        _feed.InitializeFeed();
+        _syncPeerPool.EstimateRequestLimit(RequestType.Receipts, Arg.Any<IPeerAllocationStrategy>(), AllocationContexts.Receipts, default)
+            .Returns(Task.FromResult<int?>(5));
+        ReceiptsSyncBatch req = (await _feed.PrepareRequest())!;
+        req.Infos.Length.Should().Be(5);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -38,7 +38,6 @@ namespace Nethermind.Synchronization.FastBlocks
         private readonly ISyncConfig _syncConfig;
         private readonly ISyncReport _syncReport;
         private readonly ISyncPeerPool _syncPeerPool;
-        private readonly INodeStatsManager _nodeStatsManager;
         private readonly ISyncPointers _syncPointers;
         private readonly IDb _blocksDb;
 
@@ -54,7 +53,6 @@ namespace Nethermind.Synchronization.FastBlocks
             IBlockTree blockTree,
             ISyncPointers syncPointers,
             ISyncPeerPool syncPeerPool,
-            INodeStatsManager nodeStatsManager,
             ISyncConfig syncConfig,
             ISyncReport syncReport,
             [KeyFilter(DbNames.Blocks)] IDb blocksDb,
@@ -66,7 +64,6 @@ namespace Nethermind.Synchronization.FastBlocks
             _blockTree = blockTree;
             _syncPointers = syncPointers;
             _syncPeerPool = syncPeerPool;
-            _nodeStatsManager = nodeStatsManager;
             _syncConfig = syncConfig;
             _syncReport = syncReport;
             _blocksDb = blocksDb;
@@ -142,8 +139,8 @@ namespace Nethermind.Synchronization.FastBlocks
                 SyncPeerAllocation syncPeerAllocation = await _syncPeerPool.Allocate(_approximateAllocationStrategy, AllocationContexts.Blocks, 1000, token);
                 if (syncPeerAllocation is not null && syncPeerAllocation.HasPeer)
                 {
-                    requestSize = _nodeStatsManager.GetCurrentRequestLimit(
-                        syncPeerAllocation.Current!.SyncPeer.Node,
+                    requestSize = _syncPeerPool.GetCurrentRequestLimit(
+                        syncPeerAllocation.Current!,
                         RequestType.Bodies);
                     _syncPeerPool.Free(syncPeerAllocation);
                 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -135,7 +135,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
                 // Set the request size depending on the approximate allocation strategy.
                 int requestSize =
-                    (await _syncPeerPool.EstimateRequestLimit(RequestType.Bodies, _approximateAllocationStrategy, AllocationContexts.Blocks, token))
+                    (await _syncPeerPool.EstimateRequestLimit(RequestType.Bodies, _approximateAllocationStrategy, AllocationContexts.Bodies, token))
                     ?? GethSyncLimits.MaxBodyFetch;
 
                 while (!_syncStatusList.TryGetInfosForBatch(requestSize, (info) =>

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -133,17 +133,10 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 BlockInfo?[] infos = null;
 
-                int requestSize = GethSyncLimits.MaxBodyFetch;
-
                 // Set the request size depending on the approximate allocation strategy.
-                SyncPeerAllocation syncPeerAllocation = await _syncPeerPool.Allocate(_approximateAllocationStrategy, AllocationContexts.Blocks, 1000, token);
-                if (syncPeerAllocation is not null && syncPeerAllocation.HasPeer)
-                {
-                    requestSize = _syncPeerPool.GetCurrentRequestLimit(
-                        syncPeerAllocation.Current!,
-                        RequestType.Bodies);
-                    _syncPeerPool.Free(syncPeerAllocation);
-                }
+                int requestSize =
+                    (await _syncPeerPool.EstimateRequestLimit(RequestType.Bodies, _approximateAllocationStrategy, AllocationContexts.Blocks, token))
+                    ?? GethSyncLimits.MaxBodyFetch;
 
                 while (!_syncStatusList.TryGetInfosForBatch(requestSize, (info) =>
                        {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -346,9 +346,9 @@ namespace Nethermind.Synchronization.FastBlocks
                 else if (ShouldBuildANewBatch())
                 {
                     // Set the request size depending on the approximate allocation strategy.
-                    // NOTE: Cannot async because of the lock.
+                    // NOTE: Cannot await because of the lock.
                     int requestSize =
-                        _syncPeerPool.EstimateRequestLimit(RequestType.Headers, _approximateAllocationStrategy, AllocationContexts.Receipts, cancellationToken).Result
+                        _syncPeerPool.EstimateRequestLimit(RequestType.Headers, _approximateAllocationStrategy, AllocationContexts.Headers, cancellationToken).Result
                         ?? GethSyncLimits.MaxHeaderFetch;
 
                     batch = ProcessPersistedHeadersOrBuildNewBatch(requestSize, cancellationToken);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -19,6 +19,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
+using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -37,10 +38,10 @@ namespace Nethermind.Synchronization.FastBlocks
         protected readonly ISyncConfig _syncConfig;
         private readonly IPoSSwitcher _poSSwitcher;
         private readonly ITotalDifficultyStrategy _totalDifficultyStrategy;
+        private FastBlocksAllocationStrategy _approximateAllocationStrategy = new FastBlocksAllocationStrategy(TransferSpeedType.Headers, 0, false);
 
         private readonly Lock _handlerLock = new();
 
-        private readonly int _headersRequestSize = GethSyncLimits.MaxHeaderFetch;
         private readonly ulong _fastHeadersMemoryBudget;
         protected long _lowestRequestedHeaderNumber;
 
@@ -166,11 +167,6 @@ namespace Nethermind.Synchronization.FastBlocks
             _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
             _totalDifficultyStrategy = totalDifficultyStrategy ?? new CumulativeTotalDifficultyStrategy();
             _fastHeadersMemoryBudget = syncConfig.FastHeadersMemoryBudget;
-
-            if (!_syncConfig.UseGethLimitsInFastBlocks)
-            {
-                _headersRequestSize = NethermindSyncLimits.MaxHeaderFetch;
-            }
 
             if (!_syncConfig.FastSync && !alwaysStartHeaderSync)
             {
@@ -349,7 +345,21 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
                 else if (ShouldBuildANewBatch())
                 {
-                    batch = ProcessPersistedHeadersOrBuildNewBatch(cancellationToken);
+                    int requestSize = GethSyncLimits.MaxHeaderFetch;
+
+                    // Set the request size depending on the approximate allocation strategy.
+                    // NOTE: Cannot async because of the lock.
+                    SyncPeerAllocation syncPeerAllocation = _syncPeerPool.Allocate(_approximateAllocationStrategy,
+                        AllocationContexts.Headers, 1000, cancellationToken).Result;
+                    if (syncPeerAllocation is not null && syncPeerAllocation.HasPeer)
+                    {
+                        requestSize = _syncPeerPool.GetCurrentRequestLimit(
+                            syncPeerAllocation.Current!,
+                            RequestType.Headers);
+                        _syncPeerPool.Free(syncPeerAllocation);
+                    }
+
+                    batch = ProcessPersistedHeadersOrBuildNewBatch(requestSize, cancellationToken);
                     if (_logger.IsTrace) _logger.Trace($"New batch {batch}");
                 }
 
@@ -372,12 +382,12 @@ namespace Nethermind.Synchronization.FastBlocks
             }
         }
 
-        private HeadersSyncBatch? ProcessPersistedHeadersOrBuildNewBatch(CancellationToken cancellationToken)
+        private HeadersSyncBatch? ProcessPersistedHeadersOrBuildNewBatch(int requestSize, CancellationToken cancellationToken)
         {
             HeadersSyncBatch? batch = null;
             do
             {
-                batch = BuildNewBatch();
+                batch = BuildNewBatch(requestSize);
                 batch = ProcessPersistedPortion(batch);
 
                 if (batch is null)
@@ -394,11 +404,11 @@ namespace Nethermind.Synchronization.FastBlocks
             return batch;
         }
 
-        private HeadersSyncBatch BuildNewBatch()
+        private HeadersSyncBatch BuildNewBatch(int requestSize)
         {
             HeadersSyncBatch batch = new();
-            batch.StartNumber = Math.Max(HeadersDestinationNumber, _lowestRequestedHeaderNumber - _headersRequestSize);
-            batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber, _headersRequestSize);
+            batch.StartNumber = Math.Max(HeadersDestinationNumber, _lowestRequestedHeaderNumber - requestSize);
+            batch.RequestSize = (int)Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber, requestSize);
             _lowestRequestedHeaderNumber = batch.StartNumber;
             return batch;
         }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -35,7 +36,7 @@ namespace Nethermind.Synchronization.FastBlocks
         protected override Func<bool> HasPivot =>
             () => _receiptStorage.HasBlock(_blockTree.SyncPivot.BlockNumber, _blockTree.SyncPivot.BlockHash);
 
-        private int _requestSize = GethSyncLimits.MaxReceiptFetch;
+        private FastBlocksAllocationStrategy _approximateAllocationStrategy = new FastBlocksAllocationStrategy(TransferSpeedType.Receipts, 0, true);
 
         private readonly IBlockTree _blockTree;
         private readonly ISyncConfig _syncConfig;
@@ -127,13 +128,25 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport.FastBlocksReceipts.MarkEnd();
         }
 
-        public override Task<ReceiptsSyncBatch?> PrepareRequest(CancellationToken token = default)
+        public override async Task<ReceiptsSyncBatch?> PrepareRequest(CancellationToken token = default)
         {
             ReceiptsSyncBatch? batch = null;
             if (ShouldBuildANewBatch())
             {
+                int requestSize = GethSyncLimits.MaxReceiptFetch;
+
+                // Set the request size depending on the approximate allocation strategy.
+                SyncPeerAllocation syncPeerAllocation = await _syncPeerPool.Allocate(_approximateAllocationStrategy, AllocationContexts.Receipts, 1000, token);
+                if (syncPeerAllocation is not null && syncPeerAllocation.HasPeer)
+                {
+                    requestSize = _syncPeerPool.GetCurrentRequestLimit(
+                        syncPeerAllocation.Current!,
+                        RequestType.Receipts);
+                    _syncPeerPool.Free(syncPeerAllocation);
+                }
+
                 BlockInfo?[] infos = null;
-                while (!_syncStatusList.TryGetInfosForBatch(_requestSize, (info) =>
+                while (!_syncStatusList.TryGetInfosForBatch(requestSize, (info) =>
                        {
                            bool hasReceipt = _receiptStorage.HasBlock(info.BlockNumber, info.BlockHash);
                            if (hasReceipt) _syncReport.FastBlocksReceipts.IncrementSkipped();
@@ -156,7 +169,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
             _syncPointers.LowestInsertedReceiptBlockNumber = _syncStatusList.LowestInsertWithoutGaps;
 
-            return Task.FromResult(batch);
+            return batch;
         }
 
         public override SyncResponseHandlingResult HandleResponse(ReceiptsSyncBatch? batch, PeerInfo peer = null)
@@ -290,7 +303,6 @@ namespace Nethermind.Synchronization.FastBlocks
             }
 
             UpdateSyncReport();
-            AdjustRequestSize(batch, validResponsesCount);
             LogPostProcessingBatchInfo(batch, validResponsesCount);
             return validResponsesCount;
         }
@@ -306,23 +318,6 @@ namespace Nethermind.Synchronization.FastBlocks
         {
             _syncReport.FastBlocksReceipts.Update(_pivotNumber - _syncStatusList.LowestInsertWithoutGaps);
             _syncReport.FastBlocksReceipts.CurrentQueued = _syncStatusList.QueueSize;
-        }
-
-        private void AdjustRequestSize(ReceiptsSyncBatch batch, int validResponsesCount)
-        {
-            int currentRequestSize = Volatile.Read(ref _requestSize);
-            int requestSize = currentRequestSize;
-            if (validResponsesCount == batch.Infos.Length)
-            {
-                requestSize = Math.Min(256, currentRequestSize * 2);
-            }
-
-            if (validResponsesCount == 0)
-            {
-                requestSize = Math.Max(4, currentRequestSize / 2);
-            }
-
-            Interlocked.CompareExchange(ref _requestSize, requestSize, currentRequestSize);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
+using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
 
 namespace Nethermind.Synchronization.Peers
@@ -31,7 +32,15 @@ namespace Nethermind.Synchronization.Peers
 
         void ReportWeakPeer(PeerInfo peerInfo, AllocationContexts allocationContexts);
 
-        int GetCurrentRequestLimit(PeerInfo peerInfo, RequestType requestType);
+        /// <summary>
+        /// Estimate the request limit for a specific request type for the peer which get allocated next based
+        /// on the allocation strategy and context. May not be accurate as different peer may get allocated.
+        /// </summary>
+        Task<int?> EstimateRequestLimit(
+            RequestType bodies,
+            FastBlocksAllocationStrategy approximateAllocationStrategy,
+            AllocationContexts blocks,
+            CancellationToken token);
 
         /// <summary>
         /// Wakes up all the sleeping peers.

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -9,6 +9,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
 
@@ -29,6 +30,8 @@ namespace Nethermind.Synchronization.Peers
         void ReportBreachOfProtocol(PeerInfo peerInfo, DisconnectReason disconnectReason, string details);
 
         void ReportWeakPeer(PeerInfo peerInfo, AllocationContexts allocationContexts);
+
+        int GetCurrentRequestLimit(PeerInfo peerInfo, RequestType requestType);
 
         /// <summary>
         /// Wakes up all the sleeping peers.

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Synchronization.Peers
         /// </summary>
         Task<int?> EstimateRequestLimit(
             RequestType bodies,
-            FastBlocksAllocationStrategy approximateAllocationStrategy,
+            IPeerAllocationStrategy peerAllocationStrategy,
             AllocationContexts blocks,
             CancellationToken token);
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -125,6 +125,11 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
+        public int GetCurrentRequestLimit(PeerInfo peerInfo, RequestType requestType)
+        {
+            return _stats.GetOrAdd(peerInfo.SyncPeer.Node).GetCurrentRequestLimit(requestType);
+        }
+
         public void Start()
         {
             _refreshLoopTask = Task.Factory.StartNew(

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
-        public async Task<int?> EstimateRequestLimit(RequestType requestType, FastBlocksAllocationStrategy allocationStrategy, AllocationContexts context, CancellationToken token)
+        public async Task<int?> EstimateRequestLimit(RequestType requestType, IPeerAllocationStrategy allocationStrategy, AllocationContexts context, CancellationToken token)
         {
             // So, to know which peer is next, we just try to allocate it, and then free it back.
             SyncPeerAllocation syncPeerAllocation = await Allocate(allocationStrategy, context, 1000, token);

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -218,7 +218,6 @@ namespace Nethermind.Synchronization.SnapSync
         {
             Interlocked.Increment(ref _activeStorageRequests);
 
-
             ArrayPoolList<PathWithAccount> storagesToQuery = new(STORAGE_BATCH_SIZE);
             for (int i = 0; i < STORAGE_BATCH_SIZE && StoragesToRetrieve.TryDequeue(out PathWithAccount storage); i++)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -218,6 +218,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             Interlocked.Increment(ref _activeStorageRequests);
 
+
             ArrayPoolList<PathWithAccount> storagesToQuery = new(STORAGE_BATCH_SIZE);
             for (int i = 0; i < STORAGE_BATCH_SIZE && StoragesToRetrieve.TryDequeue(out PathWithAccount storage); i++)
             {


### PR DESCRIPTION
- To reduce timeout and high allocation, we limit the size of the bodies, receipts and snap request at protocol handler level.
- This information however is not exposed to the sync code, so sync code still try to request in a large batch, potentially causing a large portion of the request to be retried later.
- This is not a big deal for downloads that is paralelizable, bit it can be a problem for sync that requires order. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- No change in performance, but helpful for #8255 