### PR TITLE
Fix minimum gas limit when producing blocks

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/TargetAdjustedGasLimitCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/TargetAdjustedGasLimitCalculatorTests.cs
@@ -5,6 +5,7 @@
 using FluentAssertions;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -45,6 +46,18 @@ namespace Nethermind.Consensus.Test
             BlockHeader header = Build.A.BlockHeader.WithNumber(blockNumber - 1).WithGasLimit(gasLimit).TestObject;
             long actualValue = targetedAdjustedGasLimitCalculator.GetGasLimit(header);
             actualValue.Should().Be(expectedGasLimit);
+        }
+
+        [Test]
+        public void Doesnt_go_below_minimum()
+        {
+            int londonBlock = 5;
+            long gasLimit = 5000;
+            TestSpecProvider specProvider = new(London.Instance);
+            TargetAdjustedGasLimitCalculator targetedAdjustedGasLimitCalculator = new(specProvider, new BlocksConfig() { TargetBlockGasLimit = 1 });
+            BlockHeader header = Build.A.BlockHeader.WithNumber(londonBlock - 1).WithGasLimit(gasLimit).TestObject;
+            long actualValue = targetedAdjustedGasLimitCalculator.GetGasLimit(header);
+            Assert.That(actualValue, Is.EqualTo(specProvider.GetSpec(new ForkActivation(5)).MinGasLimit));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/TargetAdjustedGasLimitCalculator.cs
+++ b/src/Nethermind/Nethermind.Consensus/TargetAdjustedGasLimitCalculator.cs
@@ -8,16 +8,10 @@ using Nethermind.Core.Specs;
 
 namespace Nethermind.Consensus
 {
-    public class TargetAdjustedGasLimitCalculator : IGasLimitCalculator
+    public class TargetAdjustedGasLimitCalculator(ISpecProvider? specProvider, IBlocksConfig? miningConfig) : IGasLimitCalculator
     {
-        private readonly ISpecProvider _specProvider;
-        private readonly IBlocksConfig _blocksConfig;
-
-        public TargetAdjustedGasLimitCalculator(ISpecProvider? specProvider, IBlocksConfig? miningConfig)
-        {
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
-            _blocksConfig = miningConfig ?? throw new ArgumentNullException(nameof(miningConfig));
-        }
+        private readonly ISpecProvider _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
+        private readonly IBlocksConfig _blocksConfig = miningConfig ?? throw new ArgumentNullException(nameof(miningConfig));
 
         public long GetGasLimit(BlockHeader parentHeader)
         {
@@ -36,7 +30,7 @@ namespace Nethermind.Consensus
             }
 
             gasLimit = Eip1559GasLimitAdjuster.AdjustGasLimit(spec, gasLimit, newBlockNumber);
-            return gasLimit;
+            return Math.Max(gasLimit, spec.MinGasLimit);
         }
     }
 }


### PR DESCRIPTION
## Changes

- TargetAdjustedGasLimitCalculator will not go below spec.MinGasLimit

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes