### PR TITLE
Skip block build if no new tx have been added

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -308,7 +308,7 @@ public partial class EngineModuleTests
         {
             while (!cts.IsCancellationRequested)
             {
-                TxPool.Metrics.PendingTransactionsAdded++;
+                Interlocked.Increment(ref TxPool.Metrics.PendingTransactionsAdded);
                 await Task.Delay(10);
             }
         });

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -303,12 +303,25 @@ public partial class EngineModuleTests
         Hash256 random = Keccak.Zero;
         Address feeRecipient = Address.Zero;
 
+        CancellationTokenSource cts = new();
+        Task addingTx = Task.Run(async () =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                TxPool.Metrics.PendingTransactionsAdded++;
+                await Task.Delay(10);
+            }
+        });
+
         Task waitForImprovement = chain.WaitForImprovedBlock();
         string payloadId = rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
             new PayloadAttributes { Timestamp = timestamp, SuggestedFeeRecipient = feeRecipient, PrevRandao = random }).Result.Data.PayloadId!;
         await waitForImprovement;
 
         Assert.That(() => improvementContextFactory.CreatedContexts.Count, Is.InRange(3, 5).After(timePerSlot.Milliseconds * 10, 1));
+
+        cts.Cancel();
+        await addingTx;
 
         improvementContextFactory.CreatedContexts.Take(improvementContextFactory.CreatedContexts.Count - 1).Should().OnlyContain(static i => i.Disposed);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -149,7 +149,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
         if (_logger.IsTrace) _logger.Trace($"Start improving block from payload {payloadId} with parent {parentHeader.ToString(BlockHeader.Format.FullHashAndNumber)}");
 
         long startTimestamp = Stopwatch.GetTimestamp();
-        long added = TxPool.Metrics.PendingTransactionsAdded;
+        long added = Volatile.Read(ref TxPool.Metrics.PendingTransactionsAdded);
         IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime, currentBlockFees, cts);
         blockImprovementContext.ImprovementTask.ContinueWith(
             (b) =>
@@ -187,7 +187,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
 
                 // Loop the delay if no new txs have been added, and while not cancelled.
                 // Is no point in rebuilding an identical block.
-            } while (added == TxPool.Metrics.PendingTransactionsAdded);
+            } while (added == Volatile.Read(ref TxPool.Metrics.PendingTransactionsAdded));
 
             if (!token.IsCancellationRequested || !blockImprovementContext.Disposed) // if GetPayload wasn't called for this item or it wasn't cleared
             {

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -104,7 +104,7 @@ namespace Nethermind.TxPool
 
         [CounterMetric]
         [Description("Number of pending transactions added to transaction pool.")]
-        public static long PendingTransactionsAdded { get; set; }
+        public static long PendingTransactionsAdded;
 
         [CounterMetric]
         [Description("Number of pending 1559-type transactions added to transaction pool.")]

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -563,7 +563,7 @@ namespace Nethermind.TxPool
             }
 
             relevantPool.UpdateGroup(tx.SenderAddress!, state.SenderAccount, _updateBucketAdded);
-            Metrics.PendingTransactionsAdded++;
+            Interlocked.Increment(ref Metrics.PendingTransactionsAdded);
             if (tx.Supports1559) { Metrics.Pending1559TransactionsAdded++; }
             if (tx.SupportsBlobs) { Metrics.PendingBlobTransactionsAdded++; }
 


### PR DESCRIPTION
## Changes

- If no new txs have been added to pool since last block build; skip the improvement and wait for next delay.
- Is no reason to build a block if it will build the same as previous

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] Yes - modified existing test