### PR TITLE
Consider dependency chains in optimal blob packing

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -277,7 +277,7 @@ namespace Nethermind.AuRa.Test.Transactions
 
             const int DefaultGasLimit = 36_000_000;
 
-            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, DefaultGasLimit).ToArray();
+            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, DefaultGasLimit, (tx) => true).ToArray();
             orderedTransactions.Should().BeEquivalentTo(expectation, o => o.WithStrictOrdering());
         }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -277,7 +277,7 @@ namespace Nethermind.AuRa.Test.Transactions
 
             const int DefaultGasLimit = 36_000_000;
 
-            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, DefaultGasLimit, (tx) => true).ToArray();
+            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, _ => true, DefaultGasLimit).ToArray();
             orderedTransactions.Should().BeEquivalentTo(expectation, o => o.WithStrictOrdering());
         }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -275,8 +275,9 @@ namespace Nethermind.AuRa.Test.Transactions
                         // to simulate order coming from TxPool
                         comparer.GetPoolUniqueTxComparerByNonce()).ToArray());
 
+            const int DefaultGasLimit = 36_000_000;
 
-            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, 36_000_000).ToArray();
+            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, DefaultGasLimit).ToArray();
             orderedTransactions.Should().BeEquivalentTo(expectation, o => o.WithStrictOrdering());
         }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -276,7 +276,7 @@ namespace Nethermind.AuRa.Test.Transactions
                         comparer.GetPoolUniqueTxComparerByNonce()).ToArray());
 
 
-            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer).ToArray();
+            Transaction[] orderedTransactions = TxPoolTxSource.Order(txBySender, comparer, 36_000_000).ToArray();
             orderedTransactions.Should().BeEquivalentTo(expectation, o => o.WithStrictOrdering());
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -293,6 +293,55 @@ namespace Nethermind.Blockchain.Test
 
                     yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts");
                 }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 5, blobsPerTx: 5, account: 0, txs, ref nonce0);
+                    UInt256 nonce1 = 2;
+                    AddTxs(txCount: 5, blobsPerTx: 3, account: 1, txs, ref nonce1);
+                    AddTxs(txCount: 5, blobsPerTx: 1, account: 0, txs, ref nonce0);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(5).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 1");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 5, blobsPerTx: 4, account: 1, txs, ref nonce1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 0, txs, ref nonce0);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Take(1));
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(6).Take(1));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 2");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 2, blobsPerTx: 2, account: 1, txs, ref nonce1, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 2, account: 0, txs, ref nonce0, priority: 1);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(1).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 3");
+                }
 
                 static ProperTransactionsSelectedTestCase CreateTestCase()
                 {
@@ -305,12 +354,13 @@ namespace Nethermind.Blockchain.Test
                     return higherPriorityTransactionsSelected;
                 }
 
-                void AddTxs(int txCount, int blobsPerTx, int account, List<Transaction> txs, ref UInt256 nonce)
+                void AddTxs(int txCount, int blobsPerTx, int account, List<Transaction> txs, ref UInt256 nonce, int priority = -1)
                 {
                     var eoa = Accounts[account];
                     for (int i = 0; i < txCount; i++)
                     {
-                        txs.Add(CreateBlobTransaction(eoa.address, eoa.key, maxFee: 1000, blobsPerTx, nonce, priority: (uint)(blobsPerTx * 2)));
+                        txs.Add(CreateBlobTransaction(eoa.address, eoa.key, maxFee: 1000, blobsPerTx, nonce,
+                            priority: priority < 0 ? (uint)(blobsPerTx * 2) : (uint)priority));
                         nonce++;
                     }
                 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -342,6 +342,101 @@ namespace Nethermind.Blockchain.Test
 
                     yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 3");
                 }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 2, blobsPerTx: 2, account: 1, txs, ref nonce1, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 0, txs, ref nonce0, priority: 1);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(1).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 4");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 2, blobsPerTx: 2, account: 1, txs, ref nonce1, priority: 1);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(4).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 5a");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 2, blobsPerTx: 2, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 1, txs, ref nonce1, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 1, txs, ref nonce1, priority: 1);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 5b");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 1, txs, ref nonce1, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 0, txs, ref nonce0, priority: 1);
