### PR TITLE
Refactor/Reduce `AuraNethermindApi` usage.

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Consensus.AuRa
             _nethermindApi = nethermindApi as AuRaNethermindApi;
             if (_nethermindApi is not null)
             {
-                _blockProducerStarter = new(_nethermindApi);
+                _blockProducerStarter = _nethermindApi.CreateStartBlockProducer();
             }
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
@@ -39,22 +39,19 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
             this.WorldStateManager!,
             this.BlockTree!,
             this.ReceiptFinder!,
-            this.TransactionPermissionContractVersions,
+            this.AuraStatefulComponents,
             this.TxFilterCache,
             this.LogManager
         );
 
         private PermissionBasedTxFilter.Cache? _txFilterCache = null;
-        public PermissionBasedTxFilter.Cache TxFilterCache => _txFilterCache ??= new PermissionBasedTxFilter.Cache();
+        private PermissionBasedTxFilter.Cache TxFilterCache => _txFilterCache ??= new PermissionBasedTxFilter.Cache();
 
         private IValidatorStore? _validatorStore = null;
         public IValidatorStore ValidatorStore => _validatorStore ??= new ValidatorStore(DbProvider!.BlockInfosDb);
 
-        public LruCache<ValueHash256, UInt256> TransactionPermissionContractVersions { get; }
-            = new(
-                PermissionBasedTxFilter.Cache.MaxCacheSize,
-                nameof(TransactionPermissionContract));
-
+        private AuraStatefulComponents? _auraStatefulComponents = null;
+        private AuraStatefulComponents AuraStatefulComponents => _auraStatefulComponents ??= new AuraStatefulComponents();
 
         private AuRaContractGasLimitOverride.Cache? _gasLimitCalculatorCache = null;
         public AuRaContractGasLimitOverride.Cache GasLimitCalculatorCache => _gasLimitCalculatorCache ??= new AuRaContractGasLimitOverride.Cache();
@@ -125,5 +122,13 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                 this.BlockProducerEnvFactory,
                 this.LogManager);
         }
+    }
+
+    public class AuraStatefulComponents
+    {
+        public LruCache<ValueHash256, UInt256> TransactionPermissionContractVersions { get; }
+            = new(
+                PermissionBasedTxFilter.Cache.MaxCacheSize,
+                nameof(TransactionPermissionContract));
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Api;
 using Nethermind.Blockchain;
+using Nethermind.Config;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Transactions;
@@ -26,6 +27,22 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
             get => base.FinalizationManager as IAuRaBlockFinalizationManager;
             set => base.FinalizationManager = value;
         }
+
+        private TxAuRaFilterBuilders? _txAuRaFilterBuilders = null;
+
+        public TxAuRaFilterBuilders TxAuRaFilterBuilders => _txAuRaFilterBuilders ??= new TxAuRaFilterBuilders(
+            this.ChainSpec,
+            this.SpecProvider,
+            this.Config<IBlocksConfig>(),
+            this.Config<IAuraConfig>(),
+            this.AbiEncoder,
+            this.WorldStateManager!,
+            this.BlockTree!,
+            this.ReceiptFinder!,
+            this.TransactionPermissionContractVersions,
+            this.TxFilterCache,
+            this.LogManager
+        );
 
         private PermissionBasedTxFilter.Cache? _txFilterCache = null;
         public PermissionBasedTxFilter.Cache TxFilterCache => _txFilterCache ??= new PermissionBasedTxFilter.Cache();

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
@@ -93,8 +93,37 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
         public StartBlockProducerAuRa CreateStartBlockProducer()
         {
             return new StartBlockProducerAuRa(
-                this,
-                this.Config<IAuraConfig>());
+                this.SpecProvider,
+                this.ChainSpec,
+                this.ConfigProvider.GetConfig<IBlocksConfig>(),
+                this.Config<IAuraConfig>(),
+                this.BlockProcessingQueue!,
+                this.BlockTree!,
+                this.Sealer!,
+                this.Timestamper,
+                this.ReportingValidator!,
+                this.ReceiptStorage!,
+                this.ValidatorStore,
+                this.FinalizationManager!,
+                this.EngineSigner!,
+                this.GasPriceOracle!,
+                this.ReportingContractValidatorCache,
+                this.DisposeStack,
+                this.GasLimitCalculatorCache!,
+                this.AbiEncoder,
+                this.WorldStateManager!,
+                this.TxAuRaFilterBuilders!,
+                this.TxPriorityContractLocalDataSource!,
+                this.TxPool!,
+                this.StateReader,
+                this.TransactionComparerProvider,
+                this.BlockPreprocessor,
+                this.NodeKey,
+                this.CryptoRandom,
+                this.BlockValidator,
+                this.RewardCalculatorSource,
+                this.BlockProducerEnvFactory,
+                this.LogManager);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaNethermindApi.cs
@@ -90,5 +90,11 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
         public ReadOnlyTxProcessingEnv CreateReadOnlyTransactionProcessorSource() =>
             new ReadOnlyTxProcessingEnv(WorldStateManager!, BlockTree!.AsReadOnly(), SpecProvider!, LogManager!);
 
