### PR TITLE
Improve Block caching and reduce lookup allocations

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -53,7 +53,7 @@ public class HeaderStoreTests
         HeaderStore store = new(new MemDb(), new MemDb());
 
         BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
-        store.Cache(header);
+        store.Cache(header, hasDifficulty: true);
         store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1078,7 +1078,7 @@ namespace Nethermind.Blockchain
                     for (int i = 0; i < level.BlockInfos.Length; ++i)
                     {
                         level.BlockInfos[i].Metadata &= ~BlockMetadata.BeaconMainChain;
-                        _headerStore.ClearCanonicalCache(level.BlockInfos[i].BlockHash);
+                        _headerStore.DeleteCanonicalCache(level.BlockInfos[i].BlockHash);
                     }
 
                     _chainLevelInfoRepository.PersistLevel(j, level, batch);
@@ -1101,7 +1101,7 @@ namespace Nethermind.Blockchain
                         else
                         {
                             level.BlockInfos[i].Metadata &= ~BlockMetadata.BeaconMainChain;
-                            _headerStore.ClearCanonicalCache(blockHash);
+                            _headerStore.DeleteCanonicalCache(blockHash);
                         }
                     }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1438,7 +1438,8 @@ namespace Nethermind.Blockchain
                 block = _blockStore.Get(
                     blockNumber.Value,
                     blockHash,
-                    (options & BlockTreeLookupOptions.ExcludeTxHashes) != 0 ? RlpBehaviors.ExcludeHashes : RlpBehaviors.None,
+                    ((options & BlockTreeLookupOptions.ExcludeTxHashes) != 0 ? RlpBehaviors.ExcludeHashes : RlpBehaviors.None) |
+                    ((options & BlockTreeLookupOptions.OnlyTxHashes) != 0 ? RlpBehaviors.OnlyHashes : RlpBehaviors.None),
                     shouldCache: false);
             }
 
@@ -1493,7 +1494,7 @@ namespace Nethermind.Blockchain
                 }
             }
 
-            if (block is not null && ShouldCache(block.Number))
+            if (block is not null && (options & BlockTreeLookupOptions.OnlyTxHashes) == 0 && ShouldCache(block.Number))
             {
                 _blockStore.Cache(block);
                 _headerStore.Cache(block.Header, hasDifficulty: totalDifficultyNeeded, requiresCanonical);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
@@ -14,7 +14,8 @@ public enum BlockTreeLookupOptions
     DoNotCreateLevelIfMissing = 4,
     AllowInvalid = 8,
     ExcludeTxHashes = 16,
-    All = 31
+    All = 31,
+    OnlyTxHashes = 32
 }
 
 [Flags]

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -18,8 +18,7 @@ public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb) : IBlockStore
     private readonly BlockDecoder _blockDecoder = new();
     public const int CacheSize = 128 + 32;
 
-    private readonly ClockCache<ValueHash256, Block>
-        _blockCache = new(CacheSize);
+    private readonly ClockCache<ValueHash256, Block> _blockCache = new(CacheSize);
 
     public void SetMetadata(byte[] key, byte[] value)
     {

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
@@ -33,7 +34,7 @@ public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb) : IBlockStore
     public bool HasBlock(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
-        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
+        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, in blockHash.ValueHash256, dbKey);
         return blockDb.KeyExists(dbKey);
     }
 
@@ -66,20 +67,22 @@ public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb) : IBlockStore
 
     public Block? Get(long blockNumber, Hash256 blockHash, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = false)
     {
-        Block? b = blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        Block? b = blockDb.Get(blockNumber, in blockHash.ValueHash256, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
         if (b is not null) return b;
-        return blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
+        return blockDb.Get(in blockHash.ValueHash256, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
     }
 
+    [SkipLocalsInit]
     public byte[]? GetRlp(long blockNumber, Hash256 blockHash)
     {
         Span<byte> dbKey = stackalloc byte[40];
-        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, blockHash, dbKey);
+        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, in blockHash.ValueHash256, dbKey);
         var b = blockDb.Get(dbKey);
         if (b is not null) return b;
         return blockDb.Get(blockHash);
     }
 
