### PR TITLE
Use reference equals in clock cache

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
@@ -177,6 +177,18 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity, int? lockPartition
         public readonly int Offset = offset;
 
         public bool Equals(LruCacheItem other)
-            => other.Offset == Offset && EqualityComparer<TValue>.Default.Equals(other.Value, Value);
+        {
+            if (other.Offset != Offset)
+            {
+                return false;
+            }
+
+            if (typeof(TValue).IsValueType)
+            {
+                return EqualityComparer<TValue>.Default.Equals(other.Value, Value);
+            }
+
+            return ReferenceEquals(other.Value, Value);
+        }
     }
 }


### PR DESCRIPTION
## Changes

- https://github.com/NethermindEth/nethermind/pull/8679 fixed atomic updates; however if the value is a class type and implements `IEquatable<T>` then this will do a full element by element compare; whereas we are really just interested if same so can more efficiently use ReferenceEquals for these cases.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
