### PR TITLE
Reduce txPool allocations for blobs and txs

### DIFF
--- a/src/Nethermind/Nethermind.Core/Pooling/ByteBufferPool.cs
+++ b/src/Nethermind/Nethermind.Core/Pooling/ByteBufferPool.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Nethermind.Core.Pooling;
+
+public class ByteBufferPool
+{
+    public const int BlobSize = 131072;
+    public const int ProofSize = 48;
+    private const int _poolSize = 256;
+
+    private readonly static ByteBufferPool _blobPool = new(BlobSize, _poolSize); // 32 MiB
+    private readonly static ByteBufferPool _proofPool = new(ProofSize, _poolSize * 2); // 24 KiB
+
+    public static byte[] RentBlob() => _blobPool.Rent();
+    public static void PoolBlobs(byte[][] bytesArrays)
+    {
+        foreach (var array in bytesArrays)
+        {
+            if (!_blobPool.Return(array)) break;
+        }
+    }
+    public static byte[] RentProof() => _proofPool.Rent();
+    public static void PoolProofs(byte[][] bytesArrays)
+    {
+        foreach (var array in bytesArrays)
+        {
+            if (!_proofPool.Return(array)) break;
+        }
+    }
+
+    private readonly int _bufferSize;
+    private readonly int _maxPoolSize;
+    private readonly ConcurrentQueue<byte[]> _pool;
+    private int _count;
+
+    public ByteBufferPool(int bufferSize, int maxPoolSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+
+        _bufferSize = bufferSize;
+        _maxPoolSize = maxPoolSize;
+        _pool = new ConcurrentQueue<byte[]>();
+        for (var i = 0; i < maxPoolSize; i++)
+        {
+            _pool.Enqueue(new byte[bufferSize]);
+        }
+        _count = maxPoolSize;
+    }
+
+    /// <summary>
+    /// Rent a buffer: either from the pool or a new one if the pool is empty.
+    /// </summary>
+    public byte[] Rent()
+    {
+        if (_pool.TryDequeue(out var buffer))
+        {
+            Interlocked.Decrement(ref _count);
+            return buffer;
+        }
+
+        // Pool empty -> allocate new
+        return new byte[_bufferSize];
+    }
+
+    /// <summary>
+    /// Return a buffer to the pool if it matches the size and there's room.
+    /// Otherwise it's simply discarded (GC will collect it eventually).
+    /// </summary>
+    public bool Return(byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        // Drop mismatched sizes
+        if (buffer.Length != _bufferSize)
+            return true;
+
+        // Only enqueue if we haven't reached the cap
+        // increment count first, then check against max to avoid races
+        var newCount = Interlocked.Increment(ref _count);
+        if (newCount <= _maxPoolSize)
+        {
+            _pool.Enqueue(buffer);
+            return true;
+        }
+        else
+        {
+            // We went over the cap: decrement back and drop
+            Interlocked.Decrement(ref _count);
+            return false;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -325,6 +325,7 @@ namespace Nethermind.Core
             tx.To = To;
             tx.SenderAddress = SenderAddress;
             tx.Signature = Signature;
+            tx._hash = _hash;
             tx.AccessList = AccessList;
             tx.BlobVersionedHashes = BlobVersionedHashes;
             tx.NetworkWrapper = NetworkWrapper;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -321,30 +321,32 @@ namespace Nethermind.Core
 
         public void CopyTo(Transaction tx)
         {
-            tx.ChainId = ChainId;
-            tx.Type = Type;
             tx.SourceHash = SourceHash;
-            tx.Mint = Mint;
-            tx.IsOPSystemTransaction = IsOPSystemTransaction;
-            tx.Nonce = Nonce;
-            tx.GasPrice = GasPrice;
-            tx.GasBottleneck = GasBottleneck;
-            tx.DecodedMaxFeePerGas = DecodedMaxFeePerGas;
-            tx.GasLimit = GasLimit;
             tx.To = To;
-            tx.Value = Value;
-            tx.Data = Data;
             tx.SenderAddress = SenderAddress;
             tx.Signature = Signature;
-            tx.Timestamp = Timestamp;
             tx.AccessList = AccessList;
-            tx.MaxFeePerBlobGas = MaxFeePerBlobGas;
             tx.BlobVersionedHashes = BlobVersionedHashes;
             tx.NetworkWrapper = NetworkWrapper;
-            tx.IsServiceTransaction = IsServiceTransaction;
-            tx.PoolIndex = PoolIndex;
-            tx._size = _size;
             tx.AuthorizationList = AuthorizationList;
+            tx.GasLimit = GasLimit;
+            tx.SpentGas = SpentGas;
+            tx.PoolIndex = PoolIndex;
+            tx.Type = Type;
+            tx.IsAnchorTx = IsAnchorTx;
+            tx.IsOPSystemTransaction = IsOPSystemTransaction;
+            tx.IsServiceTransaction = IsServiceTransaction;
+            tx.ChainId = ChainId;
+            tx.Mint = Mint;
+            tx.GasPrice = GasPrice;
+            tx.Nonce = Nonce;
+            tx.GasBottleneck = GasBottleneck;
+            tx.DecodedMaxFeePerGas = DecodedMaxFeePerGas;
+            tx.Value = Value;
+            tx.Data = Data;
+            tx.Timestamp = Timestamp;
+            tx.MaxFeePerBlobGas = MaxFeePerBlobGas;
+            tx._size = _size;
         }
 
         public void Reset()

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -331,6 +331,13 @@ namespace Nethermind.Core
             }
         }
 
+        public Transaction Clone()
+        {
+            Transaction copy = new();
+            CopyTo(copy);
+            return copy;
+        }
+
         public void CopyTo(Transaction tx)
         {
             tx.SourceHash = SourceHash;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -192,7 +192,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         public void SendNewTransaction(Transaction tx)
         {
-            if (ShouldNotifyTransaction(tx.Hash))
+            if (!tx.IsDisposed && ShouldNotifyTransaction(tx.Hash))
             {
                 SendNewTransactionCore(tx);
             }
@@ -202,6 +202,9 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             if (!tx.SupportsBlobs) //additional protection from sending full tx with blob
             {
+                tx.MarkBroadcasting();
+                if (tx.IsDisposed) return;
+
                 SendMessage(new ArrayPoolList<Transaction>(1) { tx });
             }
         }
@@ -229,6 +232,9 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
             foreach (Transaction tx in txs)
             {
+                tx.MarkBroadcasting();
+                if (tx.IsDisposed) continue;
+
                 int txSize = tx.GetLength();
 
                 if (txSize > packetSizeLeft && txsToSend.Count > 0)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             for (int i = 0; i < hashes.Length; i++)
             {
                 Hash256 hash = hashes[i];
-                if (!txPool.IsKnown(hash) && _pendingHashes.Set(hash))
+                if (!txPool.IsKnown(hash) && !txPool.ContainsTx(hash) && _pendingHashes.Set(hash))
                 {
                     discoveredTxHashes.Add(hash);
                 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -17,6 +17,7 @@ using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -265,6 +266,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                             // time in the queue as the queue is probably full. In this case, queuing again wont help
                             // as it later will just take as much time in the queue, then timing out again.
                             if (Logger.IsDebug) Logger.Debug("Background task queue full. Dropping transactions.");
+
+                            foreach (var tx in transactionsSpan.Slice(startIdx))
+                            {
+                                TxDecoder.TxObjectPool.Return(tx);
+                            }
+
                             return ValueTask.CompletedTask;
                         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
@@ -27,7 +27,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public override void Dispose()
         {
             base.Dispose();
-            Transactions?.Dispose();
+            if (Transactions is null) return;
+
+            foreach (Transaction tx in Transactions.AsSpan())
+            {
+                tx.UnmarkBroadcasting();
+            }
+
+            Transactions.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -136,6 +136,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
                 if (_txPool.TryGetPendingTransaction(hash, out Transaction tx))
                 {
+                    tx.MarkBroadcasting();
+                    if (tx.IsDisposed) continue;
+
                     int txSize = tx.GetLength();
 
                     if (txSize > packetSizeLeft && txsToSend.Count > 0)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -109,11 +109,16 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
         }
         else
         {
+            tx.MarkBroadcasting();
+            if (tx.IsDisposed) return;
+
             SendMessage(
                 new ArrayPoolList<byte>(1) { (byte)tx.Type },
                 new ArrayPoolList<int>(1) { tx.GetLength() },
                 new ArrayPoolList<Hash256>(1) { tx.Hash }
             );
+
+            tx.UnmarkBroadcasting();
         }
     }
 
@@ -131,6 +136,9 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 
         foreach (Transaction tx in txs)
         {
+            tx.MarkBroadcasting();
+            if (tx.IsDisposed) continue;
+
             if (hashes.Count == NewPooledTransactionHashesMessage68.MaxCount)
             {
                 SendMessage(types, sizes, hashes);
@@ -146,6 +154,8 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
                 hashes.Add(tx.Hash);
                 TxPool.Metrics.PendingTransactionsHashesSent++;
             }
+
+            tx.UnmarkBroadcasting();
         }
 
         if (hashes.Count != 0)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -17,6 +17,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Pooling;
 using Nethermind.Int256;
 
 namespace Nethermind.Serialization.Rlp
@@ -241,7 +242,23 @@ namespace Nethermind.Serialization.Rlp
                 }
             }
 
-            return span.ToArray();
+            byte[] array;
+            if (span.Length == ByteBufferPool.ProofSize)
+            {
+                array = ByteBufferPool.RentProof();
+                span.CopyTo(array);
+            }
+            else if (span.Length == ByteBufferPool.BlobSize)
+            {
+                array = ByteBufferPool.RentBlob();
+                span.CopyTo(array);
+            }
+            else
+            {
+                array = span.ToArray();
+            }
+
+            return array;
         }
 
         internal static ArrayPoolList<byte> ByteSpanToArrayPool(ReadOnlySpan<byte> span)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2394,6 +2394,10 @@ namespace Nethermind.TxPool.Test
 
             Transaction[] txsA = { GetTx(TestItem.PrivateKeyA), GetTx(TestItem.PrivateKeyB) };
             Transaction[] txsB = { GetTx(TestItem.PrivateKeyC) };
+            
+            Transaction[] txsAc = { txsA[0].Clone(), txsA[1].Clone() };
+            Transaction[] txsBc = { txsB[0].Clone() };
+
 
             _txPool.SubmitTx(txsA[0], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
             _txPool.SubmitTx(txsA[1], TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
@@ -2408,26 +2412,26 @@ namespace Nethermind.TxPool.Test
 
             _txPool.GetPendingTransactionsCount().Should().Be(txsB.Length);
             _txPool.GetPendingBlobTransactionsCount().Should().Be(0);
-            _txPool.TryGetPendingTransaction(txsA[0].Hash!, out _).Should().BeFalse();
-            _txPool.TryGetPendingTransaction(txsA[1].Hash!, out _).Should().BeFalse();
-            _txPool.TryGetPendingTransaction(txsB[0].Hash!, out _).Should().BeTrue();
+            _txPool.TryGetPendingTransaction(txsAc[0].Hash!, out _).Should().BeFalse();
+            _txPool.TryGetPendingTransaction(txsAc[1].Hash!, out _).Should().BeFalse();
+            _txPool.TryGetPendingTransaction(txsBc[0].Hash!, out _).Should().BeTrue();
 
             // reorganized from block A to block B
-            Block blockB = Build.A.Block.WithNumber(blockNumber).WithTransactions(txsB).TestObject;
+            Block blockB = Build.A.Block.WithNumber(blockNumber).WithTransactions(txsBc).TestObject;
             await RaiseBlockAddedToMainAndWaitForNewHead(blockB, blockA);
 
             // tx from block B should be removed from tx pool
-            _txPool.TryGetPendingTransaction(txsB[0].Hash!, out _).Should().BeFalse();
+            _txPool.TryGetPendingTransaction(txsBc[0].Hash!, out _).Should().BeFalse();
 
             // txs from reorganized blockA should be readded to tx pool
             _txPool.GetPendingTransactionsCount().Should().Be(txsA.Length);
-            _txPool.TryGetPendingTransaction(txsA[0].Hash!, out Transaction tx1).Should().BeTrue();
-            _txPool.TryGetPendingTransaction(txsA[1].Hash!, out Transaction tx2).Should().BeTrue();
+            _txPool.TryGetPendingTransaction(txsAc[0].Hash!, out Transaction tx1).Should().BeTrue();
+            _txPool.TryGetPendingTransaction(txsAc[1].Hash!, out Transaction tx2).Should().BeTrue();
 
-            tx1.Should().BeEquivalentTo(txsA[0], static options => options
+            tx1.Should().BeEquivalentTo(txsAc[0], static options => options
                 .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
 
-            tx2.Should().BeEquivalentTo(txsA[1], static options => options
+            tx2.Should().BeEquivalentTo(txsAc[1], static options => options
                 .Excluding(static t => t.PoolIndex));      // ...as well as PoolIndex
         }
 

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -37,6 +37,7 @@ namespace Nethermind.TxPool
         Transaction[] GetPendingTransactionsBySender(Address address);
         void AddPeer(ITxPoolPeer peer);
         void RemovePeer(PublicKey nodeId);
+        bool ContainsTx(Hash256 hash);
         bool ContainsTx(Hash256 hash, TxType txType);
         AcceptTxResult SubmitTx(Transaction tx, TxHandlingOptions handlingOptions);
         bool RemoveTransaction(Hash256? hash);

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -40,6 +40,8 @@ namespace Nethermind.TxPool
 
         public void RemovePeer(PublicKey nodeId) { }
 
+        public bool ContainsTx(Hash256 hash) => false;
+
         public bool ContainsTx(Hash256 hash, TxType txType) => false;
 
         public AcceptTxResult SubmitTx(Transaction tx, TxHandlingOptions txHandlingOptions) => AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -838,7 +838,7 @@ namespace Nethermind.TxPool
             return hasBeenRemoved;
         }
 
-        public bool ContainsTx(Hash256 hash) => 
+        public bool ContainsTx(Hash256 hash) =>
             _blobTransactions.ContainsKey(hash) ||
             _transactions.ContainsKey(hash) ||
             _broadcaster.ContainsTx(hash);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -838,6 +838,11 @@ namespace Nethermind.TxPool
             return hasBeenRemoved;
         }
 
+        public bool ContainsTx(Hash256 hash) => 
+            _blobTransactions.ContainsKey(hash) ||
+            _transactions.ContainsKey(hash) ||
+            _broadcaster.ContainsTx(hash);
+
         public bool ContainsTx(Hash256 hash, TxType txType) => txType == TxType.Blob
             ? _blobTransactions.ContainsKey(hash)
             : _transactions.ContainsKey(hash) || _broadcaster.ContainsTx(hash);


### PR DESCRIPTION
## Changes

- Pool blobs, proofs and commitments
- Extend tx pooling to return regular tx pool txs and reuse them
- Reduce allocations in PacketSender

Before
![image](https://github.com/user-attachments/assets/8ed56983-024c-4e45-afe4-bcf2b3caf499)

After
![image](https://github.com/user-attachments/assets/292b35e1-8e84-4b9e-a371-e4a83aba9779)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No