### PR TITLE
Fix ParityStyleTracerTests in debug mode

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/StandardBlockProducerRunner.cs
+++ b/src/Nethermind/Nethermind.Consensus/StandardBlockProducerRunner.cs
@@ -60,6 +60,7 @@ public class StandardBlockProducerRunner(IBlockProductionTrigger trigger, IBlock
 
     public virtual Task StopAsync()
     {
+        if (!_isRunning) return Task.CompletedTask;
         _producerCancellationToken?.Cancel();
         _isRunning = false;
         trigger.TriggerBlockProduction -= OnTriggerBlockProduction;

--- a/src/Nethermind/Nethermind.Core.Test/Builders/Build.ChainSpec.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/Build.ChainSpec.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Test.Builders;
+
+public partial class Build
+{
+    public ChainSpecBuilder ChainSpec => new ChainSpecBuilder();
+}

--- a/src/Nethermind/Nethermind.Core.Test/Builders/ChainSpecBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/ChainSpecBuilder.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Int256;
+using Nethermind.Specs.ChainSpecStyle;
+
+namespace Nethermind.Core.Test.Builders;
+
+public class ChainSpecBuilder: BuilderBase<ChainSpec>
+{
+    private Dictionary<Address, ChainSpecAllocation> _allocations = new();
+
+    public ChainSpecBuilder WithAllocation(Address address, UInt256 ether)
+    {
+        _allocations[address] = new ChainSpecAllocation(ether);
+        return this;
+    }
+
+    protected override void BeforeReturn()
+    {
+        TestObjectInternal = new ChainSpec()
+        {
+            Parameters = new ChainParameters(),
+            Allocations = _allocations,
+            Genesis = Build.A.Block.Genesis.TestObject
+        };
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Builders/ChainSpecBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/ChainSpecBuilder.cs
@@ -7,7 +7,7 @@ using Nethermind.Specs.ChainSpecStyle;
 
 namespace Nethermind.Core.Test.Builders;
 
-public class ChainSpecBuilder: BuilderBase<ChainSpec>
+public class ChainSpecBuilder : BuilderBase<ChainSpec>
 {
     private Dictionary<Address, ChainSpecAllocation> _allocations = new();
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
@@ -18,13 +18,21 @@ namespace Nethermind.Core.Test.Modules;
 /// component later anyway.
 /// </summary>
 /// <param name="configProvider"></param>
-public class TestNethermindModule(IConfigProvider configProvider) : Module
+public class TestNethermindModule(IConfigProvider configProvider, ChainSpec chainSpec) : Module
 {
     public TestNethermindModule() : this(new ConfigProvider())
     {
     }
 
     public TestNethermindModule(params IConfig[] configs) : this(new ConfigProvider(configs))
+    {
+    }
+
+    public TestNethermindModule(IConfigProvider configProvider) : this(configProvider, new ChainSpec() { Parameters = new ChainParameters() })
+    {
+    }
+
+    public TestNethermindModule(ChainSpec chainSpec) : this(new ConfigProvider(), chainSpec)
     {
     }
 
@@ -35,7 +43,7 @@ public class TestNethermindModule(IConfigProvider configProvider) : Module
         LongDisposeTracker.Configure(builder);
 
         builder
-            .AddModule(new PseudoNethermindModule(new ChainSpec() { Parameters = new ChainParameters() }, configProvider, LimboLogs.Instance))
+            .AddModule(new PseudoNethermindModule(chainSpec, configProvider, LimboLogs.Instance))
             .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, Random.Shared.Next().ToString()))
             .AddSingleton<ISpecProvider>(new TestSpecProvider(Cancun.Instance));
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Autofac;
@@ -84,7 +85,9 @@ public class ParityStyleTracerTests
         _blockTree!.SuggestBlock(block).Should().Be(AddBlockResult.Added);
         _poSSwitcher!.IsPostMerge(Arg.Any<BlockHeader>()).Returns(isPostMerge);
 
-        ParityTxTraceFromStore[] result = _traceRpcModule.trace_block(new BlockParameter(block.Number)).Data.ToArray();
+        ResultWrapper<IEnumerable<ParityTxTraceFromStore>> rpcResult = _traceRpcModule.trace_block(new BlockParameter(block.Number));
+        rpcResult.Result.Should().Be(Result.Success);
+        ParityTxTraceFromStore[] result = rpcResult.Data.ToArray();
         if (isPostMerge)
         {
             result.Length.Should().Be(1);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -3,57 +3,35 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Autofac;
 using FluentAssertions;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.BeaconBlockRoot;
-using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
-using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus;
-using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Rewards;
-using Nethermind.Consensus.Tracing;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Crypto;
-using Nethermind.Db;
-using Nethermind.Evm;
-using Nethermind.Evm.Tracing;
 using Nethermind.JsonRpc.Modules.Trace;
-using Nethermind.Logging;
 using Nethermind.Specs;
-using Nethermind.State;
-using Nethermind.TxPool;
 using NUnit.Framework;
-using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Trie.Pruning;
 using NSubstitute;
-using Nethermind.Facade;
-using Nethermind.Config;
-using Nethermind.Consensus.ExecutionRequests;
-using Nethermind.Consensus.Withdrawals;
-using Nethermind.Core.Test;
+using Nethermind.Core.Test.Modules;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.Specs.ChainSpecStyle;
 
 namespace Nethermind.JsonRpc.Test.Modules.Trace;
 
 [Parallelizable(ParallelScope.Self)]
 public class ParityStyleTracerTests
 {
-#pragma warning disable NUnit1032 // An IDisposable field/property should be Disposed in a TearDown method
-    private BlockchainProcessor? _processor;
-#pragma warning restore NUnit1032 // An IDisposable field/property should be Disposed in a TearDown method
     private BlockTree? _blockTree;
-    private Tracer? _tracer;
     private IPoSSwitcher? _poSSwitcher;
-    private IStateReader _stateReader;
-    private TraceRpcModule _traceRpcModule;
-    private readonly IJsonRpcConfig _jsonRpcConfig = new JsonRpcConfig();
+    private ITraceRpcModule _traceRpcModule;
+    private IContainer _container;
 
     [SetUp]
-    public void Setup()
+    public async Task Setup()
     {
         ISpecProvider specProvider = MainnetSpecProvider.Instance;
 
@@ -62,45 +40,27 @@ public class ParityStyleTracerTests
             .WithSpecProvider(specProvider)
             .TestObject;
 
-        IDbProvider dbProvider = TestMemDbProvider.Init();
-        WorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest(dbProvider, LimboLogs.Instance);
-        IWorldState stateProvider = worldStateManager.GlobalWorldState;
-        _stateReader = worldStateManager.GlobalStateReader;
-
-        BlockhashProvider blockhashProvider = new(_blockTree, specProvider, stateProvider, LimboLogs.Instance);
-        CodeInfoRepository codeInfoRepository = new();
-        VirtualMachine virtualMachine = new(blockhashProvider, specProvider, LimboLogs.Instance);
-        TransactionProcessor transactionProcessor = new(specProvider, stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        ChainSpec cp = Build.A.ChainSpec
+            .WithAllocation(new Address("0xdea60e4f8ea50d5ed92b0a5b15ae9d24aeba0bee"), 1.Ether() )
+            .TestObject;
 
         _poSSwitcher = Substitute.For<IPoSSwitcher>();
-        BlockProcessor blockProcessor = new BlockProcessor(
-            specProvider,
-            Always.Valid,
-            new MergeRpcRewardCalculator(NoBlockRewards.Instance, _poSSwitcher),
-            new BlockProcessor.BlockValidationTransactionsExecutor(new ExecuteTransactionProcessorAdapter(transactionProcessor), stateProvider),
-            stateProvider,
-            NullReceiptStorage.Instance,
-            new BeaconBlockRootHandler(transactionProcessor, stateProvider),
-            new BlockhashStore(specProvider, stateProvider),
-            LimboLogs.Instance,
-            new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
-            new ExecutionRequestsProcessor(transactionProcessor));
+        _container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(cp))
+            .AddSingleton<ISpecProvider>(specProvider)
+            .AddSingleton<IPoSSwitcher>(_poSSwitcher)
+            .AddSingleton<IBlockTree>(_blockTree)
+            .Build();
 
-        RecoverSignatures txRecovery = new(new EthereumEcdsa(TestBlockchainIds.ChainId), specProvider, LimboLogs.Instance);
-        _processor = new BlockchainProcessor(_blockTree, blockProcessor, txRecovery, _stateReader, LimboLogs.Instance, BlockchainProcessor.Options.NoReceipts);
-
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        _blockTree.SuggestBlock(genesis);
-        _processor.Process(genesis, ProcessingOptions.None, NullBlockTracer.Instance);
-
-        IOverridableTxProcessorSource txProcessingSource = Substitute.For<IOverridableTxProcessorSource>();
-        _tracer = new Tracer(stateProvider, _processor, _processor);
-        var env = new TracerEnv(_tracer, txProcessingSource);
-        _traceRpcModule = new(NullReceiptStorage.Instance, env, _blockTree, _jsonRpcConfig, _stateReader, Substitute.For<IBlockchainBridge>(), new BlocksConfig());
+        await _container.Resolve<PseudoNethermindRunner>().StartBlockProcessing(default);
+        _traceRpcModule = _container.Resolve<IRpcModuleFactory<ITraceRpcModule>>().Create();
     }
 
     [TearDown]
-    public async Task TearDownAsync() => await (_processor?.DisposeAsync() ?? default);
+    public async Task TearDownAsync()
+    {
+        await _container.DisposeAsync();
+    }
 
     [Test]
     public void Can_trace_raw_parity_style()
@@ -120,7 +80,7 @@ public class ParityStyleTracerTests
     [TestCase(false)]
     public void Should_return_correct_block_reward(bool isPostMerge)
     {
-        Block block = Build.A.Block.WithParent(Build.A.Block.Genesis.TestObject).TestObject;
+        Block block = Build.A.Block.WithParent(_blockTree!.Head!).TestObject;
         _blockTree!.SuggestBlock(block).Should().Be(AddBlockResult.Added);
         _poSSwitcher!.IsPostMerge(Arg.Any<BlockHeader>()).Returns(isPostMerge);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -41,7 +41,7 @@ public class ParityStyleTracerTests
             .TestObject;
 
         ChainSpec cp = Build.A.ChainSpec
-            .WithAllocation(new Address("0xdea60e4f8ea50d5ed92b0a5b15ae9d24aeba0bee"), 1.Ether() )
+            .WithAllocation(new Address("0xdea60e4f8ea50d5ed92b0a5b15ae9d24aeba0bee"), 1.Ether())
             .TestObject;
 
         _poSSwitcher = Substitute.For<IPoSSwitcher>();


### PR DESCRIPTION
- `ITraceRpcModule` not created the same way in tests and in prod. 
  - Use of writable world state, causes assertion failure due to block commit set not sealing due to null root ref.
  - One of the block processing context uses trace execution instead of execute, which result in error as the sender balance is null which is a path not reached as on process it is validated.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Not throwing in debug mode anymore.