### PR TITLE
Fix FCU result in simulated block production scenarios

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -304,10 +304,12 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
     private ResultWrapper<ForkchoiceUpdatedV1Result> StartBuildingPayload(Block newHeadBlock, ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes)
     {
         string? payloadId = null;
+        bool isPayloadSimulated = false;
 
-        if (_simulateBlockProduction)
+        if (_simulateBlockProduction && payloadAttributes is null)
         {
-            payloadAttributes ??= newHeadBlock.Header.GenerateSimulatedPayload();
+            isPayloadSimulated = true;
+            payloadAttributes = newHeadBlock.Header.GenerateSimulatedPayload();
         }
 
         if (payloadAttributes is not null)
@@ -322,7 +324,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         }
 
         _blockTree.ForkChoiceUpdated(forkchoiceState.FinalizedBlockHash, forkchoiceState.SafeBlockHash);
-        return ForkchoiceUpdatedV1Result.Valid(payloadId, forkchoiceState.HeadBlockHash);
+        return ForkchoiceUpdatedV1Result.Valid(isPayloadSimulated ? null : payloadId, forkchoiceState.HeadBlockHash);
     }
 
     private ResultWrapper<ForkchoiceUpdatedV1Result>? ValidateAttributes(PayloadAttributes? payloadAttributes, int version)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -304,11 +304,10 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
     private ResultWrapper<ForkchoiceUpdatedV1Result> StartBuildingPayload(Block newHeadBlock, ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes)
     {
         string? payloadId = null;
-        bool isPayloadSimulated = false;
+        bool isPayloadSimulated = _simulateBlockProduction && payloadAttributes is null;
 
-        if (_simulateBlockProduction && payloadAttributes is null)
+        if (isPayloadSimulated)
         {
-            isPayloadSimulated = true;
             payloadAttributes = newHeadBlock.Header.GenerateSimulatedPayload();
         }
 


### PR DESCRIPTION
## Changes

- fix `ForkchoiceUpdatedV1Result` in simulated block production scenarios
Currently, during simulated block production (when payload attributes are added by us), we return a `payloadId` even though it wasn't requested by CL. This PR corrects that behavior by returning `null` in such cases, ensuring the simulation remains internal to Nethermind and is not exposed to the CL.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No