### PR TITLE
Add additional block production logs

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -74,21 +74,24 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
         string payloadId = payloadAttributes.GetPayloadId(parentHeader);
         if (!_payloadStorage.ContainsKey(payloadId))
         {
+            if (_logger.IsInfo) _logger.Info($" Production Request  {parentHeader.Number + 1} PayloadId: {payloadId}");
+            long startTimestamp = Stopwatch.GetTimestamp();
             Block emptyBlock = ProduceEmptyBlock(payloadId, parentHeader, payloadAttributes);
+            if (_logger.IsInfo) _logger.Info($" Produced (Empty)    {emptyBlock.ToString(emptyBlock.Difficulty != 0 ? Block.Format.HashNumberDiffAndTx : Block.Format.HashNumberMGasAndTx)} | {Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds,8:N2} ms");
             ImproveBlock(payloadId, parentHeader, payloadAttributes, emptyBlock, DateTimeOffset.UtcNow, default, CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token));
         }
         else if (_logger.IsInfo)
         {
             // Shouldn't really happen so move string construction code out of hot method
-            LogMultiStartRequest(payloadId);
+            LogMultiStartRequest(payloadId, parentHeader.Number + 1);
         }
 
         return payloadId;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void LogMultiStartRequest(string payloadId)
+        void LogMultiStartRequest(string payloadId, long number)
         {
-            _logger.Info($"Payload with the same parameters has already started. PayloadId: {payloadId}");
+            _logger.Info($"Payload for block {number} with same parameters has already started. PayloadId: {payloadId}");
         }
     }
 


### PR DESCRIPTION
## Changes

- Add block requested
- Add empty block produced
- Also add which block number, when duplicate requests come in

We have issues around multiple requests to produce same block and potentially a contention on block production lock; so these logs will provide valuable insight

![image](https://github.com/user-attachments/assets/d7a19f4a-a4d0-4e84-a3f5-3b15a40e81b6)


## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Other: Logging

## Testing

#### Requires testing

- [x] No
