### PR TITLE
Allocate 96 bytes less per tx sender recovery

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
@@ -196,7 +196,7 @@ namespace Nethermind.AuRa.Test
 
             Hash256 hash = block.CalculateHash(RlpBehaviors.ForSealing);
             block.AuRaSignature = _wallet.Sign(hash, signedAddress).BytesWithRecovery;
-            _ethereumEcdsa.RecoverAddress(Arg.Any<Signature>(), hash).Returns(recoveredAddress);
+            _ethereumEcdsa.RecoverAddress(Arg.Any<Signature>(), in hash.ValueHash256).Returns(recoveredAddress);
 
             return _sealValidator.ValidateSeal(block, false);
         }

--- a/src/Nethermind/Nethermind.Benchmark/Core/RecoverSignaturesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/RecoverSignaturesBenchmark.cs
@@ -128,13 +128,10 @@ namespace Nethermind.Benchmarks.Core
 
             static AuthorizationTuple CreateAuthorizationTuple(PrivateKey signer, ulong chainId, Address codeAddress, ulong nonce)
             {
-                AuthorizationTupleDecoder decoder = new();
-                RlpStream rlp = decoder.EncodeWithoutSignature(chainId, codeAddress, nonce);
-                Span<byte> code = stackalloc byte[rlp.Length + 1];
-                code[0] = Eip7702Constants.Magic;
-                rlp.Data.AsSpan().CopyTo(code.Slice(1));
-
-                Signature sig = _ethereumEcdsa.Sign(signer, Keccak.Compute(code));
+                KeccakRlpStream rlp = new();
+                rlp.WriteByte(Eip7702Constants.Magic);
+                AuthorizationTupleDecoder.EncodeWithoutSignature(rlp, chainId, codeAddress, nonce);
+                Signature sig = _ethereumEcdsa.Sign(signer, rlp.GetValueHash());
 
                 return new AuthorizationTuple(chainId, codeAddress, nonce, sig);
             }

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueTests.cs
@@ -114,13 +114,13 @@ public class CliqueTests
         ISigner signer = Substitute.For<ISigner>();
         signer.CanSign.Returns(true);
         signer.Address.Returns(new Address("0x7ffc57839b00206d1ad20c69a1981b489f772031"));
-        signer.Sign(Arg.Any<Hash256>()).Returns(new Signature(new byte[65]));
+        signer.Sign(Arg.Any<ValueHash256>()).Returns(new Signature(new byte[65]));
         CliqueSealer sut = new CliqueSealer(signer, new CliqueConfig(), _snapshotManager, LimboLogs.Instance);
         Block block = Rlp.Decode<Block>(new Rlp(Bytes.FromHexString(blockRlp)));
 
         await sut.SealBlock(block, System.Threading.CancellationToken.None);
 
-        signer.Received().Sign(Arg.Any<Hash256>());
+        signer.Received().Sign(Arg.Any<ValueHash256>());
     }
 
     public static Block GetGenesis()

--- a/src/Nethermind/Nethermind.Clique.Test/SnapshotManagerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/SnapshotManagerTests.cs
@@ -85,8 +85,8 @@ public class SnapshotManagerTests
     {
         BlockHeader header = BuildCliqueBlock();
 
-        Hash256 expectedHeaderHash = new("0x7b27b6add9e8d0184c722dde86a2a3f626630264bae3d62ffeea1585ce6e3cdd");
-        Hash256 headerHash = SnapshotManager.CalculateCliqueHeaderHash(header);
+        ValueHash256 expectedHeaderHash = new("0x7b27b6add9e8d0184c722dde86a2a3f626630264bae3d62ffeea1585ce6e3cdd");
+        ValueHash256 headerHash = SnapshotManager.CalculateCliqueHeaderHash(header);
         Assert.That(headerHash, Is.EqualTo(expectedHeaderHash));
     }
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
@@ -165,8 +165,8 @@ namespace Nethermind.Consensus.AuRa
         {
             Signature signature = new Signature(header.AuRaSignature);
             signature.V += Signature.VOffset;
-            Hash256 message = header.CalculateHash(RlpBehaviors.ForSealing);
-            return _ecdsa.RecoverAddress(signature, message);
+            ValueHash256 message = header.CalculateValueHash(RlpBehaviors.ForSealing);
+            return _ecdsa.RecoverAddress(signature, in message);
         }
 
         private class ReceivedSteps

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
@@ -62,13 +62,13 @@ namespace Nethermind.Consensus.Clique
             }
 
             // Sign all the things!
