### PR TITLE
Only warn about 4444 once

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
@@ -118,7 +118,7 @@ namespace Nethermind.JsonRpc
         public const int ClientLimitExceededError = -38026;
 
         /// <summary>
-        /// Block is not available due to history expirty policy
+        /// Block is not available due to history expiry policy
         /// </summary>
         public const int PrunedHistoryUnavailable = 4444;
     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -380,9 +380,10 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         bool isSuccess = localErrorResponse is null;
         if (!isSuccess)
         {
-            if (localErrorResponse?.Error?.SuppressWarning == false)
+            int code = localErrorResponse?.Error?.Code ?? 0;
+            if (localErrorResponse?.Error?.SuppressWarning == false && ShouldWarn(code))
             {
-                if (_logger.IsWarn) _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {localErrorResponse.Error.Code} Message: {localErrorResponse.Error.Message}");
+                if (_logger.IsWarn) _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {code} Message: {localErrorResponse.Error.Message}");
                 if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {JsonSerializer.Serialize(localErrorResponse, EthereumJsonSerializer.JsonOptionsIndented)}");
             }
             Metrics.JsonRpcErrors++;
@@ -397,6 +398,17 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
         if (_logger.IsTrace) TraceResult(result);
         return result;
+    }
+
+    private bool _hasWarnedAbout4444 = false;
+    private bool ShouldWarn(int code)
+    {
+        if (code == 4444)
+        {
+            return !Interlocked.Exchange(ref _hasWarnedAbout4444, true);
+        }
+
+        return true;
     }
 
     private static bool TryParseJson(ref ReadOnlySequence<byte> buffer, [NotNullWhen(true)] out JsonDocument? jsonDocument)


### PR DESCRIPTION
## Changes

- Only warn about 4444 once per run, rather than per request (very noisy)

<img width="1770" height="1104" alt="image" src="https://github.com/user-attachments/assets/a49c6424-e46f-4950-9a56-f0873b2220f0" />

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Logging

## Testing

#### Requires testing

- [x] No
