### PR TITLE
Adjust block size to CL pessimistic block size

### DIFF
--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Config
 {
     public class BlocksConfig : IBlocksConfig
     {
-        public const int DefaultMaxTxKilobytes = 9728;
+        public const int DefaultMaxTxKilobytes = 7228;
         private const string _clientExtraData = "Nethermind";
         public static string DefaultExtraData = _clientExtraData;
 


### PR DESCRIPTION
## Changes

In the worst case, the CL overhead can be 2.5 MB, so I adjusted our block production limit to be even more conservative.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
