### PR TITLE
Fix adaptive code resolver

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -589,7 +589,7 @@ namespace Nethermind.Network.P2P
 
         private AdaptiveCodeResolver GetOrCreateResolver()
         {
-            string key = string.Join(":", _protocols.Select(static p => p.Key).OrderBy(static x => x).ToArray());
+            string key = string.Join(":", _protocols.Select(static p => string.Join("/", p.Value.ProtocolCode, p.Value.ProtocolVersion)).OrderBy(static x => x).ToArray());
             if (!_resolvers.TryGetValue(key, out AdaptiveCodeResolver? value))
             {
                 value = new AdaptiveCodeResolver(_protocols);


### PR DESCRIPTION
## Changes

- if protocol version is updated during session, resolver is not updated, because key was just `ProtocolCode`. Changed to `ProrocolCode/ProtocolVersion`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No
