### PR TITLE
Renable targeted GC cleanup

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -239,7 +239,7 @@ public abstract partial class BaseEngineModuleTests
                 .AddSingleton<ISyncProgressResolver>(Substitute.For<ISyncProgressResolver>())
                 .AddSingleton<ISyncModeSelector>(new StaticSelector(SyncMode.All))
                 .AddSingleton<IPeerRefresher>(Substitute.For<IPeerRefresher>())
-                .Intercept<IInitConfig>((initConfig) => initConfig.DisableGcOnNewPayload = true);
+                .Intercept<IInitConfig>((initConfig) => initConfig.DisableGcOnNewPayload = false);
 
         protected override IBlockProducer CreateTestBlockProducer()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -333,8 +333,8 @@ public class BaseMergePluginModule : Module
                     IInitConfig initConfig = ctx.Resolve<IInitConfig>();
                     return new GCKeeper(
                         initConfig.DisableGcOnNewPayload
-                            ? NoGCStrategy.Instance
-                            : ctx.Resolve<NoSyncGcRegionStrategy>(),
+                            ? ctx.Resolve<NoSyncGcRegionStrategy>()
+                            : NoGCStrategy.Instance,
                         ctx.Resolve<ILogManager>());
                 })
             ;

--- a/src/Nethermind/Nethermind.Runner/configs/base-mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/base-mainnet_archive.json
@@ -4,8 +4,7 @@
     "ChainSpecPath": "chainspec/base-mainnet.json.zst",
     "GenesisHash": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd",
     "BaseDbPath": "nethermind_db/base-mainnet_archive",
-    "LogFileName": "base-mainnet_archive.log",
-    "DisableGcOnNewPayload": false
+    "LogFileName": "base-mainnet_archive.log"
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
@@ -4,8 +4,7 @@
     "ChainSpecPath": "chainspec/taiko-alethia.json",
     "GenesisHash": "0x90bc60466882de9637e269e87abab53c9108cf9113188bc4f80bcfcb10e489b9",
     "BaseDbPath": "nethermind_db/taiko-alethia",
-    "LogFileName": "taiko-alethia.log",
-    "DisableGcOnNewPayload": false
+    "LogFileName": "taiko-alethia.log"
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Runner/configs/taiko-hekla.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-hekla.json
@@ -4,8 +4,7 @@
     "ChainSpecPath": "chainspec/taiko-hekla.json",
     "GenesisHash": "0x1f5554042aa50dc0712936ae234d8803b80b84251f85d074756a2f391896e109",
     "BaseDbPath": "nethermind_db/taiko-hekla",
-    "LogFileName": "taiko-hekla.log",
-    "DisableGcOnNewPayload": false
+    "LogFileName": "taiko-hekla.log"
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Runner/configs/worldchain-mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/worldchain-mainnet_archive.json
@@ -4,8 +4,7 @@
     "ChainSpecPath": "chainspec/worldchain-mainnet.json.zst",
     "GenesisHash": "0x70d316d2e0973b62332ba2e9768dd7854298d7ffe77f0409ffdb8d859f2d3fa3",
     "BaseDbPath": "nethermind_db/worldchain-mainnet_archive",
-    "LogFileName": "worldchain-mainnet_archive.log",
-    "DisableGcOnNewPayload": false
+    "LogFileName": "worldchain-mainnet_archive.log"
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Runner/configs/worldchain-sepolia_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/worldchain-sepolia_archive.json
@@ -4,8 +4,7 @@
     "ChainSpecPath": "chainspec/worldchain-sepolia.json.zst",
     "GenesisHash": "0xf1deb67ee953f94d8545d2647918687fa8ba1f30fa6103771f11b7c483984070",
     "BaseDbPath": "nethermind_db/worldchain-sepolia_archive",
-    "LogFileName": "worldchain-sepolia_archive.log",
-    "DisableGcOnNewPayload": false
+    "LogFileName": "worldchain-sepolia_archive.log"
   },
   "TxPool": {
     "BlobsSupport": "Disabled"


### PR DESCRIPTION
## Changes

- https://github.com/NethermindEth/nethermind/pull/8919 inverted the GC condition leading switching off manual memory management around newpayload to automated memory management, which causes the GC to be in greedy mode and not release memory until it has filled the available RAM. Switching back allows it to release the memory more aggressively, leaving more for SSD cache

![image](https://github.com/user-attachments/assets/26bc80e9-7d8b-4d22-b8cf-7b23d8d8be5c)


- Also make it the setting for other networks that have it switched off

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No