### PR TITLE
Optimize RlpStream.Encode(ulong)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotDecoder.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotDecoder.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Consensus.Clique
             (int contentLength, int signersLength, int votesLength, int tallyLength) =
                 GetContentLength(item, rlpBehaviors);
             stream.StartSequence(contentLength);
-            stream.Encode((UInt256)item.Number);
+            stream.Encode(item.Number);
             stream.Encode(item.Hash);
             EncodeSigners(stream, item.Signers, signersLength);
             EncodeVotes(stream, item.Votes, votesLength);
@@ -137,7 +137,7 @@ namespace Nethermind.Consensus.Clique
             foreach ((Address address, long signedAt) in signers)
             {
                 stream.Encode(address);
-                stream.Encode((UInt256)signedAt);
+                stream.Encode(signedAt);
                 i += 2;
             }
         }
@@ -167,7 +167,7 @@ namespace Nethermind.Consensus.Clique
             for (int i = 0; i < voteCount; i++)
             {
                 stream.Encode(votes[i].Signer);
-                stream.Encode((UInt256)votes[i].Block);
+                stream.Encode(votes[i].Block);
                 stream.Encode(votes[i].Address);
                 stream.Encode(votes[i].Authorize);
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -387,7 +387,7 @@ namespace Nethermind.Serialization.Rlp
 
         public void Encode(bool value) => Encode(value ? (byte)1 : (byte)0);
 
-        public void Encode(int value) => Encode((long)value);
+        public void Encode(int value) => Encode((ulong)(long)value);
 
         public void Encode(long value) => Encode((ulong)value);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -385,136 +385,48 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
-        public void Encode(bool value)
-        {
-            Encode(value ? (byte)1 : (byte)0);
-        }
+        public void Encode(bool value) => Encode(value ? (byte)1 : (byte)0);
 
-        public void Encode(int value)
-        {
-            Encode((long)value);
-        }
+        public void Encode(int value) => Encode((long)value);
 
-        public void Encode(long value)
-        {
-            if (value == 0L)
-            {
-                EncodeEmptyByteArray();
-                return;
-            }
+        public void Encode(long value) => Encode((ulong)value);
 
-            if (value > 0)
-            {
-                byte byte6 = (byte)(value >> 8);
-                byte byte5 = (byte)(value >> 16);
-                byte byte4 = (byte)(value >> 24);
-                byte byte3 = (byte)(value >> 32);
-                byte byte2 = (byte)(value >> 40);
-                byte byte1 = (byte)(value >> 48);
-                byte byte0 = (byte)(value >> 56);
-
-                if (value < 256L * 256L * 256L * 256L * 256L * 256L * 256L)
-                {
-                    if (value < 256L * 256L * 256L * 256L * 256L * 256L)
-                    {
-                        if (value < 256L * 256L * 256L * 256L * 256L)
-                        {
-                            if (value < 256L * 256L * 256L * 256L)
-                            {
-                                if (value < 256 * 256 * 256)
-                                {
-                                    if (value < 256 * 256)
-                                    {
-                                        if (value < 128)
-                                        {
-                                            WriteByte((byte)value);
-                                            return;
-                                        }
-
-                                        if (value < 256)
-                                        {
-                                            WriteByte(129);
-                                            WriteByte((byte)value);
-                                            return;
-                                        }
-
-                                        WriteByte(130);
-                                        WriteByte(byte6);
-                                        WriteByte((byte)value);
-                                        return;
-                                    }
-
-                                    WriteByte(131);
-                                    WriteByte(byte5);
-                                    WriteByte(byte6);
-                                    WriteByte((byte)value);
-                                    return;
-                                }
-
-                                WriteByte(132);
-                                WriteByte(byte4);
-                                WriteByte(byte5);
-                                WriteByte(byte6);
-                                WriteByte((byte)value);
-                                return;
-                            }
-
-                            WriteByte(133);
-                            WriteByte(byte3);
-                            WriteByte(byte4);
-                            WriteByte(byte5);
-                            WriteByte(byte6);
-                            WriteByte((byte)value);
-                            return;
-                        }
-
-                        WriteByte(134);
-                        WriteByte(byte2);
-                        WriteByte(byte3);
-                        WriteByte(byte4);
-                        WriteByte(byte5);
-                        WriteByte(byte6);
-                        WriteByte((byte)value);
-                        return;
-                    }
-
-                    WriteByte(135);
-                    WriteByte(byte1);
-                    WriteByte(byte2);
-                    WriteByte(byte3);
-                    WriteByte(byte4);
-                    WriteByte(byte5);
-                    WriteByte(byte6);
-                    WriteByte((byte)value);
-                    return;
-                }
-
-                WriteByte(136);
-                WriteByte(byte0);
-                WriteByte(byte1);
-                WriteByte(byte2);
-                WriteByte(byte3);
-                WriteByte(byte4);
-                WriteByte(byte5);
-                WriteByte(byte6);
-                WriteByte((byte)value);
-                return;
-            }
-
-            Encode(value, 8);
-        }
-
-        private void Encode(BigInteger bigInteger, int outputLength = -1)
-        {
-            Rlp rlp = bigInteger == 0
-                ? Rlp.OfEmptyByteArray
-                : Rlp.Encode(bigInteger.ToBigEndianByteArray(outputLength));
-            Write(rlp.Bytes);
-        }
-
+        [SkipLocalsInit]
         public void Encode(ulong value)
         {
-            Encode((UInt256)value);
+            if (value < 128)
+            {
+                // Single-byte optimization for [0..127]
+                byte singleByte = value > 0 ? (byte)value : EmptyArrayByte;
+                WriteByte(singleByte);
+                return;
+            }
+
+            // Count leading zero bytes
+            int leadingZeroBytes = BitOperations.LeadingZeroCount(value) >> 3;
+            int valueLength = sizeof(ulong) - leadingZeroBytes;
+
+            value = BinaryPrimitives.ReverseEndianness(value);
+            Span<byte> valueSpan = MemoryMarshal.CreateSpan(ref Unsafe.As<ulong, byte>(ref value), sizeof(ulong));
+            // Ok to stackalloc even if we don't use with SkipLocalsInit
+            Span<byte> output = stackalloc byte[1 + sizeof(ulong)];
+
+            byte prefix = (byte)(0x80 + valueLength);
+            if (leadingZeroBytes > 0)
+            {
+                // Reuse space in valueSpan for prefix rather than copying
+                valueSpan[leadingZeroBytes - 1] = prefix;
+                output = valueSpan.Slice(leadingZeroBytes - 1, 1 + valueLength);
+            }
+            else
+            {
+                // Build final output: prefix + value bytes
+                output[0] = prefix;
+                valueSpan.Slice(leadingZeroBytes, valueLength).CopyTo(output.Slice(1));
+                output = output.Slice(0, 1 + valueLength);
+            }
+
+            Write(output);
         }
 
         public void Encode(in UInt256 value, int length = -1)


### PR DESCRIPTION
## Changes

- Call single `virtual Write(ReadOnlySpan<byte>)` rather than multiple `virtual WriteByte(byte)` calls

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
