### PR TITLE
Cache PropertyInfo lookups for JsonRpc

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/TypeAsKey.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/TypeAsKey.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Core.Collections;
+
+public readonly struct TypeAsKey(Type key) : IEquatable<TypeAsKey>
+{
+    private readonly Type _key = key;
+
+    public static implicit operator Type(TypeAsKey key) => key._key;
+    public static implicit operator TypeAsKey(Type key) => new(key);
+
+    public bool Equals(TypeAsKey other) => ReferenceEquals(_key, other._key);
+    public override int GetHashCode() => _key?.GetHashCode() ?? 0;
+    public override bool Equals(object? obj) => obj is TypeAsKey && Equals((TypeAsKey)obj);
+}


### PR DESCRIPTION
## Changes

- Cache PropertyInfo lookups for JsonRpc rather than searching with reflection each time

Before

<img width="1119" height="553" alt="image" src="https://github.com/user-attachments/assets/10cbd9c5-9f7c-40f0-ad0e-cd733489d1bb" />

After

<img  alt="image" src="https://github.com/user-attachments/assets/43dbc9a8-369a-4a63-8ab3-9fa68c81b758" />


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No