### PR TITLE
Split SSTORE to two Opcodes

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -407,10 +407,7 @@ internal static partial class EvmInstructions
         // Report storage changes for tracing if enabled.
         if (TTracingInst.IsActive)
         {
-            ReadOnlySpan<byte> valueToStore = newIsZero ? BytesZero.AsSpan() : bytes;
-            byte[] storageBytes = new byte[32]; // Allocated on the heap to avoid stack allocation.
-            storageCell.Index.ToBigEndian(storageBytes);
-            vm.TxTracer.ReportStorageChange(storageBytes, valueToStore);
+            TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
         if (vm.TxTracer.IsTracingStorage)
@@ -570,10 +567,7 @@ internal static partial class EvmInstructions
         // Report storage changes for tracing if enabled.
         if (TTracingInst.IsActive)
         {
-            ReadOnlySpan<byte> valueToStore = newIsZero ? BytesZero.AsSpan() : bytes;
-            byte[] storageBytes = new byte[32]; // Allocated on the heap to avoid stack allocation.
-            storageCell.Index.ToBigEndian(storageBytes);
-            vm.TxTracer.ReportStorageChange(storageBytes, valueToStore);
+            TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
         if (vm.TxTracer.IsTracingStorage)
@@ -589,6 +583,15 @@ internal static partial class EvmInstructions
         return EvmExceptionType.StackUnderflow;
     StaticCallViolation:
         return EvmExceptionType.StaticCallViolation;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TraceSstore(VirtualMachine vm, bool newIsZero, in StorageCell storageCell, ReadOnlySpan<byte> bytes)
+    {
+        ReadOnlySpan<byte> valueToStore = newIsZero ? BytesZero.AsSpan() : bytes;
+        byte[] storageBytes = new byte[32]; // Allocated on the heap to avoid stack allocation.
+        storageCell.Index.ToBigEndian(storageBytes);
+        vm.TxTracer.ReportStorageChange(storageBytes, valueToStore);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -144,7 +144,12 @@ internal static unsafe partial class EvmInstructions
         lookup[(int)Instruction.MSTORE] = &InstructionMStore<TTracingInst>;
         lookup[(int)Instruction.MSTORE8] = &InstructionMStore8<TTracingInst>;
         lookup[(int)Instruction.SLOAD] = &InstructionSLoad<TTracingInst>;
-        lookup[(int)Instruction.SSTORE] = &InstructionSStore<TTracingInst>;
+        lookup[(int)Instruction.SSTORE] = spec.UseNetGasMetering ?
+            (spec.UseNetGasMeteringWithAStipendFix ?
+                &InstructionSStoreMetered<TTracingInst, OnFlag> :
+                &InstructionSStoreMetered<TTracingInst, OffFlag>
+            ) :
+            &InstructionSStoreUnmetered<TTracingInst>;
 
         // Jump instructions.
         lookup[(int)Instruction.JUMP] = &InstructionJump;


### PR DESCRIPTION
## Changes

- Split SSTORE to two opcodes to simplify branching/nesting
  - InstructionSStoreUnmetered (pre Eip1283)
  - InstructionSStoreMetered (post Eip1283, Eip2200)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No