### PR TITLE
Refactor/rename to add instance

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -127,11 +127,11 @@ public abstract class BlockchainTestBase
         // configProvider.GetConfig<IBlocksConfig>().PreWarmStateOnBlockProcessing = false;
         await using IContainer container = new ContainerBuilder()
             .AddModule(new TestNethermindModule(configProvider))
-            .AddSingleton(specProvider)
-            .AddSingleton(_logManager)
-            .AddSingleton(rewardCalculator)
-            .AddSingleton<IDifficultyCalculator>(DifficultyCalculator)
-            .AddSingleton<ITxPool>(NullTxPool.Instance)
+            .AddInstance(specProvider)
+            .AddInstance(_logManager)
+            .AddInstance(rewardCalculator)
+            .AddInstance<IDifficultyCalculator>(DifficultyCalculator)
+            .AddInstance<ITxPool>(NullTxPool.Instance)
             .Build();
 
         MainBlockProcessingContext mainBlockProcessingContext = container.Resolve<MainBlockProcessingContext>();

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -79,9 +79,9 @@ namespace Ethereum.Test.Base
             IConfigProvider configProvider = new ConfigProvider();
             using IContainer container = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
-                .AddSingleton<IBlockhashProvider>(new TestBlockhashProvider())
-                .AddSingleton(specProvider)
-                .AddSingleton(_logManager)
+                .AddInstance<IBlockhashProvider>(new TestBlockhashProvider())
+                .AddInstance(specProvider)
+                .AddInstance(_logManager)
                 .Build();
 
             MainBlockProcessingContext mainBlockProcessingContext = container.Resolve<MainBlockProcessingContext>();

--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -132,8 +132,8 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
     public async Task<IList<INethermindPlugin>> LoadPlugins(IConfigProvider configProvider, ChainSpec chainSpec)
     {
         ContainerBuilder builder = new ContainerBuilder()
-            .AddSingleton(configProvider)
-            .AddSingleton(chainSpec)
+            .AddInstance(configProvider)
+            .AddInstance(chainSpec)
             .AddSource(new ConfigRegistrationSource());
 
         foreach (var pluginType in PluginTypes)

--- a/src/Nethermind/Nethermind.Api/Steps/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Api/Steps/ContainerBuilderExtensions.cs
@@ -11,7 +11,7 @@ public static class ContainerBuilderExtensions
 {
     public static ContainerBuilder AddStep(this ContainerBuilder builder, StepInfo stepInfo)
     {
-        builder.AddSingleton<StepInfo>(stepInfo);
+        builder.AddInstance<StepInfo>(stepInfo);
         builder.RegisterType(stepInfo.StepType).WithAttributeFiltering().SingleInstance();
         return builder;
     }

--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/TestContractBlockchain.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/TestContractBlockchain.cs
@@ -37,7 +37,7 @@ namespace Nethermind.AuRa.Test.Contract
             (ChainSpec ChainSpec, ISpecProvider SpecProvider) provider = GetSpecProvider();
             TTest test = new() { ChainSpecOverride = provider.ChainSpec };
             return (TTest)await test.Build(builder =>
-                builder.AddSingleton<ISpecProvider>(provider.SpecProvider));
+                builder.AddInstance<ISpecProvider>(provider.SpecProvider));
         }
 
         protected override ChainSpec CreateChainSpec()

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -83,7 +83,7 @@ public class FullPruningDiskTest
             standardDbInitializer.InitStandardDbs(true);
 
             return base.ConfigureContainer(builder, configProvider)
-                .AddSingleton<IDbProvider>(dbProvider);
+                .AddInstance<IDbProvider>(dbProvider);
         }
 
         public override void Dispose()

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaPlugin.cs
@@ -92,7 +92,7 @@ namespace Nethermind.Consensus.AuRa
 
             builder
                 .AddSingleton<NethermindApi, AuRaNethermindApi>()
-                .AddSingleton<AuRaChainSpecEngineParameters>(specParam)
+                .AddInstance<AuRaChainSpecEngineParameters>(specParam)
                 .AddDecorator<IBetterPeerStrategy, AuRaBetterPeerStrategy>()
                 .Add<StartBlockProducerAuRa>() // Note: Stateful. Probably just some strange unintentional side effect though.
                 .AddSingleton<AuraStatefulComponents>()

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -20,7 +20,7 @@ public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, I
         ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
         {
             builder
-                .AddSingleton<IVisitingWorldState>(worldState).AddSingleton<IWorldState>(worldState)
+                .AddInstance<IVisitingWorldState>(worldState).AddInstance<IWorldState>(worldState)
                 .AddSingleton<AutoReadOnlyTxProcessingEnv>();
         });
 
@@ -33,7 +33,7 @@ public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, I
         ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
         {
             builder
-                .AddSingleton<IVisitingWorldState>(worldState).AddSingleton<IWorldState>(worldState)
+                .AddInstance<IVisitingWorldState>(worldState).AddInstance<IWorldState>(worldState)
                 .AddSingleton<AutoReadOnlyTxProcessingEnv>();
         });
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerEnvFactory.cs
@@ -20,9 +20,9 @@ namespace Nethermind.Consensus.Producers
     ) : IBlockProducerEnvFactory
     {
         protected virtual ContainerBuilder ConfigureBuilder(ContainerBuilder builder) => builder
-            .AddScoped<ITxSource>(txSourceFactory.Create())
-            .AddScoped<IReceiptStorage>(NullReceiptStorage.Instance)
-            .AddScoped(BlockchainProcessor.Options.NoReceipts)
+            .AddInstance<ITxSource>(txSourceFactory.Create())
+            .AddInstance<IReceiptStorage>(NullReceiptStorage.Instance)
+            .AddInstance(BlockchainProcessor.Options.NoReceipts)
             .AddScoped<ITransactionProcessorAdapter, BuildUpTransactionProcessorAdapter>()
             .AddScoped<IBlockProcessor.IBlockTransactionsExecutor, BlockProcessor.BlockProductionTransactionsExecutor>()
             .AddDecorator<IWithdrawalProcessor, BlockProductionWithdrawalProcessor>()
@@ -35,7 +35,7 @@ namespace Nethermind.Consensus.Producers
             IWorldState worldState = worldStateManager.CreateResettableWorldState();
             ILifetimeScope lifetimeScope = rootLifetime.BeginLifetimeScope(builder =>
                 ConfigureBuilder(builder)
-                    .AddScoped(worldState));
+                    .AddInstance(worldState));
 
             rootLifetime.Disposer.AddInstanceForAsyncDisposal(lifetimeScope);
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -271,16 +271,16 @@ public class TestBlockchain : IDisposable
         builder
             .AddModule(new PseudoNethermindModule(ChainSpec, configProvider, LimboLogs.Instance))
             .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, Random.Shared.Next().ToString()))
-            .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
+            .AddInstance<ISpecProvider>(MainnetSpecProvider.Instance)
             .AddDecorator<ISpecProvider>((ctx, specProvider) => WrapSpecProvider(specProvider))
-            .AddSingleton<ManualTimestamper>(new ManualTimestamper(InitialTimestamp))
+            .AddInstance<ManualTimestamper>(new ManualTimestamper(InitialTimestamp))
             .AddSingleton<Configuration>()
             .AddSingleton<FromContainer>()
 
             // Some validator configurations
-            .AddSingleton<ISealValidator>(Always.Valid)
-            .AddSingleton<IUnclesValidator>(Always.Valid)
-            .AddSingleton<ISealer>(new NethDevSealEngine(TestItem.AddressD))
+            .AddInstance<ISealValidator>(Always.Valid)
+            .AddInstance<IUnclesValidator>(Always.Valid)
+            .AddInstance<ISealer>(new NethDevSealEngine(TestItem.AddressD))
 
             .AddSingleton<IBlockProducer>((_) => this.BlockProducer)
             .AddSingleton<IBlockProducerRunner>((_) => this.BlockProducerRunner)

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
@@ -56,18 +56,18 @@ public class PseudoNethermindModule(ChainSpec spec, IConfigProvider configProvid
                 initConfig.BackgroundTaskConcurrency,
                 initConfig.BackgroundTaskMaxNumber,
                 logManager))
-            .AddSingleton<IFileSystem>(new FileSystem())
-            .AddSingleton<IDbProvider>(new DbProvider())
-            .AddSingleton<IProcessExitSource>(new ProcessExitSource(default))
+            .AddInstance<IFileSystem>(new FileSystem())
+            .AddInstance<IDbProvider>(new DbProvider())
+            .AddInstance<IProcessExitSource>(new ProcessExitSource(default))
             .AddSingleton<IJsonSerializer, EthereumJsonSerializer>()
 
             // Crypto
-            .AddSingleton<ICryptoRandom>(new CryptoRandom())
+            .AddInstance<ICryptoRandom>(new CryptoRandom())
 
-            .AddSingleton<ISignerStore>(NullSigner.Instance)
-            .AddSingleton<IKeyStore>(Substitute.For<IKeyStore>())
+            .AddInstance<ISignerStore>(NullSigner.Instance)
+            .AddInstance<IKeyStore>(Substitute.For<IKeyStore>())
             .AddSingleton<IWallet, DevWallet>()
-            .AddSingleton<ITxSender>(Substitute.For<ITxSender>())
+            .AddInstance<ITxSender>(Substitute.For<ITxSender>())
 
             // Rpc
             .AddSingleton<IJsonRpcService, JsonRpcService>()

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PsudoNetworkModule.cs
@@ -35,12 +35,12 @@ public class PsudoNetworkModule() : Module
 
         builder
             .AddSingleton<IFullStateFinder, FullStateFinder>()
