### PR TITLE
Safely cast Optimism subtypes (2)

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
@@ -251,7 +251,7 @@ public class OptimismEthRpcModule : EthRpcModule, IOptimismEthRpcModule
                     txIndex: index);
                 if (transactionModel is DepositTransactionForRpc depositTx)
                 {
-                    OptimismTxReceipt? receipt = (OptimismTxReceipt?)receipts.FirstOrDefault(r => r.TxHash?.Equals(hash) ?? false);
+                    OptimismTxReceipt? receipt = receipts.FirstOrDefault(r => r.TxHash?.Equals(hash) ?? false) as OptimismTxReceipt;
                     depositTx.DepositReceiptVersion = receipt?.DepositReceiptVersion;
                 }
 


### PR DESCRIPTION
Fixes #8515

## Changes

- Be even more conservative when casting to avoid `InvalidCastException`s.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The user did not provide a reproducible scenario and the logs are not enough. We are mostly guessing what could be the issue.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Originally reported through Discord: https://discord.com/channels/629004402170134531/1364406090779070585/1370824352450482196
