### PR TITLE
Adjust names of engine_getBlobs metrics

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
@@ -45,11 +45,11 @@ public class GetBlobsHandler(ITxPool txPool) : IAsyncHandler<byte[][], IEnumerab
 
         if (allBlobsAvailable)
         {
-            Metrics.NumberOfGetBlobsSuccesses++;
+            Metrics.GetBlobsRequestsSuccessTotal++;
         }
         else
         {
-            Metrics.NumberOfGetBlobsFailures++;
+            Metrics.GetBlobsRequestsFailureTotal++;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -33,11 +33,11 @@ namespace Nethermind.Merge.Plugin
         public static int NumberOfSentBlobs { get; set; }
 
         [GaugeMetric]
-        [Description("Number of responses to engine_getBlobsV1 with all requested blobs")]
-        public static int NumberOfGetBlobsSuccesses { get; set; }
+        [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 with all requested blobs")]
+        public static int GetBlobsRequestsSuccessTotal { get; set; }
 
         [GaugeMetric]
-        [Description("Number of responses to engine_getBlobsV1 without all requested blobs")]
-        public static int NumberOfGetBlobsFailures { get; set; }
+        [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 without all requested blobs")]
+        public static int GetBlobsRequestsFailureTotal { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -33,11 +33,11 @@ namespace Nethermind.Merge.Plugin
         public static int NumberOfSentBlobs { get; set; }
 
         [GaugeMetric]
-        [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 with all requested blobs")]
+        [Description("Number of responses to engine_getBlobsV1 with all requested blobs")]
         public static int GetBlobsRequestsSuccessTotal { get; set; }
 
         [GaugeMetric]
-        [Description("Number of responses to engine_getBlobsV1 and engine_getBlobsV2 without all requested blobs")]
+        [Description("Number of responses to engine_getBlobsV1 without all requested blobs")]
         public static int GetBlobsRequestsFailureTotal { get; set; }
     }
 }


### PR DESCRIPTION
## Changes

- adjust metrics names to follow convention

Basing on https://github.com/NethermindEth/nethermind/pull/8579 and https://testinprod.notion.site/Proposal-for-Unified-EL-metrics-for-PeerDAS-1d28fc57f54680f2a3cbfe408d7db4b8

Current version wasn't released yet so there is no issue with simple renaming.

More context:
- metrics introduced in https://github.com/NethermindEth/nethermind/pull/8495 to collect some data before fusaka

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No