-            .AddSingleton<IBeaconSyncStrategy>(No.BeaconSync)
-            .AddSingleton<IPoSSwitcher>(NoPoS.Instance)
+            .AddInstance<IBeaconSyncStrategy>(No.BeaconSync)
+            .AddInstance<IPoSSwitcher>(NoPoS.Instance)
 
             .AddSingleton<IProtocolValidator, ProtocolValidator>()
             .AddSingleton<IPooledTxsRequestor, PooledTxsRequestor>()
-            .AddSingleton<IGossipPolicy>(Policy.FullGossip)
+            .AddInstance<IGossipPolicy>(Policy.FullGossip)
             .AddComposite<ITxGossipPolicy, CompositeTxGossipPolicy>()
 
             // TODO: LastNStateRootTracker

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestBlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestBlockProcessingModule.cs
@@ -70,7 +70,7 @@ public class TestBlockProcessingModule : Module
             .AddSingleton<ProducedBlockSuggester>()
             .ResolveOnServiceActivation<ProducedBlockSuggester, IBlockProducerRunner>()
 
-            .AddSingleton<ISigner>(NullSigner.Instance)
+            .AddInstance<ISigner>(NullSigner.Instance)
 
             ;
     }
@@ -88,11 +88,12 @@ public class TestBlockProcessingModule : Module
         {
             processingCtxBuilder
                 // These are main block processing specific
-                .AddScoped<ICodeInfoRepository>(mainCodeInfoRepository)
-                .AddSingleton<IVisitingWorldState>(mainWorldState).AddSingleton<IWorldState>(mainWorldState)
+                .AddInstance<ICodeInfoRepository>(mainCodeInfoRepository)
+                .AddInstance<IVisitingWorldState>(mainWorldState)
+                .AddInstance<IWorldState>(mainWorldState)
                 .Bind<IBlockProcessor.IBlockTransactionsExecutor, IValidationTransactionExecutor>()
                 .AddScoped<ITransactionProcessorAdapter, ExecuteTransactionProcessorAdapter>()
-                .AddScoped(new BlockchainProcessor.Options
+                .AddInstance(new BlockchainProcessor.Options
                 {
                     StoreReceiptsByDefault = receiptConfig.StoreReceipts,
                     DumpOptions = initConfig.AutoDump
@@ -108,7 +109,7 @@ public class TestBlockProcessingModule : Module
             if (blocksConfig.PreWarmStateOnBlockProcessing)
             {
                 processingCtxBuilder
-                    .AddScoped<PreBlockCaches>((mainWorldState as IPreBlockCaches)!.Caches)
+                    .AddInstance<PreBlockCaches>((mainWorldState as IPreBlockCaches)!.Caches)
                     .AddScoped<IBlockCachePreWarmer, BlockCachePreWarmer>()
                     ;
             }
@@ -125,9 +126,9 @@ public class TestBlockProcessingModule : Module
             ILifetimeScope innerScope = rootLifetime.BeginLifetimeScope((builder) => builder
                 // Block producer specific things is in `IBlockProducerEnvFactory`.
                 // Yea, it can be added as `AddScoped` too and then mapped out, but its clearer this way.
-                .AddScoped<IWorldState>(env.ReadOnlyStateProvider)
-                .AddScoped<IBlockchainProcessor>(env.ChainProcessor)
-                .AddScoped<ITxSource>(env.TxSource)
+                .AddInstance<IWorldState>(env.ReadOnlyStateProvider)
+                .AddInstance<IBlockchainProcessor>(env.ChainProcessor)
+                .AddInstance<ITxSource>(env.TxSource)
 
                 .AddScoped<IBlockProducer, T>());
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -37,17 +37,17 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
         base.Load(builder);
 
         builder
-            .AddSingleton<ILogManager>(new TestLogManager(LogLevel.Error)) // Limbologs actually have IsTrace set to true, so actually slow.
+            .AddInstance<ILogManager>(new TestLogManager(LogLevel.Error)) // Limbologs actually have IsTrace set to true, so actually slow.
             .AddSingleton<IDbFactory>((_) => new MemDbFactory())
-            .AddSingleton<IDbProvider>(TestMemDbProvider.Init())
+            .AddInstance<IDbProvider>(TestMemDbProvider.Init())
             // These two dont use db provider
             .AddKeyedSingleton<IFullDb>(DbNames.PeersDb, (_) => new MemDb())
             .AddKeyedSingleton<IFullDb>(DbNames.DiscoveryNodes, (_) => new MemDb())
-            .AddSingleton<IFileStoreFactory>(new InMemoryDictionaryFileStoreFactory())
+            .AddInstance<IFileStoreFactory>(new InMemoryDictionaryFileStoreFactory())
             .AddSingleton<IChannelFactory, INetworkConfig>(networkConfig => new LocalChannelFactory(networkGroup ?? nameof(TestEnvironmentModule), networkConfig))
 
             .AddSingleton<PseudoNethermindRunner>()
-            .AddSingleton<ISealer>(new NethDevSealEngine(nodeKey.Address))
+            .AddInstance<ISealer>(new NethDevSealEngine(nodeKey.Address))
             .AddSingleton<ITimestamper, ManualTimestamper>()
             .AddSingleton<IIPResolver, FixedIpResolver>()
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
@@ -45,6 +45,6 @@ public class TestNethermindModule(IConfigProvider configProvider, ChainSpec chai
         builder
             .AddModule(new PseudoNethermindModule(chainSpec, configProvider, LimboLogs.Instance))
             .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, Random.Shared.Next().ToString()))
-            .AddSingleton<ISpecProvider>(new TestSpecProvider(Cancun.Instance));
+            .AddInstance<ISpecProvider>(new TestSpecProvider(Cancun.Instance));
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/ServiceStopperTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ServiceStopperTests.cs
@@ -19,7 +19,7 @@ public class ServiceStopperTests
             .AddServiceStopper()
             .AddSingleton<Service1>()
             .AddSingleton<Service2>()
-            .AddSingleton<ILogManager>(LimboLogs.Instance)
+            .AddInstance<ILogManager>(LimboLogs.Instance)
             .Build();
 
         Service1 service1 = container.Resolve<Service1>();
@@ -37,7 +37,7 @@ public class ServiceStopperTests
             .AddServiceStopper()
             .AddSingleton<Service1>()
             .Add<Service2>()
-            .AddSingleton<ILogManager>(LimboLogs.Instance)
+            .AddInstance<ILogManager>(LimboLogs.Instance)
             .Build();
 
         Service1 service1 = container.Resolve<Service1>();

--- a/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class ContainerBuilderExtensions
         return builder;
     }
 
-    public static ContainerBuilder AddSingleton<T>(this ContainerBuilder builder, T instance) where T : class
+    public static ContainerBuilder AddInstance<T>(this ContainerBuilder builder, T instance) where T : class
     {
         builder.RegisterInstance(instance)
             .As<T>()
@@ -176,17 +176,6 @@ public static class ContainerBuilderExtensions
             .As<T>()
             .AsSelf()
             .CommonNethermindConfig()
-            .InstancePerLifetimeScope();
-
-        return builder;
-    }
-
-    public static ContainerBuilder AddScoped<T>(this ContainerBuilder builder, T instance) where T : class
-    {
-        builder.Register(ctx => instance)
-            .As<T>()
-            .AsSelf()
-            .ExternallyOwned()
             .InstancePerLifetimeScope();
 
         return builder;

--- a/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
+++ b/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
@@ -304,12 +304,12 @@ public class Era1ModuleTests
         }
 
         await using IContainer inCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
-            .AddSingleton<ISyncConfig>(new SyncConfig()
+            .AddInstance<IBlockTree>(inTree)
+            .AddInstance<ISyncConfig>(new SyncConfig()
             {
                 FastSync = fastSync
             })
-            .AddSingleton<IEraConfig>(new EraConfig()
+            .AddInstance<IEraConfig>(new EraConfig()
             {
                 From = start,
                 To = end,

--- a/src/Nethermind/Nethermind.Era.Test/EraExporterTests.cs
+++ b/src/Nethermind/Nethermind.Era.Test/EraExporterTests.cs
@@ -22,7 +22,7 @@ public class EraExporterTests
     public async Task Export_ChainHasDifferentLength_CorrectNumberOfFilesCreated(int chainlength, int start, int end, int size, int expectedNumberOfFiles)
     {
         await using IContainer container = EraTestModule.BuildContainerBuilderWithBlockTreeOfLength(chainlength)
-            .AddSingleton<IEraConfig>(new EraConfig() { MaxEra1Size = size })
+            .AddInstance<IEraConfig>(new EraConfig() { MaxEra1Size = size })
             .Build();
 
         string tmpDirectory = container.ResolveTempDirPath();
@@ -53,7 +53,7 @@ public class EraExporterTests
     public void Export_ReceiptsAreNull_ThrowEraException()
     {
         using IContainer container = EraTestModule.BuildContainerBuilderWithBlockTreeOfLength(10)
-            .AddSingleton<IReceiptStorage>(Substitute.For<IReceiptStorage>())
+            .AddInstance<IReceiptStorage>(Substitute.For<IReceiptStorage>())
             .Build();
 
         string tmpDirectory = container.ResolveTempDirPath();

--- a/src/Nethermind/Nethermind.Era.Test/EraImporterTest.cs
+++ b/src/Nethermind/Nethermind.Era.Test/EraImporterTest.cs
@@ -55,8 +55,8 @@ public class EraImporterTest
         blockTree.SuggestBlock(sourceBlocktree.FindBlock(0)!, BlockTreeSuggestOptions.None);
 
         await using IContainer targetCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(blockTree)
-            .AddSingleton<IBlockValidator>(Always.Invalid)
+            .AddInstance<IBlockTree>(blockTree)
+            .AddInstance<IBlockValidator>(Always.Invalid)
             .Build();
 
         IEraImporter sut = targetCtx.Resolve<IEraImporter>();
@@ -75,7 +75,7 @@ public class EraImporterTest
             .WithBlocks(fromCtx.Resolve<IBlockTree>().FindBlock(0, BlockTreeLookupOptions.None)!).TestObject;
 
         await using IContainer toCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
+            .AddInstance<IBlockTree>(inTree)
             .Build();
 
         IEraImporter sut = toCtx.Resolve<IEraImporter>();
@@ -97,7 +97,7 @@ public class EraImporterTest
         BlockTree inTree = Build.A.BlockTree()
             .WithBlocks(outputCtx.Resolve<IBlockTree>().FindBlock(0, BlockTreeLookupOptions.None)!).TestObject;
         using IContainer inCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
+            .AddInstance<IBlockTree>(inTree)
             .Build();
 
         IEraImporter sut = inCtx.Resolve<IEraImporter>();
@@ -122,7 +122,7 @@ public class EraImporterTest
         BlockTree inTree = Build.A.BlockTree()
             .WithBlocks(outputCtx.Resolve<IBlockTree>().FindBlock(0, BlockTreeLookupOptions.None)!).TestObject;
         using IContainer inCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
+            .AddInstance<IBlockTree>(inTree)
             .Build();
 
         IEraImporter sut = inCtx.Resolve<IEraImporter>();
@@ -144,8 +144,8 @@ public class EraImporterTest
             .TestObject;
 
         await using IContainer inCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
-            .AddSingleton<IEraConfig>(new EraConfig()
+            .AddInstance<IBlockTree>(inTree)
+            .AddInstance<IEraConfig>(new EraConfig()
             {
                 ImportBlocksBufferSize = 10,
                 MaxEra1Size = 16,
@@ -190,8 +190,8 @@ public class EraImporterTest
             .TestObject;
 
         await using IContainer inCtx = EraTestModule.BuildContainerBuilder()
-            .AddSingleton<IBlockTree>(inTree)
-            .AddSingleton<IEraConfig>(new EraConfig()
+            .AddInstance<IBlockTree>(inTree)
+            .AddInstance<IEraConfig>(new EraConfig()
             {
                 ImportBlocksBufferSize = 10,
                 MaxEra1Size = 16,

--- a/src/Nethermind/Nethermind.Era.Test/EraTestModule.cs
+++ b/src/Nethermind/Nethermind.Era.Test/EraTestModule.cs
@@ -29,7 +29,7 @@ public class EraTestModule : Module
 
         return new ContainerBuilder()
             .AddModule(new EraTestModule())
-            .AddSingleton<IBlockTree>(blockTreeBuilder.TestObject)
+            .AddInstance<IBlockTree>(blockTreeBuilder.TestObject)
             .OnBuild((ctx) =>
             {
                 blockTreeBuilder
@@ -52,9 +52,9 @@ public class EraTestModule : Module
         builder
             .AddModule(new TestNethermindModule(new ConfigProvider()))
             .AddModule(new EraModule())
-            .AddSingleton<IBlockValidator>(Always.Valid)
-            .AddSingleton<IFileSystem>(new FileSystem()) // Run on real filesystem.
-            .AddSingleton<IEraConfig>(new EraConfig()
+            .AddInstance<IBlockValidator>(Always.Valid)
+            .AddInstance<IFileSystem>(new FileSystem()) // Run on real filesystem.
+            .AddInstance<IEraConfig>(new EraConfig()
             {
                 MaxEra1Size = 16,
                 NetworkName = TestNetwork,

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -44,12 +44,12 @@ public class BlockchainBridgeTests
 
         _container = new ContainerBuilder()
             .AddModule(new TestNethermindModule())
-            .AddSingleton(_blockTree)
-            .AddSingleton<IReceiptFinder>(_receiptStorage)
-            .AddSingleton(_timestamper)
-            .AddSingleton(Substitute.For<ILogFinder>())
-            .AddSingleton<IMiningConfig>(new MiningConfig() { Enabled = false })
-            .AddScoped<ITransactionProcessor>(_transactionProcessor)
+            .AddInstance(_blockTree)
+            .AddInstance<IReceiptFinder>(_receiptStorage)
+            .AddInstance(_timestamper)
+            .AddInstance(Substitute.For<ILogFinder>())
+            .AddInstance<IMiningConfig>(new MiningConfig() { Enabled = false })
+            .AddInstance<ITransactionProcessor>(_transactionProcessor)
             .Build();
 
         _blockchainBridge = _container.Resolve<IBlockchainBridge>();

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -432,7 +432,7 @@ namespace Nethermind.Facade
 
             ILifetimeScope blockchainBridgeLifetime = rootLifetimeScope.BeginLifetimeScope((builder) => builder
                 .AddScoped<BlockchainBridge>()
-                .AddScoped(blockProcessingEnv));
+                .AddInstance(blockProcessingEnv));
 
             blockchainBridgeLifetime.Disposer.AddInstanceForAsyncDisposal(overridableScopeLifetime);
             rootLifetimeScope.Disposer.AddInstanceForDisposal(blockchainBridgeLifetime);

--- a/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.Setup.cs
@@ -52,7 +52,7 @@ public partial class FlashbotsModuleTests
         IReleaseSpec? releaseSpec = null)
         => await new EngineModuleTests.MergeTestBlockchain()
             .BuildMergeTestBlockchain(configurer: (builder) => builder
-                .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance))
+                .AddInstance<ISpecProvider>(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance))
                 .AddModule(new FlashbotsModule(new FlashbotsConfig(), new JsonRpcConfig()))
             );
 }

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Flashbots.Modules.Flashbots
 
             ILifetimeScope moduleLifetime = rootLifetime.BeginLifetimeScope((builder) => builder
                 .Bind<IBlockProcessor.IBlockTransactionsExecutor, IValidationTransactionExecutor>()
-                .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)
+                .AddInstance<IReceiptStorage>(NullReceiptStorage.Instance)
                 .AddSingleton<ITransactionProcessorAdapter, ExecuteTransactionProcessorAdapter>()
                 .AddScoped<ValidateSubmissionHandler.ProcessingEnv>()
                 .AddModule(overridableEnv));

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -63,9 +63,9 @@ public class BlockProcessingModule : Module
             .AddScoped<IValidationTransactionExecutor, BlockProcessor.BlockValidationTransactionsExecutor>()
 
             // Block production components
-            .AddSingleton<IRewardCalculatorSource>(NoBlockRewards.Instance)
-            .AddSingleton<ISealValidator>(NullSealEngine.Instance)
-            .AddSingleton<ISealer>(NullSealEngine.Instance)
+            .AddInstance<IRewardCalculatorSource>(NoBlockRewards.Instance)
+            .AddInstance<ISealValidator>(NullSealEngine.Instance)
+            .AddInstance<ISealer>(NullSealEngine.Instance)
             .AddSingleton<ISealEngine, SealEngine>()
 
             .AddSingleton<IBlockProducerEnvFactory, BlockProducerEnvFactory>()

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -53,7 +53,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             .AddSingleton<IReadOnlyBlockTree, IBlockTree>((bt) => bt.AsReadOnly())
 
             .AddKeyedSingleton<IProtectedPrivateKey>(IProtectedPrivateKey.NodeKey, (ctx) => ctx.Resolve<INethermindApi>().NodeKey!)
-            .AddSingleton<IAbiEncoder>(Nethermind.Abi.AbiEncoder.Instance)
+            .AddInstance<IAbiEncoder>(Nethermind.Abi.AbiEncoder.Instance)
             .AddSingleton<IEciesCipher, EciesCipher>()
             .AddSingleton<ICryptoRandom, CryptoRandom>()
 
@@ -77,9 +77,9 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             base.Load(builder);
 
             builder
-                .AddSingleton(configProvider)
-                .AddSingleton<ChainSpec>(chainSpec)
-                .AddSingleton<ILogManager>(logManager)
+                .AddInstance(configProvider)
+                .AddInstance<ChainSpec>(chainSpec)
+                .AddInstance<ILogManager>(logManager)
                 .AddSingleton<ISpecProvider, ChainSpecBasedSpecProvider>()
                 ;
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -1,63 +1,32 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Threading.Tasks;
 using Autofac;
 using BenchmarkDotNet.Attributes;
 using Nethermind.Api;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.BeaconBlockRoot;
-using Nethermind.Blockchain.Blocks;
-using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
-using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Rewards;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Crypto;
-using Nethermind.Db;
-using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Facade;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Logging;
 using Nethermind.State;
-using Nethermind.State.Repositories;
-using Nethermind.Db.Blooms;
-using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Facade.Eth;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 using Nethermind.JsonRpc.Modules.Eth.GasPrice;
-using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
-using BlockTree = Nethermind.Blockchain.BlockTree;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
-using Nethermind.Consensus.ExecutionRequests;
-using Nethermind.Consensus;
-using Nethermind.Consensus.Scheduler;
-using Nethermind.Consensus.Withdrawals;
-using Nethermind.Core.Test;
 using Nethermind.Core.Test.Modules;
-using Nethermind.Facade.Find;
-using Nethermind.Facade.Simulate;
 using Nethermind.Network;
-using Nethermind.Network.Config;
-using Nethermind.Network.P2P.Subprotocols.Eth;
-using Nethermind.Network.Rlpx;
-using Nethermind.Stats;
-using Nethermind.Synchronization;
-using Nethermind.Synchronization.ParallelSync;
-using Nethermind.Synchronization.Peers;
-using NSubstitute;
 
 namespace Nethermind.JsonRpc.Benchmark
 {
@@ -71,7 +40,7 @@ namespace Nethermind.JsonRpc.Benchmark
         {
             _container = new ContainerBuilder()
                 .AddModule(new TestNethermindModule())
-                .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
+                .AddInstance<ISpecProvider>(MainnetSpecProvider.Instance)
                 .Build();
 
             IWorldState stateProvider = _container.Resolve<IWorldStateManager>().GlobalWorldState;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1590,7 +1590,7 @@ public partial class EthRpcModuleTests
         {
             Action<ContainerBuilder> wrappedConfigurer = builder =>
             {
-                if (specProvider is not null) builder.AddSingleton<ISpecProvider>(specProvider);
+                if (specProvider is not null) builder.AddInstance<ISpecProvider>(specProvider);
                 configurer?.Invoke(builder);
             };
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsHiveBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsHiveBase.cs
@@ -129,7 +129,7 @@ new object[] {"multicall-transaction-too-low-nonce-38010", "{\"blockStateCalls\"
             })
             .Build((builder) => builder
                 .ConfigureTestConfiguration((config) => config.AddBlockOnStart = false)
-                .AddSingleton<ISpecProvider>(new TestSpecProvider(London.Instance)));
+                .AddInstance<ISpecProvider>(new TestSpecProvider(London.Instance)));
 
         await chain.AddBlock();
         await chain.AddBlock(BuildSimpleTransaction.WithNonce(0).TestObject);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -80,12 +80,12 @@ public class ProofRpcModuleTests
 
         _container = new ContainerBuilder()
             .AddModule(new TestNethermindModule(new ConfigProvider()))
-            .AddSingleton<ISpecProvider>(_specProvider)
-            .AddSingleton<IBlockPreprocessorStep>(new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId), _specProvider, LimboLogs.Instance)))
-            .AddSingleton<IBlockTree>(_blockTree)
-            .AddSingleton<IDbProvider>(_dbProvider)
-            .AddSingleton<IReceiptStorage>(receiptStorage)
-            .AddSingleton<IWorldStateManager>(_worldStateManager)
+            .AddInstance<ISpecProvider>(_specProvider)
+            .AddInstance<IBlockPreprocessorStep>(new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId), _specProvider, LimboLogs.Instance)))
+            .AddInstance<IBlockTree>(_blockTree)
+            .AddInstance<IDbProvider>(_dbProvider)
+            .AddInstance<IReceiptStorage>(receiptStorage)
+            .AddInstance<IWorldStateManager>(_worldStateManager)
             .Build();
         _proofRpcModule = _container.Resolve<IRpcModuleFactory<IProofRpcModule>>().Create();
     }
@@ -231,12 +231,12 @@ public class ProofRpcModuleTests
         _container.Dispose();
         _container = new ContainerBuilder()
             .AddModule(new TestNethermindModule(new ConfigProvider()))
-            .AddSingleton<ISpecProvider>(_specProvider)
-            .AddSingleton<IBlockPreprocessorStep>(new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId), _specProvider, LimboLogs.Instance)))
-            .AddSingleton<IBlockTree>(_blockTree)
-            .AddSingleton<IReceiptFinder>(_receiptFinder)
-            .AddSingleton<IDbProvider>(_dbProvider)
-            .AddSingleton<IWorldStateManager>(_worldStateManager)
+            .AddInstance<ISpecProvider>(_specProvider)
+            .AddInstance<IBlockPreprocessorStep>(new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId), _specProvider, LimboLogs.Instance)))
+            .AddInstance<IBlockTree>(_blockTree)
+            .AddInstance<IReceiptFinder>(_receiptFinder)
+            .AddInstance<IDbProvider>(_dbProvider)
+            .AddInstance<IWorldStateManager>(_worldStateManager)
             .Build();
         _proofRpcModule = _container.Resolve<IRpcModuleFactory<IProofRpcModule>>().Create();
         ReceiptWithProof receiptWithProof = _proofRpcModule.proof_getTransactionReceipt(txHash, withHeader).Data;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -144,7 +144,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             {
                 return Build((builder) =>
                 {
-                    if (specProvider is not null) builder.AddSingleton<ISpecProvider>(specProvider);
+                    if (specProvider is not null) builder.AddInstance<ISpecProvider>(specProvider);
                 });
             }
 
