### PR TITLE
fix: regenerate receipt bloom when Erigon sends zero bloom with non-empty logs

### DIFF
--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -211,19 +211,7 @@ namespace Nethermind.Core
             public bool IsZero() => Index1 == 0 && Index2 == 0 && Index3 == 0;
         }
 
-        public bool IsZero()
-        {
-            ReadOnlySpan<byte> bytes = Bytes;
-            for (int i = 0; i < ByteLength; i++)
-            {
-                if (bytes[i] != 0)
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
+        public bool IsZero() => !Bytes.ContainsAnyExcept((byte)0);
         public BloomStructRef ToStructRef() => new(Bytes);
 
         public Bloom Clone()

--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -211,6 +211,19 @@ namespace Nethermind.Core
             public bool IsZero() => Index1 == 0 && Index2 == 0 && Index3 == 0;
         }
 
+        public bool IsZero()
+        {
+            ReadOnlySpan<byte> bytes = Bytes;
+            for (int i = 0; i < ByteLength; i++)
+            {
+                if (bytes[i] != 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public BloomStructRef ToStructRef() => new(Bytes);
 
         public Bloom Clone()

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -62,7 +62,13 @@ namespace Nethermind.Core
         ///     Removed in EIP-658
         /// </summary>
         public Hash256? PostTransactionState { get; set; }
-        public Bloom? Bloom { get => _boom ?? CalculateBloom(); set => _boom = value; }
+        public Bloom? Bloom
+        {
+            get => _boom is null || (_boom.IsZero() && Logs?.Length > 0)
+                ? CalculateBloom()
+                : _boom;
+            set => _boom = value;
+        }
         public LogEntry[]? Logs { get; set; }
         public string? Error { get; set; }
 


### PR DESCRIPTION
Fixes  #8508 

## Changes

1. Added an `IsZero()` method to the `Bloom` class that checks if all bits in the bloom filter are zero.
2. Modified the `Bloom` property in `TransactionReceipt` to regenerate the bloom if either:
   - The bloom is null, OR
   - The bloom is a zero bloom AND there are logs present (which means it should have a non-zero bloom)

This change ensures that when Erigon sends a zero bloom for a receipt that has logs, we'll regenerate the bloom locally instead of using the zero bloom. This should prevent the disconnection issues during old receipt synchronization.

The changes maintain backward compatibility while fixing the specific issue with Erigon's behavior. When a receipt truly has no logs, a zero bloom is correct and will be preserved. But when there are logs present and we receive a zero bloom (the Erigon case), we'll regenerate it correctly.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
