### PR TITLE
Skip reloads of accounts for txpool delegations

### DIFF
--- a/src/Nethermind/Nethermind.Core/Account.cs
+++ b/src/Nethermind/Nethermind.Core/Account.cs
@@ -136,14 +136,14 @@ namespace Nethermind.Core
 
         private readonly UInt256 _balance;
         private readonly UInt256 _nonce = default;
-        private readonly ValueHash256 _codeHash = Keccak.OfAnEmptyString.ValueHash256;
+        public readonly ValueHash256 CodeHash = Keccak.OfAnEmptyString.ValueHash256;
         private readonly ValueHash256 _storageRoot = Keccak.EmptyTreeHash.ValueHash256;
 
         public AccountStruct(in UInt256 nonce, in UInt256 balance, in ValueHash256 storageRoot, in ValueHash256 codeHash)
         {
             _balance = balance;
             _nonce = nonce;
-            _codeHash = codeHash;
+            CodeHash = codeHash;
             _storageRoot = storageRoot;
         }
 
@@ -158,17 +158,16 @@ namespace Nethermind.Core
             _balance = balance;
         }
 
-        public bool HasCode => _codeHash != Keccak.OfAnEmptyString.ValueHash256;
+        public bool HasCode => CodeHash != Keccak.OfAnEmptyString.ValueHash256;
 
         public bool HasStorage => _storageRoot != Keccak.EmptyTreeHash.ValueHash256;
 
         public UInt256 Nonce => _nonce;
         public UInt256 Balance => _balance;
         public ValueHash256 StorageRoot => _storageRoot;
-        public ValueHash256 CodeHash => _codeHash;
         public bool IsTotallyEmpty => IsEmpty && _storageRoot == Keccak.EmptyTreeHash.ValueHash256;
-        public bool IsEmpty => Balance.IsZero && Nonce.IsZero && _codeHash == Keccak.OfAnEmptyString.ValueHash256;
-        public bool IsContract => _codeHash != Keccak.OfAnEmptyString.ValueHash256;
+        public bool IsEmpty => Balance.IsZero && Nonce.IsZero && CodeHash == Keccak.OfAnEmptyString.ValueHash256;
+        public bool IsContract => CodeHash != Keccak.OfAnEmptyString.ValueHash256;
         public bool IsNull
         {
             get
@@ -195,7 +194,7 @@ namespace Nethermind.Core
 
                 return (Unsafe.As<UInt256, Vector256<byte>>(ref Unsafe.AsRef(in _balance)) |
                     Unsafe.As<UInt256, Vector256<byte>>(ref Unsafe.AsRef(in _nonce)) |
-                    Unsafe.As<ValueHash256, Vector256<byte>>(ref Unsafe.AsRef(in _codeHash)) |
+                    Unsafe.As<ValueHash256, Vector256<byte>>(ref Unsafe.AsRef(in CodeHash)) |
                     Unsafe.As<ValueHash256, Vector256<byte>>(ref Unsafe.AsRef(in _storageRoot))) == default;
             }
         }

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -18,6 +18,7 @@ public interface ICodeInfoRepository
     void InsertCode(IWorldState state, ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec);
     void SetDelegation(IWorldState state, Address codeSource, Address authority, IReleaseSpec spec);
     bool TryGetDelegation(IReadOnlyStateProvider worldState, Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress);
+    bool TryGetDelegation(IReadOnlyStateProvider worldState, in ValueHash256 codeHash, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress);
 }
 
 public static class CodeInfoRepositoryExtensions

--- a/src/Nethermind/Nethermind.Evm/OverridableCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/OverridableCodeInfoRepository.cs
@@ -48,6 +48,9 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
     public bool TryGetDelegation(IReadOnlyStateProvider worldState, Address address, IReleaseSpec vmSpec, [NotNullWhen(true)] out Address? delegatedAddress) =>
         codeInfoRepository.TryGetDelegation(worldState, address, vmSpec, out delegatedAddress);
 
+    public bool TryGetDelegation(IReadOnlyStateProvider worldState, in ValueHash256 codeHash, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress) =>
+        codeInfoRepository.TryGetDelegation(worldState, in codeHash, spec, out delegatedAddress);
+
     public ValueHash256 GetExecutableCodeHash(IWorldState worldState, Address address, IReleaseSpec spec) =>
         codeInfoRepository.GetExecutableCodeHash(worldState, address, spec);
 

--- a/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
@@ -31,7 +31,7 @@ internal class DelegatedAccountFilterTest
         TxDistinctSortedPool blobPool = new BlobTxDistinctSortedPool(10, Substitute.For<IComparer<Transaction>>(), NullLogManager.Instance);
         DelegatedAccountFilter filter = new(headInfoProvider, standardPool, blobPool, Substitute.For<IReadOnlyStateProvider>(), new CodeInfoRepository(), new DelegationCache());
         Transaction transaction = Build.A.Transaction.SignedAndResolved(new EthereumEcdsa(0), TestItem.PrivateKeyA).TestObject;
-        TxFilteringState state = new();
+        TxFilteringState state = new(transaction, Substitute.For<IAccountStateProvider>());
 
         AcceptTxResult result = filter.Accept(transaction, ref state, TxHandlingOptions.None);
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
@@ -23,7 +23,7 @@ namespace Nethermind.TxPool.Filters
             if (tx.HasAuthorizationList && AuthorityHasPendingTx(tx.AuthorizationList))
                 return AcceptTxResult.DelegatorHasPendingTx;
 
-            if (!codeInfoRepository.TryGetDelegation(worldState, tx.SenderAddress!, spec, out _)
+            if ((!state.SenderAccount.HasCode || !codeInfoRepository.TryGetDelegation(worldState, state.SenderAccount.CodeHash, spec, out _))
                 && !pendingDelegations.HasPending(tx.SenderAddress!))
                 return AcceptTxResult.Accepted;
             //If the account is delegated or has pending delegation we only accept the next transaction nonce 

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -18,7 +18,7 @@ namespace Nethermind.TxPool.Filters
         public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
-            return worldState.IsInvalidContractSender(spec,
+            return state.SenderAccount.HasCode && worldState.IsInvalidContractSender(spec,
                 tx.SenderAddress!,
                 _isDelegatedCode)
                 ? AcceptTxResult.SenderIsContract


### PR DESCRIPTION
## Changes

- Account has been already loaded, so don't load 2 more times checking code hash

Before

<img width="477" alt="image" src="https://github.com/user-attachments/assets/575bdbcc-4aa5-40e9-ab13-dfef1dc6315f" />

After

<img width="474" alt="image" src="https://github.com/user-attachments/assets/223081e6-b17e-4f0d-a974-97a361fd3fcc" />

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No