### PR TITLE
Fix StateTestTxTracer top-level precompile calls tracing

### DIFF
--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -101,7 +101,7 @@ public class StateTestTxTracer : ITxTracer, IDisposable
 
     public void SetOperationStack(TraceStack stack)
     {
-        _traceEntry.Stack = new List<string>();
+        _traceEntry.Stack = [];
         foreach (string s in stack.ToHexWordList())
         {
             ReadOnlySpan<char> inProgress = s.AsSpan();

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -67,6 +67,8 @@ public class StateTestTxTracer : ITxTracer, IDisposable
 
     public void ReportOperationError(EvmExceptionType error)
     {
+        if (_traceEntry is null) return;
+
         _traceEntry.Error = GetErrorDescription(error);
     }
 
@@ -88,6 +90,8 @@ public class StateTestTxTracer : ITxTracer, IDisposable
 
     public void ReportOperationRemainingGas(long gas)
     {
+        if (_traceEntry is null) return;
+
         if (!_gasAlreadySetForCurrentOp)
         {
             _gasAlreadySetForCurrentOp = true;


### PR DESCRIPTION
Fixes #8548
Fixes #8471

## Changes

* Makes `StateTestTxTracer.ReportOperationError` and `StateTextTxTracer.ReportOperationRemainingGas` no-op in the case there's no active operation
  * This is needed in the case of top-level precompile calls since there is no associated opcode
  * It was considered that while we could do the same for the `StateTextTxTracer.SetOperation*` methods, semantically it makes more sense to keep them as they are, and this does not impact the issue
* Adds a very minor refactoring

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

To test the fix, `nethtest` can be executed with e.g. the input provided in #8548, as such:
`nethtest --trace -m --input input.json`

Being `input.json` the following:
```JSON
{
  "00000030-mixed-0": {
    "env": {
      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "currentDifficulty": "0x200000",
      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
      "currentGasLimit": "0x26e1f476fe1e22",
      "currentNumber": "0x1",
      "currentTimestamp": "0x3e8",
      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
      "currentBaseFee": "0x10"
    },
    "pre": {
      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
        "code": "0x",
        "storage": {},
        "balance": "0xffffffffff",
        "nonce": "0x0"
      }
    },
    "transaction": {
      "maxFeePerGas": "0x10",
      "maxPriorityFeePerGas": "0x10",
      "nonce": "0x0",
      "to": "0x000000000000000000000000000000000000000A",
      "data": [
        "0xe205224aa8d3db95b7922777bbb0a08d23da7776986cc90e27a3fdf7927a81af9781bf23ef2ce4345a7eadcf7a0ee4cb2ecfd5ca9711b3a3782dcd73d48056"
      ],
      "gasLimit": [
        "0x5be0"
      ],
      "value": [
        "0xfe5b24"
      ],
      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
    },
    "out": "0x",
    "post": {
      "Prague": [
        {
          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "logs": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "indexes": {
            "data": 0,
            "gas": 0,
            "value": 0
          }
        }
      ]
    }
  }
}
```

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
