### PR TITLE
Fix Failing Ethereum Tests

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/EvmToIlEmitter.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/EvmToIlEmitter.cs
@@ -561,8 +561,8 @@ internal static class OpcodeEmitters
         Label endOfOpcode = method.DefineLabel(locals.GetLabelName());
 
         using Local byteMatrix = method.DeclareLocal(typeof(byte[][]), locals.GetLocalName());
-        envLoader.LoadTxContext(method, locals, true);
-        method.LoadFieldAddress(GetFieldInfo(typeof(TxExecutionContext), nameof(TxExecutionContext.BlobVersionedHashes)));
+        envLoader.LoadTxContext(method, locals, false);
+        method.LoadField(GetFieldInfo(typeof(TxExecutionContext), nameof(TxExecutionContext.BlobVersionedHashes)));
         method.StoreLocal(byteMatrix);
 
         method.LoadLocal(byteMatrix);

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/IlAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/IlAnalyzer.cs
@@ -346,14 +346,7 @@ public static class IlAnalyzer
             }
             notStart = false;
 
-            if (op.IsCall() || op.IsCreate())
-            {
-                lastOpcodeIsCallOrCreate = true;
-            }
-            else
-            {
-                lastOpcodeIsCallOrCreate = false;
-            }
+            lastOpcodeIsCallOrCreate = op.IsCall() || op.IsCreate();
         }
 
         if ((subsegmentStart < segmentRange.End.Value && !subSegmentData.ContainsKey(subsegmentStart)) || lastOpcodeIsAjumpdest)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/IlAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/IL/IlAnalyzer.cs
@@ -212,6 +212,7 @@ public static class IlAnalyzer
 
         bool notStart = true;
         bool lastOpcodeIsAjumpdest = false;
+        bool lastOpcodeIsCallOrCreate = false;
 
         bool requiresAvailabilityCheck = false;
         bool requiresStaticEnvCheck = false;
@@ -234,12 +235,16 @@ public static class IlAnalyzer
                     subSegment.Instructions = instructionsIncluded;
                     subSegment.RequiresOpcodeCheck = requiresAvailabilityCheck;
                     subSegment.RequiresStaticEnvCheck = requiresStaticEnvCheck;
-
                     gasOffsets[costStart] = coststack;
                     subSegmentData[subSegment.Start] = subSegment; // remember the stackHeadRef chain of opcodes
 
                     subsegmentStart = pc;
                     subSegment = new();
+                    if (lastOpcodeIsCallOrCreate)
+                    {
+                        subSegment.IsEntryPoint = true;
+                    }
+
                     instructionsIncluded = [op];
                     subSegment.Start = subsegmentStart;
 
@@ -340,6 +345,15 @@ public static class IlAnalyzer
                     break;
             }
             notStart = false;
+
+            if (op.IsCall() || op.IsCreate())
+            {
+                lastOpcodeIsCallOrCreate = true;
+            }
+            else
+            {
+                lastOpcodeIsCallOrCreate = false;
+            }
         }
 
         if ((subsegmentStart < segmentRange.End.Value && !subSegmentData.ContainsKey(subsegmentStart)) || lastOpcodeIsAjumpdest)


### PR DESCRIPTION
- Fix subsegment  metadata for segments starting at jumpdest after call or create. The proceeding subsegments should have entry point set to true but were being overwritten by the jumpdest metdata and being set to false. Hence Ilevm was not able to return to the original call frame if jumpdest followed a call or create

- Fix blob hash : TxExecutionContext is a ref field, that shouldn't be loaded as an address