@@ -175,10 +175,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                     builder.AddSingleton<IFilterManager, IFilterStore, ITxPool, ILogManager>((store, txPool, logManager) =>
                             new FilterManager(store, _blockchain.BlockProcessor, txPool, logManager));
 
-                    if (_blockFinderOverride is not null) builder.AddSingleton(_blockFinderOverride);
-                    if (_receiptFinderOverride is not null) builder.AddSingleton(_receiptFinderOverride);
-                    if (_blockchainBridgeOverride is not null) builder.AddSingleton(_blockchainBridgeOverride);
-                    if (_blocksConfigOverride is not null) builder.AddSingleton(_blocksConfigOverride);
+                    if (_blockFinderOverride is not null) builder.AddInstance(_blockFinderOverride);
+                    if (_receiptFinderOverride is not null) builder.AddInstance(_receiptFinderOverride);
+                    if (_blockchainBridgeOverride is not null) builder.AddInstance(_blockchainBridgeOverride);
+                    if (_blocksConfigOverride is not null) builder.AddInstance(_blocksConfigOverride);
                 });
             }
         }
@@ -206,7 +206,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             await base.Build(builder =>
             {
-                builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Berlin.Instance));
+                builder.AddInstance<ISpecProvider>(new TestSpecProvider(Berlin.Instance));
                 configurer?.Invoke(builder);
             });
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -48,9 +48,9 @@ public class ParityStyleTracerTests
         _poSSwitcher = Substitute.For<IPoSSwitcher>();
         _container = new ContainerBuilder()
             .AddModule(new TestNethermindModule(cp))
