### PR TITLE
Update SurgeGasPriceOracle (Issues from Devnet)

### DIFF
--- a/src/Nethermind/Nethermind.Taiko/Config/ISurgeConfig.cs
+++ b/src/Nethermind/Nethermind.Taiko/Config/ISurgeConfig.cs
@@ -36,4 +36,7 @@ public interface ISurgeConfig : IConfig
 
     [ConfigItem(Description = "Percentage of the base fee that is shared with the L2 batch submitter.", DefaultValue = "75")]
     int SharingPercentage { get; set; }
+
+    [ConfigItem(Description = "Maximum time in seconds to use cached gas price estimates before forcing a refresh.", DefaultValue = "30")]
+    int GasPriceRefreshTimeoutSeconds { get; set; }
 }

--- a/src/Nethermind/Nethermind.Taiko/Config/SurgeConfig.cs
+++ b/src/Nethermind/Nethermind.Taiko/Config/SurgeConfig.cs
@@ -15,4 +15,5 @@ public class SurgeConfig : ISurgeConfig
     public int L2GasUsageWindowSize { get; set; } = 20;
     public string? TaikoInboxAddress { get; set; }
     public int SharingPercentage { get; set; } = 75;
+    public int GasPriceRefreshTimeoutSeconds { get; set; } = 30;
 }


### PR DESCRIPTION
Fixes SurgeGasPriceOracle to handle batch Id 1 and add force refresh gas estimate based on timeout.

## Changes
- Fix SurgeGasPriceOracle to correctly handle batch Id 1
-  Add cache timeout to ensure the gas price is periodically updated even if the head block doesn't change
 

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Due to low gas fee on devnet, most of the times profitability checks are failing:
```
INFO [07-01|09:28:25.584] Profitability check  estimatedCost=0.001911000001 collectedFees=0.002896074234 isProfitable=true l2BaseFee=1.824528592e-09 txCount=1
INFO [07-01|09:28:42.606] Profitability check  estimatedCost=0.001911000001 collectedFees=0.0008208640177 isProfitable=false l2BaseFee=9.36668034e-10  txCount=1
INFO [07-01|09:28:47.616] Profitability check  estimatedCost=0.001911000001 collectedFees=0.0008208640177 isProfitable=false l2BaseFee=9.36668034e-10  txCount=1
INFO [07-01|09:28:52.626] Profitability check  estimatedCost=0.001911000001 collectedFees=0.0008208640177 isProfitable=false l2BaseFee=9.36668034e-10  txCount=1
```

```
L2 cost estimation  l1BaseFee=1.100000001e-09 costWithCalldata=0.001086 costWithBlobs=0 blobBaseFee=0 proofPostingCost=0.0008250000008 provingCostPerL2Batch=0.0008 totalCost=0.001911000001
```

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No