-            Hash256 headerHash = SnapshotManager.CalculateCliqueHeaderHash(header);
+            ValueHash256 headerHash = SnapshotManager.CalculateCliqueHeaderHash(header);
             Signature signature;
             if (_signer is IHeaderSigner headerSigner)
             {
                 BlockHeader clone = header.Clone();
                 clone.ExtraData = SnapshotManager.SliceExtraSealFromExtraData(clone.ExtraData);
-                clone.Hash = headerHash;
+                clone.Hash = new Hash256(headerHash);
                 signature = headerSigner.Sign(clone);
             }
             else

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -66,8 +66,8 @@ namespace Nethermind.Consensus.Clique
             Span<byte> signatureBytes = header.ExtraData.AsSpan(header.ExtraData.Length - extraSeal, extraSeal);
             Signature signature = new(signatureBytes);
             signature.V += Signature.VOffset;
-            Hash256 message = CalculateCliqueHeaderHash(header);
-            Address address = _ecdsa.RecoverAddress(signatureBytes, message);
+            ValueHash256 message = CalculateCliqueHeaderHash(header);
+            Address address = _ecdsa.RecoverAddress(signatureBytes, in message);
             _signatures.Set(header.Hash, address);
             return address;
         }
@@ -80,12 +80,12 @@ namespace Nethermind.Consensus.Clique
             return signersCount;
         }
 
-        public static Hash256 CalculateCliqueHeaderHash(BlockHeader blockHeader)
+        public static ValueHash256 CalculateCliqueHeaderHash(BlockHeader blockHeader)
         {
             byte[] fullExtraData = blockHeader.ExtraData;
             byte[] shortExtraData = SliceExtraSealFromExtraData(blockHeader.ExtraData);
             blockHeader.ExtraData = shortExtraData;
-            Hash256 sigHash = blockHeader.CalculateHash();
+            ValueHash256 sigHash = blockHeader.CalculateValueHash();
             blockHeader.ExtraData = fullExtraData;
             return sigHash;
         }

--- a/src/Nethermind/Nethermind.Consensus/ISigner.cs
+++ b/src/Nethermind/Nethermind.Consensus/ISigner.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Consensus
         // TODO: this breaks the encapsulation of the key inside the signer, would like to see this removed
         PrivateKey? Key { get; }
         Address Address { get; }
-        Signature Sign(Hash256 message);
+        Signature Sign(in ValueHash256 message);
         bool CanSign { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/NullSigner.cs
+++ b/src/Nethermind/Nethermind.Consensus/NullSigner.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Consensus
 
         public ValueTask Sign(Transaction tx) => default;
 
-        public Signature Sign(Hash256 message) { return new(new byte[65]); }
+        public Signature Sign(in ValueHash256 message) { return new(new byte[65]); }
 
         public bool CanSign { get; } = true; // TODO: why true?
 

--- a/src/Nethermind/Nethermind.Consensus/Signer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Signer.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Consensus
             SetSigner(key);
         }
 