-            .AddSingleton<ISpecProvider>(specProvider)
-            .AddSingleton<IPoSSwitcher>(_poSSwitcher)
-            .AddSingleton<IBlockTree>(_blockTree)
+            .AddInstance<ISpecProvider>(specProvider)
+            .AddInstance<IPoSSwitcher>(_poSSwitcher)
+            .AddInstance<IBlockTree>(_blockTree)
             .Build();
 
         await _container.Resolve<PseudoNethermindRunner>().StartBlockProcessing(default);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -67,7 +67,7 @@ public static class RpcTest
                 EnabledModules = [typeof(T).GetCustomAttribute<RpcModuleAttribute>()!.ModuleType]
             }))
             .RegisterBoundedJsonRpcModule<T, AutoRpcModuleFactory<T>>(1, new JsonRpcConfig().Timeout)
-            .AddScoped<T>(module)
+            .AddInstance<T>(module)
             .Build();
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -19,7 +19,7 @@ public class DebugModuleFactory(IOverridableEnvFactory envFactory, ILifetimeScop
                 // Note: Not overriding `IReceiptStorage` to null.
                 .Bind<IBlockProcessor.IBlockTransactionsExecutor, IValidationTransactionExecutor>()
                 .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
-                .AddScoped<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
+                .AddInstance<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
 
                 // So the debug rpc change the adapter sometime.
                 .AddScoped<ITransactionProcessorAdapter, ChangeableTransactionProcessorAdapter>()
@@ -38,7 +38,7 @@ public class DebugModuleFactory(IOverridableEnvFactory envFactory, ILifetimeScop
         // This is to prevent leaking processor or world state accidentally.
         // `GethStyleTracer` must be very careful to always dispose overridable env.
         ILifetimeScope debugRpcModuleLifetime = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-            .AddScoped<IGethStyleTracer>(tracerLifecyccle.Resolve<IGethStyleTracer>()));
+            .AddInstance<IGethStyleTracer>(tracerLifecyccle.Resolve<IGethStyleTracer>()));
 
         debugRpcModuleLifetime.Disposer.AddInstanceForAsyncDisposal(tracerLifecyccle);
         rootLifetimeScope.Disposer.AddInstanceForAsyncDisposal(debugRpcModuleLifetime);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -35,13 +35,13 @@ namespace Nethermind.JsonRpc.Modules.Proof
                     .Bind<IBlockProcessor.IBlockTransactionsExecutor, IValidationTransactionExecutor>()
                     .AddScoped<ITransactionProcessorAdapter, TraceTransactionProcessorAdapter>()
                     .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
-                    .AddScoped<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
-                    .AddScoped<IBlockValidator>(Always.Valid) // Why?
+                    .AddInstance<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
+                    .AddInstance<IBlockValidator>(Always.Valid) // Why?
 
                     // Specific for proof rpc
-                    .AddScoped<IReceiptStorage>(new InMemoryReceiptStorage()) // Umm.... not `NullReceiptStorage`?
-                    .AddScoped<IRewardCalculator>(NoBlockRewards.Instance)
-                    .AddScoped<IVisitingWorldState>(txProcessingEnv.WorldState).AddScoped<IWorldState>(txProcessingEnv.WorldState)
+                    .AddInstance<IReceiptStorage>(new InMemoryReceiptStorage()) // Umm.... not `NullReceiptStorage`?
+                    .AddInstance<IRewardCalculator>(NoBlockRewards.Instance)
+                    .AddInstance<IVisitingWorldState>(txProcessingEnv.WorldState).AddInstance<IWorldState>(txProcessingEnv.WorldState)
 
                     .AddScoped<ITracer, Tracer>()
                     ;
