### PR TITLE
Use ArgumentNullException.ThrowIfNull

### DIFF
--- a/src/Nethermind/Nethermind.Era1/EraPathUtils.cs
+++ b/src/Nethermind/Nethermind.Era1/EraPathUtils.cs
@@ -42,9 +42,9 @@ public static class EraPathUtils
 
     public static string Filename(string network, long epoch, Hash256 root)
     {
-        if (string.IsNullOrEmpty(network)) throw new ArgumentException($"'{nameof(network)}' cannot be null or empty.", nameof(network));
-        if (root is null) throw new ArgumentNullException(nameof(root));
-        if (epoch < 0) throw new ArgumentOutOfRangeException(nameof(epoch), "Cannot be a negative number.");
+        ArgumentNullException.ThrowIfNullOrEmpty(network);
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentOutOfRangeException.ThrowIfLessThan(epoch, 0);
 
         return $"{network}-{epoch.ToString("D5")}-{root.ToString(true)[2..10]}.era1";
     }

--- a/src/Nethermind/Nethermind.Era1/EraReader.cs
+++ b/src/Nethermind/Nethermind.Era1/EraReader.cs
@@ -69,7 +69,7 @@ public class EraReader : IAsyncEnumerable<(Block, TxReceipt[])>, IDisposable
     /// <returns>Returns <see cref="true"/> if the expected accumulator matches, and <see cref="false"/> if there is no match.</returns>
     public async Task<ValueHash256> VerifyContent(ISpecProvider specProvider, IBlockValidator blockValidator, CancellationToken cancellation = default)
     {
-        if (specProvider is null) throw new ArgumentNullException(nameof(specProvider));
+        ArgumentNullException.ThrowIfNull(specProvider);
 
         ValueHash256 accumulator = ReadAccumulator();
 

--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -39,12 +39,12 @@ public class HivePlugin(IHiveConfig hiveConfig) : INethermindPlugin
 
     public async Task InitNetworkProtocol()
     {
-        if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-        if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-        if (_api.ConfigProvider is null) throw new ArgumentNullException(nameof(_api.ConfigProvider));
-        if (_api.LogManager is null) throw new ArgumentNullException(nameof(_api.LogManager));
-        if (_api.FileSystem is null) throw new ArgumentNullException(nameof(_api.FileSystem));
-        if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
+        ArgumentNullException.ThrowIfNull(_api.BlockTree);
+        ArgumentNullException.ThrowIfNull(_api.BlockProcessingQueue);
+        ArgumentNullException.ThrowIfNull(_api.ConfigProvider);
+        ArgumentNullException.ThrowIfNull(_api.LogManager);
+        ArgumentNullException.ThrowIfNull(_api.FileSystem);
+        ArgumentNullException.ThrowIfNull(_api.BlockValidator);
 
         _api.TxPool!.AcceptTxWhenNotSynced = true;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
@@ -22,20 +22,20 @@ namespace Nethermind.Merge.Plugin
         {
             if (MergeEnabled)
             {
-                if (_api.EngineSigner is null) throw new ArgumentNullException(nameof(_api.EngineSigner));
-                if (_api.ChainSpec is null) throw new ArgumentNullException(nameof(_api.ChainSpec));
-                if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-                if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-                if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-                if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
-                if (_api.RewardCalculatorSource is null) throw new ArgumentNullException(nameof(_api.RewardCalculatorSource));
-                if (_api.ReceiptStorage is null) throw new ArgumentNullException(nameof(_api.ReceiptStorage));
-                if (_api.TxPool is null) throw new ArgumentNullException(nameof(_api.TxPool));
-                if (_api.DbProvider is null) throw new ArgumentNullException(nameof(_api.DbProvider));
-                if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
-                if (_mergeBlockProductionPolicy is null) throw new ArgumentNullException(nameof(_mergeBlockProductionPolicy));
-                if (_api.SealValidator is null) throw new ArgumentNullException(nameof(_api.SealValidator));
-                if (_api.BlockProducerEnvFactory is null) throw new ArgumentNullException(nameof(_api.BlockProducerEnvFactory));
+                ArgumentNullException.ThrowIfNull(_api.EngineSigner);
+                ArgumentNullException.ThrowIfNull(_api.ChainSpec);
+                ArgumentNullException.ThrowIfNull(_api.BlockTree);
+                ArgumentNullException.ThrowIfNull(_api.BlockProcessingQueue);
+                ArgumentNullException.ThrowIfNull(_api.SpecProvider);
+                ArgumentNullException.ThrowIfNull(_api.BlockValidator);
+                ArgumentNullException.ThrowIfNull(_api.RewardCalculatorSource);
+                ArgumentNullException.ThrowIfNull(_api.ReceiptStorage);
+                ArgumentNullException.ThrowIfNull(_api.TxPool);
+                ArgumentNullException.ThrowIfNull(_api.DbProvider);
+                ArgumentNullException.ThrowIfNull(_api.HeaderValidator);
+                ArgumentNullException.ThrowIfNull(_mergeBlockProductionPolicy);
+                ArgumentNullException.ThrowIfNull(_api.SealValidator);
+                ArgumentNullException.ThrowIfNull(_api.BlockProducerEnvFactory);
 
                 if (_logger.IsInfo) _logger.Info("Starting Merge block producer & sealer");
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -215,9 +215,9 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
     {
         if (MergeEnabled)
         {
-            if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-            if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-            if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
+            ArgumentNullException.ThrowIfNull(_api.BlockTree);
+            ArgumentNullException.ThrowIfNull(_api.SpecProvider);
+            ArgumentNullException.ThrowIfNull(_api.UnclesValidator);
             if (_api.BlockProductionPolicy is null) throw new ArgumentException(nameof(_api.BlockProductionPolicy));
             if (_api.SealValidator is null) throw new ArgumentException(nameof(_api.SealValidator));
 
@@ -243,16 +243,16 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
     {
         if (MergeEnabled)
         {
-            if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-            if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
-            if (_api.EthSyncingInfo is null) throw new ArgumentNullException(nameof(_api.EthSyncingInfo));
-            if (_api.Sealer is null) throw new ArgumentNullException(nameof(_api.Sealer));
-            if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
-            if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-            if (_api.TxPool is null) throw new ArgumentNullException(nameof(_api.TxPool));
-            if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-            if (_api.StateReader is null) throw new ArgumentNullException(nameof(_api.StateReader));
-            if (_postMergeBlockProducer is null) throw new ArgumentNullException(nameof(_postMergeBlockProducer));
+            ArgumentNullException.ThrowIfNull(_api.BlockTree);
+            ArgumentNullException.ThrowIfNull(_api.HeaderValidator);
+            ArgumentNullException.ThrowIfNull(_api.EthSyncingInfo);
+            ArgumentNullException.ThrowIfNull(_api.Sealer);
+            ArgumentNullException.ThrowIfNull(_api.BlockValidator);
+            ArgumentNullException.ThrowIfNull(_api.BlockProcessingQueue);
+            ArgumentNullException.ThrowIfNull(_api.TxPool);
+            ArgumentNullException.ThrowIfNull(_api.SpecProvider);
+            ArgumentNullException.ThrowIfNull(_api.StateReader);
+            ArgumentNullException.ThrowIfNull(_postMergeBlockProducer);
 
             // ToDo: ugly temporary hack to not receive engine API messages before end of processing of all blocks after restart. Then we will wait 5s more to ensure everything is processed
             while (!_api.BlockProcessingQueue.IsEmpty)

--- a/src/Nethermind/Nethermind.Shutter/ShutterPlugin.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterPlugin.cs
@@ -58,11 +58,11 @@ public class ShutterPlugin(IShutterConfig shutterConfig, IMergeConfig mergeConfi
     {
         if (_api!.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
         if (_api.EthereumEcdsa is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-        if (_api.LogFinder is null) throw new ArgumentNullException(nameof(_api.LogFinder));
-        if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-        if (_api.ReceiptFinder is null) throw new ArgumentNullException(nameof(_api.ReceiptFinder));
-        if (_api.WorldStateManager is null) throw new ArgumentNullException(nameof(_api.WorldStateManager));
-        if (_api.IpResolver is null) throw new ArgumentNullException(nameof(_api.IpResolver));
+        ArgumentNullException.ThrowIfNull(_api.LogFinder);
+        ArgumentNullException.ThrowIfNull(_api.SpecProvider);
+        ArgumentNullException.ThrowIfNull(_api.ReceiptFinder);
+        ArgumentNullException.ThrowIfNull(_api.WorldStateManager);
+        ArgumentNullException.ThrowIfNull(_api.IpResolver);
 
         if (_logger.IsInfo) _logger.Info("Initializing Shutter block producer.");
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -153,7 +153,7 @@ namespace Nethermind.TxPool.Collections
         {
             using var lockRelease = Lock.Acquire();
 
-            if (group is null) throw new ArgumentNullException(nameof(group));
+            ArgumentNullException.ThrowIfNull(group);
             return _buckets.TryGetValue(group, out EnhancedSortedSet<TValue>? bucket) ? bucket.ToArray() : [];
         }
 
@@ -164,7 +164,7 @@ namespace Nethermind.TxPool.Collections
         {
             using var lockRelease = Lock.Acquire();
 
-            if (group is null) throw new ArgumentNullException(nameof(group));
+            ArgumentNullException.ThrowIfNull(group);
             return _buckets.TryGetValue(group, out EnhancedSortedSet<TValue>? bucket) ? bucket.Count : 0;
         }
 
@@ -592,7 +592,7 @@ namespace Nethermind.TxPool.Collections
         {
             using var lockRelease = Lock.Acquire();
 
-            if (groupKey is null) throw new ArgumentNullException(nameof(groupKey));
+            ArgumentNullException.ThrowIfNull(groupKey);
             if (_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
             {
                 Debug.Assert(bucket.Count > 0);


### PR DESCRIPTION
## Changes

- Use `ArgumentNullException.ThrowIfNull` is better for hot code than having `throw new exception` in main code

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No