-        public Signature Sign(Hash256 message)
+        public Signature Sign(in ValueHash256 message)
         {
             if (!CanSign) throw new InvalidOperationException("Cannot sign without provided key.");
             byte[] rs = SpanSecP256k1.SignCompact(message.Bytes, _key!.KeyBytes, out int v);

--- a/src/Nethermind/Nethermind.Core.Test/SignerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SignerTests.cs
@@ -33,10 +33,10 @@ namespace Nethermind.Core.Test
         {
             EthereumEcdsa ethereumEcdsa = new(BlockchainIds.Olympic);
 
-            Hash256 message = Keccak.Compute("Test message");
+            ValueHash256 message = ValueKeccak.Compute("Test message");
             PrivateKey privateKey = Build.A.PrivateKey.TestObject;
-            Signature signature = ethereumEcdsa.Sign(privateKey, message);
-            Assert.That(ethereumEcdsa.RecoverAddress(signature, message), Is.EqualTo(privateKey.Address));
+            Signature signature = ethereumEcdsa.Sign(privateKey, in message);
+            Assert.That(ethereumEcdsa.RecoverAddress(signature, in message), Is.EqualTo(privateKey.Address));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Crypto/BlockHeaderExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/BlockHeaderExtensions.cs
@@ -13,11 +13,14 @@ namespace Nethermind.Crypto
         private static readonly HeaderDecoder _headerDecoder = new();
 
         public static Hash256 CalculateHash(this BlockHeader header, RlpBehaviors behaviors = RlpBehaviors.None)
+            => new Hash256(CalculateValueHash(header, behaviors));
+
+        public static ValueHash256 CalculateValueHash(this BlockHeader header, RlpBehaviors behaviors = RlpBehaviors.None)
         {
             KeccakRlpStream stream = new();
             _headerDecoder.Encode(stream, header, behaviors);
 
-            return stream.GetHash();
+            return stream.GetValueHash();
         }
 
         public static Hash256 CalculateHash(this Block block, RlpBehaviors behaviors = RlpBehaviors.None) => CalculateHash(block.Header, behaviors);

--- a/src/Nethermind/Nethermind.Crypto/Ecdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/Ecdsa.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Crypto
@@ -12,29 +14,14 @@ namespace Nethermind.Crypto
     /// </summary>
     public class Ecdsa : IEcdsa
     {
-        public Signature Sign(PrivateKey privateKey, Hash256 message)
+        public Signature Sign(PrivateKey privateKey, in ValueHash256 message)
         {
             if (!SecP256k1.VerifyPrivateKey(privateKey.KeyBytes))
             {
-                throw new ArgumentException("Invalid private key", nameof(privateKey));
+                InvalidPrivateKey();
             }
 
             byte[] signatureBytes = SpanSecP256k1.SignCompact(message.Bytes, privateKey.KeyBytes, out int recoveryId);
-
-            //// https://bitcoin.stackexchange.com/questions/59820/sign-a-tx-with-low-s-value-using-openssl
-
-            //byte[] sBytes = signatureBytes.Slice(32, 32);
-            //BigInteger s = sBytes.ToUnsignedBigInteger();
-            //if (s > MaxLowS)
-            //{
-            //    s = LowSTransform - s;
-            //    byte[] newSBytes = s.ToBigEndianByteArray();
-            //    for (int i = 0; i < 32; i++)
-            //    {
-            //        signatureBytes[32 + 1] = newSBytes[i];
-            //    }
-            //}
-
             Signature signature = new(signatureBytes, recoveryId);
 
 #if DEBUG
@@ -44,11 +31,13 @@ namespace Nethermind.Crypto
                 throw new InvalidOperationException("After signing recovery returns different address than ecdsa's");
             }
 #endif
-
             return signature;
+
+            [DoesNotReturn, StackTraceHidden]
+            static void InvalidPrivateKey() => throw new ArgumentException("Invalid private key");
         }
 
-        public PublicKey? RecoverPublicKey(Signature signature, Hash256 message)
+        public PublicKey? RecoverPublicKey(Signature signature, in ValueHash256 message)
         {
             Span<byte> publicKey = stackalloc byte[65];
             bool success = SpanSecP256k1.RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, false);
@@ -60,7 +49,7 @@ namespace Nethermind.Crypto
             return new PublicKey(publicKey);
         }
 
-        public CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, Hash256 message)
+        public CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, in ValueHash256 message)
         {
             Span<byte> publicKey = stackalloc byte[33];
             bool success = SpanSecP256k1.RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, true);

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
@@ -31,12 +31,13 @@ namespace Nethermind.Crypto
         {
         }
 
