### PR TITLE
Refactor/Slight reduction in duplicated block producer code

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProducer.cs
@@ -56,11 +56,11 @@ namespace Nethermind.Consensus.AuRa
             _config = config ?? throw new ArgumentNullException(nameof(config));
         }
 
-        protected override Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
+        protected override BlockHeader PrepareBlockHeader(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
         {
-            Block block = base.PrepareBlock(parent, payloadAttributes);
-            block.Header.AuRaStep = _auRaStepCalculator.CurrentStep;
-            return block;
+            BlockHeader header = base.PrepareBlockHeader(parent, payloadAttributes);
+            header.AuRaStep = _auRaStepCalculator.CurrentStep;
+            return header;
         }
 
         protected override Block? ProcessPreparedBlock(Block block, IBlockTracer? blockTracer, CancellationToken token)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProducer.cs
@@ -56,11 +56,11 @@ namespace Nethermind.Consensus.AuRa
             _config = config ?? throw new ArgumentNullException(nameof(config));
         }
 
-        protected override BlockHeader PrepareBlockHeader(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
+        protected override BlockToProduce PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
-            BlockHeader header = base.PrepareBlockHeader(parent, payloadAttributes);
-            header.AuRaStep = _auRaStepCalculator.CurrentStep;
-            return header;
+            BlockToProduce block = base.PrepareBlock(parent, payloadAttributes, flags);
+            block.Header.AuRaStep = _auRaStepCalculator.CurrentStep;
+            return block;
         }
 
         protected override Block? ProcessPreparedBlock(Block block, IBlockTracer? blockTracer, CancellationToken token)

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -329,7 +329,7 @@ public class CliqueBlockProducer : IBlockProducer
     public ConcurrentDictionary<Address, bool> Proposals => _proposals;
 
     public async Task<Block?> BuildBlock(BlockHeader? parentHeader, IBlockTracer? blockTracer = null,
-        PayloadAttributes? payloadAttributes = null, CancellationToken token = default)
+        PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0, CancellationToken token = default)
     {
         Block? block = PrepareBlock(parentHeader);
         if (block is null)

--- a/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
@@ -15,5 +16,13 @@ public interface IBlockProducer
         BlockHeader? parentHeader = null,
         IBlockTracer? blockTracer = null,
         PayloadAttributes? payloadAttributes = null,
+        Flags flags = 0,
         CancellationToken cancellationToken = default);
