### PR TITLE
Use faster span enumerator for ArrayPoolList

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -546,7 +546,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
         else
         {
-            foreach (Block block in processingBranch.Blocks)
+            foreach (Block block in processingBranch.Blocks.AsSpan())
             {
                 CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Consensus.Producers
 
             if (selectedBlobTxs.Count > 0)
             {
-                foreach (Transaction blobTx in selectedBlobTxs.AsSpan())
+                foreach (Transaction blobTx in selectedBlobTxs)
                 {
                     yield return blobTx;
                 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Consensus.Producers
 
             if (selectedBlobTxs.Count > 0)
             {
-                foreach (Transaction blobTx in selectedBlobTxs)
+                foreach (Transaction blobTx in selectedBlobTxs.AsSpan())
                 {
                     yield return blobTx;
                 }

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -50,10 +50,10 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         return AsSpan();
     }
 
-    public IEnumerator<T> GetEnumerator()
+    public Span<T>.Enumerator GetEnumerator()
     {
         GuardDispose();
-        return new ArrayPoolListEnumerator(_array, Count);
+        return AsSpan().GetEnumerator();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -71,7 +71,17 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         }
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        GuardDispose();
+        return new ArrayPoolListEnumerator(_array, Count);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        GuardDispose();
+        return new ArrayPoolListEnumerator(_array, Count);
+    }
 
     public void Add(T item)
     {

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -50,10 +50,10 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         return AsSpan();
     }
 
-    public Span<T>.Enumerator GetEnumerator()
+    public ArrayPoolListEnumerator GetEnumerator()
     {
         GuardDispose();
-        return AsSpan().GetEnumerator();
+        return new ArrayPoolListEnumerator(_array, Count);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -71,17 +71,9 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         }
     }
 
-    IEnumerator<T> IEnumerable<T>.GetEnumerator()
-    {
-        GuardDispose();
-        return new ArrayPoolListEnumerator(_array, Count);
-    }
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        GuardDispose();
-        return new ArrayPoolListEnumerator(_array, Count);
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public void Add(T item)
     {
@@ -350,7 +342,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 
     public static ArrayPoolList<T> Empty() => new(0);
 
-    private struct ArrayPoolListEnumerator(T[] array, int count) : IEnumerator<T>
+    public struct ArrayPoolListEnumerator(T[] array, int count) : IEnumerator<T>
     {
         private int _index = -1;
 

--- a/src/Nethermind/Nethermind.Era1/EraReader.cs
+++ b/src/Nethermind/Nethermind.Era1/EraReader.cs
@@ -111,7 +111,7 @@ public class EraReader : IAsyncEnumerable<(Block, TxReceipt[])>, IDisposable
         await Task.WhenAll(workers.AsSpan());
 
         using AccumulatorCalculator calculator = new();
-        foreach (var valueTuple in blockHashes)
+        foreach (var valueTuple in blockHashes.AsSpan())
         {
             calculator.Add(valueTuple.Item1, valueTuple.Item2);
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -267,7 +267,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
             callFrame.Logs = null;
         }
 
-        foreach (NativeCallTracerCallFrame childCallFrame in callFrame.Calls)
+        foreach (NativeCallTracerCallFrame childCallFrame in callFrame.Calls.AsSpan())
         {
             ClearFailedLogs(childCallFrame, failed);
         }

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -119,7 +119,7 @@ public class ShutterTxLoader(
 
         using ArrayPoolList<int> sortedKeyIndexes = new(txCount, txCount);
         int keyIndex = 0;
-        foreach (SequencedTransaction index in sortedIndexes)
+        foreach (SequencedTransaction index in sortedIndexes.AsSpan())
         {
             sortedKeyIndexes[index.Index] = keyIndex++;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -193,7 +193,7 @@ public class HealingTreeTests
             allValues.AsSpan().Sort(((k1, k2) => ((IComparer<byte[]>)Bytes.Comparer).Compare(k1.Key, k2.Key)));
 
             // Copy from server to client, but randomly remove some of them.
-            foreach (var kv in allValues)
+            foreach (var kv in allValues.AsSpan())
             {
                 if (random.NextDouble() < 0.9)
                 {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -655,7 +655,7 @@ namespace Nethermind.Synchronization.FastBlocks
             }
 
             UInt256? totalDifficulty = nextHeaderTotalDifficulty;
-            foreach (var blockHeader in headersToAdd)
+            foreach (var blockHeader in headersToAdd.AsSpan())
             {
                 blockHeader.TotalDifficulty = totalDifficulty;
                 totalDifficulty = DetermineParentTotalDifficulty(blockHeader);

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -275,7 +275,7 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
                 RlpStream rlpStream = new(data);
 
                 rlpStream.StartSequence(contentLength);
-                foreach (Transaction tx in Transactions)
+                foreach (Transaction tx in Transactions.AsSpan())
                 {
                     txDecoder.Encode(rlpStream, tx);
                 }


### PR DESCRIPTION
## Changes

- Use non-boxing return of `ArrayPoolListEnumerator` for `ArrayPoolList<T>.GetEnumerator()`
- Convert to `.AsSpan` in `foreach` loops as the C# compiler converts enumeration of spans to a bounds check eliminated `for i` loop 

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
