### PR TITLE
Fix/OOM when downloading from genesis.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -173,4 +173,7 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = "_Technical._ Max tx in forward sync buffer.", DefaultValue = "200000", HiddenFromDocs = true)]
     int MaxTxInForwardSyncBuffer { get; set; }
+
+    [ConfigItem(Description = "_Technical._ Max tx waiting for processing before stopping.", DefaultValue = "400000", HiddenFromDocs = true)]
+    int MaxTxInProcessingQueue { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -171,9 +171,9 @@ public interface ISyncConfig : IConfig
     [ConfigItem(Description = "_Technical._ Enable storage range split.", DefaultValue = "false", HiddenFromDocs = true)]
     bool EnableSnapSyncStorageRangeSplit { get; set; }
 
-    [ConfigItem(Description = "_Technical._ Max tx in forward sync buffer.", DefaultValue = "200000", HiddenFromDocs = true)]
-    int MaxTxInForwardSyncBuffer { get; set; }
+    [ConfigItem(Description = "_Technical._ Estimated size of memory for storing blocks during download.", DefaultValue = "200000000", HiddenFromDocs = true)]
+    long ForwardSyncDownloadBufferMemoryBudget { get; set; }
 
-    [ConfigItem(Description = "_Technical._ Max tx waiting for processing before stopping.", DefaultValue = "400000", HiddenFromDocs = true)]
-    int MaxTxInProcessingQueue { get; set; }
+    [ConfigItem(Description = "_Technical._ Estimated max size of blocks in block processing queue before stop downloading.", DefaultValue = "200000000", HiddenFromDocs = true)]
+    long ForwardSyncBlockProcessingQueueMemoryBudget { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -83,8 +83,8 @@ namespace Nethermind.Blockchain.Synchronization
 
         public ulong FastHeadersMemoryBudget { get; set; } = (ulong)128.MB();
         public bool EnableSnapSyncStorageRangeSplit { get; set; } = false;
-        public int MaxTxInForwardSyncBuffer { get; set; } = 200000;
-        public int MaxTxInProcessingQueue { get; set; } = 400000;
+        public long ForwardSyncDownloadBufferMemoryBudget { get; set; } = 200.MiB();
+        public long ForwardSyncBlockProcessingQueueMemoryBudget { get; set; } = 200.MiB();
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -83,7 +83,8 @@ namespace Nethermind.Blockchain.Synchronization
 
         public ulong FastHeadersMemoryBudget { get; set; } = (ulong)128.MB();
         public bool EnableSnapSyncStorageRangeSplit { get; set; } = false;
-        public int MaxTxInForwardSyncBuffer { get; set; } = 20000;
+        public int MaxTxInForwardSyncBuffer { get; set; } = 200000;
+        public int MaxTxInProcessingQueue { get; set; } = 400000;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -18,32 +18,36 @@ using Nethermind.Synchronization.Reporting;
 
 namespace Nethermind.Merge.Plugin.Synchronization
 {
-    public class MergeBlockDownloader : BlockDownloader
+    public class MergeBlockDownloader(
+        IBeaconPivot beaconPivot,
+        IBlockTree blockTree,
+        IBlockValidator blockValidator,
+        ISyncReport syncReport,
+        IReceiptStorage receiptStorage,
+        ISpecProvider specProvider,
+        IBetterPeerStrategy betterPeerStrategy,
+        IFullStateFinder fullStateFinder,
+        IForwardHeaderProvider forwardHeaderProvider,
+        ISyncPeerPool syncPeerPool,
+        IReceiptsRecovery receiptsRecovery,
+        ISyncConfig syncConfig,
+        ILogManager logManager)
+        : BlockDownloader(
+            blockTree,
+            blockValidator,
+            syncReport,
+            receiptStorage,
+            specProvider,
+            betterPeerStrategy,
+            fullStateFinder,
+            forwardHeaderProvider,
+            syncPeerPool,
+            receiptsRecovery,
+            syncConfig,
+            logManager)
     {
-        private readonly IBeaconPivot _beaconPivot;
-        private readonly IBlockTree _blockTree;
-        private readonly ILogger _logger;
-
-        public MergeBlockDownloader(
-            IBeaconPivot beaconPivot,
-            IBlockTree? blockTree,
-            IBlockValidator? blockValidator,
-            ISyncReport? syncReport,
-            IReceiptStorage? receiptStorage,
-            ISpecProvider specProvider,
-            IBetterPeerStrategy betterPeerStrategy,
-            IFullStateFinder fullStateFinder,
-            IForwardHeaderProvider forwardHeaderProvider,
-            ISyncPeerPool syncPeerPool,
-            ISyncConfig syncConfig,
-            ILogManager logManager)
-            : base(blockTree, blockValidator, syncReport, receiptStorage,
-                specProvider, betterPeerStrategy, fullStateFinder, forwardHeaderProvider, syncPeerPool, syncConfig, logManager)
-        {
-            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-            _beaconPivot = beaconPivot;
-            _logger = logManager.GetClassLogger();
-        }
+        private readonly IBlockTree _blockTree = blockTree;
+        private readonly ILogger _logger = logManager.GetClassLogger();
 
         protected override BlockTreeSuggestOptions GetSuggestOption(bool shouldProcess, Block currentBlock)
         {
@@ -51,7 +55,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                 shouldProcess ? BlockTreeSuggestOptions.ShouldProcess : BlockTreeSuggestOptions.None;
 
             bool isKnownBeaconBlock = _blockTree.IsKnownBeaconBlock(currentBlock.Number, currentBlock.GetOrCalculateHash());
-            if (_logger.IsTrace) _logger.Trace($"Current block {currentBlock}, BeaconPivot: {_beaconPivot.PivotNumber}, IsKnownBeaconBlock: {isKnownBeaconBlock}");
+            if (_logger.IsTrace) _logger.Trace($"Current block {currentBlock}, BeaconPivot: {beaconPivot.PivotNumber}, IsKnownBeaconBlock: {isKnownBeaconBlock}");
 
             if (isKnownBeaconBlock)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -30,6 +31,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
         IForwardHeaderProvider forwardHeaderProvider,
         ISyncPeerPool syncPeerPool,
         IReceiptsRecovery receiptsRecovery,
+        IBlockProcessingQueue blockProcessingQueue,
         ISyncConfig syncConfig,
         ILogManager logManager)
         : BlockDownloader(
@@ -43,6 +45,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             forwardHeaderProvider,
             syncPeerPool,
             receiptsRecovery,
+            blockProcessingQueue,
             syncConfig,
             logManager)
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -519,7 +519,7 @@ public partial class BlockDownloaderTests
         await using IContainer node = CreateNode(builder => builder
             .AddDecorator<ISyncConfig>((_, syncConfig) =>
             {
-                syncConfig.MaxTxInForwardSyncBuffer = 3200;
+                syncConfig.ForwardSyncBlockProcessingQueueMemoryBudget = 3200000;
                 return syncConfig;
             })
             .AddSingleton<IBlockValidator>(Always.Invalid));

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -519,7 +519,7 @@ public partial class BlockDownloaderTests
         await using IContainer node = CreateNode(builder => builder
             .AddDecorator<ISyncConfig>((_, syncConfig) =>
             {
-                syncConfig.ForwardSyncBlockProcessingQueueMemoryBudget = 3200000;
+                syncConfig.ForwardSyncDownloadBufferMemoryBudget = 3200000;
                 return syncConfig;
             })
             .AddSingleton<IBlockValidator>(Always.Invalid));

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -217,9 +217,9 @@ public partial class BlockDownloaderTests
         blockProcessingQueue.Count.Returns(10000);
 
         await using IContainer node = CreateNode(configProvider: new ConfigProvider(new SyncConfig()
-            {
-                FastSync = true
-            }),
+        {
+            FastSync = true
+        }),
             configurer: (builder) => builder
                 .AddSingleton<IForwardHeaderProvider>(mockForwardHeaderProvider)
                 .AddSingleton<IBlockProcessingQueue>(blockProcessingQueue));

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -72,31 +72,31 @@ namespace Nethermind.Synchronization.Blocks
         private SemaphoreSlim _requestLock = new(1);
 
         public BlockDownloader(
-            IBlockTree? blockTree,
-            IBlockValidator? blockValidator,
-            ISyncReport? syncReport,
-            IReceiptStorage? receiptStorage,
-            ISpecProvider? specProvider,
+            IBlockTree blockTree,
+            IBlockValidator blockValidator,
+            ISyncReport syncReport,
+            IReceiptStorage receiptStorage,
+            ISpecProvider specProvider,
             IBetterPeerStrategy betterPeerStrategy,
             IFullStateFinder fullStateFinder,
             IForwardHeaderProvider forwardHeaderProvider,
             ISyncPeerPool syncPeerPool,
+            IReceiptsRecovery receiptsRecovery,
             ISyncConfig syncConfig,
-            ILogManager? logManager)
+            ILogManager logManager)
         {
-            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-            _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));
-            _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
-            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
-            _betterPeerStrategy = betterPeerStrategy ?? throw new ArgumentNullException(nameof(betterPeerStrategy));
-            _fullStateFinder = fullStateFinder ?? throw new ArgumentNullException(nameof(fullStateFinder));
+            _blockTree = blockTree;
+            _blockValidator = blockValidator;
+            _syncReport = syncReport;
+            _receiptStorage = receiptStorage;
+            _specProvider = specProvider;
+            _betterPeerStrategy = betterPeerStrategy;
+            _fullStateFinder = fullStateFinder;
             _forwardHeaderProvider = forwardHeaderProvider;
             _syncPeerPool = syncPeerPool;
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _maxTxInBuffer = syncConfig.MaxTxInForwardSyncBuffer;
-
-            _receiptsRecovery = new ReceiptsRecovery(new EthereumEcdsa(_specProvider.ChainId), _specProvider);
+            _receiptsRecovery = receiptsRecovery;
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -99,8 +99,9 @@ namespace Nethermind.Synchronization.Blocks
             _forwardHeaderProvider = forwardHeaderProvider;
             _syncPeerPool = syncPeerPool;
             _logger = logManager.GetClassLogger();
-            _maxTxInBuffer = syncConfig.MaxTxInForwardSyncBuffer;
-            _maxTxInInProcessingQueue = syncConfig.MaxTxInProcessingQueue;
+            // Assume that each tx cost about 1kb.
+            _maxTxInBuffer = (int)(syncConfig.ForwardSyncDownloadBufferMemoryBudget / 1000);
+            _maxTxInInProcessingQueue = (int)(syncConfig.ForwardSyncBlockProcessingQueueMemoryBudget / 1000);
             _receiptsRecovery = receiptsRecovery;
             _processingQueue = processingQueue;
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;


### PR DESCRIPTION
- Block downloader can download block faster than nethermind can process.
- This causes OOM when syncing from genesis as the blocks are buffered in block processing queue.
- This PR stop spawing request when the size of the processing queue exceed certain configured threshold.
- This and previous download buffer size is not configured as MB, although internally it still use TX count.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet can sync normally
