### PR TITLE
Use RocksDB PinnableSlice when available

### DIFF
--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -39,6 +39,18 @@ namespace Nethermind.Core
         void DangerousReleaseMemory(in ReadOnlySpan<byte> span) { }
     }
 
+    public interface IReadOnlyNativeKeyValueStore
+    {
+        /// <summary>
+        /// Return span. Must call `DangerousReleaseSlice` or there can be some leak.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>Can return null or empty Span on missing key</returns>
+        ReadOnlySpan<byte> GetNativeSlice(scoped ReadOnlySpan<byte> key, out IntPtr handle, ReadFlags flags = ReadFlags.None);
+
+        void DangerousReleaseHandle(IntPtr handle);
+    }
+
     public interface IWriteOnlyKeyValueStore
     {
         byte[]? this[ReadOnlySpan<byte> key]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -50,12 +50,12 @@ public static class KeyValueStoreRlpExtensions
             if (decoder is IRlpValueDecoder<TItem> valueDecoder)
             {
                 item = db is IReadOnlyNativeKeyValueStore native
-                    ? GetViaNative(native, key, valueDecoder, rlpBehaviors)
-                    : GetViaSpan(db, key, valueDecoder, rlpBehaviors);
+                    ? Get(native, key, valueDecoder, rlpBehaviors)
+                    : Get(db, key, valueDecoder, rlpBehaviors);
             }
             else
             {
-                item = GetViaArray(db, key, decoder, rlpBehaviors);
+                item = Get(db, key, decoder, rlpBehaviors);
             }
         }
 
@@ -67,7 +67,7 @@ public static class KeyValueStoreRlpExtensions
         return item;
     }
 
-    private static TItem? GetViaNative<TItem>(IReadOnlyNativeKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
+    private static TItem? Get<TItem>(IReadOnlyNativeKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
     {
         ReadOnlySpan<byte> data = db.GetNativeSlice(key, out IntPtr handle);
         if (data.IsNull())
@@ -91,7 +91,7 @@ public static class KeyValueStoreRlpExtensions
         }
     }
 
-    private static TItem? GetViaSpan<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
+    private static TItem? Get<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
     {
         Span<byte> data = db.GetSpan(key);
         if (data.IsNull())
@@ -115,7 +115,7 @@ public static class KeyValueStoreRlpExtensions
         }
     }
 
-    private static TItem? GetViaArray<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpStreamDecoder<TItem> decoder, RlpBehaviors rlpBehaviors) where TItem : class
+    private static TItem? Get<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpStreamDecoder<TItem> decoder, RlpBehaviors rlpBehaviors) where TItem : class
     {
         Span<byte> data = db.Get(key);
         if (data.IsNull())

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -49,42 +49,13 @@ public static class KeyValueStoreRlpExtensions
         {
             if (decoder is IRlpValueDecoder<TItem> valueDecoder)
             {
-                Span<byte> data = db.GetSpan(key);
-                if (data.IsNull())
-                {
-                    return null;
-                }
-
-                try
-                {
-                    if (data.Length == 0)
-                    {
-                        return null;
-                    }
-
-                    var rlpValueContext = data.AsRlpValueContext();
-                    item = valueDecoder.Decode(ref rlpValueContext, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
-                }
-                finally
-                {
-                    db.DangerousReleaseMemory(data);
-                }
+                item = db is IReadOnlyNativeKeyValueStore native
+                    ? GetViaNative(native, key, valueDecoder, rlpBehaviors)
+                    : GetViaSpan(db, key, valueDecoder, rlpBehaviors);
             }
             else
             {
-                Span<byte> data = db.Get(key);
-                if (data.IsNull())
-                {
-                    return null;
-                }
-
-                IByteBuffer buff = PooledByteBufferAllocator.Default.Buffer(data.Length);
-                data.CopyTo(buff.Array.AsSpan(buff.ArrayOffset + buff.WriterIndex));
-                buff.SetWriterIndex(buff.WriterIndex + data.Length);
-
-                using NettyRlpStream nettyRlpStream = new NettyRlpStream(buff);
-
-                item = decoder.Decode(nettyRlpStream, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
+                item = GetViaArray(db, key, decoder, rlpBehaviors);
             }
         }
 
@@ -94,5 +65,70 @@ public static class KeyValueStoreRlpExtensions
         }
 
         return item;
+    }
+
+    private static TItem? GetViaNative<TItem>(IReadOnlyNativeKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
+    {
+        ReadOnlySpan<byte> data = db.GetNativeSlice(key, out IntPtr handle);
+        if (data.IsNull())
+        {
+            return null;
+        }
+
+        try
+        {
+            if (data.Length == 0)
+            {
+                return null;
+            }
+
+            var rlpValueContext = data.AsRlpValueContext();
+            return valueDecoder.Decode(ref rlpValueContext, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
+        }
+        finally
+        {
+            db.DangerousReleaseHandle(handle);
+        }
+    }
+
+    private static TItem? GetViaSpan<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpValueDecoder<TItem> valueDecoder, RlpBehaviors rlpBehaviors) where TItem : class
+    {
+        Span<byte> data = db.GetSpan(key);
+        if (data.IsNull())
+        {
+            return null;
+        }
+
+        try
+        {
+            if (data.Length == 0)
+            {
+                return null;
+            }
+
+            var rlpValueContext = data.AsRlpValueContext();
+            return valueDecoder.Decode(ref rlpValueContext, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
+        }
+        finally
+        {
+            db.DangerousReleaseMemory(data);
+        }
+    }
+
+    private static TItem? GetViaArray<TItem>(IReadOnlyKeyValueStore db, ReadOnlySpan<byte> key, IRlpStreamDecoder<TItem> decoder, RlpBehaviors rlpBehaviors) where TItem : class
+    {
+        Span<byte> data = db.Get(key);
+        if (data.IsNull())
+        {
+            return null;
+        }
+
+        IByteBuffer buff = PooledByteBufferAllocator.Default.Buffer(data.Length);
+        data.CopyTo(buff.Array.AsSpan(buff.ArrayOffset + buff.WriterIndex));
+        buff.SetWriterIndex(buff.WriterIndex + data.Length);
+
+        using NettyRlpStream nettyRlpStream = new(buff);
+
+        return decoder.Decode(nettyRlpStream, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
     }
 }


### PR DESCRIPTION
## Changes

- Reduces allocation and additional copy from RocksDB; which is good for large objects like Blocks
- Better performance when downloading receipts (as they load blocks)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
