### PR TITLE
Fix/disconnect without sending reason

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
@@ -45,7 +45,7 @@ public class PsudoNetworkModule() : Module
 
             .AddSingleton<IProtocolValidator, ProtocolValidator>()
             .AddSingleton<IPooledTxsRequestor, PooledTxsRequestor>()
-            .AddSingleton<ForkInfo>()
+            .AddSingleton<IForkInfo, ForkInfo>()
             .AddSingleton<IGossipPolicy>(Policy.FullGossip)
             .AddComposite<ITxGossipPolicy, CompositeTxGossipPolicy>()
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -298,7 +298,13 @@ public class InitializeNetwork : IStep
         ISyncServer syncServer = _api.SyncServer!;
         ForkInfo forkInfo = new(_api.SpecProvider!, syncServer.Genesis.Hash!);
 
-        ProtocolValidator protocolValidator = new(_nodeStatsManager!, _api.BlockTree, forkInfo, _api.LogManager);
+        ProtocolValidator protocolValidator = new(
+            _nodeStatsManager!,
+            _api.BlockTree,
+            forkInfo,
+            _api.PeerManager!,
+            _networkConfig,
+            _api.LogManager);
         PooledTxsRequestor pooledTxsRequestor = new(_api.TxPool!, _api.Config<ITxPoolConfig>(), _api.SpecProvider);
 
         _api.ProtocolsManager = new ProtocolsManager(
@@ -315,7 +321,6 @@ public class InitializeNetwork : IStep
             _peerStorage,
             forkInfo,
             _api.GossipPolicy,
-            _networkConfig,
             _api.WorldStateManager!,
             _api.LogManager,
             _api.TxGossipPolicy);

--- a/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
@@ -18,6 +18,7 @@ public enum DisconnectReason : byte
     DuplicatedConnection,
     PeerRemoved,
     TooManyPeers,
+    HardLimitTooManyPeers,
     SessionAlreadyExist,
     ReplacingSessionWithOppositeDirection,
     OppositeDirectionCleanup,
@@ -75,6 +76,7 @@ public static class DisconnectReasonExtension
         return disconnectReason switch
         {
             DisconnectReason.TooManyPeers => EthDisconnectReason.TooManyPeers,
+            DisconnectReason.HardLimitTooManyPeers => EthDisconnectReason.TooManyPeers,
             DisconnectReason.SessionAlreadyExist or DisconnectReason.ReplacingSessionWithOppositeDirection or DisconnectReason.OppositeDirectionCleanup or DisconnectReason.DuplicatedConnection or DisconnectReason.SessionIdAlreadyExists => EthDisconnectReason.AlreadyConnected,
             DisconnectReason.ConnectionClosed or DisconnectReason.OutgoingConnectionFailed => EthDisconnectReason.TcpSubSystemError,
             DisconnectReason.IncompatibleP2PVersion => EthDisconnectReason.IncompatibleP2PVersion,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -44,7 +44,6 @@ namespace Nethermind.Network.Test.P2P
         private IMessageSerializationService _serializer;
         private readonly Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303);
         private INodeStatsManager _nodeStatsManager;
-        private Regex? _clientIdPattern;
 
         private Packet CreatePacket<T>(T message) where T : P2PMessage
         {
@@ -69,7 +68,6 @@ namespace Nethermind.Network.Test.P2P
                 TestItem.PublicKeyA,
                 _nodeStatsManager,
                 _serializer,
-                _clientIdPattern,
                 LimboLogs.Instance);
         }
 
@@ -125,44 +123,6 @@ namespace Nethermind.Network.Test.P2P
 
             _nodeStatsManager.GetOrAdd(node).FailedCompatibilityValidation.Should().NotBeNull();
             _session.Received(1).InitiateDisconnect(DisconnectReason.NoCapabilityMatched, Arg.Any<string>());
