### PR TITLE
docs: fix dead link

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/AnalyzerReleases.Unshipped.md
@@ -1,5 +1,5 @@
 ; Unshipped analyzer release
-; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+; https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
 ### New Rules
 


### PR DESCRIPTION
## Changes
- Fixed dead link to analyzer documentation

## Context
The analyzer documentation was migrated to the Roslyn repository in https://github.com/dotnet/roslyn-analyzers/pull/7603

Dead link:
`https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md`

New link:
`https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md`

## Testing
- [x] Verified new link resolves correctly
- [x] Confirmed content matches original documentation

## Types of changes
- [x] Documentation update