+
+                    blobTxs.Transactions = txs;
+
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Take(1));
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(2).Take(1));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 6");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 1, txs, ref nonce1, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 1, txs, ref nonce1, priority: 1);
+
+                    blobTxs.Transactions = txs;
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(1).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 7a");
+                }
+                {
+                    var blobTxs = CreateTestCase();
+                    var txs = new List<Transaction>();
+
+                    UInt256 nonce1 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 1, txs, ref nonce1, priority: 1);
+                    UInt256 nonce0 = 1;
+                    AddTxs(txCount: 1, blobsPerTx: 5, account: 0, txs, ref nonce0, priority: 1);
+                    AddTxs(txCount: 3, blobsPerTx: 1, account: 0, txs, ref nonce0, priority: 1);
+
+                    blobTxs.Transactions = txs;
+                    blobTxs.ExpectedSelectedTransactions.AddRange(blobTxs.Transactions.Skip(1).Take(2));
+
+                    yield return new TestCaseData(blobTxs).SetName("Blob Transaction Ordering, Multiple Accounts, Nonce Order 7b");
+                }
 
                 static ProperTransactionsSelectedTestCase CreateTestCase()
                 {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,16 +46,16 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, int maxBlobs = 0)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, int maxBlobs = 0)
         {
             if (_logger.IsTrace)
             {
-                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, maxBlobs).ToArray();
+                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, maxBlobs).ToArray();
                 string txString = string.Join(Environment.NewLine, transactions.Select(t => $"{t.ToShortString()}, PoolIndex {t.PoolIndex}, Whitelisted: {_comparer.IsWhiteListed(t)}, Priority: {_comparer.GetPriority(t)}"));
                 _logger.Trace($"Ordered transactions with comparer {comparer} : {Environment.NewLine}{txString}");
                 return transactions;
             }
-            return base.GetOrderedTransactions(pendingTransactions, comparer, maxBlobs);
+            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, maxBlobs);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
     {
         private readonly IContractDataStore<Address> _sendersWhitelist;
         private readonly IDictionaryContractDataStore<TxPriorityContract.Destination> _priorities;
-        private CompareTxByPriorityOnSpecifiedBlock _comparer;
+        private CompareTxByPriorityOnSpecifiedBlock _comparer = null!;
 
         public TxPriorityTxSource(
             ITxPool transactionPool,
@@ -46,16 +46,16 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool> filter)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, long gasLimit)
         {
             if (_logger.IsTrace)
             {
-                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter).ToArray();
+                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, filter, gasLimit).ToArray();
                 string txString = string.Join(Environment.NewLine, transactions.Select(t => $"{t.ToShortString()}, PoolIndex {t.PoolIndex}, Whitelisted: {_comparer.IsWhiteListed(t)}, Priority: {_comparer.GetPriority(t)}"));
                 _logger.Trace($"Ordered transactions with comparer {comparer} : {Environment.NewLine}{txString}");
                 return transactions;
             }
-            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter);
+            return base.GetOrderedTransactions(pendingTransactions, comparer, filter, gasLimit);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,16 +46,16 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, int maxBlobs = 0)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool>? filter = null, int maxBlobs = 0)
         {
             if (_logger.IsTrace)
             {
-                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, maxBlobs).ToArray();
+                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter, maxBlobs).ToArray();
                 string txString = string.Join(Environment.NewLine, transactions.Select(t => $"{t.ToShortString()}, PoolIndex {t.PoolIndex}, Whitelisted: {_comparer.IsWhiteListed(t)}, Priority: {_comparer.GetPriority(t)}"));
                 _logger.Trace($"Ordered transactions with comparer {comparer} : {Environment.NewLine}{txString}");
                 return transactions;
             }
-            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, maxBlobs);
+            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter, maxBlobs);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,16 +46,16 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, int maxBlobs = 0)
         {
             if (_logger.IsTrace)
             {
-                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer).ToArray();
+                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, maxBlobs).ToArray();
                 string txString = string.Join(Environment.NewLine, transactions.Select(t => $"{t.ToShortString()}, PoolIndex {t.PoolIndex}, Whitelisted: {_comparer.IsWhiteListed(t)}, Priority: {_comparer.GetPriority(t)}"));
                 _logger.Trace($"Ordered transactions with comparer {comparer} : {Environment.NewLine}{txString}");
                 return transactions;
             }