@@ -51,7 +51,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
             // Eh, its a good idea to separate what need block processing and what does not anyway.
             ILifetimeScope proofRpcScope = rootLifetimeScope.BeginLifetimeScope((builder) =>
             {
-                builder.AddSingleton<ITracer>(tracerScope.Resolve<ITracer>());
+                builder.AddInstance<ITracer>(tracerScope.Resolve<ITracer>());
             });
 
             proofRpcScope.Disposer.AddInstanceForAsyncDisposal(tracerScope);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
@@ -24,8 +24,8 @@ public class TraceModuleFactory(IOverridableEnvFactory overridableEnvFactory, IL
             .Bind<IBlockProcessor.IBlockTransactionsExecutor, IValidationTransactionExecutor>()
             .AddScoped<ITransactionProcessorAdapter, T>() // T can be trace or execute
             .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
-            .AddScoped<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
-            .AddScoped<IBlockValidator>(Always.Valid) // Why?
+            .AddInstance<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
+            .AddInstance<IBlockValidator>(Always.Valid) // Why?
 
             .AddDecorator<IRewardCalculator, MergeRpcRewardCalculator>(); // TODO: Check, what if this is pre merge?
 
@@ -54,7 +54,7 @@ public class TraceModuleFactory(IOverridableEnvFactory overridableEnvFactory, IL
         IOverridableEnv<ITracer> tracerEnv = tracerLifetimeScope.Resolve<IOverridableEnv<ITracer>>();
 
         ILifetimeScope rpcLifetimeScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-            .AddScoped(tracerEnv));
+            .AddInstance(tracerEnv));
 
         tracerLifetimeScope.Disposer.AddInstanceForAsyncDisposal(rpcProcessingScope);
         tracerLifetimeScope.Disposer.AddInstanceForAsyncDisposal(validationProcessingScope);

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -130,8 +130,8 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
                 .AddModule(new AuRaModule(ChainSpec))
                 .AddModule(new AuRaMergeModule())
                 .AddSingleton<NethermindApi.Dependencies>()
-                .AddSingleton<IReportingValidator>(NullReportingValidator.Instance)
-                .AddSingleton<ISealer>(NullSealEngine.Instance) // Test not originally made with aura sealer
+                .AddInstance<IReportingValidator>(NullReportingValidator.Instance)
+                .AddInstance<ISealer>(NullSealEngine.Instance) // Test not originally made with aura sealer
 
                 .AddScoped<WithdrawalContractFactory>()
                 .AddScoped<IWithdrawalContract, WithdrawalContractFactory, ITransactionProcessor>((factory, txProcessor) => factory.Create(txProcessor))

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -85,10 +85,10 @@ public abstract partial class BaseEngineModuleTests
         return await bc
             .BuildMergeTestBlockchain(configurer: (builder) =>
             {
-                builder.AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance));
+                builder.AddInstance<ISpecProvider>(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance));
 
-                if (mockedExecutionRequestsProcessor is not null) builder.AddScoped<IExecutionRequestsProcessor>(mockedExecutionRequestsProcessor);
-                if (mockedPayloadService is not null) builder.AddSingleton<IPayloadPreparationService>(mockedPayloadService);
+                if (mockedExecutionRequestsProcessor is not null) builder.AddInstance<IExecutionRequestsProcessor>(mockedExecutionRequestsProcessor);
+                if (mockedPayloadService is not null) builder.AddInstance<IPayloadPreparationService>(mockedPayloadService);
 
                 configurer?.Invoke(builder);
             });
@@ -381,7 +381,7 @@ public abstract partial class BaseEngineModuleTests
             Container.Resolve<IBlockImprovementContextFactory>();
 
         public async Task<MergeTestBlockchain> Build(ISpecProvider specProvider) =>
-            (MergeTestBlockchain)await Build(configurer: (builder) => builder.AddSingleton<ISpecProvider>(specProvider));
+            (MergeTestBlockchain)await Build(configurer: (builder) => builder.AddInstance<ISpecProvider>(specProvider));
 
         public async Task<MergeTestBlockchain> BuildMergeTestBlockchain(Action<ContainerBuilder> configurer) =>
             (MergeTestBlockchain)await Build(configurer: configurer);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -334,7 +334,7 @@ public partial class EngineModuleTests
         using MergeTestBlockchain chain = await CreateBlockchain(null, mergeConfig, configurer: (builder) => builder
             .AddSingleton<IBlockImprovementContextFactory>(static chain => new StoringBlockImprovementContextFactory(new MockBlockImprovementContextFactory()))
             .AddSingleton(ConfigurePayloadPreparationService(timePerSlot, delay))
-            .AddSingleton(txPool)
+            .AddInstance(txPool)
         );
 
         StoringBlockImprovementContextFactory improvementContextFactory = chain.StoringBlockImprovementContextFactory!;
@@ -434,7 +434,7 @@ public partial class EngineModuleTests
         using MergeTestBlockchain chain = await blockchain.BuildMergeTestBlockchain(builder =>
         {
             builder
-                .AddSingleton<ISpecProvider>(SepoliaSpecProvider.Instance)
+                .AddInstance<ISpecProvider>(SepoliaSpecProvider.Instance)
                 .AddSingleton(ConfigurePayloadPreparationService(timePerSlot, delay))
                 ;
 
@@ -509,7 +509,7 @@ public partial class EngineModuleTests
         TimeSpan timePerSlot = 4 * delay;
 
         using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder
-            .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(London.Instance))
+            .AddInstance<ISpecProvider>(new TestSingleReleaseSpecProvider(London.Instance))
             .AddSingleton<IBlockImprovementContextFactory>(ctx =>
                 new StoringBlockImprovementContextFactory(new BlockImprovementContextFactory(
                     ctx.Resolve<IBlockProducer>(),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -54,7 +54,7 @@ public partial class EngineModuleTests
             });
 
         using MergeTestBlockchain chain = await CreateBlockchain(null, mergeConfig, configurer: builder => builder
-            .AddSingleton<IBlocksConfig>(blocksConfig)
+            .AddInstance<IBlocksConfig>(blocksConfig)
             .AddSingleton<IBlockImprovementContextFactory>((ctx) =>
             {
                 BoostBlockImprovementContextFactory improvementContextFactory = new(ctx.Resolve<IBlockProducer>(),
@@ -165,7 +165,7 @@ public partial class EngineModuleTests
                     TimeSpan.FromSeconds(5000), boostRelay, stateReader);
                 return improvementContextFactory;
             })
-            .AddSingleton<IBlocksConfig>(new BlocksConfig() { SecondsPerSlot = 1000 })
+            .AddInstance<IBlocksConfig>(new BlocksConfig() { SecondsPerSlot = 1000 })
         );
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -212,7 +212,7 @@ public partial class EngineModuleTests
 
                 return improvementContextFactory;
             })
-            .AddSingleton<IBlocksConfig>(new BlocksConfig() { SecondsPerSlot = 10 })
+            .AddInstance<IBlocksConfig>(new BlocksConfig() { SecondsPerSlot = 10 })
         );
 
         IEngineRpcModule rpc = CreateEngineModule(chain);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -847,7 +847,7 @@ public partial class EngineModuleTests
             };
         }
 
-        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddSingleton<ISyncConfig>(syncConfig));
+        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddInstance<ISyncConfig>(syncConfig));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload prePivotRequest = ExecutionPayload.Create(blockBeforePivot);
         ResultWrapper<PayloadStatusV1> payloadStatus = await rpc.engine_newPayloadV1(prePivotRequest);
@@ -875,7 +875,7 @@ public partial class EngineModuleTests
             };
         }
 
-        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddSingleton<ISyncConfig>(syncConfig));
+        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddInstance<ISyncConfig>(syncConfig));
         await chain.BlockTree.SuggestBlockAsync(blockNr1, BlockTreeSuggestOptions.None);
         chain.BlockTree.UpdateMainChain(new List<Block>() { blockNr1 }, true, true);
 
@@ -906,7 +906,7 @@ public partial class EngineModuleTests
         }
 
 
-        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddSingleton<ISyncConfig>(syncConfig));
+        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder.AddInstance<ISyncConfig>(syncConfig));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         // create block gap from fast sync pivot
         int gap = 7;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1546,8 +1546,8 @@ public partial class EngineModuleTests
 
         using MergeTestBlockchain chain = await CreateBaseBlockchain()
             .BuildMergeTestBlockchain(configurer: builder => builder
-                .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(Prague.Instance))
-                .AddSingleton<ILogManager>(loggerManager));
+                .AddInstance<ISpecProvider>(new TestSingleReleaseSpecProvider(Prague.Instance))
+                .AddInstance<ILogManager>(loggerManager));
 
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         string[] list = new[]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -506,8 +506,8 @@ public partial class EngineModuleTests
 
         using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance, configurer: (builder) =>
             builder
-                .AddSingleton<IBlockTree>(blockTree)
-                .AddSingleton(new TestBlockchain.Configuration()
+                .AddInstance<IBlockTree>(blockTree)
+                .AddInstance(new TestBlockchain.Configuration()
                 {
                     SuggestGenesisOnStart = false,
                 }));
