### PR TITLE
Skip recovery queue when no blocks queued

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Blockchain
         private int _canAcceptNewBlocksCounter;
         public bool CanAcceptNewBlocks => _canAcceptNewBlocksCounter == 0;
 
-        private TaskCompletionSource<bool>? _taskCompletionSource;
+        private TaskCompletionSource? _taskCompletionSource;
 
         public BlockTree(
             IBlockStore? blockStore,
@@ -1707,7 +1707,7 @@ namespace Nethermind.Blockchain
         {
             if (CanAcceptNewBlocks)
             {
-                _taskCompletionSource = new TaskCompletionSource<bool>();
+                Interlocked.CompareExchange(ref _taskCompletionSource, new TaskCompletionSource(), null);
             }
 
             Interlocked.Increment(ref _canAcceptNewBlocksCounter);
@@ -1718,8 +1718,8 @@ namespace Nethermind.Blockchain
             Interlocked.Decrement(ref _canAcceptNewBlocksCounter);
             if (CanAcceptNewBlocks)
             {
-                _taskCompletionSource.SetResult(true);
-                _taskCompletionSource = null;
+                TaskCompletionSource tcs = Interlocked.Exchange(ref _taskCompletionSource, null);
+                tcs?.SetResult();
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -140,11 +140,11 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         if (!_recoveryComplete)
         {
             Interlocked.Increment(ref _queueCount);
+            _lastProcessedBlock = DateTime.UtcNow;
             try
             {
                 if (blockRef.Resolve(_blockTree))
                 {
-                    _lastProcessedBlock = DateTime.UtcNow;
                     if (_logger.IsTrace) _logger.Trace($"A new block {block.ToString(Block.Format.Short)} enqueued for processing.");
                     if (_queueCount > 1)
                     {
@@ -231,6 +231,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private async Task RunRecoveryLoop()
     {
         if (_logger.IsDebug) _logger.Debug($"Starting recovery loop - {_blockQueue.Reader.Count} blocks waiting in the queue.");
+        _lastProcessedBlock = DateTime.UtcNow;
         await foreach (BlockRef blockRef in _recoveryQueue.Reader.ReadAllAsync(CancellationToken))
         {
             try

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -57,8 +57,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         {
             // Optimize for single reader concurrency
             SingleReader = true,
-            // Optimize for single writer concurrency (recovery queue)
-            SingleWriter = true,
+            AllowSynchronousContinuations = true
         });
 
     private bool _recoveryComplete = false;
@@ -125,11 +124,11 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
         if (blockEventArgs.Block is not null)
         {
-            Enqueue(blockEventArgs.Block, options);
+            _ = Enqueue(blockEventArgs.Block, options);
         }
     }
 
-    public void Enqueue(Block block, ProcessingOptions processingOptions)
+    public async ValueTask Enqueue(Block block, ProcessingOptions processingOptions)
     {
         if (_logger.IsTrace) _logger.Trace($"Enqueuing a new block {block.ToString(Block.Format.Short)} for processing.");
 
@@ -144,8 +143,25 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             Interlocked.Increment(ref _queueCount);
             try
             {
-                _recoveryQueue.Writer.TryWrite(blockRef);
-                if (_logger.IsTrace) _logger.Trace($"A new block {block.ToString(Block.Format.Short)} enqueued for processing.");
+                if (blockRef.Resolve(_blockTree))
+                {
+                    _lastProcessedBlock = DateTime.UtcNow;
+                    if (_logger.IsTrace) _logger.Trace($"A new block {block.ToString(Block.Format.Short)} enqueued for processing.");
+                    if (_queueCount > 1)
+                    {
+                        _recoveryQueue.Writer.TryWrite(blockRef);
+                    }
+                    else
+                    {
+                        // Skip recovery queue if nothing in queue
+                        await _blockQueue.Writer.WriteAsync(blockRef);
+                    }
+                }
+                else
+                {
+                    DecrementQueue(blockRef.BlockHash, ProcessingResult.MissingBlock);
+                    if (_logger.IsTrace) _logger.Trace("Block was removed from the DB and cannot be recovered (it belonged to an invalid branch). Skipping.");
+                }
             }
             catch (Exception e)
             {
@@ -203,48 +219,39 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
     }
 
+    private void DecrementQueue(Hash256 blockHash, ProcessingResult processingResult, Exception? exception = null)
+    {
+        Interlocked.Decrement(ref _queueCount);
+        BlockRemoved?.Invoke(this, new BlockRemovedEventArgs(blockHash, processingResult, exception));
+        FireProcessingQueueEmpty();
+    }
+
     private async Task RunRecoveryLoop()
     {
-        void DecrementQueue(Hash256 blockHash, ProcessingResult processingResult, Exception? exception = null)
-        {
-            Interlocked.Decrement(ref _queueCount);
-            BlockRemoved?.Invoke(this, new BlockRemovedEventArgs(blockHash, processingResult, exception));
-            FireProcessingQueueEmpty();
-        }
-
         if (_logger.IsDebug) _logger.Debug($"Starting recovery loop - {_blockQueue.Reader.Count} blocks waiting in the queue.");
-        _lastProcessedBlock = DateTime.UtcNow;
         await foreach (BlockRef blockRef in _recoveryQueue.Reader.ReadAllAsync(CancellationToken))
         {
             try
             {
-                if (blockRef.Resolve(_blockTree))
+                Interlocked.Add(ref _currentRecoveryQueueSize, -blockRef.Block!.Transactions.Length);
+                if (_logger.IsTrace) _logger.Trace($"Recovering addresses for block {blockRef.BlockHash}.");
+                _recoveryStep.RecoverData(blockRef.Block);
+
+                try
                 {
-                    Interlocked.Add(ref _currentRecoveryQueueSize, -blockRef.Block!.Transactions.Length);
-                    if (_logger.IsTrace) _logger.Trace($"Recovering addresses for block {blockRef.BlockHash}.");
-                    _recoveryStep.RecoverData(blockRef.Block);
-
-                    try
-                    {
-                        await _blockQueue.Writer.WriteAsync(blockRef);
-                    }
-                    catch (Exception e) when (e is not OperationCanceledException)
-                    {
-                        DecrementQueue(blockRef.BlockHash, ProcessingResult.QueueException, e);
-
-                        if (e is InvalidOperationException)
-                        {
-                            if (_logger.IsDebug) _logger.Debug($"Recovery loop stopping.");
-                            return;
-                        }
-
-                        throw;
-                    }
+                    await _blockQueue.Writer.WriteAsync(blockRef);
                 }
-                else
+                catch (Exception e) when (e is not OperationCanceledException)
                 {
-                    DecrementQueue(blockRef.BlockHash, ProcessingResult.MissingBlock);
-                    if (_logger.IsTrace) _logger.Trace("Block was removed from the DB and cannot be recovered (it belonged to an invalid branch). Skipping.");
+                    DecrementQueue(blockRef.BlockHash, ProcessingResult.QueueException, e);
+
+                    if (e is InvalidOperationException)
+                    {
+                        if (_logger.IsDebug) _logger.Debug($"Recovery loop stopping.");
+                        return;
+                    }
+
+                    throw;
                 }
             }
             catch (Exception e)
@@ -286,7 +293,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         GCScheduler.Instance.SwitchOnBackgroundGC(0);
         await foreach (BlockRef blockRef in _blockQueue.Reader.ReadAllAsync(CancellationToken))
         {
-            using var handle = Thread.CurrentThread.BoostPriorityHighest();
             // Have block, switch off background GC timer
             GCScheduler.Instance.SwitchOffBackgroundGC(_blockQueue.Reader.Count);
             _isProcessingBlock = true;
@@ -337,7 +343,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     private void FireProcessingQueueEmpty()
     {
-        if (((IBlockProcessingQueue)this).IsEmpty)
+        if (IsEmpty)
         {
             ProcessingQueueEmpty?.Invoke(this, EventArgs.Empty);
         }
@@ -345,8 +351,8 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     public event EventHandler? ProcessingQueueEmpty;
     public event EventHandler<BlockRemovedEventArgs>? BlockRemoved;
-
-    int IBlockProcessingQueue.Count => _queueCount;
+    public bool IsEmpty => Volatile.Read(ref _queueCount) == 0;
+    public int Count => Volatile.Read(ref _queueCount);
 
     public Block? Process(Block suggestedBlock, ProcessingOptions options, IBlockTracer tracer, CancellationToken token = default) =>
         Process(suggestedBlock, options, tracer, token, out _);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -56,8 +56,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         new BoundedChannelOptions(MaxProcessingQueueSize)
         {
             // Optimize for single reader concurrency
-            SingleReader = true,
-            AllowSynchronousContinuations = true
+            SingleReader = true
         });
 
     private bool _recoveryComplete = false;
@@ -154,7 +153,10 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
                     else
                     {
                         // Skip recovery queue if nothing in queue
-                        await _blockQueue.Writer.WriteAsync(blockRef);
+                        if (!_blockQueue.Writer.TryWrite(blockRef))
+                        {
+                            await _blockQueue.Writer.WriteAsync(blockRef);
+                        }
                     }
                 }
                 else

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingQueue.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingQueue.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 
@@ -17,7 +18,7 @@ namespace Nethermind.Consensus.Processing
         /// <param name="processingOptions">
         /// Processing options that block processor and transaction processor will adhere to.
         /// </param>
-        void Enqueue(Block block, ProcessingOptions processingOptions);
+        ValueTask Enqueue(Block block, ProcessingOptions processingOptions);
 
         /// <summary>
         /// Fired when all blocks from the processing queue has been taken.

--- a/src/Nethermind/Nethermind.Core/Threading/ThreadExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ThreadExtensions.cs
@@ -34,11 +34,6 @@ public static class ThreadExtensions
         return new Disposable(thread);
     }
 
-    public static Disposable BoostPriorityHighest(this Thread thread)
-    {
-        return new Disposable(thread, ThreadPriority.Highest);
-    }
-
     public static Disposable SetNormalPriority(this Thread thread)
     {
         return new Disposable(thread, ThreadPriority.Normal);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -324,8 +324,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
             return (TryCacheResult(ValidationResult.Invalid, validationMessage), validationMessage);
         }
 
-        TaskCompletionSource<ValidationResult?> blockProcessedTaskCompletionSource = new();
-        Task<ValidationResult?> blockProcessed = blockProcessedTaskCompletionSource.Task;
+        TaskCompletionSource<ValidationResult?> blockProcessed = new();
 
         void GetProcessingQueueOnBlockRemoved(object? o, BlockRemovedEventArgs e)
         {
@@ -336,7 +335,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
                 if (e.ProcessingResult == ProcessingResult.Exception)
                 {
                     BlockchainException? exception = new(e.Exception?.Message ?? "Block processing threw exception.", e.Exception);
-                    blockProcessedTaskCompletionSource.SetException(exception);
+                    blockProcessed.SetException(exception);
                     return;
                 }
 
@@ -355,14 +354,15 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
                     _ => null
                 };
 
-                blockProcessedTaskCompletionSource.TrySetResult(validationResult);
+                blockProcessed.TrySetResult(validationResult);
             }
         }
 
         _processingQueue.BlockRemoved += GetProcessingQueueOnBlockRemoved;
         try
         {
-            Task timeoutTask = Task.Delay(_timeout);
+            CancellationTokenSource cts = new();
+            Task timeoutTask = Task.Delay(_timeout, cts.Token);
 
             AddBlockResult addResult = await _blockTree
                 .SuggestBlockAsync(block, BlockTreeSuggestOptions.ForceDontSetAsMain)
@@ -396,7 +396,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
                 // of a previous newPayload or the block being discovered during syncing
                 // but add it to the processing queue just in case.
                 await _processingQueue.Enqueue(block, processingOptions);
-                result = await blockProcessed.TimeoutOn(timeoutTask);
+                result = await blockProcessed.Task.TimeoutOn(timeoutTask, cts);
             }
         }
         catch (TimeoutException)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -395,7 +395,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
                 // probably the block is already in the processing queue as a result
                 // of a previous newPayload or the block being discovered during syncing
                 // but add it to the processing queue just in case.
-                _processingQueue.Enqueue(block, processingOptions);
+                await _processingQueue.Enqueue(block, processingOptions);
                 result = await blockProcessed.TimeoutOn(timeoutTask);
             }
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/TimeoutUtils.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TimeoutUtils.cs
@@ -2,20 +2,28 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.Merge.Plugin;
 
 public static class TimeoutUtils
 {
-    public static async Task<T> TimeoutOn<T>(this Task<T> task, Task timeoutTask)
+    public static async Task<T> TimeoutOn<T>(this Task<T> task, Task timeoutTask, CancellationTokenSource? tcs = null)
     {
         Task firstToComplete = await Task.WhenAny(timeoutTask, task);
         if (firstToComplete == timeoutTask)
         {
-            throw new TimeoutException();
+            ThrowTimeout();
         }
+
+        tcs?.Cancel();
 
         return await task;
     }
+
+    [StackTraceHidden, DoesNotReturn]
+    private static void ThrowTimeout() => throw new TimeoutException();
 }


### PR DESCRIPTION
## Changes

- When no blocks queued (regular processing) skip the recovery queue and queue direct to the block processing queue to reduce latency

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
