### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -183,7 +183,7 @@ jobs:
     if: always() && needs.aggregate_rpcs.result == 'success'
     timeout-minutes: 1440
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Wait for the nodes to sync
         timeout-minutes: 1440

--- a/.github/workflows/update-poa-bootnodes.yml
+++ b/.github/workflows/update-poa-bootnodes.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out Nethermind repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Check out poa-chain-spec repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'poanetwork/poa-chain-spec'
         path: poa-chain-spec


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected