### PR TITLE
Reintroduce Jit time branch elimination

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -32,11 +32,11 @@ public ref struct EvmStack
     public EvmStack(scoped in int head, ITxTracer txTracer, scoped in Span<byte> bytes)
     {
         Head = head;
-        _tracer = txTracer.IsTracingInstructions ? txTracer : null;
+        _tracer = txTracer;
         _bytes = bytes;
     }
 
-    private readonly ITxTracer? _tracer;
+    private readonly ITxTracer _tracer;
     private readonly Span<byte> _bytes;
     public int Head;
 
@@ -61,9 +61,11 @@ public ref struct EvmStack
     private static Word CreateWordFromUInt64(ulong value)
         => Vector256.Create(0UL, 0UL, 0UL, value).AsByte();
 
-    public void PushBytes(scoped ReadOnlySpan<byte> value)
+    public void PushBytes<TTracingInst>(scoped ReadOnlySpan<byte> value)
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(value);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(value);
 
         if (value.Length != WordSize)
         {
@@ -78,9 +80,11 @@ public ref struct EvmStack
         }
     }
 
-    public void PushBytes(scoped in ZeroPaddedSpan value)
+    public void PushBytes<TTracingInst>(scoped in ZeroPaddedSpan value)
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(value);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(value);
 
         ReadOnlySpan<byte> valueSpan = value.Span;
         if (valueSpan.Length != WordSize)
@@ -97,76 +101,93 @@ public ref struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void PushByte(byte value)
+    public void PushByte<TTracingInst>(byte value)
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(value);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(value);
 
         // Build a 256-bit vector: [ 0, 0, 0, (value << 56) ]
         // - when viewed as bytes: all zeros except byte[31] == value
-
+        ref Word head = ref PushedHead();
         // Single 32-byte store: last byte as value
-        PushedHead() = CreateWordFromUInt64((ulong)value << 56);
+        head = CreateWordFromUInt64((ulong)value << 56);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe void Push2Bytes(ref byte value)
+    public unsafe void Push2Bytes<TTracingInst>(ref byte value)
+        where TTracingInst : struct, IFlag
     {
         // ushort size
-        _tracer?.TraceBytes(in value, sizeof(ushort));
-
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in value, sizeof(ushort));
+        
+        ref Word head = ref PushedHead();
         // Load 2-byte source into the top 16 bits of the last 64-bit lane:
         // lane3 covers bytes [24..31], so shifting by 48 bits
         ulong lane3 = (ulong)Unsafe.As<byte, ushort>(ref value) << 48;
 
         // Single 32-byte store
-        PushedHead() = CreateWordFromUInt64(lane3);
+        head = CreateWordFromUInt64(lane3);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe void Push4Bytes(ref byte value)
+    public unsafe void Push4Bytes<TTracingInst>(ref byte value)
+        where TTracingInst : struct, IFlag
     {
         // uint size
-        _tracer?.TraceBytes(in value, sizeof(uint));
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in value, sizeof(uint));
 
+        ref Word head = ref PushedHead();
         // Load 4-byte source into the top 32 bits of the last 64-bit lane:
         // lane3 covers bytes [24..31], so shifting by 32 bits
         ulong lane3 = ((ulong)Unsafe.As<byte, uint>(ref value)) << 32;
 
         // Single 32-byte store
-        PushedHead() = CreateWordFromUInt64(lane3);
+        head = CreateWordFromUInt64(lane3);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe void Push8Bytes(ref byte value)
+    public unsafe void Push8Bytes<TTracingInst>(ref byte value)
+        where TTracingInst : struct, IFlag
     {
         // ulong size
-        _tracer?.TraceBytes(in value, sizeof(ulong));
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in value, sizeof(ulong));
 
+        ref Word head = ref PushedHead();
         // Load 8-byte source into last 64-bit lane
         ulong lane3 = Unsafe.As<byte, ulong>(ref value);
 
         // Single 32-byte store
-        PushedHead() = CreateWordFromUInt64(lane3);
+        head = CreateWordFromUInt64(lane3);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe void Push16Bytes(ref byte value)
+    public unsafe void Push16Bytes<TTracingInst>(ref byte value)
+        where TTracingInst : struct, IFlag
     {
         // UInt128 size
-        _tracer?.TraceBytes(in value, sizeof(HalfWord));
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in value, sizeof(HalfWord));
 
+        ref Word head = ref PushedHead();
         // Load 16-byte source into 16-byte source as a Vector128<byte>
         HalfWord src = Unsafe.As<byte, HalfWord>(ref value);
         // Single 32-byte store
-        PushedHead() = Vector256.Create(default, src);
+        head = Vector256.Create(default, src);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Push20Bytes(ref byte value)
+    public void Push20Bytes<TTracingInst>(ref byte value)
+        where TTracingInst : struct, IFlag
     {
         // Address size
-        _tracer?.TraceBytes(in value, 20);
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in value, 20);
 
+        ref Word head = ref PushedHead();
         // build the 4×8-byte lanes:
         // - lane0 = 0UL
         // - lane1 = first 4 bytes of 'value', shifted up into the high half
@@ -176,30 +197,36 @@ public ref struct EvmStack
         ulong lane2 = Unsafe.As<byte, ulong>(ref Unsafe.Add(ref value, 4));
         ulong lane3 = Unsafe.As<byte, ulong>(ref Unsafe.Add(ref value, 12));
 
-        PushedHead() = Vector256.Create(default, lane1, lane2, lane3).AsByte();
+        head = Vector256.Create(default, lane1, lane2, lane3).AsByte();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void PushAddress(Address address)
-        => Push20Bytes(ref MemoryMarshal.GetArrayDataReference(address.Bytes));
+    public void PushAddress<TTracingInst>(Address address)
+        where TTracingInst : struct, IFlag
+        => Push20Bytes<TTracingInst>(ref MemoryMarshal.GetArrayDataReference(address.Bytes));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Push32Bytes(in Word value)
+    public void Push32Bytes<TTracingInst>(in Word value)
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.TraceWord(in value);
+        if (TTracingInst.IsActive)
+            _tracer.TraceWord(in value);
 
         // Single 32-byte store
         PushedHead() = value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Push32Bytes(in ValueHash256 hash)
-        => Push32Bytes(in Unsafe.As<ValueHash256, Word>(ref Unsafe.AsRef(in hash)));
+    public void Push32Bytes<TTracingInst>(in ValueHash256 hash)
+        where TTracingInst : struct, IFlag
+        => Push32Bytes<TTracingInst>(in Unsafe.As<ValueHash256, Word>(ref Unsafe.AsRef(in hash)));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void PushLeftPaddedBytes(ReadOnlySpan<byte> value, int paddingLength)
+    public void PushLeftPaddedBytes<TTracingInst>(ReadOnlySpan<byte> value, int paddingLength)
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(value);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(value);
 
         if (value.Length != WordSize)
         {
@@ -214,9 +241,12 @@ public ref struct EvmStack
         }
     }
 
-    public void PushOne()
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PushOne<TTracingInst>()
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(Bytes.OneByteSpan);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(Bytes.OneByteSpan);
 
         // Build a 256-bit vector: [ 0, 0, 0, (1UL << 56) ]
         // - when viewed as bytes: all zeros except byte[31] == 1
@@ -225,35 +255,42 @@ public ref struct EvmStack
         PushedHead() = CreateWordFromUInt64(1UL << 56);
     }
 
-    public void PushZero()
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PushZero<TTracingInst>()
+        where TTracingInst : struct, IFlag
     {
-        _tracer?.ReportStackPush(Bytes.ZeroByteSpan);
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(Bytes.ZeroByteSpan);
 
         // Single 32-byte store: Zero 
         PushedHead() = default;
     }
 
-    public unsafe void PushUInt32(uint value)
+    public unsafe void PushUInt32<TTracingInst>(uint value)
+        where TTracingInst : struct, IFlag
     {
         if (BitConverter.IsLittleEndian)
         {
             value = BinaryPrimitives.ReverseEndianness(value);
         }
         // uint size
-        _tracer?.TraceBytes(in Unsafe.As<uint, byte>(ref value), sizeof(uint));
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in Unsafe.As<uint, byte>(ref value), sizeof(uint));
 
         // Single 32-byte store
         PushedHead() = Vector256.Create(0U, 0U, 0U, 0U, 0U, 0U, 0U, value).AsByte();
     }
 
-    public unsafe void PushUInt64(ulong value)
+    public unsafe void PushUInt64<TTracingInst>(ulong value)
+        where TTracingInst : struct, IFlag
     {
         if (BitConverter.IsLittleEndian)
         {
             value = BinaryPrimitives.ReverseEndianness(value);
         }
         // ulong size
-        _tracer?.TraceBytes(in Unsafe.As<ulong, byte>(ref value), sizeof(ulong));
+        if (TTracingInst.IsActive)
+            _tracer.TraceBytes(in Unsafe.As<ulong, byte>(ref value), sizeof(ulong));
 
         // Single 32-byte store
         PushedHead() = CreateWordFromUInt64(value);
@@ -265,9 +302,11 @@ public ref struct EvmStack
     /// <remarks>
     /// This method is a counterpart to <see cref="PopUInt256"/> and uses the same, raw data approach to write data back.
     /// </remarks>
-    public void PushUInt256(in UInt256 value)
+
+    public void PushUInt256<TTracingInst>(in UInt256 value)
+        where TTracingInst : struct, IFlag
     {
-        ref byte bytes = ref PushBytesRef();
+        ref Word head = ref PushedHead();
         if (Avx2.IsSupported)
         {
             Word shuffle = Vector256.Create(
@@ -278,13 +317,13 @@ public ref struct EvmStack
             if (Avx512Vbmi.VL.IsSupported)
             {
                 Word data = Unsafe.As<UInt256, Word>(ref Unsafe.AsRef(in value));
-                Unsafe.WriteUnaligned(ref bytes, Avx512Vbmi.VL.PermuteVar32x8(data, shuffle));
+                head = Avx512Vbmi.VL.PermuteVar32x8(data, shuffle);
             }
             else if (Avx2.IsSupported)
             {
                 Vector256<ulong> permute = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in value));
                 Vector256<ulong> convert = Avx2.Permute4x64(permute, 0b_01_00_11_10);
-                Unsafe.WriteUnaligned(ref bytes, Avx2.Shuffle(Unsafe.As<Vector256<ulong>, Word>(ref convert), shuffle));
+                head = Avx2.Shuffle(Unsafe.As<Vector256<ulong>, Word>(ref convert), shuffle);
             }
         }
         else
@@ -305,16 +344,18 @@ public ref struct EvmStack
                 u0 = value.u0;
             }
 
-            Unsafe.WriteUnaligned(ref bytes, Vector256.Create(u3, u2, u1, u0));
+            head = Vector256.Create(u3, u2, u1, u0).AsByte();
         }
 
-        _tracer?.ReportStackPush(MemoryMarshal.CreateReadOnlySpan(ref bytes, WordSize));
+        if (TTracingInst.IsActive)
+            _tracer.ReportStackPush(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<Word, byte>(ref head), WordSize));
     }
 
-    public void PushSignedInt256(in Int256.Int256 value)
+    public void PushSignedInt256<TTracingInst>(in Int256.Int256 value)
+        where TTracingInst : struct, IFlag
     {
         // tail call into UInt256
-        PushUInt256(in Unsafe.As<Int256.Int256, UInt256>(ref Unsafe.AsRef(in value)));
+        PushUInt256<TTracingInst>(in Unsafe.As<Int256.Int256, UInt256>(ref Unsafe.AsRef(in value)));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -477,7 +518,8 @@ public ref struct EvmStack
         return Unsafe.Add(ref bytes, WordSize - sizeof(byte));
     }
 
-    public bool Dup(in int depth)
+    public bool Dup<TTracingInst>(in int depth)
+        where TTracingInst : struct, IFlag
     {
         if (!EnsureDepth(depth)) return false;
 
@@ -488,7 +530,7 @@ public ref struct EvmStack
 
         Unsafe.WriteUnaligned(ref to, Unsafe.ReadUnaligned<Word>(ref from));
 
-        if (_tracer is not null) Trace(depth);
+        if (TTracingInst.IsActive) Trace(depth);
 
         if (++Head >= MaxStackSize)
         {
@@ -501,7 +543,8 @@ public ref struct EvmStack
     public readonly bool EnsureDepth(int depth)
         => Head >= depth;
 
-    public readonly bool Swap(int depth)
+    public readonly bool Swap<TTracingInst>(int depth)
+        where TTracingInst : struct, IFlag
     {
         if (!EnsureDepth(depth)) return false;
 
@@ -514,12 +557,13 @@ public ref struct EvmStack
         Unsafe.WriteUnaligned(ref bottom, Unsafe.ReadUnaligned<Word>(ref top));
         Unsafe.WriteUnaligned(ref top, buffer);
 
-        if (_tracer is not null) Trace(depth);
+        if (TTracingInst.IsActive) Trace(depth);
 
         return true;
     }
 
-    public readonly bool Exchange(int n, int m)
+    public readonly bool Exchange<TTracingInst>(int n, int m)
+        where TTracingInst : struct, IFlag
     {
         int maxDepth = Math.Max(n, m);
         if (!EnsureDepth(maxDepth)) return false;
@@ -533,7 +577,7 @@ public ref struct EvmStack
         Unsafe.WriteUnaligned(ref first, Unsafe.ReadUnaligned<Word>(ref second));
         Unsafe.WriteUnaligned(ref second, buffer);
 
-        if (_tracer is not null) Trace(maxDepth);
+        if (TTracingInst.IsActive) Trace(maxDepth);
 
         return true;
     }

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Evm
 {
     public interface IVirtualMachine
     {
-        TransactionSubstate ExecuteTransaction<TTracingInstructions>(EvmState state, IWorldState worldState, ITxTracer txTracer)
-            where TTracingInstructions : struct, IFlag;
+        TransactionSubstate ExecuteTransaction<TTracingInst>(EvmState state, IWorldState worldState, ITxTracer txTracer)
+            where TTracingInst : struct, IFlag;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -25,12 +25,13 @@ internal static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/> on success.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionProgramCounter(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionProgramCounter<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Deduct the base gas cost for reading the program counter.
         gasAvailable -= GasCostOf.Base;
         // The program counter pushed is adjusted by -1 to reflect the correct opcode location.
-        stack.PushUInt32((uint)(programCounter - 1));
+        stack.PushUInt32<TTracingInst>((uint)(programCounter - 1));
 
         return EvmExceptionType.None;
     }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Crypto.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Crypto.cs
@@ -18,7 +18,8 @@ internal static partial class EvmInstructions
     /// and pushes the resulting 256-bit hash onto the stack.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionKeccak256(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionKeccak256<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Ensure two 256-bit words are available (memory offset and length).
         if (!stack.PopUInt256(out UInt256 a) || !stack.PopUInt256(out UInt256 b))
@@ -39,7 +40,7 @@ internal static partial class EvmInstructions
         // Compute the Keccak-256 hash.
         KeccakCache.ComputeTo(bytes, out ValueHash256 keccak);
         // Push the 256-bit hash result onto the stack.
-        stack.Push32Bytes(in keccak);
+        stack.Push32Bytes<TTracingInst>(in keccak);
 
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Eof.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Eof.cs
@@ -64,13 +64,14 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the current program counter.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating the outcome.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionReturnDataSize(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionReturnDataSize<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Deduct base gas cost for this instruction.
         gasAvailable -= GasCostOf.Base;
 
         // Push the length of the return data buffer (as a 32-bit unsigned integer) onto the stack.
-        stack.PushUInt32((uint)vm.ReturnDataBuffer.Length);
+        stack.PushUInt32<TTracingInst>((uint)vm.ReturnDataBuffer.Length);
 
         return EvmExceptionType.None;
     }
@@ -80,7 +81,7 @@ internal static partial class EvmInstructions
     /// Parameters are popped from the stack (destination offset, source offset, and size).
     /// Performs gas and memory expansion cost updates before copying.
     /// </summary>
-    /// <typeparam name="TTracingInstructions">
+    /// <typeparam name="TTracingInst">
     /// A tracing flag type to conditionally report memory changes.
     /// </typeparam>
     /// <param name="vm">The current virtual machine instance.</param>
@@ -89,8 +90,8 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the current program counter.</param>
     /// <returns>An <see cref="EvmExceptionType"/> representing success or the type of failure.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionReturnDataCopy<TTracingInstructions>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
-        where TTracingInstructions : struct, IFlag
+    public static EvmExceptionType InstructionReturnDataCopy<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Pop the required parameters: destination memory offset, source offset in return data, and number of bytes to copy.
         if (!stack.PopUInt256(out UInt256 destOffset) ||
@@ -124,7 +125,7 @@ internal static partial class EvmInstructions
             vm.EvmState.Memory.Save(in destOffset, in slice);
 
             // Report the memory change if tracing is active.
-            if (TTracingInstructions.IsActive)
+            if (TTracingInst.IsActive)
             {
                 vm.TxTracer.ReportMemoryChange(destOffset, in slice);
             }
@@ -150,7 +151,8 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the program counter.</param>
     /// <returns>An <see cref="EvmExceptionType"/> representing success or an error.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDataLoad(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionDataLoad<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         // Ensure the instruction is only valid for non-legacy (EOF) code.
@@ -165,7 +167,7 @@ internal static partial class EvmInstructions
         stack.PopUInt256(out UInt256 offset);
         // Load 32 bytes from the data section at the given offset (with zero padding if necessary).
         ZeroPaddedSpan bytes = codeInfo.DataSection.SliceWithZeroPadding(offset, 32);
-        stack.PushBytes(bytes);
+        stack.PushBytes<TTracingInst>(bytes);
 
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
@@ -180,7 +182,8 @@ internal static partial class EvmInstructions
     /// Advances the program counter accordingly.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDataLoadN(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionDataLoadN<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -193,7 +196,7 @@ internal static partial class EvmInstructions
         ushort offset = codeInfo.CodeSection.Span.Slice(programCounter, EofValidator.TWO_BYTE_LENGTH).ReadEthUInt16();
         // Load the 32-byte word from the data section at the immediate offset.
         ZeroPaddedSpan bytes = codeInfo.DataSection.SliceWithZeroPadding(offset, 32);
-        stack.PushBytes(bytes);
+        stack.PushBytes<TTracingInst>(bytes);
 
         // Advance the program counter past the immediate operand.
         programCounter += EofValidator.TWO_BYTE_LENGTH;
@@ -210,7 +213,8 @@ internal static partial class EvmInstructions
     /// Pushes the size of the code's data section onto the stack.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDataSize(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionDataSize<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -219,7 +223,7 @@ internal static partial class EvmInstructions
         if (!UpdateGas(GasCostOf.DataSize, ref gasAvailable))
             goto OutOfGas;
 
-        stack.PushUInt32((uint)codeInfo.DataSection.Length);
+        stack.PushUInt32<TTracingInst>((uint)codeInfo.DataSection.Length);
 
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
@@ -234,8 +238,8 @@ internal static partial class EvmInstructions
     /// The source offset, destination memory offset, and number of bytes are specified on the stack.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDataCopy<TTracingInstructions>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
-        where TTracingInstructions : struct, IFlag
+    public static EvmExceptionType InstructionDataCopy<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -265,7 +269,7 @@ internal static partial class EvmInstructions
             ZeroPaddedSpan dataSectionSlice = codeInfo.DataSection.SliceWithZeroPadding(offset, (int)size);
             vm.EvmState.Memory.Save(in memOffset, dataSectionSlice);
 
-            if (TTracingInstructions.IsActive)
+            if (TTracingInst.IsActive)
             {
                 vm.TxTracer.ReportMemoryChange(memOffset, dataSectionSlice);
             }
@@ -506,7 +510,8 @@ internal static partial class EvmInstructions
     /// The immediate value (n) specifies that the (n+1)th element from the top is duplicated.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDupN(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionDupN<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -518,7 +523,7 @@ internal static partial class EvmInstructions
         // Read the immediate operand.
         int imm = codeInfo.CodeSection.Span[programCounter];
         // Duplicate the (imm+1)th stack element.
-        stack.Dup(imm + 1);
+        stack.Dup<TTracingInst>(imm + 1);
 
         programCounter += 1;
 
@@ -535,7 +540,8 @@ internal static partial class EvmInstructions
     /// Swaps the top-of-stack with the (n+1)th element.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSwapN(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionSwapN<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -546,7 +552,7 @@ internal static partial class EvmInstructions
 
         // Immediate operand determines the swap index.
         int n = 1 + (int)codeInfo.CodeSection.Span[programCounter];
-        if (!stack.Swap(n + 1))
+        if (!stack.Swap<TTracingInst>(n + 1))
             goto StackUnderflow;
 
         programCounter += 1;
@@ -566,7 +572,8 @@ internal static partial class EvmInstructions
     /// The high nibble and low nibble of the operand specify the two swap distances.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionExchange(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionExchange<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
         if (codeInfo.Version == 0)
@@ -581,7 +588,7 @@ internal static partial class EvmInstructions
         int m = 1 + (int)(codeSection[programCounter] & 0x0f);
 
         // Exchange the elements at the calculated positions.
-        stack.Exchange(n + 1, m + n + 1);
+        stack.Exchange<TTracingInst>(n + 1, m + n + 1);
 
         programCounter += 1;
 
@@ -598,12 +605,12 @@ internal static partial class EvmInstructions
     /// This method performs multiple steps including gas deductions, memory expansion,
     /// reading immediate operands, balance checks, and preparing the execution environment for the new contract.
     /// </summary>
-    /// <typeparam name="TTracingInstructions">
+    /// <typeparam name="TTracingInst">
     /// A tracing flag type to conditionally report events.
     /// </typeparam>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionEofCreate<TTracingInstructions>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
-        where TTracingInstructions : struct, IFlag
+    public static EvmExceptionType InstructionEofCreate<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         Metrics.IncrementCreates();
         vm.ReturnData = null;
@@ -663,7 +670,7 @@ internal static partial class EvmInstructions
         {
             // In case of failure, do not consume additional gas.
             vm.ReturnDataBuffer = Array.Empty<byte>();
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
             return EvmExceptionType.None;
         }
 
@@ -681,7 +688,7 @@ internal static partial class EvmInstructions
         if (accountNonce >= maxNonce)
         {
             vm.ReturnDataBuffer = Array.Empty<byte>();
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
             return EvmExceptionType.None;
         }
         state.IncrementNonce(env.ExecutingAccount);
@@ -694,7 +701,7 @@ internal static partial class EvmInstructions
             vm.EvmState.AccessTracker.WarmUp(contractAddress);
         }
 
-        if (TTracingInstructions.IsActive)
+        if (TTracingInst.IsActive)
             vm.EndInstructionTrace(gasAvailable);
 
         // Take a snapshot before modifying state for the new contract.
@@ -706,7 +713,7 @@ internal static partial class EvmInstructions
         if (accountExists && contractAddress.IsNonZeroAccount(spec, vm.CodeInfoRepository, state))
         {
             vm.ReturnDataBuffer = Array.Empty<byte>();
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
             return EvmExceptionType.None;
         }
 
@@ -812,7 +819,8 @@ internal static partial class EvmInstructions
     /// This instruction is only valid when EOF is enabled.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionReturnDataLoad(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionReturnDataLoad<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         IReleaseSpec spec = vm.Spec;
         ICodeInfo codeInfo = vm.EvmState.Env.CodeInfo;
@@ -825,7 +833,7 @@ internal static partial class EvmInstructions
             goto StackUnderflow;
 
         ZeroPaddedSpan slice = vm.ReturnDataBuffer.Span.SliceWithZeroPadding(offset, 32);
-        stack.PushBytes(slice);
+        stack.PushBytes<TTracingInst>(slice);
 
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
@@ -843,13 +851,13 @@ internal static partial class EvmInstructions
     /// <typeparam name="TOpEofCall">
     /// The call type (standard, delegate, or static) that determines behavior and execution type.
     /// </typeparam>
-    /// <typeparam name="TTracingInstructions">
+    /// <typeparam name="TTracingInst">
     /// A tracing flag type used to report VM state changes during the call.
     /// </typeparam>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionEofCall<TOpEofCall, TTracingInstructions>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionEofCall<TOpEofCall, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpEofCall : struct, IOpEofCall
-        where TTracingInstructions : struct, IFlag
+        where TTracingInst : struct, IFlag
     {
         Metrics.IncrementCalls();
 
@@ -938,11 +946,11 @@ internal static partial class EvmInstructions
         {
             vm.ReturnData = null;
             vm.ReturnDataBuffer = Array.Empty<byte>();
-            stack.PushOne();
+            stack.PushOne<TTracingInst>();
 
             // If tracing is active, record additional details regarding the failure.
             ITxTracer txTracer = vm.TxTracer;
-            if (TTracingInstructions.IsActive)
+            if (TTracingInst.IsActive)
             {
                 ReadOnlyMemory<byte> memoryTrace = vm.EvmState.Memory.Inspect(in dataOffset, 32);
                 txTracer.ReportMemoryChange(dataOffset, memoryTrace.Span);
@@ -963,7 +971,7 @@ internal static partial class EvmInstructions
         {
             vm.ReturnData = null;
             vm.ReturnDataBuffer = Array.Empty<byte>();
-            stack.PushOne();
+            stack.PushOne<TTracingInst>();
             return EvmExceptionType.None;
         }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
@@ -95,7 +95,8 @@ internal static partial class EvmInstructions
     /// Extracts a byte from a 256-bit word at the position specified by the stack.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionByte(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionByte<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         gasAvailable -= GasCostOf.VeryLow;
 
@@ -107,19 +108,19 @@ internal static partial class EvmInstructions
         // If the position is out-of-range, push zero.
         if (a >= BigInt32)
         {
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
         }
         else
         {
             int adjustedPosition = bytes.Length - 32 + (int)a;
             if (adjustedPosition < 0)
             {
-                stack.PushZero();
+                stack.PushZero<TTracingInst>();
             }
             else
             {
                 // Push the extracted byte.
-                stack.PushByte(bytes[adjustedPosition]);
+                stack.PushByte<TTracingInst>(bytes[adjustedPosition]);
             }
         }
 
@@ -134,7 +135,7 @@ internal static partial class EvmInstructions
     /// Performs sign extension on a 256-bit integer in-place based on a specified byte index.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSignExtend(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionSignExtend<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
     {
         gasAvailable -= GasCostOf.Low;
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
@@ -46,8 +46,9 @@ internal static partial class EvmInstructions
     /// otherwise, <see cref="EvmExceptionType.StackUnderflow"/> if insufficient stack elements are available.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionMath2Param<TOpMath>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionMath2Param<TOpMath, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpMath : struct, IOpMath2Param
+        where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost for the specific math operation.
         gasAvailable -= TOpMath.GasCost;
@@ -59,7 +60,7 @@ internal static partial class EvmInstructions
         TOpMath.Operation(in a, in b, out UInt256 result);
 
         // Push the computed result onto the stack.
-        stack.PushUInt256(in result);
+        stack.PushUInt256<TTracingInst>(in result);
 
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
@@ -256,7 +257,8 @@ internal static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/> on success; or <see cref="EvmExceptionType.StackUnderflow"/> if not enough items on stack.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionExp(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionExp<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Charge the fixed gas cost for exponentiation.
         gasAvailable -= GasCostOf.Exp;
@@ -273,7 +275,7 @@ internal static partial class EvmInstructions
         if (leadingZeros == 32)
         {
             // Exponent is zero, so the result is 1.
-            stack.PushOne();
+            stack.PushOne<TTracingInst>();
         }
         else
         {
@@ -283,17 +285,17 @@ internal static partial class EvmInstructions
 
             if (a.IsZero)
             {
-                stack.PushZero();
+                stack.PushZero<TTracingInst>();
             }
             else if (a.IsOne)
             {
-                stack.PushOne();
+                stack.PushOne<TTracingInst>();
             }
             else
             {
                 // Perform exponentiation and push the 256-bit result onto the stack.
                 UInt256.Exp(a, new UInt256(bytes, true), out UInt256 result);
-                stack.PushUInt256(in result);
+                stack.PushUInt256<TTracingInst>(in result);
             }
         }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math3Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math3Param.cs
@@ -15,8 +15,9 @@ internal static partial class EvmInstructions
     }
 
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionMath3Param<TOpMath>(VirtualMachine _, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionMath3Param<TOpMath, TTracingInst>(VirtualMachine _, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpMath : struct, IOpMath3Param
+        where TTracingInst : struct, IFlag
     {
         gasAvailable -= TOpMath.GasCost;
 
@@ -24,12 +25,12 @@ internal static partial class EvmInstructions
 
         if (c.IsZero)
         {
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
         }
         else
         {
             TOpMath.Operation(in a, in b, in c, out UInt256 result);
-            stack.PushUInt256(in result);
+            stack.PushUInt256<TTracingInst>(in result);
         }
 
         return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Shifts.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Shifts.cs
@@ -46,8 +46,9 @@ internal static partial class EvmInstructions
     /// otherwise, <see cref="EvmExceptionType.StackUnderflow"/> if there are insufficient stack elements.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionShift<TOpShift>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionShift<TOpShift, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpShift : struct, IOpShift
+        where TTracingInst : struct, IFlag
     {
         // Deduct gas cost specific to the shift operation.
         gasAvailable -= TOpShift.GasCost;
@@ -60,7 +61,7 @@ internal static partial class EvmInstructions
         {
             // Pop the second operand without using its value.
             if (!stack.PopLimbo()) goto StackUnderflow;
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
         }
         else
         {
@@ -68,7 +69,7 @@ internal static partial class EvmInstructions
             if (!stack.PopUInt256(out UInt256 b)) goto StackUnderflow;
             // Perform the shift operation using the specific implementation.
             TOpShift.Operation(in a, in b, out UInt256 result);
-            stack.PushUInt256(in result);
+            stack.PushUInt256<TTracingInst>(in result);
         }
 
         return EvmExceptionType.None;
@@ -91,7 +92,8 @@ internal static partial class EvmInstructions
     /// if insufficient stack elements are available.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSar(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionSar<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost for the arithmetic shift operation.
         gasAvailable -= GasCostOf.VeryLow;
@@ -106,12 +108,12 @@ internal static partial class EvmInstructions
             if (As<UInt256, Int256>(ref b).Sign >= 0)
             {
                 // Non-negative value: result is zero.
-                stack.PushZero();
+                stack.PushZero<TTracingInst>();
             }
             else
             {
                 // Negative value: result is -1 (all bits set).
-                stack.PushSignedInt256(in Int256.MinusOne);
+                stack.PushSignedInt256<TTracingInst>(in Int256.MinusOne);
             }
         }
         else
@@ -119,7 +121,7 @@ internal static partial class EvmInstructions
             // For a valid shift amount (<256), perform an arithmetic right shift.
             As<UInt256, Int256>(ref b).RightShift((int)a, out Int256 result);
             // Convert the signed result back to unsigned representation.
-            stack.PushUInt256(in As<Int256, UInt256>(ref result));
+            stack.PushUInt256<TTracingInst>(in As<Int256, UInt256>(ref result));
         }
 
         return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -56,11 +56,12 @@ internal static partial class EvmInstructions
         /// <param name="programCounter">The program counter.</param>
         /// <param name="code">The code segment containing the immediate data.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        virtual static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        virtual static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             // Use available bytes and pad left if fewer than expected.
             int usedFromCode = Math.Min(code.Length - programCounter, length);
-            stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+            stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
         }
     }
 
@@ -84,7 +85,8 @@ internal static partial class EvmInstructions
         /// If exactly one byte is available, it is pushed; otherwise, zero is pushed.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             // Determine how many bytes can be used from the code.
             int usedFromCode = Math.Min(code.Length - programCounter, length);
@@ -92,12 +94,12 @@ internal static partial class EvmInstructions
             {
                 // Directly push the single byte.
                 ref byte bytes = ref MemoryMarshal.GetReference(code);
-                stack.PushByte(Add(ref bytes, programCounter));
+                stack.PushByte<TTracingInst>(Add(ref bytes, programCounter));
             }
             else
             {
                 // Fallback when immediate data is incomplete.
-                stack.PushZero();
+                stack.PushZero<TTracingInst>();
             }
         }
     }
@@ -111,8 +113,8 @@ internal static partial class EvmInstructions
     /// Push operation for two bytes.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionPush2<TTracingInstructions>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
-        where TTracingInstructions : struct, IFlag
+    public static EvmExceptionType InstructionPush2<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         const int Size = sizeof(ushort);
         // Deduct a very low gas cost for the push operation.
@@ -123,7 +125,7 @@ internal static partial class EvmInstructions
         ref byte bytes = ref MemoryMarshal.GetReference(code);
         int remainingCode = code.Length - programCounter;
         Instruction nextInstruction;
-        if (!TTracingInstructions.IsActive &&
+        if (!TTracingInst.IsActive &&
             remainingCode > Size &&
             ((nextInstruction = (Instruction)Add(ref bytes, programCounter + Size))
                 is Instruction.JUMP or Instruction.JUMPI))
@@ -161,17 +163,17 @@ internal static partial class EvmInstructions
         else if (remainingCode >= Size)
         {
             // Optimized push for exactly two bytes.
-            stack.Push2Bytes(ref Add(ref bytes, programCounter));
+            stack.Push2Bytes<TTracingInst>(ref Add(ref bytes, programCounter));
         }
         else if (remainingCode == Op1.Count)
         {
             // Directly push the single byte.
-            stack.PushByte(Add(ref bytes, programCounter));
+            stack.PushByte<TTracingInst>(Add(ref bytes, programCounter));
         }
         else
         {
             // Fallback when immediate data is incomplete.
-            stack.PushZero();
+            stack.PushZero<TTracingInst>();
         }
 
         programCounter += Size;
@@ -199,18 +201,19 @@ internal static partial class EvmInstructions
         public static int Count => Size;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             int usedFromCode = Math.Min(code.Length - programCounter, length);
             if (usedFromCode == Size)
             {
                 ref byte bytes = ref MemoryMarshal.GetReference(code);
                 // Direct push of a 4-byte value.
-                stack.Push4Bytes(ref Add(ref bytes, programCounter));
+                stack.Push4Bytes<TTracingInst>(ref Add(ref bytes, programCounter));
             }
             else
             {
-                stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+                stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
             }
         }
     }
@@ -245,17 +248,18 @@ internal static partial class EvmInstructions
         /// Push operation for eight bytes.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             int usedFromCode = Math.Min(code.Length - programCounter, length);
             if (usedFromCode == Size)
             {
                 ref byte bytes = ref MemoryMarshal.GetReference(code);
-                stack.Push8Bytes(ref Add(ref bytes, programCounter));
+                stack.Push8Bytes<TTracingInst>(ref Add(ref bytes, programCounter));
             }
             else
             {
-                stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+                stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
             }
         }
     }
@@ -311,17 +315,18 @@ internal static partial class EvmInstructions
         /// Push operation for 16 bytes.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             int usedFromCode = Math.Min(code.Length - programCounter, length);
             if (usedFromCode == Size)
             {
                 ref byte bytes = ref MemoryMarshal.GetReference(code);
-                stack.Push16Bytes(ref Add(ref bytes, programCounter));
+                stack.Push16Bytes<TTracingInst>(ref Add(ref bytes, programCounter));
             }
             else
             {
-                stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+                stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
             }
         }
     }
@@ -356,18 +361,19 @@ internal static partial class EvmInstructions
         /// Push operation for 20 bytes (commonly used for addresses).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             int usedFromCode = Math.Min(code.Length - programCounter, length);
             if (usedFromCode == Size)
             {
                 // Optimized push for address size data.
                 ref byte bytes = ref MemoryMarshal.GetReference(code);
-                stack.Push20Bytes(ref Add(ref bytes, programCounter));
+                stack.Push20Bytes<TTracingInst>(ref Add(ref bytes, programCounter));
             }
             else
             {
-                stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+                stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
             }
         }
     }
