### PR TITLE
Drop async where just pass through and return Task directly

### DIFF
--- a/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
@@ -38,15 +38,11 @@ public class AnalyticsWebSocketsModule : IWebSocketsModule, IPublisher
 
     public void RemoveClient(string id) => _clients.TryRemove(id, out _);
 
-    public async Task PublishAsync<T>(T data) where T : class
-    {
-        await SendAsync(new SocketsMessage("analytics", null, data));
-    }
+    public Task PublishAsync<T>(T data) where T : class
+        => SendAsync(new SocketsMessage("analytics", null, data));
 
-    public async Task SendAsync(SocketsMessage message)
-    {
-        await Task.WhenAll(_clients.Values.Select(v => v.SendAsync(message)));
-    }
+    public Task SendAsync(SocketsMessage message)
+        => Task.WhenAll(_clients.Values.Select(v => v.SendAsync(message)));
 
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -105,9 +105,9 @@ namespace Nethermind.Blockchain.FullPruning
             }
         }
 
-        private async Task WaitForMainChainChange(Func<OnUpdateMainChainArgs, bool> handler, CancellationToken cancellationToken)
+        private Task WaitForMainChainChange(Func<OnUpdateMainChainArgs, bool> handler, CancellationToken cancellationToken)
         {
-            await Wait.ForEventCondition<OnUpdateMainChainArgs>(
+            return Wait.ForEventCondition<OnUpdateMainChainArgs>(
                 cancellationToken,
                 (h) => _blockTree.OnUpdateMainChain += h,
                 (h) => _blockTree.OnUpdateMainChain -= h,

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -57,10 +57,8 @@ namespace Nethermind.Blockchain
         public (BlockInfo Info, ChainLevelInfo Level) GetInfo(long number, Hash256 blockHash) => _wrapped.GetInfo(number, blockHash);
         public bool CanAcceptNewBlocks { get; } = false;
 
-        public async Task Accept(IBlockTreeVisitor blockTreeVisitor, CancellationToken cancellationToken)
-        {
-            await _wrapped.Accept(blockTreeVisitor, cancellationToken);
-        }
+        public Task Accept(IBlockTreeVisitor blockTreeVisitor, CancellationToken cancellationToken)
+            => _wrapped.Accept(blockTreeVisitor, cancellationToken);
 
         public ChainLevelInfo FindLevel(long number) => _wrapped.FindLevel(number);
         public BlockInfo FindCanonicalBlockInfo(long blockNumber) => _wrapped.FindCanonicalBlockInfo(blockNumber);

--- a/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksInALoop.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksInALoop.cs
@@ -58,11 +58,11 @@ namespace Nethermind.Consensus.Producers
             }
         }
 
-        protected virtual async Task ProducerLoopStep(CancellationToken token)
+        protected virtual Task ProducerLoopStep(CancellationToken token)
         {
             BlockProductionEventArgs args = new(cancellationToken: token);
             TriggerBlockProduction?.Invoke(this, args);
-            await args.BlockProductionTask;
+            return args.BlockProductionTask;
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
@@ -55,9 +55,9 @@ public class LatencyAndMessageSizeBasedRequestSizer
     /// <typeparam name="TRequest">request type</typeparam>
     /// <typeparam name="TResponseItem">response item type</typeparam>
     /// <returns></returns>
-    public async Task<TResponse> Run<TResponse, TRequest, TResponseItem>(IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem>
+    public Task<TResponse> Run<TResponse, TRequest, TResponseItem>(IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem>
     {
-        return await _requestSizer.Run(async (adjustedRequestSize) =>
+        return _requestSizer.Run(async (adjustedRequestSize) =>
         {
             long startTime = Stopwatch.GetTimestamp();
             long affectiveRequestSize = Math.Min(adjustedRequestSize, request.Count);

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
@@ -34,9 +34,9 @@ public class LatencyBasedRequestSizer
     /// <param name="func"></param>
     /// <typeparam name="TResponse"></typeparam>
     /// <returns></returns>
-    public async Task<TResponse> MeasureLatency<TResponse>(Func<int, Task<TResponse>> func)
+    public Task<TResponse> MeasureLatency<TResponse>(Func<int, Task<TResponse>> func)
     {
-        return await _requestSizer.Run(async (requestSize) =>
+        return _requestSizer.Run(async (requestSize) =>
         {
             long startTime = Stopwatch.GetTimestamp();
             TResponse result = await func(requestSize);

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -27,10 +27,10 @@ namespace Nethermind.Db
             InitAll();
         }
 
-        public async Task InitStandardDbsAsync(bool useReceiptsDb, bool useBlobsDb = true)
+        public Task InitStandardDbsAsync(bool useReceiptsDb, bool useBlobsDb = true)
         {
             RegisterAll(useReceiptsDb, useBlobsDb);
-            await InitAllAsync();
+            return InitAllAsync();
         }
 
         private void RegisterAll(bool useReceiptsDb, bool useBlobsDb)

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -38,11 +38,11 @@ public class RegisterRpcModules(
     ILogManager logManager
 ) : IStep
 {
-    public virtual async Task Execute(CancellationToken cancellationToken)
+    public virtual Task Execute(CancellationToken cancellationToken)
     {
         if (!jsonRpcConfig.Enabled)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         // lets add threads to support parallel eth_getLogs
@@ -68,6 +68,6 @@ public class RegisterRpcModules(
         if (logger.IsDebug) logger.Debug($"RPC modules  : {string.Join(", ", rpcModuleProvider.Value.Enabled.OrderBy(static x => x))}");
         ThisNodeInfo.AddInfo("RPC modules  :", $"{string.Join(", ", rpcModuleProvider.Value.Enabled.OrderBy(static x => x))}");
 
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Cancun.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Cancun.cs
@@ -23,9 +23,9 @@ public partial class EngineRpcModule : IEngineRpcModule
     public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV3(ExecutionPayloadV3 executionPayload, byte[]?[] blobVersionedHashes, Hash256? parentBeaconBlockRoot) =>
         NewPayload(new ExecutionPayloadParams<ExecutionPayloadV3>(executionPayload, blobVersionedHashes, parentBeaconBlockRoot), EngineApiVersions.Cancun);
 
-    public async Task<ResultWrapper<GetPayloadV3Result?>> engine_getPayloadV3(byte[] payloadId) =>
-        await _getPayloadHandlerV3.HandleAsync(payloadId);
+    public Task<ResultWrapper<GetPayloadV3Result?>> engine_getPayloadV3(byte[] payloadId) =>
+        _getPayloadHandlerV3.HandleAsync(payloadId);
 
-    public async Task<ResultWrapper<IEnumerable<BlobAndProofV1?>>> engine_getBlobsV1(byte[][] blobVersionedHashes) =>
-        await _getBlobsHandler.HandleAsync(blobVersionedHashes);
+    public Task<ResultWrapper<IEnumerable<BlobAndProofV1?>>> engine_getBlobsV1(byte[][] blobVersionedHashes) =>
+        _getBlobsHandler.HandleAsync(blobVersionedHashes);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Osaka.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Osaka.cs
@@ -14,9 +14,9 @@ public partial class EngineRpcModule : IEngineRpcModule
     private readonly IAsyncHandler<byte[], GetPayloadV5Result?> _getPayloadHandlerV5;
     private readonly IAsyncHandler<byte[][], IEnumerable<BlobAndProofV2>?> _getBlobsHandlerV2;
 
-    public async Task<ResultWrapper<GetPayloadV5Result?>> engine_getPayloadV5(byte[] payloadId) =>
-        await _getPayloadHandlerV5.HandleAsync(payloadId);
+    public Task<ResultWrapper<GetPayloadV5Result?>> engine_getPayloadV5(byte[] payloadId)
+        => _getPayloadHandlerV5.HandleAsync(payloadId);
 
-    public async Task<ResultWrapper<IEnumerable<BlobAndProofV2>?>> engine_getBlobsV2(byte[][] blobVersionedHashes) =>
-        await _getBlobsHandlerV2.HandleAsync(blobVersionedHashes);
+    public Task<ResultWrapper<IEnumerable<BlobAndProofV2>?>> engine_getBlobsV2(byte[][] blobVersionedHashes)
+         => _getBlobsHandlerV2.HandleAsync(blobVersionedHashes);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -31,14 +31,14 @@ public partial class EngineRpcModule : IEngineRpcModule
     public ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(
         TransitionConfigurationV1 beaconTransitionConfiguration) => _transitionConfigurationHandler.Handle(beaconTransitionConfiguration);
 
-    public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
-        => await ForkchoiceUpdated(forkchoiceState, payloadAttributes, EngineApiVersions.Paris);
+    public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
+        => ForkchoiceUpdated(forkchoiceState, payloadAttributes, EngineApiVersions.Paris);
 
     public Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId) =>
         _getPayloadHandlerV1.HandleAsync(payloadId);
 
-    public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
-        => await NewPayload(executionPayload, EngineApiVersions.Paris);
+    public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
+        => NewPayload(executionPayload, EngineApiVersions.Paris);
 
     protected async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> ForkchoiceUpdated(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Prague.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Prague.cs
@@ -19,10 +19,8 @@ public partial class EngineRpcModule : IEngineRpcModule
     /// <see href="https://eips.ethereum.org/EIPS/eip-7685">EIP-7685</see>.
     /// </summary>
     public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV4(ExecutionPayloadV3 executionPayload, byte[]?[] blobVersionedHashes, Hash256? parentBeaconBlockRoot, byte[][]? executionRequests)
-    {
-        return NewPayload(new ExecutionPayloadParams<ExecutionPayloadV3>(executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests), EngineApiVersions.Prague);
-    }
+        => NewPayload(new ExecutionPayloadParams<ExecutionPayloadV3>(executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests), EngineApiVersions.Prague);
 
-    public async Task<ResultWrapper<GetPayloadV4Result?>> engine_getPayloadV4(byte[] payloadId) =>
-        await _getPayloadHandlerV4.HandleAsync(payloadId);
+    public Task<ResultWrapper<GetPayloadV4Result?>> engine_getPayloadV4(byte[] payloadId)
+        => _getPayloadHandlerV4.HandleAsync(payloadId);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
@@ -60,8 +60,8 @@ public class UnsafeStartingSyncPivotUpdater(
         return null;
     }
 
-    private async Task<BlockHeader?> TryGetFromPeers(long blockNumber, CancellationToken cancellationToken) =>
-        await TryGetFromPeers(blockNumber, cancellationToken, static async (peer, number, token) =>
+    private Task<BlockHeader?> TryGetFromPeers(long blockNumber, CancellationToken cancellationToken) =>
+        TryGetFromPeers(blockNumber, cancellationToken, static async (peer, number, token) =>
         {
             using IOwnedReadOnlyList<BlockHeader>? x = await peer.GetBlockHeaders(number, 1, 0, token);
             return x?.Count == 1 ? x[0] : null;

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -263,11 +263,11 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
     private DateTime _lastPingSent = DateTime.MinValue;
 
-    public async Task SendPingAsync()
+    public Task SendPingAsync()
     {
         _lastPingSent = DateTime.UtcNow;
         _sentPing = true;
-        await CreateAndSendPingAsync(_discoveryConfig.PingRetryCount);
+        return CreateAndSendPingAsync(_discoveryConfig.PingRetryCount);
     }
 
     private long CalculateExpirationTime()
@@ -326,9 +326,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
         if (newState == NodeLifecycleState.New)
         {
             //if node is just discovered we send ping to confirm it is active
-#pragma warning disable 4014
-            SendPingAsync();
-#pragma warning restore 4014
+            _ = SendPingAsync();
         }
         else if (newState == NodeLifecycleState.Active)
         {
@@ -356,9 +354,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
             if (DateTime.UtcNow - _lastPingSent > TimeSpan.FromSeconds(5))
             {
-#pragma warning disable 4014
-                SendPingAsync();
-#pragma warning restore 4014
+                _ = SendPingAsync();
             }
             else
             {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         public abstract void HandleMessage(ZeroPacket message);
 
-        protected async Task<TResponse> SendRequestGeneric<TRequest, TResponse>(
+        protected Task<TResponse> SendRequestGeneric<TRequest, TResponse>(
             MessageQueue<TRequest, TResponse> messageQueue,
             TRequest message,
             TransferSpeedType speedType,
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             Request<TRequest, TResponse> request = new(message);
             messageQueue.Send(request);
 
-            return await HandleResponse(request, speedType, describeRequestFunc, token);
+            return HandleResponse(request, speedType, describeRequestFunc, token);
         }
 
         protected async Task<TResponse> HandleResponse<TRequest, TResponse>(

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -113,19 +113,18 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             _nodeDataRequests.Handle(msg.Data, size);
         }
 
-        public override async Task<IOwnedReadOnlyList<byte[]>> GetNodeData(IReadOnlyList<Hash256> keys, CancellationToken token)
+        public override Task<IOwnedReadOnlyList<byte[]>> GetNodeData(IReadOnlyList<Hash256> keys, CancellationToken token)
         {
             if (keys.Count == 0)
             {
-                return ArrayPoolList<byte[]>.Empty();
+                return Task.FromResult<IOwnedReadOnlyList<byte[]>>(ArrayPoolList<byte[]>.Empty());
             }
 
             GetNodeDataMessage msg = new(keys.ToPooledList());
 
             // could use more array pooled lists (pooled memmory) here.
             // maybe remeasure allocations on another network since goerli has been phased out.
-            IOwnedReadOnlyList<byte[]> nodeData = await SendRequest(msg, token);
-            return nodeData;
+            return SendRequest(msg, token);
         }
         public override async Task<IOwnedReadOnlyList<TxReceipt[]>> GetReceipts(IReadOnlyList<Hash256> blockHashes, CancellationToken token)
         {
@@ -140,7 +139,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             return txReceipts;
         }
 
-        protected virtual async Task<IOwnedReadOnlyList<byte[]>> SendRequest(GetNodeDataMessage message, CancellationToken token)
+        protected virtual Task<IOwnedReadOnlyList<byte[]>> SendRequest(GetNodeDataMessage message, CancellationToken token)
         {
             if (Logger.IsTrace)
             {
@@ -148,7 +147,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 Logger.Trace($"Keys count: {message.Hashes.Count}");
             }
 
-            return await SendRequestGeneric(
+            return SendRequestGeneric(
                 _nodeDataRequests,
                 message,
                 TransferSpeedType.NodeData,
@@ -156,7 +155,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 token);
         }
 
-        protected virtual async Task<(IOwnedReadOnlyList<TxReceipt[]>, long)> SendRequest(GetReceiptsMessage message, CancellationToken token)
+        protected virtual Task<(IOwnedReadOnlyList<TxReceipt[]>, long)> SendRequest(GetReceiptsMessage message, CancellationToken token)
         {
             if (Logger.IsTrace)
             {
@@ -164,7 +163,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 Logger.Trace($"Hashes count: {message.Hashes.Count}");
             }
 
-            return await SendRequestGeneric(
+            return SendRequestGeneric(
                 _receiptsRequests,
                 message,
                 TransferSpeedType.Receipts,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -280,7 +280,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                 token);
         }
 
-        private async Task<TResponse> SendRequestGenericEth66<T66, TResponse>(
+        private Task<TResponse> SendRequestGenericEth66<T66, TResponse>(
             MessageDictionary<T66, TResponse> messageQueue,
             T66 message,
             TransferSpeedType speedType,
@@ -292,7 +292,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             Request<T66, TResponse> request = new(message);
             messageQueue.Send(request);
 
-            return await HandleResponse(request, speedType, describeRequestFunc, token);
+            return HandleResponse(request, speedType, describeRequestFunc, token);
         }
     }
 }


### PR DESCRIPTION
## Changes

- Skip the C# compiler creating an async state machine; when `await` is last item in method, no additional work is don't after the await (this includes `using`s as they dispose after); then just pass out the returned Task

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
