### PR TITLE
Revise JSON-RPC docs generation

### DIFF
--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -13,7 +13,7 @@ namespace Nethermind.DocGen;
 
 internal static class JsonRpcGenerator
 {
-    private const string _objectTypeName = "*object*";
+    private const string _objectTypeName = "_object_";
 
     internal static void Generate(string path)
     {
@@ -283,28 +283,28 @@ internal static class JsonRpcGenerator
             return GetJsonTypeName(underlyingType);
 
         if (type.IsEnum)
-            return "*integer*";
+            return "_integer_";
 
         if (TryGetEnumerableItemType(type, out var itemType, out var isDictionary))
             return $"{(isDictionary ? "map" : "array")} of {GetJsonTypeName(itemType!)}";
 
         return type.Name switch
         {
-            "Address" => "*string* (address)",
+            "Address" => "_string_ (address)",
             "BigInteger"
                 or "Int32"
                 or "Int64"
                 or "Int64&"
                 or "UInt64"
-                or "UInt256" => "*string* (hex integer)",
-            "BlockParameter" => "*string* (block number or hash or either of `earliest`, `finalized`, `latest`, `pending`, or `safe`)",
+                or "UInt256" => "_string_ (hex integer)",
+            "BlockParameter" => "_string_ (block number or hash or either of `earliest`, `finalized`, `latest`, `pending`, or `safe`)",
             "Bloom"
                 or "Byte"
-                or "Byte[]" => "*string* (hex data)",
-            "Boolean" => "*boolean*",
-            "Hash256" => "*string* (hash)",
-            "String" => "*string*",
-            "TxType" => "*string* (transaction type)",
+                or "Byte[]" => "_string_ (hex data)",
+            "Boolean" => "_boolean_",
+            "Hash256" => "_string_ (hash)",
+            "String" => "_string_",
+            "TxType" => "_string_ (transaction type)",
             _ => _objectTypeName
         };
     }

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -297,7 +297,7 @@ internal static class JsonRpcGenerator
         }
         catch (Exception)
         {
-            Console.WriteLine($"Failed copying from {fileName}");
+            AnsiConsole.WriteLine($"[red]Failed copying from[/] {fileName}");
         }
     }
 


### PR DESCRIPTION
## Changes

- Updated JSON-RPC docs generation to include namespaces like `flashbots`, `rbuilder`, `health`. Also, included lots of methods that were missing in the `admin` namespace. Generation results are available [here](https://docs.nethermind.io/next/interacting/json-rpc-ns/admin) (see sidebar namespaces too).
- Revised markdown

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No
