### PR TITLE
Maybe fix incorrect total difficulty

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -89,7 +89,6 @@ public class BeaconHeadersSyncTests
             SyncConfig,
             Report,
             BeaconPivot,
-            MergeConfig,
             InvalidChainTracker,
             LimboLogs.Instance
         );

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -86,7 +86,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
 
         // First, we assume pivot
         _pivotNumber = ExpectedPivotNumber;
-        _expectedNextHeader = (ExpectedPivotHash, _poSSwitcher.FinalTotalDifficulty);
+        _expectedNextHeader = new NextHeader(ExpectedPivotHash, _poSSwitcher.FinalTotalDifficulty);
 
         long startNumber = _pivotNumber;
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -45,7 +45,9 @@ namespace Nethermind.Synchronization.FastBlocks
         private readonly ulong _fastHeadersMemoryBudget;
         protected long _lowestRequestedHeaderNumber;
         protected long _pivotNumber;
-        protected (Hash256 Hash, UInt256? TotalDifficulty) _expectedNextHeader;
+
+        protected record NextHeader(Hash256 Hash256, UInt256? TotalDifficulty);
+        protected NextHeader _expectedNextHeader;
 
         /// <summary>
         /// Requests awaiting to be sent - these are results of partial or invalid responses being queued again
@@ -192,7 +194,7 @@ namespace Nethermind.Synchronization.FastBlocks
         {
             (_pivotNumber, Hash256 nextHeaderHash) = _blockTree.SyncPivot;
             _lowestRequestedHeaderNumber = _pivotNumber + 1; // Because we want the pivot to be requested
-            _expectedNextHeader = (nextHeaderHash, TryGetPivotTotalDifficulty(nextHeaderHash));
+            _expectedNextHeader = new NextHeader(nextHeaderHash, TryGetPivotTotalDifficulty(nextHeaderHash));
 
             // Resume logic
             BlockHeader? lowestInserted = _blockTree.LowestInsertedHeader;
@@ -835,7 +837,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         protected void SetExpectedNextHeaderToParent(BlockHeader header)
         {
-            _expectedNextHeader = (header.ParentHash, DetermineParentTotalDifficulty(header));
+            _expectedNextHeader = new NextHeader(header.ParentHash, DetermineParentTotalDifficulty(header));
         }
 
         protected virtual UInt256? DetermineParentTotalDifficulty(BlockHeader header)


### PR DESCRIPTION
- There seems to be a chance that the next header difficulty is not updated by about one batch.
- Unfortunately this is not reliably reproducable nor can I figureout how can that be.
- Anyway, this combine the next header hash and next header difficulty into one so that they are both updated at the same time.
- Also set the next expected header in a finally block in case an exception happen in blocktree maybe. But that would also mean next header hash also not updated, so what happen? I don't know.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Can't reproduce issue.