+        public StartBlockProducerAuRa CreateStartBlockProducer()
+        {
+            return new StartBlockProducerAuRa(
+                this,
+                this.Config<IAuraConfig>());
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -89,8 +89,7 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
         if (_api.GasPriceOracle is null) throw new StepDependencyException(nameof(_api.GasPriceOracle));
         if (_api.ChainSpec is null) throw new StepDependencyException(nameof(_api.ChainSpec));
 
-        ITxFilter auRaTxFilter = TxAuRaFilterBuilders.CreateAuRaTxFilter(
-            _api,
+        ITxFilter auRaTxFilter = _api.TxAuRaFilterBuilders.CreateAuRaTxFilter(
             new ServiceTxFilter(_api.SpecProvider));
 
         return NewAuraBlockProcessor(auRaTxFilter, preWarmer, transactionProcessor, worldState);
@@ -246,15 +245,15 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
     protected override TxPool.TxPool CreateTxPool(CodeInfoRepository codeInfoRepository)
     {
         // This has to be different object than the _processingReadOnlyTransactionProcessorSource as this is in separate thread
-        TxPriorityContract txPriorityContract = TxAuRaFilterBuilders.CreateTxPrioritySources(_api);
+        TxPriorityContract txPriorityContract = _api.TxAuRaFilterBuilders.CreateTxPrioritySources();
         TxPriorityContract.LocalDataSource? localDataSource = _api.TxPriorityContractLocalDataSource;
 
         ReportTxPriorityRules(txPriorityContract, localDataSource);
 
         DictionaryContractDataStore<TxPriorityContract.Destination>? minGasPricesContractDataStore
-            = TxAuRaFilterBuilders.CreateMinGasPricesDataStore(_api, txPriorityContract, localDataSource);
+            = _api.TxAuRaFilterBuilders.CreateMinGasPricesDataStore(txPriorityContract, localDataSource);
 
-        ITxFilter txPoolFilter = TxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_api, minGasPricesContractDataStore);
+        ITxFilter txPoolFilter = _api.TxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(minGasPricesContractDataStore);
 
         return new TxPool.TxPool(
             _api.EthereumEcdsa!,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -115,8 +115,7 @@ public class StartBlockProducerAuRa
         if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
         if (_api.GasPriceOracle is null) throw new StepDependencyException(nameof(_api.GasPriceOracle));
 
-        ITxFilter auRaTxFilter = TxAuRaFilterBuilders.CreateAuRaTxFilter(
-            _api,
+        ITxFilter auRaTxFilter = _api.TxAuRaFilterBuilders.CreateAuRaTxFilter(
             new LocalTxFilter(_api.EngineSigner));
 
         _validator = new AuRaValidatorFactory(_api.AbiEncoder,
@@ -167,12 +166,12 @@ public class StartBlockProducerAuRa
 
     internal TxPoolTxSource CreateTxPoolTxSource()
     {
-        _txPriorityContract = TxAuRaFilterBuilders.CreateTxPrioritySources(_api);
+        _txPriorityContract = _api.TxAuRaFilterBuilders.CreateTxPrioritySources();
         _localDataSource = _api.TxPriorityContractLocalDataSource;
 
         if (_txPriorityContract is not null || _localDataSource is not null)
         {
-            _minGasPricesContractDataStore = TxAuRaFilterBuilders.CreateMinGasPricesDataStore(_api, _txPriorityContract, _localDataSource)!;
+            _minGasPricesContractDataStore = _api.TxAuRaFilterBuilders.CreateMinGasPricesDataStore(_txPriorityContract, _localDataSource)!;
             _api.DisposeStack.Push(_minGasPricesContractDataStore);
 
             ContractDataStore<Address> whitelistContractDataStore = new ContractDataStoreWithLocalData<Address>(
@@ -270,7 +269,7 @@ public class StartBlockProducerAuRa
         return new TxPoolTxSource(_api.TxPool, _api.SpecProvider, _api.TransactionComparerProvider, _api.LogManager, txFilterPipeline);
     }
 
-    private ITxFilter CreateAuraTxFilterForProducer() => TxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_api, _minGasPricesContractDataStore);
+    private ITxFilter CreateAuraTxFilterForProducer() => _api.TxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_minGasPricesContractDataStore);
 
     private ITxSource CreateTxSourceForProducer(ITxSource? additionalTxSource)
     {
@@ -342,7 +341,7 @@ public class StartBlockProducerAuRa
             txSource = new GeneratedTxSource(txSource, transactionSealer, _api.StateReader, _api.LogManager);
         }
 
-        ITxFilter? txPermissionFilter = TxAuRaFilterBuilders.CreateTxPermissionFilter(_api);
+        ITxFilter? txPermissionFilter = _api.TxAuRaFilterBuilders.CreateTxPermissionFilter();
         if (txPermissionFilter is not null)
         {
             // we now only need to filter generated transactions here, as regular ones are filtered on TxPoolTxSource filter based on CreateTxSourceFilter method

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -5,26 +5,32 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Abi;
-using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Data;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Consensus.AuRa.Transactions;
 using Nethermind.Consensus.AuRa.Validators;
+using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
+using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Validators;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Init.Steps;
+using Nethermind.JsonRpc.Modules.Eth.GasPrice;
 using Nethermind.Logging;
+using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.AuRa.InitializationSteps;
@@ -32,17 +38,43 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps;
 // Note: Not a step!! Its a factory of some kind!
 // Note: Stateful!! Can't use a singleton!
 public class StartBlockProducerAuRa(
-    AuRaNethermindApi api,
-    IAuraConfig auraConfig
-)
+    ISpecProvider specProvider,
+    ChainSpec chainSpec,
+    IBlocksConfig blocksConfig,
+    IAuraConfig auraConfig,
+    IBlockProcessingQueue blockProcessingQueue,
+    IBlockTree blockTree,
+    ISealer sealer,
+    ITimestamper timestamper,
+    IReportingValidator reportingValidator,
+    IReceiptStorage receiptStorage,
+    IValidatorStore validatorStore,
+    IAuRaBlockFinalizationManager auRaBlockFinalizationManager,
+    ISigner engineSigner,
+    IGasPriceOracle gasPriceOracle,
+    ReportingContractBasedValidator.Cache reportingContractValidatorCache,
+    DisposableStack disposeStack,
+    AuRaContractGasLimitOverride.Cache gasLimitCalculatorCache,
+    IAbiEncoder abiEncoder,
+    IWorldStateManager worldStateManager,
+    TxAuRaFilterBuilders apiTxAuRaFilterBuilders,
+    TxPriorityContract.LocalDataSource txPriorityContractLocalDataSource,
+    ITxPool txPool,
+    IStateReader apiStateReader,
+    ITransactionComparerProvider transactionComparerProvider,
+    CompositeBlockPreprocessorStep compositeBlockPreprocessorStep,
+    IProtectedPrivateKey protectedPrivateKey,
+    ICryptoRandom cryptoRandom,
+    IBlockValidator blockValidator,
+    IRewardCalculatorSource rewardCalculatorSource,
+    IBlockProducerEnvFactory blockProducerEnvFactory,
+    ILogManager logManager)
 {
-    private readonly AuRaNethermindApi _api = api;
-    private readonly AuRaChainSpecEngineParameters _parameters = api.ChainSpec.EngineChainSpecParametersProvider
+    private readonly AuRaChainSpecEngineParameters _parameters = chainSpec.EngineChainSpecParametersProvider
         .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
 
     private BlockProducerEnv? _blockProducerContext;
 
-    private readonly IAuraConfig _auraConfig = auraConfig;
     private IAuRaValidator? _validator;
     private DictionaryContractDataStore<TxPriorityContract.Destination>? _minGasPricesContractDataStore;
     private TxPriorityContract? _txPriorityContract;
@@ -53,162 +85,151 @@ public class StartBlockProducerAuRa(
     {
         get
         {
-            return _stepCalculator ??= new AuRaStepCalculator(_parameters.StepDuration, _api.Timestamper, _api.LogManager);
+            return _stepCalculator ??= new AuRaStepCalculator(_parameters.StepDuration, timestamper, logManager);
         }
     }
 
     public IBlockProductionTrigger CreateTrigger()
     {
-        BuildBlocksOnAuRaSteps onAuRaSteps = new(StepCalculator, _api.LogManager);
+        BuildBlocksOnAuRaSteps onAuRaSteps = new(StepCalculator, logManager);
         BuildBlocksOnlyWhenNotProcessing onlyWhenNotProcessing = new(
             onAuRaSteps,
-            _api.BlockProcessingQueue,
-            _api.BlockTree,
-            _api.LogManager,
-            !_auraConfig.AllowAuRaPrivateChains);
+            blockProcessingQueue,
+            blockTree,
+            logManager,
+            !auraConfig.AllowAuRaPrivateChains);
 
-        _api.DisposeStack.Push((IAsyncDisposable)onlyWhenNotProcessing);
+        disposeStack.Push((IAsyncDisposable)onlyWhenNotProcessing);
 
         return onlyWhenNotProcessing;
     }
 
     public IBlockProducer BuildProducer(ITxSource? additionalTxSource = null)
     {
-        if (_api.EngineSigner is null) throw new StepDependencyException(nameof(_api.EngineSigner));
-        if (_api.ChainSpec is null) throw new StepDependencyException(nameof(_api.ChainSpec));
-
-        ILogger logger = _api.LogManager.GetClassLogger();
+        ILogger logger = logManager.GetClassLogger();
         if (logger.IsInfo) logger.Info("Starting AuRa block producer & sealer");
 
         BlockProducerEnv producerEnv = GetProducerChain(additionalTxSource);
 
-        IGasLimitCalculator gasLimitCalculator = CreateGasLimitCalculator(_api);
+        IGasLimitCalculator gasLimitCalculator = CreateGasLimitCalculator();
 
         IBlockProducer blockProducer = new AuRaBlockProducer(
             producerEnv.TxSource,
             producerEnv.ChainProcessor,
             producerEnv.ReadOnlyStateProvider,
-            _api.Sealer,
-            _api.BlockTree,
-            _api.Timestamper,
+            sealer,
+            blockTree,
+            timestamper,
             StepCalculator,
-            _api.ReportingValidator,
-            _auraConfig,
+            reportingValidator,
+            auraConfig,
             gasLimitCalculator,
-            _api.SpecProvider,
-            _api.LogManager,
-            _api.ConfigProvider.GetConfig<IBlocksConfig>());
+            specProvider,
+            logManager,
+            blocksConfig);
 
         return blockProducer;
     }
 
     private BlockProcessor CreateBlockProcessor(IReadOnlyTxProcessingScope changeableTxProcessingEnv)
     {
-        if (_api.RewardCalculatorSource is null) throw new StepDependencyException(nameof(_api.RewardCalculatorSource));
-        if (_api.ValidatorStore is null) throw new StepDependencyException(nameof(_api.ValidatorStore));
-        if (_api.ChainSpec is null) throw new StepDependencyException(nameof(_api.ChainSpec));
-        if (_api.BlockTree is null) throw new StepDependencyException(nameof(_api.BlockTree));
-        if (_api.EngineSigner is null) throw new StepDependencyException(nameof(_api.EngineSigner));
-        if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
-        if (_api.GasPriceOracle is null) throw new StepDependencyException(nameof(_api.GasPriceOracle));
+        ITxFilter auRaTxFilter = apiTxAuRaFilterBuilders.CreateAuRaTxFilter(
+            new LocalTxFilter(engineSigner));
 
-        ITxFilter auRaTxFilter = _api.TxAuRaFilterBuilders.CreateAuRaTxFilter(
-            new LocalTxFilter(_api.EngineSigner));
-
-        _validator = new AuRaValidatorFactory(_api.AbiEncoder,
+        _validator = new AuRaValidatorFactory(abiEncoder,
                 changeableTxProcessingEnv.WorldState,
                 changeableTxProcessingEnv.TransactionProcessor,
-                _api.BlockTree,
-                _api.CreateReadOnlyTransactionProcessorSource(),
-                _api.ReceiptStorage,
-                _api.ValidatorStore,
-                _api.FinalizationManager,
+                blockTree,
+                CreateReadOnlyTransactionProcessorSource(),
+                receiptStorage,
+                validatorStore,
+                auRaBlockFinalizationManager,
                 NullTxSender.Instance,
                 NullTxPool.Instance,
-                _api.Config<IBlocksConfig>(),
-                _api.LogManager,
-                _api.EngineSigner,
-                _api.SpecProvider,
-                _api.GasPriceOracle,
-                _api.ReportingContractValidatorCache,
+                blocksConfig,
+                logManager,
+                engineSigner,
+                specProvider,
+                gasPriceOracle,
+                reportingContractValidatorCache,
                 _parameters.PosdaoTransition,
                 true)
-            .CreateValidatorProcessor(_parameters.Validators, _api.BlockTree.Head?.Header);
+            .CreateValidatorProcessor(_parameters.Validators, blockTree.Head?.Header);
 
         if (_validator is IDisposable disposableValidator)
         {
-            _api.DisposeStack.Push(disposableValidator);
+            disposeStack.Push(disposableValidator);
         }
 
         IDictionary<long, IDictionary<Address, byte[]>> rewriteBytecode = _parameters.RewriteBytecode;
         ContractRewriter? contractRewriter = rewriteBytecode?.Count > 0 ? new ContractRewriter(rewriteBytecode) : null;
 
         return new AuRaBlockProcessor(
-            _api.SpecProvider,
-            _api.BlockValidator,
-            _api.RewardCalculatorSource.Get(changeableTxProcessingEnv.TransactionProcessor),
-            _api.BlockProducerEnvFactory.TransactionsExecutorFactory.Create(changeableTxProcessingEnv),
+            specProvider,
+            blockValidator,
+            rewardCalculatorSource.Get(changeableTxProcessingEnv.TransactionProcessor),
+            blockProducerEnvFactory.TransactionsExecutorFactory.Create(changeableTxProcessingEnv),
             changeableTxProcessingEnv.WorldState,
-            _api.ReceiptStorage,
+            receiptStorage,
             new BeaconBlockRootHandler(changeableTxProcessingEnv.TransactionProcessor, changeableTxProcessingEnv.WorldState),
-            _api.LogManager,
-            _api.BlockTree,
+            logManager,
+            blockTree,
             NullWithdrawalProcessor.Instance,
             changeableTxProcessingEnv.TransactionProcessor,
             _validator,
             auRaTxFilter,
-            CreateGasLimitCalculator(_api) as AuRaContractGasLimitOverride,
+            CreateGasLimitCalculator() as AuRaContractGasLimitOverride,
             contractRewriter);
     }
 
     internal TxPoolTxSource CreateTxPoolTxSource()
     {
-        _txPriorityContract = _api.TxAuRaFilterBuilders.CreateTxPrioritySources();
-        _localDataSource = _api.TxPriorityContractLocalDataSource;
+        _txPriorityContract = apiTxAuRaFilterBuilders.CreateTxPrioritySources();
+        _localDataSource = txPriorityContractLocalDataSource;
 
         if (_txPriorityContract is not null || _localDataSource is not null)
         {
-            _minGasPricesContractDataStore = _api.TxAuRaFilterBuilders.CreateMinGasPricesDataStore(_txPriorityContract, _localDataSource)!;
-            _api.DisposeStack.Push(_minGasPricesContractDataStore);
+            _minGasPricesContractDataStore = apiTxAuRaFilterBuilders.CreateMinGasPricesDataStore(_txPriorityContract, _localDataSource)!;
+            disposeStack.Push(_minGasPricesContractDataStore);
 
             ContractDataStore<Address> whitelistContractDataStore = new ContractDataStoreWithLocalData<Address>(
                 new HashSetContractDataStoreCollection<Address>(),
                 _txPriorityContract?.SendersWhitelist,
-                _api.BlockTree,
-                _api.ReceiptFinder,
-                _api.LogManager,
+                blockTree,
+                receiptStorage,
+                logManager,
                 _localDataSource?.GetWhitelistLocalDataSource() ?? new EmptyLocalDataSource<IEnumerable<Address>>());
 
             DictionaryContractDataStore<TxPriorityContract.Destination> prioritiesContractDataStore =
                 new DictionaryContractDataStore<TxPriorityContract.Destination>(
                     new TxPriorityContract.DestinationSortedListContractDataStoreCollection(),
                     _txPriorityContract?.Priorities,
-                    _api.BlockTree,
-                    _api.ReceiptFinder,
-                    _api.LogManager,
+                    blockTree,
+                    receiptStorage,
+                    logManager,
                     _localDataSource?.GetPrioritiesLocalDataSource());
 
-            _api.DisposeStack.Push(whitelistContractDataStore);
-            _api.DisposeStack.Push(prioritiesContractDataStore);
+            disposeStack.Push(whitelistContractDataStore);
+            disposeStack.Push(prioritiesContractDataStore);
 
             ITxFilter auraTxFilter =
-                CreateAuraTxFilterForProducer();
-            ITxFilterPipeline txFilterPipeline = new TxFilterPipelineBuilder(_api.LogManager)
+                apiTxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_minGasPricesContractDataStore);
+            ITxFilterPipeline txFilterPipeline = new TxFilterPipelineBuilder(logManager)
                 .WithCustomTxFilter(auraTxFilter)
-                .WithBaseFeeFilter(_api.SpecProvider)
+                .WithBaseFeeFilter(specProvider)
                 .WithNullTxFilter()
                 .Build;
 
 
             return new TxPriorityTxSource(
-                _api.TxPool,
-                _api.StateReader,
-                _api.LogManager,
+                txPool,
+                apiStateReader,
+                logManager,
                 txFilterPipeline,
                 whitelistContractDataStore,
                 prioritiesContractDataStore,
-                _api.SpecProvider,
-                _api.TransactionComparerProvider);
+                specProvider,
+                transactionComparerProvider);
         }
         else
         {
@@ -216,14 +237,25 @@ public class StartBlockProducerAuRa(
         }
     }
 
+    private TxPoolTxSource CreateStandardTxPoolTxSource()
+    {
+        ITxFilter txSourceFilter = apiTxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_minGasPricesContractDataStore);
+        ITxFilterPipeline txFilterPipeline = new TxFilterPipelineBuilder(logManager)
+            .WithCustomTxFilter(txSourceFilter)
+            .WithBaseFeeFilter(specProvider)
+            .Build;
+        return new TxPoolTxSource(txPool, specProvider, transactionComparerProvider, logManager, txFilterPipeline);
+    }
+
+
     // TODO: Use BlockProducerEnvFactory
     private BlockProducerEnv GetProducerChain(ITxSource? additionalTxSource)
     {
         BlockProducerEnv Create()
         {
-            ReadOnlyBlockTree readOnlyBlockTree = _api.BlockTree.AsReadOnly();
+            ReadOnlyBlockTree readOnlyBlockTree = blockTree.AsReadOnly();
 
-            ReadOnlyTxProcessingEnv txProcessingEnv = _api.CreateReadOnlyTransactionProcessorSource();
+            ReadOnlyTxProcessingEnv txProcessingEnv = CreateReadOnlyTransactionProcessorSource();
             IReadOnlyTxProcessingScope scope = txProcessingEnv.Build(Keccak.EmptyTreeHash);
             BlockProcessor blockProcessor = CreateBlockProcessor(scope);
 
@@ -231,9 +263,9 @@ public class StartBlockProducerAuRa(
                 new BlockchainProcessor(
                     readOnlyBlockTree,
                     blockProcessor,
-                    _api.BlockPreprocessor,
-                    _api.StateReader,
-                    _api.LogManager,
+                    compositeBlockPreprocessorStep,
+                    apiStateReader,
+                    logManager,
                     BlockchainProcessor.Options.NoReceipts);
 
             OneTimeChainProcessor chainProcessor = new(
@@ -246,27 +278,14 @@ public class StartBlockProducerAuRa(
                 ChainProcessor = chainProcessor,
                 ReadOnlyStateProvider = scope.WorldState,
                 TxSource = CreateTxSourceForProducer(additionalTxSource),
-                ReadOnlyTxProcessingEnv = _api.CreateReadOnlyTransactionProcessorSource(),
+                ReadOnlyTxProcessingEnv = CreateReadOnlyTransactionProcessorSource(),
             };
         }
 
         return _blockProducerContext ??= Create();
     }
 
-    private ITxSource CreateStandardTxSourceForProducer() =>
-        CreateTxPoolTxSource();
-
-    private TxPoolTxSource CreateStandardTxPoolTxSource()
-    {
-        ITxFilter txSourceFilter = CreateAuraTxFilterForProducer();
-        ITxFilterPipeline txFilterPipeline = new TxFilterPipelineBuilder(_api.LogManager)
-            .WithCustomTxFilter(txSourceFilter)
-            .WithBaseFeeFilter(_api.SpecProvider)
-            .Build;
-        return new TxPoolTxSource(_api.TxPool, _api.SpecProvider, _api.TransactionComparerProvider, _api.LogManager, txFilterPipeline);
-    }
-
-    private ITxFilter CreateAuraTxFilterForProducer() => _api.TxAuRaFilterBuilders.CreateAuRaTxFilterForProducer(_minGasPricesContractDataStore);
+    private ITxSource CreateStandardTxSourceForProducer() => CreateTxPoolTxSource();
 
     private ITxSource CreateTxSourceForProducer(ITxSource? additionalTxSource)
     {
@@ -300,14 +319,14 @@ public class StartBlockProducerAuRa(
             if (randomnessContractAddress?.Any() == true)
             {
                 RandomContractTxSource randomContractTxSource = new RandomContractTxSource(
-                    GetRandomContracts(randomnessContractAddress, _api.AbiEncoder,
-                        _api.CreateReadOnlyTransactionProcessorSource(),
+                    GetRandomContracts(randomnessContractAddress, abiEncoder,
+                        CreateReadOnlyTransactionProcessorSource(),
                         signer),
-                    new EciesCipher(_api.CryptoRandom),
+                    new EciesCipher(cryptoRandom),
                     signer,
-                    _api.NodeKey,
-                    _api.CryptoRandom,
-                    _api.LogManager);
+                    protectedPrivateKey,
+                    cryptoRandom,
+                    logManager);
 
                 list.Insert(0, randomContractTxSource);
                 return true;
@@ -315,10 +334,6 @@ public class StartBlockProducerAuRa(
 
             return false;
         }
-
-        if (_api.ChainSpec is null) throw new StepDependencyException(nameof(_api.ChainSpec));
-        if (_api.BlockTree is null) throw new StepDependencyException(nameof(_api.BlockTree));
-        if (_api.EngineSigner is null) throw new StepDependencyException(nameof(_api.EngineSigner));
 
         IList<ITxSource> txSources = new List<ITxSource> { CreateStandardTxSourceForProducer() };
         bool needSigner = false;
@@ -328,51 +343,53 @@ public class StartBlockProducerAuRa(
             txSources.Insert(0, additionalTxSource);
         }
         needSigner |= CheckAddPosdaoTransactions(txSources, _parameters.PosdaoTransition);
-        needSigner |= CheckAddRandomnessTransactions(txSources, _parameters.RandomnessContractAddress, _api.EngineSigner);
+        needSigner |= CheckAddRandomnessTransactions(txSources, _parameters.RandomnessContractAddress, engineSigner);
 
         ITxSource txSource = txSources.Count > 1 ? new CompositeTxSource(txSources.ToArray()) : txSources[0];
 
         if (needSigner)
         {
-            TxSealer transactionSealer = new TxSealer(_api.EngineSigner, _api.Timestamper);
-            txSource = new GeneratedTxSource(txSource, transactionSealer, _api.StateReader, _api.LogManager);
+            TxSealer transactionSealer = new TxSealer(engineSigner, timestamper);
+            txSource = new GeneratedTxSource(txSource, transactionSealer, apiStateReader, logManager);
         }
 
-        ITxFilter? txPermissionFilter = _api.TxAuRaFilterBuilders.CreateTxPermissionFilter();
+        ITxFilter? txPermissionFilter = apiTxAuRaFilterBuilders.CreateTxPermissionFilter();
         if (txPermissionFilter is not null)
         {
             // we now only need to filter generated transactions here, as regular ones are filtered on TxPoolTxSource filter based on CreateTxSourceFilter method
-            txSource = new FilteredTxSource<GeneratedTransaction>(txSource, txPermissionFilter, _api.LogManager);
+            txSource = new FilteredTxSource<GeneratedTransaction>(txSource, txPermissionFilter, logManager);
         }
 
         return txSource;
     }
 
-    private static IGasLimitCalculator CreateGasLimitCalculator(AuRaNethermindApi api)
+    private IGasLimitCalculator CreateGasLimitCalculator()
     {
-        if (api.ChainSpec is null) throw new StepDependencyException(nameof(api.ChainSpec));
-        var blockGasLimitContractTransitions = api.ChainSpec.EngineChainSpecParametersProvider
+        var blockGasLimitContractTransitions = chainSpec.EngineChainSpecParametersProvider
             .GetChainSpecParameters<AuRaChainSpecEngineParameters>().BlockGasLimitContractTransitions;
 
-        IGasLimitCalculator gasLimitCalculator = new TargetAdjustedGasLimitCalculator(api.SpecProvider, api.Config<IBlocksConfig>());
+        IGasLimitCalculator gasLimitCalculator = new TargetAdjustedGasLimitCalculator(specProvider, blocksConfig);
         if (blockGasLimitContractTransitions?.Count > 0)
         {
             AuRaContractGasLimitOverride auRaContractGasLimitOverride = new(
                     blockGasLimitContractTransitions.Select(blockGasLimitContractTransition =>
                             new BlockGasLimitContract(
-                                api.AbiEncoder,
+                                abiEncoder,
                                 blockGasLimitContractTransition.Value,
                                 blockGasLimitContractTransition.Key,
-                                api.CreateReadOnlyTransactionProcessorSource()))
+                                CreateReadOnlyTransactionProcessorSource()))
                         .ToArray<IBlockGasLimitContract>(),
-                    api.GasLimitCalculatorCache,
-                    api.Config<IAuraConfig>().Minimum2MlnGasPerBlockWhenUsingBlockGasLimitContract == true,
+                    gasLimitCalculatorCache,
+                    auraConfig.Minimum2MlnGasPerBlockWhenUsingBlockGasLimitContract == true,
                     gasLimitCalculator,
-                    api.LogManager);
+                    logManager);
 
             gasLimitCalculator = auRaContractGasLimitOverride;
         }
 
         return gasLimitCalculator;
     }
+
+    private ReadOnlyTxProcessingEnv CreateReadOnlyTransactionProcessorSource() =>
+        new ReadOnlyTxProcessingEnv(worldStateManager!, blockTree!.AsReadOnly(), specProvider!, logManager!);
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -29,28 +29,25 @@ using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.AuRa.InitializationSteps;
 
-public class StartBlockProducerAuRa
+// Note: Not a step!! Its a factory of some kind!
+// Note: Stateful!! Can't use a singleton!
+public class StartBlockProducerAuRa(
+    AuRaNethermindApi api,
+    IAuraConfig auraConfig
+)
 {
-    private readonly AuRaNethermindApi _api;
-    private readonly AuRaChainSpecEngineParameters _parameters;
+    private readonly AuRaNethermindApi _api = api;
+    private readonly AuRaChainSpecEngineParameters _parameters = api.ChainSpec.EngineChainSpecParametersProvider
+        .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
 
     private BlockProducerEnv? _blockProducerContext;
-    private INethermindApi NethermindApi => _api;
 
-    private readonly IAuraConfig _auraConfig;
+    private readonly IAuraConfig _auraConfig = auraConfig;
     private IAuRaValidator? _validator;
     private DictionaryContractDataStore<TxPriorityContract.Destination>? _minGasPricesContractDataStore;
     private TxPriorityContract? _txPriorityContract;
     private TxPriorityContract.LocalDataSource? _localDataSource;
     private IAuRaStepCalculator? _stepCalculator;
-
-    public StartBlockProducerAuRa(AuRaNethermindApi api)
-    {
-        _api = api;
-        _parameters = _api.ChainSpec.EngineChainSpecParametersProvider
-            .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
-        _auraConfig = NethermindApi.Config<IAuraConfig>();
-    }
 
     private IAuRaStepCalculator StepCalculator
     {
@@ -128,7 +125,7 @@ public class StartBlockProducerAuRa
                 _api.FinalizationManager,
                 NullTxSender.Instance,
                 NullTxPool.Instance,
-                NethermindApi.Config<IBlocksConfig>(),
+                _api.Config<IBlocksConfig>(),
                 _api.LogManager,
                 _api.EngineSigner,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/TxAuRaFilterBuilders.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/TxAuRaFilterBuilders.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Abi;
-using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
@@ -13,10 +12,7 @@ using Nethermind.Consensus.AuRa.Transactions;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State;
@@ -32,7 +28,7 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
         IWorldStateManager worldStateManager,
         IBlockTree blockTree,
         IReceiptFinder receiptFinder,
-        LruCache<ValueHash256, UInt256> transactionPermissionContractVersions,
+        AuraStatefulComponents statefulComponents,
         PermissionBasedTxFilter.Cache txFilterCache,
         ILogManager logManager
     )
@@ -100,7 +96,7 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                         chainSpec.Parameters.TransactionPermissionContract,
                         chainSpec.Parameters.TransactionPermissionContractTransition ?? 0,
                         CreateReadOnlyTransactionProcessorSource(),
-                        transactionPermissionContractVersions,
+                        statefulComponents.TransactionPermissionContractVersions,
                         logManager,
                         specProvider),
                     txFilterCache,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/TxAuRaFilterBuilders.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/TxAuRaFilterBuilders.cs
@@ -1,20 +1,41 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Abi;
 using Nethermind.Api;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Consensus.AuRa.Transactions;
+using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
-using Nethermind.Init.Steps;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 
 namespace Nethermind.Consensus.AuRa.InitializationSteps
 {
-    public static class TxAuRaFilterBuilders
+    public class TxAuRaFilterBuilders(
+        ChainSpec chainSpec,
+        ISpecProvider specProvider,
+        IBlocksConfig blocksConfig,
+        IAuraConfig auraConfig,
+        IAbiEncoder abiEncoder,
+        IWorldStateManager worldStateManager,
+        IBlockTree blockTree,
+        IReceiptFinder receiptFinder,
+        LruCache<ValueHash256, UInt256> transactionPermissionContractVersions,
+        PermissionBasedTxFilter.Cache txFilterCache,
+        ILogManager logManager
+    )
     {
         /// <summary>
         /// Filter decorator.
@@ -32,12 +53,12 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
         /// </remarks>
         public static FilterDecorator CreateFilter { get; set; } = static (x, _) => x;
 
-        private static ITxFilter CreateBaseAuRaTxFilter(
-            AuRaNethermindApi api,
+        public ReadOnlyTxProcessingEnv CreateReadOnlyTransactionProcessorSource() =>
+            new ReadOnlyTxProcessingEnv(worldStateManager, blockTree.AsReadOnly(), specProvider, logManager);
+
+        private ITxFilter CreateBaseAuRaTxFilter(
             IDictionaryContractDataStore<TxPriorityContract.Destination>? minGasPricesContractDataStore)
         {
-            ISpecProvider specProvider = api.SpecProvider!;
-            IBlocksConfig blocksConfig = api.Config<IBlocksConfig>();
             IMinGasPriceTxFilter minGasPriceTxFilter = TxFilterBuilders.CreateStandardMinGasPriceTxFilter(blocksConfig, specProvider);
             ITxFilter gasPriceTxFilter = minGasPriceTxFilter;
             if (minGasPricesContractDataStore is not null)
@@ -45,50 +66,45 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                 gasPriceTxFilter = CreateFilter(new MinGasPriceContractTxFilter(minGasPriceTxFilter, minGasPricesContractDataStore), minGasPriceTxFilter);
             }
 
-            Address? registrar = api.ChainSpec?.Parameters.Registrar;
+            Address? registrar = chainSpec?.Parameters.Registrar;
             if (registrar is not null)
             {
-                RegisterContract registerContract = new(api.AbiEncoder, registrar, api.CreateReadOnlyTransactionProcessorSource());
-                CertifierContract certifierContract = new(api.AbiEncoder, registerContract, api.CreateReadOnlyTransactionProcessorSource());
-                return CreateFilter(new TxCertifierFilter(certifierContract, gasPriceTxFilter, specProvider, api.LogManager), gasPriceTxFilter);
+                RegisterContract registerContract = new(abiEncoder, registrar, CreateReadOnlyTransactionProcessorSource());
+                CertifierContract certifierContract = new(abiEncoder, registerContract, CreateReadOnlyTransactionProcessorSource());
+                return CreateFilter(new TxCertifierFilter(certifierContract, gasPriceTxFilter, specProvider, logManager), gasPriceTxFilter);
             }
 
             return gasPriceTxFilter;
         }
 
-        private static ITxFilter CreateBaseAuRaTxFilter(
-            AuRaNethermindApi api,
-            ITxFilter baseTxFilter)
+        private ITxFilter CreateBaseAuRaTxFilter(ITxFilter baseTxFilter)
         {
-            Address? registrar = api.ChainSpec?.Parameters.Registrar;
+            Address? registrar = chainSpec?.Parameters.Registrar;
             if (registrar is not null)
             {
-                RegisterContract registerContract = new(api.AbiEncoder, registrar, api.CreateReadOnlyTransactionProcessorSource());
-                CertifierContract certifierContract = new(api.AbiEncoder, registerContract, api.CreateReadOnlyTransactionProcessorSource());
-                return CreateFilter(new TxCertifierFilter(certifierContract, baseTxFilter, api.SpecProvider, api.LogManager));
+                RegisterContract registerContract = new(abiEncoder, registrar, CreateReadOnlyTransactionProcessorSource());
+                CertifierContract certifierContract = new(abiEncoder, registerContract, CreateReadOnlyTransactionProcessorSource());
+                return CreateFilter(new TxCertifierFilter(certifierContract, baseTxFilter, specProvider, logManager));
             }
 
             return baseTxFilter;
         }
 
 
-        public static ITxFilter? CreateTxPermissionFilter(AuRaNethermindApi api)
+        public ITxFilter? CreateTxPermissionFilter()
         {
-            if (api.ChainSpec is null) throw new StepDependencyException(nameof(api.ChainSpec));
-            if (api.SpecProvider is null) throw new StepDependencyException(nameof(api.SpecProvider));
-
-            if (api.ChainSpec.Parameters.TransactionPermissionContract is not null)
+            if (chainSpec.Parameters.TransactionPermissionContract is not null)
             {
                 var txPermissionFilter = CreateFilter(new PermissionBasedTxFilter(
-                    new VersionedTransactionPermissionContract(api.AbiEncoder,
-                        api.ChainSpec.Parameters.TransactionPermissionContract,
-                        api.ChainSpec.Parameters.TransactionPermissionContractTransition ?? 0,
-                        api.CreateReadOnlyTransactionProcessorSource(),
-                        api.TransactionPermissionContractVersions,
-                        api.LogManager,
-                        api.SpecProvider),
-                    api.TxFilterCache,
-                    api.LogManager));
+                    new VersionedTransactionPermissionContract(abiEncoder,
+                        chainSpec.Parameters.TransactionPermissionContract,
+                        chainSpec.Parameters.TransactionPermissionContractTransition ?? 0,
+                        CreateReadOnlyTransactionProcessorSource(),
+                        transactionPermissionContractVersions,
+                        logManager,
+                        specProvider),
+                    txFilterCache,
+                    logManager));
 
                 return txPermissionFilter;
             }
@@ -96,43 +112,39 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
             return null;
         }
 
-        public static ITxFilter CreateAuRaTxFilterForProducer(
-            AuRaNethermindApi api,
-            IDictionaryContractDataStore<TxPriorityContract.Destination>? minGasPricesContractDataStore)
+        public ITxFilter CreateAuRaTxFilterForProducer(IDictionaryContractDataStore<TxPriorityContract.Destination>? minGasPricesContractDataStore)
         {
-            ITxFilter baseAuRaTxFilter = CreateBaseAuRaTxFilter(api, minGasPricesContractDataStore);
-            ITxFilter? txPermissionFilter = CreateTxPermissionFilter(api);
+            ITxFilter baseAuRaTxFilter = CreateBaseAuRaTxFilter(minGasPricesContractDataStore);
+            ITxFilter? txPermissionFilter = CreateTxPermissionFilter();
             return txPermissionFilter is not null
                 ? new CompositeTxFilter(baseAuRaTxFilter, txPermissionFilter)
                 : baseAuRaTxFilter;
         }
 
-        public static ITxFilter CreateAuRaTxFilter(AuRaNethermindApi api, ITxFilter baseTxFilter)
+        public ITxFilter CreateAuRaTxFilter(ITxFilter baseTxFilter)
         {
-            ITxFilter baseAuRaTxFilter = CreateBaseAuRaTxFilter(api, baseTxFilter);
-            ITxFilter? txPermissionFilter = CreateTxPermissionFilter(api);
+            ITxFilter baseAuRaTxFilter = CreateBaseAuRaTxFilter(baseTxFilter);
+            ITxFilter? txPermissionFilter = CreateTxPermissionFilter();
             return txPermissionFilter is not null
                 ? new CompositeTxFilter(baseAuRaTxFilter, txPermissionFilter)
                 : baseAuRaTxFilter;
         }
 
-        public static TxPriorityContract? CreateTxPrioritySources(AuRaNethermindApi api)
+        public TxPriorityContract? CreateTxPrioritySources()
         {
-            IAuraConfig config = api.Config<IAuraConfig>();
-            Address.TryParse(config.TxPriorityContractAddress, out Address? txPriorityContractAddress);
+            Address.TryParse(auraConfig.TxPriorityContractAddress, out Address? txPriorityContractAddress);
             bool usesTxPriorityContract = txPriorityContractAddress is not null;
 
             TxPriorityContract? txPriorityContract = null;
             if (usesTxPriorityContract)
             {
-                txPriorityContract = new TxPriorityContract(api.AbiEncoder, txPriorityContractAddress, api.CreateReadOnlyTransactionProcessorSource());
+                txPriorityContract = new TxPriorityContract(abiEncoder, txPriorityContractAddress, CreateReadOnlyTransactionProcessorSource());
             }
 
             return txPriorityContract;
         }
 
-        public static DictionaryContractDataStore<TxPriorityContract.Destination>? CreateMinGasPricesDataStore(
-            AuRaNethermindApi api,
+        public DictionaryContractDataStore<TxPriorityContract.Destination>? CreateMinGasPricesDataStore(
             TxPriorityContract? txPriorityContract,
             TxPriorityContract.LocalDataSource? localDataSource)
         {
@@ -140,9 +152,9 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                 ? new DictionaryContractDataStore<TxPriorityContract.Destination>(
                     new TxPriorityContract.DestinationSortedListContractDataStoreCollection(),
                     txPriorityContract?.MinGasPrices,
-                    api.BlockTree,
-                    api.ReceiptFinder,
-                    api.LogManager,
+                    blockTree,
+                    receiptFinder,
+                    logManager,
                     localDataSource?.GetMinGasPricesLocalDataSource())
                 : null;
         }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
@@ -20,6 +20,10 @@ namespace Nethermind.Core.Test.Modules;
 /// <param name="configProvider"></param>
 public class TestNethermindModule(IConfigProvider configProvider) : Module
 {
+    public TestNethermindModule() : this(new ConfigProvider())
+    {
+    }
+
     protected override void Load(ContainerBuilder builder)
     {
         base.Load(builder);

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -234,7 +234,9 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
                 targetAdjustedGasLimitCalculator);
 
             AuRaMergeBlockProducerEnvFactory blockProducerEnvFactory = new(
-                _api!,
+                _api!.ChainSpec,
+                _api.AbiEncoder,
+                _api.CreateStartBlockProducer,
                 WorldStateManager,
                 BlockTree,
                 SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -166,30 +166,6 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
 
         protected override IBlockProcessor CreateBlockProcessor(IWorldState state)
         {
-            /*
-            NethermindApi.Dependencies apiDependencies = new NethermindApi.Dependencies(
-                new ConfigProvider(),
-                new EthereumJsonSerializer(),
-                LogManager,
-                new ChainSpec
-                {
-                    EngineChainSpecParametersProvider =
-                },
-                SpecProvider,
-                [],
-                Substitute.For<IProcessExitSource>(),
-                Substitute.For<IContainer>()
-            );
-
-            _api = new(apiDependencies)
-            {
-                BlockTree = BlockTree,
-                DbProvider = DbProvider,
-                TransactionComparerProvider = TransactionComparerProvider,
-                TxPool = TxPool
-            };
-            */
-
             _api = Container.Resolve<AuRaNethermindApi>();
 
             WithdrawalContractFactory withdrawalContractFactory = new(Container.Resolve<ChainSpec>().EngineChainSpecParametersProvider

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Abi;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Receipts;
@@ -17,6 +19,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
 using Nethermind.Merge.AuRa.Withdrawals;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State;
 using Nethermind.TxPool;
 
@@ -24,10 +27,15 @@ namespace Nethermind.Merge.AuRa;
 
 public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
 {
-    private readonly AuRaNethermindApi _auraApi;
+    private readonly ChainSpec _chainSpec;
     private readonly IExecutionRequestsProcessor? _executionRequestsProcessor;
+    private readonly IAbiEncoder _abiEncoder;
+    private readonly Func<StartBlockProducerAuRa> _startBlockProducerFactory;
+
     public AuRaMergeBlockProducerEnvFactory(
-        AuRaNethermindApi auraApi,
+        ChainSpec chainSpec,
+        IAbiEncoder abiEncoder,
+        Func<StartBlockProducerAuRa> startBlockProducerFactory,
         IWorldStateManager worldStateManager,
         IBlockTree blockTree,
         ISpecProvider specProvider,
@@ -53,7 +61,9 @@ public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
             logManager,
             executionRequestsProcessor)
     {
-        _auraApi = auraApi;
+        _chainSpec = chainSpec;
+        _abiEncoder = abiEncoder;
+        _startBlockProducerFactory = startBlockProducerFactory;
         _executionRequestsProcessor = executionRequestsProcessor;
     }
 
@@ -67,8 +77,8 @@ public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
         IBlocksConfig blocksConfig)
     {
         var withdrawalContractFactory = new WithdrawalContractFactory(
-            _auraApi.ChainSpec.EngineChainSpecParametersProvider
-                .GetChainSpecParameters<AuRaChainSpecEngineParameters>(), _auraApi.AbiEncoder);
+            _chainSpec.EngineChainSpecParametersProvider
+                .GetChainSpecParameters<AuRaChainSpecEngineParameters>(), _abiEncoder);
 
         return new AuRaMergeBlockProcessor(
             specProvider,
@@ -98,6 +108,6 @@ public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
         ITransactionComparerProvider transactionComparerProvider,
         ILogManager logManager)
     {
-        return _auraApi.CreateStartBlockProducer().CreateTxPoolTxSource();
+        return _startBlockProducerFactory().CreateTxPoolTxSource();
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
@@ -98,6 +98,6 @@ public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
         ITransactionComparerProvider transactionComparerProvider,
         ILogManager logManager)
     {
-        return new StartBlockProducerAuRa(_auraApi).CreateTxPoolTxSource();
+        return _auraApi.CreateStartBlockProducer().CreateTxPoolTxSource();
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -53,7 +53,9 @@ namespace Nethermind.Merge.AuRa
         public override IBlockProducer InitBlockProducer(IBlockProducerFactory consensusPlugin, ITxSource? txSource)
         {
             _api.BlockProducerEnvFactory = new AuRaMergeBlockProducerEnvFactory(
-                _auraApi!,
+                _auraApi!.ChainSpec,
+                _auraApi.AbiEncoder,
+                _auraApi.CreateStartBlockProducer,
                 _api.WorldStateManager!,
                 _api.BlockTree!,
                 _api.SpecProvider!,


### PR DESCRIPTION
- Remove `AuraNethermindApi` from `StartBlockProducerAuRa`, `TxAuraFiltersBuilder` and `AuRaMergeBlockProducerEnvFactor`.
- `MergeAuRaTestBlockchain` uses a completely different initialization so I kept it mostly the same instead of trying to remove `AuraNethermindApi` from it in this PR.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Gnosis mainnet can sync with simulate block production.