### PR TITLE
Unwrap invalid configuation exception

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/StepInitializationException.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StepInitializationException.cs
@@ -13,8 +13,8 @@ namespace Nethermind.Init.Steps
         {
         }
 
-        public StepDependencyException(string message)
-            : base(message)
+        public StepDependencyException(string message, Exception? innerException = null)
+            : base(message, innerException)
         {
         }
 

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsLoaderTests.cs
@@ -81,6 +81,7 @@ public class EthereumStepsLoaderTests
                 new StepInfo(typeof(StepCAuRa)),
                 new StepInfo(typeof(StepCStandard)),
                 new StepInfo(typeof(StepE)),
+                new StepInfo(typeof(FailedConstructorWithInvalidConfigurationStep)),
             ]);
     }
 


### PR DESCRIPTION
## Changes

- Bubble up `InvalidConfigurationException` so that it is less spammy. Looks like this:

```
9 
01 Jul 07:28:19 | Address 0x9b9020f7f9b1074d4776952639468d53c68b3976 is configured for signing blocks. 
01 Jul 07:28:19 | Initializing 6 plugins 
01 Jul 07:28:19 |   Ethash by Nethermind 
01 Jul 07:28:19 |   Ethash by Nethermind initialized in 0ms 
01 Jul 07:28:19 |   Merge by Nethermind 
01 Jul 07:28:19 | Client started with TTD: 58750000000000000000000, TTD reached: True, Terminal Block Number , FinalTotalDifficulty: 58750003716598352816469 
01 Jul 07:28:19 |   Merge by Nethermind initialized in 18ms 
01 Jul 07:28:19 |   HealthChecks by Nethermind 
01 Jul 07:28:19 |   HealthChecks by Nethermind initialized in 4ms 
01 Jul 07:28:19 |   EthStats by Nethermind 
01 Jul 07:28:19 |   EthStats by Nethermind initialized in 0ms 
01 Jul 07:28:19 |   Flashbots by Nethermind 
01 Jul 07:28:19 |   Flashbots by Nethermind initialized in 0ms 
01 Jul 07:28:19 |   UPnP by Nethermind 
01 Jul 07:28:19 |   UPnP by Nethermind initialized in 0ms 
01 Jul 07:28:19 | Detected HalfPath key scheme. 
01 Jul 07:28:19 | A critical error has occurred Nethermind.Core.Exceptions.InvalidConfigurationException: Dirty pruning cache size must be less than persisted pruning cache size.
   at Nethermind.Init.PruningTrieStateFactory.AdviseConfig() in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs:line 156
   at Nethermind.Init.PruningTrieStateFactory.Build() in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs:line 57
   at lambda_method154(Closure, Object[])
   at Autofac.Core.Activators.Reflection.BoundConstructor.Instantiate()
--- End of stack trace from previous location ---
   at Nethermind.Init.Steps.EthereumStepsManager.CreateStepInstance(StepInfo stepInfo) in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 154
   at Nethermind.Init.Steps.EthereumStepsManager.<>c__DisplayClass5_0.<CreateAndExecuteSteps>b__0() in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 67
   at Nethermind.Init.Steps.EthereumStepsManager.StepWrapper.get_Step() in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 276
   at Nethermind.Init.Steps.EthereumStepsManager.ExecuteStep(StepWrapper stepWrapper, Dictionary`2 stepBaseTypeMap, CancellationToken cancellationToken) in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 123
   at Nethermind.Init.Steps.EthereumStepsManager.ReviewFailedAndThrow(Task task) in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 181
   at Nethermind.Init.Steps.EthereumStepsManager.InitializeAll(CancellationToken cancellationToken) in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 49
   at Nethermind.Runner.Ethereum.EthereumRunner.Start(CancellationToken cancellationToken) in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs:line 27
   at Program.<>c__DisplayClass0_0.<<<Main>$>g__RunAsync|2>d.MoveNext() in /home/amirul/repo/nethermind/src/Nethermind/Nethermind.Runner/Program.cs:line 188
01 Jul 07:28:19 | Nethermind is shutting down... Please wait until all activities are stopped. 

```

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Manually trigger exception by setting very low cache size.