-            return base.GetOrderedTransactions(pendingTransactions, comparer);
+            return base.GetOrderedTransactions(pendingTransactions, comparer, maxBlobs);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool>? filter = null, int maxBlobs = 0)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool> filter, int maxBlobs = 0)
         {
             if (_logger.IsTrace)
             {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,16 +46,16 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool> filter, int maxBlobs = 0)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool> filter)
         {
             if (_logger.IsTrace)
             {
-                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter, maxBlobs).ToArray();
+                var transactions = base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter).ToArray();
                 string txString = string.Join(Environment.NewLine, transactions.Select(t => $"{t.ToShortString()}, PoolIndex {t.PoolIndex}, Whitelisted: {_comparer.IsWhiteListed(t)}, Priority: {_comparer.GetPriority(t)}"));
                 _logger.Trace($"Ordered transactions with comparer {comparer} : {Environment.NewLine}{txString}");
                 return transactions;
             }
-            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter, maxBlobs);
+            return base.GetOrderedTransactions(pendingTransactions, comparer, gasLimit, filter);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -455,7 +455,7 @@ namespace Nethermind.Consensus.Producers
                 DisposeEnumerators(bySenderEnumerators);
             }
         }
-        
+
         private static IEnumerator<Transaction>[] GetEnumerators(IDictionary<AddressAsKey, Transaction[]> pendingTransactions)
         {
             return pendingTransactions

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -242,7 +242,7 @@ namespace Nethermind.Consensus.Producers
                 // If this tx has explicit dependencies (i.e. it requires k prior blobs
                 // from the *same address* to be in the block before it), include them here.
                 // We'll need a capacity of blobDependenciesCount slots *plus* its own blobCount.
-                int blobCapacityNeeded = tx.blobDependenciesCount + blobCount;
+                int blobCapacityNeeded = tx.BlobDependenciesCount + blobCount;
                 // Compute the total fee this tx contributes (premium * gas used).
                 // Use actual gas used (SpentGas) when available as the tx may be using over-estimated gaslimit
                 ulong feeValue = (ulong)premiumPerGas * (ulong)tx.SpentGas;
@@ -396,7 +396,7 @@ namespace Nethermind.Consensus.Producers
                         continue;
                     }
 
-                    addedTx.blobDependenciesCount = blobCount;
+                    addedTx.BlobDependenciesCount = blobCount;
                     // we replace it by next transaction from same sender, on first call N5_P3 from B
                     if (enumerator.MoveNext())
                     {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Consensus.Producers
         /// Selects a subset of candidate transactions
         /// that maximizes the total fee without exceeding the available blob capacity.
         /// Uses a 1D knapsack dynamic programming approach to find the optimal selection.
-        /// The chosen transactions are appended to <paramref name="finalSelectedBlobTxs"/>.
+        /// The chosen transactions are appended to <paramref name="selectedBlobTxs"/>.
         /// </summary>
         /// <param name="candidateTxs">A list of candidate blob transactions.</param>
         /// <param name="leftoverCapacity">The maximum remaining blob capacity available.</param>
@@ -224,7 +224,7 @@ namespace Nethermind.Consensus.Producers
 
                 if (!tx.TryCalculatePremiumPerGas(baseFee, out UInt256 premiumPerGas))
                 {
-                    // Skip any tx where where tx can't cover the premium per gas.
+                    // Skip any tx where tx can't cover the premium per gas.
                     continue;
                 }
 
@@ -421,7 +421,7 @@ namespace Nethermind.Consensus.Producers
 
         public override string ToString() => $"{nameof(TxPoolTxSource)}";
 
-        private class ArrayPoolBitMap : IDisposable
+        private readonly ref struct ArrayPoolBitMap : IDisposable
         {
             private const int BitShiftPerInt64 = 6;
             private static int GetLengthOfBitLength(int n) => (n - 1 + (1 << BitShiftPerInt64)) >>> BitShiftPerInt64;

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -352,7 +352,7 @@ namespace Nethermind.Consensus.Producers
         protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, long gasLimit, Func<Transaction, bool> filter) =>
             Order(pendingTransactions, comparer, gasLimit, filter);
 
-        protected IEnumerable<(Transaction tx, int blobChain)> GetOrderedBlobTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, int maxBlobs = 0) =>
+        protected static IEnumerable<(Transaction tx, int blobChain)> GetOrderedBlobTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, int maxBlobs = 0) =>
             OrderBlobs(pendingTransactions, comparer, filter, maxBlobs);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -139,9 +139,6 @@ namespace Nethermind.Consensus.Producers
                     continue;
                 }
 
