### PR TITLE
Hide OP-CL specific options

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/CL/Rpc/IOptimismOptimismRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Rpc/IOptimismOptimismRpcModule.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Optimism.Cl.Rpc;
 public interface IOptimismOptimismRpcModule : IRpcModule
 {
     [JsonRpcMethod(
-        IsImplemented = true,
+        IsImplemented = false,
         Description = "Get the output root at a specific block",
         IsSharable = true,
         ExampleResponse = """
@@ -134,7 +134,7 @@ public interface IOptimismOptimismRpcModule : IRpcModule
     public Task<ResultWrapper<OptimismOutputAtBlock>> optimism_outputAtBlock(ulong blockNumber);
 
     [JsonRpcMethod(
-        IsImplemented = true,
+        IsImplemented = false,
         Description = "Get the synchronization status.",
         IsSharable = true,
         ExampleResponse = """
@@ -240,7 +240,7 @@ public interface IOptimismOptimismRpcModule : IRpcModule
     public Task<ResultWrapper<OptimismSyncStatus>> optimism_syncStatus();
 
     [JsonRpcMethod(
-        IsImplemented = true,
+        IsImplemented = false,
         Description = "Get the rollup configuration parameters.",
         IsSharable = true,
         ExampleResponse = """
@@ -279,7 +279,7 @@ public interface IOptimismOptimismRpcModule : IRpcModule
     public Task<ResultWrapper<OptimismRollupConfig>> optimism_rollupConfig();
 
     [JsonRpcMethod(
-        IsImplemented = true,
+        IsImplemented = false,
         Description = "Get the software version.",
         IsSharable = true,
         ExampleResponse = "1.31.10")]

--- a/src/Nethermind/Nethermind.Optimism/IOptimismConfig.cs
+++ b/src/Nethermind/Nethermind.Optimism/IOptimismConfig.cs
@@ -9,14 +9,19 @@ public interface IOptimismConfig : IConfig
 {
     [ConfigItem(Description = "The Optimism sequencer URL.", DefaultValue = "null")]
     string? SequencerUrl { get; set; }
-    [ConfigItem(Description = "Whether to use the enshrined Optimism consensus layer.", DefaultValue = "false")]
+
+    [ConfigItem(Description = "Whether to use the enshrined Optimism consensus layer.", DefaultValue = "false", HiddenFromDocs = true)]
     bool ClEnabled { get; set; }
-    [ConfigItem(Description = "The Optimism consensus layer host.", DefaultValue = "null")]
+
+    [ConfigItem(Description = "The Optimism consensus layer host.", DefaultValue = "null", HiddenFromDocs = true)]
     public string? ClP2PHost { get; set; }
-    [ConfigItem(Description = "CL p2p communication host", DefaultValue = "3030")]
+
+    [ConfigItem(Description = "CL p2p communication host", DefaultValue = "3030", HiddenFromDocs = true)]
     public int ClP2PPort { get; set; }
-    [ConfigItem(Description = "The URL of the Optimism L1 consensus node API.", DefaultValue = "null")]
+
+    [ConfigItem(Description = "The URL of the Optimism L1 consensus node API.", DefaultValue = "null", HiddenFromDocs = true)]
     string? L1BeaconApiEndpoint { get; set; }
-    [ConfigItem(Description = "The URL of the Optimism L1 execution node JSON-RPC API.", DefaultValue = "null")]
+
+    [ConfigItem(Description = "The URL of the Optimism L1 execution node JSON-RPC API.", DefaultValue = "null", HiddenFromDocs = true)]
     string? L1EthApiEndpoint { get; set; }
 }


### PR DESCRIPTION
## Changes

- Hide OP-CL `optimism` RPC namespace
- Hide OP-CL specific configurations

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [x] Yes
- [] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Until all OP-CL features are to be included in a release we want to hide configurations and RPC modules from user facing docs like CLI help and official Nethermind docs.
