### PR TITLE
Add BuilderNet to highlighted log brands

### DIFF
--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -56,7 +56,7 @@
       <highlight-word regex="(was set as head|\(partial offline mode until it finishes\)|disabled|WaitingForBlock|UpdatingPivot|Skipped Request|Pivot changed)" foregroundColor="Cyan" wholeWords="true" />
       <highlight-word regex="(0.00 MGas|0    txs)" foregroundColor="Red" wholeWords="true" />
       <!-- Brand names -->
-      <highlight-word regex="((?&lt;!\\)Nethermind(?![\\/\.])|Geth|Erigon|Besu|RocksDB|Intel|AMD|Arm|Reth|Nimbus|EthereumJS)" foregroundColor="Magenta" wholeWords="true" ignoreCase="true" />
+      <highlight-word regex="((?&lt;!\\)Nethermind(?![\\/\.])|Geth|Erigon|Besu|RocksDB|Intel|AMD|Arm|Reth|Nimbus|EthereumJS|BuilderNet)" foregroundColor="Magenta" wholeWords="true" ignoreCase="true" />
       <!-- Percentage progress -->
       <highlight-word regex="[0-9]{1,3}\.[0-9]{2} \%|[0-9]{1,3} \%" foregroundColor="DarkYellow" />
       <!-- Denominator of nnn / NNN (de-emphasize) -->


### PR DESCRIPTION
## Changes

- Add the `BuilerNet` consortium to the highlighted log brands https://buildernet.org/blog/introducing-buildernet

<img width="812" alt="image" src="https://github.com/user-attachments/assets/0e4bf02b-5cdf-45c7-9428-e9ae49ed2da4" />


## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Logging

## Testing

#### Requires testing

- [x] No