+    [SkipLocalsInit]
     public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash)
     {
         Span<byte> keyWithBlockNumber = stackalloc byte[40];

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -16,7 +16,7 @@ public interface IHeaderStore
     BlockHeader? Get(Hash256 blockHash, long? blockNumber = null);
     bool Cache(BlockHeader header, bool hasDifficulty, bool isCanonical = false);
     bool TryGetCache(Hash256 blockHash, bool needsDifficulty, bool requiresCanonical, [NotNullWhen(true)] out BlockHeader? header);
-    void ClearCanonicalCache(Hash256 blockHash);
+    void DeleteCanonicalCache(Hash256 blockHash);
     void Delete(Hash256 blockHash);
     void InsertBlockNumber(Hash256 blockHash, long blockNumber);
     long? GetBlockNumber(Hash256 blockHash);

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -12,8 +13,10 @@ public interface IHeaderStore
 {
     void Insert(BlockHeader header);
     void BulkInsert(IReadOnlyList<BlockHeader> headers);
-    BlockHeader? Get(Hash256 blockHash, bool shouldCache, long? blockNumber = null);
-    void Cache(BlockHeader header);
+    BlockHeader? Get(Hash256 blockHash, long? blockNumber = null);
+    bool Cache(BlockHeader header, bool hasDifficulty, bool isCanonical = false);
+    bool TryGetCache(Hash256 blockHash, bool needsDifficulty, bool requiresCanonical, [NotNullWhen(true)] out BlockHeader? header);
+    void ClearCanonicalCache(Hash256 blockHash);
     void Delete(Hash256 blockHash);
     void InsertBlockNumber(Hash256 blockHash, long blockNumber);
     long? GetBlockNumber(Hash256 blockHash);

--- a/src/Nethermind/Nethermind.Config/GCConfig.cs
+++ b/src/Nethermind/Nethermind.Config/GCConfig.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Config;
+
+public static class GCConfig
+{
+    public const int GCBlockProcessingDelayMs = 250;
+}

--- a/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
@@ -14,7 +14,8 @@ using CollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
 
 namespace Nethermind.Core.Caching;
 
-public sealed class ClockCache<TKey, TValue>(int maxCapacity, int? lockPartition = null) : ClockCacheBase<TKey>(maxCapacity)
+public sealed class ClockCache<TKey, TValue>(int maxCapacity, int? lockPartition = null) :
+    ClockCacheBase<TKey>(maxCapacity), IClockCache<TKey, TValue>
     where TKey : struct, IEquatable<TKey>
 {
     private readonly ConcurrentDictionary<TKey, LruCacheItem> _cacheMap = new(lockPartition ?? CollectionExtensions.LockPartitions, maxCapacity);

--- a/src/Nethermind/Nethermind.Core/Caching/IClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/IClockCache.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Core.Caching;
+public interface IClockCache<TKey, TValue> where TKey : struct, IEquatable<TKey>
+{
+    TValue Get(TKey key);
+    bool Set(TKey key, TValue val);
+    bool TryGet(TKey key, out TValue value);
+}

--- a/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
@@ -115,14 +115,15 @@ namespace Nethermind.Core
             db.PutSpan(key.Bytes, value.AsSpan(), writeFlags);
         }
 
+        [SkipLocalsInit]
         public static void Set(this IWriteOnlyKeyValueStore db, long blockNumber, Hash256 key, ReadOnlySpan<byte> value, WriteFlags writeFlags = WriteFlags.None)
         {
             Span<byte> blockNumberPrefixedKey = stackalloc byte[40];
-            GetBlockNumPrefixedKey(blockNumber, key, blockNumberPrefixedKey);
+            GetBlockNumPrefixedKey(blockNumber, in key.ValueHash256, blockNumberPrefixedKey);
             db.PutSpan(blockNumberPrefixedKey, value, writeFlags);
         }
 
-        public static void GetBlockNumPrefixedKey(long blockNumber, ValueHash256 blockHash, Span<byte> output)
+        public static void GetBlockNumPrefixedKey(long blockNumber, in ValueHash256 blockHash, Span<byte> output)
         {
             blockNumber.WriteBigEndian(output);
             blockHash!.Bytes.CopyTo(output[8..]);
@@ -147,7 +148,7 @@ namespace Nethermind.Core
         public static void Delete(this IWriteOnlyKeyValueStore db, long blockNumber, Hash256 hash)
         {
             Span<byte> key = stackalloc byte[40];
-            GetBlockNumPrefixedKey(blockNumber, hash, key);
+            GetBlockNumPrefixedKey(blockNumber, in hash.ValueHash256, key);
             db.Remove(key);
         }
 

--- a/src/Nethermind/Nethermind.Core/Utils/ObjectCreator.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/ObjectCreator.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Nethermind.Core;
+
+public static class ObjectCreator<T> where T : new()
+{
+    // Cache in readonly static
+    public static Func<T> Create { get; } = BuildCreator();
+
+    private static Func<T> BuildCreator()
+    {
+        // find the public parameterless ctor (throws if none)
+        ConstructorInfo? ci = typeof(T).GetConstructor(BindingFlags.Public | BindingFlags.Instance, []) ??
+            throw new InvalidOperationException($"{typeof(T).Name} has no parameterless ctor.");
+
+        NewExpression newExpr = Expression.New(ci);
+        Expression<Func<T>> lambda = Expression.Lambda<Func<T>>(
+            newExpr,
+            name: $"Create{typeof(T).Name}",
+            tailCall: false,
+            parameters: Array.Empty<ParameterExpression>()
+        );
+        return lambda.Compile();
+    }
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
@@ -76,5 +76,5 @@ public class SimulateDictionaryHeaderStore(IHeaderStore readonlyBaseHeaderStore)
         return !requiresCanonical && _headerDict.TryGetValue(blockHash, out header);
     }
 
-    public void ClearCanonicalCache(Hash256 blockHash) { }
+    public void DeleteCanonicalCache(Hash256 blockHash) { }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
@@ -58,14 +58,14 @@ namespace Nethermind.JsonRpc.Modules
                 : new SearchResult<BlockHeader>(header);
         }
 
-        public static SearchResult<Block> SearchForBlock(this IBlockFinder blockFinder, BlockParameter? blockParameter, bool allowNulls = false)
+        public static SearchResult<Block> SearchForBlock(this IBlockFinder blockFinder, BlockParameter? blockParameter, bool allowNulls = false, bool onlyTxHashes = false)
         {
             blockParameter ??= BlockParameter.Latest;
 
             Block block;
             if (blockParameter.RequireCanonical)
             {
-                block = blockFinder.FindBlock(blockParameter.BlockHash!, BlockTreeLookupOptions.RequireCanonical);
+                block = blockFinder.FindBlock(blockParameter.BlockHash!, BlockTreeLookupOptions.RequireCanonical | (onlyTxHashes ? BlockTreeLookupOptions.OnlyTxHashes : BlockTreeLookupOptions.None));
                 if (block is null && !allowNulls)
                 {
                     BlockHeader? header = blockFinder.FindHeader(blockParameter.BlockHash);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -363,7 +363,7 @@ public partial class EthRpcModule(
 
     protected virtual ResultWrapper<BlockForRpc?> GetBlock(BlockParameter blockParameter, bool returnFullTransactionObjects)
     {
-        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter, true);
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter, allowNulls: true, onlyTxHashes: !returnFullTransactionObjects);
         if (searchResult.IsError)
         {
             return ResultWrapper<BlockForRpc?>.Success(null);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -219,7 +219,7 @@ public partial class EthRpcModule(
 
     public ResultWrapper<UInt256?> eth_getBlockTransactionCountByHash(Hash256 blockHash)
     {
-        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash), onlyTxHashes: true);
         return searchResult.IsError
             ? ResultWrapper<UInt256?>.Success(null)
             : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Transactions.Length);
@@ -227,7 +227,7 @@ public partial class EthRpcModule(
 
     public ResultWrapper<UInt256?> eth_getBlockTransactionCountByNumber(BlockParameter blockParameter)
     {
-        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter, onlyTxHashes: true);
         return searchResult.IsError
             ? ResultWrapper<UInt256?>.Success(null)
             : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Transactions.Length);
@@ -235,7 +235,7 @@ public partial class EthRpcModule(
 
     public ResultWrapper<UInt256?> eth_getUncleCountByBlockHash(Hash256 blockHash)
     {
-        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash), onlyTxHashes: true);
         return searchResult.IsError
             ? ResultWrapper<UInt256?>.Success(null)
             : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Uncles.Length);
@@ -243,7 +243,7 @@ public partial class EthRpcModule(
 
     public ResultWrapper<UInt256?> eth_getUncleCountByBlockNumber(BlockParameter? blockParameter)
     {
-        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter, onlyTxHashes: true);
         return searchResult.IsError
             ? ResultWrapper<UInt256?>.Success(null)
             : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Uncles.Length);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -362,7 +362,7 @@ public class BeaconHeadersSyncTests
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeTrue();
         blockTree.BestKnownNumber.Should().Be(bestPointer);
         BlockHeader? startBestHeader = syncedBlockTree.FindHeader(bestPointer, BlockTreeLookupOptions.None);
-        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader);
+        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader, options => options.Excluding(h => h!.AuRaStep));
         blockTree.LowestInsertedBeaconHeader.Should().BeEquivalentTo(syncedBlockTree.FindHeader(pivot.PivotNumber, BlockTreeLookupOptions.None));
 
         BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, endLowestBeaconHeader);
@@ -373,7 +373,12 @@ public class BeaconHeadersSyncTests
         blockTree.FindHeader(pivot.PivotNumber - 1, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().NotBeNull();
         blockTree.LowestInsertedBeaconHeader?.Hash.Should().BeEquivalentTo(syncedBlockTree.FindHeader(endLowestBeaconHeader, BlockTreeLookupOptions.None)?.Hash);
         blockTree.BestKnownNumber.Should().Be(bestPointer);
-        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader, options => options.Excluding(h => h!.TotalDifficulty));
+        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader, options =>
+        {
+            return options
+                .Excluding(h => h!.TotalDifficulty)
+                .Excluding(h => h!.AuRaStep);
+        });
         ctx.Feed.CurrentState.Should().Be(SyncFeedState.Dormant);
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -373,7 +373,7 @@ public class BeaconHeadersSyncTests
         blockTree.FindHeader(pivot.PivotNumber - 1, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().NotBeNull();
         blockTree.LowestInsertedBeaconHeader?.Hash.Should().BeEquivalentTo(syncedBlockTree.FindHeader(endLowestBeaconHeader, BlockTreeLookupOptions.None)?.Hash);
         blockTree.BestKnownNumber.Should().Be(bestPointer);
-        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader);
+        blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader, options => options.Excluding(h => h!.TotalDifficulty));
         ctx.Feed.CurrentState.Should().Be(SyncFeedState.Dormant);
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -6,6 +6,7 @@ using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
 using FastEnumUtility;
