### PR TITLE
Moved unit tests to use IWorldState instead of ITrieStore

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -148,10 +148,8 @@ namespace Nethermind.AuRa.Test
 
         private (AuRaBlockProcessor Processor, IWorldState StateProvider) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)
         {
-            IDb stateDb = new MemDb();
-            IDb codeDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-            IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
             AuRaBlockProcessor processor = new AuRaBlockProcessor(
                 HoleskySpecProvider.Instance,

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -40,10 +40,8 @@ public class BlockProcessorTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Prepared_block_contains_author_field()
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
         BlockProcessor processor = new BlockProcessor(HoleskySpecProvider.Instance,
             TestBlockValidator.AlwaysValid,
@@ -71,10 +69,8 @@ public class BlockProcessorTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Recovers_state_on_cancel()
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
         BlockProcessor processor = new BlockProcessor(
             HoleskySpecProvider.Instance,

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
@@ -24,8 +24,8 @@ public class BlockhashProviderTests
 {
     private static IWorldState CreateWorldState()
     {
-        var trieStore = TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
-        var worldState = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState worldState = worldStateManager.GlobalWorldState;
         worldState.CreateAccount(Eip2935Constants.BlockHashHistoryAddress, 0, 1);
         worldState.Commit(Frontier.Instance);
         return worldState;

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
@@ -84,7 +84,15 @@ public class CopyTreeVisitorTests
     {
         LimboLogs logManager = LimboLogs.Instance;
         PatriciaTree trie = Build.A.Trie(new NodeStorage(trieDb, _keyScheme)).WithAccountsByIndex(0, 100).TestObject;
-        IStateReader stateReader = new StateReader(TestTrieStoreFactory.Build(trieDb, logManager), new MemDb(), logManager);
+        
+        // Create a custom DbProvider that uses the trieDb from the test
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.StateDb.Returns(trieDb);
+        dbProvider.CodeDb.Returns(new MemDb());
+        
+        // Use TestWorldStateFactory.CreateForTest() with the custom DbProvider
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, logManager);
+        IStateReader stateReader = worldStateManager.GlobalStateReader;
 
         if (_keyScheme == INodeStorage.KeyScheme.Hash)
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/GenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/GenesisLoaderTests.cs
@@ -56,10 +56,8 @@ public class GenesisLoaderTests
     {
         string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, chainspecPath);
         ChainSpec chainSpec = LoadChainSpec(path);
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
         specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Berlin.Instance);
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -42,8 +42,8 @@ public class ReorgTests
     {
         ISpecProvider specProvider = MainnetSpecProvider.Instance;
         IDbProvider memDbProvider = TestMemDbProvider.Init();
-        TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
-        WorldState stateProvider = new(trieStore, memDbProvider.CodeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(memDbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
 
         IReleaseSpec finalSpec = specProvider.GetFinalSpec();
 
@@ -62,7 +62,7 @@ public class ReorgTests
         stateProvider.Commit(specProvider.GenesisSpec);
         stateProvider.CommitTree(0);
 
-        StateReader stateReader = new(trieStore, memDbProvider.CodeDb, LimboLogs.Instance);
+        IStateReader stateReader = worldStateManager.GlobalStateReader;
         EthereumEcdsa ecdsa = new(1);
         ITransactionComparerProvider transactionComparerProvider =
             new TransactionComparerProvider(specProvider, _blockTree);

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -476,11 +476,9 @@ namespace Nethermind.Blockchain.Test
         [TestCaseSource(nameof(BlobTransactionOrderingTestCases))]
         public void Proper_transactions_selected(ProperTransactionsSelectedTestCase testCase)
         {
-            MemDb stateDb = new();
-            MemDb codeDb = new();
-            TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-            IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
-            StateReader _ = new(TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance), codeDb, LimboLogs.Instance);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
+            IStateReader _ = worldStateManager.GlobalStateReader;
             ISpecProvider specProvider = Substitute.For<ISpecProvider>();
 
             void SetAccountStates(IEnumerable<Address> missingAddresses)

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -260,10 +260,8 @@ namespace Nethermind.Blockchain.Test
         [TestCaseSource(nameof(EIP3860TestCases))]
         public void Proper_transactions_selected(TransactionSelectorTests.ProperTransactionsSelectedTestCase testCase)
         {
-            MemDb stateDb = new();
-            MemDb codeDb = new();
-            TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-            IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
             ISpecProvider specProvider = Substitute.For<ISpecProvider>();
 
             IReleaseSpec spec = testCase.ReleaseSpec;

--- a/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Consensus.Test;
 public class CensorshipDetectorTests
 {
     private ILogManager _logManager;
-    private WorldState _stateProvider;
+    private IWorldState _stateProvider;
     private IBlockTree _blockTree;
     private IBlockProcessor _blockProcessor;
     private ISpecProvider _specProvider;
@@ -46,9 +46,8 @@ public class CensorshipDetectorTests
     public void Setup()
     {
         _logManager = LimboLogs.Instance;
-        TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), _logManager);
-        MemDb codeDb = new();
-        _stateProvider = new WorldState(trieStore, codeDb, _logManager);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _blockProcessor = Substitute.For<IBlockProcessor>();
     }
 

--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
@@ -33,7 +33,7 @@ public class ExecutionProcessorTests
 {
     private ISpecProvider _specProvider;
     private ITransactionProcessor _transactionProcessor;
-    private WorldState _stateProvider;
+    private IWorldState _stateProvider;
     private IReleaseSpec _spec;
     private static readonly UInt256 AccountBalance = 1.Ether();
     private static readonly Address DepositContractAddress = Eip6110Constants.MainnetDepositContractAddress;
@@ -68,10 +68,8 @@ public class ExecutionProcessorTests
     public void Setup()
     {
         _specProvider = MainnetSpecProvider.Instance;
-        MemDb stateDb = new();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _stateProvider.CreateAccount(eip7002Account, AccountBalance);
         _stateProvider.CreateAccount(eip7251Account, AccountBalance);
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -42,6 +42,7 @@ using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Test;
 using Nethermind.State;
 using Nethermind.State.Repositories;
+using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 
@@ -500,7 +501,8 @@ public static class ContainerBuilderExtensions
         return builder
             // Need to manually create the WorldStateManager to expose the triestore which is normally hidden by PruningTrieStateFactory
             // This means it does not use pruning triestore by default though which is potential edge case.
-            .AddSingleton<TrieStore>(ctx => TestTrieStoreFactory.Build(ctx.Resolve<IDbProvider>().StateDb, LimboLogs.Instance))
+            .AddSingleton<TrieStore>(ctx =>
+                new TrieStore(new NodeStorage(ctx.Resolve<IDbProvider>().StateDb), No.Pruning, Persist.EveryBlock, ctx.Resolve<IPruningConfig>(), LimboLogs.Instance))
             .Bind<IPruningTrieStore, TrieStore>()
             .AddSingleton<IWorldStateManager>(ctx =>
             {

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Core.Test.Builders
 
             public static StateTree GetStateTree(ITrieStore? store = null)
             {
-                store ??= TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
+                store ??= new TestRawTrieStore(new MemDb());
 
                 var stateTree = new StateTree(store.GetTrieStore(null), LimboLogs.Instance);
 

--- a/src/Nethermind/Nethermind.Core.Test/TestRawTrieStore.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestRawTrieStore.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Core.Test;
+
+/// <summary>
+/// Expose <see cref="IPruningTrieStore"/> interface without actually having any pruning logic.
+/// <see cref="RawScopedTrieStore"/> does not have any concept of two level trie, just trie, because its for <see cref="PatriciaTree"/>.
+/// Note: If you are using this, consider interacting with <see cref="TestWorldStateFactory"/> instead, or if you
+/// actually don't need the whole worldstate or the two level trie, <see cref="RawScopedTrieStore"/>.
+/// </summary>
+/// <param name="nodeStorage"></param>
+/// <param name="isReadOnly"></param>
+public class TestRawTrieStore(INodeStorage nodeStorage, bool isReadOnly = false) : IPruningTrieStore, IReadOnlyTrieStore
+{
+    public TestRawTrieStore(IKeyValueStoreWithBatching kv) : this(new NodeStorage(kv))
+    {
+    }
+
+    void IDisposable.Dispose()
+    {
+    }
+
+    public ICommitter BeginCommit(Hash256? address, TrieNode? root, WriteFlags writeFlags)
+    {
+        if (isReadOnly) return NullCommitter.Instance;
+        return new RawScopedTrieStore.Committer(nodeStorage, address, writeFlags);
+    }
+
+    public TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256 hash)
+    {
+        return new TrieNode(NodeType.Unknown, hash);
+    }
+
+    public byte[]? LoadRlp(Hash256? address, in TreePath path, Hash256 hash, ReadFlags flags)
+    {
+        byte[]? ret = nodeStorage.Get(address, path, hash, flags);
+        if (ret is null) throw new MissingTrieNodeException("Node missing", address, path, hash);
+        return ret;
+    }
+
+    public byte[]? TryLoadRlp(Hash256? address, in TreePath path, Hash256 hash, ReadFlags flags)
+    {
+        return nodeStorage.Get(address, path, hash, flags);
+    }
+
+    public bool IsPersisted(Hash256? address, in TreePath path, in ValueHash256 keccak)
+    {
+        return nodeStorage.KeyExists(address, path, keccak);
+    }
+
+    public INodeStorage.KeyScheme Scheme { get; } = nodeStorage.Scheme;
+
+    public bool HasRoot(Hash256 stateRoot)
+    {
+        return nodeStorage.KeyExists(null, TreePath.Empty, stateRoot);
+    }
+
+    public IScopedTrieStore GetTrieStore(Hash256? address)
+    {
+        return new RawScopedTrieStore(nodeStorage, address);
+    }
+
+    public IBlockCommitter BeginBlockCommit(long blockNumber)
+    {
+        return NullCommitter.Instance;
+    }
+
+    public void PersistCache(CancellationToken cancellationToken)
+    {
+    }
+
+    public IReadOnlyTrieStore AsReadOnly(INodeStorage? store = null) =>
+        new TestRawTrieStore(nodeStorage, true);
+
+    public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached
+    {
+        add => throw new Exception("Unsupported operation");
+        remove => throw new Exception("Unsupported operation");
+    }
+
+    public IReadOnlyKeyValueStore TrieNodeRlpStore => throw new Exception("Unsupported operatioon");
+}

--- a/src/Nethermind/Nethermind.Core.Test/TestTrieStoreFactory.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestTrieStoreFactory.cs
@@ -13,15 +13,16 @@ public static class TestTrieStoreFactory
 {
     private static IPruningConfig _testPruningConfig = new PruningConfig()
     {
-        Mode = PruningMode.Full
+        Mode = PruningMode.Full,
+        DirtyNodeShardBit = 1,
     };
 
-    public static TrieStore Build(INodeStorage nodeStorage, ILogManager logManager)
+    public static TestRawTrieStore Build(INodeStorage nodeStorage, ILogManager logManager)
     {
-        return new TrieStore(nodeStorage, No.Pruning, Persist.EveryBlock, _testPruningConfig, logManager);
+        return new TestRawTrieStore(nodeStorage);
     }
 
-    public static TrieStore Build(IKeyValueStoreWithBatching keyValueStore, ILogManager logManager)
+    public static TestRawTrieStore Build(IKeyValueStoreWithBatching keyValueStore, ILogManager logManager)
     {
         return Build(new NodeStorage(keyValueStore), logManager);
     }

--- a/src/Nethermind/Nethermind.Core.Test/TestWorldStateFactory.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestWorldStateFactory.cs
@@ -1,18 +1,30 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Consensus.Validators;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
+using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Core.Test;
 
 public static class TestWorldStateFactory
 {
+    public static WorldStateManager CreateForTest()
+    {
+        return CreateForTest(TestMemDbProvider.Init(), LimboLogs.Instance);
+    }
+
     public static WorldStateManager CreateForTest(IDbProvider dbProvider, ILogManager logManager)
     {
-        IPruningTrieStore trieStore = TestTrieStoreFactory.Build(dbProvider.StateDb, logManager);
+        IPruningTrieStore trieStore = new TrieStore(
+            new NodeStorage(dbProvider.StateDb),
+            No.Pruning,
+            Persist.EveryBlock,
+            new PruningConfig(),
+            LimboLogs.Instance);
         IWorldState worldState = new WorldState(trieStore, dbProvider.CodeDb, logManager);
 
         return new WorldStateManager(worldState, trieStore, dbProvider, logManager);

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -39,9 +39,8 @@ namespace Nethermind.Evm.Benchmark
             ByteCode = Bytes.FromHexString(Environment.GetEnvironmentVariable("NETH.BENCHMARK.BYTECODE") ?? string.Empty);
             Console.WriteLine($"Running benchmark for bytecode {ByteCode?.ToHexString()}");
 
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));
-            IKeyValueStoreWithBatching codeDb = new MemDb();
-            _stateProvider = new WorldState(trieStore, codeDb, new OneLoggerLogManager(NullLogger.Instance));
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            _stateProvider = worldStateManager.GlobalWorldState;
             _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
             _stateProvider.Commit(_spec);
             CodeInfoRepository codeInfoRepository = new();

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -69,10 +69,8 @@ public class MultipleUnsignedOperations
     [GlobalSetup]
     public void GlobalSetup()
     {
-        TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));
-        IKeyValueStoreWithBatching codeDb = new MemDb();
-
-        _stateProvider = new WorldState(trieStore, codeDb, new OneLoggerLogManager(NullLogger.Instance));
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
         _stateProvider.Commit(_spec);
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -80,10 +80,8 @@ namespace Nethermind.Evm.Benchmark
         [GlobalSetup]
         public void GlobalSetup()
         {
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));
-            IKeyValueStoreWithBatching codeDb = new MemDb();
-
-            _stateProvider = new WorldState(trieStore, codeDb, new OneLoggerLogManager(NullLogger.Instance));
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            _stateProvider = worldStateManager.GlobalWorldState;
             _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
             _stateProvider.Commit(_spec);
 

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -64,10 +64,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(NotDelegationCodeCases))]
     public void TryGetDelegation_CodeIsNotDelegation_ReturnsFalse(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
         CodeInfoRepository sut = new();
@@ -94,10 +93,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(DelegationCodeCases))]
     public void TryGetDelegation_CodeTryGetDelegation_ReturnsTrue(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
         CodeInfoRepository sut = new();
@@ -108,10 +106,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(DelegationCodeCases))]
     public void TryGetDelegation_CodeTryGetDelegation_CorrectDelegationAddressIsSet(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
         CodeInfoRepository sut = new();
@@ -125,10 +122,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(DelegationCodeCases))]
     public void GetExecutableCodeHash_CodeTryGetDelegation_ReturnsHashOfDelegated(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
         Address delegationAddress = new Address(code.Slice(3, Address.Size));
@@ -144,10 +140,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(NotDelegationCodeCases))]
     public void GetExecutableCodeHash_CodeIsNotDelegation_ReturnsCodeHashOfAddress(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
 
@@ -159,10 +154,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(DelegationCodeCases))]
     public void GetCachedCodeInfo_CodeTryGetDelegation_ReturnsCodeOfDelegation(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
         Address delegationAddress = new Address(code.Slice(3, Address.Size));
@@ -178,10 +172,9 @@ public class CodeInfoRepositoryTests
     [TestCaseSource(nameof(NotDelegationCodeCases))]
     public void GetCachedCodeInfo_CodeIsNotDelegation_ReturnsCodeOfAddress(byte[] code)
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         stateProvider.InsertCode(TestItem.AddressA, code, Substitute.For<IReleaseSpec>());
 

--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -148,13 +148,8 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
         long blocknr = 12965000;
         long gas = 34218;
         ulong ts = 123456;
-        MemDb stateDb = new();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb,
-            LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(
-                trieStore,
-                new MemDb(),
-                LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         ISpecProvider specProvider = new TestSpecProvider(London.Instance);
         CodeInfoRepository codeInfoRepository = new();
         VirtualMachine virtualMachine = new(

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -387,9 +387,8 @@ namespace Nethermind.Evm.Test.Tracing
             public TestEnvironment()
             {
                 _specProvider = MainnetSpecProvider.Instance;
-                MemDb stateDb = new();
-                TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-                _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+                IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+                _stateProvider = worldStateManager.GlobalWorldState;
                 _stateProvider.CreateAccount(TestItem.AddressA, 1.Ether());
                 _stateProvider.Commit(_specProvider.GenesisSpec);
                 _stateProvider.CommitTree(0);

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -32,10 +32,9 @@ internal class TransactionProcessorEip4844Tests
     [SetUp]
     public void Setup()
     {
-        MemDb stateDb = new();
         _specProvider = new TestSpecProvider(Cancun.Instance);
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         CodeInfoRepository codeInfoRepository = new();
         VirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
         _transactionProcessor = new TransactionProcessor(_specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7623Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7623Tests.cs
@@ -32,10 +32,9 @@ public class TransactionProcessorEip7623Tests
     [SetUp]
     public void Setup()
     {
-        MemDb stateDb = new();
         _specProvider = new TestSpecProvider(Prague.Instance);
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         CodeInfoRepository codeInfoRepository = new();
         VirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
         _transactionProcessor = new TransactionProcessor(_specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7702Tests.cs
@@ -35,10 +35,9 @@ internal class TransactionProcessorEip7702Tests
     [SetUp]
     public void Setup()
     {
-        MemDb stateDb = new();
         _specProvider = new TestSpecProvider(Prague.Instance);
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         CodeInfoRepository codeInfoRepository = new();
         VirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
         _transactionProcessor = new TransactionProcessor(_specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
@@ -37,9 +37,8 @@ public class TransactionProcessorFeeTests
         _spec = new(PragueGnosis.Instance);
         _specProvider = new TestSpecProvider(_spec);
 
-        TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
-
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _stateProvider.CreateAccount(TestItem.AddressA, 1.Ether());
         _stateProvider.Commit(_specProvider.GenesisSpec);
         _stateProvider.CommitTree(0);

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
@@ -52,10 +52,8 @@ public class TransactionProcessorTests
     [SetUp]
     public void Setup()
     {
-        MemDb stateDb = new();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        PreBlockCaches preBlockCaches = new();
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance, preBlockCaches);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _stateProvider.CreateAccount(TestItem.AddressA, AccountBalance);
         _stateProvider.Commit(_specProvider.GenesisSpec);
         _stateProvider.CommitTree(0);

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -62,10 +62,10 @@ public abstract class VirtualMachineTestsBase
     {
         ILogManager logManager = GetLogManager();
 
-        IDb codeDb = new MemDb();
         _stateDb = new MemDb();
-        ITrieStore trieStore = TestTrieStoreFactory.Build(_stateDb, logManager);
-        TestState = new WorldState(trieStore, codeDb, logManager);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, logManager);
+        TestState = worldStateManager.GlobalWorldState;
         _ethereumEcdsa = new EthereumEcdsa(SpecProvider.ChainId);
         IBlockhashProvider blockhashProvider = new TestBlockhashProvider(SpecProvider);
         CodeInfoRepository = new CodeInfoRepository();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
@@ -31,9 +31,9 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -64,9 +64,9 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -67,7 +67,9 @@ namespace Nethermind.JsonRpc.Test.Modules
             peerManager.ConnectedPeers.Returns(new List<Peer> { peerA, peerB, peerA, peerC, peerB });
             peerManager.MaxActivePeers.Returns(15);
 
-            WorldState stateProvider = new(TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
 
             _blockTree = Build.A.BlockTree()
                 .WithoutSettingHead

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -879,7 +879,8 @@ public class ProofRpcModuleTests
 
     private WorldState CreateInitialState(byte[]? code)
     {
-        WorldState stateProvider = new(TestTrieStoreFactory.Build(_dbProvider.StateDb, LimboLogs.Instance), _dbProvider.CodeDb, LimboLogs.Instance);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(_dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         AddAccount(stateProvider, TestItem.AddressA, 1.Ether());
         AddAccount(stateProvider, TestItem.AddressB, 1.Ether());
 
@@ -895,16 +896,16 @@ public class ProofRpcModuleTests
 
         stateProvider.CommitTree(0);
 
-        return stateProvider;
+        return (WorldState)stateProvider;
     }
 
-    private void AddAccount(WorldState stateProvider, Address account, UInt256 initialBalance)
+    private void AddAccount(IWorldState stateProvider, Address account, UInt256 initialBalance)
     {
         stateProvider.CreateAccount(account, initialBalance);
         stateProvider.Commit(MuirGlacier.Instance, NullStateTracer.Instance);
     }
 
-    private void AddCode(WorldState stateProvider, Address account, byte[] code)
+    private void AddCode(IWorldState stateProvider, Address account, byte[] code)
     {
         stateProvider.InsertCode(account, code, MuirGlacier.Instance);
         stateProvider.Commit(MainnetSpecProvider.Instance.GenesisSpec, NullStateTracer.Instance);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -62,11 +62,10 @@ public class ParityStyleTracerTests
             .WithSpecProvider(specProvider)
             .TestObject;
 
-        MemDb stateDb = new();
-        MemDb codeDb = new();
-        ITrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance).AsReadOnly();
-        WorldState stateProvider = new(trieStore, codeDb, LimboLogs.Instance);
-        _stateReader = new StateReader(trieStore, codeDb, LimboLogs.Instance);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
+        _stateReader = worldStateManager.GlobalStateReader;
 
         BlockhashProvider blockhashProvider = new(_blockTree, specProvider, stateProvider, LimboLogs.Instance);
         CodeInfoRepository codeInfoRepository = new();

--- a/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
@@ -55,7 +55,8 @@ namespace Nethermind.Network.Benchmarks
             NodeStatsManager stats = new NodeStatsManager(TimerFactory.Default, LimboLogs.Instance);
             var ecdsa = new EthereumEcdsa(TestBlockchainIds.ChainId);
             var tree = Build.A.BlockTree().TestObject;
-            var stateProvider = new WorldState(TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
+            WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
             var specProvider = MainnetSpecProvider.Instance;
             TxPool.TxPool txPool = new TxPool.TxPool(
                 ecdsa,

--- a/src/Nethermind/Nethermind.Optimism.Test/Create2DeployerContractRewriterTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Create2DeployerContractRewriterTests.cs
@@ -21,23 +21,31 @@ internal class Create2DeployerContractRewriterTests
     public void Test_Create2DeployerContractRewriter_Ensures_Preinstallation()
     {
         BlockTree blockTree = Build.A.BlockTree().OfChainLength(2).TestObject;
-        BlockHeader canyonHeader = blockTree.FindHeader(1, BlockTreeLookupOptions.None)!;
+        BlockHeader? canyonHeader = blockTree.FindHeader(1, BlockTreeLookupOptions.None);
+        Assert.That(canyonHeader, Is.Not.Null, "Canyon header should not be null");
 
+        // Use a default timestamp if canyonHeader is null (which shouldn't happen due to the assertion)
+        ulong canyonTimestamp = canyonHeader != null ? canyonHeader.Timestamp : 0;
+        
         OptimismSpecHelper specHelper = new(new OptimismChainSpecEngineParameters
         {
-            CanyonTimestamp = canyonHeader.Timestamp,
+            CanyonTimestamp = canyonTimestamp,
         });
 
-        MemDb stateDb = new();
-        MemDb codeDb = new();
-        TrieStore ts = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        WorldState ws = new(ts, codeDb, LimboLogs.Instance);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState ws = worldStateManager.GlobalWorldState;
 
         Create2DeployerContractRewriter rewriter = new(specHelper, new TestSingleReleaseSpecProvider(Cancun.Instance), blockTree);
 
-        rewriter.RewriteContract(blockTree.FindHeader(1, BlockTreeLookupOptions.None)!, ws);
+        BlockHeader? header = blockTree.FindHeader(1, BlockTreeLookupOptions.None);
+        Assert.That(header, Is.Not.Null, "Header should not be null");
+        if (header != null)
+        {
+            rewriter.RewriteContract(header, ws);
+        }
 
-        byte[] setCode = ws.GetCode(PreInstalls.Create2Deployer);
-        Assert.That(setCode, Is.Not.Empty);
+        byte[]? setCode = ws.GetCode(PreInstalls.Create2Deployer);
+        Assert.That(setCode, Is.Not.Null, "Code should not be null");
+        Assert.That(setCode, Is.Not.Empty, "Code should not be empty");
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismWithdrawalTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismWithdrawalTests.cs
@@ -29,10 +29,8 @@ public class OptimismWithdrawalTests
     [TestCaseSource(nameof(WithdrawalsRootData))]
     public void WithdrawalsRoots_Should_Be_Set_According_To_Block_Timestamp(ulong timestamp, Hash256? withdrawalHash)
     {
-        using var db = new MemDb();
-        using var store = TestTrieStoreFactory.Build(db, TestLogManager.Instance);
-
-        var state = new WorldState(store, NullDb.Instance, TestLogManager.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        var state = worldStateManager.GlobalWorldState;
 
         var genesis = Build.A.BlockHeader
             .WithNumber(0)
@@ -83,10 +81,8 @@ public class OptimismWithdrawalTests
     [Test]
     public void WithdrawalsRoot_IsAlwaysUpToDate_PostIsthmus()
     {
-        using var db = new MemDb();
-        using var store = TestTrieStoreFactory.Build(db, TestLogManager.Instance);
-
-        var state = new WorldState(store, NullDb.Instance, TestLogManager.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        var state = worldStateManager.GlobalWorldState;
         var processor = new OptimismWithdrawalProcessor(state, TestLogManager.Instance, Spec.Instance);
         var releaseSpec = Substitute.For<IReleaseSpec>();
 

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -268,9 +268,9 @@ namespace Nethermind.Store.Test.Proofs
         public void Storage_proofs_have_values_set()
         {
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(UInt256.Zero, Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000"));
             storageTree.Set(UInt256.One, Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000"));
             storageTree.Commit();
@@ -292,9 +292,9 @@ namespace Nethermind.Store.Test.Proofs
         public void Storage_proofs_have_keys_set()
         {
             IDb memDb = new MemDb();
-            ITrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(UInt256.Zero, Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000"));
             storageTree.Set(UInt256.One, Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000"));
             storageTree.Commit();
@@ -320,9 +320,9 @@ namespace Nethermind.Store.Test.Proofs
             byte[] c = Bytes.FromHexString("0x0000000000cccccccccccccccccccccccccccccccccccccccccccccccccccccc");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -356,9 +356,9 @@ namespace Nethermind.Store.Test.Proofs
             byte[] e = Bytes.FromHexString("0x0000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -396,9 +396,9 @@ namespace Nethermind.Store.Test.Proofs
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -436,9 +436,9 @@ namespace Nethermind.Store.Test.Proofs
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(e).Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -471,7 +471,7 @@ namespace Nethermind.Store.Test.Proofs
         public void Shows_empty_values_when_account_is_missing()
         {
             IDb memDb = new MemDb();
-            StateTree tree = new(TestTrieStoreFactory.Build(memDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTree tree = new(new RawScopedTrieStore(memDb), LimboLogs.Instance);
             _ = new byte[] { 1, 2, 3 };
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressB, account2);
@@ -500,9 +500,9 @@ namespace Nethermind.Store.Test.Proofs
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -591,8 +591,8 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             int storageCount = lines.Length - 2;
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
 
             Address address = new(Bytes.FromHexString(lines[0]));
             int accountIndex = int.Parse(lines[1]);
@@ -606,7 +606,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             addressWithStorage.StorageCells = new StorageCell[storageCount];
             addressWithStorage.Address = address;
 
-            StorageTree storageTree = new(trieStore.GetTrieStore(address), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            StorageTree storageTree = new(new RawScopedTrieStore(memDb, address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             for (int j = 0; j < storageCount; j++)
             {
                 UInt256 index = UInt256.Parse(lines[j + 2].Replace("storage: ", string.Empty));
@@ -644,7 +644,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             for (int j = 0; j < accountProof.StorageProofs.Length; j++)
             {
                 TrieNode node = new(NodeType.Unknown, accountProof.StorageProofs[j].Proof.Last());
-                node.ResolveNode(TestTrieStoreFactory.Build(memDb, NullLogManager.Instance).GetTrieStore(null), TreePath.Empty);
+                node.ResolveNode(new RawScopedTrieStore(memDb), TreePath.Empty);
                 if (node.Value.Length != 1)
                 {
                     TestContext.Out.WriteLine($"{j}");
@@ -680,13 +680,13 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             }
 
             IDb memDb = new MemDb();
-            TrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-            StateTree tree = new(trieStore, LimboLogs.Instance);
+            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
+            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
 
             for (int i = 0; i < accountsCount; i++)
             {
                 Account account = Build.An.Account.WithBalance((UInt256)i).TestObject;
-                StorageTree storageTree = new(trieStore.GetTrieStore(addressesWithStorage[i].Address), Keccak.EmptyTreeHash, LimboLogs.Instance);
+                StorageTree storageTree = new(new RawScopedTrieStore(memDb, addressesWithStorage[i].Address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
                 for (int j = 0; j < i; j++)
                 {
                     storageTree.Set(addressesWithStorage[i].StorageCells[j].Index, new byte[1] { 1 });

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -16,8 +16,6 @@ using Nethermind.Evm.Tracing.ParityStyle;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie;
-using Nethermind.Trie.Pruning;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test;
@@ -33,14 +31,13 @@ public class StateProviderTests
     [Test]
     public void Eip_158_zero_value_transfer_deletes()
     {
-        var codeDb = new MemDb();
-        var trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-        WorldState frontierProvider = new(trieStore, codeDb, Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState frontierProvider = worldStateManager.GlobalWorldState;
         frontierProvider.CreateAccount(_address1, 0);
         frontierProvider.Commit(Frontier.Instance);
         frontierProvider.CommitTree(0);
 
-        WorldState provider = new(trieStore, codeDb, Logger);
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.StateRoot = frontierProvider.StateRoot;
 
         provider.AddToBalance(_address1, 0, SpuriousDragon.Instance);
@@ -51,9 +48,8 @@ public class StateProviderTests
     [Test]
     public void Eip_158_touch_zero_value_system_account_is_not_deleted()
     {
-        var codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-        WorldState provider = new(trieStore, codeDb, Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         var systemUser = Address.SystemUser;
 
         provider.CreateAccount(systemUser, 0);
@@ -63,13 +59,14 @@ public class StateProviderTests
         provider.InsertCode(systemUser, System.Text.Encoding.UTF8.GetBytes(""), releaseSpec);
         provider.Commit(releaseSpec);
 
-        provider.GetAccount(systemUser).Should().NotBeNull();
+        ((WorldState)provider).GetAccount(systemUser).Should().NotBeNull();
     }
 
     [Test]
     public void Can_dump_state()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(TestItem.AddressA, 1.Ether());
         provider.Commit(MuirGlacier.Instance);
         provider.CommitTree(0);
@@ -81,7 +78,8 @@ public class StateProviderTests
     [Test]
     public void Can_accepts_visitors()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), Substitute.For<IDb>(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(TestItem.AddressA, 1.Ether());
         provider.Commit(MuirGlacier.Instance);
         provider.CommitTree(0);
@@ -93,7 +91,8 @@ public class StateProviderTests
     [Test]
     public void Empty_commit_restore()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.Commit(Frontier.Instance);
         provider.Restore(Snapshot.Empty);
     }
@@ -101,14 +100,16 @@ public class StateProviderTests
     [Test]
     public void Update_balance_on_non_existing_account_throws()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         Assert.Throws<InvalidOperationException>(() => provider.AddToBalance(TestItem.AddressA, 1.Ether(), Olympic.Instance));
     }
 
     [Test]
     public void Is_empty_account()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(_address1, 0);
         provider.Commit(Frontier.Instance);
         Assert.That(provider.IsEmptyAccount(_address1), Is.True);
@@ -117,7 +118,8 @@ public class StateProviderTests
     [Test]
     public void Returns_empty_byte_code_for_non_existing_accounts()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         byte[] code = provider.GetCode(TestItem.AddressA);
         code.Should().BeEmpty();
     }
@@ -125,7 +127,8 @@ public class StateProviderTests
     [Test]
     public void Restore_update_restore()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(_address1, 0);
         provider.AddToBalance(_address1, 1, Frontier.Instance);
         provider.AddToBalance(_address1, 1, Frontier.Instance);
@@ -151,7 +154,8 @@ public class StateProviderTests
     [Test]
     public void Keep_in_cache()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(_address1, 0);
         provider.Commit(Frontier.Instance);
         provider.GetBalance(_address1);
@@ -169,7 +173,8 @@ public class StateProviderTests
     {
         byte[] code = [1];
 
-        IWorldState provider = new WorldState(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(_address1, 1);
         provider.AddToBalance(_address1, 1, Frontier.Instance);
         provider.IncrementNonce(_address1);
@@ -208,9 +213,11 @@ public class StateProviderTests
     {
         ParityLikeTxTracer tracer = new(Build.A.Block.TestObject, null, ParityTraceTypes.StateDiff);
 
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(_address1, 0);
-        Account account = provider.GetAccount(_address1);
+        provider.TryGetAccount(_address1, out AccountStruct account);
+
         Assert.That(account.IsEmpty, Is.True);
         provider.Commit(Frontier.Instance); // commit empty account (before the empty account fix in Spurious Dragon)
         Assert.That(provider.AccountExists(_address1), Is.True);
@@ -225,7 +232,8 @@ public class StateProviderTests
     [Test]
     public void Does_not_require_recalculation_after_reset()
     {
-        WorldState provider = new(TestTrieStoreFactory.Build(new MemDb(), Logger), new MemDb(), Logger);
+        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState provider = worldStateManager.GlobalWorldState;
         provider.CreateAccount(TestItem.AddressA, 5);
 
         Action action = () => { _ = provider.StateRoot; };

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -32,9 +32,9 @@ namespace Nethermind.Store.Test
         public async Task Can_ask_about_balance_in_parallel()
         {
             IReleaseSpec spec = MainnetSpecProvider.Instance.GetSpec((ForkActivation)MainnetSpecProvider.ConstantinopleFixBlockNumber);
-            MemDb stateDb = new();
-            WorldState provider =
-                new(TestTrieStoreFactory.Build(stateDb, Logger), Substitute.For<IDb>(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState provider = worldStateManager.GlobalWorldState;
             provider.CreateAccount(_address1, 0);
             provider.AddToBalance(_address1, 1, spec);
             provider.Commit(spec);
@@ -58,8 +58,7 @@ namespace Nethermind.Store.Test
 
             provider.CommitTree(0);
 
-            StateReader reader =
-                new(TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance), Substitute.For<IDb>(), Logger);
+            IStateReader reader = worldStateManager.GlobalStateReader;
 
             Task a = StartTask(reader, stateRoot0, 1);
             Task b = StartTask(reader, stateRoot1, 2);
@@ -74,9 +73,9 @@ namespace Nethermind.Store.Test
         {
             StorageCell storageCell = new(_address1, UInt256.One);
             IReleaseSpec spec = MuirGlacier.Instance;
-            MemDb stateDb = new();
-            TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, Logger);
-            WorldState provider = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState provider = worldStateManager.GlobalWorldState;
 
             void UpdateStorageValue(byte[] newValue)
             {
@@ -117,8 +116,7 @@ namespace Nethermind.Store.Test
             CommitEverything();
             Hash256 stateRoot3 = provider.StateRoot;
 
-            StateReader reader =
-                new(TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance), Substitute.For<IDb>(), Logger);
+            IStateReader reader = worldStateManager.GlobalStateReader;
 
             Task a = StartStorageTask(reader, stateRoot0, storageCell, new byte[] { 1 });
             Task b = StartStorageTask(reader, stateRoot1, storageCell, new byte[] { 2 });
@@ -134,9 +132,8 @@ namespace Nethermind.Store.Test
             StorageCell storageCell = new(_address1, UInt256.One);
             IReleaseSpec spec = MuirGlacier.Instance;
 
-            MemDb stateDb = new();
-            TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, Logger);
-            WorldState provider = new(trieStore, new MemDb(), Logger);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState provider = worldStateManager.GlobalWorldState;
 
             void CommitEverything()
             {
@@ -149,12 +146,11 @@ namespace Nethermind.Store.Test
             CommitEverything();
             Hash256 stateRoot0 = provider.StateRoot;
 
-            StateReader reader =
-                new(TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance), Substitute.For<IDb>(), Logger);
+            IStateReader reader = worldStateManager.GlobalStateReader;
             reader.GetStorage(stateRoot0, _address1, storageCell.Index + 1).ToArray().Should().BeEquivalentTo(new byte[] { 0 });
         }
 
-        private Task StartTask(StateReader reader, Hash256 stateRoot, UInt256 value)
+        private Task StartTask(IStateReader reader, Hash256 stateRoot, UInt256 value)
         {
             return Task.Run(
                 () =>
@@ -167,7 +163,7 @@ namespace Nethermind.Store.Test
                 });
         }
 
-        private Task StartStorageTask(StateReader reader, Hash256 stateRoot, StorageCell storageCell, byte[] value)
+        private Task StartStorageTask(IStateReader reader, Hash256 stateRoot, StorageCell storageCell, byte[] value)
         {
             return Task.Run(
                 () =>
@@ -181,15 +177,14 @@ namespace Nethermind.Store.Test
         }
 
         [Test]
-        public async Task Get_storage()
+        public void Get_storage()
         {
-            IDbProvider dbProvider = await TestMemDbProvider.InitAsync();
-
             /* all testing will be touching just a single storage cell */
             StorageCell storageCell = new(_address1, UInt256.One);
 
-            TrieStore trieStore = TestTrieStoreFactory.Build(dbProvider.StateDb, Logger);
-            WorldState state = new(trieStore, dbProvider.CodeDb, Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState state = worldStateManager.GlobalWorldState;
 
             /* to start with we need to create an account that we will be setting storage at */
             state.CreateAccount(storageCell.Address, UInt256.One);
@@ -203,8 +198,7 @@ namespace Nethermind.Store.Test
             state.Commit(MuirGlacier.Instance);
             state.CommitTree(2);
 
-            StateReader reader = new(
-                TestTrieStoreFactory.Build(dbProvider.StateDb, LimboLogs.Instance), dbProvider.CodeDb, Logger);
+            IStateReader reader = worldStateManager.GlobalStateReader;
 
             var retrieved = reader.GetStorage(state.StateRoot, _address1, storageCell.Index).ToArray();
             retrieved.Should().BeEquivalentTo(initialValue);
@@ -217,8 +211,7 @@ namespace Nethermind.Store.Test
 
             byte[] newValue = new byte[] { 1, 2, 3, 4, 5 };
 
-            WorldState processorStateProvider =
-                new(trieStore, new MemDb(), LimboLogs.Instance);
+            IWorldState processorStateProvider = state; // They are the same
             processorStateProvider.StateRoot = state.StateRoot;
 
             processorStateProvider.Set(storageCell, newValue);
@@ -238,13 +231,14 @@ namespace Nethermind.Store.Test
         [Test]
         public void Can_collect_stats()
         {
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState provider = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState provider = worldStateManager.GlobalWorldState;
             provider.CreateAccount(TestItem.AddressA, 1.Ether());
             provider.Commit(MuirGlacier.Instance);
             provider.CommitTree(0);
 
-            StateReader stateReader = new StateReader(trieStore.AsReadOnly(), new MemDb(), Logger);
+            IStateReader stateReader = worldStateManager.GlobalStateReader;
             var stats = stateReader.CollectStats(provider.StateRoot, new MemDb(), Logger);
             stats.AccountCount.Should().Be(1);
         }
@@ -255,8 +249,9 @@ namespace Nethermind.Store.Test
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip3607Enabled.Returns(true);
             releaseSpec.IsEip7702Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             sut.InsertCode(TestItem.AddressA, ValueKeccak.Compute(new byte[1]), new byte[1], releaseSpec, false);
             sut.Commit(MuirGlacier.Instance);
@@ -273,8 +268,9 @@ namespace Nethermind.Store.Test
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip3607Enabled.Returns(true);
             releaseSpec.IsEip7702Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             sut.Commit(MuirGlacier.Instance);
             sut.CommitTree(0);
@@ -290,8 +286,9 @@ namespace Nethermind.Store.Test
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip3607Enabled.Returns(true);
             releaseSpec.IsEip7702Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             byte[] code = [.. Eip7702Constants.DelegationHeader, .. new byte[20]];
             sut.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code), code, releaseSpec, false);
@@ -309,8 +306,9 @@ namespace Nethermind.Store.Test
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip3607Enabled.Returns(true);
             releaseSpec.IsEip7702Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             byte[] code = new byte[20];
             sut.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code), code, releaseSpec, false);
@@ -327,8 +325,9 @@ namespace Nethermind.Store.Test
         {
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip3607Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             byte[] code = [.. Eip7702Constants.DelegationHeader, .. new byte[20]];
             sut.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code), code, releaseSpec, false);
@@ -345,8 +344,9 @@ namespace Nethermind.Store.Test
         {
             IReleaseSpec releaseSpec = Substitute.For<IReleaseSpec>();
             releaseSpec.IsEip7702Enabled.Returns(true);
-            TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(), Logger);
-            WorldState sut = new(trieStore, new MemDb(), Logger);
+            IDbProvider dbProvider = TestMemDbProvider.Init();
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
+            IWorldState sut = worldStateManager.GlobalWorldState;
             sut.CreateAccount(TestItem.AddressA, 0);
             byte[] code = [.. Eip7702Constants.DelegationHeader, .. new byte[20]];
             sut.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code), code, releaseSpec, false);

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -202,7 +202,7 @@ public class RangeQueryVisitorTests
     [Test]
     public void StorageRangeFetchVisitor()
     {
-        TrieStore store = TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
+        TestRawTrieStore store = TestTrieStoreFactory.Build(new MemDb(), LimboLogs.Instance);
         (StateTree inputStateTree, StorageTree _, Hash256 account) = TestItem.Tree.GetTrees(store);
 
         RlpCollector leafCollector = new();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -52,8 +52,7 @@ public class RecreateStateFromAccountRangesTests
         byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
         MemDb db = new();
-        TrieStore fullStore = TestTrieStoreFactory.Build(db, LimboLogs.Instance);
-        IScopedTrieStore store = fullStore.GetTrieStore(null);
+        IScopedTrieStore store = new RawScopedTrieStore(db);
         StateTree tree = new(store, LimboLogs.Instance);
 
         IList<TrieNode> nodes = new List<TrieNode>();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using Autofac;
 using Nethermind.Core;
@@ -17,7 +18,6 @@ using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
-using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.SnapSync
@@ -26,7 +26,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
     public class RecreateStateFromStorageRangesTests
     {
 
-        private TrieStore _store;
+        private TestRawTrieStore _store;
         private StateTree _inputStateTree;
         private StorageTree _inputStorageTree;
         private Hash256 _storage;
@@ -39,7 +39,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
         }
 
         [OneTimeTearDown]
-        public void TearDown() => _store?.Dispose();
+        public void TearDown() => ((IDisposable)_store)?.Dispose();
 
         [Test]
         public void RecreateStorageStateFromOneRangeWithNonExistenceProof()

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -190,7 +190,7 @@ public class SnapProviderTests
     private static (SnapServer, Hash256) BuildSnapServerFromEntries((Hash256, Account)[] entries)
     {
         TestMemDb stateDb = new TestMemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
+        TestRawTrieStore trieStore = new TestRawTrieStore(stateDb);
         StateTree st = new StateTree(trieStore, LimboLogs.Instance);
         foreach (var entry in entries)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -38,7 +38,7 @@ public class SnapServerTest
     {
         MemDb stateDbServer = new();
         MemDb codeDbServer = new();
-        TrieStore store = TestTrieStoreFactory.Build(stateDbServer, LimboLogs.Instance);
+        TestRawTrieStore store = new TestRawTrieStore(stateDbServer);
         StateTree tree = new(store, LimboLogs.Instance);
         SnapServer server = new(store.AsReadOnly(), codeDbServer, stateRootTracker ?? CreateConstantStateRootTracker(true), LimboLogs.Instance, lastNStateRootTracker);
 
@@ -263,7 +263,7 @@ public class SnapServerTest
     {
         MemDb stateDb = new MemDb();
         MemDb codeDb = new MemDb();
-        TrieStore store = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
+        TestRawTrieStore store = new TestRawTrieStore(stateDb);
 
         (StateTree inputStateTree, StorageTree inputStorageTree, Hash256 _) = TestItem.Tree.GetTrees(store);
 
@@ -303,7 +303,7 @@ public class SnapServerTest
     {
         MemDb stateDb = new MemDb();
         MemDb codeDb = new MemDb();
-        TrieStore store = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
+        TestRawTrieStore store = new TestRawTrieStore(stateDb);
 
         (StateTree inputStateTree, StorageTree inputStorageTree, Hash256 _) = TestItem.Tree.GetTrees(store);
 
@@ -333,7 +333,7 @@ public class SnapServerTest
     {
         MemDb stateDb = new MemDb();
         MemDb codeDb = new MemDb();
-        TrieStore store = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
+        TestRawTrieStore store = new TestRawTrieStore(stateDb);
 
         (StateTree inputStateTree, StorageTree inputStorageTree, Hash256 _) = TestItem.Tree.GetTrees(store, 10000);
 
@@ -383,7 +383,7 @@ public class SnapServerTest
     {
         MemDb stateDb = new MemDb();
         MemDb codeDb = new MemDb();
-        TrieStore store = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
+        TestRawTrieStore store = new TestRawTrieStore(stateDb);
 
         StateTree stateTree = new(store, LimboLogs.Instance);
 

--- a/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
@@ -28,7 +28,7 @@ public class TransactionProcessorTests
     private readonly ISpecProvider _specProvider;
     private readonly IEthereumEcdsa _ethereumEcdsa;
     private TaikoTransactionProcessor? _transactionProcessor;
-    private WorldState? _stateProvider;
+    private IWorldState? _stateProvider;
 
     public TransactionProcessorTests()
     {
@@ -44,9 +44,8 @@ public class TransactionProcessorTests
     {
         _spec.FeeCollector = TestItem.AddressB;
 
-        MemDb stateDb = new();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _stateProvider.CreateAccount(TestItem.AddressA, AccountBalance);
         _stateProvider.Commit(_specProvider.GenesisSpec);
         _stateProvider.CommitTree(0);

--- a/src/Nethermind/Nethermind.Trie.Test/OverlayTrieStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/OverlayTrieStoreTests.cs
@@ -20,7 +20,7 @@ public class OverlayTrieStoreTests
     public void TrieStore_OverlayExistingStore()
     {
         IDbProvider dbProvider = TestMemDbProvider.Init();
-        TrieStore existingStore = TestTrieStoreFactory.Build(dbProvider.StateDb, LimboLogs.Instance);
+        TestRawTrieStore existingStore = new TestRawTrieStore(dbProvider.StateDb);
 
         PatriciaTree patriciaTree = new PatriciaTree(existingStore, LimboLogs.Instance);
         patriciaTree.Set(TestItem.Keccaks[0].Bytes, TestItem.Keccaks[0].BytesToArray());

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Trie.Test
                 _pruningStrategy = pruningStrategy;
 
                 _pruningConfig = pruningConfig ?? new PruningConfig() { TrackPastKeys = false };
-                _trieStore = TestTrieStoreFactory.Build(_dbProvider.StateDb, _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
+                _trieStore = new TrieStore(new NodeStorage(_dbProvider.StateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
                 _stateProvider = new WorldState(_trieStore, _dbProvider.CodeDb, _logManager);
                 _stateReader = new StateReader(_trieStore, _dbProvider.CodeDb, _logManager);
             }
@@ -224,7 +224,7 @@ namespace Nethermind.Trie.Test
             public PruningContext DisposeAndRecreate()
             {
                 _trieStore.Dispose();
-                _trieStore = TestTrieStoreFactory.Build(_dbProvider.StateDb, _pruningStrategy, _persistenceStrategy, _logManager);
+                _trieStore = new TrieStore(new NodeStorage(_dbProvider.StateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
                 _stateProvider = new WorldState(_trieStore, _dbProvider.CodeDb, _logManager);
                 _stateReader = new StateReader(_trieStore, _dbProvider.CodeDb, _logManager);
                 return this;

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -1074,8 +1074,8 @@ namespace Nethermind.Trie.Test
 
             Queue<Hash256> rootQueue = new();
 
-            using TrieStore trieStore = trieStoreConfigurations.CreateTrieStore();
-            WorldState stateProvider = new WorldState(trieStore, new MemDb(), _logManager);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            IWorldState stateProvider = worldStateManager.GlobalWorldState;
 
             Account[] accounts = new Account[accountsCount];
             Address[] addresses = new Address[accountsCount];
@@ -1110,7 +1110,8 @@ namespace Nethermind.Trie.Test
 
                         if (stateProvider.AccountExists(address))
                         {
-                            Account existing = stateProvider.GetAccount(address);
+                            stateProvider.TryGetAccount(address, out AccountStruct existingStruct);
+                            Account existing = new Account(existingStruct.Nonce, existingStruct.Balance, new Hash256(existingStruct.StorageRoot), new Hash256(existingStruct.CodeHash));
                             if (existing.Balance != account.Balance)
                             {
                                 if (account.Balance > existing.Balance)

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullCommitter.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullCommitter.cs
@@ -6,7 +6,7 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie.Pruning;
 
-internal class NullCommitter : ICommitter, IBlockCommitter
+public class NullCommitter : ICommitter, IBlockCommitter
 {
     public static NullCommitter Instance = new NullCommitter();
 

--- a/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
@@ -42,10 +42,8 @@ internal class DelegatedAccountFilterTest
     [Test]
     public void Accept_SenderIsDelegatedWithNoTransactionsInPool_ReturnsAccepted()
     {
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         CodeInfoRepository codeInfoRepository = new();
         byte[] code = [.. Eip7702Constants.DelegationHeader, .. TestItem.PrivateKeyA.Address.Bytes];
@@ -72,10 +70,8 @@ internal class DelegatedAccountFilterTest
         TxDistinctSortedPool blobPool = new BlobTxDistinctSortedPool(10, Substitute.For<IComparer<Transaction>>(), NullLogManager.Instance);
         Transaction inPool = Build.A.Transaction.SignedAndResolved(new EthereumEcdsa(0), TestItem.PrivateKeyA).TestObject;
         standardPool.TryInsert(inPool.Hash, inPool);
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         CodeInfoRepository codeInfoRepository = new();
         byte[] code = [.. Eip7702Constants.DelegationHeader, .. TestItem.PrivateKeyA.Address.Bytes];
@@ -98,10 +94,8 @@ internal class DelegatedAccountFilterTest
         TxDistinctSortedPool blobPool = new BlobTxDistinctSortedPool(10, Substitute.For<IComparer<Transaction>>(), NullLogManager.Instance);
         Transaction inPool = Build.A.Transaction.SignedAndResolved(new EthereumEcdsa(0), TestItem.PrivateKeyA).TestObject;
         standardPool.TryInsert(inPool.Hash, inPool);
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         CodeInfoRepository codeInfoRepository = new();
         byte[] code = [.. Eip7702Constants.DelegationHeader, .. TestItem.PrivateKeyA.Address.Bytes];
@@ -129,10 +123,8 @@ internal class DelegatedAccountFilterTest
         TxDistinctSortedPool blobPool = new BlobTxDistinctSortedPool(10, Substitute.For<IComparer<Transaction>>(), NullLogManager.Instance);
         Transaction inPool = Build.A.Transaction.WithNonce(0).SignedAndResolved(new EthereumEcdsa(0), TestItem.PrivateKeyA).TestObject;
         standardPool.TryInsert(inPool.Hash, inPool);
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0);
         CodeInfoRepository codeInfoRepository = new();
         byte[] code = [.. Eip7702Constants.DelegationHeader, .. TestItem.PrivateKeyA.Address.Bytes];
@@ -164,10 +156,8 @@ internal class DelegatedAccountFilterTest
         pendingDelegations.IncrementDelegationCount(TestItem.AddressA);
         DelegatedAccountFilter filter = new(headInfoProvider, standardPool, blobPool, Substitute.For<IReadOnlyStateProvider>(), new CodeInfoRepository(), pendingDelegations);
         Transaction transaction = Build.A.Transaction.WithNonce((UInt256)nonce).SignedAndResolved(new EthereumEcdsa(0), TestItem.PrivateKeyA).TestObject;
-        IDb stateDb = new MemDb();
-        IDb codeDb = new MemDb();
-        TrieStore trieStore = TestTrieStoreFactory.Build(stateDb, LimboLogs.Instance);
-        IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        IWorldState stateProvider = worldStateManager.GlobalWorldState;
         stateProvider.CreateAccount(TestItem.AddressA, 0, 1);
         TxFilteringState state = new(transaction, stateProvider);
 

--- a/src/Nethermind/Nethermind.TxPool.Test/NonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/NonceManagerTests.cs
@@ -34,11 +34,9 @@ public class NonceManagerTests
     [SetUp]
     public void Setup()
     {
-        ILogManager logManager = LimboLogs.Instance;
         _specProvider = MainnetSpecProvider.Instance;
-        var trieStore = TestTrieStoreFactory.Build(new MemDb(), logManager);
-        var codeDb = new MemDb();
-        _stateProvider = new WorldState(trieStore, codeDb, logManager);
+        IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+        _stateProvider = worldStateManager.GlobalWorldState;
         _blockTree = Substitute.For<IBlockTree>();
         Block block = Build.A.Block.WithNumber(0).TestObject;
         _blockTree.Head.Returns(block);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -54,9 +54,8 @@ namespace Nethermind.TxPool.Test
             _logManager = LimboLogs.Instance;
             _specProvider = MainnetSpecProvider.Instance;
             _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId);
-            var trieStore = TestTrieStoreFactory.Build(new MemDb(), _logManager);
-            var codeDb = new MemDb();
-            _stateProvider = new WorldState(trieStore, codeDb, _logManager);
+            IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
+            _stateProvider = worldStateManager.GlobalWorldState;
             _blockTree = Substitute.For<IBlockTree>();
             Block block = Build.A.Block.WithNumber(10000000 - 1).TestObject;
             _blockTree.Head.Returns(block);


### PR DESCRIPTION
- Make tests that can use `IWorldState` to create `IWorldState` instead of `TrieStore` first.
- Make #8655 smaller.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Testing...