### PR TITLE
Add state availability checks before debug module tracing

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -51,12 +51,17 @@ public class GethStyleTracer(
         Block block = _blockTree.FindBlock(blockHash, BlockTreeLookupOptions.None) ?? throw new InvalidOperationException($"No historical block found for {blockHash}");
         if (txIndex > block.Transactions.Length - 1) throw new InvalidOperationException($"Block {blockHash} has only {block.Transactions.Length} transactions and the requested tx index was {txIndex}");
 
-        return Trace(block, block.Transactions[txIndex].Hash, cancellationToken, options);
+        return TraceImpl(block, block.Transactions[txIndex].Hash, cancellationToken, options);
     }
 
-    public GethLikeTxTrace? Trace(Rlp block, Hash256 txHash, GethTraceOptions options, CancellationToken cancellationToken)
+    public GethLikeTxTrace? Trace(Rlp blockRlp, Hash256 txHash, GethTraceOptions options, CancellationToken cancellationToken)
     {
-        return TraceBlock(GetBlockToTrace(block), options with { TxHash = txHash }, cancellationToken).FirstOrDefault();
+        return TraceBlockImpl(GetBlockToTrace(blockRlp), options with { TxHash = txHash }, cancellationToken).FirstOrDefault();
+    }
+
+    public GethLikeTxTrace? Trace(Block block, Hash256 txHash, GethTraceOptions options, CancellationToken cancellationToken)
+    {
+        return TraceBlockImpl(block, options with { TxHash = txHash }, cancellationToken).FirstOrDefault();
     }
 
     public GethLikeTxTrace? Trace(BlockParameter blockParameter, Transaction tx, GethTraceOptions options, CancellationToken cancellationToken)
@@ -69,7 +74,7 @@ public class GethStyleTracer(
 
         try
         {
-            return Trace(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions);
+            return TraceImpl(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions);
         }
         finally
         {
@@ -91,7 +96,7 @@ public class GethStyleTracer(
             return null;
         }
 
-        return Trace(block, txHash, cancellationToken, traceOptions);
+        return TraceImpl(block, txHash, cancellationToken, traceOptions);
     }
 
     public GethLikeTxTrace? Trace(long blockNumber, int txIndex, GethTraceOptions options, CancellationToken cancellationToken)
@@ -99,7 +104,7 @@ public class GethStyleTracer(
         Block block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical) ?? throw new InvalidOperationException($"No historical block found for {blockNumber}");
         if (txIndex > block.Transactions.Length - 1) throw new InvalidOperationException($"Block {blockNumber} has only {block.Transactions.Length} transactions and the requested tx index was {txIndex}");
 
-        return Trace(block, block.Transactions[txIndex].Hash, cancellationToken, options);
+        return TraceImpl(block, block.Transactions[txIndex].Hash, cancellationToken, options);
     }
 
     public GethLikeTxTrace? Trace(long blockNumber, Transaction tx, GethTraceOptions options, CancellationToken cancellationToken)
@@ -126,12 +131,17 @@ public class GethStyleTracer(
     {
         var block = _blockTree.FindBlock(blockParameter);
 
-        return TraceBlock(block, options, cancellationToken);
+        return TraceBlockImpl(block, options, cancellationToken);
     }
 
     public IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken)
     {
-        return TraceBlock(GetBlockToTrace(blockRlp), options, cancellationToken);
+        return TraceBlockImpl(GetBlockToTrace(blockRlp), options, cancellationToken);
+    }
+
+    public IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block block, GethTraceOptions options, CancellationToken cancellationToken)
+    {
+        return TraceBlockImpl(block, options, cancellationToken);
     }
 
     public IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken)
@@ -173,7 +183,7 @@ public class GethStyleTracer(
         return tracer.FileNames;
     }
 
