### PR TITLE
Fix E2ESyncTest

### DIFF
--- a/src/Nethermind/Nethermind.Core/ManualTimestamper.cs
+++ b/src/Nethermind/Nethermind.Core/ManualTimestamper.cs
@@ -9,6 +9,16 @@ namespace Nethermind.Core
     {
         public ManualTimestamper() : this(DateTime.UtcNow) { }
 
+        public static ManualTimestamper PreMerge
+        {
+            get
+            {
+                // Note: Should be new instance as multiple tests tend to mutate it.
+                DateTime mergeTime = new DateTime(2022, 9, 15, 13, 45, 0, DateTimeKind.Utc);
+                return new ManualTimestamper(mergeTime.AddDays(-1));
+            }
+        }
+
         public ManualTimestamper(DateTime initialValue)
         {
             UtcNow = initialValue;

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -167,8 +167,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         else
         {
             // So that any EIP after the merge is not activated.
-            DateTime mergeTime = new DateTime(2022, 9, 15, 13, 45, 0, DateTimeKind.Utc);
-            ManualTimestamper timestamper = new ManualTimestamper(mergeTime.AddDays(-1));
+            ManualTimestamper timestamper = ManualTimestamper.PreMerge;
             builder
                 .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
                 .AddSingleton<ITimestamper>(timestamper)


### PR DESCRIPTION
- E2ESyncTests fails after pectra as post merge EIP is activated. 
- ParentBeaconBlockRoot must not be null so that header is encoded correctly.
- Now the `ITimestamper` changed so that any EIP post merge is not activated in pre merge tests.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
