### PR TITLE
Handle tx reorged blocks better

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Blockchain
                     return false;
                 }
 
-                (bool isSyncing, _, _) = _blockTree.IsSyncing(maxDistanceForSynced: 2);
+                (bool isSyncing, _, _) = _blockTree.IsSyncing(maxDistanceForSynced: 16);
                 return isSyncing;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -532,7 +532,7 @@ namespace Nethermind.TxPool.Test
         [Test]
         public void RecoverAddress_should_work_correctly()
         {
-            Transaction tx = GetTx(TestItem.PrivateKeyA);
+            Transaction tx = GetBlobTx(TestItem.PrivateKeyA);
             _ethereumEcdsa.RecoverAddress(tx).Should().Be(tx.SenderAddress);
         }
 
@@ -552,7 +552,7 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
 
-            Transaction[] txs = { GetTx(TestItem.PrivateKeyA), GetTx(TestItem.PrivateKeyB) };
+            Transaction[] txs = { GetBlobTx(TestItem.PrivateKeyA), GetBlobTx(TestItem.PrivateKeyB) };
 
             _txPool.SubmitTx(txs[0], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
             _txPool.SubmitTx(txs[1], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
@@ -597,8 +597,8 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
             EnsureSenderBalance(TestItem.AddressC, UInt256.MaxValue);
 
-            Transaction[] txsA = { GetTx(TestItem.PrivateKeyA), GetTx(TestItem.PrivateKeyB) };
-            Transaction[] txsB = { GetTx(TestItem.PrivateKeyC) };
+            Transaction[] txsA = { GetBlobTx(TestItem.PrivateKeyA), GetBlobTx(TestItem.PrivateKeyB) };
+            Transaction[] txsB = { GetBlobTx(TestItem.PrivateKeyC) };
 
             _txPool.SubmitTx(txsA[0], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
             _txPool.SubmitTx(txsA[1], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
@@ -775,7 +775,7 @@ namespace Nethermind.TxPool.Test
             values.Count.Should().Be(poolSize / 2);
         }
 
-        private Transaction GetTx(PrivateKey sender)
+        private Transaction GetBlobTx(PrivateKey sender)
         {
             return Build.A.Transaction
                 .WithShardBlobTxTypeAndFields()

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2340,5 +2340,71 @@ namespace Nethermind.TxPool.Test
             _blockTree.BlockAddedToMain += Raise.EventWith(blockReplacementEventArgs);
             await waitTask;
         }
+
+        [Test]
+        public async Task should_bring_back_reorganized_txs()
+        {
+            const long blockNumber = 358;
+
+            ITxPoolConfig txPoolConfig = new TxPoolConfig()
+            {
+                Size = 128,
+                BlobsSupport = BlobsSupportMode.Disabled
+            };
+            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider());
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressC, UInt256.MaxValue);
+
+            Transaction[] txsA = { GetTx(TestItem.PrivateKeyA), GetTx(TestItem.PrivateKeyB) };
+            Transaction[] txsB = { GetTx(TestItem.PrivateKeyC) };
+
+            _txPool.SubmitTx(txsA[0], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
+            _txPool.SubmitTx(txsA[1], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
+            _txPool.SubmitTx(txsB[0], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
+
+            _txPool.GetPendingTransactionsCount().Should().Be(txsA.Length + txsB.Length);
+            _txPool.GetPendingBlobTransactionsCount().Should().Be(0);
+
+            // adding block A
+            Block blockA = Build.A.Block.WithNumber(blockNumber).WithTransactions(txsA).TestObject;
+            await RaiseBlockAddedToMainAndWaitForNewHead(blockA);
+
+            _txPool.GetPendingTransactionsCount().Should().Be(txsB.Length);
+            _txPool.GetPendingBlobTransactionsCount().Should().Be(0);
+            _txPool.TryGetPendingTransaction(txsA[0].Hash!, out _).Should().BeFalse();
+            _txPool.TryGetPendingTransaction(txsA[1].Hash!, out _).Should().BeFalse();
+            _txPool.TryGetPendingTransaction(txsB[0].Hash!, out _).Should().BeTrue();
+
+            // reorganized from block A to block B
+            Block blockB = Build.A.Block.WithNumber(blockNumber).WithTransactions(txsB).TestObject;
+            await RaiseBlockAddedToMainAndWaitForNewHead(blockB, blockA);
+
+            // tx from block B should be removed from tx pool
+            _txPool.TryGetPendingTransaction(txsB[0].Hash!, out _).Should().BeFalse();
+
+            // txs from reorganized blockA should be readded to tx pool
+            _txPool.GetPendingTransactionsCount().Should().Be(txsA.Length);
+            _txPool.TryGetPendingTransaction(txsA[0].Hash!, out Transaction tx1).Should().BeTrue();
+            _txPool.TryGetPendingTransaction(txsA[1].Hash!, out Transaction tx2).Should().BeTrue();
+
+            tx1.Should().BeEquivalentTo(txsA[0], static options => options
+                .Excluding(static t => t.GasBottleneck)    // GasBottleneck is not encoded/decoded...
+                .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
+
+            tx2.Should().BeEquivalentTo(txsA[1], static options => options
+                .Excluding(static t => t.GasBottleneck)    // GasBottleneck is not encoded/decoded...
+                .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
+        }
+
+        private Transaction GetTx(PrivateKey sender)
+        {
+            return Build.A.Transaction
+                .WithMaxFeePerGas(1.GWei())
+                .WithMaxPriorityFeePerGas(1.GWei())
+                .WithNonce(UInt256.Zero)
+                .SignedAndResolved(_ethereumEcdsa, sender).TestObject;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2390,11 +2390,9 @@ namespace Nethermind.TxPool.Test
             _txPool.TryGetPendingTransaction(txsA[1].Hash!, out Transaction tx2).Should().BeTrue();
 
             tx1.Should().BeEquivalentTo(txsA[0], static options => options
-                .Excluding(static t => t.GasBottleneck)    // GasBottleneck is not encoded/decoded...
                 .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
 
             tx2.Should().BeEquivalentTo(txsA[1], static options => options
-                .Excluding(static t => t.GasBottleneck)    // GasBottleneck is not encoded/decoded...
                 .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
         }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -251,7 +251,7 @@ namespace Nethermind.TxPool
                     try
                     {
                         ArrayPoolList<AddressAsKey>? accountChanges = args.Block.AccountChanges;
-                        if (args.PreviousBlock is not null && !CanUseCache(args.Block, accountChanges))
+                        if (args.PreviousBlock is not null || !CanUseCache(args.Block, accountChanges))
                         {
                             // Non-sequential block or reorganization detected, reset cache
                             _accountCache.Reset();

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -251,9 +251,9 @@ namespace Nethermind.TxPool
                     try
                     {
                         ArrayPoolList<AddressAsKey>? accountChanges = args.Block.AccountChanges;
-                        if (args.PreviousBlock is not null || !CanUseCache(args.Block, accountChanges))
+                        if (args.PreviousBlock is not null && !CanUseCache(args.Block, accountChanges))
                         {
-                            // Not sequential block, reset cache
+                            // Non-sequential block or reorganization detected, reset cache
                             _accountCache.Reset();
                         }
                         else

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -53,7 +53,6 @@ namespace Nethermind.TxPool
         private readonly bool _blobReorgsSupportEnabled;
         private readonly DelegationCache _pendingDelegations = new();
 
-
         private readonly ILogger _logger;
 
         private readonly Channel<BlockReplacementEventArgs> _headBlocksChannel = Channel.CreateUnbounded<BlockReplacementEventArgs>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
@@ -480,7 +479,7 @@ namespace Nethermind.TxPool
             TxFilteringState state = new(tx, _accounts);
             AcceptTxResult accepted;
 
-             _newHeadLock.EnterReadLock();
+            _newHeadLock.EnterReadLock();
             try
             {
                 accepted = FilterTransactions(tx, handlingOptions, ref state);


### PR DESCRIPTION
Contributes to #8484; test passed so can't recreate

## Changes

- Added test for regular tx reorgs
- Changed reorged txs to PersistentBroadcast
- Cleared more caches on reorg
- Increased "Not syncing" distance
- Changed Debug message to Warn message when TxPool can't be updated
- Add ReaderWriterLock around HeadUpdate and AddTx; so new tx don't mess with the changes from changing head
  - Update head takes a write lock
  - Submitting Tx takes a read lock

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring
- [x] Other: Test

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes - Is test
