### PR TITLE
Fix for `Block.AccountChanges` not being disposed in some cases

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1023,7 +1023,7 @@ Db usage:
         // Cleanup ArrayPoolList AccountChanges as they are not used anywhere else
         private static void DisposeBlockAccountChanges(Block block)
         {
-            if (block.AccountChanges == null) return;
+            if (block.AccountChanges is null) return;
 
             block.AccountChanges.Dispose();
             block.AccountChanges = null;


### PR DESCRIPTION
## Changes

- Fixed `Block.AccountChanges` not being disposed when rerunning blocks during syncing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No