### PR TITLE
Fix/unencodable header

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/HeaderDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/HeaderDecoderTests.cs
@@ -220,6 +220,24 @@ public class HeaderDecoderTests
         _ = Rlp.Decode<BlockHeader>(rlp.Bytes.AsSpan());
     }
 
+    [Test]
+    public void Can_encode_decode_with_zero_basefee_but_has_later_field()
+    {
+        BlockHeader header = Build.A.BlockHeader
+            .WithTimestamp(ulong.MaxValue)
+            .WithBaseFee(0)
+            .WithWithdrawalsRoot(Keccak.Zero)
+            .WithBlobGasUsed(0)
+            .WithExcessBlobGas(0)
+            .WithParentBeaconBlockRoot(TestItem.KeccakB)
+            .WithRequestsHash(Keccak.Zero).TestObject;
+
+        Rlp rlp = Rlp.Encode(header);
+        BlockHeader blockHeader = Rlp.Decode<BlockHeader>(rlp.Bytes.AsSpan());
+
+        blockHeader.Should().BeEquivalentTo(header);
+    }
+
     public static IEnumerable<object?[]> CancunFieldsSource()
     {
         yield return new object?[] { null, null, null };

--- a/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
@@ -79,7 +79,7 @@ public partial class FlashbotsModuleTests
 
         Hash256 prevRandao = Keccak.Zero;
 
-        Hash256 expectedBlockHash = new("0x961f11bf7889f09f3ada48da02506d1459310c0386c328d8cf760a7a20d92dd5");
+        Hash256 expectedBlockHash = new("0xed7c356cda6ea2e7d79be86be2b11c24f97b6501bf5519a5826fd384a458a060");
         string stateRoot = "0xa272b2f949e4a0e411c9b45542bd5d0ef3c311b5f26c4ed6b7a8d4f605a91154";
 
         return new(

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -62,16 +62,16 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
         => base.forkchoiceUpdatedV2_should_validate_withdrawals(input);
 
     [TestCase(
-        "0x1f26afbef938a122f4f55d2f081ac81cd9c8851ca22452fa5baf58845e574fc6",
-        "0x343ab3716f2475c9cdd993dc654dd0ea143379a62f0556180bff1869eb451858",
+        "0xd6ac1db7fee77f895121329b5949ddfb5258c952868a3707bb1104d8f219df2e",
+        "0x912ef8152bf54f81762e26d2a4f0793fb2a0a55b7ce5a9ff7f6879df6d94a6b3",
         "0x26b9598dd31cd520c6dcaf4f6fa13e279b4fa1f94d150357290df0e944f53115",
-        "0x2de3ad8b5939b3b9")]
+        "0x0117c925cabe3c1d")]
     public override Task Should_process_block_as_expected_V4(string latestValidHash, string blockHash, string stateRoot, string payloadId)
         => base.Should_process_block_as_expected_V4(latestValidHash, blockHash, stateRoot, payloadId);
 
     [TestCase(
         "0xca2fbb93848df6500fcc33f9036f43f33db9844719f0a5fc69079d8d90dbb28f",
-        "0xc6caeb09b3f26ddda9b1adb956fadbe29d7d90cff9bf2e2b0f3f1d0ec9296a72",
+        "0x4b8e5a6567229461665f1475a39665a3df55b367ca5fd9cc861fe70d4d5836c3",
         "0xd4ab6af74f5566d54b164115a9b00726bd35e2170d206e466c4be30ebfe23894",
         "0x103ea062e6e09c06")]
     public override Task Should_process_block_as_expected_V2(string latestValidHash, string blockHash, string stateRoot, string payloadId)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -43,6 +43,7 @@ using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.GC;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs;