+using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
@@ -151,7 +152,7 @@ public class GCKeeper
             // This should give time to finalize response in Engine API
             // Normally we should get block every 12s (5s on some chains)
             // Lets say we process block in 2s, then delay 125ms, then invoke GC
-            await Task.Delay(125);
+            await Task.Delay(GCConfig.GCBlockProcessingDelayMs);
 
             if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -255,7 +255,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         bool shouldUpdateHead = !newHeadTheSameAsCurrentHead && blocks is not null;
         if (shouldUpdateHead)
         {
-            _blockTree.UpdateMainChain(blocks!, true, true);
+            _blockTree.UpdateMainChain(blocks!, wereProcessed: true, forceHeadBlock: true);
         }
 
         if (IsInconsistent(finalizedBlockHash))

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -61,16 +61,14 @@ public class BlockBodyDecoder : IRlpValueDecoder<BlockBody>, IRlpStreamDecoder<B
 
     public BlockBody? DecodeUnwrapped(ref Rlp.ValueDecoderContext ctx, int lastPosition, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-
         // quite significant allocations (>0.5%) here based on a sample 3M blocks sync
         // (just on these delegates)
         Transaction[] transactions = ctx.DecodeArray(_txDecoder, rlpBehaviors: rlpBehaviors);
-        bool onlyTxHashes = rlpBehaviors.HasFlag(RlpBehaviors.OnlyHashes);
 
-        BlockHeader[] uncles = !onlyTxHashes ? ctx.DecodeArray(_headerDecoder) : null;
+        BlockHeader[] uncles = ctx.DecodeArray(_headerDecoder);
         Withdrawal[]? withdrawals = null;
 
-        if (!onlyTxHashes && ctx.PeekNumberOfItemsRemaining(lastPosition, 1) > 0)
+        if (ctx.PeekNumberOfItemsRemaining(lastPosition, 1) > 0)
         {
             withdrawals = ctx.DecodeArray(_withdrawalDecoderDecoder);
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Serialization.Rlp
             int blockCheck = decoderContext.Position + sequenceLength;
 
             BlockHeader header = Rlp.Decode<BlockHeader>(ref decoderContext);
-            BlockBody body = _blockBodyDecoder.DecodeUnwrapped(ref decoderContext, blockCheck);
+            BlockBody body = _blockBodyDecoder.DecodeUnwrapped(ref decoderContext, blockCheck, rlpBehaviors);
 
             Block block = new(header, body)
             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -15,7 +15,7 @@ public static class KeyValueStoreRlpExtensions
 {
     [SkipLocalsInit]
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, ValueHash256 hash, IRlpStreamDecoder<TItem> decoder,
-        ClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+        IClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
@@ -24,23 +24,23 @@ public static class KeyValueStoreRlpExtensions
 
     [SkipLocalsInit]
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, Hash256 hash, IRlpStreamDecoder<TItem> decoder,
-        ClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+        IClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, ClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, IClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
     }
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, Hash256 key, IRlpStreamDecoder<TItem> decoder, ClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, Hash256 key, IRlpStreamDecoder<TItem> decoder, IClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long key, IRlpStreamDecoder<TItem>? decoder, ClockCache<long, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long key, IRlpStreamDecoder<TItem>? decoder, IClockCache<long, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         ReadOnlySpan<byte> keyDb = key.ToBigEndianSpanWithoutLeadingZeros(out _);
         return Get(db, key, keyDb, decoder, cache, rlpBehaviors, shouldCache);
@@ -51,7 +51,7 @@ public static class KeyValueStoreRlpExtensions
         TCacheKey cacheKey,
         ReadOnlySpan<byte> key,
         IRlpStreamDecoder<TItem> decoder,
-        ClockCache<TCacheKey, TItem> cache = null,
+        IClockCache<TCacheKey, TItem> cache = null,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None,
         bool shouldCache = true
     ) where TItem : class

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -22,7 +22,20 @@ public static class KeyValueStoreRlpExtensions
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
+    [SkipLocalsInit]
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, Hash256 hash, IRlpStreamDecoder<TItem> decoder,
+        ClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    {
+        Span<byte> dbKey = stackalloc byte[40];
+        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
+        return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
+    }
+
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, ClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    {
+        return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
+    }
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, Hash256 key, IRlpStreamDecoder<TItem> decoder, ClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -14,11 +14,11 @@ namespace Nethermind.Serialization.Rlp;
 public static class KeyValueStoreRlpExtensions
 {
     [SkipLocalsInit]
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, ValueHash256 hash, IRlpStreamDecoder<TItem> decoder,
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, in ValueHash256 hash, IRlpStreamDecoder<TItem> decoder,
         IClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
-        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
+        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, in hash, dbKey);
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
@@ -27,11 +27,11 @@ public static class KeyValueStoreRlpExtensions
         IClockCache<Hash256AsKey, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
-        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
+        KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, in hash.ValueHash256, dbKey);
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, IClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, in ValueHash256 key, IRlpStreamDecoder<TItem> decoder, IClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1582,7 +1582,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             public T[] DecodeArray<T>(IRlpValueDecoder<T>? decoder = null, bool checkPositions = true,
-                T defaultElement = default)
+                T defaultElement = default, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
             {
                 if (decoder is null)
                 {
@@ -1604,7 +1604,7 @@ namespace Nethermind.Serialization.Rlp
                     }
                     else
                     {
-                        result[i] = decoder.Decode(ref this);
+                        result[i] = decoder.Decode(ref this, rlpBehaviors);
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpBehaviors.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpBehaviors.cs
@@ -30,5 +30,6 @@ public enum RlpBehaviors
     /// See https://eips.ethereum.org/EIPS/eip-4844#networking
     /// </summary>
     InMempoolForm = 64,
-    ExcludeHashes = 128
+    ExcludeHashes = 128,
+    OnlyHashes = 256
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -35,7 +35,7 @@ public class TxDecoder<T> : IRlpStreamDecoder<T>, IRlpValueDecoder<T> where T : 
 
     protected TxDecoder(Func<T>? transactionFactory = null)
     {
-        Func<T> factory = transactionFactory ?? (static () => new T());
+        Func<T> factory = transactionFactory ?? ObjectCreator<T>.Create;
         RegisterDecoder(new LegacyTxDecoder<T>(factory));
         RegisterDecoder(new AccessListTxDecoder<T>(factory));
         RegisterDecoder(new EIP1559TxDecoder<T>(factory));
@@ -130,7 +130,7 @@ public class TxDecoder<T> : IRlpStreamDecoder<T>, IRlpValueDecoder<T> where T : 
 
         if (rlpBehaviors.HasFlag(RlpBehaviors.OnlyHashes) && !rlpBehaviors.HasFlag(RlpBehaviors.InMempoolForm))
         {
-            BaseTxDecoder<Transaction>.CalculateHash(transaction ??= new T(), transactionSequence, forceHashes: true);
+            BaseTxDecoder<Transaction>.CalculateHash(transaction ??= ObjectCreator<T>.Create(), transactionSequence, forceHashes: true);
             decoderContext.Position = txSequenceStart + transactionSequence.Length;
         }
         else

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -128,7 +128,15 @@ public class TxDecoder<T> : IRlpStreamDecoder<T>, IRlpValueDecoder<T> where T : 
             }
         }
 
-        GetDecoder(txType).Decode(ref Unsafe.As<T, Transaction>(ref transaction), txSequenceStart, transactionSequence, ref decoderContext, rlpBehaviors);
+        if (rlpBehaviors.HasFlag(RlpBehaviors.OnlyHashes) && !rlpBehaviors.HasFlag(RlpBehaviors.InMempoolForm))
+        {
+            BaseTxDecoder<Transaction>.CalculateHash(transaction ??= new T(), transactionSequence, forceHashes: true);
+            decoderContext.Position = txSequenceStart + transactionSequence.Length;
+        }
+        else
+        {
+            GetDecoder(txType).Decode(ref Unsafe.As<T, Transaction>(ref transaction), txSequenceStart, transactionSequence, ref decoderContext, rlpBehaviors);
+        }
     }
 
     public Rlp Encode(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -38,15 +38,15 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
 
         if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
         {
-            CalculateHash(transaction, transactionSequence);
+            CalculateHash(transaction, transactionSequence, forceHashes: rlpBehaviors.HasFlag(RlpBehaviors.OnlyHashes));
         }
 
         return transaction;
     }
 
