### PR TITLE
Ignore `Celo` in Superchain Registry

### DIFF
--- a/scripts/superchain.py
+++ b/scripts/superchain.py
@@ -16,7 +16,7 @@ from urllib.request import urlopen
 from zipfile import ZipFile
 
 SUPERCHAIN_REPOSITORY = "https://github.com/ethereum-optimism/superchain-registry/archive/refs/heads/main.zip"
-IGNORED_CHAINS = ["arena-z-testnet", "creator-chain-testnet"]
+IGNORED_CHAINS = ["arena-z-testnet", "creator-chain-testnet", "celo"]
 IGNORED_L1S = ["sepolia-dev-0"]
 
 


### PR DESCRIPTION
## Changes

- Ignore `Celo` when processing Superchain Registry chains

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Ran the `superchain.py` script locally and I can confirm that it's working as expected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This is essentially a workaround for an issue that the Superchain Registry maintainers introduced by adding and later removing Celo. This issue is described in https://github.com/ethereum-optimism/superchain-registry/pull/1078 and we can revert this workaround once it's fixed on their side.
