### PR TITLE
Fix Taiko Engine Api

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Container/OrderedComponentsTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Container/OrderedComponentsTests.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using FluentAssertions;
+using Nethermind.Core.Container;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Container;
+
+public class OrderedComponentsTests
+{
+    [Test]
+    public void TestNestedModuleConsistency()
+    {
+        using IContainer ctx = new ContainerBuilder()
+            .AddModule(new ModuleA())
+            .AddLast(_ => new Item("4"))
+            .Build();
+
+        ctx.Resolve<Item[]>().Select(item => item.Name).Should().BeEquivalentTo(["1", "2", "3", "4"]);
+        ctx.Resolve<IEnumerable<Item>>().Select(item => item.Name).Should().BeEquivalentTo(["1", "2", "3", "4"]);
+        ctx.Resolve<IReadOnlyList<Item>>().Select(item => item.Name).Should().BeEquivalentTo(["1", "2", "3", "4"]);
+    }
+
+    [Test]
+    public void TestAddFirst()
+    {
+        using IContainer ctx = new ContainerBuilder()
+            .AddLast(_ => new Item("2"))
+            .AddLast(_ => new Item("3"))
+            .AddFirst(_ => new Item("1"))
+            .Build();
+
+        ctx.Resolve<Item[]>().Select(item => item.Name).Should().BeEquivalentTo(["1", "2", "3"]);
+    }
+
+    [Test]
+    public void TestDisallowIndividualRegistration()
+    {
+        Action act = () => new ContainerBuilder()
+            .AddLast(_ => new Item("1"))
+            .AddSingleton<Item>(_ => new Item("2"))
+            .Build();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private class ModuleA : Module
+    {
+        protected override void Load(ContainerBuilder builder) =>
+            builder
+                .AddModule(new ModuleB())
+                .AddLast(_ => new Item("3"));
+    }
+
+    private class ModuleB : Module
+    {
+        protected override void Load(ContainerBuilder builder) =>
+            builder
+                .AddModule(new ModuleC())
+                .AddLast(_ => new Item("2"));
+    }
+
+
+    private class ModuleC : Module
+    {
+        protected override void Load(ContainerBuilder builder) =>
+            builder
+                .AddLast(_ => new Item("1"));
+    }
+    private record Item(string Name);
+}

--- a/src/Nethermind/Nethermind.Core/Container/OrderedComponents.cs
+++ b/src/Nethermind/Nethermind.Core/Container/OrderedComponents.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Nethermind.Core.Container;
 
-public class OrderedComponents<T>: List<T>
+public class OrderedComponents<T>
 {
     private IList<T> _components = new List<T>();
     public IEnumerable<T> Components => _components;

--- a/src/Nethermind/Nethermind.Core/Container/OrderedComponents.cs
+++ b/src/Nethermind/Nethermind.Core/Container/OrderedComponents.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Nethermind.Core.Container;
+
+public class OrderedComponents<T>: List<T>
+{
+    private IList<T> _components = new List<T>();
+    public IEnumerable<T> Components => _components;
+
+    public void AddLast(T item)
+    {
+        _components.Add(item);
+    }
+
+    public void AddFirst(T item)
+    {
+        _components.Insert(0, item);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Autofac.Core;
+
+namespace Nethermind.Core.Container;
+
+/// <summary>
+/// A set of dsl to register components where the order matter. Internally it has an <see cref="OrderedComponents{T}"/>
+/// and uses decorators to add the items. The order of invocation matter, but there is explicit method like <see cref="AddFirst{T}"/>
+/// allowing component that should appear first to appear first.
+/// </summary>
+public static class OrderedComponentsContainerBuilderExtensions
+{
+    public static ContainerBuilder AddLast<T>(this ContainerBuilder builder, Func<IComponentContext, T> factory) =>
+        builder
+            .EnsureOrderedComponents<T>()
+            .AddDecorator<OrderedComponents<T>>((ctx, orderedComponents) =>
+            {
+                orderedComponents.AddLast(factory(ctx));
+                return orderedComponents;
+            });
+
+    public static ContainerBuilder AddFirst<T>(this ContainerBuilder builder, Func<IComponentContext, T> factory) =>
+        builder
+            .EnsureOrderedComponents<T>()
+            .AddDecorator<OrderedComponents<T>>((ctx, orderedComponents) =>
+            {
+                orderedComponents.AddFirst(factory(ctx));
+                return orderedComponents;
+            });
+
+    private static ContainerBuilder EnsureOrderedComponents<T>(this ContainerBuilder builder)
+    {
+        string registeredMarker = $"Registerd OrderedComponents For {typeof(T).Name}";
+        if (!builder.Properties.TryAdd(registeredMarker, null))
+        {
+            return builder;
+        }
+
+        // Prevent registering separately which has no explicit ordering
+        builder.RegisterBuildCallback(scope =>
+        {
+            if (scope.ComponentRegistry.ServiceRegistrationsFor(new TypedService(typeof(T))).Any())
+            {
+                throw new InvalidOperationException(
+                    $"Service of type {typeof(T).Name} must only be registered with one of DSL in {nameof(OrderedComponentsContainerBuilderExtensions)}");
+            }
+        });
+
+        // Not a singleton which allow it to work seamlessly with scoped lifetime with additional component
+        builder.Add<OrderedComponents<T>>();
+
+        builder
+            .Register((ctx) => ctx.Resolve<OrderedComponents<T>>().Components)
+            .As<IEnumerable<T>>()
+            .Fixed();
+
+        builder.Register((ctx) => ctx.Resolve<OrderedComponents<T>>().Components.ToArray())
+            .As<IReadOnlyList<T>>()
+            .As<T[]>()
+            .Fixed();
+
+        builder.Register((ctx) => ctx.Resolve<OrderedComponents<T>>().Components.ToList())
+            .As<IList<T>>()
+            .Fixed();
+
+        return builder;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Autofac;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Core.Registration;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core.Container;
@@ -477,6 +478,13 @@ public static class ContainerBuilderExtensions
             return (ctx) => ctx.ResolveKeyed<T>(keyFilter.Key);
         }
         return (ctx) => ctx.Resolve<T>();
+    }
+
+    public static IRegistrationBuilder<T, TAct, TStyle> Fixed<T, TAct, TStyle>(this IRegistrationBuilder<T, TAct, TStyle> reg)
+    {
+        // Fixed registration is one where it is always the default. Can't be overridden by later registration.
+        reg.RegistrationData.Options |= RegistrationOptions.Fixed;
+        return reg;
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IContainerBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Autofac;
 using Nethermind.Core;
+using Nethermind.Core.Container;
 
 namespace Nethermind.JsonRpc.Modules;
 
@@ -19,7 +20,7 @@ public static class IContainerBuilderExtensions
     public static ContainerBuilder RegisterSingletonJsonRpcModule<T>(this ContainerBuilder builder) where T : IRpcModule
     {
         return builder
-            .AddSingleton<RpcModuleInfo>((ctx) =>
+            .AddLast<RpcModuleInfo>((ctx) =>
             {
                 Lazy<T> instance = ctx.Resolve<Lazy<T>>();
                 return new RpcModuleInfo(typeof(T), new LazyModulePool<T>(new Lazy<IRpcModulePool<T>>(() =>
@@ -39,7 +40,7 @@ public static class IContainerBuilderExtensions
         return builder
             .AddSingleton<TFactory>()
             .AddSingleton<IRpcModuleFactory<T>, TFactory>()
-            .AddSingleton<RpcModuleInfo>((ctx) =>
+            .AddLast<RpcModuleInfo>((ctx) =>
             {
                 Lazy<IRpcModuleFactory<T>> factory = ctx.Resolve<Lazy<IRpcModuleFactory<T>>>();
                 return new RpcModuleInfo(typeof(T), new LazyModulePool<T>(new Lazy<IRpcModulePool<T>>(() =>


### PR DESCRIPTION
- The auto collection resolver have a weird ordering behaviour with nested module causing the default engine api to be used instead of taiko's engine api as its registration appear later than taiko's. 
- This PR add some explicit DSL to ensure ordering.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Logged the registered module order.