### PR TITLE
Fix: dispose ArrayPoolList in SyncStatusList

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -105,6 +105,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 if (hasNonNull || !hasInserted)
                 {
                     CompileOutput(out infos);
+                    workingArray.Dispose();
                     return true;
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -90,80 +90,84 @@ namespace Nethermind.Synchronization.FastBlocks
         public bool TryGetInfosForBatch(int batchSize, Func<BlockInfo, bool> blockExist, out BlockInfo?[] infos)
         {
             ArrayPoolList<BlockInfo?> workingArray = new(batchSize, batchSize);
-
-            // Need to be a max attempt to update sync progress
-            const int maxAttempt = 8;
-            for (int attempt = 0; attempt < maxAttempt; attempt++)
+            try
             {
-                // Because the last clause of GetInfosForBatch increment the _lowestInsertWithoutGap need to be run
-                // sequentially, can't find an easy way to parallelize the checking for block exist part in the check
-                // So here we are...
-                GetInfosForBatch(workingArray.AsSpan());
-
-                (bool hasNonNull, bool hasInserted) = ClearExistingBlock();
-
-                if (hasNonNull || !hasInserted)
+                // Need to be a max attempt to update sync progress
+                const int maxAttempt = 8;
+                for (int attempt = 0; attempt < maxAttempt; attempt++)
                 {
-                    CompileOutput(out infos);
-                    workingArray.Dispose();
-                    return true;
-                }
+                    // Because the last clause of GetInfosForBatch increment the _lowestInsertWithoutGap need to be run
+                    // sequentially, can't find an easy way to parallelize the checking for block exist part in the check
+                    // So here we are...
+                    GetInfosForBatch(workingArray.AsSpan());
 
-                // At this point, hasNonNull is false and hasInserted is true, meaning all entry in workingArray
-                // already exist. We switch to a bigger array to improve parallelization throughput
-                if (workingArray.Count < ParallelExistCheckSize)
-                {
-                    workingArray.Dispose();
-                    workingArray = new ArrayPoolList<BlockInfo?>(ParallelExistCheckSize, ParallelExistCheckSize);
-                }
-            }
+                    (bool hasNonNull, bool hasInserted) = ClearExistingBlock();
 
-            infos = [];
-            workingArray.Dispose();
-            return false;
-
-            (bool, bool) ClearExistingBlock()
-            {
-                bool hasNonNull = false;
-                bool hasInserted = false;
-                ParallelUnbalancedWork.For(0, workingArray.Count, (i) =>
-                {
-                    if (workingArray[i] is not null)
+                    if (hasNonNull || !hasInserted)
                     {
-                        if (blockExist(workingArray[i]))
+                        CompileOutput(out infos);
+                        return true;
+                    }
+
+                    // At this point, hasNonNull is false and hasInserted is true, meaning all entry in workingArray
+                    // already exist. We switch to a bigger array to improve parallelization throughput
+                    if (workingArray.Count < ParallelExistCheckSize)
+                    {
+                        workingArray.Dispose();
+                        workingArray = new ArrayPoolList<BlockInfo?>(ParallelExistCheckSize, ParallelExistCheckSize);
+                    }
+                }
+
+                infos = [];
+                return false;
+
+                (bool, bool) ClearExistingBlock()
+                {
+                    bool hasNonNull = false;
+                    bool hasInserted = false;
+                    ParallelUnbalancedWork.For(0, workingArray.Count, (i) =>
+                    {
+                        if (workingArray[i] is not null)
                         {
-                            MarkInserted(workingArray[i].BlockNumber);
-                            hasInserted = true;
-                            workingArray[i] = null;
+                            if (blockExist(workingArray[i]))
+                            {
+                                MarkInserted(workingArray[i].BlockNumber);
+                                hasInserted = true;
+                                workingArray[i] = null;
+                            }
+                            else
+                            {
+                                hasNonNull = true;
+                            }
+                        }
+                    });
+                    return (hasNonNull, hasInserted);
+                }
+
+                void CompileOutput(out BlockInfo?[] outputArray)
+                {
+                    int slot = 0;
+                    outputArray = new BlockInfo?[batchSize];
+                    for (int i = 0; i < workingArray.Count; i++)
+                    {
+                        if (workingArray[i] is null) continue;
+
+                        if (slot < outputArray.Length)
+                        {
+                            outputArray[slot] = workingArray[i];
+                            slot++;
                         }
                         else
                         {
-                            hasNonNull = true;
+                            // Not enough space in output we'll need to put back the block
+                            MarkPending(workingArray[i]);
                         }
                     }
-                });
-                return (hasNonNull, hasInserted);
-            }
-
-            void CompileOutput(out BlockInfo?[] outputArray)
-            {
-                int slot = 0;
-                outputArray = new BlockInfo?[batchSize];
-                for (int i = 0; i < workingArray.Count; i++)
-                {
-                    if (workingArray[i] is null) continue;
-
-                    if (slot < outputArray.Length)
-                    {
-                        outputArray[slot] = workingArray[i];
-                        slot++;
-                    }
-                    else
-                    {
-                        // Not enough space in output we'll need to put back the block
-                        MarkPending(workingArray[i]);
-                    }
                 }
+            }
+            finally
+            {
+                workingArray.Dispose();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -112,11 +112,13 @@ namespace Nethermind.Synchronization.FastBlocks
                 // already exist. We switch to a bigger array to improve parallelization throughput
                 if (workingArray.Count < ParallelExistCheckSize)
                 {
+                    workingArray.Dispose();
                     workingArray = new ArrayPoolList<BlockInfo?>(ParallelExistCheckSize, ParallelExistCheckSize);
                 }
             }
 
             infos = [];
+            workingArray.Dispose();
             return false;
 
             (bool, bool) ClearExistingBlock()


### PR DESCRIPTION
```
Unhandled exception. System.InvalidOperationException: ArrayPoolList hasn't been disposed. Created    at Nethermind.Core.Collections.ArrayPoolList`1..ctor(ArrayPool`1 arrayPool, Int32 capacity, Int32 startingCount)
   at Nethermind.Core.Collections.ArrayPoolList`1..ctor(Int32 capacity, Int32 count)
   at Nethermind.Synchronization.FastBlocks.SyncStatusList.TryGetInfosForBatch(Int32 batchSize, Func`2 blockExist, BlockInfo[]& infos)
   at Nethermind.Synchronization.FastBlocks.BodiesSyncFeed.PrepareRequest(CancellationToken token)
   at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.DispatchLoop(CancellationToken cancellationToken)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.Allocate(T request)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at Nethermind.Synchronization.Peers.SyncPeerPool.Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts, Int32 timeoutMilliseconds, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetResult(TResult result)
   at Nethermind.Core.Extensions.WaitHandleExtensions.WaitOneAsync(WaitHandle handle, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Threading.Tasks.TaskCompletionSource`1.TrySetResult(TResult result)
   at Nethermind.Core.Extensions.WaitHandleExtensions.<>c.<WaitOneAsync>b__0_0(Object state, Boolean timedOut)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.RegisteredWaitHandle.PerformCallbackPortableCore(Boolean timedOut)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()

   at Nethermind.Core.Collections.ArrayPoolList`1.Finalize() in /root/nethermind/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs:line 386
   at System.GC.RunFinalizers()
```

## Changes

- Dispose ArrayPoolList

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No