### PR TITLE
Fix typos in error messages and comments

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/BlockProcessingModule.cs
@@ -35,7 +35,7 @@ public class BlockProcessingModule : Module
             .AddSingleton<IRewardCalculatorSource>(NoBlockRewards.Instance)
             .AddSingleton<ISealValidator>(NullSealEngine.Instance)
             .AddSingleton<ITransactionComparerProvider, TransactionComparerProvider>()
-            // NOTE: The ordering of block preprocessor is not guarenteed
+            // NOTE: The ordering of block preprocessor is not guaranteed
             .AddComposite<IBlockPreprocessorStep, CompositeBlockPreprocessorStep>()
             .AddSingleton<IBlockPreprocessorStep, RecoverSignatures>()
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/LocalChannelFactory.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/LocalChannelFactory.cs
@@ -90,7 +90,7 @@ internal class LocalChannelFactory(string networkGroup, INetworkConfig networkCo
         }
     }
 
-    // Needed because the default local address did not compare the id and because it need to be convertiable to
+    // Needed because the default local address did not compare the id and because it need to be convertible to
     // IPEndpoint
     private class NethermindLocalAddress(string id, IPEndPoint ipEndPoint) : LocalAddress(id), IIPEndpointSource
     {

--- a/src/Nethermind/Nethermind.Era1/EraReader.cs
+++ b/src/Nethermind/Nethermind.Era1/EraReader.cs
@@ -88,7 +88,7 @@ public class EraReader : IAsyncEnumerable<(Block, TxReceipt[])>, IDisposable
 
                 if (!BlockValidator.ValidateBodyAgainstHeader(err.Block.Header, err.Block.Body))
                 {
-                    throw new EraVerificationException($"Mismatched block body againts header. Block number {blockNumber}.");
+                    throw new EraVerificationException($"Mismatched block body against header. Block number {blockNumber}.");
                 }
 
                 if (!blockValidator.ValidateOrphanedBlock(err.Block, out string? error))


### PR DESCRIPTION

**Description:**
This PR fixes several spelling mistakes:

1. Corrected "guarenteed" to "guaranteed" in BlockProcessingModule comment
2. Fixed "againts" to "against" in error message in EraReader
3. Changed "convertiable" to "convertible" in LocalChannelFactory comment

The changes are minor text corrections that improve code readability and error message accuracy without affecting functionality.

