### PR TITLE
Add more contracts to whitelist for testing

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Config/VMConfig.cs
+++ b/src/Nethermind/Nethermind.Evm/Config/VMConfig.cs
@@ -15,7 +15,6 @@ namespace Nethermind.Evm.Config;
 public class VMConfig : IVMConfig
 {
 
-    const string WETH = "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23";
 
     public bool IsILEvmEnabled { get; set; } = true;
     public ILMode IlEvmEnabledMode { get; set; } = ILMode.AOT_MODE;
@@ -28,6 +27,15 @@ public class VMConfig : IVMConfig
     public float IlEvmAnalysisCoreUsage { get; set; } = 0.0f;
     public int? IlEvmBytecodeMaxLength { get; set; } = null;
     public int IlEvmBytecodeMinLength { get; set; } = 16;
-    public string[] IlEvmAllowedContracts { get; set; } = [WETH];
+    public string[] IlEvmAllowedContracts { get; set; } =
+    {
+        WhitelistedContracts.Weth,
+        WhitelistedContracts.UsdcProxy,
+        WhitelistedContracts.AllowanceHolder,
+        WhitelistedContracts.Erc20Router,
+        WhitelistedContracts.Permit2,
+        WhitelistedContracts.Uniswap,
+        WhitelistedContracts.Gasspas
+    };
 
 }

--- a/src/Nethermind/Nethermind.Evm/Data/WhitelistedContracts.cs
+++ b/src/Nethermind/Nethermind.Evm/Data/WhitelistedContracts.cs
@@ -1,0 +1,12 @@
+namespace Nethermind.Evm;
+
+public static class WhitelistedContracts
+{
+    public const string Weth = "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23";
+    public const string UsdcProxy = "0xd80d4b7c890cb9d6a4893e6b52bc34b56b25335cb13716e0d1d31383e6b41505";
+    public const string AllowanceHolder = "0x99f5e8edaceacfdd183eb5f1da8a7757b322495b80cf7928db289a1b1a09f799";
+    public const string Erc20Router = "0x3270015b4cefce79b97dd1e9c491e68509739fc3dee07a5d1dcbed1d94a0fe24";
+    public const string Permit2 = "0xc67d1657868aa5146eaf24fb879fb1fdec3d2d493b3683a61c9c2f4fb2851131";
+    public const string Uniswap = "0xdeba17f16fdba566b45d8019575e068625403cc6986fa17ceadd6edf08aa0868";
+    public const string Gasspas = "0x62dd439514a5552a8ef8fb9142ebc272898a0eaadfc17382ed6af6ba2eb1c4cd";
+}


### PR DESCRIPTION

# Changes
     - Added Weth, UsdcProxy, AllowanceHolder, Erc20Router, Permit2, Uniswap, Gasspas to the whitelisted contracts for ilevm
     - Created a seperate file to hold the data for contract code hashes
        