@@ -139,7 +140,7 @@ public abstract partial class BaseEngineModuleTests
                 chain.LogManager),
             new NewPayloadHandler(
                 chain.PayloadPreparationService,
-                chain.BlockValidator,
+                new InvalidBlockInterceptor(chain.BlockValidator, invalidChainTracker, LimboLogs.Instance),
                 chain.BlockTree,
                 chain.PoSSwitcher,
                 chain.BeaconSync,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -33,7 +33,7 @@ public partial class EngineModuleTests
 {
     [TestCase(
         "0x73b538422b679dae9148c7de383813d96182bcdf2636955096a19da1ffe97967",
-        "0x43b85f31b7441048476f2dd80f7d58486a0ca37b7f421e5107e6cbf26032b74b",
+        "0xe89937a887c84cf0422c4445780f573929fa8bdec06eaac39be91cd428a9c249",
         "0x0cb5b20122ce36c5d13058d8d6ec33b9fee729730f41a3adeacfb76dd8116ab7",
         "0x0c26dbd2461b7b5d")]
     public virtual async Task Should_process_block_as_expected_V2(string latestValidHash, string blockHash,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -731,8 +731,8 @@ public partial class EngineModuleTests
         await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultA2.BlockHash, chainC.BlockTree.GenesisHash, chainC.BlockTree.GenesisHash), null);
         await Task.Delay(1000);
 
-        await rpcModuleC.engine_newPayloadV3(payloadResultB2, [], TestItem.KeccakE);
-        await rpcModuleC.engine_newPayloadV3(payloadResultB3, [], TestItem.KeccakE);
+        (await rpcModuleC.engine_newPayloadV3(payloadResultB2, [], TestItem.KeccakE)).Data.Status.Should().Be("SYNCING");
+        (await rpcModuleC.engine_newPayloadV3(payloadResultB3, [], TestItem.KeccakE)).Data.Status.Should().Be("SYNCING");
 
         await Task.Delay(1000);
         AddBlockResult res = chainC.BlockTree.Insert(chainB.BlockTree.FindBlock(2)!.Header, BlockTreeInsertHeaderOptions.BeaconHeaderInsert);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -23,10 +23,10 @@ namespace Nethermind.Merge.Plugin.Test;
 public partial class EngineModuleTests
 {
     [TestCase(
-        "0x9e205909311e6808bd7167e07bda30bda2b1061127e89e76167781214f3024bf",
-        "0x701f48fd56e6ded89a9ec83926eb99eebf9a38b15b4b8f0066574ac1dd9ff6df",
+        "0x0b2e24d802b4664b6f64f87a3e9498566080b2e9f8adf6e00896f89e4cc8a83b",
+        "0xf0444d3c2e8d725d7884803ff71b62a680fe9f96765a9f01b9c4e47dacb2f3b0",
         "0x73cecfc66bc1c8545aa3521e21be51c31bd2054badeeaa781f5fd5b871883f35",
-        "0x80ce7f68a5211b5d")]
+        "0xd814b750baa05a39")]
     public virtual async Task Should_process_block_as_expected_V4(string latestValidHash, string blockHash,
         string stateRoot, string payloadId)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -268,7 +268,7 @@ namespace Nethermind.Serialization.Rlp
             requiredItems[0] = !item.BaseFeePerGas.IsZero;
             requiredItems[1] = (item.WithdrawalsRoot is not null);
             requiredItems[2] = (item.BlobGasUsed is not null);
-            requiredItems[3] = (item.ExcessBlobGas is not null || item.ExcessBlobGas is not null);
+            requiredItems[3] = (item.BlobGasUsed is not null || item.ExcessBlobGas is not null);
             requiredItems[4] = (item.ParentBeaconBlockRoot is not null);
             requiredItems[5] = (item.RequestsHash is not null);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Serialization.Rlp
             requiredItems[0] = !header.BaseFeePerGas.IsZero;
             requiredItems[1] = (header.WithdrawalsRoot is not null);
             requiredItems[2] = (header.BlobGasUsed is not null);
-            requiredItems[3] = (header.ExcessBlobGas is not null || header.ExcessBlobGas is not null);
+            requiredItems[3] = (header.BlobGasUsed is not null || header.ExcessBlobGas is not null);
             requiredItems[4] = (header.ParentBeaconBlockRoot is not null);
             requiredItems[5] = (header.RequestsHash is not null);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Serialization.Rlp
             requiredItems[0] = !header.BaseFeePerGas.IsZero;
             requiredItems[1] = (header.WithdrawalsRoot is not null);
             requiredItems[2] = (header.BlobGasUsed is not null);
-            requiredItems[3] = (header.ExcessBlobGas is not null);
+            requiredItems[3] = (header.ExcessBlobGas is not null || header.ExcessBlobGas is not null);
             requiredItems[4] = (header.ParentBeaconBlockRoot is not null);
             requiredItems[5] = (header.RequestsHash is not null);
 
@@ -268,7 +268,7 @@ namespace Nethermind.Serialization.Rlp
             requiredItems[0] = !item.BaseFeePerGas.IsZero;
             requiredItems[1] = (item.WithdrawalsRoot is not null);
             requiredItems[2] = (item.BlobGasUsed is not null);
-            requiredItems[3] = (item.ExcessBlobGas is not null);
+            requiredItems[3] = (item.ExcessBlobGas is not null || item.ExcessBlobGas is not null);
             requiredItems[4] = (item.ParentBeaconBlockRoot is not null);
             requiredItems[5] = (item.RequestsHash is not null);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -166,17 +166,21 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             .AddSingleton<ITestEnv, PreMergeTestEnv>()
             ;
 
+        ManualTimestamper timestamper;
         if (isPostMerge)
         {
+            // Activate configured mainnet future EIP
+            timestamper = new ManualTimestamper(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             builder
                 .AddModule(new TestMergeModule(configProvider.GetConfig<ITxPoolConfig>()))
+                .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
                 .AddDecorator<ITestEnv, PostMergeTestEnv>()
                 ;
         }
         else
         {
             // So that any EIP after the merge is not activated.
-            ManualTimestamper timestamper = ManualTimestamper.PreMerge;
+            timestamper = ManualTimestamper.PreMerge;
             builder
                 .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
                 .AddSingleton<ITimestamper>(timestamper)


### PR DESCRIPTION
- The header encoder cannot encode certain header.
  - If base fee is 0, and later field is not zero, it will skip base fee, and encode later field but then decode the later field as basefee without throwing.
- This does not happen in mainnet, but cause long debugging session in test, and make it so that test must activate the right spec all the time.
- This PR change it so that if any later field is populated, earlier field must be set (even null) which make the encoding and decoding consistent.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet can sync