-        }
-
-        [TestCase("besu", "besu/v23.4.0/linux-x86_64/openjdk-java-17", false)]
-        [TestCase("besu", "Geth/v1.12.1-unstable-b8d7da87-20230808/linux-amd64/go1.19.2", true)]
-        [TestCase("^((?!besu).)*$", "Geth/v1.12.1-unstable-b8d7da87-20230808/linux-amd64/go1.19.2", false)]
-        [TestCase("^((?!besu).)*$", "besu/v23.4.0/linux-x86_64/openjdk-java-17", true)]
-        public void On_hello_with_not_matching_client_id(string pattern, string clientId, bool shouldDisconnect)
-        {
-            _clientIdPattern = new Regex(pattern);
-            P2PProtocolHandler p2PProtocolHandler = CreateSession();
-
-            using HelloMessage message = new()
-            {
-                Capabilities = new ArrayPoolList<Capability>(1) { new Capability(Protocol.Eth, 63) },
-                NodeId = TestItem.PublicKeyA,
-                ClientId = clientId,
-            };
-
-            IByteBuffer data = _serializer.ZeroSerialize(message);
-            // to account for adaptive packet type
-            data.ReadByte();
-
-            Packet packet = new Packet(data.ReadAllBytesAsArray())
-            {
-                Protocol = message.Protocol,
-                PacketType = (byte)message.PacketType,
-            };
-
-            p2PProtocolHandler.HandleMessage(packet);
-
-            if (shouldDisconnect)
-            {
-                _session.Received(1).InitiateDisconnect(DisconnectReason.ClientFiltered, Arg.Any<string>());
-            }
-            else
-            {
-                _session.DidNotReceive().InitiateDisconnect(DisconnectReason.ClientFiltered, Arg.Any<string>());
-            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolValidatorTests.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Logging;
+using Nethermind.Network.Config;
+using Nethermind.Network.Contract.P2P;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.EventArg;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test;
+
+public class ProtocolValidatorTests
+{
+    [TestCase("besu", "besu/v23.4.0/linux-x86_64/openjdk-java-17", false)]
+    [TestCase("besu", "Geth/v1.12.1-unstable-b8d7da87-20230808/linux-amd64/go1.19.2", true)]
+    [TestCase("^((?!besu).)*$", "Geth/v1.12.1-unstable-b8d7da87-20230808/linux-amd64/go1.19.2", false)]
+    [TestCase("^((?!besu).)*$", "besu/v23.4.0/linux-x86_64/openjdk-java-17", true)]
+    public void On_hello_with_not_matching_client_id(string pattern, string clientId, bool shouldDisconnect)
+    {
+        ProtocolValidator protocolValidator = new ProtocolValidator(
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IBlockTree>(),
+            Substitute.For<IForkInfo>(),
+            Substitute.For<IPeerManager>(),
+            new NetworkConfig()
+            {
+                ClientIdMatcher = pattern
+            },
+            LimboLogs.Instance
+        );
+
+        ISession session = Substitute.For<ISession>();
+        session.Node.Returns(new Node(new NetworkNode("enode://0d837e193233c08d6950913bf69105096457fbe204679d6c6c021c36bb5ad83d167350440670e7fec189d80abc18076f45f44bfe480c85b6c632735463d34e4b@89.197.135.74:30303")));
+        IProtocolHandler protocolHandler = Substitute.For<IProtocolHandler>();
+        protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, new P2PProtocolInitializedEventArgs(protocolHandler)
+        {
+            ClientId = clientId,
+            P2PVersion = 5
+        });
+        if (shouldDisconnect)
+        {
+            session.Received(1).InitiateDisconnect(DisconnectReason.ClientFiltered, Arg.Any<string>());
+        }
+        else
+        {
+            session.DidNotReceive().InitiateDisconnect(DisconnectReason.ClientFiltered, Arg.Any<string>());
+        }
+    }
+
+    [TestCase(11, 10, true)]
+    [TestCase(10, 10, false)]
+    [TestCase(9, 10, false)]
+    public void On_max_active_peer_limit(int activePeerCount, int maxActivePeer, bool shouldDisconnect)
+    {
+        IPeerManager peerManager = Substitute.For<IPeerManager>();
+        peerManager.MaxActivePeers.Returns(maxActivePeer);
+        peerManager.ActivePeersCount.Returns(activePeerCount);
+
+        ProtocolValidator protocolValidator = new ProtocolValidator(
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IBlockTree>(),
+            Substitute.For<IForkInfo>(),
+            peerManager,
+            new NetworkConfig(),
+            LimboLogs.Instance
+        );
+
+        ISession session = Substitute.For<ISession>();
+        session.Node.Returns(new Node(new NetworkNode("enode://0d837e193233c08d6950913bf69105096457fbe204679d6c6c021c36bb5ad83d167350440670e7fec189d80abc18076f45f44bfe480c85b6c632735463d34e4b@89.197.135.74:30303")));
+        IProtocolHandler protocolHandler = Substitute.For<IProtocolHandler>();
+        protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, new P2PProtocolInitializedEventArgs(protocolHandler)
+        {
+            P2PVersion = 5
+        });
+
+        if (shouldDisconnect)
+        {
+            session.Received(1).InitiateDisconnect(DisconnectReason.TooManyPeers, Arg.Any<string>());
+        }
+        else
+        {
+            session.DidNotReceive().InitiateDisconnect(DisconnectReason.TooManyPeers, Arg.Any<string>());
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -70,6 +70,8 @@ public class ProtocolsManagerTests
         private readonly IPacketSender _packetSender;
         private readonly IBlockTree _blockTree;
         private readonly IGossipPolicy _gossipPolicy;
+        private readonly IPeerManager _peerManager;
+        private readonly INetworkConfig _networkConfig;
 
         public Context()
         {
@@ -104,7 +106,9 @@ public class ProtocolsManagerTests
             _blockTree.ChainId.Returns((ulong)TestBlockchainIds.ChainId);
             _blockTree.Genesis.Returns(Build.A.Block.Genesis.TestObject.Header);
             ForkInfo forkInfo = new ForkInfo(MainnetSpecProvider.Instance, _syncServer.Genesis.Hash!);
-            _protocolValidator = new ProtocolValidator(_nodeStatsManager, _blockTree, forkInfo, LimboLogs.Instance);
+            _peerManager = Substitute.For<IPeerManager>();
+            _networkConfig = new NetworkConfig();
+            _protocolValidator = new ProtocolValidator(_nodeStatsManager, _blockTree, forkInfo, _peerManager, _networkConfig, LimboLogs.Instance);
             _peerStorage = Substitute.For<INetworkStorage>();
             _syncPeerPool = Substitute.For<ISyncPeerPool>();
             _gossipPolicy = Substitute.For<IGossipPolicy>();
@@ -122,7 +126,6 @@ public class ProtocolsManagerTests
                 _peerStorage,
                 forkInfo,
                 _gossipPolicy,
-                new NetworkConfig(),
                 Substitute.For<IWorldStateManager>(),
                 LimboLogs.Instance);
         }

--- a/src/Nethermind/Nethermind.Network/ForkInfo.cs
+++ b/src/Nethermind/Nethermind.Network/ForkInfo.cs
@@ -16,7 +16,7 @@ using Nethermind.Synchronization;
 
 namespace Nethermind.Network
 {
-    public class ForkInfo
+    public class ForkInfo : IForkInfo
     {
         private Dictionary<uint, (ForkActivation Activation, ForkId Id)> DictForks { get; }
         private (ForkActivation Activation, ForkId Id)[] Forks { get; }

--- a/src/Nethermind/Nethermind.Network/IForkInfo.cs
+++ b/src/Nethermind/Nethermind.Network/IForkInfo.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Network;
+
+public interface IForkInfo
+{
+    ForkId GetForkId(long headNumber, ulong headTimestamp);
+
+    /// <summary>
+    /// Verify that the forkid from peer matches our forks.
+    /// </summary>
+    /// <param name="peerId"></param>
+    /// <param name="head"></param>
+    /// <returns></returns>
+    ValidationResult ValidateForkId(ForkId peerId, BlockHeader? head);
+}

--- a/src/Nethermind/Nethermind.Network/IPeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/IPeerManager.cs
@@ -13,5 +13,6 @@ namespace Nethermind.Network
         IReadOnlyCollection<Peer> ActivePeers { get; }
         IReadOnlyCollection<Peer> ConnectedPeers { get; }
         int MaxActivePeers { get; }
+        int ActivePeersCount { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/IProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/IProtocolsManager.cs
@@ -15,6 +15,5 @@ namespace Nethermind.Network
         void RemoveSupportedCapability(Capability capability);
         void SendNewCapability(Capability capability);
         void AddProtocol(string code, Func<ISession, IProtocolHandler> factory);
-        event EventHandler<ProtocolInitializedEventArgs> P2PProtocolInitialized;
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -29,7 +29,6 @@ public class P2PProtocolHandler(
     PublicKey localNodeId,
     INodeStatsManager nodeStatsManager,
     IMessageSerializationService serializer,
-    Regex? clientIdPattern,
     ILogManager logManager)
     : ProtocolHandlerBase(session, nodeStatsManager, serializer, logManager), IPingSender, IP2PProtocolHandler
 {
@@ -217,13 +216,6 @@ public class P2PProtocolHandler(
             Session.InitiateDisconnect(
                 DisconnectReason.NoCapabilityMatched,
                 $"capabilities: {string.Join(", ", capabilities)}");
-        }
-
-        if (clientIdPattern?.IsMatch(hello.ClientId) == false)
-        {
-            Session.InitiateDisconnect(
-                DisconnectReason.ClientFiltered,
-                $"clientId: {hello.ClientId}");
         }
 
         ReceivedProtocolInitMsg(hello);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -85,7 +85,14 @@ namespace Nethermind.Network
         public IReadOnlyCollection<Peer> ConnectedPeers => _peerPool.ActivePeers.Values.Where(IsConnected).ToList();
 
         public int MaxActivePeers => _networkConfig.MaxActivePeers + _peerPool.StaticPeerCount;
+        public int ActivePeersCount => _peerPool.ActivePeerCount;
         private int AvailableActivePeersCount => MaxActivePeers - _peerPool.ActivePeers.Count;
+
+        /// <summary>
+        /// Allow some incoming peer connection before disconnecting. This is to allow the protocol to be initialized
+        /// before disconnecting through <see cref="IProtocolValidator"/> so that disconnect message is sent properly
+        /// </summary>
+        private int MaxActivePeerMargin = 10;
 
         /// <summary>
         /// The simplest hack for now until it is cleaned further.
@@ -724,26 +731,11 @@ namespace Nethermind.Network
                 return;
             }
 
-            if (!session.Node.IsStatic && _peerPool.ActivePeers.Count >= MaxActivePeers)
+            if (!session.Node.IsStatic && ActivePeersCount >= MaxActivePeers + MaxActivePeerMargin)
             {
-                int initCount = 0;
-                foreach (KeyValuePair<PublicKeyAsKey, Peer> pair in _peerPool.ActivePeers)
-                {
-                    // we need to count initialized as we may have a list of active peers that is just being initialized
-                    // and we do not know yet whether they are fine or not
-                    if (pair.Value.InSession?.State == SessionState.Initialized ||
-                        pair.Value.OutSession?.State == SessionState.Initialized)
-                    {
-                        initCount++;
-                    }
-                }
-
-                if (initCount >= MaxActivePeers)
-                {
-                    if (_logger.IsTrace) _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
-                    session.InitiateDisconnect(DisconnectReason.HardLimitTooManyPeers, $"{initCount}");
-                    return;
-                }
+                if (_logger.IsTrace) _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
+                session.InitiateDisconnect(DisconnectReason.HardLimitTooManyPeers, $"{ActivePeersCount}");
+                return;
             }
 
             try

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -740,8 +740,8 @@ namespace Nethermind.Network
 
                 if (initCount >= MaxActivePeers)
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.TooManyPeers} {DisconnectType.Local}");
-                    session.InitiateDisconnect(DisconnectReason.TooManyPeers, $"{initCount}");
+                    if (_logger.IsTrace) _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
+                    session.InitiateDisconnect(DisconnectReason.HardLimitTooManyPeers, $"{initCount}");
                     return;
                 }
             }

--- a/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Network
     {
         private readonly INodeStatsManager _nodeStatsManager;
         private readonly IBlockTree _blockTree;
-        private readonly ForkInfo _forkInfo;
+        private readonly IForkInfo _forkInfo;
         private readonly ILogger _logger;
         private readonly Regex? _clientIdPattern;
         private readonly IPeerManager _peerManager;
@@ -29,7 +29,7 @@ namespace Nethermind.Network
         public ProtocolValidator(
             INodeStatsManager nodeStatsManager,
             IBlockTree blockTree,
-            ForkInfo forkInfo,
+            IForkInfo forkInfo,
             IPeerManager peerManager,
             INetworkConfig networkConfig,
             ILogManager logManager
@@ -68,7 +68,7 @@ namespace Nethermind.Network
                 return false;
             }
 
-            if (_peerManager.ActivePeers.Count > _peerManager.MaxActivePeers)
+            if (_peerManager.ActivePeersCount > _peerManager.MaxActivePeers)
             {
                 session.InitiateDisconnect(DisconnectReason.TooManyPeers, $"Too many peer");
                 return false;

--- a/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Text.RegularExpressions;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
@@ -21,13 +23,27 @@ namespace Nethermind.Network
         private readonly IBlockTree _blockTree;
         private readonly ForkInfo _forkInfo;
         private readonly ILogger _logger;
+        private readonly Regex? _clientIdPattern;
+        private readonly IPeerManager _peerManager;
 
-        public ProtocolValidator(INodeStatsManager nodeStatsManager, IBlockTree blockTree, ForkInfo forkInfo, ILogManager? logManager)
+        public ProtocolValidator(
+            INodeStatsManager nodeStatsManager,
+            IBlockTree blockTree,
+            ForkInfo forkInfo,
+            IPeerManager peerManager,
+            INetworkConfig networkConfig,
+            ILogManager logManager
+        )
         {
-            _logger = logManager?.GetClassLogger<ProtocolValidator>() ?? throw new ArgumentNullException(nameof(logManager));
-            _nodeStatsManager = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
-            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-            _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
+            if (networkConfig.ClientIdMatcher is not null)
+            {
+                _clientIdPattern = new Regex(networkConfig.ClientIdMatcher, RegexOptions.Compiled);
+            }
+            _logger = logManager.GetClassLogger<ProtocolValidator>();
+            _nodeStatsManager = nodeStatsManager;
+            _blockTree = blockTree;
+            _forkInfo = forkInfo;
+            _peerManager = peerManager;
         }
 
         public bool DisconnectOnInvalid(string protocol, ISession session, ProtocolInitializedEventArgs eventArgs)
@@ -43,7 +59,22 @@ namespace Nethermind.Network
         private bool ValidateP2PProtocol(ISession session, ProtocolInitializedEventArgs eventArgs)
         {
             P2PProtocolInitializedEventArgs args = (P2PProtocolInitializedEventArgs)eventArgs;
-            return ValidateP2PVersion(args.P2PVersion) || Disconnect(session, DisconnectReason.IncompatibleP2PVersion, CompatibilityValidationType.P2PVersion, $"p2p.{args.P2PVersion}");
+            bool valid = ValidateP2PVersion(args.P2PVersion) || Disconnect(session, DisconnectReason.IncompatibleP2PVersion, CompatibilityValidationType.P2PVersion, $"p2p.{args.P2PVersion}");
+            if (!valid) return false;
+
+            if (_clientIdPattern?.IsMatch(args.ClientId) == false)
+            {
+                session.InitiateDisconnect(DisconnectReason.ClientFiltered, $"clientId: {args.ClientId}");
+                return false;
+            }
+
+            if (_peerManager.ActivePeers.Count > _peerManager.MaxActivePeers)
+            {
+                session.InitiateDisconnect(DisconnectReason.TooManyPeers, $"Too many peer");
+                return false;
+            }
+
+            return true;
         }
 
         private bool ValidateEthProtocol(ISession session, ProtocolInitializedEventArgs eventArgs)

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -88,7 +88,7 @@ namespace Nethermind.Network
             IGossipPolicy gossipPolicy,
             IWorldStateManager worldStateManager,
             ILogManager logManager,
-            ITxGossipPolicy transactionsGossipPolicy)
+            ITxGossipPolicy? transactionsGossipPolicy = null)
         {
             _syncPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
             _syncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));


### PR DESCRIPTION
- On incoming connection, if the max active peer count is full, we immediately disconnect the peer. 
- This happen so early in the connection that the disconnect reason message is sent uncompressed as p2p handler does not have the opportunity to turn on compression.

## Changes

- PeerManager does not disconnect the peer unless active peer count exceed max active peer + margin.
- IProtocolValidator now check peer manager for peer limit.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Testing...