### PR TITLE
Move high volume logs from Debug to Trace

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Blockchain.Filters
                 int filterId = filter.Id;
                 List<Hash256> transactions = _pendingTransactions.GetOrAdd(filterId, static _ => new List<Hash256>());
                 transactions.Add(e.Transaction.Hash);
-                if (_logger.IsDebug) _logger.Debug($"Filter with id: {filterId} contains {transactions.Count} transactions.");
+                if (_logger.IsTrace) _logger.Trace($"Filter with id: {filterId} contains {transactions.Count} transactions.");
 
             }
         }
@@ -90,7 +90,7 @@ namespace Nethermind.Blockchain.Filters
                 int filterId = filter.Id;
                 List<Hash256> transactions = _pendingTransactions.GetOrAdd(filterId, static _ => new List<Hash256>());
                 transactions.Remove(e.Transaction.Hash);
-                if (_logger.IsDebug) _logger.Debug($"Filter with id: {filterId} contains {transactions.Count} transactions.");
+                if (_logger.IsTrace) _logger.Trace($"Filter with id: {filterId} contains {transactions.Count} transactions.");
 
             }
         }
@@ -194,7 +194,7 @@ namespace Nethermind.Blockchain.Filters
 
             List<Hash256> blocks = _blockHashes.GetOrAdd(filter.Id, static i => new List<Hash256>());
             blocks.Add(block.Hash);
-            if (_logger.IsDebug) _logger.Debug($"Filter with id: {filter.Id} contains {blocks.Count} blocks.");
+            if (_logger.IsTrace) _logger.Trace($"Filter with id: {filter.Id} contains {blocks.Count} blocks.");
         }
 
         private void StoreLogs(LogFilter filter, TxReceipt txReceipt, long logIndex)
@@ -220,7 +220,7 @@ namespace Nethermind.Blockchain.Filters
                 return;
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Filter with id: {filter.Id} contains {logs.Count} logs.");
+            if (_logger.IsTrace) _logger.Trace($"Filter with id: {filter.Id} contains {logs.Count} logs.");
         }
 
         private static FilterLog? CreateLog(LogFilter logFilter, TxReceipt txReceipt, LogEntry logEntry, long index)

--- a/src/Nethermind/Nethermind.Facade/Find/LogScanner.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogScanner.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Facade.Find
                     count++;
                 }
 
-                if (_logger.IsDebug) _logger.Debug($"{GetType().Name} found {count} events from logs in block range {logFilter.FromBlock} - {logFilter.ToBlock}");
+                if (_logger.IsTrace) _logger.Trace($"{GetType().Name} found {count} events from logs in block range {logFilter.FromBlock} - {logFilter.ToBlock}");
 
                 if (atGenesis || (count != 0 && shouldStopScanning(first)))
                 {
@@ -78,7 +78,7 @@ namespace Nethermind.Facade.Find
                 }
             }
 
-            if (_logger.IsDebug) _logger.Debug($"{GetType().Name} found {count} events events in block {blockNumber}.");
+            if (_logger.IsTrace) _logger.Trace($"{GetType().Name} found {count} events events in block {blockNumber}.");
         }
 
         protected abstract T ParseEvent(ILogEntry log);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -225,7 +225,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                 // Handles a single JSON RPC request.
                 if (model is not null)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"JSON RPC request {model}");
+                    if (_logger.IsTrace) _logger.Trace($"JSON RPC request {model}");
 
                     // Processes the individual request.
                     JsonRpcResult.Entry result = await HandleSingleRequest(model, context);
@@ -238,7 +238,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                 // Processes a collection of JSON RPC requests.
                 if (collection is not null)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"{collection.Count} JSON RPC requests");
+                    if (_logger.IsTrace) _logger.Trace($"{collection.Count} JSON RPC requests");
 
                     // Checks for authentication and batch size limit.
                     if (!context.IsAuthenticated && collection.Count > _jsonRpcConfig.MaxBatchSize)
@@ -265,7 +265,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     errorResponse.AddDisposable(() => jsonDocument.Dispose());
 
                     TraceResult(errorResponse);
-                    if (_logger.IsDebug) _logger.Debug($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+                    if (_logger.IsTrace) _logger.Trace($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
                     deserializationFailureResult = JsonRpcResult.Single(RecordResponse(errorResponse, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMilliseconds, false)));
                     yield return deserializationFailureResult.Value;
                     break;
@@ -349,12 +349,12 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                         RpcReport.Error)
                     : await HandleSingleRequest(jsonRpcRequest, context);
 
