### PR TITLE
Optimise OpOrigin

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -79,7 +79,7 @@ internal static unsafe partial class EvmInstructions
         // Environment opcodes.
         lookup[(int)Instruction.ADDRESS] = &InstructionEnvAddress<OpAddress, TTracingInst>;
         lookup[(int)Instruction.BALANCE] = &InstructionBalance<TTracingInst>;
-        lookup[(int)Instruction.ORIGIN] = &InstructionBlkAddress<OpOrigin, TTracingInst>;
+        lookup[(int)Instruction.ORIGIN] = &InstructionEnv32Bytes<OpOrigin, TTracingInst>;
         lookup[(int)Instruction.CALLER] = &InstructionEnvAddress<OpCaller, TTracingInst>;
         lookup[(int)Instruction.CALLVALUE] = &InstructionEnvUInt256<OpCallValue, TTracingInst>;
         lookup[(int)Instruction.CALLDATALOAD] = &InstructionCallDataLoad<TTracingInst>;
@@ -117,7 +117,7 @@ internal static unsafe partial class EvmInstructions
         lookup[(int)Instruction.GASLIMIT] = &InstructionBlkUInt64<OpGasLimit, TTracingInst>;
         if (spec.ChainIdOpcodeEnabled)
         {
-            lookup[(int)Instruction.CHAINID] = &InstructionChainId<TTracingInst>;
+            lookup[(int)Instruction.CHAINID] = &InstructionEnv32Bytes<OpChainId, TTracingInst>;
         }
         if (spec.SelfBalanceOpcodeEnabled)
         {

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 
 namespace Nethermind.Evm
@@ -12,7 +13,7 @@ namespace Nethermind.Evm
         byte[][] blobVersionedHashes,
         in UInt256 gasPrice)
     {
-        public readonly Address Origin = origin;
+        public readonly ValueHash256 Origin = origin.ToHash();
         public readonly ICodeInfoRepository CodeInfoRepository = codeInfoRepository;
         public readonly byte[][]? BlobVersionedHashes = blobVersionedHashes;
         public readonly UInt256 GasPrice = gasPrice;


### PR DESCRIPTION
## Changes

- Optimise OpOrigin by using 32 byte address (rather than 20 byte) when pushing to stack

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