-    private GethLikeTxTrace? Trace(Block block, Hash256? txHash, CancellationToken cancellationToken, GethTraceOptions options,
+    private GethLikeTxTrace? TraceImpl(Block block, Hash256? txHash, CancellationToken cancellationToken, GethTraceOptions options,
         ProcessingOptions processingOptions = ProcessingOptions.Trace)
     {
         ArgumentNullException.ThrowIfNull(txHash);
@@ -201,7 +211,7 @@ public class GethStyleTracer(
             _ => new GethLikeBlockMemoryTracer(options),
         };
 
-    private IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block? block, GethTraceOptions options, CancellationToken cancellationToken)
+    private IReadOnlyCollection<GethLikeTxTrace> TraceBlockImpl(Block? block, GethTraceOptions options, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(block);
 

--- a/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
@@ -18,9 +18,11 @@ public interface IGethStyleTracer
     GethLikeTxTrace Trace(long blockNumber, int txIndex, GethTraceOptions options, CancellationToken cancellationToken);
     GethLikeTxTrace Trace(Hash256 blockHash, int txIndex, GethTraceOptions options, CancellationToken cancellationToken);
     GethLikeTxTrace Trace(Rlp blockRlp, Hash256 txHash, GethTraceOptions options, CancellationToken cancellationToken);
+    GethLikeTxTrace Trace(Block block, Hash256 txHash, GethTraceOptions options, CancellationToken cancellationToken);
     GethLikeTxTrace? Trace(BlockParameter blockParameter, Transaction tx, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(BlockParameter blockParameter, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken);
+    IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block block, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBadBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -38,6 +38,8 @@ public class DebugModuleTests
     private readonly IJsonRpcConfig jsonRpcConfig = new JsonRpcConfig();
     private readonly ISpecProvider specProvider = Substitute.For<ISpecProvider>();
     private readonly IDebugBridge debugBridge = Substitute.For<IDebugBridge>();
+    private readonly IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+    private readonly IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
     private DebugRpcModule CreateDebugRpcModule(IDebugBridge customDebugBridge)
@@ -47,9 +49,9 @@ public class DebugModuleTests
             customDebugBridge,
             jsonRpcConfig,
             specProvider,
-            Substitute.For<IBlockchainBridge>(),
+            blockchainBridge,
             new BlocksConfig().SecondsPerSlot,
-            Substitute.For<IBlockFinder>()
+            blockFinder
         );
     }
 
@@ -263,6 +265,10 @@ public class DebugModuleTests
         TransactionForRpc txForRpc = TransactionForRpc.FromTransaction(transaction);
 
         debugBridge.GetTransactionTrace(Arg.Any<Transaction>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
+        blockFinder.Head.Returns(Build.A.Block.WithNumber(1).TestObject);
+        blockFinder.FindHeader(Arg.Any<Hash256>(), Arg.Any<BlockTreeLookupOptions>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
+        blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
+        blockchainBridge.HasStateForRoot(Arg.Any<Hash256>()).Returns(true);
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
         ResultWrapper<GethLikeTxTrace> debugTraceCall = rpcModule.debug_traceCall(txForRpc, null, gtOptions);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -49,12 +49,16 @@ public partial class DebugRpcModuleTests
             IConfigProvider configProvider = Substitute.For<IConfigProvider>();
             IReceiptsMigration receiptsMigration = Substitute.For<IReceiptsMigration>();
             ISyncModeSelector syncModeSelector = Substitute.For<ISyncModeSelector>();
+
+            IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
+            blockchainBridge.HasStateForRoot(Arg.Any<Hash256>()).Returns(true);
+
             var factory = new DebugModuleFactory(
                 blockchain.WorldStateManager,
                 blockchain.DbProvider,
                 blockchain.BlockTree,
                 blockchain.RpcConfig,
-                Substitute.For<IBlockchainBridge>(),
+                blockchainBridge,
                 new BlocksConfig().SecondsPerSlot,
                 blockchain.BlockValidator,
                 blockchain.BlockPreprocessorStep,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -198,6 +198,8 @@ public class DebugBridge : IDebugBridge
         };
     }
 
+    public bool HaveNotSyncedHeadersYet() => _syncModeSelector.Current.HaveNotSyncedHeadersYet();
+
     public IEnumerable<string> TraceBlockToFile(
         Hash256 blockHash,
         CancellationToken cancellationToken,
@@ -209,4 +211,6 @@ public class DebugBridge : IDebugBridge
         CancellationToken cancellationToken,
         GethTraceOptions? gethTraceOptions = null) =>
         _tracer.TraceBadBlockToFile(blockHash, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
+
+    public Hash256? GetTransactionBlockHash(Hash256 transactionHash) => _receiptStorage.FindBlockHash(transactionHash);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -149,6 +149,9 @@ public class DebugBridge : IDebugBridge
     public GethLikeTxTrace GetTransactionTrace(Rlp blockRlp, Hash256 transactionHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
         _tracer.Trace(blockRlp, transactionHash, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
 
+    public GethLikeTxTrace GetTransactionTrace(Block block, Hash256 txHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
+        _tracer.Trace(block, txHash, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
+
     public GethLikeTxTrace? GetTransactionTrace(Transaction transaction, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
         _tracer.Trace(blockParameter, transaction, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
 
@@ -157,6 +160,9 @@ public class DebugBridge : IDebugBridge
 
     public IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Rlp blockRlp, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
         _tracer.TraceBlock(blockRlp, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
+
+    public IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Block block, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
+        _tracer.TraceBlock(block, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
 
     public byte[]? GetBlockRlp(BlockParameter parameter)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -528,7 +528,8 @@ public class DebugRpcModule : IDebugRpcModule
 
     private void TryGetBlock<TResult>(Rlp blockRlp, out Block? block, out ResultWrapper<TResult>? error)
     {
-        try {
+        try
+        {
             block = _blockDecoder.Decode(blockRlp.Bytes);
             if (block is null)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -79,12 +79,12 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(new BlockParameter(blockHash));
         if (searchResult.IsError)
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<GethLikeTxTrace, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
         
         if (!HasStateForBlock(_blockchainBridge, searchResult.Object!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {searchResult.Object!.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(searchResult.Object!);
         }
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -106,13 +106,13 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<GethLikeTxTrace, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
 
         BlockHeader header = searchResult.Object;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(header!);
         }
 
         // default to previous block gas if unspecified
@@ -140,13 +140,13 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(new BlockParameter(blockhash));
         if (searchResult.IsError)
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<GethLikeTxTrace, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
 
         BlockHeader header = searchResult.Object;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(header!);
         }
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -166,13 +166,13 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<GethLikeTxTrace, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
 
         BlockHeader header = searchResult.Object;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(header!);
         }
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -199,7 +199,7 @@ public class DebugRpcModule : IDebugRpcModule
         BlockHeader header = block.Header;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(header!);
         }
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -219,7 +219,7 @@ public class DebugRpcModule : IDebugRpcModule
         BlockHeader header = block.Header;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<GethLikeTxTrace>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<GethLikeTxTrace>(header!);
         }
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -249,7 +249,7 @@ public class DebugRpcModule : IDebugRpcModule
         BlockHeader header = block.Header;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<IReadOnlyCollection<GethLikeTxTrace>>(header!);
         }
 
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
@@ -280,13 +280,13 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockNumber);
         if (searchResult.IsError)
         {
-            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<IReadOnlyCollection<GethLikeTxTrace>, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
 
         BlockHeader header = searchResult.Object;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<IReadOnlyCollection<GethLikeTxTrace>>(header!);
         }
 
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
@@ -313,13 +313,13 @@ public class DebugRpcModule : IDebugRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(new BlockParameter(blockHash));
         if (searchResult.IsError)
         {
-            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail(searchResult, _debugBridge.HaveNotSyncedHeadersYet() && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+            return GetFailureResult<IReadOnlyCollection<GethLikeTxTrace>, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
 
         BlockHeader header = searchResult.Object;
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<IReadOnlyCollection<GethLikeTxTrace>>(header!);
         }   
 
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
@@ -512,4 +512,11 @@ public class DebugRpcModule : IDebugRpcModule
         return new SimulateTxExecutor<GethLikeTxTrace>(_blockchainBridge, _blockFinder, _jsonRpcConfig, new GethStyleSimulateBlockTracerFactory(options: options ?? GethTraceOptions.Default), _secondsPerSlot)
             .Execute(payload, blockParameter);
     }
+
+    private static ResultWrapper<TResult> GetFailureResult<TResult, TSearch>(SearchResult<TSearch> searchResult, bool isTemporary)
+        where TSearch : class =>
+        ResultWrapper<TResult>.Fail(searchResult, isTemporary && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
+
+    private static ResultWrapper<TResult> GetStateFailureResult<TResult>(BlockHeader header) =>
+        ResultWrapper<TResult>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -539,6 +539,11 @@ public class DebugRpcModule : IDebugRpcModule
                 error = GetRlpDecodingFailureResult<TResult>(blockRlp);
                 return null;
             }
+
+            if (block.TotalDifficulty is null)
+            {
+                block.Header.TotalDifficulty = 1;
+            }
         }
         catch (RlpException)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -81,7 +81,7 @@ public class DebugRpcModule : IDebugRpcModule
         {
             return GetFailureResult<GethLikeTxTrace, BlockHeader>(searchResult, _debugBridge.HaveNotSyncedHeadersYet());
         }
-        
+
         if (!HasStateForBlock(_blockchainBridge, searchResult.Object!))
         {
             return GetStateFailureResult<GethLikeTxTrace>(searchResult.Object!);
@@ -320,7 +320,7 @@ public class DebugRpcModule : IDebugRpcModule
         if (!HasStateForBlock(_blockchainBridge, header!))
         {
             return GetStateFailureResult<IReadOnlyCollection<GethLikeTxTrace>>(header!);
-        }   
+        }
 
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
@@ -34,9 +34,11 @@ public interface IDebugBridge
     Task<bool> MigrateReceipts(long from, long to);
     void InsertReceipts(BlockParameter blockParameter, TxReceipt[] receipts);
     SyncReportSymmary GetCurrentSyncStage();
+    bool HaveNotSyncedHeadersYet();
     IEnumerable<string> TraceBlockToFile(Hash256 blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     IEnumerable<string> TraceBadBlockToFile(Hash256 blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     public IEnumerable<Block> GetBadBlocks();
     TxReceipt[]? GetReceiptsForBlock(BlockParameter param);
     Transaction? GetTransactionFromHash(Hash256 hash);
+    Hash256? GetTransactionBlockHash(Hash256 transactionHash);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -19,9 +19,11 @@ public interface IDebugBridge
     GethLikeTxTrace GetTransactionTrace(long blockNumber, int index, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     GethLikeTxTrace GetTransactionTrace(Hash256 blockHash, int index, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     GethLikeTxTrace GetTransactionTrace(Rlp blockRlp, Hash256 transactionHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+    GethLikeTxTrace GetTransactionTrace(Block block, Hash256 txHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     GethLikeTxTrace? GetTransactionTrace(Transaction transaction, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null);
     IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Rlp blockRlp, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+    IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Block block, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     byte[] GetBlockRlp(BlockParameter param);
     Block? GetBlock(BlockParameter param);
     byte[] GetBlockRlp(Hash256 blockHash);


### PR DESCRIPTION
Fixes #8600
Closes #8607

## Changes

- Resolve and check block state availability in each of the `DebugRpcModule` calls, similarly to `EthRpcModule`
- Add relevant utilities to `DebugBridge`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

A similar scenario to #8600 could be tested in a running node.

## Remarks

One detail is that with these changes there are now some duplicate operations - as a block search is done for the state availability check and done again for the actual tracing inside `GethStyleTracer`. There doesn't seem to be a very good way to avoid this without bigger changes or with error catching, which would be hacky.
