### PR TITLE
Add metrics for `engine_getBlobsV1` full and partial responses

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
@@ -26,6 +26,7 @@ public class GetBlobsHandler(ITxPool txPool) : IAsyncHandler<byte[][], IEnumerab
 
     private IEnumerable<BlobAndProofV1?> GetBlobsAndProofs(byte[][] request)
     {
+        bool allBlobsAvailable = true;
         Metrics.NumberOfRequestedBlobs += request.Length;
 
         foreach (byte[] requestedBlobVersionedHash in request)
@@ -37,8 +38,18 @@ public class GetBlobsHandler(ITxPool txPool) : IAsyncHandler<byte[][], IEnumerab
             }
             else
             {
+                allBlobsAvailable = false;
                 yield return null;
             }
+        }
+
+        if (allBlobsAvailable)
+        {
+            Metrics.NumberOfGetBlobsSuccesses++;
+        }
+        else
+        {
+            Metrics.NumberOfGetBlobsFailures++;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -31,5 +31,13 @@ namespace Nethermind.Merge.Plugin
         [GaugeMetric]
         [Description("Number of Blobs sent by engine_getBlobsV1")]
         public static int NumberOfSentBlobs { get; set; }
+
+        [GaugeMetric]
+        [Description("Number of responses to engine_getBlobsV1 with all requested blobs")]
+        public static int NumberOfGetBlobsSuccesses { get; set; }
+
+        [GaugeMetric]
+        [Description("Number of responses to engine_getBlobsV1 without all requested blobs")]
+        public static int NumberOfGetBlobsFailures { get; set; }
     }
 }


### PR DESCRIPTION
## Changes

- add metrics `NumberOfGetBlobsSuccesses` and `NumberOfGetBlobsFailures`
A successful response to `engine_getBlobsV1` may include some (or even all) `null` values, indicating that the requested blobs are not available. We already track metrics for the number of blobs requested and the number of blobs sent, and based on that, we estimate the return rate on mainnet to be around 85%. For now, partial responses (some blobs returned, some `nulls`) are useful for the CL.
However, after Fusaka's PeerDAS, partial responses will no longer be useful - CL will require either all requested blobs or none. This PR introduces new metrics to track fully successful responses (where all requested blobs are returned) versus successful but incomplete responses (where some blobs are missing). These metrics will help us estimate the rate of fully successful responses, which are critical for PeerDAS.
These metrics are already included in the PeerDAS branch, but we also want to start collecting data from mainnet.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No