### PR TITLE
fix: implement latest block validation in FilterManager

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -139,7 +139,7 @@ namespace Nethermind.Init.Steps
 
             IJsonRpcConfig rpcConfig = _api.Config<IJsonRpcConfig>();
             IFilterStore filterStore = setApi.FilterStore = new FilterStore(getApi.TimerFactory, rpcConfig.FiltersTimeout);
-            setApi.FilterManager = new FilterManager(filterStore, mainBlockProcessor, txPool, getApi.LogManager);
+            setApi.FilterManager = new FilterManager(filterStore, mainBlockProcessor, txPool, getApi.LogManager, getApi.BlockTree!);
             setApi.BlockProductionPolicy = CreateBlockProductionPolicy();
             _api.DisposeStack.Push(filterStore);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -172,8 +172,8 @@ namespace Nethermind.JsonRpc.Test.Modules
                     builder.UpdateSingleton<IRpcModuleFactory<ITraceRpcModule>>(builder => builder.AddSingleton<IRewardCalculatorSource, RewardCalculator>());
 
                     // Filter manager need the block processor, but the block processor is currently not completely DI, so need to patch it in.
-                    builder.AddSingleton<IFilterManager, IFilterStore, ITxPool, ILogManager>((store, txPool, logManager) =>
-                            new FilterManager(store, _blockchain.BlockProcessor, txPool, logManager));
+                    builder.AddSingleton<IFilterManager, IFilterStore, ITxPool, ILogManager, IBlockFinder>((store, txPool, logManager, blockFinder) =>
+                            new FilterManager(store, _blockchain.BlockProcessor, txPool, logManager, blockFinder));
 
                     if (_blockFinderOverride is not null) builder.AddSingleton(_blockFinderOverride);
                     if (_receiptFinderOverride is not null) builder.AddSingleton(_receiptFinderOverride);


### PR DESCRIPTION
Resolves TODO comment in FilterManager.cs

## Changes

- Added IBlockFinder dependency to FilterManager constructor
- Implemented latest block validation in CreateLog method for BlockParameterType.Latest filters
- Updated dependency injection in InitializeBlockchain and test modules
- Added tests for latest block validation scenarios

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added comprehensive tests for latest block validation including edge cases when latest block is null or receipt is from different block.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This change resolves the TODO comment `//TODO: check if is last mined block` by properly validating that log filters with `BlockParameterType.Latest` only include logs from the actual latest mined block, preventing potential inconsistencies in filter results.