### PR TITLE
Add timeout to node filter

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
@@ -10,7 +10,6 @@ using FluentAssertions;
 using MathNet.Numerics.Random;
 using Nethermind.Config;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
@@ -86,7 +85,7 @@ public class NodeLifecycleManagerTests
         _discoveryManager.MsgSender = udpClient;
 
         _discoveryManagerMock = Substitute.For<IDiscoveryManager>();
-        _discoveryManagerMock.NodesFilter.Returns(new ClockKeyCache<IDiscoveryManager.IpAddressAsKey>(16));
+        _discoveryManagerMock.NodesFilter.Returns(new NodeFilter(16));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -27,7 +26,7 @@ public class DiscoveryManager : IDiscoveryManager
     private readonly ConcurrentDictionary<Hash256, INodeLifecycleManager> _nodeLifecycleManagers = new();
     private readonly INodeTable _nodeTable;
     private readonly INetworkStorage _discoveryStorage;
-    public ClockKeyCache<IDiscoveryManager.IpAddressAsKey> NodesFilter { get; }
+    public NodeFilter NodesFilter { get; }
 
     private readonly ConcurrentDictionary<MessageTypeKey, TaskCompletionSource<DiscoveryMsg>> _waitingEvents = new();
     private readonly Func<Hash256, Node, INodeLifecycleManager> _createNodeLifecycleManager;

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Net;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Network.Discovery.Lifecycle;
 using Nethermind.Network.Discovery.Messages;
@@ -22,15 +20,6 @@ public interface IDiscoveryManager : IDiscoveryMsgListener
 
     IReadOnlyCollection<INodeLifecycleManager> GetNodeLifecycleManagers();
     IReadOnlyCollection<INodeLifecycleManager> GetOrAddNodeLifecycleManagers(Func<INodeLifecycleManager, bool> query);
-    ClockKeyCache<IpAddressAsKey> NodesFilter { get; }
+    NodeFilter NodesFilter { get; }
     NodeRecord SelfNodeRecord { get; }
-
-    public readonly struct IpAddressAsKey(IPAddress ipAddress) : IEquatable<IpAddressAsKey>
-    {
-        private readonly IPAddress _ipAddress = ipAddress;
-        public static implicit operator IpAddressAsKey(IPAddress ip) => new(ip);
-        public bool Equals(IpAddressAsKey other) => _ipAddress.Equals(other._ipAddress);
-        public override bool Equals(object? obj) => obj is IpAddressAsKey ip && _ipAddress.Equals(ip._ipAddress);
-        public override int GetHashCode() => _ipAddress.GetHashCode();
-    }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeFilter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeFilter.cs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Net;
+using Nethermind.Core.Caching;
+
+namespace Nethermind.Network.Discovery;
+
+/// <summary>
+/// Represents a filter that temporarily rejects repeated IP addresses within a specified time window.
+/// </summary>
+/// <param name="size">The maximum capacity of the underlying cache storing IP addresses and their timestamps.</param>
+public class NodeFilter(int size)
+{
+    /// <summary>
+    /// Defines the duration within which an IP address is considered "recent" 
+    /// and will cause the filter to reject new attempts from that same IP.
+    /// </summary>
+    private static readonly TimeSpan _timeOut = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// A clock-based cache that stores the timestamps for IP addresses.
+    /// It is initialized with the specified size limit.
+    /// </summary>
+    private readonly ClockCache<IpAddressAsKey, DateTime> _nodesFilter = new(size);
+
+    /// <summary>
+    /// Attempts to set (or update) the specified IP address in the filter. If the IP address has been seen 
+    /// within the timeout window, this method returns <c>false</c>. Otherwise, it updates the cache 
+    /// with the current time and returns <c>true</c>.
+    /// </summary>
+    /// <param name="ipAddress">The IP address to check and insert/update in the filter.</param>
+    /// <returns>
+    /// <c>true</c> if the IP address was not found (or was outside the timeout window) 
+    /// and was successfully inserted. <c>false</c> if the IP address was found 
+    /// and is still within the timeout window.
+    /// </returns>
+    public bool Set(IPAddress ipAddress)
+    {
+        // Get the current UTC timestamp.
+        DateTime now = DateTime.UtcNow;
+
+        // Try to retrieve a previously recorded timestamp for the IP address.
+        if (_nodesFilter.TryGet(ipAddress, out DateTime lastSeen) &&
+            // Check if the last seen time is still within the timeout window.
+            now - lastSeen < _timeOut)
+        {
+            // If yes, reject by returning false.
+            return false;
+        }
+        else
+        {
+            // Otherwise, update (or add) the IP address timestamp to the current time.
+            _nodesFilter.Set(ipAddress, now);
+            return true;
+        }
+    }
+
+    private readonly struct IpAddressAsKey(IPAddress ipAddress) : IEquatable<IpAddressAsKey>
+    {
+        private readonly IPAddress _ipAddress = ipAddress;
+        public static implicit operator IpAddressAsKey(IPAddress ip) => new(ip);
+        public bool Equals(IpAddressAsKey other) => _ipAddress.Equals(other._ipAddress);
+        public override bool Equals(object? obj) => obj is IpAddressAsKey ip && _ipAddress.Equals(ip._ipAddress);
+        public override int GetHashCode() => _ipAddress.GetHashCode();
+    }
+}


### PR DESCRIPTION
## Changes

- On a low peer network the retry mechanism from peers being pushed out of the filter may not kick in; so also add a 5 min timeout after which the peer is also reconsidered.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Refactoring

## Testing

#### Requires testing

- [x] No