### PR TITLE
Make simulate env lazy

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Blockchain
             ISyncConfig? syncConfig,
             ILogManager? logManager)
         {
-            _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
+            _logger = logManager?.GetClassLogger<BlockTree>() ?? throw new ArgumentNullException(nameof(logManager));
             _blockStore = blockStore ?? throw new ArgumentNullException(nameof(blockStore));
             _headerStore = headerDb ?? throw new ArgumentNullException(nameof(headerDb));
             _blockInfoDb = blockInfoDb ?? throw new ArgumentNullException(nameof(blockInfoDb));

--- a/src/Nethermind/Nethermind.Facade/Simulate/ISimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/ISimulateReadOnlyBlocksProcessingEnv.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Facade.Simulate;
+
+public interface ISimulateReadOnlyBlocksProcessingEnv
+{
+    SimulateReadOnlyBlocksProcessingScope Begin(BlockHeader? baseBlock);
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/ISimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/ISimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Facade.Simulate;
+
+public interface ISimulateReadOnlyBlocksProcessingEnvFactory
+{
+    ISimulateReadOnlyBlocksProcessingEnv Create();
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockValidationTransactionsExecutor.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
+using Nethermind.Evm.Tracing;
+
+namespace Nethermind.Facade.Simulate;
+
+public class SimulateBlockValidationTransactionsExecutor(
+    IBlockProcessor.IBlockTransactionsExecutor baseTransactionExecutor,
+    SimulateRequestState simulateState)
+    : IBlockProcessor.IBlockTransactionsExecutor
+{
+    private IReleaseSpec _spec;
+    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
+    {
+        _spec = blockExecutionContext.Spec;
+        baseTransactionExecutor.SetBlockExecutionContext(in blockExecutionContext);
+    }
+
+    public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer,
+        CancellationToken token = default)
+    {
+        if (!simulateState.Validate)
+        {
+            processingOptions |= ProcessingOptions.ForceProcessing | ProcessingOptions.DoNotVerifyNonce | ProcessingOptions.NoValidation;
+        }
+
+        if (simulateState.BlobBaseFeeOverride is not null)
+        {
+            SetBlockExecutionContext(new BlockExecutionContext(block.Header, _spec, simulateState.BlobBaseFeeOverride.Value));
+        }
+
+        return baseTransactionExecutor.ProcessTransactions(block, processingOptions, receiptsTracer, token);
+    }
+
+    public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
+    {
+        add => baseTransactionExecutor.TransactionProcessed += value;
+        remove => baseTransactionExecutor.TransactionProcessed -= value;
+    }
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
@@ -11,63 +10,8 @@ using Nethermind.Db;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
-using Nethermind.Evm.Tracing;
-using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Int256;
 
 namespace Nethermind.Facade.Simulate;
-
-public class SimulateRequestState
-{
-    public bool Validate { get; set; }
-    public UInt256? BlobBaseFeeOverride { get; set; }
-}
-
-public class SimulateBlockValidationTransactionsExecutor(
-    IBlockProcessor.IBlockTransactionsExecutor baseTransactionExecutor,
-    SimulateRequestState simulateState)
-    : IBlockProcessor.IBlockTransactionsExecutor
-{
-    private IReleaseSpec _spec;
-    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
-    {
-        _spec = blockExecutionContext.Spec;
-        baseTransactionExecutor.SetBlockExecutionContext(in blockExecutionContext);
-    }
-
-    public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer,
-        CancellationToken token = default)
-    {
-        if (!simulateState.Validate)
-        {
-            processingOptions |= ProcessingOptions.ForceProcessing | ProcessingOptions.DoNotVerifyNonce | ProcessingOptions.NoValidation;
-        }
-
-        if (simulateState.BlobBaseFeeOverride is not null)
-        {
-            SetBlockExecutionContext(new BlockExecutionContext(block.Header, _spec, simulateState.BlobBaseFeeOverride.Value));
-        }
-
-        return baseTransactionExecutor.ProcessTransactions(block, processingOptions, receiptsTracer, token);
-    }
-
-    public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
-    {
-        add => baseTransactionExecutor.TransactionProcessed += value;
-        remove => baseTransactionExecutor.TransactionProcessed -= value;
-    }
-}
-
-public class SimulateTransactionProcessorAdapter(ITransactionProcessor transactionProcessor, SimulateRequestState simulateRequestState) : ITransactionProcessorAdapter
-{
-    public TransactionResult Execute(Transaction transaction, ITxTracer txTracer)
-    {
-        return simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Trace(transaction, txTracer);
-    }
-
-    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
-        => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
-}
 
 /// <summary>
 /// This is an env for eth simulater. It is constructed by <see cref="SimulateReadOnlyBlocksProcessingEnvFactory"/>.
@@ -84,7 +28,7 @@ public class SimulateReadOnlyBlocksProcessingEnv(
     BlockTreeOverlay blockTreeOverlay,
     IOverridableEnv overridableEnv,
     IReadOnlyDbProvider readOnlyDbProvider
-)
+) : ISimulateReadOnlyBlocksProcessingEnv
 {
     public SimulateReadOnlyBlocksProcessingScope Begin(BlockHeader? baseBlock)
     {

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateRequestState.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateRequestState.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Int256;
+
+namespace Nethermind.Facade.Simulate;
+
+public class SimulateRequestState
+{
+    public bool Validate { get; set; }
+    public UInt256? BlobBaseFeeOverride { get; set; }
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Evm;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+
+namespace Nethermind.Facade.Simulate;
+
+public class SimulateTransactionProcessorAdapter(ITransactionProcessor transactionProcessor, SimulateRequestState simulateRequestState) : ITransactionProcessorAdapter
+{
+    public TransactionResult Execute(Transaction transaction, ITxTracer txTracer)
+    {
+        return simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Trace(transaction, txTracer);
+    }
+
+    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
+        => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
+}

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -19,7 +19,6 @@ using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Facade.Simulate;
 using Nethermind.JsonRpc.Modules.Eth.GasPrice;
 using Nethermind.Logging;
 using Nethermind.State;

--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -82,7 +82,7 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
                     .AddSingleton<IFeeHistoryOracle, FeeHistoryOracle>()
                     .AddSingleton<IFilterStore, ITimerFactory, IJsonRpcConfig>((timerFactory, rpcConfig) => new FilterStore(timerFactory, rpcConfig.FiltersTimeout))
                     .AddSingleton<IFilterManager, IFilterStore, IMainProcessingContext, ITxPool, ILogManager>((store, processingContext, txPool, logManager) => new FilterManager(store, processingContext.BlockProcessor, txPool, logManager))
-                    .AddSingleton<SimulateReadOnlyBlocksProcessingEnvFactory>()
+                    .AddSingleton<ISimulateReadOnlyBlocksProcessingEnvFactory, SimulateReadOnlyBlocksProcessingEnvFactory>()
 
             // Proof
             .RegisterBoundedJsonRpcModule<IProofRpcModule, ProofModuleFactory>(2, jsonRpcConfig.Timeout)


### PR DESCRIPTION
- Turns out the blocktree used by the overlay blocktree in eth simulate is quiet heavy. And the fact that blockchain bridge is used a lot causes it to be loaded almost all the time.
- This PR make the simulate env lazy. 
- Also hide the blocktree logger.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- No longer show up logs.