### PR TITLE
Set default `LegacyTransactionForRpc` gas price to zero

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -95,7 +95,7 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         tx.GasLimit = Gas ?? 90_000;
         tx.Value = Value ?? 0;
         tx.Data = Input;
-        tx.GasPrice = GasPrice ?? 20.GWei();
+        tx.GasPrice = GasPrice ?? 0;
         tx.ChainId = ChainId;
         tx.SenderAddress = From ?? Address.SystemUser;
         if ((R != 0 || S != 0) && (R is not null || S is not null))


### PR DESCRIPTION
Fixes #8316

## Changes

- Set the default gas price to `0` in `LegacyTransactionForRpc.ToTransaction`, standardizing it with geth

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Testing can be done based on #8316 scenario.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
