### PR TITLE
Use all tx types in pending delegation test

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2114,29 +2114,39 @@ namespace Nethermind.TxPool.Test
             AcceptTxResult result = _txPool.SubmitTx(setCodeTx, TxHandlingOptions.PersistentBroadcast);
             result.Should().Be(AcceptTxResult.Accepted);
 
-            Transaction firstTx = Build.A.Transaction
+            //Submit a replacement tx of each type with current nonce
+            foreach (byte type in ((byte[])Enum.GetValues(typeof(TxType))))
+            {
+                UInt256 feeCap;
+                1.GWei().Multiply((UInt256)type, out feeCap);
+                TransactionBuilder<Transaction> builder = Build.A.Transaction
                 .WithNonce(0)
-                .WithType(TxType.EIP1559)
-                .WithMaxFeePerGas(20.GWei())
-                .WithMaxPriorityFeePerGas(20.GWei())
-                .WithGasLimit(GasCostOf.Transaction)
-                .WithTo(TestItem.AddressB)
-                .SignedAndResolved(_ethereumEcdsa, signer).TestObject;
-
-            result = _txPool.SubmitTx(firstTx, TxHandlingOptions.PersistentBroadcast);
-            result.Should().Be(AcceptTxResult.Accepted);
-
-            Transaction secondTx = Build.A.Transaction
-                .WithNonce(0)
-                .WithType(TxType.Legacy)
-                .WithMaxFeePerGas(25.GWei())
-                .WithMaxPriorityFeePerGas(25.GWei())
+                .WithType((TxType)type)
+                .WithMaxFeePerGas(feeCap)
+                .WithMaxPriorityFeePerGas(feeCap)
                 .WithGasLimit(100_000)
-                .WithTo(TestItem.AddressB)
-                .SignedAndResolved(_ethereumEcdsa, signer).TestObject;
+                .WithTo(TestItem.AddressB);
+                switch ((TxType)type)
+                {
+                    case TxType.Legacy:
+                        break;
+                    case TxType.EIP1559:
+                        break;
+                    case TxType.Blob:
+                        //Blob tx are not allowed when another type is already in the pool
+                        continue;
+                    case TxType.SetCode:
+                        builder.WithAuthorizationCodeIfAuthorizationListTx();
+                        break;
+                    case TxType.DepositTx:
+                        continue;
+                }
+                builder.SignedAndResolved(_ethereumEcdsa, signer);
 
-            result = _txPool.SubmitTx(secondTx, TxHandlingOptions.PersistentBroadcast);
-            result.Should().Be(AcceptTxResult.Accepted);
+                //Signer submits a tx of all every type with current nonce
+                result = _txPool.SubmitTx(builder.TestObject, TxHandlingOptions.PersistentBroadcast);
+                result.Should().Be(AcceptTxResult.Accepted);
+            }
         }
 
         private IDictionary<ITxPoolPeer, PrivateKey> GetPeers(int limit = 100)


### PR DESCRIPTION
Just a small refactor to emphasize that any tx type can be used as replacement, when account is pending delegation.