### PR TITLE
Fix Surge Hoodi Genesis Hash in Config

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
+++ b/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/NethermindEth/core-scripts/refs/heads/main/schemas/config.json",
   "Init": {
     "ChainSpecPath": "chainspec/surge-hoodi.json",
-    "GenesisHash": "0xbbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b",
+    "GenesisHash": "0xf4ca134e6355f2225d89119e9ddb917910b4fad86cf8c9d8640b8ddab292c0a1",
     "BaseDbPath": "nethermind_db/surge-hoodi",
     "LogFileName": "surge-hoodi.log"
   },


### PR DESCRIPTION
Fixes incorrect genesis hash from https://github.com/NethermindEth/nethermind/pull/8890 to the one specified here https://github.com/NethermindEth/simple-surge-node/blob/main/.env.hoodi#L30

## Changes

- Changes `GenesisHash`

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No