### PR TITLE
Don't broadcast txs while processing a block

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1741,6 +1741,8 @@ namespace Nethermind.Blockchain
             }
         }
 
+        public bool IsProcessingBlock { get; set; }
+
         public void ForkChoiceUpdated(Hash256? finalizedBlockHash, Hash256? safeBlockHash)
         {
             FinalizedHash = finalizedBlockHash;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -231,6 +231,7 @@ public class BlockTreeOverlay : IBlockTree
         get => _baseTree.SyncPivot;
         set => _baseTree.SyncPivot = value;
     }
+    public bool IsProcessingBlock { get => _baseTree.IsProcessingBlock; set => _baseTree.IsProcessingBlock = value; }
 
     public Block? FindBlock(Hash256 blockHash, BlockTreeLookupOptions options, long? blockNumber = null) =>
         _overlayTree.FindBlock(blockHash, options, blockNumber) ?? _baseTree.FindBlock(blockHash, options, blockNumber);

--- a/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
@@ -72,6 +72,8 @@ namespace Nethermind.Blockchain
             }
         }
 
+        public bool IsProcessingBlock => _blockTree.IsProcessingBlock;
+
         public event EventHandler<BlockReplacementEventArgs>? HeadChanged;
 
         private void OnHeadChanged(object? sender, BlockReplacementEventArgs e)

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -195,5 +195,6 @@ namespace Nethermind.Blockchain
         /// Before sync pivot, there is no guarantee that blocks and receipts are available or continuous.
         /// </summary>
         (long BlockNumber, Hash256 BlockHash) SyncPivot { get; set; }
+        bool IsProcessingBlock { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -202,6 +202,8 @@ namespace Nethermind.Blockchain
             }
         }
 
+        public bool IsProcessingBlock { get => _wrapped.IsProcessingBlock; set { } }
+
         public void UpdateMainChain(IReadOnlyList<Block> blocks, bool wereProcessed, bool forceHeadBlock = false) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(UpdateMainChain)} calls");
 
         public void ForkChoiceUpdated(Hash256? finalizedBlockHash, Hash256? safeBlockBlockHash) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(ForkChoiceUpdated)} calls");

--- a/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
@@ -29,6 +29,7 @@ namespace Nethermind.TxPool
         ProofVersion CurrentProofVersion { get; }
 
         bool IsSyncing { get; }
+        bool IsProcessingBlock { get; }
 
         event EventHandler<BlockReplacementEventArgs> HeadChanged;
     }


### PR DESCRIPTION
## Changes

-  Don't broadcast txs while producing a block as it allocates a lot and we want to minimize GCs at this time also head about to change which could change the filter results; reducing variance during long blocks

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No