### PR TITLE
Refactor/Move DiscoveryApp initialization to DI

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -38,6 +38,9 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
         builder
             .AddSingleton<ILogManager>(new TestLogManager(LogLevel.Error)) // Limbologs actually have IsTrace set to true, so actually slow.
             .AddSingleton<IDbProvider>(TestMemDbProvider.Init())
+            // These two dont use db provider
+            .AddKeyedSingleton<IFullDb>(DbNames.PeersDb, (_) => new MemDb())
+            .AddKeyedSingleton<IFullDb>(DbNames.DiscoveryNodes, (_) => new MemDb())
             .AddSingleton<IFileStoreFactory>(new InMemoryDictionaryFileStoreFactory())
             .AddSingleton<IChannelFactory, INetworkConfig>(networkConfig => new LocalChannelFactory(networkGroup ?? nameof(TestEnvironmentModule), networkConfig))
 

--- a/src/Nethermind/Nethermind.Db/DbNames.cs
+++ b/src/Nethermind/Nethermind.Db/DbNames.cs
@@ -17,6 +17,7 @@ namespace Nethermind.Db
         public const string Bloom = "bloom";
         public const string Metadata = "metadata";
         public const string BlobTransactions = "blobTransactions";
-        public const string DiscV5Db = "discV5";
+        public const string DiscoveryNodes = "discoveryNodes";
+        public const string PeersDb = "peers";
     }
 }

--- a/src/Nethermind/Nethermind.Db/DbNames.cs
+++ b/src/Nethermind/Nethermind.Db/DbNames.cs
@@ -17,5 +17,6 @@ namespace Nethermind.Db
         public const string Bloom = "bloom";
         public const string Metadata = "metadata";
         public const string BlobTransactions = "blobTransactions";
