### PR TITLE
Cap snappy output span

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
@@ -23,7 +23,7 @@ public class ZeroSnappyEncoder : MessageToByteEncoder<IByteBuffer>
     {
         byte packetType = input.ReadByte();
 
-        var maxLength = Snappy.GetMaxCompressedLength(input.ReadableBytes);
+        int maxLength = Snappy.GetMaxCompressedLength(input.ReadableBytes);
         output.EnsureWritable(1 + maxLength);
         output.WriteByte(packetType);
 

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
@@ -23,14 +23,15 @@ public class ZeroSnappyEncoder : MessageToByteEncoder<IByteBuffer>
     {
         byte packetType = input.ReadByte();
 
-        output.EnsureWritable(1 + Snappy.GetMaxCompressedLength(input.ReadableBytes));
+        var maxLength = Snappy.GetMaxCompressedLength(input.ReadableBytes);
+        output.EnsureWritable(1 + maxLength);
         output.WriteByte(packetType);
 
         if (_logger.IsTrace) _logger.Trace($"Compressing with Snappy a message of length {input.ReadableBytes}");
 
         int length = Snappy.Compress(
             input.Array.AsSpan(input.ArrayOffset + input.ReaderIndex, input.ReadableBytes),
-            output.Array.AsSpan(output.ArrayOffset + output.WriterIndex));
+            output.Array.AsSpan(output.ArrayOffset + output.WriterIndex, maxLength));
 
         input.SetReaderIndex(input.ReaderIndex + input.ReadableBytes);
         output.SetWriterIndex(output.WriterIndex + length);


### PR DESCRIPTION
## Changes

- Cap snappy output span, as at infinite length Snappy thinks are overlapping ranges (change from dependency upgrade)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
