### PR TITLE
Trim JsonRpc Webhost for lower latency

### DIFF
--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
 [assembly: InternalsVisibleTo("Nethermind.Consensus")]
+[assembly: InternalsVisibleTo("Nethermind.State")]
 namespace Nethermind.Core
 {
     [DebuggerDisplay("{Hash}, Value: {Value}, To: {To}, Gas: {GasLimit}")]
@@ -121,6 +122,7 @@ namespace Nethermind.Core
         }
 
         private Memory<byte> _preHash;
+        internal ref readonly Memory<byte> PreHash => ref _preHash;
         private IMemoryOwner<byte>? _preHashMemoryOwner;
         public void SetPreHash(ReadOnlySpan<byte> transactionSequence)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.IO.Pipelines;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -56,19 +57,16 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
     private (JsonRpcRequest? Model, ArrayPoolList<JsonRpcRequest>? Collection) DeserializeObjectOrArray(JsonDocument doc)
     {
-        JsonValueKind type = doc.RootElement.ValueKind;
-        if (type == JsonValueKind.Array)
+        return doc.RootElement.ValueKind switch
         {
-            return (null, DeserializeArray(doc.RootElement));
-        }
-        else if (type == JsonValueKind.Object)
-        {
-            return (DeserializeObject(doc.RootElement), null);
-        }
-        else
-        {
-            throw new JsonException("Invalid");
-        }
+            JsonValueKind.Array => (null, DeserializeArray(doc.RootElement)),
+            JsonValueKind.Object => (DeserializeObject(doc.RootElement), null),
+            _ => ThrowInvalid()
+        };
+
+        [DoesNotReturn, StackTraceHidden]
+        static (JsonRpcRequest? Model, ArrayPoolList<JsonRpcRequest>? Collection) ThrowInvalid()
+            => throw new JsonException("Invalid");
     }
 
     private JsonRpcRequest DeserializeObject(JsonElement element)
@@ -133,39 +131,13 @@ public class JsonRpcProcessor : IJsonRpcProcessor
             yield return JsonRpcResult.Single(RecordResponse(response, new RpcReport("Shutdown", 0, false)));
         }
 
-        reader = await RecordRequest(reader);
+        if (IsRecordingRequest)
+        {
+            reader = await RecordRequest(reader);
+        }
+
         long startTime = Stopwatch.GetTimestamp();
         using CancellationTokenSource timeoutSource = _jsonRpcConfig.BuildTimeoutCancellationToken();
-
-        // Handles general exceptions during parsing and validation.
-        // Sends an error response and stops the stopwatch.
-        JsonRpcResult GetParsingError(ref readonly ReadOnlySequence<byte> buffer, string error, Exception? exception = null)
-        {
-            Metrics.JsonRpcRequestDeserializationFailures++;
-
-            if (_logger.IsError)
-            {
-                _logger.Error(error, exception);
-            }
-
-            if (_logger.IsDebug)
-            {
-                // Attempt to get and log the request body from the bytes buffer if Debug logging is enabled
-                const int sliceSize = 1000;
-                if (Encoding.UTF8.TryGetStringSlice(in buffer, sliceSize, out bool isFullString, out string data))
-                {
-                    error = isFullString
-                        ? $"{error} Data:\n{data}\n"
-                        : $"{error} Data (first {sliceSize} chars):\n{data[..sliceSize]}\n";
-
-                    _logger.Debug(error);
-                }
-            }
-
-            JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ParseError, "Incorrect message");
-            TraceResult(response);
-            return JsonRpcResult.Single(RecordResponse(response, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false)));
-        }
 
         // Initializes a buffer to store the data read from the reader.
         ReadOnlySequence<byte> buffer = default;
@@ -189,7 +161,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     // Tries to parse the JSON from the buffer.
                     if (!TryParseJson(ref buffer, out jsonDocument))
                     {
-                        deserializationFailureResult = GetParsingError(in buffer, "Error during parsing/validation.");
+                        deserializationFailureResult = GetParsingError(startTime, in buffer, "Error during parsing/validation.");
                     }
                     else
                     {
@@ -212,7 +184,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                 }
                 catch (Exception ex)
                 {
-                    deserializationFailureResult = GetParsingError(in buffer, "Error during parsing/validation.", ex);
+                    deserializationFailureResult = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
                 }
 
                 // Checks for deserialization failure and yields the result.
