### PR TITLE
PatriciaTree ignoreMissingDelete is not used

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -500,12 +500,11 @@ namespace Nethermind.Trie
             in CappedArray<byte> updateValue,
             Span<byte> updatePath,
             bool isUpdate,
-            bool ignoreMissingDelete = true,
             Hash256? startRootHash = null,
             bool isNodeRead = false)
         {
             TraverseContext traverseContext =
-                new(updatePath, ref updatePathTreePath, updateValue, isUpdate, ignoreMissingDelete, isNodeRead: isNodeRead);
+                new(updatePath, ref updatePathTreePath, updateValue, isUpdate, isNodeRead: isNodeRead);
 
             if (startRootHash is not null)
             {
@@ -989,19 +988,9 @@ namespace Nethermind.Trie
                 return ref traverseContext.UpdateValue;
             }
 
-            if (traverseContext.IsRead)
+            if (traverseContext.IsRead || traverseContext.IsDelete)
             {
                 return ref CappedArray<byte>.Null;
-            }
-
-            if (traverseContext.IsDelete)
-            {
-                if (traverseContext.IgnoreMissingDelete)
-                {
-                    return ref CappedArray<byte>.Null;
-                }
-
-                ThrowMissingLeafException(in traverseContext);
             }
 
             if (extensionLength != 0)
@@ -1065,19 +1054,9 @@ namespace Nethermind.Trie
                     ref TraverseNode(next, newContext, ref path);
             }
 
-            if (traverseContext.IsRead)
+            if (traverseContext.IsRead || traverseContext.IsDelete)
             {
                 return ref CappedArray<byte>.Null;
-            }
-
-            if (traverseContext.IsDelete)
-            {
-                if (traverseContext.IgnoreMissingDelete)
-                {
-                    return ref CappedArray<byte>.Null;
-                }
-
-                ThrowMissingLeafException(in traverseContext);
             }
 
             byte[] pathBeforeUpdate = node.Key;
@@ -1126,19 +1105,9 @@ namespace Nethermind.Trie
 
         private ref readonly CappedArray<byte> ResolveCurrent(scoped in TraverseContext traverseContext)
         {
-            if (traverseContext.IsRead)
+            if (traverseContext.IsRead || traverseContext.IsDelete)
             {
                 return ref CappedArray<byte>.Null;
-            }
-
-            if (traverseContext.IsDelete)
-            {
-                if (traverseContext.IgnoreMissingDelete)
-                {
-                    return ref CappedArray<byte>.Null;
-                }
-
-                ThrowMissingLeafException(in traverseContext);
             }
 
             int currentIndex = traverseContext.CurrentIndex + 1;
@@ -1196,7 +1165,6 @@ namespace Nethermind.Trie
             public bool IsReadValue => !IsUpdate && !IsNodeRead;
             public bool IsRead => IsNodeRead || IsReadValue;
             public bool IsDelete => IsUpdate && UpdateValue.IsNull;
-            public bool IgnoreMissingDelete { get; }
             public int CurrentIndex { get; }
             public int RemainingUpdatePathLength => UpdatePath.Length - CurrentIndex;
 
@@ -1228,7 +1196,6 @@ namespace Nethermind.Trie
                 UpdatePathTreePath = ref updatePathTreePath;
                 UpdateValue = ref updateValue.IsNotNull && updateValue.Length == 0 ? ref CappedArray<byte>.Null : ref updateValue;
                 IsUpdate = isUpdate;
-                IgnoreMissingDelete = ignoreMissingDelete;
                 CurrentIndex = 0;
                 IsNodeRead = isNodeRead;
             }
@@ -1412,14 +1379,6 @@ namespace Nethermind.Trie
         {
             throw new TrieException(
                 $"Found an {nameof(NodeType.Extension)} {node.Keccak} that is missing a child.");
-        }
-
-        [DoesNotReturn]
-        [StackTraceHidden]
-        private static void ThrowMissingLeafException(in TraverseContext traverseContext)
-        {
-            throw new TrieException(
-                $"Could not find the leaf node to delete: {traverseContext.UpdatePath.ToHexString()}");
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
## Changes

-I was reading the PatriciaTree code for fun and to improve my understanding, and I came across unused _ignoreMissingDelete_ (always true)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._


