### PR TITLE
Dial back JsonRpc log spam

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -374,18 +374,16 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         {
             if (localErrorResponse?.Error?.SuppressWarning == false)
             {
-                if (_logger.IsWarn) _logger.Warn($"Error when handling {request} | {JsonSerializer.Serialize(localErrorResponse, EthereumJsonSerializer.JsonOptionsIndented)}");
+                if (_logger.IsWarn) _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {localErrorResponse.Error.Code} Message: {localErrorResponse.Error.Message}");
+                if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {JsonSerializer.Serialize(localErrorResponse, EthereumJsonSerializer.JsonOptionsIndented)}");
             }
             Metrics.JsonRpcErrors++;
         }
         else
         {
-            if (_logger.IsDebug) _logger.Debug($"Responded to {request}");
+            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method}");
             Metrics.JsonRpcSuccesses++;
         }
-
-
-        if (_logger.IsDebug) _logger.Debug($"  {request} handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
 
         JsonRpcResult.Entry result = new(response, new RpcReport(request.Method, (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, isSuccess));
         TraceResult(result);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -381,7 +381,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         }
         else
         {
-            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms"");
+            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
             Metrics.JsonRpcSuccesses++;
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -381,7 +381,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         }
         else
         {
-            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method}");
+            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms"");
             Metrics.JsonRpcSuccesses++;
         }
 


### PR DESCRIPTION
## Changes

- We output far too much data in JsonRpc error lines, reduce to a single line
- Currently causing issue for ethPandaOps as logging is the predominate performance hog for them
- No one really uses the additional detail; and it is a very serious issue we output other Error logs

<img src="https://github.com/user-attachments/assets/fce7f524-76f7-4936-8e19-948c164b0582" />

Open question on whether we want to log the error at all by default as do keep its metric

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Other: Logging

## Testing

#### Requires testing

- [x] No