-    protected void CalculateHash(Transaction transaction, ReadOnlySpan<byte> transactionSequence)
+    public static void CalculateHash(Transaction transaction, ReadOnlySpan<byte> transactionSequence, bool forceHashes)
     {
-        if (transactionSequence.Length <= MaxDelayedHashTxnSize)
+        if (!forceHashes && transactionSequence.Length <= MaxDelayedHashTxnSize)
         {
             // Delay hash generation, as may be filtered as having too low gas etc
             transaction.SetPreHashNoLock(transactionSequence);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -12,7 +12,7 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
     : ITxDecoder where T : Transaction, new()
 {
     private const int MaxDelayedHashTxnSize = 32768;
-    private readonly Func<T> _createTransaction = transactionFactory ?? (static () => new T());
+    private readonly Func<T> _createTransaction = transactionFactory ?? ObjectCreator<T>.Create;
 
     public TxType Type => txType;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactory = null)
     : ITxDecoder where T : Transaction, new()
 {
-    private const int MaxDelayedHashTxnSize = 32768;
+    private const int MaxDelayedHashTxnSize = 1024;
     private readonly Func<T> _createTransaction = transactionFactory ?? ObjectCreator<T>.Create;
 
     public TxType Type => txType;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -41,7 +41,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
             }
             else if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
             {
-                CalculateHash(transaction!, transactionSequence);
+                CalculateHash(transaction!, transactionSequence, forceHashes: rlpBehaviors.HasFlag(RlpBehaviors.OnlyHashes));
             }
         }
 


### PR DESCRIPTION
## Changes

- Introduce block hash -> block number cache
- Layer header cache, depending if difficulty is available or canonical
- Add ability to only decode tx haches as used by `RemoveOldReceipts` rather than allocating everything; also use for `eth_eth_getBlockBy...` when only hashes
- Delay RemoveOldReceipts by half of the GC delay
- Introduce fast generic constructor, rather than the slower `new T()` vis CreateInstanceT
- Return header directly if found in cache
- Reduce delayed hash from 32kB to 1kB as it burns through the array pool when decoding blocks

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
