### PR TITLE
Remove SkipLocalsInit to avoid garbage in first bytes of hash

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/AddressTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/AddressTests.cs
@@ -210,7 +210,7 @@ public class AddressTests
             Span<byte> addressBytes = stackalloc byte[Address.Size];
             for (var i = 0; i < Address.Size; i++)
             {
-                addressBytes[i] = (byte)(i + 1);
+                addressBytes[i] = (byte)(i + j);
             }
 
             var address = new Address(addressBytes);

--- a/src/Nethermind/Nethermind.Core.Test/AddressTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/AddressTests.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -196,6 +198,29 @@ public class AddressTests
     {
         Address.TryParseVariableLength("1", out Address? address).Should().Be(true);
         address.Should().Be(new Address("0000000000000000000000000000000000000001"));
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "StackAllocInsideLoop")]
+    [SuppressMessage("Reliability", "CA2014:Do not use stackalloc in loops")]
+    public void ToHash_avoid_garbage_in_first_bytes()
+    {
+        for (var j = 0; j < 2; j++) // Loop to ensure stack is filled with some data
+        {
+            Span<byte> addressBytes = stackalloc byte[Address.Size];
+            for (var i = 0; i < Address.Size; i++)
+            {
+                addressBytes[i] = (byte)(i + 1);
+            }
+
+            var address = new Address(addressBytes);
+
+            Span<byte> expectedHashBytes = stackalloc byte[Hash256.Size];
+            addressBytes.CopyTo(expectedHashBytes[(Hash256.Size - Address.Size)..]);
+            var expectedHash = new ValueHash256(expectedHashBytes);
+
+            address.ToHash().Should().BeEquivalentTo(expectedHash);
+        }
     }
 
     public static IEnumerable PointEvaluationPrecompileTestCases

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -254,11 +254,25 @@ namespace Nethermind.Core
 
         public ValueHash256 ToAccountPath => KeccakCache.Compute(Bytes);
 
+        [SkipLocalsInit]
         public ValueHash256 ToHash()
         {
-            Span<byte> addressBytes = stackalloc byte[Hash256.Size];
-            Bytes.CopyTo(addressBytes[(Hash256.Size - Address.Size)..]);
-            return new ValueHash256(addressBytes);
+            ref byte value = ref MemoryMarshal.GetArrayDataReference(Bytes);
+
+            Unsafe.SkipInit(out ValueHash256 result);
+            ref byte bytes = ref Unsafe.As<ValueHash256, byte>(ref result);
+
+            // First 4+8 bytes are zero, zero 16 bytes to maximize write combining
+            Unsafe.As<byte, Vector128<byte>>(ref bytes) = default;
+
+            // 20 bytes which is uint+Vector128
+            Unsafe.As<byte, uint>(ref Unsafe.Add(ref bytes, sizeof(uint) + sizeof(ulong)))
+                = Unsafe.As<byte, uint>(ref value);
+
+            Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bytes, sizeof(ulong) + sizeof(ulong)))
+                = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref value, sizeof(uint)));
+
+            return result;
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -254,7 +254,6 @@ namespace Nethermind.Core
 
         public ValueHash256 ToAccountPath => KeccakCache.Compute(Bytes);
 
-        [SkipLocalsInit]
         public ValueHash256 ToHash()
         {
             Span<byte> addressBytes = stackalloc byte[Hash256.Size];


### PR DESCRIPTION
## Changes

Removes `SkipLocalsInit` from `Address.ToHash()` to avoid garbage in the first 12 bytes of hash.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
