### PR TITLE
Rename peerdas getBlobsV2 metrics

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -39,5 +39,17 @@ namespace Nethermind.Merge.Plugin
         [GaugeMetric]
         [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 without all requested blobs")]
         public static int NumberOfGetBlobsFailures { get; set; }
+
+        [CounterMetric]
+        [Description("Number of Blobs requested by engine_getBlobsV2")]
+        public static int ExecutionGetBlobsRequestedFromCLTotal { get; set; }
+
+        [CounterMetric]
+        [Description("Number of Blobs requested by engine_getBlobsV2 that are present in the blobpool")]
+        public static int ExecutionGetBlobsRequestedFromCLHit { get; set; }
+
+        [GaugeMetric]
+        [Description("Time taken to return the blobs from engine_getBlobsV2 request")]
+        public static long ExecutionGetBlobsRequestDurationSeconds { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -34,22 +34,22 @@ namespace Nethermind.Merge.Plugin
 
         [GaugeMetric]
         [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 with all requested blobs")]
-        public static int NumberOfGetBlobsSuccesses { get; set; }
+        public static int GetBlobsRequestsSuccessTotal { get; set; }
 
         [GaugeMetric]
         [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 without all requested blobs")]
-        public static int NumberOfGetBlobsFailures { get; set; }
+        public static int GetBlobsRequestsFailureTotal { get; set; }
 
         [CounterMetric]
         [Description("Number of Blobs requested by engine_getBlobsV2")]
-        public static int ExecutionGetBlobsRequestedFromCLTotal { get; set; }
+        public static int GetBlobsRequestsTotal { get; set; }
 
         [CounterMetric]
         [Description("Number of Blobs requested by engine_getBlobsV2 that are present in the blobpool")]
-        public static int ExecutionGetBlobsRequestedFromCLHit { get; set; }
+        public static int GetBlobsRequestsInBlobpoolTotal { get; set; }
 
         [GaugeMetric]
         [Description("Time taken to return the blobs from engine_getBlobsV2 request")]
-        public static long ExecutionGetBlobsRequestDurationSeconds { get; set; }
+        public static long GetBlobsRequestDurationSeconds { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -109,6 +109,22 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         return true;
     }
 
+    public int GetBlobCounts(byte[][] requestedBlobVersionedHashes)
+    {
+        using var lockRelease = Lock.Acquire();
+        int count = 0;
+
+        foreach (byte[] requestedBlobVersionedHash in requestedBlobVersionedHashes)
+        {
+            if (BlobIndex.ContainsKey(requestedBlobVersionedHash))
+            {
+                count += 1;
+            }
+        }
+
+        return count;
+    }
+
     protected override bool InsertCore(ValueHash256 key, Transaction value, AddressAsKey groupKey)
     {
         if (base.InsertCore(key, value, groupKey))

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -94,21 +94,6 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         return false;
     }
 
-    public bool AreBlobsAvailable(byte[][] requestedBlobVersionedHashes)
-    {
-        using var lockRelease = Lock.Acquire();
-
-        foreach (byte[] requestedBlobVersionedHash in requestedBlobVersionedHashes)
-        {
-            if (!BlobIndex.TryGetValue(requestedBlobVersionedHash, out _))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     public int GetBlobCounts(byte[][] requestedBlobVersionedHashes)
     {
         using var lockRelease = Lock.Acquire();

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -52,6 +52,7 @@ namespace Nethermind.TxPool
             [NotNullWhen(true)] out byte[]? blob,
             [NotNullWhen(true)] out byte[][]? cellProofs);
         bool AreBlobsAvailable(byte[][] blobVersionedHashes);
+        int GetBlobCounts(byte[][] blobVersionedHashes);
         UInt256 GetLatestPendingNonce(Address address);
         event EventHandler<TxEventArgs> NewDiscovered;
         event EventHandler<TxEventArgs> NewPending;

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -51,7 +51,6 @@ namespace Nethermind.TxPool
         bool TryGetBlobAndProofV2(byte[] blobVersionedHash,
             [NotNullWhen(true)] out byte[]? blob,
             [NotNullWhen(true)] out byte[][]? cellProofs);
-        bool AreBlobsAvailable(byte[][] blobVersionedHashes);
         int GetBlobCounts(byte[][] blobVersionedHashes);
         UInt256 GetLatestPendingNonce(Address address);
         event EventHandler<TxEventArgs> NewDiscovered;

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -83,6 +83,8 @@ namespace Nethermind.TxPool
 
         public bool AreBlobsAvailable(byte[][] blobVersionedHashes) => false;
 
+        public int GetBlobCounts(byte[][] blobVersionedHashes) => 0;
+
         public UInt256 GetLatestPendingNonce(Address address) => 0;
 
 

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -81,8 +81,6 @@ namespace Nethermind.TxPool
             return false;
         }
 
-        public bool AreBlobsAvailable(byte[][] blobVersionedHashes) => false;
-
         public int GetBlobCounts(byte[][] blobVersionedHashes) => 0;
 
         public UInt256 GetLatestPendingNonce(Address address) => 0;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -212,9 +212,6 @@ namespace Nethermind.TxPool
             [NotNullWhen(true)] out byte[][]? cellProofs)
             => _blobTransactions.TryGetBlobAndProofV2(blobVersionedHash, out blob, out cellProofs);
 
-        public bool AreBlobsAvailable(byte[][] blobVersionedHashes)
-            => _blobTransactions.AreBlobsAvailable(blobVersionedHashes);
-
         public int GetBlobCounts(byte[][] blobVersionedHashes)
             => _blobTransactions.GetBlobCounts(blobVersionedHashes);
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -215,6 +215,9 @@ namespace Nethermind.TxPool
         public bool AreBlobsAvailable(byte[][] blobVersionedHashes)
             => _blobTransactions.AreBlobsAvailable(blobVersionedHashes);
 
+        public int GetBlobCounts(byte[][] blobVersionedHashes)
+            => _blobTransactions.GetBlobCounts(blobVersionedHashes);
+
         private void OnRemovedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolRemovedEventArgs args)
         {
             RemovePendingDelegations(args.Value);


### PR DESCRIPTION
## Changes
This PR renames execution metrics for the new engine_getBlobsV2 rpc for peerdas.
This rename is for unifying the execution metric naming, shown in [this proposal](https://testinprod.notion.site/Proposal-for-Unified-EL-metrics-for-PeerDAS-1d28fc57f54680f2a3cbfe408d7db4b8?pvs=4).

To correctly identify the number of blobs in the blobpool, this PR modifies `AreBlobsAvailable` to `GetBlobCounts` which will return the number of blobs in the blobpool, then use that blob count to compare against the number of blobhashes requested.

Because this is naming change for metric that isn't public yet, so I think the naming changes won't be breaking change. 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No