@@ -451,17 +457,18 @@ internal static partial class EvmInstructions
         /// Push operation for 32 bytes.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Push(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+        public static void Push<TTracingInst>(int length, ref EvmStack stack, int programCounter, ReadOnlySpan<byte> code)
+            where TTracingInst : struct, IFlag
         {
             int usedFromCode = Math.Min(code.Length - programCounter, length);
             if (usedFromCode == Size)
             {
                 // Leverage reinterpretation of bytes as a 256-bit vector.
-                stack.Push32Bytes(in As<byte, Word>(ref Add(ref MemoryMarshal.GetReference(code), programCounter)));
+                stack.Push32Bytes<TTracingInst>(in As<byte, Word>(ref Add(ref MemoryMarshal.GetReference(code), programCounter)));
             }
             else
             {
-                stack.PushLeftPaddedBytes(code.Slice(programCounter, usedFromCode), length);
+                stack.PushLeftPaddedBytes<TTracingInst>(code.Slice(programCounter, usedFromCode), length);
             }
         }
     }
@@ -475,10 +482,11 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">The program counter.</param>
     /// <returns><see cref="EvmExceptionType.None"/> on success.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionPush0(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionPush0<TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+        where TTracingInst : struct, IFlag
     {
         gasAvailable -= GasCostOf.Base;
-        stack.PushZero();
+        stack.PushZero<TTracingInst>();
         return EvmExceptionType.None;
     }
 
