### PR TITLE
Reduce `Forward header starting block number did not changed.` exception to log.

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -157,6 +157,35 @@ public partial class BlockDownloaderTests
     }
 
     [Test]
+    public async Task ForwardHeaderProvider_ReturnedSameHeaders_EvenAfterSuggestion()
+    {
+        long headNumber = 200;
+        int fastSyncLag = 10;
+        bool withReceipts = true;
+        long chainLength = headNumber + 1;
+
+        IForwardHeaderProvider mockForwardHeaderProvider = Substitute.For<IForwardHeaderProvider>();
+
+        await using IContainer node = CreateNode(configProvider: new ConfigProvider(new SyncConfig()
+            {
+                FastSync = true,
+                StateMinDistanceFromHead = fastSyncLag,
+            }),
+            configurer: (builder) => builder.AddSingleton<IForwardHeaderProvider>(mockForwardHeaderProvider));
+
+        Context ctx = node.Resolve<Context>();
+        SyncPeerMock syncPeer = new(chainLength, withReceipts, Response.AllCorrect | Response.WithTransactions);
+        PeerInfo peerInfo = new(syncPeer);
+        ctx.ConfigureBestPeer(peerInfo);
+
+        mockForwardHeaderProvider.GetBlockHeaders(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())!
+            .Returns((c) => syncPeer.GetBlockHeaders(0, 200, 0, default));
+
+        Func<Task> act = async () => await ctx.FastSyncUntilNoRequest(peerInfo);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
     public async Task Ancestor_lookup_simple()
     {
         IBlockTree instance = CachedBlockTreeBuilder.OfLength(1024);

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -142,8 +142,10 @@ namespace Nethermind.Synchronization.Blocks
 
                 if (previousStartingHeaderNumber == headers[0].Number)
                 {
-                    // Note: Could be change in peer or a fork.
-                    throw new InvalidOperationException("Forward header starting block number did not changed. This is unexpected");
+                    // When the block is suggested right between a `NewPayload` and `ForkChoiceUpdatedHandler` the block is not added because it was added already
+                    // by NP, but it still a beacon block because `FCU` has not happened yet. Causing this situation.
+                    if (_logger.IsDebug) _logger.Debug($"Forward header starting block number did not changed from {previousStartingHeaderNumber}.");
+                    return null;
                 }
                 previousStartingHeaderNumber = headers[0].Number;
 


### PR DESCRIPTION
- This exception seems to happen when the block is suggested between an NP and FCU. 
- This tend to happen randomly on mainnet after sync with a pretty good chance.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested to happen before.