-        public Address? RecoverAddress(Signature signature, Hash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
+        public Address? RecoverAddress(Signature signature, in ValueHash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
 
+        public Address? RecoverAddress(Signature signature, Hash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
 
         public Address? RecoverAddress(Span<byte> signatureBytes65, Hash256 message) => RecoverAddress(signatureBytes65[..64], signatureBytes65[64], message.Bytes);
 
-        public static Address? RecoverAddress(Span<byte> signatureBytes64, byte v, Span<byte> message)
+        public static Address? RecoverAddress(Span<byte> signatureBytes64, byte v, ReadOnlySpan<byte> message)
         {
             Span<byte> publicKey = stackalloc byte[65];
             bool success = SpanSecP256k1.RecoverKeyFromCompact(

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Crypto
         {
         }
 
-        public Address? RecoverAddress(Signature signature, Hash256 message) => RecoverAddress(signature.BytesWithRecovery, message);
+        public Address? RecoverAddress(Signature signature, Hash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
 
 
         public Address? RecoverAddress(Span<byte> signatureBytes65, Hash256 message) => RecoverAddress(signatureBytes65[..64], signatureBytes65[64], message.Bytes);

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
@@ -33,9 +33,7 @@ namespace Nethermind.Crypto
 
         public Address? RecoverAddress(Signature signature, in ValueHash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
 
-        public Address? RecoverAddress(Signature signature, Hash256 message) => RecoverAddress(signature.Bytes, signature.RecoveryId, message.Bytes);
-
-        public Address? RecoverAddress(Span<byte> signatureBytes65, Hash256 message) => RecoverAddress(signatureBytes65[..64], signatureBytes65[64], message.Bytes);
+        public Address? RecoverAddress(Span<byte> signatureBytes65, in ValueHash256 message) => RecoverAddress(signatureBytes65[..64], signatureBytes65[64], message.Bytes);
 
         public static Address? RecoverAddress(Span<byte> signatureBytes64, byte v, ReadOnlySpan<byte> message)
         {

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -15,11 +14,10 @@ namespace Nethermind.Crypto
         private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
         public static AuthorizationTuple Sign(this IEthereumEcdsa ecdsa, PrivateKey signer, ulong chainId, Address codeAddress, ulong nonce)
         {
-            using NettyRlpStream rlp = AuthorizationTupleDecoder.Instance.EncodeWithoutSignature(chainId, codeAddress, nonce);
-            Span<byte> preImage = stackalloc byte[rlp.Length + 1];
-            preImage[0] = Eip7702Constants.Magic;
-            rlp.AsSpan().CopyTo(preImage[1..]);
-            Signature sig = ecdsa.Sign(signer, Keccak.Compute(preImage));
+            KeccakRlpStream stream = new();
+            stream.WriteByte(Eip7702Constants.Magic);
+            AuthorizationTupleDecoder.EncodeWithoutSignature(stream, chainId, codeAddress, nonce);
+            Signature sig = ecdsa.Sign(signer, stream.GetValueHash());
             return new AuthorizationTuple(chainId, codeAddress, nonce, sig);
         }
 
@@ -30,8 +28,8 @@ namespace Nethermind.Crypto
                 tx.ChainId = ecdsa.ChainId;
             }
 
-            Hash256 hash = Keccak.Compute(Rlp.Encode(tx, true, isEip155Enabled, ecdsa.ChainId).Bytes);
-            tx.Signature = ecdsa.Sign(privateKey, hash);
+            ValueHash256 hash = ValueKeccak.Compute(Rlp.Encode(tx, true, isEip155Enabled, ecdsa.ChainId).Bytes);
+            tx.Signature = ecdsa.Sign(privateKey, in hash);
 
             if (tx.Type == TxType.Legacy && isEip155Enabled)
             {
@@ -85,14 +83,12 @@ namespace Nethermind.Crypto
 
         public static ulong CalculateV(ulong chainId, bool addParity = true) => chainId * 2 + 35ul + (addParity ? 1u : 0u);
 
-        [SkipLocalsInit]
         public static Address? RecoverAddress(this IEthereumEcdsa ecdsa, AuthorizationTuple tuple)
         {
-            Span<byte> buffer = stackalloc byte[128];
-            buffer[0] = Eip7702Constants.Magic;
-            using NettyRlpStream stream = AuthorizationTupleDecoder.Instance.EncodeWithoutSignature(tuple.ChainId, tuple.CodeAddress, tuple.Nonce);
-            stream.AsSpan().CopyTo(buffer[1..]);
-            return ecdsa.RecoverAddress(tuple.AuthoritySignature, Keccak.Compute(buffer[..(stream.Length + 1)]));
+            KeccakRlpStream stream = new();
+            stream.WriteByte(Eip7702Constants.Magic);
+            AuthorizationTupleDecoder.EncodeWithoutSignature(stream, tuple.ChainId, tuple.CodeAddress, tuple.Nonce);
+            return ecdsa.RecoverAddress(tuple.AuthoritySignature, stream.GetValueHash());
         }
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -80,7 +80,7 @@ namespace Nethermind.Crypto
             KeccakRlpStream stream = new();
             _txDecoder.EncodeTx(stream, tx, RlpBehaviors.SkipTypedWrapping, true, applyEip155, chainId);
 
-            return ecdsa.RecoverAddress(tx.Signature, stream.GetHash());
+            return ecdsa.RecoverAddress(tx.Signature, stream.GetValueHash());
         }
 
         public static ulong CalculateV(ulong chainId, bool addParity = true) => chainId * 2 + 35ul + (addParity ? 1u : 0u);

--- a/src/Nethermind/Nethermind.Crypto/IEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/IEcdsa.cs
@@ -7,8 +7,19 @@ namespace Nethermind.Crypto
 {
     public interface IEcdsa
     {
-        Signature Sign(PrivateKey privateKey, Hash256 message);
-        PublicKey? RecoverPublicKey(Signature signature, Hash256 message);
-        CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, Hash256 message);
+        Signature Sign(PrivateKey privateKey, Hash256 message)
+            => Sign(privateKey, in message.ValueHash256);
+
+        Signature Sign(PrivateKey privateKey, in ValueHash256 message);
+        
+        PublicKey? RecoverPublicKey(Signature signature, Hash256 message)
+            => RecoverPublicKey(signature, in message.ValueHash256);
+
+        PublicKey? RecoverPublicKey(Signature signature, in ValueHash256 message);
+
+        CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, Hash256 message)
+            => RecoverCompressedPublicKey(signature, in message.ValueHash256);
+
+        CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, in ValueHash256 message);
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/IEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/IEcdsa.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Crypto
             => Sign(privateKey, in message.ValueHash256);
 
         Signature Sign(PrivateKey privateKey, in ValueHash256 message);
-        
+
         PublicKey? RecoverPublicKey(Signature signature, Hash256 message)
             => RecoverPublicKey(signature, in message.ValueHash256);
 

--- a/src/Nethermind/Nethermind.Crypto/IEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/IEthereumEcdsa.cs
@@ -10,8 +10,12 @@ namespace Nethermind.Crypto
     public interface IEthereumEcdsa : IEcdsa
     {
         ulong ChainId { get; }
+        Address? RecoverAddress(Signature signature, Hash256 message)
+            => RecoverAddress(signature, in message.ValueHash256);
+
         Address? RecoverAddress(Signature signature, in ValueHash256 message);
-        Address? RecoverAddress(Signature signature, Hash256 message);
-        Address? RecoverAddress(Span<byte> signatureBytes, Hash256 message);
+        Address? RecoverAddress(Span<byte> signatureBytes, Hash256 message)
+            => RecoverAddress(signatureBytes, in message.ValueHash256);
+        Address? RecoverAddress(Span<byte> signatureBytes, in ValueHash256 message);
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/IEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/IEthereumEcdsa.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Crypto
     public interface IEthereumEcdsa : IEcdsa
     {
         ulong ChainId { get; }
+        Address? RecoverAddress(Signature signature, in ValueHash256 message);
         Address? RecoverAddress(Signature signature, Hash256 message);
         Address? RecoverAddress(Span<byte> signatureBytes, Hash256 message);
     }

--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -14,10 +14,9 @@ namespace Nethermind.Crypto
     {
         private readonly KeccakHash _keccakHash;
 
-        public Hash256 GetHash()
-        {
-            return new Hash256(_keccakHash.GenerateValueHash());
-        }
+        public Hash256 GetHash() => new Hash256(_keccakHash.GenerateValueHash());
+
+        public ValueHash256 GetValueHash() => _keccakHash.GenerateValueHash();
 
         public KeccakRlpStream()
         {

--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;

--- a/src/Nethermind/Nethermind.Crypto/NullEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/NullEthereumEcdsa.cs
@@ -51,5 +51,10 @@ namespace Nethermind.Crypto
         {
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }
+
+        public Address? RecoverAddress(Signature signature, in ValueHash256 message)
+        {
+            throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/NullEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/NullEthereumEcdsa.cs
@@ -17,17 +17,17 @@ namespace Nethermind.Crypto
         {
         }
 
-        public Signature Sign(PrivateKey privateKey, Hash256 message)
+        public Signature Sign(PrivateKey privateKey, in ValueHash256 message)
         {
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }
 
-        public PublicKey RecoverPublicKey(Signature signature, Hash256 message)
+        public PublicKey RecoverPublicKey(Signature signature, in ValueHash256 message)
         {
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }
 
-        public CompressedPublicKey RecoverCompressedPublicKey(Signature signature, Hash256 message)
+        public CompressedPublicKey RecoverCompressedPublicKey(Signature signature, in ValueHash256 message)
         {
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }
@@ -37,12 +37,7 @@ namespace Nethermind.Crypto
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }
 
-        public Address RecoverAddress(Signature signature, Hash256 message)
-        {
-            throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
-        }
-
-        public Address RecoverAddress(Span<byte> signatureBytes, Hash256 message)
+        public Address RecoverAddress(Span<byte> signatureBytes, in ValueHash256 message)
         {
             throw new InvalidOperationException($"{nameof(NullEthereumEcdsa)} does not expect any calls");
         }

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -175,17 +175,4 @@ public class CodeInfoRepositoryTests
 
         sut.GetCachedCodeInfo(stateProvider, TestItem.AddressA, Substitute.For<IReleaseSpec>()).Should().BeEquivalentTo(new CodeInfo(code));
     }
-
-    private static AuthorizationTuple CreateAuthorizationTuple(PrivateKey signer, ulong chainId, Address codeAddress, ulong nonce)
-    {
-        AuthorizationTupleDecoder decoder = new();
-        using NettyRlpStream rlp = decoder.EncodeWithoutSignature(chainId, codeAddress, nonce);
-        Span<byte> code = stackalloc byte[rlp.Length + 1];
-        code[0] = Eip7702Constants.Magic;
-        rlp.AsSpan().CopyTo(code[1..]);
-        EthereumEcdsa ecdsa = new(1);
-        Signature sig = ecdsa.Sign(signer, Keccak.Compute(code));
-
-        return new AuthorizationTuple(chainId, codeAddress, nonce, sig, signer.Address);
-    }
 }

--- a/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSigner.cs
+++ b/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSigner.cs
@@ -38,10 +38,8 @@ public class ClefSigner : IHeaderSigner, ISignerStore
     /// </summary>
     /// <param name="message">Message to be signed.</param>
     /// <returns><see cref="Signature"/> of <paramref name="message"/>.</returns>
-    public Signature Sign(Hash256 message)
-    {
-        return _clefWallet.Sign(message, Address);
-    }
+    public Signature Sign(in ValueHash256 message)
+        => _clefWallet.Sign(new Hash256(message), Address);
 
     /// <summary>
     /// Used to sign a clique header. The full Rlp of the header has to be sent,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcSimulateTestsBase.cs
@@ -79,12 +79,12 @@ public class EthRpcSimulateTestsBase
     public static byte[] GetTxData(TestRpcBlockchain chain, PrivateKey account, string name = "recover")
     {
         // Step 1: Hash the message
-        Hash256 messageHash = Keccak.Compute("Hello, world!");
+        ValueHash256 messageHash = ValueKeccak.Compute("Hello, world!");
         // Step 2: Sign the hash
-        Signature signature = chain.EthereumEcdsa.Sign(account, messageHash);
+        Signature signature = chain.EthereumEcdsa.Sign(account, in messageHash);
 
         //Check real address
-        return GenerateTransactionDataForEcRecover(messageHash, signature, name);
+        return GenerateTransactionDataForEcRecover(new Hash256(messageHash), signature, name);
     }
 
     public static async Task<Address> DeployEcRecoverContract(TestRpcBlockchain chain, PrivateKey privateKey, string contractBytecode)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsSimplePrecompiles.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsSimplePrecompiles.cs
@@ -57,12 +57,12 @@ public class EthSimulateTestsSimplePrecompiles : EthRpcSimulateTestsBase
             .Op(Instruction.RETURN).Done;
 
         // Step 1: Hash the message
-        Hash256 messageHash = Keccak.Compute("Hello, world!");
+        ValueHash256 messageHash = ValueKeccak.Compute("Hello, world!");
         // Step 2: Sign the hash
-        Signature signature = chain.EthereumEcdsa.Sign(TestItem.PrivateKeyA, messageHash);
+        Signature signature = chain.EthereumEcdsa.Sign(TestItem.PrivateKeyA, in messageHash);
 
         Address contractAddress = await DeployEcRecoverContract(chain, TestItem.PrivateKeyB, EcRecoverCallerContractBytecode);
-        byte[] transactionData = GenerateTransactionDataForEcRecover(messageHash, signature);
+        byte[] transactionData = GenerateTransactionDataForEcRecover(new Hash256(messageHash), signature);
 
         SystemTransaction tx = new()
         {

--- a/src/Nethermind/Nethermind.Network.Discovery/Messages/NodeIdResolver.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Messages/NodeIdResolver.cs
@@ -17,6 +17,6 @@ public class NodeIdResolver : INodeIdResolver
 
     public PublicKey GetNodeId(ReadOnlySpan<byte> signature, int recoveryId, Span<byte> typeAndData)
     {
-        return _ecdsa.RecoverPublicKey(new Signature(signature, recoveryId), Keccak.Compute(typeAndData))!;
+        return _ecdsa.RecoverPublicKey(new Signature(signature, recoveryId), ValueKeccak.Compute(typeAndData))!;
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Serializers/DiscoveryMsgSerializerBase.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Serializers/DiscoveryMsgSerializerBase.cs
@@ -43,10 +43,10 @@ public abstract class DiscoveryMsgSerializerBase
         byteBuffer.WriteBytes(data.ToArray(), 0, data.Length);
 
         byteBuffer.SetReaderIndex(startReadIndex + 32 + 65);
-        Hash256 toSign = Keccak.Compute(byteBuffer.ReadAllBytesAsSpan());
+        ValueHash256 toSign = ValueKeccak.Compute(byteBuffer.ReadAllBytesAsSpan());
         byteBuffer.SetReaderIndex(startReadIndex);
 
-        Signature signature = _ecdsa.Sign(_privateKey, toSign);
+        Signature signature = _ecdsa.Sign(_privateKey, in toSign);
         byteBuffer.SetWriterIndex(startWriteIndex + 32);
         byteBuffer.WriteBytes(signature.Bytes);
         byteBuffer.WriteByte(signature.RecoveryId);
@@ -71,10 +71,10 @@ public abstract class DiscoveryMsgSerializerBase
 
         byteBuffer.SetWriterIndex(startWriteIndex + length);
         byteBuffer.SetReaderIndex(startReadIndex + 32 + 65);
-        Hash256 toSign = Keccak.Compute(byteBuffer.ReadAllBytesAsSpan());
+        ValueHash256 toSign = ValueKeccak.Compute(byteBuffer.ReadAllBytesAsSpan());
         byteBuffer.SetReaderIndex(startReadIndex);
 
-        Signature signature = _ecdsa.Sign(_privateKey, toSign);
+        Signature signature = _ecdsa.Sign(_privateKey, in toSign);
         byteBuffer.SetWriterIndex(startWriteIndex + 32);
         byteBuffer.WriteBytes(signature.Bytes);
         byteBuffer.WriteByte(signature.RecoveryId);

--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
@@ -29,7 +29,7 @@ public class NodeRecordSigner : INodeRecordSigner
     /// <param name="nodeRecord"></param>
     public void Sign(NodeRecord nodeRecord)
     {
-        nodeRecord.Signature = _ecdsa.Sign(_privateKey, nodeRecord.ContentHash);
+        nodeRecord.Signature = _ecdsa.Sign(_privateKey, in nodeRecord.ContentHash.ValueHash256);
     }
 
     /// <summary>
@@ -129,10 +129,10 @@ public class NodeRecordSigner : INodeRecordSigner
             throw new Exception("Cannot verify an ENR with an empty signature.");
         }
 
-        Hash256 contentHash;
+        ValueHash256 contentHash;
         if (nodeRecord.OriginalContentRlp is not null)
         {
-            contentHash = Keccak.Compute(nodeRecord.OriginalContentRlp);
+            contentHash = ValueKeccak.Compute(nodeRecord.OriginalContentRlp);
         }
         else
         {
@@ -140,10 +140,10 @@ public class NodeRecordSigner : INodeRecordSigner
         }
 
         CompressedPublicKey publicKeyA =
-            _ecdsa.RecoverCompressedPublicKey(nodeRecord.Signature!, contentHash)!;
+            _ecdsa.RecoverCompressedPublicKey(nodeRecord.Signature!, in contentHash)!;
         Signature sigB = new(nodeRecord.Signature!.Bytes, 1);
         CompressedPublicKey publicKeyB =
-            _ecdsa.RecoverCompressedPublicKey(sigB, contentHash)!;
+            _ecdsa.RecoverCompressedPublicKey(sigB, in contentHash)!;
 
         CompressedPublicKey? reportedKey =
             nodeRecord.GetObj<CompressedPublicKey>(EnrContentKey.Secp256K1);

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/HandshakeService.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/HandshakeService.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Network.Rlpx.Handshake
                 {
                     Nonce = handshake.InitiatorNonce,
                     PublicKey = _privateKey.PublicKey,
-                    Signature = _ecdsa.Sign(handshake.EphemeralPrivateKey, new Hash256(forSigning)),
+                    Signature = _ecdsa.Sign(handshake.EphemeralPrivateKey, new ValueHash256(forSigning)),
                     IsTokenUsed = false,
                     EphemeralPublicHash = Keccak.Compute(handshake.EphemeralPrivateKey.PublicKey.Bytes)
                 };
@@ -96,7 +96,7 @@ namespace Nethermind.Network.Rlpx.Handshake
                 {
                     Nonce = handshake.InitiatorNonce,
                     PublicKey = _privateKey.PublicKey,
-                    Signature = _ecdsa.Sign(handshake.EphemeralPrivateKey, new Hash256(forSigning))
+                    Signature = _ecdsa.Sign(handshake.EphemeralPrivateKey, new ValueHash256(forSigning))
                 };
 
                 IByteBuffer authData = _messageSerializationService.ZeroSerialize(authMessage);
@@ -156,7 +156,7 @@ namespace Nethermind.Network.Rlpx.Handshake
             byte[] staticSharedSecret = SecP256k1.EcdhSerialized(handshake.RemoteNodeId.Bytes, _privateKey.KeyBytes);
             byte[] forSigning = staticSharedSecret.Xor(handshake.InitiatorNonce);
 
-            handshake.RemoteEphemeralPublicKey = _ecdsa.RecoverPublicKey(authMessage.Signature, new Hash256(forSigning));
+            handshake.RemoteEphemeralPublicKey = _ecdsa.RecoverPublicKey(authMessage.Signature, new ValueHash256(forSigning));
 
             byte[] data;
             if (preEip8Format)

--- a/src/Nethermind/Nethermind.Optimism/OptimismEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismEthereumEcdsa.cs
@@ -18,9 +18,7 @@ public class OptimismEthereumEcdsa : Ecdsa, IEthereumEcdsa
     {
         _ethereumEcdsa = ethereumEcdsa;
     }
-    public Address? RecoverAddress(Signature signature, Hash256 message) => _ethereumEcdsa.RecoverAddress(signature, message);
-
-    public Address? RecoverAddress(Span<byte> signatureBytes, Hash256 message) => _ethereumEcdsa.RecoverAddress(signatureBytes, message);
-
     public Address? RecoverAddress(Signature signature, in ValueHash256 message) => _ethereumEcdsa.RecoverAddress(signature, in message);
+
+    public Address? RecoverAddress(Span<byte> signatureBytes, in ValueHash256 message) => _ethereumEcdsa.RecoverAddress(signatureBytes, in message);
 }

--- a/src/Nethermind/Nethermind.Optimism/OptimismEthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismEthereumEcdsa.cs
@@ -21,4 +21,6 @@ public class OptimismEthereumEcdsa : Ecdsa, IEthereumEcdsa
     public Address? RecoverAddress(Signature signature, Hash256 message) => _ethereumEcdsa.RecoverAddress(signature, message);
 
     public Address? RecoverAddress(Span<byte> signatureBytes, Hash256 message) => _ethereumEcdsa.RecoverAddress(signatureBytes, message);
+
+    public Address? RecoverAddress(Signature signature, in ValueHash256 message) => _ethereumEcdsa.RecoverAddress(signature, in message);
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Eip7702/AuthorizationTupleDecoder.cs
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -82,17 +80,7 @@ public class AuthorizationTupleDecoder : IRlpStreamDecoder<AuthorizationTuple>, 
         stream.Encode(new UInt256(item.AuthoritySignature.S.Span, true));
     }
 
-    public NettyRlpStream EncodeWithoutSignature(UInt256 chainId, Address codeAddress, ulong nonce)
-    {
-        int contentLength = GetContentLengthWithoutSig(chainId, codeAddress, nonce);
-        var totalLength = Rlp.LengthOfSequence(contentLength);
-        IByteBuffer byteBuffer = PooledByteBufferAllocator.Default.Buffer(totalLength);
-        NettyRlpStream stream = new(byteBuffer);
-        EncodeWithoutSignature(stream, chainId, codeAddress, nonce);
-        return stream;
-    }
-
-    public void EncodeWithoutSignature(RlpStream stream, UInt256 chainId, Address codeAddress, ulong nonce)
+    public static void EncodeWithoutSignature(RlpStream stream, UInt256 chainId, Address codeAddress, ulong nonce)
     {
         int contentLength = GetContentLengthWithoutSig(chainId, codeAddress, nonce);
         stream.StartSequence(contentLength);


### PR DESCRIPTION
## Changes

Saves 96 bytes per tx recovery

- `Signature.BytesWithRecovery` allocates as 65 byte array; can skip this allocation
- Skip `Hash256` allocation

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No