### PR TITLE
Add Surge Hoodi Config in Runner

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
+++ b/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
@@ -7,7 +7,8 @@
     "LogFileName": "surge-hoodi.log"
   },
   "TxPool": {
-    "Size": 1024
+    "Size": 1024,
+    "BlobsSupport": "Disabled"
   },
   "Sync": {
     "FastSync": true,
@@ -22,14 +23,6 @@
   },
   "JsonRpc": {
     "Enabled": true,
-    "Timeout": 20000,
-    "Host": "127.0.0.1",
-    "Port": 8545,
-    "EngineHost": "127.0.0.1",
-    "EnginePort": 8551,
-    "EngineEnabledModules": "net,eth,subscribe,engine,web3,client,flashbots"
-  },
-  "Merge": {
-    "Enabled": true
+    "EnginePort": 8551
   }
 }


### PR DESCRIPTION
Fixes configuration file not found error for surge-hoodi.

## Changes

- Adds a new config file for surge-hoodi in Nethermind.Runner

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

Tested with publishing nethermind runner and it now generates `surge-hoodi.json` in the `configs` directory.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No