@@ -493,15 +501,16 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the program counter, which will be advanced.</param>
     /// <returns><see cref="EvmExceptionType.None"/> on success.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionPush<TOpCount>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionPush<TOpCount, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpCount : IOpCount
+        where TTracingInst : struct, IFlag
     {
         // Deduct a very low gas cost for the push operation.
         gasAvailable -= GasCostOf.VeryLow;
         // Retrieve the code segment containing immediate data.
         ReadOnlySpan<byte> code = vm.EvmState.Env.CodeInfo.CodeSection.Span;
         // Use the push method defined by the specific push operation.
-        TOpCount.Push(TOpCount.Count, ref stack, programCounter, code);
+        TOpCount.Push<TTracingInst>(TOpCount.Count, ref stack, programCounter, code);
         // Advance the program counter by the number of bytes consumed.
         programCounter += TOpCount.Count;
         return EvmExceptionType.None;
@@ -517,12 +526,13 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the program counter.</param>
     /// <returns><see cref="EvmExceptionType.None"/> on success or <see cref="EvmExceptionType.StackUnderflow"/> if insufficient stack elements.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionDup<TOpCount>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionDup<TOpCount, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpCount : IOpCount
+        where TTracingInst : struct, IFlag
     {
         gasAvailable -= GasCostOf.VeryLow;
         // Duplicate the nth element from the top; if it fails, signal a stack underflow.
-        if (!stack.Dup(TOpCount.Count)) goto StackUnderflow;
+        if (!stack.Dup<TTracingInst>(TOpCount.Count)) goto StackUnderflow;
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
     StackUnderflow:
@@ -539,12 +549,13 @@ internal static partial class EvmInstructions
     /// <param name="programCounter">Reference to the program counter.</param>
     /// <returns><see cref="EvmExceptionType.None"/> on success or <see cref="EvmExceptionType.StackUnderflow"/> if insufficient elements.</returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSwap<TOpCount>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
+    public static EvmExceptionType InstructionSwap<TOpCount, TTracingInst>(VirtualMachine vm, ref EvmStack stack, ref long gasAvailable, ref int programCounter)
         where TOpCount : IOpCount
+        where TTracingInst : struct, IFlag
     {
         gasAvailable -= GasCostOf.VeryLow;
         // Swap the top element with the (n+1)th element; ensure adequate stack depth.
-        if (!stack.Swap(TOpCount.Count + 1)) goto StackUnderflow;
+        if (!stack.Swap<TTracingInst>(TOpCount.Count + 1)) goto StackUnderflow;
         return EvmExceptionType.None;
     // Jump forward to be unpredicted by the branch predictor.
     StackUnderflow:

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -17,11 +17,11 @@ internal static unsafe partial class EvmInstructions
     /// Each of the 256 entries in the returned array corresponds to an EVM instruction,
     /// with unassigned opcodes defaulting to a bad instruction handler.
     /// </summary>
-    /// <typeparam name="TTracingInstructions">A struct implementing IFlag used for tracing purposes.</typeparam>
+    /// <typeparam name="TTracingInst">A struct implementing IFlag used for tracing purposes.</typeparam>
     /// <param name="spec">The release specification containing enabled features and opcode flags.</param>
     /// <returns>An array of function pointers (opcode handlers) indexed by opcode value.</returns>
-    public static OpCode[] GenerateOpCodes<TTracingInstructions>(IReleaseSpec spec)
-        where TTracingInstructions : struct, IFlag
+    public static OpCode[] GenerateOpCodes<TTracingInst>(IReleaseSpec spec)
+        where TTracingInst : struct, IFlag
     {
         // Allocate lookup table for all possible opcodes.
         OpCode[] lookup = new OpCode[byte.MaxValue + 1];
@@ -33,204 +33,204 @@ internal static unsafe partial class EvmInstructions
 
         // Set basic control and arithmetic opcodes.
         lookup[(int)Instruction.STOP] = &InstructionStop;
-        lookup[(int)Instruction.ADD] = &InstructionMath2Param<OpAdd>;
-        lookup[(int)Instruction.MUL] = &InstructionMath2Param<OpMul>;
-        lookup[(int)Instruction.SUB] = &InstructionMath2Param<OpSub>;
-        lookup[(int)Instruction.DIV] = &InstructionMath2Param<OpDiv>;
-        lookup[(int)Instruction.SDIV] = &InstructionMath2Param<OpSDiv>;
-        lookup[(int)Instruction.MOD] = &InstructionMath2Param<OpMod>;
-        lookup[(int)Instruction.SMOD] = &InstructionMath2Param<OpSMod>;
-        lookup[(int)Instruction.ADDMOD] = &InstructionMath3Param<OpAddMod>;
-        lookup[(int)Instruction.MULMOD] = &InstructionMath3Param<OpMulMod>;
-        lookup[(int)Instruction.EXP] = &InstructionExp;
-        lookup[(int)Instruction.SIGNEXTEND] = &InstructionSignExtend;
+        lookup[(int)Instruction.ADD] = &InstructionMath2Param<OpAdd, TTracingInst>;
+        lookup[(int)Instruction.MUL] = &InstructionMath2Param<OpMul, TTracingInst>;
+        lookup[(int)Instruction.SUB] = &InstructionMath2Param<OpSub, TTracingInst>;
+        lookup[(int)Instruction.DIV] = &InstructionMath2Param<OpDiv, TTracingInst>;
+        lookup[(int)Instruction.SDIV] = &InstructionMath2Param<OpSDiv, TTracingInst>;
+        lookup[(int)Instruction.MOD] = &InstructionMath2Param<OpMod, TTracingInst>;
+        lookup[(int)Instruction.SMOD] = &InstructionMath2Param<OpSMod, TTracingInst>;
+        lookup[(int)Instruction.ADDMOD] = &InstructionMath3Param<OpAddMod, TTracingInst>;
+        lookup[(int)Instruction.MULMOD] = &InstructionMath3Param<OpMulMod, TTracingInst>;
+        lookup[(int)Instruction.EXP] = &InstructionExp<TTracingInst>;
+        lookup[(int)Instruction.SIGNEXTEND] = &InstructionSignExtend<TTracingInst>;
 
         // Comparison and bitwise opcodes.
-        lookup[(int)Instruction.LT] = &InstructionMath2Param<OpLt>;
-        lookup[(int)Instruction.GT] = &InstructionMath2Param<OpGt>;
-        lookup[(int)Instruction.SLT] = &InstructionMath2Param<OpSLt>;
-        lookup[(int)Instruction.SGT] = &InstructionMath2Param<OpSGt>;
+        lookup[(int)Instruction.LT] = &InstructionMath2Param<OpLt, TTracingInst>;
+        lookup[(int)Instruction.GT] = &InstructionMath2Param<OpGt, TTracingInst>;
+        lookup[(int)Instruction.SLT] = &InstructionMath2Param<OpSLt, TTracingInst>;
+        lookup[(int)Instruction.SGT] = &InstructionMath2Param<OpSGt, TTracingInst>;
         lookup[(int)Instruction.EQ] = &InstructionBitwise<OpBitwiseEq>;
         lookup[(int)Instruction.ISZERO] = &InstructionMath1Param<OpIsZero>;
         lookup[(int)Instruction.AND] = &InstructionBitwise<OpBitwiseAnd>;
         lookup[(int)Instruction.OR] = &InstructionBitwise<OpBitwiseOr>;
         lookup[(int)Instruction.XOR] = &InstructionBitwise<OpBitwiseXor>;
         lookup[(int)Instruction.NOT] = &InstructionMath1Param<OpNot>;
-        lookup[(int)Instruction.BYTE] = &InstructionByte;
+        lookup[(int)Instruction.BYTE] = &InstructionByte<TTracingInst>;
 
         // Conditional: enable shift opcodes if the spec allows.
         if (spec.ShiftOpcodesEnabled)
         {
-            lookup[(int)Instruction.SHL] = &InstructionShift<OpShl>;
-            lookup[(int)Instruction.SHR] = &InstructionShift<OpShr>;
-            lookup[(int)Instruction.SAR] = &InstructionSar;
+            lookup[(int)Instruction.SHL] = &InstructionShift<OpShl, TTracingInst>;
+            lookup[(int)Instruction.SHR] = &InstructionShift<OpShr, TTracingInst>;
+            lookup[(int)Instruction.SAR] = &InstructionSar<TTracingInst>;
         }
 
         // Cryptographic hash opcode.
-        lookup[(int)Instruction.KECCAK256] = &InstructionKeccak256;
+        lookup[(int)Instruction.KECCAK256] = &InstructionKeccak256<TTracingInst>;
 
         // Environment opcodes.
-        lookup[(int)Instruction.ADDRESS] = &InstructionEnvAddress<OpAddress>;
-        lookup[(int)Instruction.BALANCE] = &InstructionBalance;
-        lookup[(int)Instruction.ORIGIN] = &InstructionEnvAddress<OpOrigin>;
-        lookup[(int)Instruction.CALLER] = &InstructionEnvAddress<OpCaller>;
-        lookup[(int)Instruction.CALLVALUE] = &InstructionEnvUInt256<OpCallValue>;
-        lookup[(int)Instruction.CALLDATALOAD] = &InstructionCallDataLoad;
-        lookup[(int)Instruction.CALLDATASIZE] = &InstructionEnvUInt32<OpCallDataSize>;
-        lookup[(int)Instruction.CALLDATACOPY] = &InstructionCodeCopy<OpCallDataCopy, TTracingInstructions>;
-        lookup[(int)Instruction.CODESIZE] = &InstructionEnvUInt32<OpCodeSize>;
-        lookup[(int)Instruction.CODECOPY] = &InstructionCodeCopy<OpCodeCopy, TTracingInstructions>;
-        lookup[(int)Instruction.GASPRICE] = &InstructionEnvUInt256<OpGasPrice>;
+        lookup[(int)Instruction.ADDRESS] = &InstructionEnvAddress<OpAddress, TTracingInst>;
+        lookup[(int)Instruction.BALANCE] = &InstructionBalance<TTracingInst>;
+        lookup[(int)Instruction.ORIGIN] = &InstructionEnvAddress<OpOrigin, TTracingInst>;
+        lookup[(int)Instruction.CALLER] = &InstructionEnvAddress<OpCaller, TTracingInst>;
+        lookup[(int)Instruction.CALLVALUE] = &InstructionEnvUInt256<OpCallValue, TTracingInst>;
+        lookup[(int)Instruction.CALLDATALOAD] = &InstructionCallDataLoad<TTracingInst>;
+        lookup[(int)Instruction.CALLDATASIZE] = &InstructionEnvUInt32<OpCallDataSize, TTracingInst>;
+        lookup[(int)Instruction.CALLDATACOPY] = &InstructionCodeCopy<OpCallDataCopy, TTracingInst>;
+        lookup[(int)Instruction.CODESIZE] = &InstructionEnvUInt32<OpCodeSize, TTracingInst>;
+        lookup[(int)Instruction.CODECOPY] = &InstructionCodeCopy<OpCodeCopy, TTracingInst>;
+        lookup[(int)Instruction.GASPRICE] = &InstructionEnvUInt256<OpGasPrice, TTracingInst>;
 
-        lookup[(int)Instruction.EXTCODESIZE] = &InstructionExtCodeSize<TTracingInstructions>;
-        lookup[(int)Instruction.EXTCODECOPY] = &InstructionExtCodeCopy<TTracingInstructions>;
+        lookup[(int)Instruction.EXTCODESIZE] = &InstructionExtCodeSize<TTracingInst>;
+        lookup[(int)Instruction.EXTCODECOPY] = &InstructionExtCodeCopy<TTracingInst>;
 
         // Return data opcodes (if enabled).
         if (spec.ReturnDataOpcodesEnabled)
         {
-            lookup[(int)Instruction.RETURNDATASIZE] = &InstructionReturnDataSize;
-            lookup[(int)Instruction.RETURNDATACOPY] = &InstructionReturnDataCopy<TTracingInstructions>;
+            lookup[(int)Instruction.RETURNDATASIZE] = &InstructionReturnDataSize<TTracingInst>;
+            lookup[(int)Instruction.RETURNDATACOPY] = &InstructionReturnDataCopy<TTracingInst>;
         }
 
         // Extended code hash opcode handling.
         if (spec.ExtCodeHashOpcodeEnabled)
         {
-            lookup[(int)Instruction.EXTCODEHASH] = spec.IsEofEnabled ? &InstructionExtCodeHashEof : &InstructionExtCodeHash;
+            lookup[(int)Instruction.EXTCODEHASH] = spec.IsEofEnabled ? &InstructionExtCodeHashEof<TTracingInst> : &InstructionExtCodeHash<TTracingInst>;
         }
 
-        lookup[(int)Instruction.BLOCKHASH] = &InstructionBlockHash;
+        lookup[(int)Instruction.BLOCKHASH] = &InstructionBlockHash<TTracingInst>;
 
         // More environment opcodes.
-        lookup[(int)Instruction.COINBASE] = &InstructionEnvAddress<OpCoinbase>;
-        lookup[(int)Instruction.TIMESTAMP] = &InstructionEnvUInt64<OpTimestamp>;
-        lookup[(int)Instruction.NUMBER] = &InstructionEnvUInt64<OpNumber>;
-        lookup[(int)Instruction.PREVRANDAO] = &InstructionPrevRandao;
-        lookup[(int)Instruction.GASLIMIT] = &InstructionEnvUInt64<OpGasLimit>;
+        lookup[(int)Instruction.COINBASE] = &InstructionEnvAddress<OpCoinbase, TTracingInst>;
+        lookup[(int)Instruction.TIMESTAMP] = &InstructionEnvUInt64<OpTimestamp, TTracingInst>;
+        lookup[(int)Instruction.NUMBER] = &InstructionEnvUInt64<OpNumber, TTracingInst>;
+        lookup[(int)Instruction.PREVRANDAO] = &InstructionPrevRandao<TTracingInst>;
+        lookup[(int)Instruction.GASLIMIT] = &InstructionEnvUInt64<OpGasLimit, TTracingInst>;
         if (spec.ChainIdOpcodeEnabled)
         {
-            lookup[(int)Instruction.CHAINID] = &InstructionChainId;
+            lookup[(int)Instruction.CHAINID] = &InstructionChainId<TTracingInst>;
         }
         if (spec.SelfBalanceOpcodeEnabled)
         {
-            lookup[(int)Instruction.SELFBALANCE] = &InstructionSelfBalance;
+            lookup[(int)Instruction.SELFBALANCE] = &InstructionSelfBalance<TTracingInst>;
         }
         if (spec.BaseFeeEnabled)
         {
-            lookup[(int)Instruction.BASEFEE] = &InstructionEnvUInt256<OpBaseFee>;
+            lookup[(int)Instruction.BASEFEE] = &InstructionEnvUInt256<OpBaseFee, TTracingInst>;
         }
         if (spec.IsEip4844Enabled)
         {
-            lookup[(int)Instruction.BLOBHASH] = &InstructionBlobHash;
+            lookup[(int)Instruction.BLOBHASH] = &InstructionBlobHash<TTracingInst>;
         }
         if (spec.BlobBaseFeeEnabled)
         {
-            lookup[(int)Instruction.BLOBBASEFEE] = &InstructionEnvUInt256<OpBlobBaseFee>;
+            lookup[(int)Instruction.BLOBBASEFEE] = &InstructionEnvUInt256<OpBlobBaseFee, TTracingInst>;
         }
 
         // Gap: opcodes 0x4b to 0x4f are unassigned.
 
         // Memory and storage instructions.
         lookup[(int)Instruction.POP] = &InstructionPop;
-        lookup[(int)Instruction.MLOAD] = &InstructionMLoad<TTracingInstructions>;
-        lookup[(int)Instruction.MSTORE] = &InstructionMStore<TTracingInstructions>;
-        lookup[(int)Instruction.MSTORE8] = &InstructionMStore8<TTracingInstructions>;
-        lookup[(int)Instruction.SLOAD] = &InstructionSLoad;
-        lookup[(int)Instruction.SSTORE] = &InstructionSStore<TTracingInstructions>;
+        lookup[(int)Instruction.MLOAD] = &InstructionMLoad<TTracingInst>;
+        lookup[(int)Instruction.MSTORE] = &InstructionMStore<TTracingInst>;
+        lookup[(int)Instruction.MSTORE8] = &InstructionMStore8<TTracingInst>;
+        lookup[(int)Instruction.SLOAD] = &InstructionSLoad<TTracingInst>;
+        lookup[(int)Instruction.SSTORE] = &InstructionSStore<TTracingInst>;
 
         // Jump instructions.
         lookup[(int)Instruction.JUMP] = &InstructionJump;
         lookup[(int)Instruction.JUMPI] = &InstructionJumpIf;
-        lookup[(int)Instruction.PC] = &InstructionProgramCounter;
-        lookup[(int)Instruction.MSIZE] = &InstructionEnvUInt64<OpMSize>;
-        lookup[(int)Instruction.GAS] = &InstructionGas;
+        lookup[(int)Instruction.PC] = &InstructionProgramCounter<TTracingInst>;
+        lookup[(int)Instruction.MSIZE] = &InstructionEnvUInt64<OpMSize, TTracingInst>;
+        lookup[(int)Instruction.GAS] = &InstructionGas<TTracingInst>;
         lookup[(int)Instruction.JUMPDEST] = &InstructionJumpDest;
 
         // Transient storage opcodes.
         if (spec.TransientStorageEnabled)
         {
-            lookup[(int)Instruction.TLOAD] = &InstructionTLoad;
+            lookup[(int)Instruction.TLOAD] = &InstructionTLoad<TTracingInst>;
             lookup[(int)Instruction.TSTORE] = &InstructionTStore;
         }
         if (spec.MCopyIncluded)
         {
-            lookup[(int)Instruction.MCOPY] = &InstructionMCopy<TTracingInstructions>;
+            lookup[(int)Instruction.MCOPY] = &InstructionMCopy<TTracingInst>;
         }
 
         // Optional PUSH0 instruction.
         if (spec.IncludePush0Instruction)
         {
-            lookup[(int)Instruction.PUSH0] = &InstructionPush0;
+            lookup[(int)Instruction.PUSH0] = &InstructionPush0<TTracingInst>;
         }
 
         // PUSH opcodes (PUSH1 to PUSH32).
-        lookup[(int)Instruction.PUSH1] = &InstructionPush<Op1>;
-        lookup[(int)Instruction.PUSH2] = &InstructionPush2<TTracingInstructions>;
-        lookup[(int)Instruction.PUSH3] = &InstructionPush<Op3>;
-        lookup[(int)Instruction.PUSH4] = &InstructionPush<Op4>;
-        lookup[(int)Instruction.PUSH5] = &InstructionPush<Op5>;
-        lookup[(int)Instruction.PUSH6] = &InstructionPush<Op6>;
-        lookup[(int)Instruction.PUSH7] = &InstructionPush<Op7>;
-        lookup[(int)Instruction.PUSH8] = &InstructionPush<Op8>;
-        lookup[(int)Instruction.PUSH9] = &InstructionPush<Op9>;
-        lookup[(int)Instruction.PUSH10] = &InstructionPush<Op10>;
-        lookup[(int)Instruction.PUSH11] = &InstructionPush<Op11>;
-        lookup[(int)Instruction.PUSH12] = &InstructionPush<Op12>;
-        lookup[(int)Instruction.PUSH13] = &InstructionPush<Op13>;
-        lookup[(int)Instruction.PUSH14] = &InstructionPush<Op14>;
-        lookup[(int)Instruction.PUSH15] = &InstructionPush<Op15>;
-        lookup[(int)Instruction.PUSH16] = &InstructionPush<Op16>;
-        lookup[(int)Instruction.PUSH17] = &InstructionPush<Op17>;
-        lookup[(int)Instruction.PUSH18] = &InstructionPush<Op18>;
-        lookup[(int)Instruction.PUSH19] = &InstructionPush<Op19>;
-        lookup[(int)Instruction.PUSH20] = &InstructionPush<Op20>;
-        lookup[(int)Instruction.PUSH21] = &InstructionPush<Op21>;
-        lookup[(int)Instruction.PUSH22] = &InstructionPush<Op22>;
-        lookup[(int)Instruction.PUSH23] = &InstructionPush<Op23>;
-        lookup[(int)Instruction.PUSH24] = &InstructionPush<Op24>;
-        lookup[(int)Instruction.PUSH25] = &InstructionPush<Op25>;
-        lookup[(int)Instruction.PUSH26] = &InstructionPush<Op26>;
-        lookup[(int)Instruction.PUSH27] = &InstructionPush<Op27>;
-        lookup[(int)Instruction.PUSH28] = &InstructionPush<Op28>;
-        lookup[(int)Instruction.PUSH29] = &InstructionPush<Op29>;
-        lookup[(int)Instruction.PUSH30] = &InstructionPush<Op30>;
-        lookup[(int)Instruction.PUSH31] = &InstructionPush<Op31>;
-        lookup[(int)Instruction.PUSH32] = &InstructionPush<Op32>;
+        lookup[(int)Instruction.PUSH1] = &InstructionPush<Op1, TTracingInst>;
+        lookup[(int)Instruction.PUSH2] = &InstructionPush2<TTracingInst>;
+        lookup[(int)Instruction.PUSH3] = &InstructionPush<Op3, TTracingInst>;
+        lookup[(int)Instruction.PUSH4] = &InstructionPush<Op4, TTracingInst>;
+        lookup[(int)Instruction.PUSH5] = &InstructionPush<Op5, TTracingInst>;
+        lookup[(int)Instruction.PUSH6] = &InstructionPush<Op6, TTracingInst>;
+        lookup[(int)Instruction.PUSH7] = &InstructionPush<Op7, TTracingInst>;
+        lookup[(int)Instruction.PUSH8] = &InstructionPush<Op8, TTracingInst>;
+        lookup[(int)Instruction.PUSH9] = &InstructionPush<Op9, TTracingInst>;
+        lookup[(int)Instruction.PUSH10] = &InstructionPush<Op10, TTracingInst>;
+        lookup[(int)Instruction.PUSH11] = &InstructionPush<Op11, TTracingInst>;
+        lookup[(int)Instruction.PUSH12] = &InstructionPush<Op12, TTracingInst>;
+        lookup[(int)Instruction.PUSH13] = &InstructionPush<Op13, TTracingInst>;
+        lookup[(int)Instruction.PUSH14] = &InstructionPush<Op14, TTracingInst>;
+        lookup[(int)Instruction.PUSH15] = &InstructionPush<Op15, TTracingInst>;
+        lookup[(int)Instruction.PUSH16] = &InstructionPush<Op16, TTracingInst>;
+        lookup[(int)Instruction.PUSH17] = &InstructionPush<Op17, TTracingInst>;
+        lookup[(int)Instruction.PUSH18] = &InstructionPush<Op18, TTracingInst>;
+        lookup[(int)Instruction.PUSH19] = &InstructionPush<Op19, TTracingInst>;
+        lookup[(int)Instruction.PUSH20] = &InstructionPush<Op20, TTracingInst>;
+        lookup[(int)Instruction.PUSH21] = &InstructionPush<Op21, TTracingInst>;
+        lookup[(int)Instruction.PUSH22] = &InstructionPush<Op22, TTracingInst>;
+        lookup[(int)Instruction.PUSH23] = &InstructionPush<Op23, TTracingInst>;
+        lookup[(int)Instruction.PUSH24] = &InstructionPush<Op24, TTracingInst>;
+        lookup[(int)Instruction.PUSH25] = &InstructionPush<Op25, TTracingInst>;
+        lookup[(int)Instruction.PUSH26] = &InstructionPush<Op26, TTracingInst>;
+        lookup[(int)Instruction.PUSH27] = &InstructionPush<Op27, TTracingInst>;
+        lookup[(int)Instruction.PUSH28] = &InstructionPush<Op28, TTracingInst>;
+        lookup[(int)Instruction.PUSH29] = &InstructionPush<Op29, TTracingInst>;
+        lookup[(int)Instruction.PUSH30] = &InstructionPush<Op30, TTracingInst>;
+        lookup[(int)Instruction.PUSH31] = &InstructionPush<Op31, TTracingInst>;
+        lookup[(int)Instruction.PUSH32] = &InstructionPush<Op32, TTracingInst>;
 
         // DUP opcodes (DUP1 to DUP16).
-        lookup[(int)Instruction.DUP1] = &InstructionDup<Op1>;
-        lookup[(int)Instruction.DUP2] = &InstructionDup<Op2>;
-        lookup[(int)Instruction.DUP3] = &InstructionDup<Op3>;
-        lookup[(int)Instruction.DUP4] = &InstructionDup<Op4>;
-        lookup[(int)Instruction.DUP5] = &InstructionDup<Op5>;
-        lookup[(int)Instruction.DUP6] = &InstructionDup<Op6>;
-        lookup[(int)Instruction.DUP7] = &InstructionDup<Op7>;
-        lookup[(int)Instruction.DUP8] = &InstructionDup<Op8>;
-        lookup[(int)Instruction.DUP9] = &InstructionDup<Op9>;
-        lookup[(int)Instruction.DUP10] = &InstructionDup<Op10>;
-        lookup[(int)Instruction.DUP11] = &InstructionDup<Op11>;
-        lookup[(int)Instruction.DUP12] = &InstructionDup<Op12>;
-        lookup[(int)Instruction.DUP13] = &InstructionDup<Op13>;
-        lookup[(int)Instruction.DUP14] = &InstructionDup<Op14>;
-        lookup[(int)Instruction.DUP15] = &InstructionDup<Op15>;
-        lookup[(int)Instruction.DUP16] = &InstructionDup<Op16>;
+        lookup[(int)Instruction.DUP1] = &InstructionDup<Op1, TTracingInst>;
+        lookup[(int)Instruction.DUP2] = &InstructionDup<Op2, TTracingInst>;
+        lookup[(int)Instruction.DUP3] = &InstructionDup<Op3, TTracingInst>;
+        lookup[(int)Instruction.DUP4] = &InstructionDup<Op4, TTracingInst>;
+        lookup[(int)Instruction.DUP5] = &InstructionDup<Op5, TTracingInst>;
+        lookup[(int)Instruction.DUP6] = &InstructionDup<Op6, TTracingInst>;
+        lookup[(int)Instruction.DUP7] = &InstructionDup<Op7, TTracingInst>;
+        lookup[(int)Instruction.DUP8] = &InstructionDup<Op8, TTracingInst>;
+        lookup[(int)Instruction.DUP9] = &InstructionDup<Op9, TTracingInst>;
+        lookup[(int)Instruction.DUP10] = &InstructionDup<Op10, TTracingInst>;
+        lookup[(int)Instruction.DUP11] = &InstructionDup<Op11, TTracingInst>;
+        lookup[(int)Instruction.DUP12] = &InstructionDup<Op12, TTracingInst>;
+        lookup[(int)Instruction.DUP13] = &InstructionDup<Op13, TTracingInst>;
+        lookup[(int)Instruction.DUP14] = &InstructionDup<Op14, TTracingInst>;
+        lookup[(int)Instruction.DUP15] = &InstructionDup<Op15, TTracingInst>;
+        lookup[(int)Instruction.DUP16] = &InstructionDup<Op16, TTracingInst>;
 
         // SWAP opcodes (SWAP1 to SWAP16).
-        lookup[(int)Instruction.SWAP1] = &InstructionSwap<Op1>;
-        lookup[(int)Instruction.SWAP2] = &InstructionSwap<Op2>;
-        lookup[(int)Instruction.SWAP3] = &InstructionSwap<Op3>;
-        lookup[(int)Instruction.SWAP4] = &InstructionSwap<Op4>;
-        lookup[(int)Instruction.SWAP5] = &InstructionSwap<Op5>;
-        lookup[(int)Instruction.SWAP6] = &InstructionSwap<Op6>;
-        lookup[(int)Instruction.SWAP7] = &InstructionSwap<Op7>;
-        lookup[(int)Instruction.SWAP8] = &InstructionSwap<Op8>;
-        lookup[(int)Instruction.SWAP9] = &InstructionSwap<Op9>;
-        lookup[(int)Instruction.SWAP10] = &InstructionSwap<Op10>;
-        lookup[(int)Instruction.SWAP11] = &InstructionSwap<Op11>;
-        lookup[(int)Instruction.SWAP12] = &InstructionSwap<Op12>;
-        lookup[(int)Instruction.SWAP13] = &InstructionSwap<Op13>;
-        lookup[(int)Instruction.SWAP14] = &InstructionSwap<Op14>;
-        lookup[(int)Instruction.SWAP15] = &InstructionSwap<Op15>;
-        lookup[(int)Instruction.SWAP16] = &InstructionSwap<Op16>;
+        lookup[(int)Instruction.SWAP1] = &InstructionSwap<Op1, TTracingInst>;
+        lookup[(int)Instruction.SWAP2] = &InstructionSwap<Op2, TTracingInst>;
+        lookup[(int)Instruction.SWAP3] = &InstructionSwap<Op3, TTracingInst>;
+        lookup[(int)Instruction.SWAP4] = &InstructionSwap<Op4, TTracingInst>;
+        lookup[(int)Instruction.SWAP5] = &InstructionSwap<Op5, TTracingInst>;
+        lookup[(int)Instruction.SWAP6] = &InstructionSwap<Op6, TTracingInst>;
+        lookup[(int)Instruction.SWAP7] = &InstructionSwap<Op7, TTracingInst>;
+        lookup[(int)Instruction.SWAP8] = &InstructionSwap<Op8, TTracingInst>;
+        lookup[(int)Instruction.SWAP9] = &InstructionSwap<Op9, TTracingInst>;
+        lookup[(int)Instruction.SWAP10] = &InstructionSwap<Op10, TTracingInst>;
+        lookup[(int)Instruction.SWAP11] = &InstructionSwap<Op11, TTracingInst>;
+        lookup[(int)Instruction.SWAP12] = &InstructionSwap<Op12, TTracingInst>;
+        lookup[(int)Instruction.SWAP13] = &InstructionSwap<Op13, TTracingInst>;
+        lookup[(int)Instruction.SWAP14] = &InstructionSwap<Op14, TTracingInst>;
+        lookup[(int)Instruction.SWAP15] = &InstructionSwap<Op15, TTracingInst>;
+        lookup[(int)Instruction.SWAP16] = &InstructionSwap<Op16, TTracingInst>;
 
         // LOG opcodes.
         lookup[(int)Instruction.LOG0] = &InstructionLog<Op0>;
@@ -242,54 +242,54 @@ internal static unsafe partial class EvmInstructions
         // Extended opcodes for EO (EoF) mode.
         if (spec.IsEofEnabled)
         {
-            lookup[(int)Instruction.DATALOAD] = &InstructionDataLoad;
-            lookup[(int)Instruction.DATALOADN] = &InstructionDataLoadN;
-            lookup[(int)Instruction.DATASIZE] = &InstructionDataSize;
-            lookup[(int)Instruction.DATACOPY] = &InstructionDataCopy<TTracingInstructions>;
+            lookup[(int)Instruction.DATALOAD] = &InstructionDataLoad<TTracingInst>;
+            lookup[(int)Instruction.DATALOADN] = &InstructionDataLoadN<TTracingInst>;
+            lookup[(int)Instruction.DATASIZE] = &InstructionDataSize<TTracingInst>;
+            lookup[(int)Instruction.DATACOPY] = &InstructionDataCopy<TTracingInst>;
             lookup[(int)Instruction.RJUMP] = &InstructionRelativeJump;
             lookup[(int)Instruction.RJUMPI] = &InstructionRelativeJumpIf;
             lookup[(int)Instruction.RJUMPV] = &InstructionJumpTable;
             lookup[(int)Instruction.CALLF] = &InstructionCallFunction;
             lookup[(int)Instruction.RETF] = &InstructionReturnFunction;
             lookup[(int)Instruction.JUMPF] = &InstructionJumpFunction;
-            lookup[(int)Instruction.DUPN] = &InstructionDupN;
-            lookup[(int)Instruction.SWAPN] = &InstructionSwapN;
-            lookup[(int)Instruction.EXCHANGE] = &InstructionExchange;
-            lookup[(int)Instruction.EOFCREATE] = &InstructionEofCreate<TTracingInstructions>;
+            lookup[(int)Instruction.DUPN] = &InstructionDupN<TTracingInst>;
+            lookup[(int)Instruction.SWAPN] = &InstructionSwapN<TTracingInst>;
+            lookup[(int)Instruction.EXCHANGE] = &InstructionExchange<TTracingInst>;
+            lookup[(int)Instruction.EOFCREATE] = &InstructionEofCreate<TTracingInst>;
             lookup[(int)Instruction.RETURNCODE] = &InstructionReturnCode;
         }
 
         // Contract creation and call opcodes.
-        lookup[(int)Instruction.CREATE] = &InstructionCreate<OpCreate, TTracingInstructions>;
-        lookup[(int)Instruction.CALL] = &InstructionCall<OpCall, TTracingInstructions>;
-        lookup[(int)Instruction.CALLCODE] = &InstructionCall<OpCallCode, TTracingInstructions>;
+        lookup[(int)Instruction.CREATE] = &InstructionCreate<OpCreate, TTracingInst>;
+        lookup[(int)Instruction.CALL] = &InstructionCall<OpCall, TTracingInst>;
+        lookup[(int)Instruction.CALLCODE] = &InstructionCall<OpCallCode, TTracingInst>;
         lookup[(int)Instruction.RETURN] = &InstructionReturn;
         if (spec.DelegateCallEnabled)
         {
-            lookup[(int)Instruction.DELEGATECALL] = &InstructionCall<OpDelegateCall, TTracingInstructions>;
+            lookup[(int)Instruction.DELEGATECALL] = &InstructionCall<OpDelegateCall, TTracingInst>;
         }
         if (spec.Create2OpcodeEnabled)
         {
-            lookup[(int)Instruction.CREATE2] = &InstructionCreate<OpCreate2, TTracingInstructions>;
+            lookup[(int)Instruction.CREATE2] = &InstructionCreate<OpCreate2, TTracingInst>;
         }
 
-        lookup[(int)Instruction.RETURNDATALOAD] = &InstructionReturnDataLoad;
+        lookup[(int)Instruction.RETURNDATALOAD] = &InstructionReturnDataLoad<TTracingInst>;
         if (spec.StaticCallEnabled)
         {
-            lookup[(int)Instruction.STATICCALL] = &InstructionCall<OpStaticCall, TTracingInstructions>;
+            lookup[(int)Instruction.STATICCALL] = &InstructionCall<OpStaticCall, TTracingInst>;
         }
 
         // Extended call opcodes in EO mode.
         if (spec.IsEofEnabled)
         {
-            lookup[(int)Instruction.EXTCALL] = &InstructionEofCall<OpEofCall, TTracingInstructions>;
+            lookup[(int)Instruction.EXTCALL] = &InstructionEofCall<OpEofCall, TTracingInst>;
             if (spec.DelegateCallEnabled)
             {
-                lookup[(int)Instruction.EXTDELEGATECALL] = &InstructionEofCall<OpEofDelegateCall, TTracingInstructions>;
+                lookup[(int)Instruction.EXTDELEGATECALL] = &InstructionEofCall<OpEofDelegateCall, TTracingInst>;
             }
             if (spec.StaticCallEnabled)
             {
-                lookup[(int)Instruction.EXTSTATICCALL] = &InstructionEofCall<OpEofStaticCall, TTracingInstructions>;
+                lookup[(int)Instruction.EXTSTATICCALL] = &InstructionEofCall<OpEofStaticCall, TTracingInst>;
             }
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -595,7 +595,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual bool ShouldValidate(ExecutionOptions opts) => !opts.HasFlag(ExecutionOptions.SkipValidation);
 
-        protected virtual void ExecuteEvmCall<TTracingInstructions>(
+        protected virtual void ExecuteEvmCall<TTracingInst>(
             Transaction tx,
             BlockHeader header,
             IReleaseSpec spec,
@@ -609,7 +609,7 @@ namespace Nethermind.Evm.TransactionProcessing
             out TransactionSubstate? substate,
             out GasConsumed gasConsumed,
             out byte statusCode)
-            where TTracingInstructions : struct, IFlag
+            where TTracingInst : struct, IFlag
         {
             _ = ShouldValidate(opts);
 
@@ -649,7 +649,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             using (EvmState state = EvmState.RentTopLevel(unspentGas, executionType, snapshot, env, accessedItems))
             {
-                substate = VirtualMachine.ExecuteTransaction<TTracingInstructions>(state, WorldState, tracer);
+                substate = VirtualMachine.ExecuteTransaction<TTracingInst>(state, WorldState, tracer);
 
                 unspentGas = state.GasAvailable;
 

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateVirtualMachine.cs
@@ -10,15 +10,15 @@ namespace Nethermind.Facade.Simulate;
 
 public class SimulateVirtualMachine(IVirtualMachine virtualMachine) : IVirtualMachine
 {
-    public TransactionSubstate ExecuteTransaction<TTracingInstructions>(EvmState state, IWorldState worldState, ITxTracer txTracer)
-            where TTracingInstructions : struct, IFlag
+    public TransactionSubstate ExecuteTransaction<TTracingInst>(EvmState state, IWorldState worldState, ITxTracer txTracer)
+            where TTracingInst : struct, IFlag
     {
         if (txTracer.IsTracingActions && TryGetLogsMutator(txTracer, out ITxLogsMutator logsMutator))
         {
             logsMutator.SetLogsToMutate(state.AccessTracker.Logs);
         }
 
-        return virtualMachine.ExecuteTransaction<TTracingInstructions>(state, worldState, txTracer);
+        return virtualMachine.ExecuteTransaction<TTracingInst>(state, worldState, txTracer);
     }
 
     private static bool TryGetLogsMutator(ITxTracer txTracer, [NotNullWhen(true)] out ITxLogsMutator? txLogsMutator)


### PR DESCRIPTION
## Changes

- Reintroduce Jit time branch elimination for EvmStack; it was removed during Eof due to complexity on Type and using function pointers. However the generic can be more easily added to the methods rather than the type and achieve same effect.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No