### PR TITLE
Include version number in default extra data

### DIFF
--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
@@ -11,6 +12,8 @@ namespace Nethermind.Config
 {
     public class BlocksConfig : IBlocksConfig
     {
+        public static bool AddVersionToExtraData { get; set; }
+
         public const string DefaultExtraData = "Nethermind";
         private byte[] _extraDataBytes = [];
         private string _extraDataString;
@@ -22,7 +25,28 @@ namespace Nethermind.Config
             ExtraData = _extraDataString;
         }
 
-        private static string GetDefaultExtraData() => $"{DefaultExtraData} v{ProductInfo.Version.Replace("-unstable", "a")}";
+        private static string GetDefaultExtraData()
+        {
+            // Don't want block hashes in tests to change with every version
+            if (!AddVersionToExtraData) return DefaultExtraData;
+
+            ReadOnlySpan<char> version = ProductInfo.Version.AsSpan();
+            int index = version.IndexOfAny('+', '-');
+            string alpha = "";
+            if (index >= 0)
+            {
+                if (version[index] == '-')
+                {
+                    alpha = "a";
+                }
+            }
+            else
+            {
+                index = version.Length;
+            }
+
+            return $"{DefaultExtraData} v{version[..index]}{alpha}";
+        }
 
         public bool Enabled { get; set; }
         public long? TargetBlockGasLimit { get; set; } = null;

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Text;
+using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
@@ -11,8 +12,17 @@ namespace Nethermind.Config
     public class BlocksConfig : IBlocksConfig
     {
         public const string DefaultExtraData = "Nethermind";
-        private byte[] _extraDataBytes = Encoding.UTF8.GetBytes(DefaultExtraData);
-        private string _extraDataString = DefaultExtraData;
+        private byte[] _extraDataBytes = [];
+        private string _extraDataString;
+
+        public BlocksConfig()
+        {
+            _extraDataString = GetDefaultExtraData();
+            // Validate that it doesn't overflow when converted to bytes
+            ExtraData = _extraDataString;
+        }
+
+        private static string GetDefaultExtraData() => $"{DefaultExtraData} v{ProductInfo.Version.Replace("-unstable", "a")}";
 
         public bool Enabled { get; set; }
         public long? TargetBlockGasLimit { get; set; } = null;

--- a/src/Nethermind/Nethermind.Core/ProductInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ProductInfo.cs
@@ -36,7 +36,7 @@ public static class ProductInfo
         if (index != -1)
         {
             Commit = Version[(index + 1)..];
-            Version = Version[..Math.Min(index + 9, Version.Length - 1)];
+            Version = Version[..index];
         }
 
         ClientIdParts = new()

--- a/src/Nethermind/Nethermind.Core/ProductInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ProductInfo.cs
@@ -36,7 +36,7 @@ public static class ProductInfo
         if (index != -1)
         {
             Commit = Version[(index + 1)..];
-            Version = Version[..index];
+            Version = Version[..Math.Min(index + 9, Version.Length - 1)];
         }
 
         ClientIdParts = new()

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
@@ -19,7 +20,6 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Scheduler;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Evm;
@@ -58,6 +58,9 @@ namespace Nethermind.Init.Steps
             IReceiptConfig receiptConfig = getApi.Config<IReceiptConfig>();
 
             ThisNodeInfo.AddInfo("Gaslimit     :", $"{blocksConfig.TargetBlockGasLimit:N0}");
+            ThisNodeInfo.AddInfo("ExtraData    :", Utf8.IsValid(blocksConfig.GetExtraDataBytes()) ?
+                blocksConfig.ExtraData :
+                "- binary data -");
 
             IStateReader stateReader = setApi.StateReader!;
             IWorldState mainWorldState = _api.WorldStateManager!.GlobalWorldState;

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -51,6 +51,7 @@ Regex.CacheSize = 128;
 #if !DEBUG
 ResourceLeakDetector.Level = ResourceLeakDetector.DetectionLevel.Disabled;
 #endif
+BlocksConfig.AddVersionToExtraData = true;
 
 ManualResetEventSlim exit = new(true);
 ILogger logger = new(SimpleConsoleLogger.Instance);


### PR DESCRIPTION
## Changes

- Include version number in default extra data, meaning it is easier to determine if any issues are fixed issues or different
- Convert `-unsable` to `a` so as not to use up too much space
```
JSON RPC     : http://127.0.0.1:8545 ; http://localhost:8551
Genesis hash : 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
Gaslimit     : 36,000,000
ExtraData    : Nethermind v1.32.0a
```
## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No - will throw exception if wrong on startup and outputs value in startup banner