+        public const string DiscV5Db = "discV5";
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/ContainerBuilderExtensions.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Api;
+using Nethermind.Core;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Network;
+
+namespace Nethermind.Init.Modules;
+
+public static class ContainerBuilderExtensions
+{
+    // Register some set of component that is meant to expose `INetworkStorage`.
+    // These are stored outside of rocksdb using `SimpleFilePublicKeyDb`.
+    public static ContainerBuilder AddNetworkStorage(this ContainerBuilder builder, string dbName)
+    {
+        return builder
+            .AddKeyedSingleton<IFullDb>(dbName, ctx =>
+            {
+                ILogManager logManager = ctx.Resolve<ILogManager>();
+                IInitConfig initConfig = ctx.Resolve<IInitConfig>();
+
+                return initConfig.DiagnosticMode == DiagnosticMode.MemDb
+                    ? new MemDb(dbName)
+                    : new SimpleFilePublicKeyDb(dbName, dbName.GetApplicationResourcePath(initConfig.BaseDbPath),
+                        logManager);
+            })
+            .AddKeyedSingleton<IDb>(dbName, ctx => ctx.ResolveKeyed<IFullDb>(dbName))
+            .AddKeyedSingleton<INetworkStorage>(dbName, ctx =>
+            {
+                ILogManager logManager = ctx.Resolve<ILogManager>();
+                IFullDb db = ctx.ResolveKeyed<IFullDb>(dbName);
+                return new NetworkStorage(db, logManager);
+            });
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/ContainerBuilderExtensions.cs
@@ -12,9 +12,15 @@ namespace Nethermind.Init.Modules;
 
 public static class ContainerBuilderExtensions
 {
-    // Register some set of component that is meant to expose `INetworkStorage`.
-    // These are stored outside of rocksdb using `SimpleFilePublicKeyDb`.
-    public static ContainerBuilder AddNetworkStorage(this ContainerBuilder builder, string dbName)
+    /// <summary>
+    /// Register some set of component that is meant to expose `INetworkStorage`.
+    /// These are stored outside of rocksdb using `SimpleFilePublicKeyDb`.
+    /// </summary>
+    /// <param name="builder">The container builder</param>
+    /// <param name="dbName">Service key</param>
+    /// <param name="storePath">Path relative to BaseDbPath to store db</param>
+    /// <returns></returns>
+    public static ContainerBuilder AddNetworkStorage(this ContainerBuilder builder, string dbName, string storePath)
     {
         return builder
             .AddKeyedSingleton<IFullDb>(dbName, ctx =>
@@ -24,7 +30,7 @@ public static class ContainerBuilderExtensions
 
                 return initConfig.DiagnosticMode == DiagnosticMode.MemDb
                     ? new MemDb(dbName)
-                    : new SimpleFilePublicKeyDb(dbName, dbName.GetApplicationResourcePath(initConfig.BaseDbPath),
+                    : new SimpleFilePublicKeyDb(dbName, storePath.GetApplicationResourcePath(initConfig.BaseDbPath),
                         logManager);
             })
             .AddKeyedSingleton<IDb>(dbName, ctx => ctx.ResolveKeyed<IFullDb>(dbName))

--- a/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
@@ -53,7 +53,7 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
             .Bind<INodeSource, IStaticNodesManager>()
 
             // Used by NodesLoader, and ProtocolsManager which add entry on sync peer connected
-            .AddNetworkStorage(DbNames.PeersDb)
+            .AddNetworkStorage(DbNames.PeersDb, "peers")
             .Bind<INodeSource, NodesLoader>()
             .AddComposite<INodeSource, CompositeNodeSource>()
 
@@ -115,7 +115,7 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
                 .AddSingleton<IDiscoveryApp, CompositeDiscoveryApp>()
                 .AddSingleton<INodeRecordProvider, NodeRecordProvider>()
 
-                .AddNetworkStorage(DbNames.DiscoveryNodes)
+                .AddNetworkStorage(DbNames.DiscoveryNodes, "discoveryNodes")
                 .AddSingleton<DiscoveryV5App>()
 
                 .AddSingleton<INodeDistanceCalculator, NodeDistanceCalculator>()

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -12,6 +12,7 @@ using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Crypto;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.Config;
@@ -57,8 +58,6 @@ public static class NettyMemoryEstimator
     typeof(InitializeBlockchain))]
 public class InitializeNetwork : IStep
 {
-    public const string PeersDbPath = "peers";
-
     private readonly IApiWithNetwork _api;
     private readonly INodeStatsManager _nodeStatsManager;
     private readonly ISynchronizer _synchronizer;
@@ -83,7 +82,7 @@ public class InitializeNetwork : IStep
         NodeSourceToDiscV4Feeder enrDiscoveryAppFeeder,
         IDiscoveryApp discoveryApp,
         Lazy<IPeerPool> peerPool, // Require IRlpxPeer to be created first, hence, lazy.
-        [KeyFilter(INetworkStorage.PeerDb)] INetworkStorage peerStorage,
+        [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
         INetworkConfig networkConfig,
         ISyncConfig syncConfig,
         IInitConfig initConfig,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -174,11 +174,8 @@ public partial class EngineModuleTests
 
         await Task.Delay(PayloadPreparationService.GetPayloadWaitForNonEmptyBlockMillisecondsDelay);
 
-        ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
-
-        await Task.Delay(PayloadPreparationService.GetPayloadWaitForNonEmptyBlockMillisecondsDelay);
-
-        Assert.That(getPayloadResult.Transactions, Has.Length.InRange(minCount, maxCount));
+        Assert.That(() => rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId)).Result.Data!.Transactions,
+            Has.Length.InRange(minCount, maxCount).After(2000, 1)); // Polling interval need to be short or it might miss it.
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/CompositeDiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/CompositeDiscoveryApp.cs
@@ -3,21 +3,12 @@
 
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using Autofac.Features.AttributeFilters;
 using DotNetty.Transport.Bootstrapping;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
-using Nethermind.Api;
-using Nethermind.Core;
-using Nethermind.Crypto;
-using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery.Discv5;
-using Nethermind.Network.Discovery.Lifecycle;
-using Nethermind.Network.Discovery.RoutingTable;
-using Nethermind.Network.Enr;
-using Nethermind.Stats;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Discovery;
@@ -27,18 +18,7 @@ namespace Nethermind.Network.Discovery;
 /// </summary>
 public class CompositeDiscoveryApp : IDiscoveryApp
 {
-    private const string DiscoveryNodesDbPath = "discoveryNodes";
-
-    private readonly IProtectedPrivateKey _nodeKey;
     private readonly INetworkConfig _networkConfig;
-    private readonly IDiscoveryConfig _discoveryConfig;
-    private readonly IInitConfig _initConfig;
-    private readonly INodeRecordProvider _nodeRecordProvider;
-    private readonly IMessageSerializationService _serializationService;
-    private readonly ILogManager _logManager;
-    private readonly ITimestamper _timestamper;
-    private readonly ICryptoRandom? _cryptoRandom;
-    private readonly INodeStatsManager _nodeStatsManager;
     private readonly IConnectionsPool _connections;
     private readonly IChannelFactory? _channelFactory;
 
@@ -47,38 +27,27 @@ public class CompositeDiscoveryApp : IDiscoveryApp
     private INodeSource _compositeNodeSource = null!;
 
     public CompositeDiscoveryApp(
-        [KeyFilter(IProtectedPrivateKey.NodeKey)]
-        IProtectedPrivateKey? nodeKey,
-        INetworkConfig networkConfig, IDiscoveryConfig discoveryConfig, IInitConfig initConfig,
-        INodeRecordProvider nodeRecordProvider, IMessageSerializationService? serializationService,
-        ILogManager? logManager, ITimestamper? timestamper, ICryptoRandom? cryptoRandom,
-        INodeStatsManager? nodeStatsManager,
-        Func<DiscoveryV5App> discoveryV5Factory,
+        INetworkConfig networkConfig,
+        IDiscoveryConfig discoveryConfig,
+        ILogManager logManager,
+        Func<DiscoveryV5App> discoveryV5Factory, // These two are factory because they are optional.
+        Func<DiscoveryApp> discoveryV4Factory,
         IChannelFactory? channelFactory = null
     )
     {
-        _nodeKey = nodeKey ?? throw new ArgumentNullException(nameof(nodeKey));
         _networkConfig = networkConfig;
-        _discoveryConfig = discoveryConfig;
-        _initConfig = initConfig;
-        _nodeRecordProvider = nodeRecordProvider;
-        _serializationService = serializationService ?? throw new ArgumentNullException(nameof(serializationService));
-        _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
-        _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
-        _cryptoRandom = cryptoRandom;
-        _nodeStatsManager = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
-        _connections = new DiscoveryConnectionsPool(logManager.GetClassLogger<DiscoveryConnectionsPool>(), _networkConfig, _discoveryConfig);
+        _connections = new DiscoveryConnectionsPool(logManager.GetClassLogger<DiscoveryConnectionsPool>(), _networkConfig, discoveryConfig);
         _channelFactory = channelFactory;
 
         List<INodeSource> allNodeSources = new();
 
-        if ((_discoveryConfig.DiscoveryVersion & DiscoveryVersion.V4) != 0)
+        if ((discoveryConfig.DiscoveryVersion & DiscoveryVersion.V4) != 0)
         {
-            InitDiscoveryV4(_discoveryConfig);
+            _v4 = discoveryV4Factory();
             allNodeSources.Add(_v4!);
         }
 
-        if ((_discoveryConfig.DiscoveryVersion & DiscoveryVersion.V5) != 0)
+        if ((discoveryConfig.DiscoveryVersion & DiscoveryVersion.V5) != 0)
         {
             _v5 = discoveryV5Factory();
             allNodeSources.Add(_v5!);
@@ -127,63 +96,6 @@ public class CompositeDiscoveryApp : IDiscoveryApp
     {
         _v4?.AddNodeToDiscovery(node);
         _v5?.AddNodeToDiscovery(node);
-    }
-
-    private void InitDiscoveryV4(IDiscoveryConfig discoveryConfig)
-    {
-        NodeRecord selfNodeRecord = _nodeRecordProvider.Current;
-
-        NodeDistanceCalculator nodeDistanceCalculator = new(discoveryConfig);
-
-        NodeTable nodeTable = new(nodeDistanceCalculator, discoveryConfig, _networkConfig, _logManager);
-        EvictionManager evictionManager = new(nodeTable, _logManager);
-
-        NodeLifecycleManagerFactory nodeLifeCycleFactory = new(
-            nodeTable,
-            evictionManager,
-            _nodeStatsManager,
-            selfNodeRecord,
-            discoveryConfig,
-            _timestamper,
-            _logManager);
-
-        // ToDo: DiscoveryDB is registered outside dbProvider - bad
-        SimpleFilePublicKeyDb discoveryDb = new(
-            "DiscoveryDB",
-            DiscoveryNodesDbPath.GetApplicationResourcePath(_initConfig.BaseDbPath),
-            _logManager);
-
-        NetworkStorage discoveryStorage = new(
-            discoveryDb,
-            _logManager);
-
-        DiscoveryManager discoveryManager = new(
-            nodeLifeCycleFactory,
-            nodeTable,
-            discoveryStorage,
-            discoveryConfig,
-            _networkConfig,
-            _logManager
-        );
-
-        NodesLocator nodesLocator = new(
-            nodeTable,
-            discoveryManager,
-            discoveryConfig,
-            _logManager);
-
-        _v4 = new DiscoveryApp(
-            _nodeKey,
-            nodesLocator,
-            discoveryManager,
-            nodeTable,
-            _serializationService,
-            _cryptoRandom,
-            discoveryStorage,
-            _networkConfig,
-            discoveryConfig,
-            _timestamper,
-            _logManager);
     }
 
     public IAsyncEnumerable<Node> DiscoverNodes(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -46,7 +46,7 @@ public class DiscoveryApp : IDiscoveryApp
         INodeTable? nodeTable,
         IMessageSerializationService? msgSerializationService,
         ICryptoRandom? cryptoRandom,
-        INetworkStorage? discoveryStorage,
+        [KeyFilter(INetworkStorage.DiscV4)] INetworkStorage? discoveryStorage,
         INetworkConfig? networkConfig,
         IDiscoveryConfig? discoveryConfig,
         ITimestamper? timestamper,

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Crypto;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery.Lifecycle;
@@ -46,7 +47,7 @@ public class DiscoveryApp : IDiscoveryApp
         INodeTable? nodeTable,
         IMessageSerializationService? msgSerializationService,
         ICryptoRandom? cryptoRandom,
-        [KeyFilter(INetworkStorage.DiscV4)] INetworkStorage? discoveryStorage,
+        [KeyFilter(DbNames.DiscoveryNodes)] INetworkStorage? discoveryStorage,
         INetworkConfig? networkConfig,
         IDiscoveryConfig? discoveryConfig,
         ITimestamper? timestamper,

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -8,6 +8,7 @@ using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery.Lifecycle;
@@ -37,7 +38,7 @@ public class DiscoveryManager : IDiscoveryManager
     public DiscoveryManager(
         INodeLifecycleManagerFactory? nodeLifecycleManagerFactory,
         INodeTable? nodeTable,
-        [KeyFilter(INetworkStorage.DiscV4)] INetworkStorage? discoveryStorage,
+        [KeyFilter(DbNames.DiscoveryNodes)] INetworkStorage? discoveryStorage,
         IDiscoveryConfig? discoveryConfig,
         INetworkConfig? networkConfig,
         ILogManager? logManager)

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -36,7 +37,7 @@ public class DiscoveryManager : IDiscoveryManager
     public DiscoveryManager(
         INodeLifecycleManagerFactory? nodeLifecycleManagerFactory,
         INodeTable? nodeTable,
-        INetworkStorage? discoveryStorage,
+        [KeyFilter(INetworkStorage.DiscV4)] INetworkStorage? discoveryStorage,
         IDiscoveryConfig? discoveryConfig,
         INetworkConfig? networkConfig,
         ILogManager? logManager)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
@@ -44,7 +44,7 @@ public class DiscoveryV5App : IDiscoveryApp
         IIPResolver? ipResolver,
         INetworkConfig networkConfig,
         IDiscoveryConfig discoveryConfig,
-        [KeyFilter(DbNames.DiscV5Db)] IDb discoveryDb,
+        [KeyFilter(DbNames.DiscoveryNodes)] IDb discoveryDb,
         ILogManager logManager)
     {
         ArgumentNullException.ThrowIfNull(ipResolver);

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
@@ -39,7 +39,13 @@ public class DiscoveryV5App : IDiscoveryApp
     private readonly IServiceProvider _serviceProvider;
     private readonly SessionOptions _sessionOptions;
 
-    public DiscoveryV5App([KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey, IIPResolver? ipResolver, INetworkConfig networkConfig, IDiscoveryConfig discoveryConfig, IDb discoveryDb, ILogManager logManager)
+    public DiscoveryV5App(
+        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+        IIPResolver? ipResolver,
+        INetworkConfig networkConfig,
+        IDiscoveryConfig discoveryConfig,
+        [KeyFilter(DbNames.DiscV5Db)] IDb discoveryDb,
+        ILogManager logManager)
     {
         ArgumentNullException.ThrowIfNull(ipResolver);
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Autofac.Features.AttributeFilters;
 using DotNetty.Transport.Channels;
 using Lantern.Discv5.Enr;
 using Lantern.Discv5.Enr.Entries;
@@ -38,7 +39,7 @@ public class DiscoveryV5App : IDiscoveryApp
     private readonly IServiceProvider _serviceProvider;
     private readonly SessionOptions _sessionOptions;
 
-    public DiscoveryV5App(SameKeyGenerator privateKeyProvider, IIPResolver? ipResolver, INetworkConfig networkConfig, IDiscoveryConfig discoveryConfig, IDb discoveryDb, ILogManager logManager)
+    public DiscoveryV5App([KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey, IIPResolver? ipResolver, INetworkConfig networkConfig, IDiscoveryConfig discoveryConfig, IDb discoveryDb, ILogManager logManager)
     {
         ArgumentNullException.ThrowIfNull(ipResolver);
 
@@ -47,11 +48,12 @@ public class DiscoveryV5App : IDiscoveryApp
 
         IdentityVerifierV4 identityVerifier = new();
 
+        PrivateKey privateKey = nodeKey.Unprotect();
         _sessionOptions = new()
         {
-            Signer = new IdentitySignerV4(privateKeyProvider.Generate().KeyBytes),
+            Signer = new IdentitySignerV4(privateKey.KeyBytes),
             Verifier = identityVerifier,
-            SessionKeys = new SessionKeys(privateKeyProvider.Generate().KeyBytes),
+            SessionKeys = new SessionKeys(privateKey.KeyBytes),
         };
 
         string[] bootstrapNodes = [.. (discoveryConfig.Bootnodes ?? "").Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).Distinct()];
@@ -189,8 +191,6 @@ public class DiscoveryV5App : IDiscoveryApp
         .Build();
 
     public event EventHandler<NodeEventArgs>? NodeRemoved;
-
-    public void Initialize(PublicKey masterPublicKey) { }
 
     public void InitializeChannel(IChannel channel)
     {

--- a/src/Nethermind/Nethermind.Network.Discovery/INodeRecordProvider.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/INodeRecordProvider.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Network.Enr;
+
+namespace Nethermind.Network.Discovery;
+
+public interface INodeRecordProvider
+{
+    public NodeRecord Current { get; }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
@@ -23,6 +23,17 @@ public class NodeLifecycleManagerFactory : INodeLifecycleManagerFactory
     public NodeLifecycleManagerFactory(INodeTable nodeTable,
         IEvictionManager evictionManager,
         INodeStatsManager nodeStatsManager,
+        INodeRecordProvider nodeRecordProvider,
+        IDiscoveryConfig discoveryConfig,
+        ITimestamper timestamper,
+        ILogManager? logManager)
+        : this(nodeTable, evictionManager, nodeStatsManager, nodeRecordProvider.Current, discoveryConfig, timestamper, logManager)
+    {
+    }
+
+    public NodeLifecycleManagerFactory(INodeTable nodeTable,
+        IEvictionManager evictionManager,
+        INodeStatsManager nodeStatsManager,
         NodeRecord self,
         IDiscoveryConfig discoveryConfig,
         ITimestamper timestamper,

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Network.Discovery;
 
 public class NodeRecordProvider(
     [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
-    IPResolver ipResolver,
+    IIPResolver ipResolver,
     IEthereumEcdsa ethereumEcdsa,
     INetworkConfig networkConfig
 ): INodeRecordProvider {

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac.Features.AttributeFilters;
+using Nethermind.Crypto;using Nethermind.Network.Config;
+using Nethermind.Network.Enr;
+
+namespace Nethermind.Network.Discovery;
+
+public class NodeRecordProvider(
+    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+    IPResolver ipResolver,
+    IEthereumEcdsa ethereumEcdsa,
+    INetworkConfig networkConfig
+): INodeRecordProvider {
+
+    NodeRecord? _nodeRecord = null;
+    public NodeRecord Current => _nodeRecord ??= PrepareNodeRecord();
+
+    private NodeRecord PrepareNodeRecord()
+    {
+        // TODO: Add forkid
+        NodeRecord selfNodeRecord = new();
+        selfNodeRecord.SetEntry(IdEntry.Instance);
+        selfNodeRecord.SetEntry(new IpEntry(ipResolver.ExternalIp));
+        selfNodeRecord.SetEntry(new TcpEntry(networkConfig.P2PPort));
+        selfNodeRecord.SetEntry(new UdpEntry(networkConfig.DiscoveryPort));
+        selfNodeRecord.SetEntry(new Secp256K1Entry(nodeKey.CompressedPublicKey));
+        selfNodeRecord.EnrSequence = 1;
+        NodeRecordSigner enrSigner = new(ethereumEcdsa, nodeKey.Unprotect());
+        enrSigner.Sign(selfNodeRecord);
+        if (!enrSigner.Verify(selfNodeRecord))
+        {
+            throw new NetworkingException("Self ENR initialization failed", NetworkExceptionType.Discovery);
+        }
+
+        return selfNodeRecord;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/IDiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network/IDiscoveryApp.cs
@@ -10,7 +10,6 @@ namespace Nethermind.Network
 {
     public interface IDiscoveryApp : INodeSource
     {
-        void Initialize(PublicKey masterPublicKey);
         void InitializeChannel(IChannel channel);
         Task StartAsync();
         Task StopAsync();

--- a/src/Nethermind/Nethermind.Network/INetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/INetworkStorage.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Network
     public interface INetworkStorage
     {
         public const string PeerDb = "PeerDb";
+        public const string DiscV4 = "DiscV4";
 
         NetworkNode[] GetPersistedNodes();
         int PersistedNodesCount { get; }

--- a/src/Nethermind/Nethermind.Network/INetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/INetworkStorage.cs
@@ -9,9 +9,6 @@ namespace Nethermind.Network
 {
     public interface INetworkStorage
     {
-        public const string PeerDb = "PeerDb";
-        public const string DiscV4 = "DiscV4";
-
         NetworkNode[] GetPersistedNodes();
         int PersistedNodesCount { get; }
 

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Rlpx;
@@ -29,7 +30,7 @@ namespace Nethermind.Network
         public NodesLoader(
             INetworkConfig networkConfig,
             INodeStatsManager stats,
-            [KeyFilter(INetworkStorage.PeerDb)] INetworkStorage peerStorage,
+            [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
             IRlpxHost rlpxHost,
             ILogManager logManager)
         {

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -11,6 +11,7 @@ using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -50,7 +51,7 @@ namespace Nethermind.Network
         public PeerPool(
             INodeSource nodeSource,
             INodeStatsManager nodeStatsManager,
-            [KeyFilter(INetworkStorage.PeerDb)] INetworkStorage peerStorage,
+            [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
             INetworkConfig networkConfig,
             ILogManager logManager,
             ITrustedNodesManager trustedNodesManager)

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -11,6 +11,7 @@ using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Scheduler;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Contract.P2P;
@@ -85,7 +86,7 @@ namespace Nethermind.Network
             IRlpxHost rlpxHost,
             INodeStatsManager nodeStatsManager,
             IProtocolValidator protocolValidator,
-            [KeyFilter(INetworkStorage.PeerDb)] INetworkStorage peerStorage,
+            [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
             ForkInfo forkInfo,
             IGossipPolicy gossipPolicy,
             INetworkConfig networkConfig,


### PR DESCRIPTION
- Trying to reduce change in #8616 
- Move `DiscoveryApp` and `DiscoveryV5App` to DI. 
- Remove `IDiscoveryApp.Initialize`. 
- Add `INodeRecordProvider`.
- Replace discovery db and peer db with memdb in test env.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- 