### PR TITLE
Mild performance tweaks

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -87,9 +87,8 @@ public class BlockchainProcessorTests
                         Hash256 hash = suggestedBlock.Hash!;
                         if (!_allowed.Contains(hash))
                         {
-                            if (_allowedToFail.Contains(hash))
+                            if (_allowedToFail.Remove(hash))
                             {
-                                _allowedToFail.Remove(hash);
                                 BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(suggestedBlocks.Last(), []));
                                 throw new InvalidBlockException(suggestedBlock, "allowed to fail");
                             }

--- a/src/Nethermind/Nethermind.Config.Test/ConfigFileTestsBase.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigFileTestsBase.cs
@@ -116,7 +116,7 @@ public abstract class ConfigFileTestsBase
             string singleWildcardBase = singleWildcard.Replace("^", string.Empty);
             IEnumerable<string> result = groups.TryGetValue(singleWildcardBase, out IEnumerable<string>? value) ? value : Enumerable.Repeat(singleWildcardBase, 1);
 
-            if (singleWildcard.StartsWith("^"))
+            if (singleWildcard.StartsWith('^'))
             {
                 result = Configs.Except(result);
             }

--- a/src/Nethermind/Nethermind.Core/Tasks/WaitForPassingTasks.cs
+++ b/src/Nethermind/Nethermind.Core/Tasks/WaitForPassingTasks.cs
@@ -21,7 +21,7 @@ public static class Wait
     public static async Task<T> AnyWhere<T>(Func<T, bool> cond, params IEnumerable<Task<T>> tasks)
     {
         HashSet<Task<T>> taskSet = new HashSet<Task<T>>(tasks);
-        while (taskSet.Any())
+        while (taskSet.Count != 0)
         {
             Task<T> resolved = await Task.WhenAny<T>(taskSet);
             taskSet.Remove(resolved);
@@ -34,7 +34,7 @@ public static class Wait
                 return result;
             }
 
-            if (!taskSet.Any())
+            if (taskSet.Count == 0)
             {
                 // No more tasks, just return the last one.
                 return result;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -104,7 +104,7 @@ public class PerTableDbConfig
                 string? valObj = (string?)propertyInfo.GetValue(dbConfig);
                 if (!string.IsNullOrEmpty(valObj))
                 {
-                    if (!valObj.EndsWith(";")) throw new InvalidConfigurationException($"Rocksdb config must end with `;`. Invalid property is {propertyName} in {prefixed}.", -1);
+                    if (!valObj.EndsWith(';')) throw new InvalidConfigurationException($"Rocksdb config must end with `;`. Invalid property is {propertyName} in {prefixed}.", -1);
                     val += valObj;
                 }
             }

--- a/src/Nethermind/Nethermind.Era1/EraPathUtils.cs
+++ b/src/Nethermind/Nethermind.Era1/EraPathUtils.cs
@@ -18,7 +18,7 @@ public static class EraPathUtils
             MatchCasing = MatchCasing.PlatformDefault
         });
 
-        if (!entries.Any())
+        if (entries.Length == 0)
             yield break;
 
         uint next = 0;

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -98,9 +98,9 @@ namespace Nethermind.Init.Steps
                 List<StepWrapper> dependencies = [];
                 foreach (Type type in stepInfo.Dependencies)
                 {
-                    if (!stepBaseTypeMap.ContainsKey(type))
+                    if (!stepBaseTypeMap.TryGetValue(type, out List<StepWrapper>? value))
                         throw new StepDependencyException($"The dependent step {type.Name} for {stepInfo.StepType.Name} was not created.");
-                    dependencies.AddRange(stepBaseTypeMap[type]);
+                    dependencies.AddRange(value);
                 }
                 await stepWrapper.StartExecute(dependencies, cancellationToken);
 

--- a/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Network
             {
                 _logger.Info($"Loaded {nodes.Count} trusted nodes from: {Path.GetFullPath(_trustedNodesPath)}");
             }
-            if (_logger.IsDebug && nodes.Any())
+            if (_logger.IsDebug && !nodes.IsEmpty)
             {
                 _logger.Debug("Trusted nodes:\n" + string.Join(Environment.NewLine, nodes.Values.Select(n => n.ToString())));
             }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -398,11 +398,11 @@ public class ChainSpecLoader(IJsonSerializer serializer) : IChainSpecLoader
             if (account.Value.CodeHash is not null)
             {
                 string codeHashString = account.Value.CodeHash.ToString();
-                if (chainSpecJson.CodeHashes is null || !chainSpecJson.CodeHashes.TryGetValue(codeHashString, out var value)) throw new ArgumentException($"CodeHash {account.Value.CodeHash} is not found");
+                if (chainSpecJson.CodeHashes is null || !chainSpecJson.CodeHashes.TryGetValue(codeHashString, out var codeHash)) throw new ArgumentException($"CodeHash {account.Value.CodeHash} is not found");
                 chainSpec.Allocations[address] = new ChainSpecAllocation(
                     account.Value.Balance ?? UInt256.Zero,
                     account.Value.Nonce,
-                    value,
+                    codeHash,
                     account.Value.Constructor,
                     account.Value.GetConvertedStorage());
             }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -398,11 +398,11 @@ public class ChainSpecLoader(IJsonSerializer serializer) : IChainSpecLoader
             if (account.Value.CodeHash is not null)
             {
                 string codeHashString = account.Value.CodeHash.ToString();
-                if (chainSpecJson.CodeHashes is null || !chainSpecJson.CodeHashes.ContainsKey(codeHashString)) throw new ArgumentException($"CodeHash {account.Value.CodeHash} is not found");
+                if (chainSpecJson.CodeHashes is null || !chainSpecJson.CodeHashes.TryGetValue(codeHashString, out var value)) throw new ArgumentException($"CodeHash {account.Value.CodeHash} is not found");
                 chainSpec.Allocations[address] = new ChainSpecAllocation(
                     account.Value.Balance ?? UInt256.Zero,
                     account.Value.Nonce,
-                    chainSpecJson.CodeHashes[codeHashString],
+                    value,
                     account.Value.Constructor,
                     account.Value.GetConvertedStorage());
             }


### PR DESCRIPTION
## Changes

- Switches ContainsKey+indexer to TryGetValue for single-dictionary lookups  
- Replaces LINQ `.Any()` with `Count` or `IsEmpty` checks on collections  
- Uses char overloads instead of string for simple checks

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No