### PR TITLE
PatriciaTree remove unused field

### DIFF
--- a/src/Nethermind/Ethereum.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Ethereum.Trie.Test/TrieTests.cs
@@ -142,7 +142,7 @@ namespace Ethereum.Trie.Test
 
             TestContext.Out.WriteLine(Surrounded(permutationDescription));
 
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             foreach (KeyValuePair<string, string> keyValuePair in test.Input)
             {
                 string keyString = keyValuePair.Key;
@@ -303,14 +303,14 @@ namespace Ethereum.Trie.Test
         [Test]
         public void Quick_empty()
         {
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             Assert.That(patriciaTree.RootHash, Is.EqualTo(PatriciaTree.EmptyTreeHash));
         }
 
         [Test]
         public void Delete_on_empty()
         {
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             patriciaTree.Set(Keccak.Compute("1").Bytes, new byte[0]);
             patriciaTree.Commit();
             Assert.That(patriciaTree.RootHash, Is.EqualTo(PatriciaTree.EmptyTreeHash));
@@ -319,7 +319,7 @@ namespace Ethereum.Trie.Test
         [Test]
         public void Delete_missing_resolved_on_branch()
         {
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             patriciaTree.Set(Keccak.Compute("1123").Bytes, new byte[] { 1 });
             patriciaTree.Set(Keccak.Compute("1124").Bytes, new byte[] { 2 });
             Hash256 rootBefore = patriciaTree.RootHash;
@@ -330,7 +330,7 @@ namespace Ethereum.Trie.Test
         [Test]
         public void Delete_missing_resolved_on_extension()
         {
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             patriciaTree.Set(new Nibble[] { 1, 2, 3, 4 }.ToPackedByteArray(), new byte[] { 1 });
             patriciaTree.Set(new Nibble[] { 1, 2, 3, 4, 5 }.ToPackedByteArray(), new byte[] { 2 });
             patriciaTree.UpdateRootHash();
@@ -343,7 +343,7 @@ namespace Ethereum.Trie.Test
         [Test]
         public void Delete_missing_resolved_on_leaf()
         {
-            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree patriciaTree = new PatriciaTree(_db, Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             patriciaTree.Set(Keccak.Compute("1234567").Bytes, new byte[] { 1 });
             patriciaTree.Set(Keccak.Compute("1234501").Bytes, new byte[] { 2 });
             patriciaTree.UpdateRootHash();
@@ -356,7 +356,7 @@ namespace Ethereum.Trie.Test
         [Test]
         public void Lookup_in_empty_tree()
         {
-            PatriciaTree tree = new PatriciaTree(new MemDb(), Keccak.EmptyTreeHash, false, true, NullLogManager.Instance);
+            PatriciaTree tree = new PatriciaTree(new MemDb(), Keccak.EmptyTreeHash, true, NullLogManager.Instance);
             Assert.That(tree.RootRef, Is.Null);
             tree.Get(new byte[] { 1 });
             Assert.That(tree.RootRef, Is.Null);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -25,7 +25,7 @@ public class ReceiptTrieTests
     public void Can_calculate_root_no_eip_658()
     {
         TxReceipt receipt = Build.A.Receipt.WithAllFieldsFilled.TestObject;
-        Hash256 rootHash = ReceiptTrie<TxReceipt>.CalculateRoot(MainnetSpecProvider.Instance.GetSpec((1, null)),
+        Hash256 rootHash = ReceiptTrie.CalculateRoot(MainnetSpecProvider.Instance.GetSpec((1, null)),
             [receipt], _decoder);
         Assert.That(rootHash.ToString(),
             Is.EqualTo("0xe51a2d9f986d68628990c9d65e45c36128ec7bb697bd426b0bb4d18a3f3321be"));
@@ -35,7 +35,7 @@ public class ReceiptTrieTests
     public void Can_calculate_root()
     {
         TxReceipt receipt = Build.A.Receipt.WithAllFieldsFilled.TestObject;
-        Hash256 rootHash = ReceiptTrie<TxReceipt>.CalculateRoot(
+        Hash256 rootHash = ReceiptTrie.CalculateRoot(
             MainnetSpecProvider.Instance.GetSpec((MainnetSpecProvider.MuirGlacierBlockNumber, null)),
             [receipt], _decoder);
         Assert.That(rootHash.ToString(),
@@ -48,7 +48,7 @@ public class ReceiptTrieTests
         TxReceipt receipt1 = Build.A.Receipt.WithAllFieldsFilled.TestObject;
         TxReceipt receipt2 = Build.A.Receipt.WithAllFieldsFilled.TestObject;
         using var pool = new TrackingCappedArrayPool();
-        ReceiptTrie<TxReceipt> trie = new(MainnetSpecProvider.Instance.GetSpec((ForkActivation)1),
+        ReceiptTrie trie = new(MainnetSpecProvider.Instance.GetSpec((ForkActivation)1),
             [receipt1, receipt2], _decoder, pool, true);
         byte[][] proof = trie.BuildProof(0);
         Assert.That(proof.Length, Is.EqualTo(2));

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRootCalculator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRootCalculator.cs
@@ -22,7 +22,7 @@ public class ReceiptsRootCalculator : IReceiptsRootCalculator
             receipts.SetSkipStateAndStatusInRlp(true);
             try
             {
-                return ReceiptTrie<TxReceipt>.CalculateRoot(spec, receipts, _decoder);
+                return ReceiptTrie.CalculateRoot(spec, receipts, _decoder);
             }
             finally
             {
@@ -30,7 +30,7 @@ public class ReceiptsRootCalculator : IReceiptsRootCalculator
             }
         }
 
-        Hash256 receiptsRoot = ReceiptTrie<TxReceipt>.CalculateRoot(spec, receipts, _decoder);
+        Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, receipts, _decoder);
         if (!spec.ValidateReceipts && receiptsRoot != suggestedRoot)
         {
             var skipStateAndStatusReceiptsRoot = SkipStateAndStatusReceiptsRoot();

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
@@ -98,7 +98,7 @@ namespace Nethermind.Core.Test.Builders
             }
 
             BlockBuilder result = WithTransactions(txs);
-            Hash256 receiptHash = ReceiptTrie<TxReceipt>.CalculateRoot(specProvider.GetSpec(TestObjectInternal.Header), receipts, Rlp.GetStreamDecoder<TxReceipt>()!);
+            Hash256 receiptHash = ReceiptTrie.CalculateRoot(specProvider.GetSpec(TestObjectInternal.Header), receipts, Rlp.GetStreamDecoder<TxReceipt>()!);
             TestObjectInternal.Header.ReceiptsRoot = receiptHash;
             return result;
         }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -309,7 +309,7 @@ namespace Nethermind.Core.Test.Builders
                 currentBlock.Header.TxRoot = TxTrie.CalculateRoot(currentBlock.Transactions);
                 TxReceipt[] txReceipts = receipts.ToArray();
                 currentBlock.Header.ReceiptsRoot =
-                    ReceiptTrie<TxReceipt>.CalculateRoot(_specProvider.GetSpec(currentBlock.Header), txReceipts, Rlp.GetStreamDecoder<TxReceipt>()!);
+                    ReceiptTrie.CalculateRoot(_specProvider.GetSpec(currentBlock.Header), txReceipts, Rlp.GetStreamDecoder<TxReceipt>()!);
                 currentBlock.Header.Hash = currentBlock.CalculateHash();
                 foreach (TxReceipt txReceipt in txReceipts)
                 {

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TrieBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TrieBuilder.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Core.Test.Builders
 
         public TrieBuilder(INodeStorage db)
         {
-            TestObjectInternal = new PatriciaTree(new RawScopedTrieStore(db), Keccak.EmptyTreeHash, false, true, LimboLogs.Instance);
+            TestObjectInternal = new PatriciaTree(new RawScopedTrieStore(db), Keccak.EmptyTreeHash, true, LimboLogs.Instance);
         }
 
         public TrieBuilder WithAccountsByIndex(int start, int count)

--- a/src/Nethermind/Nethermind.Era1/EraReader.cs
+++ b/src/Nethermind/Nethermind.Era1/EraReader.cs
@@ -96,7 +96,7 @@ public class EraReader : IAsyncEnumerable<(Block, TxReceipt[])>, IDisposable
                     throw new EraVerificationException($"Invalid block {error}");
                 }
 
-                Hash256 receiptRoot = ReceiptTrie<TxReceipt>.CalculateRoot(specProvider.GetReceiptSpec(err.Block.Number), err.Receipts, _receiptDecoder);
+                Hash256 receiptRoot = ReceiptTrie.CalculateRoot(specProvider.GetReceiptSpec(err.Block.Number), err.Receipts, _receiptDecoder);
                 if (err.Block.Header.ReceiptsRoot != receiptRoot)
                 {
                     throw new EraVerificationException($"Mismatched receipt root. Block number {blockNumber}.");

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -207,7 +207,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
         private byte[][] BuildReceiptProofs(BlockHeader blockHeader, TxReceipt[] receipts, int index)
         {
-            return ReceiptTrie<TxReceipt>.CalculateReceiptProofs(_specProvider.GetSpec(blockHeader), receipts, index, _receiptDecoder);
+            return ReceiptTrie.CalculateReceiptProofs(_specProvider.GetSpec(blockHeader), receipts, index, _receiptDecoder);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
@@ -11,7 +11,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Healing;
 
-public class HealingStateTree : StateTree
+public sealed class HealingStateTree : StateTree
 {
     private IPathRecovery? _recovery;
     private readonly INodeStorage _nodeStorage;

--- a/src/Nethermind/Nethermind.State/Healing/HealingStorageTree.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingStorageTree.cs
@@ -2,18 +2,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Logging;
-using Nethermind.State.Snap;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Healing;
 
-public class HealingStorageTree : StorageTree
+public sealed class HealingStorageTree : StorageTree
 {
     private readonly INodeStorage _nodeStorage;
     private readonly Address _address;

--- a/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
@@ -23,7 +23,7 @@ public abstract class PatriciaTrie<T> : PatriciaTree
     /// otherwise, <c>false</c>.
     /// </param>
     protected PatriciaTrie(ReadOnlySpan<T> list, bool canBuildProof, ICappedArrayPool? bufferPool = null)
-        : base(canBuildProof ? new MemDb() : NullDb.Instance, EmptyTreeHash, false, false, NullLogManager.Instance, bufferPool: bufferPool)
+        : base(canBuildProof ? new MemDb() : NullDb.Instance, EmptyTreeHash, false, NullLogManager.Instance, bufferPool: bufferPool)
     {
         CanBuildProof = canBuildProof;
 

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
@@ -15,12 +15,12 @@ namespace Nethermind.State.Proofs;
 /// <summary>
 /// Represents a Patricia trie built of a collection of <see cref="TxReceipt"/>.
 /// </summary>
-public class ReceiptTrie<TReceipt> : PatriciaTrie<TReceipt>
+public sealed class ReceiptTrie : PatriciaTrie<TxReceipt>
 {
-    private readonly IRlpStreamDecoder<TReceipt> _decoder;
+    private readonly IRlpStreamDecoder<TxReceipt> _decoder;
     /// <inheritdoc/>
     /// <param name="receipts">The transaction receipts to build the trie of.</param>
-    public ReceiptTrie(IReceiptSpec spec, ReadOnlySpan<TReceipt> receipts, IRlpStreamDecoder<TReceipt> trieDecoder, ICappedArrayPool bufferPool, bool canBuildProof = false)
+    public ReceiptTrie(IReceiptSpec spec, ReadOnlySpan<TxReceipt> receipts, IRlpStreamDecoder<TxReceipt> trieDecoder, ICappedArrayPool bufferPool, bool canBuildProof = false)
         : base(null, canBuildProof, bufferPool: bufferPool)
     {
         ArgumentNullException.ThrowIfNull(spec);
@@ -34,12 +34,12 @@ public class ReceiptTrie<TReceipt> : PatriciaTrie<TReceipt>
         }
     }
 
-    private void Initialize(ReadOnlySpan<TReceipt> receipts, IReceiptSpec spec)
+    private void Initialize(ReadOnlySpan<TxReceipt> receipts, IReceiptSpec spec)
     {
         RlpBehaviors behavior = (spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None) | RlpBehaviors.SkipTypedWrapping;
         int key = 0;
 
-        foreach (TReceipt? receipt in receipts)
+        foreach (TxReceipt? receipt in receipts)
         {
             SpanSource buffer = _decoder.EncodeToSpanSource(receipt, rlpBehaviors: behavior, bufferPool: _bufferPool);
             SpanSource keyBuffer = key.EncodeToSpanSource(_bufferPool);
@@ -49,18 +49,18 @@ public class ReceiptTrie<TReceipt> : PatriciaTrie<TReceipt>
         }
     }
 
-    protected override void Initialize(ReadOnlySpan<TReceipt> list) => throw new NotSupportedException();
+    protected override void Initialize(ReadOnlySpan<TxReceipt> list) => throw new NotSupportedException();
 
-    public static byte[][] CalculateReceiptProofs(IReleaseSpec spec, ReadOnlySpan<TReceipt> receipts, int index, IRlpStreamDecoder<TReceipt> decoder)
+    public static byte[][] CalculateReceiptProofs(IReleaseSpec spec, ReadOnlySpan<TxReceipt> receipts, int index, IRlpStreamDecoder<TxReceipt> decoder)
     {
         using TrackingCappedArrayPool cappedArrayPool = new(receipts.Length * 4);
-        return new ReceiptTrie<TReceipt>(spec, receipts, decoder, cappedArrayPool, canBuildProof: true).BuildProof(index);
+        return new ReceiptTrie(spec, receipts, decoder, cappedArrayPool, canBuildProof: true).BuildProof(index);
     }
 
-    public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, ReadOnlySpan<TReceipt> txReceipts, IRlpStreamDecoder<TReceipt> decoder)
+    public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, ReadOnlySpan<TxReceipt> txReceipts, IRlpStreamDecoder<TxReceipt> decoder)
     {
         using TrackingCappedArrayPool cappedArrayPool = new(txReceipts.Length * 4);
-        Hash256 receiptsRoot = new ReceiptTrie<TReceipt>(receiptSpec, txReceipts, decoder, bufferPool: cappedArrayPool).RootHash;
+        Hash256 receiptsRoot = new ReceiptTrie(receiptSpec, txReceipts, decoder, bufferPool: cappedArrayPool).RootHash;
         return receiptsRoot;
     }
 }

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -14,7 +14,7 @@ namespace Nethermind.State.Proofs;
 /// <summary>
 /// Represents a Patricia trie built of a collection of <see cref="Transaction"/>.
 /// </summary>
-public class TxTrie : PatriciaTrie<Transaction>
+public sealed class TxTrie : PatriciaTrie<Transaction>
 {
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
 

--- a/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
@@ -12,7 +12,7 @@ namespace Nethermind.State.Proofs;
 /// <summary>
 /// Represents a Patricia trie built of a collection of <see cref="Withdrawal"/>.
 /// </summary>
-public class WithdrawalTrie : PatriciaTrie<Withdrawal>
+public sealed class WithdrawalTrie : PatriciaTrie<Withdrawal>
 {
     private static readonly WithdrawalDecoder _codec = new();
 

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -22,14 +22,14 @@ namespace Nethermind.State
 
         [DebuggerStepThrough]
         public StateTree(ICappedArrayPool? bufferPool = null)
-            : base(new MemDb(), Keccak.EmptyTreeHash, true, true, NullLogManager.Instance, bufferPool: bufferPool)
+            : base(new MemDb(), Keccak.EmptyTreeHash, true, NullLogManager.Instance, bufferPool: bufferPool)
         {
             TrieType = TrieType.State;
         }
 
         [DebuggerStepThrough]
         public StateTree(IScopedTrieStore? store, ILogManager? logManager)
-            : base(store, Keccak.EmptyTreeHash, true, true, logManager)
+            : base(store, Keccak.EmptyTreeHash, true, logManager)
         {
             TrieType = TrieType.State;
         }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -42,7 +42,7 @@ namespace Nethermind.State
         }
 
         public StorageTree(IScopedTrieStore? trieStore, Hash256 rootHash, ILogManager? logManager)
-            : base(trieStore, rootHash, false, true, logManager)
+            : base(trieStore, rootHash, true, logManager)
         {
             TrieType = TrieType.Storage;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -1402,7 +1402,7 @@ public partial class BlockDownloaderTests
 
                 _headers[blockHashes[i]].ReceiptsRoot = flags.HasFlag(Response.IncorrectReceiptRoot)
                     ? Keccak.EmptyTreeHash
-                    : ReceiptTrie<TxReceipt>.CalculateRoot(MainnetSpecProvider.Instance.GetSpec((ForkActivation)_headers[blockHashes[i]].Number), receipts[i], Rlp.GetStreamDecoder<TxReceipt>()!);
+                    : ReceiptTrie.CalculateRoot(MainnetSpecProvider.Instance.GetSpec((ForkActivation)_headers[blockHashes[i]].Number), receipts[i], Rlp.GetStreamDecoder<TxReceipt>()!);
             }
 
             using ReceiptsMessage message = new(receipts.ToPooledList());

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -465,7 +465,7 @@ namespace Nethermind.Synchronization.Blocks
 
         private bool ValidateReceiptsRoot(Block block, TxReceipt[] blockReceipts)
         {
-            Hash256 receiptsRoot = ReceiptTrie<TxReceipt>.CalculateRoot(_specProvider.GetSpec(block.Header), blockReceipts, _receiptDecoder);
+            Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(_specProvider.GetSpec(block.Header), blockReceipts, _receiptDecoder);
             return receiptsRoot == block.ReceiptsRoot;
         }
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -270,7 +270,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using TrieStore trieStore = TestTrieStoreFactory.Build(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), Keccak.EmptyTreeHash, true, true, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), Keccak.EmptyTreeHash, true, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -296,7 +296,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using TrieStore trieStore = TestTrieStoreFactory.Build(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), Keccak.EmptyTreeHash, true, true, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), Keccak.EmptyTreeHash, true, _logManager);
 
             for (int j = 0; j < i; j++)
             {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -43,8 +43,6 @@ namespace Nethermind.Trie
         public IScopedTrieStore TrieStore { get; }
         public ICappedArrayPool? _bufferPool;
 
-        private readonly bool _parallelBranches;
-
         private readonly bool _allowCommits;
 
         private int _isWriteInProgress;
@@ -75,36 +73,34 @@ namespace Nethermind.Trie
         }
 
         public PatriciaTree()
-            : this(NullTrieStore.Instance, EmptyTreeHash, false, true, NullLogManager.Instance)
+            : this(NullTrieStore.Instance, EmptyTreeHash, true, NullLogManager.Instance)
         {
         }
 
         public PatriciaTree(IKeyValueStoreWithBatching keyValueStore)
-            : this(keyValueStore, EmptyTreeHash, false, true, NullLogManager.Instance)
+            : this(keyValueStore, EmptyTreeHash, true, NullLogManager.Instance)
         {
         }
 
         public PatriciaTree(ITrieStore trieStore, ILogManager logManager, ICappedArrayPool? bufferPool = null)
-            : this(trieStore.GetTrieStore(null), EmptyTreeHash, false, true, logManager, bufferPool: bufferPool)
+            : this(trieStore.GetTrieStore(null), EmptyTreeHash, true, logManager, bufferPool: bufferPool)
         {
         }
 
         public PatriciaTree(IScopedTrieStore trieStore, ILogManager logManager, ICappedArrayPool? bufferPool = null)
-            : this(trieStore, EmptyTreeHash, false, true, logManager, bufferPool: bufferPool)
+            : this(trieStore, EmptyTreeHash, true, logManager, bufferPool: bufferPool)
         {
         }
 
         public PatriciaTree(
             IKeyValueStoreWithBatching keyValueStore,
             Hash256 rootHash,
-            bool parallelBranches,
             bool allowCommits,
             ILogManager logManager,
             ICappedArrayPool? bufferPool = null)
             : this(
                 new RawScopedTrieStore(new NodeStorage(keyValueStore), null),
                 rootHash,
-                parallelBranches,
                 allowCommits,
                 logManager,
                 bufferPool: bufferPool)
@@ -114,14 +110,12 @@ namespace Nethermind.Trie
         public PatriciaTree(
             IScopedTrieStore? trieStore,
             Hash256 rootHash,
-            bool parallelBranches,
             bool allowCommits,
             ILogManager? logManager,
             ICappedArrayPool? bufferPool = null)
         {
             _logger = logManager?.GetClassLogger<PatriciaTree>() ?? throw new ArgumentNullException(nameof(logManager));
             TrieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
-            _parallelBranches = parallelBranches;
             _allowCommits = allowCommits;
             RootHash = rootHash;
 

--- a/tools/Evm/T8n/JsonTypes/T8nExecutionResult.cs
+++ b/tools/Evm/T8n/JsonTypes/T8nExecutionResult.cs
@@ -31,7 +31,7 @@ public class T8nExecutionResult
     {
         IReceiptSpec receiptSpec = specProvider.GetSpec(block.Header);
         Hash256 txRoot = TxTrie.CalculateRoot(txReport.SuccessfulTransactions.ToArray());
-        Hash256 receiptsRoot = ReceiptTrie<TxReceipt>.CalculateRoot(receiptSpec,
+        Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(receiptSpec,
             txReport.SuccessfulTransactionReceipts.ToArray(), new ReceiptMessageDecoder());
         LogEntry[] logEntries = txReport.SuccessfulTransactionReceipts
             .SelectMany(receipt => receipt.Logs ?? Enumerable.Empty<LogEntry>())


### PR DESCRIPTION
## Changes

- Remove unused `_parallelBranches` field
- Seal
  - `HealingStateTree`
  - `HealingStorageTree`
  - `TxTrie`
  - `WithdrawalTrie`
  - `ReceiptTrie`
- Make `ReceiptTrie` non-generic (only used with one type)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No