### PR TITLE
Surface acceptTx on sync via config

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -59,4 +59,8 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "null",
         Description = "The current transaction pool state reporting interval, in minutes.")]
     int? ReportMinutes { get; set; }
+
+    [ConfigItem(DefaultValue = "false",
+        Description = "Accept transactions when not synced.")]
+    bool AcceptTxWhenNotSynced { get; set; }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -109,6 +109,7 @@ namespace Nethermind.TxPool
             _blobTxStorage = blobTxStorage ?? throw new ArgumentNullException(nameof(blobTxStorage));
             _headInfo = chainHeadInfoProvider ?? throw new ArgumentNullException(nameof(chainHeadInfoProvider));
             _txPoolConfig = txPoolConfig;
+            AcceptTxWhenNotSynced = txPoolConfig.AcceptTxWhenNotSynced;
             _blobReorgsSupportEnabled = txPoolConfig.BlobsSupport.SupportsReorgs();
             _accounts = _accountCache = new AccountCache(_headInfo.ReadOnlyStateProvider);
             _specProvider = _headInfo.SpecProvider;

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -24,5 +24,6 @@ namespace Nethermind.TxPool
         public long? MaxBlobTxSize { get; set; } = 1.MiB();
         public bool ProofsTranslationEnabled { get; set; } = false;
         public int? ReportMinutes { get; set; } = null;
+        public bool AcceptTxWhenNotSynced { get; set; } = false;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/nethermind/issues/8234

## Changes

- Allow whether to accept or reject txs when syncing to be set via config

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No (Existing tests as used by Hive, just surfacing via config)