@@ -264,8 +236,11 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     JsonRpcErrorResponse errorResponse = _jsonRpcService.GetErrorResponse(ErrorCodes.InvalidRequest, "Invalid request");
                     errorResponse.AddDisposable(() => jsonDocument.Dispose());
 
-                    TraceResult(errorResponse);
-                    if (_logger.IsTrace) _logger.Trace($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+                    if (_logger.IsTrace)
+                    {
+                        TraceResult(errorResponse);
+                        TraceFailure(startTime);
+                    }
                     deserializationFailureResult = JsonRpcResult.Single(RecordResponse(errorResponse, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMilliseconds, false)));
                     yield return deserializationFailureResult.Value;
                     break;
@@ -285,7 +260,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
             {
                 if (buffer.Length > 0 && HasNonWhitespace(buffer))
                 {
-                    yield return GetParsingError(in buffer, "Error during parsing/validation: incomplete request.");
+                    yield return GetParsingError(startTime, in buffer, "Error during parsing/validation: incomplete request.");
                 }
             }
         }
@@ -300,6 +275,39 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
         // Completes the PipeReader's asynchronous reading operation.
         await reader.CompleteAsync();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceFailure(long startTime) => _logger.Trace($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+    }
+
+    // Handles general exceptions during parsing and validation.
+    // Sends an error response and stops the stopwatch.
+    private JsonRpcResult GetParsingError(long startTime, ref readonly ReadOnlySequence<byte> buffer, string error, Exception? exception = null)
+    {
+        Metrics.JsonRpcRequestDeserializationFailures++;
+
+        if (_logger.IsError)
+        {
+            _logger.Error(error, exception);
+        }
+
+        if (_logger.IsDebug)
+        {
+            // Attempt to get and log the request body from the bytes buffer if Debug logging is enabled
+            const int sliceSize = 1000;
+            if (Encoding.UTF8.TryGetStringSlice(in buffer, sliceSize, out bool isFullString, out string data))
+            {
+                error = isFullString
+                    ? $"{error} Data:\n{data}\n"
+                    : $"{error} Data (first {sliceSize} chars):\n{data[..sliceSize]}\n";
+
+                _logger.Debug(error);
+            }
+        }
+
+        JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ParseError, "Incorrect message");
+        if (_logger.IsTrace) TraceResult(response);
+        return JsonRpcResult.Single(RecordResponse(response, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false)));
     }
 
     private static bool HasNonWhitespace(ReadOnlySequence<byte> buffer)
@@ -350,8 +358,8 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     : await HandleSingleRequest(jsonRpcRequest, context);
 
                 if (_logger.IsTrace) _logger.Trace($"  {++requestIndex}/{requests.Count} JSON RPC request - {jsonRpcRequest} handled after {response.Report.HandlingTimeMicroseconds}");
-                TraceResult(response);
-                yield return RecordResponse(response);
+                if (_logger.IsTrace) TraceResult(response);
+                yield return !IsRecordingResponse ? response : RecordResponse(response);
             }
 
             if (_logger.IsTrace) _logger.Trace($"  {requests.Count} requests handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
@@ -386,29 +394,33 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         }
 
         JsonRpcResult.Entry result = new(response, new RpcReport(request.Method, (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, isSuccess));
-        TraceResult(result);
+
+        if (_logger.IsTrace) TraceResult(result);
         return result;
     }
 
     private static bool TryParseJson(ref ReadOnlySequence<byte> buffer, [NotNullWhen(true)] out JsonDocument? jsonDocument)
     {
         Utf8JsonReader reader = new(buffer);
+        if (!JsonDocument.TryParseValue(ref reader, out jsonDocument)) return false;
+        buffer = buffer.Slice(reader.BytesConsumed);
+        return true;
 
-        if (JsonDocument.TryParseValue(ref reader, out jsonDocument))
-        {
-            buffer = buffer.Slice(reader.BytesConsumed);
-            return true;
-        }
-
-        return false;
     }
 
