### PR TITLE
feat: Make tx execution context overridable

### DIFF
--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -13,8 +13,8 @@ namespace Nethermind.Evm
         TransactionSubstate ExecuteTransaction<TTracingInst>(EvmState state, IWorldState worldState, ITxTracer txTracer)
             where TTracingInst : struct, IFlag;
         ref readonly BlockExecutionContext BlockExecutionContext { get; }
-        ref readonly TxExecutionContext TxExecutionContext { get; }
+        ref readonly ITxExecutionContext TxExecutionContext { get; }
         void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext);
-        void SetTxExecutionContext(in TxExecutionContext txExecutionContext);
+        void SetTxExecutionContext(in ITxExecutionContext txExecutionContext);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -210,7 +210,7 @@ internal static partial class EvmInstructions
     {
         gasAvailable -= TOpEnv.GasCost;
 
-        ref readonly UInt256 result = ref TOpEnv.Operation(vm);
+        UInt256 result = TOpEnv.Operation(vm);
 
         stack.PushUInt256<TTracingInst>(in result);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -154,7 +154,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(spec.IsEip1559Enabled, header.BaseFeePerGas);
 
-            VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress, _codeInfoRepository, tx.BlobVersionedHashes, in effectiveGasPrice));
+            VirtualMachine.SetTxExecutionContext(new TxExecutionContext(tx.SenderAddress, _codeInfoRepository, tx.BlobVersionedHashes, in effectiveGasPrice));
 
             UpdateMetrics(opts, effectiveGasPrice);
 

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -10,11 +10,21 @@ namespace Nethermind.Evm
         Address origin,
         ICodeInfoRepository codeInfoRepository,
         byte[][] blobVersionedHashes,
-        in UInt256 gasPrice)
+        in UInt256 gasPrice) : ITxExecutionContext
     {
-        public readonly Address Origin = origin;
-        public readonly ICodeInfoRepository CodeInfoRepository = codeInfoRepository;
-        public readonly byte[][]? BlobVersionedHashes = blobVersionedHashes;
-        public readonly UInt256 GasPrice = gasPrice;
+        private readonly UInt256 _gasPrice = gasPrice;
+
+        public readonly Address Origin => origin;
+        public readonly ICodeInfoRepository CodeInfoRepository => codeInfoRepository;
+        public readonly byte[][]? BlobVersionedHashes => blobVersionedHashes;
+        public readonly UInt256 GasPrice => _gasPrice;
+    }
+
+    public interface ITxExecutionContext
+    {
+        Address Origin { get; }
+        ICodeInfoRepository CodeInfoRepository { get; }
+        byte[][]? BlobVersionedHashes { get; }
+        UInt256 GasPrice { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachineBase.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachineBase.cs
@@ -101,12 +101,12 @@ public unsafe partial class VirtualMachineBase(
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => _blockExecutionContext = blockExecutionContext;
     public ref readonly BlockExecutionContext BlockExecutionContext => ref _blockExecutionContext;
 
-    private TxExecutionContext _txExecutionContext;
-    public ref readonly TxExecutionContext TxExecutionContext => ref _txExecutionContext;
+    private ITxExecutionContext _txExecutionContext;
+    public ref readonly ITxExecutionContext TxExecutionContext => ref _txExecutionContext;
     /// <summary>
     /// Transaction context
     /// </summary>
-    public void SetTxExecutionContext(in TxExecutionContext txExecutionContext) => _txExecutionContext = txExecutionContext;
+    public void SetTxExecutionContext(in ITxExecutionContext txExecutionContext) => _txExecutionContext = txExecutionContext;
 
     public EvmState EvmState { get => _currentState; private set => _currentState = value; }
     public int SectionIndex { get; set; }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateVirtualMachine.cs
@@ -39,11 +39,11 @@ public class SimulateVirtualMachine(IVirtualMachine virtualMachine) : IVirtualMa
 
     public ref readonly BlockExecutionContext BlockExecutionContext => ref virtualMachine.BlockExecutionContext;
 
-    public ref readonly TxExecutionContext TxExecutionContext => ref virtualMachine.TxExecutionContext;
+    public ref readonly ITxExecutionContext TxExecutionContext => ref virtualMachine.TxExecutionContext;
 
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         => virtualMachine.SetBlockExecutionContext(blockExecutionContext);
 
-    public void SetTxExecutionContext(in TxExecutionContext txExecutionContext)
+    public void SetTxExecutionContext(in ITxExecutionContext txExecutionContext)
         => virtualMachine.SetTxExecutionContext(txExecutionContext);
 }


### PR DESCRIPTION
For Arbitrum, we wanna make the TxExecutionContext overridable because we wanna add some fields there.

I'm not sure it's the best way to override it because i had to remove some `ref readonly`.
Maybe if we make it a record class (that we can then inherit from) instead of interface + struct, it'd be better ? 