### PR TITLE
Add hash->blockNumber cache

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1139,6 +1139,7 @@ namespace Nethermind.Blockchain
                     && ((Head?.Number ?? 0L).CompareTo(header.Number) > 0 // pick longer chain
                         || (Head?.Hash ?? Keccak.Zero).CompareTo(header.Hash) > 0))); // or have a deterministic order on hash
 
+        public void CacheBlockNumber(Hash256 hash, long number) => _headerStore.Cache(hash, number);
 
         /// <summary>
         /// Moves block to main chain.

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -225,6 +225,7 @@ public class BlockTreeOverlay : IBlockTree
     public void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint) =>
         _overlayTree.UpdateBeaconMainChain(blockInfos, clearBeaconMainChainStartPoint);
 
+    public void CacheBlockNumber(Hash256 hash, long number) => _overlayTree.CacheBlockNumber(hash, number);
     public void RecalculateTreeLevels() => _overlayTree.RecalculateTreeLevels();
     public (long BlockNumber, Hash256 BlockHash) SyncPivot
     {

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -99,23 +99,23 @@ public class HeaderStore : IHeaderStore
 
     public long? GetBlockNumber(Hash256 blockHash)
     {
-        long? blockNumber = GetBlockNumberFromBlockNumberDb(blockHash);
+        long? blockNumber = GetBlockNumberThroughCache(blockHash);
         if (blockNumber is not null) return blockNumber.Value;
 
         // Probably still hash based
         return Get(blockHash)?.Number;
     }
 
-    private long? GetBlockNumberFromBlockNumberDb(Hash256 blockHash)
+    private long? GetBlockNumberThroughCache(Hash256 blockHash)
     {
         if (_numberCache.TryGet(blockHash, out long value))
         {
             return value;
         }
-        return GetBlockNumberFromBlockNumberDbSlow(blockHash);
+        return GetBlockNumberFromBlockNumberDb(blockHash);
     }
 
-    private long? GetBlockNumberFromBlockNumberDbSlow(Hash256 blockHash)
+    private long? GetBlockNumberFromBlockNumberDb(Hash256 blockHash)
     {
         Span<byte> numberSpan = _blockNumberDb.GetSpan(blockHash);
         if (numberSpan.IsNullOrEmpty()) return null;

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -126,7 +126,9 @@ public class HeaderStore : IHeaderStore
                 throw new InvalidDataException($"Unexpected number span length: {numberSpan.Length}");
             }
 
-            return BinaryPrimitives.ReadInt64BigEndian(numberSpan);
+            long number = BinaryPrimitives.ReadInt64BigEndian(numberSpan);
+            _numberCache.Set(blockHash, number);
+            return number;
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -14,6 +14,7 @@ public interface IHeaderStore
     void BulkInsert(IReadOnlyList<BlockHeader> headers);
     BlockHeader? Get(Hash256 blockHash, bool shouldCache, long? blockNumber = null);
     void Cache(BlockHeader header);
+    void Cache(Hash256 blockHash, long blockNumber);
     void Delete(Hash256 blockHash);
     void InsertBlockNumber(Hash256 blockHash, long blockNumber);
     long? GetBlockNumber(Hash256 blockHash);

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -186,6 +186,7 @@ namespace Nethermind.Blockchain
         void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint);
 
         void RecalculateTreeLevels();
+        void CacheBlockNumber(Hash256 hash, long number);
 
         /// <summary>
         /// Sync pivot is mainly concerned with old blocks and receipts.

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -189,6 +189,7 @@ namespace Nethermind.Blockchain
 
         }
 
+        public void CacheBlockNumber(Hash256 hash, long number) => _wrapped.CacheBlockNumber(hash, number);
         public bool IsBetterThanHead(BlockHeader? header) => _wrapped.IsBetterThanHead(header);
         public void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(UpdateBeaconMainChain)} calls");
         public void RecalculateTreeLevels() => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(RecalculateTreeLevels)} calls");

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -481,10 +481,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             Metrics.ProcessingQueueSize = blockQueueCount;
             _stats.UpdateStats(lastProcessed, processingBranch.Root, blockProcessingTimeInMicrosecs);
 
-            foreach (Block block in processedBlocks)
-            {
-                _blockTree.CacheBlockNumber(block.Hash, block.Header.Number);
-            }
+            _blockTree.CacheBlockNumber(lastProcessed.Hash, lastProcessed.Header.Number);
         }
 
         bool updateHead = !options.ContainsFlag(ProcessingOptions.DoNotUpdateHead);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -480,6 +480,11 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             Metrics.RecoveryQueueSize = Math.Max(_queueCount - blockQueueCount - (IsProcessingBlock ? 1 : 0), 0);
             Metrics.ProcessingQueueSize = blockQueueCount;
             _stats.UpdateStats(lastProcessed, processingBranch.Root, blockProcessingTimeInMicrosecs);
+
+            foreach (Block block in processedBlocks)
+            {
+                _blockTree.CacheBlockNumber(block.Hash, block.Header.Number);
+            }
         }
 
         bool updateHead = !options.ContainsFlag(ProcessingOptions.DoNotUpdateHead);

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
@@ -55,6 +55,11 @@ public class SimulateDictionaryHeaderStore(IHeaderStore readonlyBaseHeaderStore)
         return header;
     }
 
+    public void Cache(Hash256 blockHash, long blockNumber)
+    {
+        _blockNumberDict[blockHash] = blockNumber;
+    }
+
     public void Cache(BlockHeader header)
     {
         Insert(header);


### PR DESCRIPTION
## Changes

- Is looked up fairly frequently (most for block just processed, or prior) and currently always goes to db

Before
<img width="588" alt="image" src="https://github.com/user-attachments/assets/57415d1f-3a6f-46d4-acde-04f7f8d742de" />

After
<img width="436" alt="image" src="https://github.com/user-attachments/assets/fd1aa7d1-02e3-4a0b-aaa3-86d175ce92fc" />

(Memory lookup is inlined)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