@@ -529,8 +529,8 @@ public partial class EngineModuleTests
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
         using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance, configurer: (builder) => builder
-            .AddSingleton<IBlockTree>(blockTree)
-            .AddSingleton(new TestBlockchain.Configuration()
+            .AddInstance<IBlockTree>(blockTree)
+            .AddInstance(new TestBlockchain.Configuration()
             {
                 SuggestGenesisOnStart = false,
             }));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -63,7 +63,7 @@ public class MergePluginTests
                 Substitute.For<IProcessExitSource>(),
                 [_consensusPlugin!, _plugin],
                 LimboLogs.Instance))
-            .AddSingleton<IRpcModuleProvider>(Substitute.For<IRpcModuleProvider>())
+            .AddInstance<IRpcModuleProvider>(Substitute.For<IRpcModuleProvider>())
             .AddModule(new HealthCheckPluginModule()) // The merge RPC require it.
             .OnBuild((ctx) =>
             {

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -306,7 +306,7 @@ public class OptimismModule(ChainSpec chainSpec) : Module
             .AddModule(new BaseMergePluginModule())
             .AddModule(new OptimismSynchronizerModule(chainSpec))
 
-            .AddSingleton(chainSpec.EngineChainSpecParametersProvider
+            .AddInstance(chainSpec.EngineChainSpecParametersProvider
                 .GetChainSpecParameters<OptimismChainSpecEngineParameters>())
             .AddSingleton<IOptimismSpecHelper, OptimismSpecHelper>()
             .AddSingleton<ICostHelper, OptimismCostHelper>()
@@ -320,7 +320,7 @@ public class OptimismModule(ChainSpec chainSpec) : Module
             // Validators
             .AddSingleton<IBlockValidator, OptimismBlockValidator>()
             .AddSingleton<IHeaderValidator, OptimismHeaderValidator>()
-            .AddSingleton<IUnclesValidator>(Always.Valid)
+            .AddInstance<IUnclesValidator>(Always.Valid)
 
             // Block processing
             .AddScoped<ITransactionProcessor, OptimismTransactionProcessor>()

--- a/src/Nethermind/Nethermind.Optimism/OptimismSynchronizerModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismSynchronizerModule.cs
@@ -26,7 +26,7 @@ public sealed class OptimismSynchronizerModule(ChainSpec chainSpec) : Module
                 .GetChainSpecParameters<OptimismChainSpecEngineParameters>();
             ArgumentNullException.ThrowIfNull(parameters.BedrockBlockNumber);
 
-            builder.AddSingleton<ITotalDifficultyStrategy>(
+            builder.AddInstance<ITotalDifficultyStrategy>(
                 new FixedTotalDifficultyStrategy(
                     new CumulativeTotalDifficultyStrategy(),
                     fixesBlockNumber: parameters.BedrockBlockNumber.Value - 1,

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Runner.Test.Ethereum
                 [],
                 Substitute.For<IProcessExitSource>(),
                 new ContainerBuilder()
-                    .AddSingleton<ITxValidator>(new TxValidator(MainnetSpecProvider.Instance.ChainId))
+                    .AddInstance<ITxValidator>(new TxValidator(MainnetSpecProvider.Instance.ChainId))
                     .AddSource(new NSubstituteRegistrationSource())
                     .Build()
             );

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
             consensusPlugin.ApiType.ReturnsForAnyArgs(typeof(NethermindApi));
 
             return CreateCommonBuilder(stepInfos)
-                .AddSingleton<IConsensusPlugin>(consensusPlugin)
+                .AddInstance<IConsensusPlugin>(consensusPlugin)
                 .Bind<INethermindApi, NethermindApi>()
                 .Build();
         }
@@ -165,7 +165,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
 
             return CreateCommonBuilder(stepInfos)
                 .AddSingleton<AuRaNethermindApi>()
-                .AddSingleton<IConsensusPlugin>(consensusPlugin)
+                .AddInstance<IConsensusPlugin>(consensusPlugin)
                 .Bind<INethermindApi, AuRaNethermindApi>()
                 .Build();
         }
@@ -175,16 +175,16 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
             ContainerBuilder builder = new ContainerBuilder()
                 .AddSingleton<INethermindApi, NethermindApi>()
                 .AddSingleton<NethermindApi.Dependencies>()
-                .AddSingleton<IConfigProvider>(new ConfigProvider())
-                .AddSingleton<IJsonSerializer>(new EthereumJsonSerializer())
-                .AddSingleton<ILogManager>(LimboLogs.Instance)
-                .AddSingleton<ChainSpec>(new ChainSpec())
-                .AddSingleton<ISpecProvider>(Substitute.For<ISpecProvider>())
-                .AddSingleton<IProcessExitSource>(Substitute.For<IProcessExitSource>())
+                .AddInstance<IConfigProvider>(new ConfigProvider())
+                .AddInstance<IJsonSerializer>(new EthereumJsonSerializer())
+                .AddInstance<ILogManager>(LimboLogs.Instance)
+                .AddInstance<ChainSpec>(new ChainSpec())
+                .AddInstance<ISpecProvider>(Substitute.For<ISpecProvider>())
+                .AddInstance<IProcessExitSource>(Substitute.For<IProcessExitSource>())
                 .AddSingleton<IDisposableStack, AutofacDisposableStack>()
                 .AddSingleton<IEthereumStepsLoader, EthereumStepsLoader>()
                 .AddSingleton<EthereumStepsManager>()
-                .AddSingleton<ILogManager>(LimboLogs.Instance);
+                .AddInstance<ILogManager>(LimboLogs.Instance);
 
             foreach (var stepInfo in stepInfos)
             {

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -442,7 +442,7 @@ public class EthereumRunnerTests
                 ipResolver.LocalIp.Returns(IPAddress.Parse("127.0.0.1"));
 
                 builder
-                    .AddSingleton(ipResolver)
+                    .AddInstance(ipResolver)
                     .AddDecorator<IInitConfig>((ctx, initConfig) =>
                     {
                         initConfig.DiagnosticMode = DiagnosticMode.MemDb;
@@ -461,7 +461,7 @@ public class EthereumRunnerTests
                     // to extract the reporting validator. The blockchain processor is not DI so it fail in step test but
                     // pass in runner test.
                     builder
-                        .AddSingleton(Substitute.For<IReportingValidator>())
+                        .AddInstance(Substitute.For<IReportingValidator>())
                         ;
                 }
 

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Modules/NethermindRunnerModule.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Modules/NethermindRunnerModule.cs
@@ -68,15 +68,15 @@ public class NethermindRunnerModule(
             .AddSingleton<EthereumRunner>()
             .AddSingleton<IEthereumStepsLoader, EthereumStepsLoader>()
             .AddSingleton<EthereumStepsManager>()
-            .AddSingleton<IProcessExitSource>(processExitSource)
+            .AddInstance<IProcessExitSource>(processExitSource)
 
             .AddSingleton<NethermindApi>()
             .AddSingleton<NethermindApi.Dependencies>()
             .Bind<INethermindApi, NethermindApi>()
 
             .AddSingleton<IBlockPreprocessorStep, INethermindApi>((api) => api.BlockPreprocessor)
-            .AddSingleton(jsonSerializer)
-            .AddSingleton<IConsensusPlugin>(consensusPlugin)
+            .AddInstance(jsonSerializer)
+            .AddInstance<IConsensusPlugin>(consensusPlugin)
             ;
 
         foreach (var plugin in plugins)
@@ -85,7 +85,7 @@ public class NethermindRunnerModule(
             {
                 builder.AddModule(plugin.Module);
             }
-            builder.AddSingleton<INethermindPlugin>(plugin);
+            builder.AddInstance<INethermindPlugin>(plugin);
         }
 
         builder.OnBuild((ctx) =>

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterTestBlockchain.cs
@@ -24,9 +24,9 @@ public class ShutterTestBlockchain(Random rnd, ITimestamper? timestamper = null,
             .AddModule(new ShutterPluginModule())
             .AddSingleton<ShutterApiSimulator>()
             .AddSingleton<ShutterEventSimulator>((ctx) => ShutterTestsCommon.InitEventSimulator(_rnd))
-            .AddSingleton<ShutterValidatorsInfo>(new ShutterValidatorsInfo())
-            .AddSingleton<Random>(_rnd)
-            .AddSingleton<IShutterConfig>(ShutterTestsCommon.Cfg)
+            .AddInstance<ShutterValidatorsInfo>(new ShutterValidatorsInfo())
+            .AddInstance<Random>(_rnd)
+            .AddInstance<IShutterConfig>(ShutterTestsCommon.Cfg)
             .Bind<ShutterApi, ShutterApiSimulator>()
 
             // ShutterApiSimulator add receipts to block with empty transaction. Crash with full receipt storage.
@@ -34,17 +34,17 @@ public class ShutterTestBlockchain(Random rnd, ITimestamper? timestamper = null,
 
             // It seems that it does not work with bloom.
             // This or use a separate bloom storage for LogFinder and BlockTree.
-            .AddSingleton<IBloomStorage>(NullBloomStorage.Instance)
+            .AddInstance<IBloomStorage>(NullBloomStorage.Instance)
             ;
 
         if (eventSimulator is not null)
         {
-            builder.AddSingleton<ShutterEventSimulator>(eventSimulator);
+            builder.AddInstance<ShutterEventSimulator>(eventSimulator);
         }
 
         if (_timestamper is not null)
         {
-            builder.AddSingleton<ITimestamper>(_timestamper);
+            builder.AddInstance<ITimestamper>(_timestamper);
         }
 
         return builder;

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -82,7 +82,7 @@ public class WorldStateManagerTests
         {
             using IContainer ctx = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
-                .AddSingleton(blockTree)
+                .AddInstance(blockTree)
                 .Build();
 
             IWorldState worldState = ctx.Resolve<IWorldStateManager>().GlobalWorldState;

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
@@ -65,9 +65,9 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, Func<IC
 
         protected override void Load(ContainerBuilder builder) =>
             builder
-                .AddScoped<IVisitingWorldState>(overridableScope.WorldState).AddScoped<IWorldState>(overridableScope.WorldState)
-                .AddScoped<IStateReader>(overridableScope.GlobalStateReader)
-                .AddScoped<IOverridableEnv>(this)
-                .AddScoped<ICodeInfoRepository>(codeInfoRepository);
+                .AddInstance<IVisitingWorldState>(overridableScope.WorldState).AddInstance<IWorldState>(overridableScope.WorldState)
+                .AddInstance<IStateReader>(overridableScope.GlobalStateReader)
+                .AddInstance<IOverridableEnv>(this)
+                .AddInstance<ICodeInfoRepository>(codeInfoRepository);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -222,9 +222,9 @@ public partial class BlockDownloaderTests
         await using IContainer container = CreateMergeNode((builder) =>
         {
             builder
-                .AddSingleton<IBlockTree>(notSyncedTree)
+                .AddInstance<IBlockTree>(notSyncedTree)
                 .AddKeyedSingleton<IDb>(DbNames.Metadata, blockTrees.NotSyncedTreeBuilder.MetadataDb)
-                .AddSingleton<ISealValidator>(sealValidator);
+                .AddInstance<ISealValidator>(sealValidator);
         }, new MergeConfig()
         {
             TerminalTotalDifficulty = $"{ttd}"
@@ -343,7 +343,7 @@ public partial class BlockDownloaderTests
         return CreateMergeNode((builder) =>
         {
             builder
-                .AddSingleton<IBlockTree>(treeBuilder.NotSyncedTree)
+                .AddInstance<IBlockTree>(treeBuilder.NotSyncedTree)
                 .AddKeyedSingleton<IDb>(DbNames.Metadata, treeBuilder.NotSyncedTreeBuilder.MetadataDb);
         }, configs);
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -172,7 +172,7 @@ public partial class BlockDownloaderTests
             FastSync = true,
             StateMinDistanceFromHead = fastSyncLag,
         }),
-            configurer: (builder) => builder.AddSingleton<IForwardHeaderProvider>(mockForwardHeaderProvider));
+            configurer: (builder) => builder.AddInstance<IForwardHeaderProvider>(mockForwardHeaderProvider));
 
         Context ctx = node.Resolve<Context>();
         SyncPeerMock syncPeer = new(chainLength, withReceipts, Response.AllCorrect | Response.WithTransactions);
@@ -214,7 +214,7 @@ public partial class BlockDownloaderTests
         IBlockTree instance = CachedBlockTreeBuilder.OfLength(1024);
         await using IContainer node = CreateNode(builder =>
         {
-            builder.AddSingleton<IBlockTree>(instance);
+            builder.AddInstance<IBlockTree>(instance);
         });
         Context ctx = node.Resolve<Context>();
 
@@ -246,7 +246,7 @@ public partial class BlockDownloaderTests
     {
         using IContainer node = CreateNode(builder =>
         {
-            builder.AddSingleton<IBlockTree>(CachedBlockTreeBuilder.OfLength(2048 + 1));
+            builder.AddInstance<IBlockTree>(CachedBlockTreeBuilder.OfLength(2048 + 1));
         });
         Context ctx = node.Resolve<Context>();
 
@@ -270,7 +270,7 @@ public partial class BlockDownloaderTests
     {
         Action<ContainerBuilder> configurer = builder =>
         {
-            builder.AddSingleton<ISyncPeerPool>(Substitute.For<ISyncPeerPool>());
+            builder.AddInstance<ISyncPeerPool>(Substitute.For<ISyncPeerPool>());
         };
 
         await using IContainer node = mergeDownloader ? CreateMergeNode(configurer) : CreateNode(configurer);
@@ -444,7 +444,7 @@ public partial class BlockDownloaderTests
     [Test]
     public async Task Throws_on_invalid_seal()
     {
-        await using IContainer node = CreateNode(builder => builder.AddSingleton<ISealValidator>(Always.Invalid));
+        await using IContainer node = CreateNode(builder => builder.AddInstance<ISealValidator>(Always.Invalid));
         Context ctx = node.Resolve<Context>();
 
         ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
@@ -463,7 +463,7 @@ public partial class BlockDownloaderTests
     [Test]
     public async Task Throws_on_invalid_header()
     {
-        await using IContainer node = CreateNode(builder => builder.AddSingleton<IBlockValidator>(Always.Invalid));
+        await using IContainer node = CreateNode(builder => builder.AddInstance<IBlockValidator>(Always.Invalid));
         Context ctx = node.Resolve<Context>();
 
         Response options = Response.AllCorrect | Response.Consistent;
@@ -495,7 +495,7 @@ public partial class BlockDownloaderTests
                 syncConfig.MaxTxInForwardSyncBuffer = 3200;
                 return syncConfig;
             })
-            .AddSingleton<IBlockValidator>(Always.Invalid));
+            .AddInstance<IBlockValidator>(Always.Invalid));
         Context ctx = node.Resolve<Context>();
 
         SyncPeerMock syncPeer = new(40, true, Response.AllCorrect);
@@ -929,10 +929,10 @@ public partial class BlockDownloaderTests
         ContainerBuilder b = new ContainerBuilder()
             .AddModule(new TestNethermindModule(configProvider))
             .AddSingleton<IReceiptStorage, InMemoryReceiptStorage>()
-            .AddSingleton<ISealValidator>(Always.Valid)
-            .AddSingleton<ISpecProvider>(new MainnetSpecProvider())
-            .AddSingleton<IBlockValidator>(Always.Valid)
-            .AddSingleton<ISyncPeerPool>(Substitute.For<ISyncPeerPool>())
+            .AddInstance<ISealValidator>(Always.Valid)
+            .AddInstance<ISpecProvider>(new MainnetSpecProvider())
+            .AddInstance<IBlockValidator>(Always.Valid)
+            .AddInstance<ISyncPeerPool>(Substitute.For<ISyncPeerPool>())
             .AddSingleton<ResponseBuilder>()
             .AddDecorator<IBlockTree>((ctx, tree) =>
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -173,7 +173,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             timestamper = new ManualTimestamper(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             builder
                 .AddModule(new TestMergeModule(configProvider.GetConfig<ITxPoolConfig>()))
-                .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
+                .AddInstance<ManualTimestamper>(timestamper) // Used by test code
                 .AddDecorator<ITestEnv, PostMergeTestEnv>()
                 ;
         }
@@ -182,8 +182,8 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             // So that any EIP after the merge is not activated.
             timestamper = ManualTimestamper.PreMerge;
             builder
-                .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
-                .AddSingleton<ITimestamper>(timestamper)
+                .AddInstance<ManualTimestamper>(timestamper) // Used by test code
+                .AddInstance<ITimestamper>(timestamper)
                 ;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -97,7 +97,7 @@ public abstract class StateSyncFeedTestsBase
         }
 
         ContainerBuilder builder = BuildTestContainerBuilder(dbContext, syncDispatcherAllocateTimeoutMs)
-            .AddSingleton<SyncPeerMock[]>(syncPeers);
+            .AddInstance<SyncPeerMock[]>(syncPeers);
 
         builder.RegisterBuildCallback((ctx) =>
         {
@@ -123,10 +123,10 @@ public abstract class StateSyncFeedTestsBase
                 syncConfig.SyncDispatcherAllocateTimeoutMs = syncDispatcherAllocateTimeoutMs; // there is a test for requested nodes which get affected if allocate timeout
                 return syncConfig;
             })
-            .AddSingleton<ILogManager>(_logManager)
+            .AddInstance<ILogManager>(_logManager)
             .AddKeyedSingleton<IDb>(DbNames.Code, dbContext.LocalCodeDb)
             .AddKeyedSingleton<IDb>(DbNames.State, dbContext.LocalStateDb)
-            .AddSingleton<INodeStorage>(dbContext.LocalNodeStorage)
+            .AddInstance<INodeStorage>(dbContext.LocalNodeStorage)
 
             // Use factory function to make it lazy in case test need to replace IBlockTree
             .AddSingleton<IBlockTree>((ctx) => CachedBlockTreeBuilder.BuildCached(

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.Merge.cs
@@ -143,7 +143,7 @@ public partial class ForwardHeaderProviderTests
         return CreateMergeNode((builder) =>
         {
             builder
-                .AddSingleton<IBlockTree>(treeBuilder.NotSyncedTree)
+                .AddInstance<IBlockTree>(treeBuilder.NotSyncedTree)
                 .AddKeyedSingleton<IDb>(DbNames.Metadata, treeBuilder.NotSyncedTreeBuilder.MetadataDb);
         }, configs);
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
@@ -81,7 +81,7 @@ public partial class ForwardHeaderProviderTests
         IBlockTree instance = CachedBlockTreeBuilder.OfLength(1024);
         await using IContainer node = CreateNode(builder =>
         {
-            builder.AddSingleton<IBlockTree>(instance);
+            builder.AddInstance<IBlockTree>(instance);
         });
         Context ctx = node.Resolve<Context>();
         IForwardHeaderProvider forwardHeader = ctx.ForwardHeaderProvider;
@@ -139,7 +139,7 @@ public partial class ForwardHeaderProviderTests
     {
         await using IContainer node = CreateNode(builder =>
         {
-            builder.AddSingleton<IBlockTree>(CachedBlockTreeBuilder.OfLength(2048 + 1));
+            builder.AddInstance<IBlockTree>(CachedBlockTreeBuilder.OfLength(2048 + 1));
         });
         Context ctx = node.Resolve<Context>();
         IForwardHeaderProvider forwardHeader = ctx.ForwardHeaderProvider;
@@ -197,7 +197,7 @@ public partial class ForwardHeaderProviderTests
     [Test]
     public async Task Throws_on_invalid_seal()
     {
-        await using IContainer node = CreateNode(builder => builder.AddSingleton<ISealValidator>(Always.Invalid));
+        await using IContainer node = CreateNode(builder => builder.AddInstance<ISealValidator>(Always.Invalid));
         Context ctx = node.Resolve<Context>();
 
         ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
@@ -267,7 +267,7 @@ public partial class ForwardHeaderProviderTests
     [Ignore("Fails OneLoggerLogManager Travis only")]
     public async Task Can_cancel_seal_validation()
     {
-        await using IContainer node = CreateNode(builder => builder.AddSingleton<ISealValidator>(new SlowSealValidator()));
+        await using IContainer node = CreateNode(builder => builder.AddInstance<ISealValidator>(new SlowSealValidator()));
         Context ctx = node.Resolve<Context>();
 
         ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
@@ -296,7 +296,7 @@ public partial class ForwardHeaderProviderTests
     {
         ISealValidator sealValidator = Substitute.For<ISealValidator>();
         sealValidator.ValidateSeal(Arg.Any<BlockHeader>(), Arg.Any<bool>()).Returns(true);
-        await using IContainer node = CreateNode(builder => builder.AddSingleton<ISealValidator>(sealValidator));
+        await using IContainer node = CreateNode(builder => builder.AddInstance<ISealValidator>(sealValidator));
         Context ctx = node.Resolve<Context>();
 
         using IOwnedReadOnlyList<BlockHeader>? blockHeaders = await ctx.ResponseBuilder.BuildHeaderResponse(0, 512, Response.AllCorrect);
@@ -422,10 +422,10 @@ public partial class ForwardHeaderProviderTests
         ContainerBuilder b = new ContainerBuilder()
             .AddModule(new TestNethermindModule(configProvider))
             .AddSingleton<IReceiptStorage, InMemoryReceiptStorage>()
-            .AddSingleton<ISealValidator>(Always.Valid)
-            .AddSingleton<ISpecProvider>(new MainnetSpecProvider())
-            .AddSingleton<IBlockValidator>(Always.Valid)
-            .AddSingleton<ISyncPeerPool>(Substitute.For<ISyncPeerPool>())
+            .AddInstance<ISealValidator>(Always.Valid)
+            .AddInstance<ISpecProvider>(new MainnetSpecProvider())
+            .AddInstance<IBlockValidator>(Always.Valid)
+            .AddInstance<ISyncPeerPool>(Substitute.For<ISyncPeerPool>())
             .AddSingleton<ResponseBuilder>()
             .AddDecorator<IBlockTree>((ctx, tree) =>
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/IContainerSynchronizerTestExtensions.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/IContainerSynchronizerTestExtensions.cs
@@ -19,7 +19,7 @@ public static class IContainerSynchronizerTestExtensions
         blockTree.FindHeader(Arg.Any<long>()).Returns(header);
         blockTree.BestSuggestedHeader.Returns(header);
 
-        builder.AddSingleton(blockTree);
+        builder.AddInstance(blockTree);
 
         return builder;
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -52,9 +52,9 @@ namespace Nethermind.Synchronization.Test
 
             IContainer container = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
-                .AddSingleton<IBlockTree>(_blockTree)
-                .AddSingleton<IBlockValidator>(Always.Valid)
-                .AddSingleton<ISealValidator>(Always.Valid)
+                .AddInstance<IBlockTree>(_blockTree)
+                .AddInstance<IBlockValidator>(Always.Valid)
+                .AddInstance<ISealValidator>(Always.Valid)
                 .Build();
             _container = container;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
@@ -29,8 +29,8 @@ public class SynchronizerModuleTests
                 FastSync = true,
                 VerifyTrieOnStateSyncFinished = true
             }))
-            .AddSingleton(treeSync)
-            .AddSingleton(Substitute.For<IWorldStateManager>())
+            .AddInstance(treeSync)
+            .AddInstance(Substitute.For<IWorldStateManager>())
             .Build();
     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -295,13 +295,13 @@ public class SynchronizerTests
             IConfigProvider configProvider = new ConfigProvider(syncConfig, mergeConfig, pruningConfig);
             ContainerBuilder builder = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
-                .AddSingleton<ISpecProvider>(MainnetSpecProvider.Instance)
-                .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)
-                .AddSingleton(Substitute.For<IProcessExitSource>())
-                .AddSingleton<ISealValidator>(Always.Valid)
-                .AddSingleton<IBlockValidator>(Always.Valid)
+                .AddInstance<ISpecProvider>(MainnetSpecProvider.Instance)
+                .AddInstance<IReceiptStorage>(NullReceiptStorage.Instance)
+                .AddInstance(Substitute.For<IProcessExitSource>())
+                .AddInstance<ISealValidator>(Always.Valid)
+                .AddInstance<IBlockValidator>(Always.Valid)
                 .AddSingleton<ContainerDependencies>()
-                .AddSingleton(_logManager);
+                .AddInstance(_logManager);
 
             if (IsMerge(synchronizerType))
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/TestSynchronizerModule.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/TestSynchronizerModule.cs
@@ -23,14 +23,14 @@ public class TestSynchronizerModule(ISyncConfig syncConfig) : Module
         builder
             .AddModule(new SynchronizerModule(syncConfig))
             .AddModule(new DbModule())
-            .AddSingleton<IDbProvider>(TestMemDbProvider.Init())
+            .AddInstance<IDbProvider>(TestMemDbProvider.Init())
             .Map<INodeStorage, IDbProvider>(dbProvider => new NodeStorage(dbProvider.StateDb))
-            .AddSingleton<IBlockTree>(Substitute.For<IBlockTree>())
-            .AddSingleton<ITimerFactory>(Substitute.For<ITimerFactory>())
-            .AddSingleton<ISyncConfig>(syncConfig)
-            .AddSingleton<IBetterPeerStrategy>(new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance))
+            .AddInstance<IBlockTree>(Substitute.For<IBlockTree>())
+            .AddInstance<ITimerFactory>(Substitute.For<ITimerFactory>())
+            .AddInstance<ISyncConfig>(syncConfig)
+            .AddInstance<IBetterPeerStrategy>(new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance))
             .AddSingleton<INodeStatsManager, NodeStatsManager>()
             .AddSingleton<CancelOnDisposeToken>()
-            .AddSingleton<ILogManager>(LimboLogs.Instance);
+            .AddInstance<ILogManager>(LimboLogs.Instance);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -146,7 +146,7 @@ public class HealingTreeTests
             configProvider.GetConfig<IInitConfig>().StateDbKeyScheme = keyScheme;
             return new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
-                .AddSingleton<IBlockTree>(Build.A.BlockTree().OfChainLength(1).TestObject)
+                .AddInstance<IBlockTree>(Build.A.BlockTree().OfChainLength(1).TestObject)
                 .Build();
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -302,10 +302,10 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .AddSingleton<SyncDbTuner>()
             .AddSingleton<MallocTrimmer>()
             .AddSingleton<ISyncPointers, SyncPointers>()
-            .AddSingleton<IBeaconSyncStrategy>(No.BeaconSync)
+            .AddInstance<IBeaconSyncStrategy>(No.BeaconSync)
             .AddSingleton<IPivot, Pivot>() // Used by sync report
             .AddSingleton<IBetterPeerStrategy, TotalDifficultyBetterPeerStrategy>()
-            .AddSingleton<IPoSSwitcher>(NoPoS.Instance)
+            .AddInstance<IPoSSwitcher>(NoPoS.Instance)
 
             // For blocks. There are two block scope, Fast and Full
             .AddScoped<SyncFeedComponent<BlocksRequest>>()

--- a/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
@@ -220,7 +220,7 @@ public class TaikoModule : Module
             .AddSingleton<IL1OriginStore, L1OriginStore>()
 
             // Sync modification
-            .AddSingleton<IPoSSwitcher>(AlwaysPoS.Instance)
+            .AddInstance<IPoSSwitcher>(AlwaysPoS.Instance)
             .AddSingleton<StartingSyncPivotUpdater, UnsafeStartingSyncPivotUpdater>()
             .AddDecorator<BeaconSync>((_, strategy) =>
             {
@@ -232,7 +232,7 @@ public class TaikoModule : Module
             // Validators
             .AddSingleton<IBlockValidator, TaikoBlockValidator>()
             .AddSingleton<IHeaderValidator, TaikoHeaderValidator>()
-            .AddSingleton<IUnclesValidator>(Always.Valid)
+            .AddInstance<IUnclesValidator>(Always.Valid)
 
             // Blok processing
             .AddScoped<IValidationTransactionExecutor, TaikoBlockValidationTransactionExecutor>()

--- a/src/Nethermind/nuget.config
+++ b/src/Nethermind/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Extracted from #8932 to reduce that PR size.
- Rename `AddScoped` and `AddSingleton` that take an instance to `AddInstance` to prevent future mistake.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
