### PR TITLE
Fix broken Engine API documentation link in error message

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -201,7 +201,7 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
         if (!hasEngineApiConfigured)
         {
             throw new InvalidConfigurationException(
-                "Engine module wasn't configured on any port. Nethermind can't work without engine port configured. Verify your RPC configuration. You can find examples in our docs: https://docs.nethermind.io/nethermind/ethereum-client/engine-jsonrpc-configuration-examples",
+                "Engine module wasn't configured on any port. Nethermind can't work without engine port configured. Verify your RPC configuration. You can find examples in our docs: https://docs.nethermind.io/interacting/json-rpc-server/#engine-api",
                 ExitCodes.NoEngineModule);
         }
     }


### PR DESCRIPTION
Related:
Closes [#8171](https://github.com/NethermindEth/nethermind/issues/8171)

What was changed:
Replaced the outdated and broken documentation link shown in the Engine API misconfiguration error message with a working one:

Old (404): https://docs.nethermind.io/nethermind/ethereum-client/engine-jsonrpc-configuration-examples

New (valid): https://docs.nethermind.io/interacting/json-rpc-server/#engine-api

Why:
The original link pointed to a non-existent page, which could confuse users trying to configure the Engine API.
This fix ensures the error message now points to the correct setup guide.