-                bool success = _txFilterPipeline.Execute(blobTx, parent);
-                if (!success) continue;
-
                 if (!TryGetFullBlobTx(blobTx, out Transaction fullBlobTx))
                 {
                     if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, failed to get full version of this blob tx from TxPool.");
@@ -354,13 +351,13 @@ namespace Nethermind.Consensus.Producers
             Order(pendingTransactions, comparer, filter, gasLimit);
 
         private static IEnumerable<(Transaction tx, long blobChain)> GetOrderedBlobTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, int maxBlobs = 0) =>
-            OrderCore(pendingTransactions, comparer, tx => tx.GetBlobCount(), filter, maxBlobs);
+            OrderCore(pendingTransactions, comparer, static tx => tx.GetBlobCount(), filter, maxBlobs);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
         internal static IEnumerable<Transaction> Order(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, long gasLimit) =>
-            OrderCore(pendingTransactions, comparer, tx => tx.SpentGas, filter, gasLimit).Select(static tx => tx.tx);
+            OrderCore(pendingTransactions, comparer, static tx => tx.SpentGas, filter, gasLimit).Select(static tx => tx.tx);
 
         private static IEnumerable<(Transaction tx, long resource)> OrderCore(
             IDictionary<AddressAsKey, Transaction[]> pendingTransactions,

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -214,12 +214,12 @@ namespace Nethermind.Consensus.Producers
             in UInt256 baseFee,
             ArrayPoolList<Transaction> selectedBlobTxs)
         {
-            int maxSize = leftoverCapacity + 1;
+            int maxCapacity = leftoverCapacity + 1;
             // The maximum total fee achievable with capacity
-            using ArrayPoolList<ulong> dpFeesPooled = new(capacity: maxSize, count: maxSize);
+            using ArrayPoolList<ulong> dpFeesPooled = new(capacity: maxCapacity, count: maxCapacity);
             Span<ulong> dpFees = dpFeesPooled.AsSpan();
 
-            using ArrayPoolBitMap isChosen = new(candidateTxs.Count * maxSize);
+            using ArrayPoolBitMap isChosen = new(candidateTxs.Count * maxCapacity);
 
             // Build up the DP table to find the maximum total fee for each capacity.
             // Outer loop: go through each transaction (1-based index).
@@ -290,10 +290,10 @@ namespace Nethermind.Consensus.Producers
                     {
                         dpFees[capacity] = candidateFee;
 
-                        isChosen[i * maxSize + capacity] = dependencyIndex < 0 ||
+                        isChosen[i * maxCapacity + capacity] = dependencyIndex < 0 ||
                             // with a dependency: only mark this tx as chosen
                             // if *its* predecessor was also marked in the smaller capacity.
-                            isChosen[dependencyIndex * maxSize + (capacity - blobCount)];
+                            isChosen[dependencyIndex * maxCapacity + (capacity - blobCount)];
                     }
                 }
             }
