### PR TITLE
Fix GasEstimator TODO by cloning Transaction instead of mutating original

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
@@ -109,14 +109,12 @@ namespace Nethermind.Evm.Tracing
         {
             OutOfGasTracer tracer = new();
 
-            // TODO: Workaround to not mutate the original Tx
-            long originalGasLimit = transaction.GasLimit;
-
-            transaction.GasLimit = gasLimit;
+            Transaction txClone = new Transaction();
+            transaction.CopyTo(txClone);
+            txClone.GasLimit = gasLimit;
 
             BlockExecutionContext blCtx = new(block, _specProvider.GetSpec(block));
-            _transactionProcessor.CallAndRestore(transaction, in blCtx, tracer.WithCancellation(token));
-            transaction.GasLimit = originalGasLimit;
+            _transactionProcessor.CallAndRestore(txClone, in blCtx, tracer.WithCancellation(token));
 
             return !tracer.OutOfGas;
         }


### PR DESCRIPTION
Fixes #XXX

## Changes

- Removed mutation of the original `Transaction` object during gas estimation
- Introduced safe cloning via `Transaction.CopyTo()` to solve `TODO` in `GasEstimator.TryExecutableTransaction`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _n/a_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Existing coverage is sufficient. This change preserves logic and only affects internal transaction handling during estimation.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This PR resolves the inline `// TODO: Workaround to not mutate the original Tx` by introducing a proper, non-mutating transaction cloning process using `Transaction.CopyTo()`. This improves safety and code clarity in gas estimation routines.