-    private JsonRpcResult.Entry RecordResponse(JsonRpcResponse response, RpcReport report) =>
-        RecordResponse(new JsonRpcResult.Entry(response, report));
+    private bool IsRecordingRequest => (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0;
+    private bool IsRecordingResponse => (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Response) != 0;
 
-    private JsonRpcResult.Entry RecordResponse(JsonRpcResult.Entry result)
+    private JsonRpcResult.Entry RecordResponse(JsonRpcResponse response, in RpcReport report)
     {
-        if ((_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Response) != 0)
+        JsonRpcResult.Entry result = new(response, report);
+        return !IsRecordingResponse ? result : RecordResponse(result);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private JsonRpcResult.Entry RecordResponse(in JsonRpcResult.Entry result)
+    {
+        if (IsRecordingResponse)
         {
             _recorder.RecordResponse(JsonSerializer.Serialize(result, EthereumJsonSerializer.JsonOptionsIndented));
         }
@@ -418,27 +430,29 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
     private static readonly StreamPipeReaderOptions _pipeReaderOptions = new StreamPipeReaderOptions(leaveOpen: false);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private async ValueTask<PipeReader> RecordRequest(PipeReader reader)
     {
-        if ((_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0)
+        if (!IsRecordingRequest)
         {
-            Stream memoryStream = RecyclableStream.GetStream("recorder");
-            await reader.CopyToAsync(memoryStream);
-            memoryStream.Seek(0, SeekOrigin.Begin);
-
-            StreamReader streamReader = new(memoryStream);
-
-            string requestString = await streamReader.ReadToEndAsync();
-            _recorder.RecordRequest(requestString);
-
-            memoryStream.Seek(0, SeekOrigin.Begin);
-            return PipeReader.Create(memoryStream, _pipeReaderOptions);
+            return reader;
         }
 
-        return reader;
+        Stream memoryStream = RecyclableStream.GetStream("recorder");
+        await reader.CopyToAsync(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        StreamReader streamReader = new(memoryStream);
+
+        string requestString = await streamReader.ReadToEndAsync();
+        _recorder.RecordRequest(requestString);
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        return PipeReader.Create(memoryStream, _pipeReaderOptions);
     }
 
-    private void TraceResult(JsonRpcResult.Entry response)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceResult(in JsonRpcResult.Entry response)
     {
         if (_logger.IsTrace)
         {
@@ -448,6 +462,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceResult(JsonRpcErrorResponse response)
     {
         if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
@@ -24,16 +24,16 @@ namespace Nethermind.JsonRpc
             BatchedResponses = batchedResponses;
         }
 
-        private JsonRpcResult(Entry singleResult)
+        private JsonRpcResult(in Entry singleResult)
         {
             IsCollection = false;
             SingleResponse = singleResult;
         }
 
-        public static JsonRpcResult Single(JsonRpcResponse response, RpcReport report)
+        public static JsonRpcResult Single(JsonRpcResponse response, in RpcReport report)
             => new(new Entry(response, report));
 
-        public static JsonRpcResult Single(Entry entry)
+        public static JsonRpcResult Single(in Entry entry)
             => new(entry);
 
         public static JsonRpcResult Collection(IJsonRpcBatchResult responses)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -38,52 +39,64 @@ public class JsonRpcService : IJsonRpcService
 
     public async Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
     {
+        (int? errorCode, string errorMessage) = Validate(rpcRequest, context);
+        if (errorCode.HasValue)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Validation error when handling request: {rpcRequest}");
+            return GetErrorResponse(rpcRequest.Method, errorCode.Value, errorMessage, null, rpcRequest.Id);
+        }
+
+        Exception error;
         try
         {
-            (int? errorCode, string errorMessage) = Validate(rpcRequest, context);
-            if (errorCode.HasValue)
-            {
-                if (_logger.IsDebug) _logger.Debug($"Validation error when handling request: {rpcRequest}");
-                return GetErrorResponse(rpcRequest.Method, errorCode.Value, errorMessage, null, rpcRequest.Id);
-            }
-
-            try
-            {
-                return await ExecuteRequestAsync(rpcRequest, context);
-            }
-            catch (TargetInvocationException ex)
-            {
-                if (_logger.IsError)
-                    _logger.Error($"Error during method execution, request: {rpcRequest}", ex.InnerException);
-                return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error",
-                    ex.InnerException?.ToString(), rpcRequest.Id);
-            }
-            catch (LimitExceededException ex)
-            {
-                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
-                return GetErrorResponse(rpcRequest.Method, ErrorCodes.LimitExceeded, "Too many requests", ex.ToString(), rpcRequest.Id);
-            }
-            catch (ModuleRentalTimeoutException ex)
-            {
-                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
-                return GetErrorResponse(rpcRequest.Method, ErrorCodes.ModuleTimeout, "Timeout", ex.ToString(), rpcRequest.Id);
-            }
+            return await ExecuteRequestAsync(rpcRequest, context);
         }
         catch (Exception ex)
+        {
+            error = ex;
+        }
+
+        return ReturnErrorResponse(rpcRequest, error);
+    }
+
+    private JsonRpcErrorResponse ReturnErrorResponse(JsonRpcRequest rpcRequest, Exception ex)
+    {
+        int errorCode;
+        string errorText;
+        if (ex is TargetInvocationException tx)
+        {
+            errorCode = ErrorCodes.InternalError;
+            ex = tx.InnerException;
+            errorText = "Internal error";
+        }
+        else if (ex is LimitExceededException)
+        {
+            errorCode = ErrorCodes.LimitExceeded;
+            errorText = "Too many requests";
+        }
+        else if (ex is ModuleRentalTimeoutException)
+        {
+            errorCode = ErrorCodes.ModuleTimeout;
+            errorText = "Timeout";
+        }
+        else
         {
             if (_logger.IsError) _logger.Error($"Error during validation, request: {rpcRequest}", ex);
             return GetErrorResponse(ErrorCodes.ParseError, "Parse error", rpcRequest.Id, rpcRequest.Method);
         }
+
+        if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
+        return GetErrorResponse(rpcRequest.Method, errorCode, errorText, ex.ToString(), rpcRequest.Id);
     }
 
-    private async Task<JsonRpcResponse> ExecuteRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
+    private Task<JsonRpcResponse> ExecuteRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
     {
         string methodName = rpcRequest.Method.Trim();
 
         ResolvedMethodInfo? result = _rpcModuleProvider.Resolve(methodName);
         return result?.MethodInfo is not null
-            ? await ExecuteAsync(rpcRequest, methodName, result, context)
-            : GetErrorResponse(methodName, ErrorCodes.MethodNotFound, "Method not found", $"{rpcRequest.Method}", rpcRequest.Id);
+            ? ExecuteAsync(rpcRequest, methodName, result, context)
+            : Task.FromResult<JsonRpcResponse>(GetErrorResponse(methodName, ErrorCodes.MethodNotFound, "Method not found", $"{rpcRequest.Method}", rpcRequest.Id));
     }
 
     private async Task<JsonRpcResponse> ExecuteAsync(JsonRpcRequest request, string methodName, ResolvedMethodInfo method, JsonRpcContext context)
@@ -310,7 +323,7 @@ public class JsonRpcService : IJsonRpcService
             if (providedParameter.ValueKind == JsonValueKind.String)
             {
                 JsonConverter converter = EthereumJsonSerializer.JsonOptions.GetConverter(paramType);
-                executionParam = converter.GetType().FullName.StartsWith("System.")
+                executionParam = converter.GetType().Namespace.StartsWith("System.", StringComparison.Ordinal)
                     ? JsonSerializer.Deserialize(providedParameter.GetString(), paramType, EthereumJsonSerializer.JsonOptions)
                     : providedParameter.Deserialize(paramType, EthereumJsonSerializer.JsonOptions);
             }
@@ -448,15 +461,26 @@ public class JsonRpcService : IJsonRpcService
         methodName = methodName.Trim();
 
         ModuleResolution result = _rpcModuleProvider.Check(methodName, context, out string? module);
-        return result switch
+        if (result == ModuleResolution.Enabled)
         {
-            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, $"The method '{methodName}' is not supported."),
-            ModuleResolution.Disabled => (ErrorCodes.InvalidRequest,
-                $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL."),
-            ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest,
-                $"The method '{methodName}' is found in namespace '{module}' for {context.Url?.ToString() ?? "n/a"}' but is disabled for {context.RpcEndpoint}."),
-            ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"The method '{methodName}' must be authenticated."),
-            _ => (null, null)
-        };
+            return (null, null);
+        }
+
+        return GetErrorResult(methodName, context, result, module);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static (int? ErrorType, string ErrorMessage) GetErrorResult(string methodName, JsonRpcContext context, ModuleResolution result, string module)
+        {
+            return result switch
+            {
+                ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, $"The method '{methodName}' is not supported."),
+                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest,
+                    $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL."),
+                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest,
+                    $"The method '{methodName}' is found in namespace '{module}' for {context.Url?.ToString() ?? "n/a"}' but is disabled for {context.RpcEndpoint}."),
+                ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"The method '{methodName}' must be authenticated."),
+                _ => (null, null)
+            };
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
@@ -34,11 +34,18 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 
         public int GetLength(BlockBodiesMessage message, out int contentLength)
         {
-            contentLength = message.Bodies.Bodies.Select(b => b is null
-                ? Rlp.OfEmptySequence.Length
-                : Rlp.LengthOfSequence(_blockBodyDecoder.GetBodyLength(b))
-            ).Sum();
-            return Rlp.LengthOfSequence(contentLength);
+            int length = 0;
+            foreach (BlockBody? body in message.Bodies.Bodies)
+            {
+                length += body switch
+                {
+                    null => Rlp.OfEmptySequence.Length,
+                    _ => Rlp.LengthOfSequence(_blockBodyDecoder.GetBodyLength(body))
+                };
+            }
+
+            contentLength = length;
+            return Rlp.LengthOfSequence(length);
         }
 
         public BlockBodiesMessage Deserialize(IByteBuffer byteBuffer)

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/HostingApplication.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/HostingApplication.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Nethermind.Logging;
+
+namespace Nethermind.Runner.JsonRpc;
+
+internal sealed class HostingApplication : IHttpApplication<HostingApplication.Context>
+{
+    private readonly ILogger _logger;
+    private readonly RequestDelegate _application;
+    private readonly HttpContextFactory? _httpContextFactory;
+
+    public HostingApplication(
+        RequestDelegate application,
+        ILogManager logManager,
+        HttpContextFactory httpContextFactory)
+    {
+        _logger = logManager.GetClassLogger();
+        //_logManager = logManager;
+        _application = application;
+        _httpContextFactory = httpContextFactory;
+    }
+
+    // Set up the request
+    public Context CreateContext(IFeatureCollection contextFeatures)
+    {
+        Context? hostContext;
+        if (contextFeatures is IHostContextContainer<Context> container)
+        {
+            hostContext = container.HostContext;
+            if (hostContext is null)
+            {
+                hostContext = new Context();
+                container.HostContext = hostContext;
+            }
+        }
+        else
+        {
+            // Server doesn't support pooling, so create a new Context
+            hostContext = new Context();
+        }
+
+        HttpContext httpContext;
+        var defaultHttpContext = (DefaultHttpContext?)hostContext.HttpContext;
+        if (defaultHttpContext is null)
+        {
+            httpContext = _httpContextFactory.Create(contextFeatures);
+            hostContext.HttpContext = httpContext;
+        }
+        else
+        {
+            _httpContextFactory.Initialize(defaultHttpContext, contextFeatures);
+            httpContext = defaultHttpContext;
+        }
+
+        return hostContext;
+    }
+
+    // Execute the request
+    public Task ProcessRequestAsync(Context context)
+    {
+        return _application(context.HttpContext!);
+    }
+
+    // Clean up the request
+    public void DisposeContext(Context context, Exception? exception)
+    {
+        var httpContext = context.HttpContext!;
+
+        _httpContextFactory.Dispose((DefaultHttpContext)httpContext);
+
+        if (_httpContextFactory.HttpContextAccessor != null)
+            // Clear the HttpContext if the accessor was used. It's likely that the lifetime extends
+            // past the end of the http request and we want to avoid changing the reference from under
+            // consumers.
+            context.HttpContext = null;
+
+        // Reset the context as it may be pooled
+        context.Reset();
+    }
+
+    internal sealed class Context
+    {
+        public HttpContext? HttpContext { get; set; }
+        public IDisposable? Scope { get; set; }
+
+        public void Reset()
+        {
+            Scope = null;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/HttpContextFactory.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/HttpContextFactory.cs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Nethermind.Runner.JsonRpc;
+
+public class HttpContextFactory
+{
+    private readonly IHttpContextAccessor? _httpContextAccessor;
+    private readonly FormOptions _formOptions;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    // This takes the IServiceProvider because it needs to support an ever expanding
+    // set of services that flow down into HttpContext features
+    /// <summary>
+    /// Creates a factory for creating <see cref="HttpContext" /> instances.
+    /// </summary>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to be used when retrieving services.</param>
+    public HttpContextFactory(IServiceProvider serviceProvider)
+    {
+        // May be null
+        _httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();
+        _formOptions = serviceProvider.GetRequiredService<IOptions<FormOptions>>().Value;
+        _serviceScopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    internal IHttpContextAccessor? HttpContextAccessor => _httpContextAccessor;
+
+    /// <summary>
+    /// Create an <see cref="HttpContext"/> instance given an <paramref name="featureCollection" />.
+    /// </summary>
+    /// <param name="featureCollection"></param>
+    /// <returns>An initialized <see cref="HttpContext"/> object.</returns>
+    public HttpContext Create(IFeatureCollection featureCollection)
+    {
+        ArgumentNullException.ThrowIfNull(featureCollection);
+
+        var httpContext = new DefaultHttpContext(featureCollection);
+        Initialize(httpContext, featureCollection);
+        return httpContext;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void Initialize(DefaultHttpContext httpContext, IFeatureCollection featureCollection)
+    {
+        Debug.Assert(featureCollection != null);
+        Debug.Assert(httpContext != null);
+
+        httpContext.Initialize(featureCollection);
+
+        if (_httpContextAccessor is not null)
+        {
+            _httpContextAccessor.HttpContext = httpContext;
+        }
+
+        httpContext.FormOptions = _formOptions;
+        httpContext.ServiceScopeFactory = _serviceScopeFactory;
+    }
+
+    /// <summary>
+    /// Clears the current <see cref="HttpContext" />.
+    /// </summary>
+    public void Dispose(HttpContext httpContext)
+    {
+        if (_httpContextAccessor is not null)
+        {
+            _httpContextAccessor.HttpContext = null;
+        }
+    }
+
+    internal void Dispose(DefaultHttpContext httpContext)
+    {
+        if (_httpContextAccessor is not null)
+        {
+            _httpContextAccessor.HttpContext = null;
+        }
+
+        httpContext.Uninitialize();
+    }
+}

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/NullDiagnosticListener.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/NullDiagnosticListener.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+public sealed class NullDiagnosticListener : DiagnosticListener
+{
+    public static NullDiagnosticListener Instance { get; } = new("");
+    public NullDiagnosticListener(string name) : base(name) { }
+    public override void Dispose() { }
+    public override bool IsEnabled(string name) => false;
+    public override bool IsEnabled(string name, object? arg1, object? arg2 = null) => false;
+    public override void OnActivityExport(Activity activity, object? payload) { }
+    public override void OnActivityImport(Activity activity, object? payload) { }
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer) => NullDisposable.Instance;
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled) => NullDisposable.Instance;
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Predicate<string>? isEnabled) => NullDisposable.Instance;
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled, Action<Activity, object?>? onActivityImport = null, Action<Activity, object?>? onActivityExport = null) => NullDisposable.Instance;
+    public override void Write(string name, object? value) { }
+    private sealed class NullDisposable : IDisposable
+    {
+        public static NullDisposable Instance { get; } = new();
+        public void Dispose() { }
+    }
+}

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -34,11 +34,13 @@ using Nethermind.Sockets;
 
 namespace Nethermind.Runner.JsonRpc;
 
-public class Startup
+public class Startup : IStartup
 {
     private static ReadOnlySpan<byte> _jsonOpeningBracket => [(byte)'['];
     private static ReadOnlySpan<byte> _jsonComma => [(byte)','];
     private static ReadOnlySpan<byte> _jsonClosingBracket => [(byte)']'];
+
+    IServiceProvider IStartup.ConfigureServices(IServiceCollection services) => Build(services);
 
     public void ConfigureServices(IServiceCollection services)
     {
@@ -73,6 +75,19 @@ public class Startup
     }
 
     private static ServiceProvider Build(IServiceCollection services) => services.BuildServiceProvider();
+
+
+    public void Configure(IApplicationBuilder app)
+    {
+        var services = app.ApplicationServices;
+        Configure(
+            app,
+            services.GetRequiredService<IWebHostEnvironment>(),
+            services.GetRequiredService<IJsonRpcProcessor>(),
+            services.GetRequiredService<IJsonRpcService>(),
+            services.GetRequiredService<IJsonRpcLocalStats>(),
+            services.GetRequiredService<IJsonSerializer>());
+    }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IJsonRpcProcessor jsonRpcProcessor, IJsonRpcService jsonRpcService, IJsonRpcLocalStats jsonRpcLocalStats, IJsonSerializer jsonSerializer)
     {
@@ -309,7 +324,7 @@ public class Startup
     private static bool IsLocalhost(IPAddress remoteIp)
         => IPAddress.IsLoopback(remoteIp) || remoteIp.Equals(IPAddress.IPv6Loopback);
 
-    private static int GetStatusCode(JsonRpcResult result)
+    private static int GetStatusCode(in JsonRpcResult result)
     {
         if (result.IsCollection)
         {

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/WebHost.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/WebHost.cs
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting.Internal;
+using Nethermind.Logging;
+
+namespace Nethermind.Runner.JsonRpc;
+
+internal sealed partial class WebHost : IWebHost, IAsyncDisposable
+{
+    private ApplicationLifetime? _applicationLifetime;
+    private readonly IConfiguration _config;
+    private readonly IServiceProvider? _applicationServices;
+    private readonly ILogger _logger;
+    private readonly ILogManager _logManager;
+    private readonly IStartup _startup;
+
+    private bool _stopped;
+    private bool _startedServer;
+
+    private IServer? Server { get; set; }
+
+    public WebHost(
+        IServiceProvider applicationServices,
+        IConfiguration config,
+        IStartup startup,
+        ILogManager logManager)
+    {
+        ArgumentNullException.ThrowIfNull(applicationServices);
+        ArgumentNullException.ThrowIfNull(config);
+
+        _applicationServices = applicationServices;
+        _config = config;
+        _startup = startup;
+        _logger = logManager.GetClassLogger();
+        _logManager = logManager;
+    }
+
+    public IServiceProvider Services
+    {
+        get
+        {
+            Debug.Assert(_applicationServices != null, "Initialize must be called before accessing services.");
+            return _applicationServices;
+        }
+    }
+
+    public IFeatureCollection ServerFeatures
+    {
+        get
+        {
+            EnsureServer();
+            return Server.Features;
+        }
+    }
+
+    public void Start()
+    {
+        StartAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        Debug.Assert(_applicationServices != null, "Initialize must be called first.");
+
+        var application = BuildApplication();
+
+        _applicationLifetime = _applicationServices.GetRequiredService<ApplicationLifetime>();
+
+        _applicationServices.GetRequiredService<IHttpContextFactory>();
+        var httpContextFactory = new HttpContextFactory(Services);
+        var hostingApp = new HostingApplication(application, _logManager, httpContextFactory);
+
+        await Server.StartAsync(hostingApp, cancellationToken).ConfigureAwait(false);
+        _startedServer = true;
+
+        // Fire IApplicationLifetime.Started
+        _applicationLifetime?.NotifyStarted();
+    }
+
+    [MemberNotNull(nameof(Server))]
+    private RequestDelegate BuildApplication()
+    {
+        Debug.Assert(_applicationServices != null, "Initialize must be called first.");
+
+        try
+        {
+            EnsureServer();
+
+            var builderFactory = _applicationServices.GetRequiredService<IApplicationBuilderFactory>();
+            var builder = builderFactory.CreateBuilder(Server.Features);
+            builder.ApplicationServices = _applicationServices;
+
+            Action<IApplicationBuilder> configure = _startup!.Configure;
+
+            configure(builder);
+
+            return builder.Build();
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error("Application startup exception", ex);
+            throw;
+        }
+    }
+
+    [MemberNotNull(nameof(Server))]
+    private void EnsureServer()
+    {
+        Debug.Assert(_applicationServices != null, "Initialize must be called first.");
+
+        if (Server == null)
+        {
+            Server = _applicationServices.GetRequiredService<IServer>();
+
+            var serverAddressesFeature = Server.Features?.Get<IServerAddressesFeature>();
+            var addresses = serverAddressesFeature?.Addresses;
+            if (addresses != null && !addresses.IsReadOnly && addresses.Count == 0)
+            {
+                var urls = _config[WebHostDefaults.ServerUrlsKey];//?? _config[DeprecatedServerUrlsKey];
+                if (!string.IsNullOrEmpty(urls))
+                {
+                    //serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(_config[WebHostDefaults.PreferHostingUrlsKey]);
+
+                    foreach (var value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        addresses.Add(value);
+                    }
+                }
+            }
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_stopped)
+            return;
+        _stopped = true;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(1));
+        cancellationToken = cts.Token;
+
+        // Fire IApplicationLifetime.Stopping
+        _applicationLifetime?.StopApplication();
+
+        if (Server != null && _startedServer)
+            await Server.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        // Fire IApplicationLifetime.Stopped
+        _applicationLifetime?.NotifyStopped();
+    }
+
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_stopped)
+        {
+            try
+            {
+                await StopAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsError) _logger.Error("WebHost shutdown error", ex);
+            }
+        }
+
+        await DisposeServiceProviderAsync(_applicationServices).ConfigureAwait(false);
+    }
+
+    private static ValueTask DisposeServiceProviderAsync(IServiceProvider? serviceProvider)
+    {
+        switch (serviceProvider)
+        {
+            case IAsyncDisposable asyncDisposable:
+                return asyncDisposable.DisposeAsync();
+            case IDisposable disposable:
+                disposable.Dispose();
+                break;
+        }
+        return default;
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using DotNetty.Buffers;
 using Nethermind.Core.Buffers;
@@ -141,7 +143,7 @@ namespace Nethermind.Serialization.Rlp
             return buffer;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn, StackTraceHidden]
         private static void ThrowSpanSourceNotCappedArray() => throw new InvalidOperationException("Encode to SpanSource failed to get a CappedArray.");
 
         public static Rlp Encode<T>(this IRlpObjectDecoder<T> decoder, IReadOnlyCollection<T?>? items, RlpBehaviors behaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -29,13 +31,34 @@ public sealed class TxTrie : PatriciaTrie<Transaction>
 
         foreach (Transaction? transaction in list)
         {
-            SpanSource buffer = _txDecoder.EncodeToSpanSource(transaction, rlpBehaviors: RlpBehaviors.SkipTypedWrapping, bufferPool: _bufferPool);
+            ref readonly Memory<byte> rlp = ref transaction.PreHash;
+            SpanSource buffer = (rlp.Length > 0) ?
+                CopyExistingRlp(rlp.Span, _bufferPool) :
+                _txDecoder.EncodeToSpanSource(transaction, rlpBehaviors: RlpBehaviors.SkipTypedWrapping, bufferPool: _bufferPool);
             SpanSource keyBuffer = key.EncodeToSpanSource(_bufferPool);
             key++;
 
             Set(keyBuffer.Span, buffer);
         }
+
+        static SpanSource CopyExistingRlp(ReadOnlySpan<byte> rlp, ICappedArrayPool? bufferPool)
+        {
+            // If we still have the tx rlp (usually case on new payload), just copy that rather than re-encoding
+            SpanSource buffer = bufferPool.SafeRentBuffer(rlp.Length);
+            if (buffer.TryGetCappedArray(out CappedArray<byte> capped))
+            {
+                rlp.CopyTo(capped.AsSpan());
+            }
+            else
+            {
+                ThrowSpanSourceNotCappedArray();
+            }
+            return buffer;
+        }
     }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowSpanSourceNotCappedArray() => throw new InvalidOperationException("Encode to SpanSource failed to get a CappedArray.");
 
     public static byte[][] CalculateProof(ReadOnlySpan<Transaction> transactions, int index)
     {


### PR DESCRIPTION
## Changes

- Rewrite the aspnet webhost to remove all the additional work an allocations for `Activity`, `DiagnosticListener` and `Metric`s; as we have our own metrics and Prometheus adds it's on metrics; and there isn't a ay to switch it off in the framework directly (Empty and Slim webhost both still add them)

![image](https://github.com/user-attachments/assets/b9049a31-1e83-4772-b7e0-e1898fc7a95c)

![image](https://github.com/user-attachments/assets/9b4aa1e3-9ef6-45db-96a4-dfe178ed40b6)


- If we have the Rlp for the tx already (as haven't converted it into hash yet, case for newpayload) then use that directly when calculating the TxTrie hash rather than reencoding the tx to get it.
- Move anything not hot-path in JsonRpc to non-inlined methods rather than than part of main code

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [x] No