@@ -303,7 +303,7 @@ namespace Nethermind.Consensus.Producers
             int remainingCapacity = leftoverCapacity;
             for (int i = candidateTxs.Count - 1; i >= 0; i--)
             {
-                if (isChosen[i * maxSize + remainingCapacity])
+                if (isChosen[i * maxCapacity + remainingCapacity])
                 {
                     Transaction tx = candidateTxs[i];
                     int blobCount = tx.GetBlobCount();

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -114,6 +114,7 @@ namespace Nethermind.Consensus.Producers
         private void SelectBlobTransactions(IEnumerable<(Transaction tx, long blobChain)> blobTransactions, BlockHeader parent, IReleaseSpec spec, in UInt256 baseFee, ArrayPoolList<Transaction> selectedBlobTxs)
         {
             int maxBlobsPerBlock = (int)spec.MaxBlobCount;
+            int maxBlobsToConsider = maxBlobsPerBlock * 5;
             int countOfRemainingBlobs = 0;
 
             ArrayPoolList<(Transaction tx, long blobChain)>? candidates = null;
@@ -163,6 +164,12 @@ namespace Nethermind.Consensus.Producers
 
                     candidates.Add((fullBlobTx, blobChain));
                     countOfRemainingBlobs += txBlobCount;
+                }
+
+                if (countOfRemainingBlobs > maxBlobsToConsider)
+                {
+                    // Reached max blobs to consider, should have enough to fill the block.
+                    break;
                 }
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -341,7 +341,7 @@ namespace Nethermind.Consensus.Producers
                     (Transaction addedTx, (IEnumerator<Transaction> enumerator, long gasUsed, int blobCount)) = transactions.Min;
 
                     transactions.Remove(addedTx);
-                    if (!(filter?.Invoke(addedTx) ?? true))
+                    if (filter is not null && !filter.Invoke(addedTx))
                     {
                         // Cannot be added, so stop adding more txs from this sender
                         continue;
@@ -357,7 +357,7 @@ namespace Nethermind.Consensus.Producers
                         // Only add next tx from sender if chain of blobs or tx still fit in gas
                         if (sumGasUsed + nextTx.SpentGas <= gasLimit &&
                             sumBlobs + nextTx.GetBlobCount() <= maxBlobs &&
-                            (filter?.Invoke(nextTx) ?? true))
+                            (filter is null || filter.Invoke(nextTx)))
                         {
                             transactions.Add(nextTx, (enumerator, sumGasUsed, sumBlobs));
                         }

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -25,7 +25,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 
     public ArrayPoolList(int capacity, IEnumerable<T> enumerable) : this(capacity) => this.AddRange(enumerable);
 
-    public ArrayPoolList(int capacity, ReadOnlySpan<T> span) : this(capacity) => AddRange(span);
+    public ArrayPoolList(ReadOnlySpan<T> span) : this(span.Length) => AddRange(span);
 
     public ArrayPoolList(ArrayPool<T> arrayPool, int capacity, int startingCount = 0)
     {

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -25,6 +25,8 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 
     public ArrayPoolList(int capacity, IEnumerable<T> enumerable) : this(capacity) => this.AddRange(enumerable);
 
+    public ArrayPoolList(int capacity, ReadOnlySpan<T> span) : this(capacity) => AddRange(span);
+
     public ArrayPoolList(ArrayPool<T> arrayPool, int capacity, int startingCount = 0)
     {
         _arrayPool = arrayPool;

--- a/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
@@ -15,6 +15,7 @@ namespace Nethermind.Core.Extensions
 
         public static ArrayPoolList<T> ToPooledList<T>(this IEnumerable<T> enumerable, int count) => new(count, enumerable);
         public static ArrayPoolList<T> ToPooledList<T>(this IReadOnlyCollection<T> collection) => new(collection.Count, collection);
+        public static ArrayPoolList<T> ToPooledList<T>(this ReadOnlySpan<T> span) => new(span.Length, span);
 
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> enumerable, Random rng, int maxSize = 100)
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Core.Extensions
 
         public static ArrayPoolList<T> ToPooledList<T>(this IEnumerable<T> enumerable, int count) => new(count, enumerable);
         public static ArrayPoolList<T> ToPooledList<T>(this IReadOnlyCollection<T> collection) => new(collection.Count, collection);
-        public static ArrayPoolList<T> ToPooledList<T>(this ReadOnlySpan<T> span) => new(span.Length, span);
+        public static ArrayPoolList<T> ToPooledList<T>(this ReadOnlySpan<T> span) => new(span);
 
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> enumerable, Random rng, int maxSize = 100)
         {

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Core
 
         protected int? _size = null;
         [JsonIgnore]
-        internal int blobDependenciesCount;
+        internal int BlobDependenciesCount;
 
         /// <summary>
         /// Encoded transaction length

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -197,8 +197,6 @@ namespace Nethermind.Core
         public ulong PoolIndex { get; set; }
 
         protected int? _size = null;
-        [JsonIgnore]
-        internal int BlobDependenciesCount;
 
         /// <summary>
         /// Encoded transaction length

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -197,6 +197,8 @@ namespace Nethermind.Core
         public ulong PoolIndex { get; set; }
 
         protected int? _size = null;
+        [JsonIgnore]
+        internal int blobDependenciesCount;
 
         /// <summary>
         /// Encoded transaction length

--- a/src/Nethermind/Nethermind.Core/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionExtensions.cs
@@ -79,13 +79,7 @@ namespace Nethermind.Core
             return item != null;
         }
 
-        public static ulong GetBlobGas(this Transaction tx)
-        {
-            return (uint)tx.GetBlobCount() * Eip4844Constants.GasPerBlob;
-        }
-        public static int GetBlobCount(this Transaction tx)
-        {
-            return tx.BlobVersionedHashes?.Length ?? 0;
-        }
+        public static ulong GetBlobGas(this Transaction tx) => (uint)tx.GetBlobCount() * Eip4844Constants.GasPerBlob;
+        public static int GetBlobCount(this Transaction tx) => tx.BlobVersionedHashes?.Length ?? 0;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -174,7 +174,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         base.MarkAsSuccess(recipient, gasSpent, output, logs, stateRoot);
         NativeCallTracerCallFrame firstCallFrame = _callStack[0];
         firstCallFrame.GasUsed = gasSpent.SpentGas;
-        firstCallFrame.Output = new ArrayPoolList<byte>(output.Length, output);
+        firstCallFrame.Output = new ArrayPoolList<byte>(output);
     }
 
     public override void MarkAsFailed(Address recipient, GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
@@ -183,7 +183,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         NativeCallTracerCallFrame firstCallFrame = _callStack[0];
         firstCallFrame.GasUsed = gasSpent.SpentGas;
         if (output is not null)
-            firstCallFrame.Output = new ArrayPoolList<byte>(output.Length, output);
+            firstCallFrame.Output = new ArrayPoolList<byte>(output);
 
         EvmExceptionType errorType = _error!.Value;
         firstCallFrame.Error = errorType.GetEvmExceptionDescription();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
@@ -414,14 +414,14 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = SetUpFeeHistoryManager(newestBlockParameter, spec);
             double[] rewardPercentiles = { 0 };
             using FeeHistoryResults expected = new(0,
-                new ArrayPoolList<UInt256>(3, [2, 3, 3]),
-                new ArrayPoolList<double>(2, [0.6, 0.25]),
-                new ArrayPoolList<UInt256>(3, [1, 1, 1]),
+                new ArrayPoolList<UInt256>([2, 3, 3]),
+                new ArrayPoolList<double>([0.6, 0.25]),
+                new ArrayPoolList<UInt256>([1, 1, 1]),
                 new ArrayPoolList<double>(2, blobGasUsedRatio),
-                new ArrayPoolList<ArrayPoolList<UInt256>>(2,
+                new ArrayPoolList<ArrayPoolList<UInt256>>(
                 [
-                    new ArrayPoolList<UInt256>(1, [1]),
-                    new ArrayPoolList<UInt256>(1, [0])
+                    new ArrayPoolList<UInt256>([1]),
+                    new ArrayPoolList<UInt256>([0])
                 ])
             );
 


### PR DESCRIPTION
## Changes

- Evaultate less (Perf good): When adding txs to consider during block production, stop adding from same address (don't add later nonces) when 
   - The sum of the dependency chain exceeds blob count or block gaslimit
   -  As soon as one of the txs fails tx filters e.g. gas below base fee
- Evaluate deeper (Bug fix): If dependency on blobs tx, only include blob tx in optimal list if also included parent tx

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Two hive tests check for a suboptimal built block result; testing for a lower profit blocks (will submit fix to hive)

Have had added variant tests around that; including the variant hive thinks its testing (but it's taking into account profit, so changed priority fees to produce same output), and the max profit result of what it is testing.