### PR TITLE
Fix secp256r1 precompile test cases

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/PrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/PrecompileTests.cs
@@ -42,25 +42,12 @@ public abstract class PrecompileTests<T> where T : PrecompileTests<T>, IPrecompi
         using (Assert.EnterMultipleScope())
         {
             Assert.That(success, Is.EqualTo(testCase.ExpectedError is null));
+            Assert.That(output, Is.EquivalentTo(testCase.Expected ?? []));
 
-            VerifyOutput(output, testCase);
-            VerifyGas(gas, testCase);
-        }
-    }
-
-    protected virtual void VerifyOutput(byte[] output, TestCase testCase)
-    {
-        if (testCase.Expected is not null)
-        {
-            Assert.That(output, Is.EquivalentTo(testCase.Expected));
-        }
-    }
-
-    protected virtual void VerifyGas(long gas, TestCase testCase)
-    {
-        if (testCase.Gas is not null)
-        {
-            Assert.That(gas, Is.EqualTo(testCase.Gas));
+            if (testCase.Gas is not null)
+            {
+                Assert.That(gas, Is.EqualTo(testCase.Gas));
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Secp256r1PrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Secp256r1PrecompileTests.cs
@@ -56,11 +56,6 @@ namespace Nethermind.Evm.Test
             }
         }
 
-        protected override void VerifyOutput(byte[]? output, TestCase testCase)
-        {
-            Assert.That(output, Is.EquivalentTo(testCase.Expected ?? []));
-        }
-
         public static IEnumerable<TestCaseData> RandomECDsaInputs()
         {
             var rng = RandomNumberGenerator.Create();


### PR DESCRIPTION
Fixes empty output verifications not being run for secp256r1

## Changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing
- [x] No

#### If yes, did you write tests?

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
