### PR TITLE
Fix wrong reward componets

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
@@ -84,12 +84,12 @@ namespace Nethermind.Consensus.AuRa
             yield return typeof(LoadGenesisBlockAuRa);
         }
 
-        public IModule Module => new AuraModule(chainSpec);
+        public IModule Module => new AuRaModule(chainSpec);
 
         public Type ApiType => typeof(AuRaNethermindApi);
     }
 
-    public class AuraModule(ChainSpec chainSpec) : Module
+    public class AuRaModule(ChainSpec chainSpec) : Module
     {
         protected override void Load(ContainerBuilder builder)
         {

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -130,8 +130,8 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
                     // Aura uses `AuRaNethermindApi` for initialization, so need to do some additional things here
                     // as normally, test blockchain don't use INethermindApi at all. Note: This test does not
                     // seems to use aura block processor which means a lot of aura things is not available here.
-                    .AddModule(new AuraModule(ChainSpec))
-                    .AddModule(new AuraMergeModule())
+                    .AddModule(new AuRaModule(ChainSpec))
+                    .AddModule(new AuRaMergeModule())
                     .AddSingleton<NethermindApi.Dependencies>()
                     .AddSingleton<IReportingValidator>(NullReportingValidator.Instance)
                     .AddSingleton<ISealer>(NullSealEngine.Instance) // Test not originally made with aura sealer

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -97,7 +97,6 @@ namespace Nethermind.Merge.AuRa
 
                 .AddDecorator<IHeaderValidator, MergeHeaderValidator>()
                 .AddDecorator<IUnclesValidator, MergeUnclesValidator>()
-                .AddDecorator<ISealValidator, MergeSealValidator>()
                 ;
         }
     }

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -10,10 +10,11 @@ using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
+using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.InitializationSteps;
 using Nethermind.Consensus.AuRa.Transactions;
 using Nethermind.Consensus.Producers;
-using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Merge.AuRa.InitializationSteps;
 using Nethermind.Merge.Plugin;
@@ -73,24 +74,30 @@ namespace Nethermind.Merge.AuRa
             yield return typeof(InitializeBlockchainAuRaMerge);
         }
 
-        public override IModule Module => new AuraMergeModule();
+        public override IModule Module => new AuRaMergeModule();
     }
 
-    public class AuraMergeModule : Module
+    /// <summary>
+    /// Note: <see cref="AuRaMergeModule"/> is applied also when <see cref="AuRaModule"/> is applied.
+    /// Note: <see cref="AuRaMergePlugin"/> subclasses <see cref="MergePlugin"/>, but some component that is set
+    /// in <see cref="MergePlugin"/> is replaced later by standard AuRa components.
+    /// </summary>
+    public class AuRaMergeModule : Module
     {
         protected override void Load(ContainerBuilder builder)
         {
-            base.Load(builder);
-
-            // Nothing right now, just making it clear it is using `MergePluginModule`
             builder
-                .AddModule(new MergePluginModule())
+                .AddModule(new BaseMergePluginModule())
 
                 // Aura (non merge) use `BlockProducerStarter` directly.
                 .AddSingleton<IBlockProducerEnvFactory, AuRaMergeBlockProducerEnvFactory>()
                 .AddSingleton<IBlockProducerTxSourceFactory, AuRaMergeBlockProducerTxSourceFactory>()
 
                 .AddSingleton<IAuRaBlockProcessorFactory, AuRaMergeBlockProcessorFactory>()
+
+                .AddDecorator<IHeaderValidator, MergeHeaderValidator>()
+                .AddDecorator<IUnclesValidator, MergeUnclesValidator>()
+                .AddDecorator<ISealValidator, MergeSealValidator>()
                 ;
         }
     }

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Nethermind.Blockchain.BeaconBlockRoot;
-using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.InitializationSteps;
@@ -12,7 +11,6 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Init.Steps;
 using Nethermind.Merge.AuRa.Withdrawals;
 using Nethermind.State;
 
@@ -22,12 +20,10 @@ namespace Nethermind.Merge.AuRa.InitializationSteps
     {
         private readonly AuRaNethermindApi _api;
         private readonly AuRaChainSpecEngineParameters _parameters;
-        private readonly IPoSSwitcher _poSSwitcher;
 
-        public InitializeBlockchainAuRaMerge(AuRaNethermindApi api, IPoSSwitcher poSSwitcher) : base(api)
+        public InitializeBlockchainAuRaMerge(AuRaNethermindApi api) : base(api)
         {
             _api = api;
-            _poSSwitcher = poSSwitcher;
             _parameters = _api.ChainSpec.EngineChainSpecParametersProvider
                 .GetChainSpecParameters<AuRaChainSpecEngineParameters>();
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -377,8 +377,8 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
 }
 
 /// <summary>
-/// Code for Ethereum. As in Mainnet. Block processing code should be here as other chain have a tendency to not use the
-/// same. DO NOT USE IN PLUGIN.
+/// Code for Ethereum. As in Mainnet. Block processing code should be here as other chain have a tendency to replace
+/// them completely.
 /// </summary>
 public class MergePluginModule : Module
 {
@@ -398,7 +398,7 @@ public class MergePluginModule : Module
 
 /// <summary>
 /// Common post merge code, also uses by some plugins. These are components generally needed for sync and engine api.
-/// Note: Used by Optimism, Taiko, AuraMerge.
+/// Note: Used by <see cref="OptimismModule"/>, <see cref="TaikoModule"/>, <see cref="AuRaMergeModule"/>
 /// </summary>
 public class BaseMergePluginModule : Module
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -376,6 +376,10 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
     public virtual IModule Module => new MergePluginModule();
 }
 
+/// <summary>
+/// Code for Ethereum. As in Mainnet. Block processing code should be here as other chain have a tendency to not use the
+/// same. DO NOT USE IN PLUGIN.
+/// </summary>
 public class MergePluginModule : Module
 {
     protected override void Load(ContainerBuilder builder)
@@ -384,12 +388,17 @@ public class MergePluginModule : Module
             .AddDecorator<IHeaderValidator, MergeHeaderValidator>()
             .AddDecorator<IUnclesValidator, MergeUnclesValidator>()
 
+            .AddDecorator<IRewardCalculatorSource, MergeRewardCalculatorSource>()
+            .AddDecorator<ISealValidator, MergeSealValidator>()
+            .AddDecorator<ISealer, MergeSealer>()
+
             .AddModule(new BaseMergePluginModule());
     }
 }
 
 /// <summary>
-/// Common post merge code, also uses by some plugins.
+/// Common post merge code, also uses by some plugins. These are components generally needed for sync and engine api.
+/// Note: Used by Optimism, Taiko, AuraMerge.
 /// </summary>
 public class BaseMergePluginModule : Module
 {
@@ -415,10 +424,6 @@ public class BaseMergePluginModule : Module
 
             .AddSingleton<StartingSyncPivotUpdater>()
             .ResolveOnServiceActivation<StartingSyncPivotUpdater, ISyncModeSelector>()
-
-            .AddDecorator<IRewardCalculatorSource, MergeRewardCalculatorSource>()
-            .AddDecorator<ISealValidator, MergeSealValidator>()
-            .AddDecorator<ISealer, MergeSealer>()
 
             // Invalid chain tracker wrapper should be after other validator.
             .AddDecorator<IHeaderValidator, InvalidHeaderInterceptor>()


### PR DESCRIPTION
- Fix miss in rewards components replacement as for aura the reward that is set in `MergePlugin`, is replaced in `InitializeBlockchainAuRa`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)d

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Reproducable locally.