### PR TITLE
Only return peers in admin_peers that match the network id

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -105,8 +105,20 @@ public class AdminRpcModule : IAdminRpcModule
     }
 
     public ResultWrapper<PeerInfo[]> admin_peers(bool includeDetails = false)
-        => ResultWrapper<PeerInfo[]>.Success(
-            _peerPool.ActivePeers.Select(p => new PeerInfo(p.Value, includeDetails)).ToArray());
+    {
+        var validatedPeers = _peerPool.ActivePeers
+            .Where(p => IsValidatedPeer(p.Value))
+            .Select(p => new PeerInfo(p.Value, includeDetails))
+            .ToArray();
+
+        return ResultWrapper<PeerInfo[]>.Success(validatedPeers);
+    }
+
+    private static bool IsValidatedPeer(Peer peer)
+    {
+        return peer.InSession?.IsNetworkIdMatched == true ||
+               peer.OutSession?.IsNetworkIdMatched == true;
+    }
 
     public ResultWrapper<NodeInfo> admin_nodeInfo()
     {


### PR DESCRIPTION
## Changes

The `admin_peers` endpoint was returning peers that didn't belong to the same chain. This change will filter those temporary peers out and only return a list of peers that match the network id. 


Note: All the other clients (geth, reth, besu, erigon ..) return only peers that are on the same network.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