+
+    [Flags]
+    public enum Flags
+    {
+        EmptyBlock = 1,
+        DontSeal = 2,
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
@@ -24,5 +24,7 @@ public interface IBlockProducer
     {
         EmptyBlock = 1,
         DontSeal = 2,
+
+        PrepareEmptyBlock = EmptyBlock | DontSeal,
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -113,7 +113,8 @@ namespace Nethermind.Consensus.Producers
             }
             else
             {
-                if (Sealer.CanSeal(parentHeader.Number + 1, parentHeader.Hash))
+                bool dontSeal = (flags & IBlockProducer.Flags.DontSeal) != 0;
+                if (dontSeal || Sealer.CanSeal(parentHeader.Number + 1, parentHeader.Hash))
                 {
                     Interlocked.Exchange(ref Metrics.CanProduceBlocks, 1);
                     return ProduceNewBlock(parentHeader, token, blockTracer, payloadAttributes, flags);

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -77,14 +77,14 @@ namespace Nethermind.Consensus.Producers
         }
 
         public async Task<Block?> BuildBlock(BlockHeader? parentHeader = null, IBlockTracer? blockTracer = null,
-            PayloadAttributes? payloadAttributes = null, CancellationToken token = default)
+            PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0, CancellationToken token = default)
         {
             Block? block = null;
             if (await _producingBlockLock.WaitAsync(BlockProductionTimeoutMs, token))
             {
                 try
                 {
-                    block = await TryProduceNewBlock(token, parentHeader, blockTracer, payloadAttributes);
+                    block = await TryProduceNewBlock(token, parentHeader, blockTracer, payloadAttributes, flags);
                 }
                 catch (Exception e) when (e is not TaskCanceledException)
                 {
@@ -105,7 +105,7 @@ namespace Nethermind.Consensus.Producers
             return block;
         }
 
-        protected virtual Task<Block?> TryProduceNewBlock(CancellationToken token, BlockHeader? parentHeader, IBlockTracer? blockTracer = null, PayloadAttributes? payloadAttributes = null)
+        protected virtual Task<Block?> TryProduceNewBlock(CancellationToken token, BlockHeader? parentHeader, IBlockTracer? blockTracer = null, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
             if (parentHeader is null)
             {
@@ -116,7 +116,7 @@ namespace Nethermind.Consensus.Producers
                 if (Sealer.CanSeal(parentHeader.Number + 1, parentHeader.Hash))
                 {
                     Interlocked.Exchange(ref Metrics.CanProduceBlocks, 1);
-                    return ProduceNewBlock(parentHeader, token, blockTracer, payloadAttributes);
+                    return ProduceNewBlock(parentHeader, token, blockTracer, payloadAttributes, flags);
                 }
                 else
                 {
@@ -128,11 +128,11 @@ namespace Nethermind.Consensus.Producers
             return Task.FromResult((Block?)null);
         }
 
-        private Task<Block?> ProduceNewBlock(BlockHeader parent, CancellationToken token, IBlockTracer? blockTracer, PayloadAttributes? payloadAttributes = null)
+        private Task<Block?> ProduceNewBlock(BlockHeader parent, CancellationToken token, IBlockTracer? blockTracer, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
             if (TrySetState(parent.StateRoot))
             {
-                Block block = PrepareBlock(parent, payloadAttributes);
+                Block block = PrepareBlock(parent, payloadAttributes, flags);
                 if (PreparedBlockCanBeMined(block))
                 {
                     Block? processedBlock = ProcessPreparedBlock(block, blockTracer, token);
@@ -143,6 +143,8 @@ namespace Nethermind.Consensus.Producers
                     }
                     else
                     {
+                        if ((flags & IBlockProducer.Flags.DontSeal) != 0) return Task.FromResult(processedBlock);
+
                         return SealBlock(processedBlock, parent, token).ContinueWith((Func<Task<Block?>, Block?>)(t =>
                         {
                             if (t.IsCompletedSuccessfully)
@@ -247,11 +249,13 @@ namespace Nethermind.Consensus.Producers
             return header;
         }
 
-        protected Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
+        protected Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
             BlockHeader header = PrepareBlockHeader(parent, payloadAttributes);
 
-            IEnumerable<Transaction> transactions = TxSource.GetTransactions(parent, header.GasLimit, payloadAttributes, filterSource: true);
+            IEnumerable<Transaction> transactions = (flags & IBlockProducer.Flags.EmptyBlock) != 0 ?
+                Array.Empty<Transaction>() :
+                TxSource.GetTransactions(parent, header.GasLimit, payloadAttributes, filterSource: true);
 
             return new BlockToProduce(header, transactions, Array.Empty<BlockHeader>(), payloadAttributes?.Withdrawals);
         }

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -249,7 +249,7 @@ namespace Nethermind.Consensus.Producers
             return header;
         }
 
-        protected Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
+        protected virtual BlockToProduce PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
             BlockHeader header = PrepareBlockHeader(parent, payloadAttributes);
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -247,7 +247,7 @@ namespace Nethermind.Consensus.Producers
             return header;
         }
 
-        protected virtual Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
+        protected Block PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
         {
             BlockHeader header = PrepareBlockHeader(parent, payloadAttributes);
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/FailBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/FailBlockProducer.cs
@@ -19,6 +19,7 @@ public class FailBlockProducer : IBlockProducer
         BlockHeader? parentHeader = null,
         IBlockTracer? blockTracer = null,
         PayloadAttributes? payloadAttributes = null,
+        IBlockProducer.Flags flags = 0,
         CancellationToken cancellationToken = default)
     {
         throw new InvalidOperationException("FailBlockProducer is not supposed to produce blocks.");

--- a/src/Nethermind/Nethermind.Consensus/Producers/MultipleBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/MultipleBlockProducer.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Consensus.Producers
         }
 
         public async Task<Block?> BuildBlock(BlockHeader? parentHeader, IBlockTracer? blockTracer = null,
-            PayloadAttributes? payloadAttributes = null, CancellationToken token = default)
+            PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0, CancellationToken token = default)
         {
             using ArrayPoolList<Task<Block>> produceTasks = new(_blockProducers.Length);
             for (int i = 0; i < _blockProducers.Length; i++)
@@ -39,7 +39,7 @@ namespace Nethermind.Consensus.Producers
                 T blockProducerInfo = _blockProducers[i];
                 produceTasks.Add(!blockProducerInfo.Condition.CanProduce(parentHeader!)
                     ? Task.FromResult<Block?>(null)
-                    : blockProducerInfo.BlockProducer.BuildBlock(parentHeader, blockProducerInfo.BlockTracer, cancellationToken: token));
+                    : blockProducerInfo.BlockProducer.BuildBlock(parentHeader, blockProducerInfo.BlockTracer, payloadAttributes, flags, cancellationToken: token));
             }
 
             IEnumerable<(Block? Block, T BlockProducer)> blocksWithProducers;

--- a/src/Nethermind/Nethermind.Consensus/StandardBlockProducerRunner.cs
+++ b/src/Nethermind/Nethermind.Consensus/StandardBlockProducerRunner.cs
@@ -33,7 +33,7 @@ public class StandardBlockProducerRunner(IBlockProductionTrigger trigger, IBlock
         Block? block = null;
         try
         {
-            block = await blockProducer.BuildBlock(parentHeader, blockTracer, payloadAttributes, token);
+            block = await blockProducer.BuildBlock(parentHeader, blockTracer, payloadAttributes, 0, token);
             if (block is not null)
             {
                 _lastProducedBlockDateTime = DateTime.UtcNow;

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
@@ -57,10 +57,10 @@ namespace Nethermind.Core.Test.Blockchain
             }
         }
 
-        protected override Task<Block?> TryProduceNewBlock(CancellationToken token, BlockHeader? parentHeader, IBlockTracer? blockTracer = null, PayloadAttributes? payloadAttributes = null)
+        protected override Task<Block?> TryProduceNewBlock(CancellationToken token, BlockHeader? parentHeader, IBlockTracer? blockTracer = null, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0)
         {
             parentHeader ??= BlockParent;
-            return base.TryProduceNewBlock(token, parentHeader, blockTracer, payloadAttributes);
+            return base.TryProduceNewBlock(token, parentHeader, blockTracer, payloadAttributes, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -75,7 +75,7 @@ public class TestBlockchain : IDisposable
     public IReadOnlyStateProvider ReadOnlyState => _fromContainer.ReadOnlyState;
     public IDb StateDb => DbProvider.StateDb;
     public IDb BlocksDb => DbProvider.BlocksDb;
-    public IBlockProducer BlockProducer { get; private set; } = null!;
+    public IBlockProducer BlockProducer { get; protected set; } = null!;
     public IBlockProducerRunner BlockProducerRunner { get; protected set; } = null!;
     public IDbProvider DbProvider => _fromContainer.DbProvider;
     public ISpecProvider SpecProvider => _fromContainer.SpecProvider;

--- a/src/Nethermind/Nethermind.Core.Test/Modules/MergeModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/MergeModule.cs
@@ -71,7 +71,7 @@ public class MergeModule(ITxPoolConfig txPoolConfig, IMergeConfig mergeConfig, I
             {
                 ILifetimeScope ctx = producerContext.LifetimeScope;
                 return new PayloadPreparationService(
-                    ctx.Resolve<PostMergeBlockProducer>(),
+                    ctx.Resolve<IBlockProducer>(),
                     ctx.Resolve<IBlockImprovementContextFactory>(),
                     ctx.Resolve<ITimerFactory>(),
                     ctx.Resolve<ILogManager>(),

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -208,10 +208,10 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
 
             BlockProducerEnv blockProducerEnv = BlockProducerEnvFactory.Create();
             PostMergeBlockProducer postMergeBlockProducer = blockProducerFactory.Create(blockProducerEnv);
-            PostMergeBlockProducer = postMergeBlockProducer;
+            BlockProducer = postMergeBlockProducer;
             PayloadPreparationService ??= new PayloadPreparationService(
                 postMergeBlockProducer,
-                StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(CreateBlockImprovementContextFactory(PostMergeBlockProducer)),
+                StoringBlockImprovementContextFactory = new StoringBlockImprovementContextFactory(CreateBlockImprovementContextFactory(BlockProducer)),
                 TimerFactory.Default,
                 LogManager,
                 TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -252,8 +252,6 @@ public abstract partial class BaseEngineModuleTests
     {
         public IMergeConfig MergeConfig { get; set; }
 
-        public PostMergeBlockProducer? PostMergeBlockProducer { get; set; }
-
         public IPayloadPreparationService? PayloadPreparationService { get; set; }
         public StoringBlockImprovementContextFactory? StoringBlockImprovementContextFactory { get; set; }
 
@@ -349,8 +347,8 @@ public abstract partial class BaseEngineModuleTests
 
             BlockProducerEnv blockProducerEnv = BlockProducerEnvFactory.Create();
             PostMergeBlockProducer? postMergeBlockProducer = blockProducerFactory.Create(blockProducerEnv);
-            PostMergeBlockProducer = postMergeBlockProducer;
-            BlockImprovementContextFactory ??= new BlockImprovementContextFactory(PostMergeBlockProducer, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot));
+            BlockProducer = postMergeBlockProducer;
+            BlockImprovementContextFactory ??= new BlockImprovementContextFactory(BlockProducer, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot));
             PayloadPreparationService ??= new PayloadPreparationService(
                 postMergeBlockProducer,
                 BlockImprovementContextFactory,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -64,7 +64,7 @@ public partial class EngineModuleTests
             CancellationToken cancellationToken)
         {
             await Task.Delay(delay, cancellationToken);
-            Block? block = await blockProducer.BuildBlock(parentHeader, NullBlockTracer.Instance, payloadAttributes, cancellationToken);
+            Block? block = await blockProducer.BuildBlock(parentHeader, NullBlockTracer.Instance, payloadAttributes, 0, cancellationToken);
             if (block is not null)
             {
                 CurrentBestBlock = block;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -165,23 +165,18 @@ public partial class EngineModuleTests
         using MergeTestBlockchain chain = await CreateBlockchainWithImprovementContext(
             chain => new DelayBlockImprovementContextFactory(chain.BlockProducer, TimeSpan.FromSeconds(10), improveDelay),
             TimeSpan.FromSeconds(10),
-            configurer: builder =>
-            {
-                builder
-                    .AddSingleton<ITxSource>(Substitute.For<ITxSource>())
-                    .AddSingleton<IBlockProducerTxSourceFactory>(ctx =>
-                    {
-                        IBlockProducerTxSourceFactory factory = Substitute.For<IBlockProducerTxSourceFactory>();
-                        factory.Create().Returns(new TxDelayedSource(
-                            ctx.Resolve<IBlockTree>(),
-                            ctx.Resolve<ISpecProvider>(),
-                            ctx.Resolve<IStateReader>(),
-                            ctx.Resolve<ITimestamper>(),
-                            txDelay));
-                        return factory;
-                    })
-                    ;
-            });
+            configurer: builder => builder
+                .AddSingleton<IBlockProducerTxSourceFactory>(ctx =>
+                {
+                    IBlockProducerTxSourceFactory factory = Substitute.For<IBlockProducerTxSourceFactory>();
+                    factory.Create().Returns(new TxDelayedSource(
+                        ctx.Resolve<IBlockTree>(),
+                        ctx.Resolve<ISpecProvider>(),
+                        ctx.Resolve<IStateReader>(),
+                        ctx.Resolve<ITimestamper>(),
+                        txDelay));
+                    return factory;
+                }));
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Hash256 startingHead = chain.BlockTree.HeadHash;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -48,11 +48,11 @@ public partial class EngineModuleTests
                 };
             });
 
-        BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
+        BoostBlockImprovementContextFactory improvementContextFactory = new(chain.BlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(10);
         chain.BlockImprovementContextFactory = improvementContextFactory;
         chain.PayloadPreparationService = new PayloadPreparationService(
-            chain.PostMergeBlockProducer!,
+            chain.BlockProducer!,
             chain.BlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
@@ -151,11 +151,11 @@ public partial class EngineModuleTests
 
         DefaultHttpClient defaultHttpClient = new(mockHttp.ToHttpClient(), serializer, chain.LogManager, 1, 100);
         BoostRelay boostRelay = new(defaultHttpClient, relayUrl);
-        BoostBlockImprovementContextFactory improvementContextFactory = new(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5000), boostRelay, chain.StateReader);
+        BoostBlockImprovementContextFactory improvementContextFactory = new(chain.BlockProducer!, TimeSpan.FromSeconds(5000), boostRelay, chain.StateReader);
         TimeSpan timePerSlot = TimeSpan.FromSeconds(1000);
         chain.BlockImprovementContextFactory = improvementContextFactory;
         chain.PayloadPreparationService = new PayloadPreparationService(
-            chain.PostMergeBlockProducer!,
+            chain.BlockProducer!,
             chain.BlockImprovementContextFactory,
             TimerFactory.Default,
             chain.LogManager,
@@ -194,16 +194,16 @@ public partial class EngineModuleTests
             boostRelay.GetPayloadAttributes(Arg.Any<PayloadAttributes>(), Arg.Any<CancellationToken>())
                 .Returns(static c => (BoostPayloadAttributes)c.Arg<PayloadAttributes>());
 
-            improvementContextFactory = new BoostBlockImprovementContextFactory(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
+            improvementContextFactory = new BoostBlockImprovementContextFactory(chain.BlockProducer!, TimeSpan.FromSeconds(5), boostRelay, chain.StateReader);
         }
         else
         {
-            improvementContextFactory = new BlockImprovementContextFactory(chain.PostMergeBlockProducer!, TimeSpan.FromSeconds(5));
+            improvementContextFactory = new BlockImprovementContextFactory(chain.BlockProducer!, TimeSpan.FromSeconds(5));
         }
 
         TimeSpan timePerSlot = TimeSpan.FromSeconds(10);
         chain.PayloadPreparationService = new PayloadPreparationService(
-            chain.PostMergeBlockProducer!,
+            chain.BlockProducer!,
             improvementContextFactory,
             TimerFactory.Default,
             chain.LogManager,

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -39,7 +39,7 @@ public class BlockImprovementContext : IBlockImprovementContext
         CancellationToken ct = _linkedCancellation.Token;
         // Task.Run so doesn't block FCU response while first block is being produced
         ImprovementTask = Task.Run(() => blockProducer
-            .BuildBlock(parentHeader, _feesTracer, payloadAttributes, ct)
+            .BuildBlock(parentHeader, _feesTracer, payloadAttributes, 0, ct)
             .ContinueWith(SetCurrentBestBlock));
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
@@ -54,7 +54,7 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
         payloadAttributes = await _boostRelay.GetPayloadAttributes(payloadAttributes, cancellationToken);
         _stateReader.TryGetAccount(parentHeader.StateRoot!, payloadAttributes.SuggestedFeeRecipient, out AccountStruct account);
         UInt256 balanceBefore = account.Balance;
-        Block? block = await blockProducer.BuildBlock(parentHeader, _feesTracer, payloadAttributes, cancellationToken);
+        Block? block = await blockProducer.BuildBlock(parentHeader, _feesTracer, payloadAttributes, 0, cancellationToken);
         if (block is not null)
         {
             CurrentBestBlock = block;

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/MergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/MergeBlockProducer.cs
@@ -29,10 +29,10 @@ public class MergeBlockProducer : IMergeBlockProducer
     }
 
     public Task<Block?> BuildBlock(BlockHeader? parentHeader, IBlockTracer? blockTracer = null,
-        PayloadAttributes? payloadAttributes = null, CancellationToken token = default)
+        PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = 0, CancellationToken token = default)
     {
         return _poSSwitcher.HasEverReachedTerminalBlock() || HasPreMergeProducer == false
-            ? PostMergeBlockProducer.BuildBlock(parentHeader, blockTracer, payloadAttributes, token)
-            : PreMergeBlockProducer!.BuildBlock(parentHeader, blockTracer, payloadAttributes, token);
+            ? PostMergeBlockProducer.BuildBlock(parentHeader, blockTracer, payloadAttributes, flags, token)
+            : PreMergeBlockProducer!.BuildBlock(parentHeader, blockTracer, payloadAttributes, flags, token);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -49,7 +49,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
     protected readonly ConcurrentDictionary<string, IBlockImprovementContext> _payloadStorage = new();
 
     public PayloadPreparationService(
-        PostMergeBlockProducer blockProducer,
+        IBlockProducer blockProducer,
         IBlockImprovementContextFactory blockImprovementContextFactory,
         ITimerFactory timerFactory,
         ILogManager logManager,

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
@@ -44,8 +44,6 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         {
         }
 
-        public bool SupportsBlobs => TxSource.SupportsBlobs;
-
         protected override BlockHeader PrepareBlockHeader(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
         {
             BlockHeader blockHeader = base.PrepareBlockHeader(parent, payloadAttributes);

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
@@ -11,7 +11,6 @@ namespace Nethermind.Merge.Plugin
 {
     public partial class MergePlugin
     {
-        protected PostMergeBlockProducer _postMergeBlockProducer = null!;
         protected ManualTimestamper? _manualTimestamper;
 
         protected virtual PostMergeBlockProducerFactory CreateBlockProducerFactory()
@@ -45,8 +44,8 @@ namespace Nethermind.Merge.Plugin
 
                 BlockProducerEnv blockProducerEnv = _api.BlockProducerEnvFactory.Create();
 
-                _postMergeBlockProducer = CreateBlockProducerFactory().Create(blockProducerEnv);
-                _api.BlockProducer = new MergeBlockProducer(blockProducer, _postMergeBlockProducer, _poSSwitcher);
+                PostMergeBlockProducer postMergeBlockProducer = CreateBlockProducerFactory().Create(blockProducerEnv);
+                _api.BlockProducer = new MergeBlockProducer(blockProducer, postMergeBlockProducer, _poSSwitcher);
             }
 
             return _api.BlockProducer!;
@@ -64,8 +63,6 @@ namespace Nethermind.Merge.Plugin
                     ? baseRunnerFactory.InitBlockProducerRunner(preMergeBlockProducer)
                     : null;
 
-                // IBlockProducer postMergeBlockProducer = mergeBlockProducer.PostMergeBlockProducer;
-                // TODO: Why is mergeBlockProducer used instead of postMergeBlockProducer?
                 StandardBlockProducerRunner postMergeRunner = new StandardBlockProducerRunner(
                     _api.ManualBlockProductionTrigger, _api.BlockTree!, mergeBlockProducer);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -262,7 +262,6 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
             ArgumentNullException.ThrowIfNull(_api.SpecProvider);
             ArgumentNullException.ThrowIfNull(_api.StateReader);
             ArgumentNullException.ThrowIfNull(_api.EngineRequestsTracker);
-            ArgumentNullException.ThrowIfNull(_postMergeBlockProducer);
 
             // Single block shouldn't take a full slot to run
             // We can improve the blocks until requested, but the single block still needs to be run in a timely manner
@@ -282,7 +281,7 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
             IBlockImprovementContextFactory improvementContextFactory = _api.BlockImprovementContextFactory ??= CreateBlockImprovementContextFactory();
 
             PayloadPreparationService payloadPreparationService = new(
-                _postMergeBlockProducer,
+                _api.BlockProducer!,
                 improvementContextFactory,
                 _api.TimerFactory,
                 _api.LogManager,

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadPreparationService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -22,7 +23,7 @@ public class OptimismPayloadPreparationService : PayloadPreparationService
 
     public OptimismPayloadPreparationService(
         ISpecProvider specProvider,
-        PostMergeBlockProducer blockProducer,
+        IBlockProducer blockProducer,
         IBlockImprovementContextFactory blockImprovementContextFactory,
         ITimerFactory timerFactory,
         ILogManager logManager,

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -156,7 +156,7 @@ public class OptimismPlugin(ChainSpec chainSpec) : IConsensusPlugin
 
         OptimismPayloadPreparationService payloadPreparationService = new(
             _api.SpecProvider,
-            (PostMergeBlockProducer)_api.BlockProducer,
+            _api.BlockProducer,
             improvementContextFactory,
             _api.TimerFactory,
             _api.LogManager,

--- a/src/Nethermind/Nethermind.Optimism/OptimismPostMergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPostMergeBlockProducer.cs
@@ -85,12 +85,14 @@ public class OptimismPostMergeBlockProducer : PostMergeBlockProducer
         throw new EmptyBlockProductionException("Setting state for processing block failed");
     }
 
-    protected override void AmendHeader(BlockHeader blockHeader, BlockHeader parent, PayloadAttributes? payloadAttributes = null)
+    protected override BlockHeader PrepareBlockHeader(BlockHeader parent, PayloadAttributes? payloadAttributes = null)
     {
-        base.AmendHeader(blockHeader, parent);
+        BlockHeader blockHeader = base.PrepareBlockHeader(parent, payloadAttributes);
 
         blockHeader.ExtraData = [];
         blockHeader.RequestsHash = _specHelper.IsIsthmus(blockHeader) ? PostIsthmusRequestHash : null;
+
+        return blockHeader;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Optimism/OptimismPostMergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPostMergeBlockProducer.cs
@@ -54,7 +54,7 @@ public class OptimismPostMergeBlockProducer : PostMergeBlockProducer
     protected override BlockToProduce PrepareBlock(BlockHeader parent, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = (IBlockProducer.Flags)0)
     {
         OptimismPayloadAttributes attrs = (payloadAttributes as OptimismPayloadAttributes)
-                                          ?? throw new InvalidOperationException("Payload attributes are not set");
+            ?? throw new InvalidOperationException("Payload attributes are not set");
 
         BlockToProduce blockToProduce = base.PrepareBlock(parent, payloadAttributes, flags);
         if ((flags & IBlockProducer.Flags.EmptyBlock) != 0)

--- a/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
@@ -172,7 +172,7 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
 
     private async Task BuildBlock()
     {
-        Block? result = await _blockProducer.BuildBlock(_parentHeader, null, _payloadAttributes, _linkedCancellation?.Token ?? default);
+        Block? result = await _blockProducer.BuildBlock(_parentHeader, null, _payloadAttributes, 0, _linkedCancellation?.Token ?? default);
         if (result is not null)
         {
             CurrentBestBlock = result;


### PR DESCRIPTION
- `AmendHeader` removed, just override `PrepareBlockHeader`.
- `PrepareEmptyBlock` removed, added flags to `BuildBlock` to do the same thing.
- Optimism's modification to `PrepareEmptyBlock` is replaced with an override of `PrepareBlock`.
- Change any use of `PostMergeBlockProducer` to plain `IBlockProducer.`

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [X] Mainnet can start. Block production via simulate block production still working.