### PR TITLE
Refactor/move worldstate to DI

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -53,13 +53,9 @@ namespace Nethermind.Api
         ISealer? Sealer { get; set; }
         ISealValidator? SealValidator { get; set; }
         ISealEngine SealEngine { get; set; }
-        IReadOnlyStateProvider? ChainHeadStateProvider { get; set; }
-        IStateReader? StateReader { get; set; }
+        IStateReader? StateReader { get; }
 
-        IWorldStateManager? WorldStateManager { get; set; }
-        INodeStorage? MainNodeStorage { get; set; }
-        CompositePruningTrigger? PruningTrigger { get; set; }
-        IVerifyTrieStarter? VerifyTrieStarter { get; set; }
+        IWorldStateManager? WorldStateManager { get; }
         IMainProcessingContext? MainProcessingContext { get; set; }
         ITxSender? TxSender { get; set; }
         INonceManager? NonceManager { get; set; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -194,12 +194,8 @@ namespace Nethermind.Api
         public ISyncPeerPool? SyncPeerPool => Context.Resolve<ISyncPeerPool>();
         public ISynchronizer? Synchronizer => Context.Resolve<ISynchronizer>();
         public ISyncServer? SyncServer => Context.Resolve<ISyncServer>();
-        public IReadOnlyStateProvider? ChainHeadStateProvider { get; set; }
-        public IWorldStateManager? WorldStateManager { get; set; }
-        public INodeStorage? MainNodeStorage { get; set; }
-        public CompositePruningTrigger? PruningTrigger { get; set; }
-        public IVerifyTrieStarter? VerifyTrieStarter { get; set; }
-        public IStateReader? StateReader { get; set; }
+        public IWorldStateManager? WorldStateManager => Context.Resolve<IWorldStateManager>();
+        public IStateReader? StateReader => Context.Resolve<IStateReader>();
         public IStaticNodesManager? StaticNodesManager { get; set; }
         public ITrustedNodesManager? TrustedNodesManager { get; set; }
         public ITimestamper Timestamper { get; } = Core.Timestamper.Default;

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -80,7 +80,6 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
     protected override BlockProcessor CreateBlockProcessor(BlockCachePreWarmer? preWarmer, ITransactionProcessor transactionProcessor, IWorldState worldState)
     {
         if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
-        if (_api.ChainHeadStateProvider is null) throw new StepDependencyException(nameof(_api.ChainHeadStateProvider));
         if (_api.BlockValidator is null) throw new StepDependencyException(nameof(_api.BlockValidator));
         if (_api.RewardCalculatorSource is null) throw new StepDependencyException(nameof(_api.RewardCalculatorSource));
         if (_api.DbProvider is null) throw new StepDependencyException(nameof(_api.DbProvider));

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
@@ -41,7 +41,6 @@ public class PseudoNethermindModule(ChainSpec spec, IConfigProvider configProvid
 
             .AddModule(new PsudoNetworkModule(initConfig))
             .AddModule(new DiscoveryModule(initConfig, networkConfig))
-            .AddModule(new WorldStateModule())
             .AddModule(new BlockTreeModule())
             .AddModule(new BlockProcessingModule())
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
@@ -71,18 +71,6 @@ public class PsudoNetworkModule(IInitConfig initConfig) : Module
             .AddSingleton<IGossipPolicy>(Policy.FullGossip)
             .AddComposite<ITxGossipPolicy, CompositeTxGossipPolicy>()
 
-            .OnActivate<ISyncPeerPool>((peerPool, ctx) =>
-            {
-                ILogManager logManager = ctx.Resolve<ILogManager>();
-                ctx.Resolve<IWorldStateManager>().InitializeNetwork(
-                    new PathNodeRecovery(
-                        new NodeDataRecovery(peerPool!, ctx.Resolve<INodeStorage>(), logManager),
-                        new SnapRangeRecovery(peerPool!, logManager),
-                        logManager
-                    )
-                );
-            })
-
             // TODO: LastNStateRootTracker
             .AddSingleton<ISnapServer, IWorldStateManager>(stateProvider => stateProvider.SnapServer!)
 

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -2,101 +2,57 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.IO.Abstractions;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.FullPruning;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
-using Nethermind.Db;
-using Nethermind.Db.FullPruning;
-using Nethermind.Db.Rocks.Config;
 using Nethermind.Init.Steps;
 using Nethermind.JsonRpc.Converters;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.State;
-using Nethermind.State.Healing;
-using Nethermind.Synchronization.FastSync;
-using Nethermind.Synchronization.Trie;
-using Nethermind.Trie;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Init;
 
 [RunnerStepDependencies(typeof(InitializePlugins), typeof(InitializeBlockTree), typeof(SetupKeyStore))]
 public class InitializeStateDb : IStep
 {
-    private readonly INethermindApi _api;
+    private readonly IBlockTree _blockTree;
+    private readonly IWorldStateManager _worldStateManager;
+    private readonly IInitConfig _initConfig;
+    private readonly IProcessExitSource _processExit;
     private ILogger _logger;
 
-    public InitializeStateDb(INethermindApi api)
+    public InitializeStateDb(
+        IWorldStateManager worldStateManager,
+        IBlockTree blockTree,
+        IInitConfig initConfig,
+        IProcessExitSource processExitSource,
+        ILogManager logManager)
     {
-        _api = api;
+        _worldStateManager = worldStateManager;
+        _blockTree = blockTree;
+        _initConfig = initConfig;
+        _processExit = processExitSource;
+
+        _logger = logManager.GetClassLogger<InitializeStateDb>();
     }
 
     public Task Execute(CancellationToken cancellationToken)
     {
         InitBlockTraceDumper();
 
-        (IApiWithStores getApi, IApiWithBlockchain setApi) = _api.ForBlockchain;
-
-        if (getApi.ChainSpec is null) throw new StepDependencyException(nameof(getApi.ChainSpec));
-        if (getApi.DbProvider is null) throw new StepDependencyException(nameof(getApi.DbProvider));
-        if (getApi.SpecProvider is null) throw new StepDependencyException(nameof(getApi.SpecProvider));
-        if (getApi.BlockTree is null) throw new StepDependencyException(nameof(getApi.BlockTree));
-
-        _logger = getApi.LogManager.GetClassLogger();
-        ISyncConfig syncConfig = getApi.Config<ISyncConfig>();
-        IPruningConfig pruningConfig = getApi.Config<IPruningConfig>();
-        IInitConfig initConfig = getApi.Config<IInitConfig>();
-        IBlocksConfig blockConfig = getApi.Config<IBlocksConfig>();
-        IDbConfig dbConfig = getApi.Config<IDbConfig>();
-
-        // This is probably the point where a different state implementation would switch.
-        (IWorldStateManager stateManager, INodeStorage mainNodeStorage, CompositePruningTrigger pruningTrigger) = new PruningTrieStateFactory(
-            syncConfig,
-            initConfig,
-            pruningConfig,
-            blockConfig,
-            dbConfig,
-            _api.DbProvider!,
-            _api.BlockTree!,
-            _api.FileSystem,
-            _api.TimerFactory,
-            _api.ProcessExit!,
-            _api.ChainSpec,
-            _api.DisposeStack,
-            _api.LogManager
-        ).Build();
-
-        setApi.WorldStateManager = stateManager;
-
-        // Used by state sync.
-        setApi.MainNodeStorage = mainNodeStorage;
-
-        // Used by rpc to trigger pruning.
-        setApi.PruningTrigger = pruningTrigger;
-
-        setApi.StateReader = stateManager.GlobalStateReader;
-        setApi.ChainHeadStateProvider = new ChainHeadReadOnlyStateProvider(getApi.BlockTree, stateManager.GlobalStateReader);
-        setApi.VerifyTrieStarter = new VerifyTrieStarter(stateManager, _api.ProcessExit!, _api.LogManager);
-
-        if (_api.Config<IInitConfig>().DiagnosticMode == DiagnosticMode.VerifyTrie)
+        if (_initConfig.DiagnosticMode == DiagnosticMode.VerifyTrie)
         {
             _logger!.Info("Collecting trie stats and verifying that no nodes are missing...");
-            BlockHeader? head = getApi.BlockTree!.Head?.Header;
+            BlockHeader? head = _blockTree!.Head?.Header;
             if (head is not null)
             {
                 _logger.Info($"Starting from {head.Number} {head.StateRoot}{Environment.NewLine}");
-                stateManager.VerifyTrie(head, setApi.ProcessExit!.Token);
+                _worldStateManager.VerifyTrie(head, _processExit!.Token);
             }
         }
 
@@ -105,6 +61,7 @@ public class InitializeStateDb : IStep
 
     private static void InitBlockTraceDumper()
     {
+        // TODO: What is this? Why is this here? What does it have anything to do with state? Why is it doing something global?
         EthereumJsonSerializer.AddConverter(new TxReceiptConverter());
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -34,6 +34,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
         builder
             .AddModule(new AppInputModule(chainSpec, configProvider, logManager))
             .AddModule(new NetworkModule(configProvider))
+            .AddModule(new WorldStateModule())
             .AddModule(new BuiltInStepsModule())
             .AddModule(new RpcModules())
             .AddModule(new EraModule())

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -3,11 +3,12 @@
 
 using Autofac;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.FullPruning;
-using Nethermind.Init;
+using Nethermind.Core;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.State;
 
-namespace Nethermind.Core.Test.Modules;
+namespace Nethermind.Init.Modules;
 
 public class WorldStateModule : Module
 {
@@ -20,6 +21,9 @@ public class WorldStateModule : Module
             .Map<IWorldStateManager, PruningTrieStateFactoryOutput>((o) => o.WorldStateManager)
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
             .Map<INodeStorage, PruningTrieStateFactoryOutput>((m) => m.NodeStorage)
+            .Map<IPruningTrieStateAdminRpc, PruningTrieStateFactoryOutput>((m) => m.AdminRpc)
+            .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpc>()
+
             .AddSingleton<IReadOnlyStateProvider, ChainHeadReadOnlyStateProvider>()
 
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()
@@ -31,12 +35,14 @@ public class WorldStateModule : Module
     {
         public IWorldStateManager WorldStateManager { get; }
         public INodeStorage NodeStorage { get; }
+        public IPruningTrieStateAdminRpc AdminRpc { get; }
 
         public PruningTrieStateFactoryOutput(PruningTrieStateFactory factory)
         {
-            (IWorldStateManager worldStateManager, INodeStorage mainNodeStorage, CompositePruningTrigger _) = factory.Build();
+            (IWorldStateManager worldStateManager, INodeStorage mainNodeStorage, IPruningTrieStateAdminRpc adminRpc) = factory.Build();
             WorldStateManager = worldStateManager;
             NodeStorage = mainNodeStorage;
+            AdminRpc = adminRpc;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -15,17 +15,23 @@ public class WorldStateModule : Module
     protected override void Load(ContainerBuilder builder)
     {
         builder
+            // Most config actually done in factory. We just call `Build` and then get back components from its output.
             .AddSingleton<PruningTrieStateFactory>()
             .AddSingleton<PruningTrieStateFactoryOutput>()
 
             .Map<IWorldStateManager, PruningTrieStateFactoryOutput>((o) => o.WorldStateManager)
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
+
+            // Used by sync code
             .Map<INodeStorage, PruningTrieStateFactoryOutput>((m) => m.NodeStorage)
+
+            // Some admin rpc to trigger verify trie and pruning
             .Map<IPruningTrieStateAdminRpc, PruningTrieStateFactoryOutput>((m) => m.AdminRpc)
             .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpc>()
 
             .AddSingleton<IReadOnlyStateProvider, ChainHeadReadOnlyStateProvider>()
 
+            // Prevent multiple concurrent verify trie.
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()
             ;
     }

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -26,8 +26,8 @@ public class WorldStateModule : Module
             .Map<INodeStorage, PruningTrieStateFactoryOutput>((m) => m.NodeStorage)
 
             // Some admin rpc to trigger verify trie and pruning
-            .Map<IPruningTrieStateAdminRpc, PruningTrieStateFactoryOutput>((m) => m.AdminRpc)
-            .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpc>()
+            .Map<IPruningTrieStateAdminRpcModule, PruningTrieStateFactoryOutput>((m) => m.AdminRpcModule)
+            .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpcModule>()
 
             .AddSingleton<IReadOnlyStateProvider, ChainHeadReadOnlyStateProvider>()
 
@@ -41,14 +41,14 @@ public class WorldStateModule : Module
     {
         public IWorldStateManager WorldStateManager { get; }
         public INodeStorage NodeStorage { get; }
-        public IPruningTrieStateAdminRpc AdminRpc { get; }
+        public IPruningTrieStateAdminRpcModule AdminRpcModule { get; }
 
         public PruningTrieStateFactoryOutput(PruningTrieStateFactory factory)
         {
-            (IWorldStateManager worldStateManager, INodeStorage mainNodeStorage, IPruningTrieStateAdminRpc adminRpc) = factory.Build();
+            (IWorldStateManager worldStateManager, INodeStorage mainNodeStorage, IPruningTrieStateAdminRpcModule adminRpc) = factory.Build();
             WorldStateManager = worldStateManager;
             NodeStorage = mainNodeStorage;
-            AdminRpc = adminRpc;
+            AdminRpcModule = adminRpc;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -46,7 +46,7 @@ public class PruningTrieStateFactory(
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PruningTrieStateFactory>();
 
-    public (IWorldStateManager, INodeStorage, IPruningTrieStateAdminRpc) Build()
+    public (IWorldStateManager, INodeStorage, IPruningTrieStateAdminRpcModule) Build()
     {
         CompositePruningTrigger compositePruningTrigger = new CompositePruningTrigger();
 
@@ -203,14 +203,14 @@ public class PruningTrieStateFactory(
         var verifyTrieStarter = new VerifyTrieStarter(stateManager, processExit!, logManager);
         ManualPruningTrigger pruningTrigger = new();
         compositePruningTrigger.Add(pruningTrigger);
-        PruningTrieStateAdminRpc adminRpc = new PruningTrieStateAdminRpc(
+        PruningTrieStateAdminRpcModule adminRpcModule = new PruningTrieStateAdminRpcModule(
             pruningTrigger,
             blockTree,
             stateManager.GlobalStateReader,
             verifyTrieStarter!
         );
 
-        return (stateManager, mainNodeStorage, adminRpc);
+        return (stateManager, mainNodeStorage, adminRpcModule);
     }
 
     private void InitializeFullPruning(

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -18,6 +18,7 @@ using Nethermind.Core.Timers;
 using Nethermind.Db;
 using Nethermind.Db.FullPruning;
 using Nethermind.Db.Rocks.Config;
+using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State;
@@ -45,7 +46,7 @@ public class PruningTrieStateFactory(
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PruningTrieStateFactory>();
 
-    public (IWorldStateManager, INodeStorage, CompositePruningTrigger) Build()
+    public (IWorldStateManager, INodeStorage, IPruningTrieStateAdminRpc) Build()
     {
         CompositePruningTrigger compositePruningTrigger = new CompositePruningTrigger();
 
@@ -82,15 +83,15 @@ public class PruningTrieStateFactory(
         }
 
         IKeyValueStoreWithBatching codeDb = dbProvider.CodeDb;
-        IKeyValueStoreWithBatching stateDb = dbProvider.StateDb;
+        IDb stateDb = dbProvider.StateDb;
         IPersistenceStrategy persistenceStrategy;
         IPruningStrategy pruningStrategy;
         if (pruningConfig.Mode.IsMemory())
         {
             persistenceStrategy = Persist.IfBlockOlderThan(pruningConfig.PersistenceInterval); // TODO: this should be based on time
-            if (pruningConfig.Mode.IsFull())
+            if (pruningConfig.Mode.IsFull() && stateDb is IFullPruningDb fullPruningDb)
             {
-                PruningTriggerPersistenceStrategy triggerPersistenceStrategy = new((IFullPruningDb)dbProvider!.StateDb, blockTree!, logManager);
+                PruningTriggerPersistenceStrategy triggerPersistenceStrategy = new(fullPruningDb, blockTree!, logManager);
                 disposeStack.Push(triggerPersistenceStrategy);
                 persistenceStrategy = persistenceStrategy.Or(triggerPersistenceStrategy);
             }
@@ -191,6 +192,7 @@ public class PruningTrieStateFactory(
         disposeStack.Push(mainWorldTrieStore);
 
         InitializeFullPruning(
+            stateDb,
             stateManager.GlobalStateReader,
             mainNodeStorage,
             nodeStorageFactory,
@@ -198,10 +200,21 @@ public class PruningTrieStateFactory(
             compositePruningTrigger
         );
 
-        return (stateManager, mainNodeStorage, compositePruningTrigger);
+        var verifyTrieStarter = new VerifyTrieStarter(stateManager, processExit!, logManager);
+        ManualPruningTrigger pruningTrigger = new();
+        compositePruningTrigger.Add(pruningTrigger);
+        PruningTrieStateAdminRpc adminRpc = new PruningTrieStateAdminRpc(
+            pruningTrigger,
+            blockTree,
+            stateManager.GlobalStateReader,
+            verifyTrieStarter!
+        );
+
+        return (stateManager, mainNodeStorage, adminRpc);
     }
 
     private void InitializeFullPruning(
+        IDb stateDb,
         IStateReader stateReader,
         INodeStorage mainNodeStorage,
         INodeStorageFactory nodeStorageFactory,
@@ -225,34 +238,30 @@ public class PruningTrieStateFactory(
             }
         }
 
-        if (pruningConfig.Mode.IsFull())
+        if (pruningConfig.Mode.IsFull() && stateDb is IFullPruningDb fullPruningDb)
         {
-            IDb stateDb = dbProvider!.StateDb;
-            if (stateDb is IFullPruningDb fullPruningDb)
+            string pruningDbPath = fullPruningDb.GetPath(initConfig.BaseDbPath);
+            IPruningTrigger? pruningTrigger = CreateAutomaticTrigger(pruningDbPath);
+            if (pruningTrigger is not null)
             {
-                string pruningDbPath = fullPruningDb.GetPath(initConfig.BaseDbPath);
-                IPruningTrigger? pruningTrigger = CreateAutomaticTrigger(pruningDbPath);
-                if (pruningTrigger is not null)
-                {
-                    compositePruningTrigger.Add(pruningTrigger);
-                }
-
-                IDriveInfo? drive = fileSystem.GetDriveInfos(pruningDbPath).FirstOrDefault();
-                FullPruner pruner = new(
-                    fullPruningDb,
-                    nodeStorageFactory,
-                    mainNodeStorage,
-                    compositePruningTrigger,
-                    pruningConfig,
-                    blockTree!,
-                    stateReader,
-                    processExit!,
-                    ChainSizes.CreateChainSizeInfo(chainSpec.ChainId),
-                    drive,
-                    trieStore,
-                    logManager);
-                disposeStack.Push(pruner);
+                compositePruningTrigger.Add(pruningTrigger);
             }
+
+            IDriveInfo? drive = fileSystem.GetDriveInfos(pruningDbPath).FirstOrDefault();
+            FullPruner pruner = new(
+                fullPruningDb,
+                nodeStorageFactory,
+                mainNodeStorage,
+                compositePruningTrigger,
+                pruningConfig,
+                blockTree!,
+                stateReader,
+                processExit!,
+                ChainSizes.CreateChainSizeInfo(chainSpec.ChainId),
+                drive,
+                trieStore,
+                logManager);
+            disposeStack.Push(pruner);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -101,14 +101,6 @@ public class InitializeNetwork : IStep
         int maxPeersCount = _networkConfig.ActivePeersMaxCount;
         Network.Metrics.PeerLimit = maxPeersCount;
 
-        _api.WorldStateManager!.InitializeNetwork(
-            new PathNodeRecovery(
-                new NodeDataRecovery(_api.SyncPeerPool!, _api.MainNodeStorage!, _api.LogManager),
-                new SnapRangeRecovery(_api.SyncPeerPool!, _api.LogManager),
-                _api.LogManager
-            )
-        );
-
         _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
 
         _ = _api.SyncServer; // Need to be resolved at least once before the peer pool is started.

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
-using Nethermind.Blockchain.FullPruning;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -18,15 +17,11 @@ using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
-using Nethermind.JsonRpc.Modules.Net;
-using Nethermind.JsonRpc.Modules.Parity;
 using Nethermind.JsonRpc.Modules.Personal;
 using Nethermind.JsonRpc.Modules.Proof;
 using Nethermind.JsonRpc.Modules.Rpc;
 using Nethermind.JsonRpc.Modules.Subscribe;
 using Nethermind.JsonRpc.Modules.Trace;
-using Nethermind.JsonRpc.Modules.TxPool;
-using Nethermind.JsonRpc.Modules.Web3;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 
@@ -97,8 +92,6 @@ public class RegisterRpcModules : IStep
         StepDependencyException.ThrowIfNull(_api.StaticNodesManager);
         StepDependencyException.ThrowIfNull(_api.Enode);
 
-        ManualPruningTrigger pruningTrigger = new();
-        _api.PruningTrigger?.Add(pruningTrigger);
         (IApiWithStores getFromApi, IApiWithBlockchain setInApi) = _api.ForInit;
 
         _api.SubscriptionFactory = new SubscriptionFactory();
@@ -111,11 +104,9 @@ public class RegisterRpcModules : IStep
             networkConfig,
             _api.PeerPool,
             _api.StaticNodesManager,
-            _api.VerifyTrieStarter!,
             _api.WorldStateManager.GlobalStateReader,
             _api.Enode,
             initConfig.BaseDbPath,
-            pruningTrigger,
             getFromApi.ChainSpec.Parameters,
             _api.TrustedNodesManager,
             subscriptionManager);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -9,13 +9,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.FullPruning;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Era1;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.JsonRpc.Modules.Subscribe;
@@ -49,7 +47,6 @@ public class AdminModuleTests
     private IJsonRpcDuplexClient _jsonRpcDuplexClient = null!;
     private IJsonSerializer _jsonSerializer = null!;
     private IBlockTree _blockTree = null!;
-    private IVerifyTrieStarter _verifyTrieStarter = null!;
     private IStateReader _stateReader = null!;
     private const string _enodeString = "enode://e1b7e0dc09aae610c9dec8a0bee62bab9946cc27ebdd2f9e3571ed6d444628f99e91e43f4a14d42d498217608bb3e1d1bc8ec2aa27d7f7e423413b851bae02bc@127.0.0.1:30303";
     private const string _exampleDataDir = "/example/dbdir";
@@ -70,7 +67,6 @@ public class AdminModuleTests
         _jsonRpcDuplexClient = Substitute.For<IJsonRpcDuplexClient>();
         _jsonSerializer = new EthereumJsonSerializer();
         _blockTree = Build.A.BlockTree().OfChainLength(5).TestObject;
-        _verifyTrieStarter = Substitute.For<IVerifyTrieStarter>();
         _stateReader = Substitute.For<IStateReader>();
         _networkConfig = new NetworkConfig();
         IPeerPool peerPool = Substitute.For<IPeerPool>();
@@ -109,11 +105,9 @@ public class AdminModuleTests
             _networkConfig,
             peerPool,
             staticNodesManager,
-            _verifyTrieStarter,
             _stateReader,
             enode,
             _exampleDataDir,
-            new ManualPruningTrigger(),
             chainSpec.Parameters,
             trustedNodesManager,
             _subscriptionManager);
@@ -281,15 +275,6 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task Test_admin_verifyTrie()
-    {
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Unable to start verify trie");
-        _stateReader.HasStateForRoot(Arg.Any<Hash256>()).Returns(true);
-        _verifyTrieStarter.TryStartVerifyTrie(Arg.Any<BlockHeader>()).Returns(true);
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Starting");
-    }
-
-    [Test]
     public async Task Test_hasStateForBlock()
     {
         (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_isStateRootAvailable", "latest")).Should().Contain("false");
@@ -316,11 +301,9 @@ public class AdminModuleTests
             _networkConfig,
             peerPool,
             Substitute.For<IStaticNodesManager>(),
-            Substitute.For<IVerifyTrieStarter>(),
             Substitute.For<IStateReader>(),
             new Enode(_enodeString),
             _exampleDataDir,
-            new ManualPruningTrigger(),
             chainSpec.Parameters,
             trustedNodesManager,
             _subscriptionManager);
@@ -360,11 +343,9 @@ public class AdminModuleTests
             _networkConfig,
             peerPool,
             Substitute.For<IStaticNodesManager>(),
-            Substitute.For<IVerifyTrieStarter>(),
             Substitute.For<IStateReader>(),
             new Enode(_enodeString),
             _exampleDataDir,
-            new ManualPruningTrigger(),
             chainSpec.Parameters,
             trustedNodesManager,
             _subscriptionManager);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PruningTrieStateAdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PruningTrieStateAdminModuleTests.cs
@@ -17,7 +17,7 @@ namespace Nethermind.JsonRpc.Test.Modules;
 
 public class PruningTrieStateAdminModuleTests
 {
-    private IPruningTrieStateAdminRpc _adminRpcModule = null!;
+    private IPruningTrieStateAdminRpcModule _adminRpcModuleModule = null!;
     private IBlockTree _blockTree = null!;
     private IVerifyTrieStarter _verifyTrieStarter = null!;
     private IStateReader _stateReader = null!;
@@ -29,7 +29,7 @@ public class PruningTrieStateAdminModuleTests
         _verifyTrieStarter = Substitute.For<IVerifyTrieStarter>();
         _stateReader = Substitute.For<IStateReader>();
 
-        _adminRpcModule = new PruningTrieStateAdminRpc(
+        _adminRpcModuleModule = new PruningTrieStateAdminRpcModule(
             new ManualPruningTrigger(),
             _blockTree,
             _stateReader,
@@ -39,9 +39,9 @@ public class PruningTrieStateAdminModuleTests
     [Test]
     public async Task Test_admin_verifyTrie()
     {
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Unable to start verify trie");
+        (await RpcTest.TestSerializedRequest(_adminRpcModuleModule, "admin_verifyTrie", "latest")).Should().Contain("Unable to start verify trie");
         _stateReader.HasStateForRoot(Arg.Any<Hash256>()).Returns(true);
         _verifyTrieStarter.TryStartVerifyTrie(Arg.Any<BlockHeader>()).Returns(true);
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Starting");
+        (await RpcTest.TestSerializedRequest(_adminRpcModuleModule, "admin_verifyTrie", "latest")).Should().Contain("Starting");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PruningTrieStateAdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PruningTrieStateAdminModuleTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.FullPruning;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.JsonRpc.Modules.Admin;
+using Nethermind.State;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules;
+
+public class PruningTrieStateAdminModuleTests
+{
+    private IPruningTrieStateAdminRpc _adminRpcModule = null!;
+    private IBlockTree _blockTree = null!;
+    private IVerifyTrieStarter _verifyTrieStarter = null!;
+    private IStateReader _stateReader = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _blockTree = Build.A.BlockTree().OfChainLength(5).TestObject;
+        _verifyTrieStarter = Substitute.For<IVerifyTrieStarter>();
+        _stateReader = Substitute.For<IStateReader>();
+
+        _adminRpcModule = new PruningTrieStateAdminRpc(
+            new ManualPruningTrigger(),
+            _blockTree,
+            _stateReader,
+            _verifyTrieStarter);
+    }
+
+    [Test]
+    public async Task Test_admin_verifyTrie()
+    {
+        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Unable to start verify trie");
+        _stateReader.HasStateForRoot(Arg.Any<Hash256>()).Returns(true);
+        _verifyTrieStarter.TryStartVerifyTrie(Arg.Any<BlockHeader>()).Returns(true);
+        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_verifyTrie", "latest")).Should().Contain("Starting");
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -62,23 +62,11 @@ public interface IAdminRpcModule : IContextAwareRpcModule
         IsImplemented = false)]
     ResultWrapper<bool> admin_setSolc();
 
-    [JsonRpcMethod(Description = "Runs full pruning if enabled.",
-        EdgeCaseHint = "",
-        ExampleResponse = "\"Starting\"",
-        IsImplemented = true)]
-    ResultWrapper<PruningStatus> admin_prune();
-
     [JsonRpcMethod(Description = "True if state root for the block is available",
         EdgeCaseHint = "",
         ExampleResponse = "\"Starting\"",
         IsImplemented = true)]
     ResultWrapper<bool> admin_isStateRootAvailable(BlockParameter block);
-
-    [JsonRpcMethod(Description = "Runs VerifyTrie.",
-        EdgeCaseHint = "",
-        ExampleResponse = "\"Starting\"",
-        IsImplemented = true)]
-    ResultWrapper<string> admin_verifyTrie(BlockParameter block);
 
     [JsonRpcMethod(Description = "Adds given node as a trusted peer, allowing the node to always connect even if slots are full.",
         EdgeCaseHint = "",

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IPruningTrieStateAdminRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IPruningTrieStateAdminRpc.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.FullPruning;
+
+namespace Nethermind.JsonRpc.Modules.Admin;
+
+[RpcModule(ModuleType.Admin)]
+public interface IPruningTrieStateAdminRpc : IRpcModule
+{
+    [JsonRpcMethod(Description = "Runs full pruning if enabled.",
+        EdgeCaseHint = "",
+        ExampleResponse = "\"Starting\"",
+        IsImplemented = true)]
+    ResultWrapper<PruningStatus> admin_prune();
+
+    [JsonRpcMethod(Description = "Runs VerifyTrie.",
+        EdgeCaseHint = "",
+        ExampleResponse = "\"Starting\"",
+        IsImplemented = true)]
+    ResultWrapper<string> admin_verifyTrie(BlockParameter block);
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IPruningTrieStateAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IPruningTrieStateAdminRpcModule.cs
@@ -7,7 +7,7 @@ using Nethermind.Blockchain.FullPruning;
 namespace Nethermind.JsonRpc.Modules.Admin;
 
 [RpcModule(ModuleType.Admin)]
-public interface IPruningTrieStateAdminRpc : IRpcModule
+public interface IPruningTrieStateAdminRpcModule : IRpcModule
 {
     [JsonRpcMethod(Description = "Runs full pruning if enabled.",
         EdgeCaseHint = "",

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.FullPruning;
+using Nethermind.Core;
+using Nethermind.State;
+
+namespace Nethermind.JsonRpc.Modules.Admin;
+
+public class PruningTrieStateAdminRpc (
+    ManualPruningTrigger manualPruningTrigger,
+    IBlockTree blockTree,
+    IStateReader stateReader,
+    IVerifyTrieStarter verifyTrieStarter
+) : IPruningTrieStateAdminRpc {
+    public ResultWrapper<PruningStatus> admin_prune()
+    {
+        return ResultWrapper<PruningStatus>.Success(manualPruningTrigger.Trigger());
+    }
+
+    public ResultWrapper<string> admin_verifyTrie(BlockParameter block)
+    {
+        BlockHeader? header = blockTree.FindHeader(block);
+        if (header is null)
+        {
+            return ResultWrapper<string>.Fail("Unable to find block. Unable to know state root to verify.");
+        }
+
+        if (!stateReader.HasStateForBlock(header))
+        {
+            return ResultWrapper<string>.Fail("Unable to start verify trie. State for block missing.");
+        }
+
+        if (!verifyTrieStarter.TryStartVerifyTrie(header))
+        {
+            return ResultWrapper<string>.Fail("Unable to start verify trie. Verify trie already running.");
+        }
+
+        return ResultWrapper<string>.Success("Starting.");
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
@@ -9,12 +9,12 @@ using Nethermind.State;
 
 namespace Nethermind.JsonRpc.Modules.Admin;
 
-public class PruningTrieStateAdminRpc(
+public class PruningTrieStateAdminRpcModule(
     ManualPruningTrigger manualPruningTrigger,
     IBlockTree blockTree,
     IStateReader stateReader,
     IVerifyTrieStarter verifyTrieStarter
-) : IPruningTrieStateAdminRpc
+) : IPruningTrieStateAdminRpcModule
 {
     public ResultWrapper<PruningStatus> admin_prune()
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PruningTrieStateAdminRpcModule.cs
@@ -9,12 +9,13 @@ using Nethermind.State;
 
 namespace Nethermind.JsonRpc.Modules.Admin;
 
-public class PruningTrieStateAdminRpc (
+public class PruningTrieStateAdminRpc(
     ManualPruningTrigger manualPruningTrigger,
     IBlockTree blockTree,
     IStateReader stateReader,
     IVerifyTrieStarter verifyTrieStarter
-) : IPruningTrieStateAdminRpc {
+) : IPruningTrieStateAdminRpc
+{
     public ResultWrapper<PruningStatus> admin_prune()
     {
         return ResultWrapper<PruningStatus>.Success(manualPruningTrigger.Trigger());

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IContainerBuilderExtensions.cs
@@ -12,6 +12,12 @@ public static class IContainerBuilderExtensions
     {
         return builder
             .AddSingleton<T, TImpl>()
+            .RegisterSingletonJsonRpcModule<T>();
+    }
+
+    public static ContainerBuilder RegisterSingletonJsonRpcModule<T>(this ContainerBuilder builder) where T : IRpcModule
+    {
+        return builder
             .AddSingleton<RpcModuleInfo>((ctx) =>
             {
                 T instance = ctx.Resolve<T>();

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -158,7 +158,6 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             {
                 BlockTree = BlockTree,
                 DbProvider = DbProvider,
-                WorldStateManager = WorldStateManager,
                 TransactionComparerProvider = TransactionComparerProvider,
                 TxPool = TxPool
             };

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -194,7 +194,7 @@ public class MergePluginTests
 
     [TestCase(true, true, true)]
     [TestCase(true, false, false)]
-    [TestCase(false, true, false)]
+    [TestCase(false, true, true)]
     public async Task InitThrowExceptionIfBodiesAndReceiptIsDisabled(bool downloadBody, bool downloadReceipt, bool shouldPass)
     {
         ISyncConfig syncConfig = new SyncConfig()
@@ -214,6 +214,11 @@ public class MergePluginTests
         else
         {
             await invocation.Should().ThrowAsync<InvalidConfigurationException>();
+        }
+
+        if (!downloadBody && downloadReceipt)
+        {
+            syncConfig.DownloadBodiesInFastSync.Should().BeTrue(); // Modified by PruningTrieStateFactory
         }
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -76,13 +76,14 @@ namespace Nethermind.Runner.Test.Ethereum
                     .AddSingleton(Substitute.For<IHeaderValidator>())
                     .AddSingleton(Substitute.For<IUnclesValidator>())
                     .AddSingleton(Substitute.For<IRpcModuleProvider>())
+                    .AddSingleton(Substitute.For<IWorldStateManager>())
+                    .AddSingleton(Substitute.For<IStateReader>())
                     .AddSingleton(Substitute.For<IEthSyncingInfo>())
                     .Build()
             );
 
             var api = new NethermindApi(apiDependencies);
             MockOutNethermindApi(api);
-            api.WorldStateManager = WorldStateManager.CreateForTest(api.DbProvider, LimboLogs.Instance);
             api.NodeStorageFactory = new NodeStorageFactory(INodeStorage.KeyScheme.HalfPath, LimboLogs.Instance);
             return api;
         }
@@ -120,9 +121,6 @@ namespace Nethermind.Runner.Test.Ethereum
             api.RlpxPeer = Substitute.For<IRlpxHost>();
             api.SealValidator = Substitute.For<ISealValidator>();
             api.SessionMonitor = Substitute.For<ISessionMonitor>();
-            api.StateReader = Substitute.For<IStateReader>();
-            api.VerifyTrieStarter = Substitute.For<IVerifyTrieStarter>();
-            api.MainNodeStorage = Substitute.For<INodeStorage>();
             api.MainProcessingContext = Substitute.For<IMainProcessingContext>();
             api.TxSender = Substitute.For<ITxSender>();
             api.BlockProcessingQueue = Substitute.For<IBlockProcessingQueue>();
@@ -137,7 +135,6 @@ namespace Nethermind.Runner.Test.Ethereum
             api.ReceiptMonitor = Substitute.For<IReceiptMonitor>();
             api.BadBlocksStore = Substitute.For<IBadBlockStore>();
 
-            api.WorldStateManager = WorldStateManager.CreateForTest(api.DbProvider, LimboLogs.Instance);
             api.NodeStorageFactory = new NodeStorageFactory(INodeStorage.KeyScheme.HalfPath, LimboLogs.Instance);
         }
     }


### PR DESCRIPTION
- Move `InitializeStateDb` to DI.
- Move out pruning trie state related rpc method out of `AdminRpcModule` into `PruningTrieStateAdminRpcModule`. 
- Move trie state related code out of INethermindApi.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet sync
- [x] Verify trie rpc method still working.
- [x] Prune rpc method still working.
- [x] Verify trie after sync still working.