-                if (_logger.IsDebug) _logger.Debug($"  {++requestIndex}/{requests.Count} JSON RPC request - {jsonRpcRequest} handled after {response.Report.HandlingTimeMicroseconds}");
+                if (_logger.IsTrace) _logger.Trace($"  {++requestIndex}/{requests.Count} JSON RPC request - {jsonRpcRequest} handled after {response.Report.HandlingTimeMicroseconds}");
                 TraceResult(response);
                 yield return RecordResponse(response);
             }
 
-            if (_logger.IsDebug) _logger.Debug($"  {requests.Count} requests handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+            if (_logger.IsTrace) _logger.Trace($"  {requests.Count} requests handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
         }
         finally
         {
@@ -381,7 +381,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         }
         else
         {
-            if (_logger.IsDebug) _logger.Debug($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+            if (_logger.IsTrace) _logger.Trace($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
             Metrics.JsonRpcSuccesses++;
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -90,7 +90,7 @@ public class JsonRpcService : IJsonRpcService
     {
         JsonElement providedParameters = request.Params;
 
-        LogRequest(methodName, providedParameters, method.ExpectedParameters);
+        if (_logger.IsTrace) LogRequest(methodName, providedParameters, method.ExpectedParameters);
 
         var providedParametersLength = providedParameters.ValueKind == JsonValueKind.Array ? providedParameters.GetArrayLength() : 0;
         int missingParamsCount = method.ExpectedParameters.Length - providedParametersLength;
@@ -233,7 +233,7 @@ public class JsonRpcService : IJsonRpcService
 
     private void LogRequest(string methodName, JsonElement providedParameters, ExpectedParameter[] expectedParameters)
     {
-        if (_logger.IsDebug && !_methodsLoggingFiltering.Contains(methodName))
+        if (!_methodsLoggingFiltering.Contains(methodName))
         {
             StringBuilder builder = new StringBuilder();
             builder.Append("Executing JSON RPC call ");
@@ -273,7 +273,7 @@ public class JsonRpcService : IJsonRpcService
             }
             builder.Append(']');
             string log = builder.ToString();
-            _logger.Debug(log);
+            _logger.Trace(log);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -130,7 +130,7 @@ namespace Nethermind.Network
                 _txPool.RemovePeer(removed.Node.Id);
                 if (session.BestStateReached == SessionState.Initialized)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
+                    if (_logger.IsTrace) _logger.Trace($"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
                 }
             }
 
@@ -262,7 +262,7 @@ namespace Nethermind.Network
                     {
                         peer.SyncPeer.RegisterSatelliteProtocol(handler.ProtocolCode, handler);
                         if (handler.IsPriority) _syncPool.SetPeerPriority(session.Node.Id);
-                        if (_logger.IsDebug) _logger.Debug($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
+                        if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
                     }
                     else
                     {
@@ -345,13 +345,13 @@ namespace Nethermind.Network
                             {
                                 handler.RegisterSatelliteProtocol(registration.Value);
                                 if (registration.Value.IsPriority) handler.IsPriority = true;
-                                if (_logger.IsDebug) _logger.Debug($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}. Sync peer has priority: {handler.IsPriority}");
+                                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}. Sync peer has priority: {handler.IsPriority}");
                             }
                         }
 
                         _syncPool.AddPeer(handler);
                         if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
-                        if (_logger.IsDebug) _logger.Debug($"{handler.ClientId} sync peer {session} created.");
+                        if (_logger.IsTrace) _logger.Trace($"{handler.ClientId} sync peer {session} created.");
                     }
                     else
                     {
@@ -375,7 +375,7 @@ namespace Nethermind.Network
         {
             if (session.IsClosing)
             {
-                if (_logger.IsDebug) _logger.Debug($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
                 return false;
             }
 
@@ -396,7 +396,7 @@ namespace Nethermind.Network
 
             if (session.Node.Port != eventArgs.ListenPort)
             {
-                if (_logger.IsDebug) _logger.Debug($"Updating listen port for {session:s} to: {eventArgs.ListenPort}");
+                if (_logger.IsTrace) _logger.Trace($"Updating listen port for {session:s} to: {eventArgs.ListenPort}");
                 session.Node.Port = eventArgs.ListenPort;
             }
 
@@ -413,7 +413,7 @@ namespace Nethermind.Network
         {
             if (_capabilities.Remove(capability))
             {
-                if (_logger.IsDebug) _logger.Debug($"Removed supported capability: {capability}");
+                if (_logger.IsTrace) _logger.Trace($"Removed supported capability: {capability}");
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -148,7 +148,7 @@ namespace Nethermind.Network
 
         private void StartPingTimer()
         {
-            if (_logger.IsDebug) _logger.Debug("Starting session monitor");
+            if (_logger.IsTrace) _logger.Trace("Starting session monitor");
 
             _cancellationTokenSource = new CancellationTokenSource();
             _pingTimer = new PeriodicTimer(_pingInterval);
@@ -159,7 +159,7 @@ namespace Nethermind.Network
         {
             try
             {
-                if (_logger.IsDebug) _logger.Debug("Stopping session monitor");
+                if (_logger.IsTrace) _logger.Trace("Stopping session monitor");
                 CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellationTokenSource);
             }
             catch (Exception e)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -30,7 +30,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
 
     private void RecreateLightTxCollectionAndCache(ITxStorage blobTxStorage)
     {
-        if (_logger.IsDebug) _logger.Debug("Recreating light collection of blob transactions and cache");
+        if (_logger.IsTrace) _logger.Trace("Recreating light collection of blob transactions and cache");
         int numberOfTxsInDb = 0;
         int numberOfBlobsInDb = 0;
         long startTime = Stopwatch.GetTimestamp();

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -186,7 +186,7 @@ namespace Nethermind.TxPool
 
                 if (transactionsToSend is not null)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Broadcasting {transactionsToSend.Count} persistent transactions to all peers.");
+                    if (_logger.IsTrace) _logger.Trace($"Broadcasting {transactionsToSend.Count} persistent transactions to all peers.");
 
                     foreach ((_, ITxPoolPeer peer) in _peers)
                     {
@@ -195,12 +195,12 @@ namespace Nethermind.TxPool
                 }
                 else
                 {
-                    if (_logger.IsDebug) _logger.Debug($"There are currently no transactions able to broadcast.");
+                    if (_logger.IsTrace) _logger.Trace($"There are currently no transactions able to broadcast.");
                 }
 
                 if (hashesToSend is not null)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Announcing {hashesToSend.Count} hashes of persistent transactions to all peers.");
+                    if (_logger.IsTrace) _logger.Trace($"Announcing {hashesToSend.Count} hashes of persistent transactions to all peers.");
 
                     foreach ((_, ITxPoolPeer peer) in _peers)
                     {
@@ -295,7 +295,7 @@ namespace Nethermind.TxPool
             {
                 _txsToSend = Interlocked.Exchange(ref _accumulatedTemporaryTxs, _txsToSend);
 
-                if (_logger.IsDebug) _logger.Debug($"Broadcasting transactions to all peers");
+                if (_logger.IsTrace) _logger.Trace($"Broadcasting transactions to all peers");
 
                 foreach ((_, ITxPoolPeer peer) in _peers)
                 {
@@ -330,7 +330,7 @@ namespace Nethermind.TxPool
         {
             if (!_txGossipPolicy.CanGossipTransactions || !_txGossipPolicy.ShouldGossipTransaction(tx)) return;
 
-            if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
+            if (_logger.IsTrace) _logger.Trace($"Broadcasting new local transaction {tx.Hash} to all peers");
 
             foreach ((_, ITxPoolPeer peer) in _peers)
             {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -343,7 +343,7 @@ namespace Nethermind.TxPool
                         blobTx.SenderAddress ??= _ecdsa.RecoverAddress(blobTx);
                         SubmitTx(blobTx, isEip155Enabled ? TxHandlingOptions.None : TxHandlingOptions.PreEip155Signing);
                     }
-                    if (_logger.IsDebug) _logger.Debug($"Readded txs from reorged block {previousBlock.Number} (hash {previousBlock.Hash}) to blob pool");
+                    if (_logger.IsTrace) _logger.Trace($"Readded txs from reorged block {previousBlock.Number} (hash {previousBlock.Hash}) to blob pool");
 
                     _blobTxStorage.DeleteBlobTransactionsFromBlock(previousBlock.Number);
                 }


### PR DESCRIPTION
## Changes

- Regular operation activity messages should be moved from Debug to Trace, otherwise it makes Debug traces 90% noise and hard to use to diagnose issues for Ops.

As requested by @barnabasbusa

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Other: Logging

## Testing

#### Requires testing

- [x] No