### PR TITLE
Recover signer direct from keccak without intermediary array

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -582,6 +582,13 @@ namespace Nethermind.Core.Crypto
             return output;
         }
 
+        public ValueHash256 GenerateValueHash()
+        {
+            Unsafe.SkipInit(out ValueHash256 output);
+            UpdateFinalTo(output.BytesAsSpan);
+            return output;
+        }
+
         public void UpdateFinalTo(Span<byte> output)
         {
             if (_hash is not null)

--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Crypto
 
         public Hash256 GetHash()
         {
-            return new Hash256(_keccakHash.Hash);
+            return new Hash256(_keccakHash.GenerateValueHash());
         }
 
         public KeccakRlpStream()

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -155,7 +155,7 @@ public class TxDecoder<T> : IRlpStreamDecoder<T>, IRlpValueDecoder<T> where T : 
     /// </summary>
     public int GetLength(T tx, RlpBehaviors rlpBehaviors) => GetLength(tx, rlpBehaviors, forSigning: false, isEip155Enabled: false, chainId: 0);
 
-    private void EncodeTx(RlpStream stream, T? item, RlpBehaviors rlpBehaviors, bool forSigning, bool isEip155Enabled, ulong chainId)
+    public void EncodeTx(RlpStream stream, T? item, RlpBehaviors rlpBehaviors, bool forSigning, bool isEip155Enabled, ulong chainId)
     {
         if (item is null)
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -185,7 +185,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
         Span<byte> txType = [(byte)TxType.Blob];
         hash.Update(txType);
         hash.Update(transactionSequence);
-        return new Hash256(hash.Hash);
+        return new Hash256(hash.GenerateValueHash());
     }
 
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,


### PR DESCRIPTION
## Changes

- Encode to KeccakRlpStream rather than RlpStream, create array, keccak array

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No