### PR TITLE
Add min memory rent size

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -336,6 +336,7 @@ public struct EvmPooledMemory : IEvmMemory
 
     private void UpdateSize(ulong length, bool rentIfNeeded = true)
     {
+        const int MinRentSize = 1_024;
         Length = length;
 
         if (Length > Size)
@@ -348,7 +349,7 @@ public struct EvmPooledMemory : IEvmMemory
         {
             if (_memory is null)
             {
-                _memory = ArrayPool<byte>.Shared.Rent((int)Size);
+                _memory = ArrayPool<byte>.Shared.Rent((int)Math.Max(Size, MinRentSize));
                 Array.Clear(_memory, 0, (int)Size);
             }
             else


### PR DESCRIPTION
## Changes

- Add minimum memory rental size (1kB) to not reallocate and copy at the small sizes. ArrayPool will force powers of 2 resizing so fine at larger sizes

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No