### PR TITLE
Increase Ethereum mainet gaslimit default to 60M

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -347,7 +347,7 @@ public class ConfigFilesTests : ConfigFileTestsBase
 
     [TestCase("chiado", 17_000_000L, 5UL, 3000)]
     [TestCase("gnosis", 17_000_000L, 5UL, 3000)]
-    [TestCase("mainnet", 36_000_000L)]
+    [TestCase("mainnet", 60_000_000L)]
     [TestCase("sepolia", 60_000_000L)]
     [TestCase("holesky", 60_000_000L)]
     [TestCase("^chiado ^gnosis ^mainnet ^sepolia ^holesky")]

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.json
@@ -22,7 +22,7 @@
     "NodeName": "Mainnet"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 36000000
+    "TargetBlockGasLimit": 60000000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
@@ -18,7 +18,7 @@
     "NodeName": "Mainnet Archive"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 36000000
+    "TargetBlockGasLimit": 60000000
   },
   "Receipt": {
     "TxLookupLimit": 0


### PR DESCRIPTION
## Changes

- Increase Ethereum mainnet default block gaslimit to 60M

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No