### PR TITLE
Separate branch and block processor

### DIFF
--- a/src/Nethermind/Nethermind.Api/IMainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Api/IMainProcessingContext.cs
@@ -19,6 +19,7 @@ namespace Nethermind.Api;
 public interface IMainProcessingContext : IStoppableService
 {
     ITransactionProcessor TransactionProcessor { get; }
+    IBranchProcessor BranchProcessor { get; }
     IBlockProcessor BlockProcessor { get; }
     IBlockchainProcessor BlockchainProcessor { get; }
     IWorldState WorldState { get; }

--- a/src/Nethermind/Nethermind.Api/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Api/MainProcessingContext.cs
@@ -9,6 +9,7 @@ namespace Nethermind.Api;
 
 public record MainProcessingContext(
     ITransactionProcessor TransactionProcessor,
+    IBranchProcessor BranchProcessor,
     IBlockProcessor BlockProcessor,
     IBlockchainProcessor BlockchainProcessor,
     IWorldState WorldState

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
@@ -23,7 +23,7 @@ namespace Nethermind.AuRa.Test
     public class AuRaBlockFinalizationManagerTests
     {
         private IChainLevelInfoRepository _chainLevelInfoRepository;
-        private IBlockProcessor _blockProcessor;
+        private IBranchProcessor _blockProcessor;
         private IValidatorStore _validatorStore;
         private ILogManager _logManager;
         private IValidSealerStrategy _validSealerStrategy;
@@ -32,7 +32,7 @@ namespace Nethermind.AuRa.Test
         public void Initialize()
         {
             _chainLevelInfoRepository = Substitute.For<IChainLevelInfoRepository>();
-            _blockProcessor = Substitute.For<IBlockProcessor>();
+            _blockProcessor = Substitute.For<IBranchProcessor>();
             _validatorStore = Substitute.For<IValidatorStore>();
             _logManager = LimboLogs.Instance;
             _validSealerStrategy = Substitute.For<IValidSealerStrategy>();
@@ -47,7 +47,7 @@ namespace Nethermind.AuRa.Test
             FinalizeToLevel(1, blockTreeBuilder.ChainLevelInfoRepository);
 
             AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
             finalizationManager.LastFinalizedBlockLevel.Should().Be(1);
         }
 
@@ -88,7 +88,7 @@ namespace Nethermind.AuRa.Test
             HashSet<BlockHeader> finalizedBlocks = new();
 
             AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager, twoThirdsMajorityTransition);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
             finalizationManager.BlocksFinalized += (sender, args) =>
             {
                 foreach (BlockHeader block in args.FinalizedBlocks)
@@ -119,7 +119,7 @@ namespace Nethermind.AuRa.Test
             int count = 2;
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(count, 0, 0, false, TestItem.AddressA, TestItem.AddressB);
             AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             IEnumerable<bool> result = Enumerable.Range(0, count).Select(i => blockTreeBuilder.ChainLevelInfoRepository.LoadLevel(i).MainChainBlock.IsFinalized);
             result.Should().BeEquivalentTo(new[] { true, false });
@@ -143,7 +143,7 @@ namespace Nethermind.AuRa.Test
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree(genesis);
 
             AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             blockTreeBuilder
                 .OfChainLength(out Block headBlock, chainLength, 1, 0, false, TestItem.Addresses.Take(validators).ToArray())
@@ -187,7 +187,7 @@ namespace Nethermind.AuRa.Test
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(chainLength, 0, 0, false, beneficiaries);
             BlockTree blockTree = blockTreeBuilder.TestObject;
             AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             long result = finalizationManager.GetLastLevelFinalizedBy(blockTree.Head.Hash);
             return result;
@@ -218,7 +218,7 @@ namespace Nethermind.AuRa.Test
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(chainLength, 0, 0, false, beneficiaries);
             BlockTree blockTree = blockTreeBuilder.TestObject;
             AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             long? result = finalizationManager.GetFinalizationLevel(level);
             return result;
@@ -239,7 +239,7 @@ namespace Nethermind.AuRa.Test
                 _validSealerStrategy,
                 _logManager);
 
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             return finalizationManager.GetFinalizationLevel(level);
         }
@@ -259,7 +259,7 @@ namespace Nethermind.AuRa.Test
                 _validSealerStrategy,
                 _logManager,
                 twoThirdsMajorityTransition ? 0 : long.MaxValue);
-            finalizationManager.SetMainBlockProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             blockTreeBuilder.OfChainLength(chainLength, 0, 0, false, blockCreators);
             FinalizeToLevel(chainLength, blockTreeBuilder.ChainLevelInfoRepository);

--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -42,7 +42,7 @@ namespace Nethermind.AuRa.Test
         [Test]
         public void Prepared_block_contains_author_field()
         {
-            AuRaBlockProcessor processor = CreateProcessor().Processor;
+            BranchProcessor processor = CreateProcessor().Processor;
 
             BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).TestObject;
             Block block = Build.A.Block.WithHeader(header).TestObject;
@@ -62,7 +62,7 @@ namespace Nethermind.AuRa.Test
             txFilter
                 .IsAllowed(Arg.Any<Transaction>(), Arg.Any<BlockHeader>(), Arg.Any<IReleaseSpec>())
                 .Returns(AcceptTxResult.Accepted);
-            AuRaBlockProcessor processor = CreateProcessor(txFilter).Processor;
+            BranchProcessor processor = CreateProcessor(txFilter).Processor;
 
             BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).WithNumber(3).TestObject;
             Transaction tx = Nethermind.Core.Test.Builders.Build.A.Transaction.WithData(new byte[] { 0, 1 })
@@ -79,7 +79,7 @@ namespace Nethermind.AuRa.Test
         [Test]
         public void For_normal_processing_it_should_not_fail_with_gas_remaining_rules()
         {
-            AuRaBlockProcessor processor = CreateProcessor().Processor;
+            BranchProcessor processor = CreateProcessor().Processor;
             int gasLimit = 10000000;
             BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).WithNumber(3).TestObject;
             Transaction tx = Nethermind.Core.Test.Builders.Build.A.Transaction.WithData(new byte[] { 0, 1 })
@@ -96,7 +96,7 @@ namespace Nethermind.AuRa.Test
         [Test]
         public void Should_rewrite_contracts()
         {
-            static BlockHeader Process(AuRaBlockProcessor auRaBlockProcessor, BlockHeader parent)
+            static BlockHeader Process(BranchProcessor auRaBlockProcessor, BlockHeader parent)
             {
                 BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).WithParent(parent).TestObject;
                 Block block = Build.A.Block.WithHeader(header).TestObject;
@@ -127,7 +127,7 @@ namespace Nethermind.AuRa.Test
                 },
             };
 
-            (AuRaBlockProcessor processor, IWorldState stateProvider) =
+            (BranchProcessor processor, IWorldState stateProvider) =
                 CreateProcessor(contractRewriter: new ContractRewriter(contractOverrides));
 
             stateProvider.CreateAccount(TestItem.AddressA, UInt256.One);
@@ -150,7 +150,7 @@ namespace Nethermind.AuRa.Test
             stateProvider.GetCode(TestItem.AddressB).Should().BeEquivalentTo(Bytes.FromHexString("0x654"));
         }
 
-        private (AuRaBlockProcessor Processor, IWorldState StateProvider) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)
+        private (BranchProcessor Processor, IWorldState StateProvider) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)
         {
             IWorldStateManager worldStateManager = TestWorldStateFactory.CreateForTest();
             IWorldState stateProvider = worldStateManager.GlobalWorldState;
@@ -171,7 +171,14 @@ namespace Nethermind.AuRa.Test
                 txFilter,
                 contractRewriter: contractRewriter);
 
-            return (processor, stateProvider);
+            BranchProcessor branchProcessor = new BranchProcessor(
+                processor,
+                HoleskySpecProvider.Instance,
+                stateProvider,
+                new BeaconBlockRootHandler(transactionProcessor, stateProvider),
+                LimboLogs.Instance);
+
+            return (branchProcessor, stateProvider);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -57,10 +57,16 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
             new ExecutionRequestsProcessor(transactionProcessor));
+        BranchProcessor branchProcessor = new BranchProcessor(
+            processor,
+            HoleskySpecProvider.Instance,
+            stateProvider,
+            new BeaconBlockRootHandler(transactionProcessor, stateProvider),
+            LimboLogs.Instance);
 
         BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).TestObject;
         Block block = Build.A.Block.WithHeader(header).TestObject;
-        Block[] processedBlocks = processor.Process(
+        Block[] processedBlocks = branchProcessor.Process(
             null,
             new List<Block> { block },
             ProcessingOptions.None,
@@ -87,16 +93,22 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
             new ExecutionRequestsProcessor(transactionProcessor));
+        BranchProcessor branchProcessor = new BranchProcessor(
+            processor,
+            HoleskySpecProvider.Instance,
+            stateProvider,
+            new BeaconBlockRootHandler(transactionProcessor, stateProvider),
+            LimboLogs.Instance);
 
         BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
         Block block = Build.A.Block.WithTransactions(1, MuirGlacier.Instance).WithHeader(header).TestObject;
-        Assert.Throws<OperationCanceledException>(() => processor.Process(
+        Assert.Throws<OperationCanceledException>(() => branchProcessor.Process(
             null,
             new List<Block> { block },
             ProcessingOptions.None,
             AlwaysCancelBlockTracer.Instance));
 
-        Assert.Throws<OperationCanceledException>(() => processor.Process(
+        Assert.Throws<OperationCanceledException>(() => branchProcessor.Process(
             null,
             new List<Block> { block },
             ProcessingOptions.None,

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -37,7 +37,7 @@ public class BlockchainProcessorTests
     {
         private readonly ILogManager _logManager = LimboLogs.Instance;
 
-        private class BlockProcessorMock : IBlockProcessor
+        private class BranchProcessorMock : IBranchProcessor
         {
             private readonly ILogger _logger;
 
@@ -49,7 +49,7 @@ public class BlockchainProcessorTests
 
             private readonly HashSet<Hash256> _rootProcessed = new();
 
-            public BlockProcessorMock(ILogManager logManager, IStateReader stateReader)
+            public BranchProcessorMock(ILogManager logManager, IStateReader stateReader)
             {
                 _logger = logManager.GetClassLogger();
                 stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(x => _rootProcessed.Contains(((BlockHeader?)x[0])?.StateRoot!));
@@ -178,7 +178,7 @@ public class BlockchainProcessorTests
         private readonly AutoResetEvent _resetEvent;
         private readonly AutoResetEvent _queueEmptyResetEvent;
         private readonly IStateReader _stateReader;
-        private readonly BlockProcessorMock _blockProcessor;
+        private readonly BranchProcessorMock _branchProcessor;
         private readonly RecoveryStepMock _recoveryStep;
         private readonly BlockchainProcessor _processor;
         private readonly ILogger _logger;
@@ -195,9 +195,9 @@ public class BlockchainProcessorTests
             _blockTree = Build.A.BlockTree()
                 .WithoutSettingHead
                 .TestObject;
-            _blockProcessor = new BlockProcessorMock(_logManager, _stateReader);
+            _branchProcessor = new BranchProcessorMock(_logManager, _stateReader);
             _recoveryStep = new RecoveryStepMock(_logManager);
-            _processor = new BlockchainProcessor(_blockTree, _blockProcessor, _recoveryStep, _stateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);
+            _processor = new BlockchainProcessor(_blockTree, _branchProcessor, _recoveryStep, _stateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);
             _resetEvent = new AutoResetEvent(false);
             _queueEmptyResetEvent = new AutoResetEvent(false);
 
@@ -235,7 +235,7 @@ public class BlockchainProcessorTests
             _headBefore = _blockTree.Head?.Hash;
             ManualResetEvent processedEvent = new(false);
             bool wasProcessed = false;
-            _blockProcessor.BlockProcessed += (_, args) =>
+            _branchProcessor.BlockProcessed += (_, args) =>
             {
                 if (args.Block.Hash == block.Hash)
                 {
@@ -245,7 +245,7 @@ public class BlockchainProcessorTests
             };
 
             _logger.Info($"Waiting for {block.ToString(Block.Format.Short)} to process");
-            _blockProcessor.Allow(block.Hash!);
+            _branchProcessor.Allow(block.Hash!);
             processedEvent.WaitOne(ProcessingWait);
             Assert.That(wasProcessed, Is.True, $"Expected this block to get processed but it was not: {block.ToString(Block.Format.Short)}");
 
@@ -256,7 +256,7 @@ public class BlockchainProcessorTests
         {
             _headBefore = _blockTree.Head?.Hash;
             _logger.Info($"Waiting for {block.ToString(Block.Format.Short)} to be skipped");
-            _blockProcessor.Allow(block.Hash!);
+            _branchProcessor.Allow(block.Hash!);
             return new AfterBlock(_logManager, this, block);
         }
 
@@ -265,7 +265,7 @@ public class BlockchainProcessorTests
             _headBefore = _blockTree.Head?.Hash;
             ManualResetEvent processedEvent = new(false);
             bool wasProcessed = false;
-            _blockProcessor.BlockProcessed += (_, args) =>
+            _branchProcessor.BlockProcessed += (_, args) =>
             {
                 if (args.Block.Hash == block.Hash)
                 {
@@ -275,7 +275,7 @@ public class BlockchainProcessorTests
             };
 
             _logger.Info($"Waiting for {block.ToString(Block.Format.Short)} to fail processing");
-            _blockProcessor.AllowToFail(block.Hash!);
+            _branchProcessor.AllowToFail(block.Hash!);
             processedEvent.WaitOne(ProcessingWait);
             Assert.That(wasProcessed, Is.True, $"Block was never processed {block.ToString(Block.Format.Short)}");
             Assert.That(_blockTree.Head?.Hash, Is.EqualTo(_headBefore), $"Processing did not fail - {block.ToString(Block.Format.Short)} became a new head block");
@@ -304,7 +304,7 @@ public class BlockchainProcessorTests
             }
 
             _blockTree.UpdateMainChain(new[] { block }, false);
-            _blockProcessor.Allow(block.Hash!);
+            _branchProcessor.Allow(block.Hash!);
             _recoveryStep.Allow(block.Hash!);
 
             return this;
@@ -422,7 +422,7 @@ public class BlockchainProcessorTests
 
         public ProcessingTestContext AssertProcessedBlocks(params IEnumerable<Block> blocks)
         {
-            _blockProcessor.Processed.Should().BeEquivalentTo(blocks.Select(b => b.Hash));
+            _branchProcessor.Processed.Should().BeEquivalentTo(blocks.Select(b => b.Hash));
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Blockchain.Test.Filters;
 public class FilterManagerTests
 {
     private IFilterStore _filterStore = null!;
-    private IBlockProcessor _blockProcessor = null!;
+    private IBranchProcessor _branchProcessor = null!;
     private ITxPool _txPool = null!;
     private ILogManager _logManager = null!;
     private FilterManager _filterManager = null!;
@@ -34,7 +34,7 @@ public class FilterManagerTests
     {
         _currentFilterId = 0;
         _filterStore = Substitute.For<IFilterStore>();
-        _blockProcessor = Substitute.For<IBlockProcessor>();
+        _branchProcessor = Substitute.For<IBranchProcessor>();
         _txPool = Substitute.For<ITxPool>();
         _logManager = LimboLogs.Instance;
     }
@@ -323,14 +323,14 @@ public class FilterManagerTests
 
         _filterStore.GetFilters<LogFilter>().Returns(filters.OfType<LogFilter>().ToArray());
         _filterStore.GetFilters<BlockFilter>().Returns(filters.OfType<BlockFilter>().ToArray());
-        _filterManager = new FilterManager(_filterStore, _blockProcessor, _txPool, _logManager);
+        _filterManager = new FilterManager(_filterStore, _branchProcessor, _txPool, _logManager);
 
-        _blockProcessor.BlockProcessed += Raise.EventWith(_blockProcessor, new BlockProcessedEventArgs(block, []));
+        _branchProcessor.BlockProcessed += Raise.EventWith(_branchProcessor, new BlockProcessedEventArgs(block, []));
 
         int index = 1;
         foreach (TxReceipt receipt in receipts)
         {
-            _blockProcessor.TransactionProcessed += Raise.EventWith(_blockProcessor,
+            _branchProcessor.TransactionProcessed += Raise.EventWith(_branchProcessor,
                 new TxProcessedEventArgs(index, Build.A.Transaction.TestObject, receipt));
             index++;
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -108,9 +108,16 @@ public class ReorgTests
             LimboLogs.Instance,
             new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
             new ExecutionRequestsProcessor(transactionProcessor));
+        BranchProcessor branchProcessor = new BranchProcessor(
+            blockProcessor,
+            MainnetSpecProvider.Instance,
+            stateProvider,
+            new BeaconBlockRootHandler(transactionProcessor, stateProvider),
+            LimboLogs.Instance);
+
         _blockchainProcessor = new BlockchainProcessor(
             _blockTree,
-            blockProcessor,
+            branchProcessor,
             new RecoverSignatures(
                 ecdsa,
                 specProvider,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Consensus.AuRa
         private readonly IBlockTree _blockTree;
         private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
         private readonly ILogger _logger;
-        private IBlockProcessor _blockProcessor;
+        private IBranchProcessor _branchProcessor;
         private readonly IValidatorStore _validatorStore;
         private readonly IValidSealerStrategy _validSealerStrategy;
         private readonly long _twoThirdsMajorityTransition;
@@ -48,11 +48,11 @@ namespace Nethermind.Consensus.AuRa
             Initialize();
         }
 
-        public void SetMainBlockProcessor(IBlockProcessor blockProcessor)
+        public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
         {
-            _blockProcessor = blockProcessor ?? throw new ArgumentNullException(nameof(blockProcessor));
-            _blockProcessor.BlockProcessed += OnBlockProcessed;
-            _blockProcessor.BlocksProcessing += OnBlocksProcessing;
+            _branchProcessor = branchProcessor;
+            _branchProcessor.BlockProcessed += OnBlockProcessed;
+            _branchProcessor.BlocksProcessing += OnBlocksProcessing;
         }
 
 
@@ -344,7 +344,7 @@ namespace Nethermind.Consensus.AuRa
 
         public void Dispose()
         {
-            _blockProcessor.BlockProcessed -= OnBlockProcessed;
+            _branchProcessor.BlockProcessed -= OnBlockProcessed;
         }
 
         [DebuggerDisplay("Count = {Count}")]

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -48,8 +48,7 @@ namespace Nethermind.Consensus.AuRa
             IAuRaValidator? auRaValidator,
             ITxFilter? txFilter = null,
             AuRaContractGasLimitOverride? gasLimitOverride = null,
-            ContractRewriter? contractRewriter = null,
-            IBlockCachePreWarmer? preWarmer = null)
+            ContractRewriter? contractRewriter = null)
             : base(
                 specProvider,
                 blockValidator,
@@ -61,8 +60,7 @@ namespace Nethermind.Consensus.AuRa
                 new BlockhashStore(specProvider, stateProvider),
                 logManager,
                 withdrawalProcessor,
-                executionRequestsProcessor,
-                preWarmer: preWarmer)
+                executionRequestsProcessor)
         {
             _specProvider = specProvider;
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));

--- a/src/Nethermind/Nethermind.Consensus.AuRa/IAuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/IAuRaBlockFinalizationManager.cs
@@ -24,6 +24,6 @@ namespace Nethermind.Consensus.AuRa
         /// <returns>Level at which finalization happened. Null if checked level is not yet finalized.</returns>
         long? GetFinalizationLevel(long level);
 
-        public void SetMainBlockProcessor(IBlockProcessor blockProcessor);
+        public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -64,7 +64,7 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
         await base.InitBlockchain();
 
         // Got cyclic dependency. AuRaBlockFinalizationManager -> IAuraValidator -> AuraBlockProcessor -> AuraBlockFinalizationManager.
-        _api.FinalizationManager.SetMainBlockProcessor(_api.MainProcessingContext!.BlockProcessor!);
+        _api.FinalizationManager.SetMainBlockBranchProcessor(_api.MainProcessingContext!.BranchProcessor!);
     }
 
     protected override IBlockProcessor CreateBlockProcessor(BlockCachePreWarmer? preWarmer, ITransactionProcessor transactionProcessor, IWorldState worldState)

--- a/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/CensorshipDetectorTests.cs
@@ -37,7 +37,7 @@ public class CensorshipDetectorTests
     private ILogManager _logManager;
     private TestReadOnlyStateProvider _stateProvider;
     private IBlockTree _blockTree;
-    private IBlockProcessor _blockProcessor;
+    private IBranchProcessor _branchProcessor;
     private ISpecProvider _specProvider;
     private IEthereumEcdsa _ethereumEcdsa;
     private IComparer<Transaction> _comparer;
@@ -49,7 +49,7 @@ public class CensorshipDetectorTests
     {
         _logManager = LimboLogs.Instance;
         _stateProvider = new TestReadOnlyStateProvider();
-        _blockProcessor = Substitute.For<IBlockProcessor>();
+        _branchProcessor = Substitute.For<IBranchProcessor>();
     }
 
     [TearDown]
@@ -65,7 +65,7 @@ public class CensorshipDetectorTests
     public void Censorship_when_address_censorship_is_false_and_high_paying_tx_censorship_is_true_for_all_blocks_in_main_cache()
     {
         _txPool = CreatePool();
-        _censorshipDetector = new(_blockTree, _txPool, _comparer, _blockProcessor, _logManager, new CensorshipDetectorConfig() { });
+        _censorshipDetector = new(_blockTree, _txPool, _comparer, _branchProcessor, _logManager, new CensorshipDetectorConfig() { });
 
         Transaction tx1 = SubmitTxToPool(1, TestItem.PrivateKeyA, TestItem.AddressA);
         Transaction tx2 = SubmitTxToPool(2, TestItem.PrivateKeyB, TestItem.AddressA);
@@ -96,7 +96,7 @@ public class CensorshipDetectorTests
     public void No_censorship_when_address_censorship_is_false_and_high_paying_tx_censorship_is_false_for_some_blocks_in_main_cache()
     {
         _txPool = CreatePool();
-        _censorshipDetector = new(_blockTree, _txPool, _comparer, _blockProcessor, _logManager, new CensorshipDetectorConfig() { });
+        _censorshipDetector = new(_blockTree, _txPool, _comparer, _branchProcessor, _logManager, new CensorshipDetectorConfig() { });
 
         Transaction tx1 = SubmitTxToPool(1, TestItem.PrivateKeyA, TestItem.AddressA);
         Transaction tx2 = SubmitTxToPool(2, TestItem.PrivateKeyB, TestItem.AddressA);
@@ -135,7 +135,7 @@ public class CensorshipDetectorTests
             _blockTree,
             _txPool,
             _comparer,
-            _blockProcessor,
+            _branchProcessor,
             _logManager,
             new CensorshipDetectorConfig()
             {
@@ -191,7 +191,7 @@ public class CensorshipDetectorTests
             _blockTree,
             _txPool,
             _comparer,
-            _blockProcessor,
+            _branchProcessor,
             _logManager,
             new CensorshipDetectorConfig()
             {
@@ -272,7 +272,7 @@ public class CensorshipDetectorTests
 
     private void BlockProcessingWorkflow(Block block)
     {
-        _blockProcessor.BlockProcessing += Raise.EventWith(new BlockEventArgs(block));
+        _branchProcessor.BlockProcessing += Raise.EventWith(new BlockEventArgs(block));
         Assert.That(() => _censorshipDetector.BlockPotentiallyCensored(block.Number, block.Hash), Is.EqualTo(true).After(10, 1));
 
         foreach (Transaction tx in block.Transactions)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -65,7 +65,6 @@ public partial class BlockProcessor(
         remove { blockTransactionsExecutor.TransactionProcessed -= value; }
     }
 
-    // TODO: block processor pipeline
     public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
     {
         if (_logger.IsTrace) _logger.Trace($"Processing block {suggestedBlock.ToString(Block.Format.Short)} ({options})");
@@ -82,7 +81,6 @@ public partial class BlockProcessor(
         return (block, receipts);
     }
 
-    // TODO: block processor pipeline
     private void ValidateProcessedBlock(Block suggestedBlock, ProcessingOptions options, Block block, TxReceipt[] receipts)
     {
         if (!options.ContainsFlag(ProcessingOptions.NoValidation) && !blockValidator.ValidateProcessedBlock(block, receipts, suggestedBlock, out string? error))
@@ -99,7 +97,6 @@ public partial class BlockProcessor(
     private bool ShouldComputeStateRoot(BlockHeader header) =>
         !header.IsGenesis || !specProvider.GenesisStateUnavailable;
 
-    // TODO: block processor pipeline
     protected virtual TxReceipt[] ProcessBlock(
         Block block,
         IBlockTracer blockTracer,
@@ -188,14 +185,12 @@ public partial class BlockProcessor(
         }
     }
 
-    // TODO: block processor pipeline
     private void StoreTxReceipts(Block block, TxReceipt[] txReceipts, IReleaseSpec spec)
     {
         // Setting canonical is done when the BlockAddedToMain event is fired
         receiptStorage.Insert(block, txReceipts, spec, false);
     }
 
-    // TODO: block processor pipeline
     private Block PrepareBlockForProcessing(Block suggestedBlock)
     {
         if (_logger.IsTrace) _logger.Trace($"{suggestedBlock.Header.ToString(BlockHeader.Format.Full)}");
@@ -237,7 +232,6 @@ public partial class BlockProcessor(
         return suggestedBlock.WithReplacedHeader(headerForProcessing);
     }
 
-    // TODO: block processor pipeline
     private void ApplyMinerRewards(Block block, IBlockTracer tracer, IReleaseSpec spec)
     {
         if (_logger.IsTrace) _logger.Trace("Applying miner rewards:");
@@ -265,7 +259,6 @@ public partial class BlockProcessor(
         }
     }
 
-    // TODO: block processor pipeline (only where rewards needed)
     private void ApplyMinerReward(Block block, BlockReward reward, IReleaseSpec spec)
     {
         if (_logger.IsTrace) _logger.Trace($"  {(BigInteger)reward.Value / (BigInteger)Unit.Ether:N3}{Unit.EthSymbol} for account at {reward.Address}");
@@ -273,7 +266,6 @@ public partial class BlockProcessor(
         _stateProvider.AddToBalanceAndCreateIfNotExists(reward.Address, reward.Value, spec);
     }
 
-    // TODO: block processor pipeline
     private void ApplyDaoTransition(Block block)
     {
         long? daoBlockNumber = specProvider.DaoBlockNumber;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -46,17 +46,12 @@ public partial class BlockProcessor(
     IBlockhashStore blockHashStore,
     ILogManager logManager,
     IWithdrawalProcessor withdrawalProcessor,
-    IExecutionRequestsProcessor executionRequestsProcessor,
-    IBlockCachePreWarmer? preWarmer = null)
+    IExecutionRequestsProcessor executionRequestsProcessor)
     : IBlockProcessor
 {
     private readonly ILogger _logger = logManager.GetClassLogger();
     protected readonly WorldStateMetricsDecorator _stateProvider = new WorldStateMetricsDecorator(stateProvider);
     private readonly IReceiptsRootCalculator _receiptsRootCalculator = ReceiptsRootCalculator.Instance;
-    private Task _clearTask = Task.CompletedTask;
-
-    private const int MaxUncommittedBlocks = 64;
-    private readonly Action<Task> _clearCaches = _ => preWarmer?.ClearCaches();
 
     /// <summary>
     /// We use a single receipt tracer for all blocks. Internally receipt tracer forwards most of the calls
@@ -64,207 +59,14 @@ public partial class BlockProcessor(
     /// </summary>
     protected BlockReceiptsTracer ReceiptsTracer { get; set; } = new();
 
-    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed;
-
     public event EventHandler<TxProcessedEventArgs> TransactionProcessed
     {
         add { blockTransactionsExecutor.TransactionProcessed += value; }
         remove { blockTransactionsExecutor.TransactionProcessed -= value; }
     }
 
-    // TODO: move to branch processor
-    public Block[] Process(BlockHeader? baseBlock, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions options, IBlockTracer blockTracer, CancellationToken token = default)
-    {
-        if (suggestedBlocks.Count == 0) return [];
-
-        BlockHeader? previousBranchStateRoot = baseBlock;
-        InitBranch(baseBlock);
-
-        Block suggestedBlock = suggestedBlocks[0];
-        // Start prewarming as early as possible
-        WaitForCacheClear();
-        IReleaseSpec spec = specProvider.GetSpec(suggestedBlock.Header);
-        (CancellationTokenSource? prewarmCancellation, Task? preWarmTask)
-            = PreWarmTransactions(suggestedBlock, baseBlock, spec);
-
-        BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(suggestedBlocks));
-
-        BlockHeader? preBlockBaseBlock = baseBlock;
-
-        bool notReadOnly = !options.ContainsFlag(ProcessingOptions.ReadOnlyChain);
-        int blocksCount = suggestedBlocks.Count;
-        Block[] processedBlocks = new Block[blocksCount];
-        try
-        {
-            for (int i = 0; i < blocksCount; i++)
-            {
-                WaitForCacheClear();
-                suggestedBlock = suggestedBlocks[i];
-                if (i > 0)
-                {
-                    // Refresh spec
-                    spec = specProvider.GetSpec(suggestedBlock.Header);
-                }
-                // If prewarmCancellation is not null it means we are in first iteration of loop
-                // and started prewarming at method entry, so don't start it again
-                if (prewarmCancellation is null)
-                {
-                    (prewarmCancellation, preWarmTask) = PreWarmTransactions(suggestedBlock, preBlockBaseBlock, spec);
-                }
-
-                if (blocksCount > 64 && i % 8 == 0)
-                {
-                    if (_logger.IsInfo) _logger.Info($"Processing part of a long blocks branch {i}/{blocksCount}. Block: {suggestedBlock}");
-                }
-
-                if (notReadOnly)
-                {
-                    BlockProcessing?.Invoke(this, new BlockEventArgs(suggestedBlock));
-                }
-
-                Block processedBlock;
-                TxReceipt[] receipts;
-
-                if (prewarmCancellation is not null)
-                {
-                    (processedBlock, receipts) = ProcessOne(suggestedBlock, options, blockTracer, spec, token);
-                    // Block is processed, we can cancel the prewarm task
-                    CancellationTokenExtensions.CancelDisposeAndClear(ref prewarmCancellation);
-                }
-                else
-                {
-                    // Even though we skip prewarming we still need to ensure the caches are cleared
-                    CacheType result = preWarmer?.ClearCaches() ?? default;
-                    if (result != default)
-                    {
-                        if (_logger.IsWarn) _logger.Warn($"Low txs, caches {result} are not empty. Clearing them.");
-                    }
-                    (processedBlock, receipts) = ProcessOne(suggestedBlock, options, blockTracer, spec, token);
-                }
-
-                processedBlocks[i] = processedBlock;
-
-                // be cautious here as AuRa depends on processing
-                PreCommitBlock(suggestedBlock.Header);
-                QueueClearCaches(preWarmTask);
-
-                if (notReadOnly)
-                {
-                    Metrics.StateMerkleizationTime = _stateProvider.StateMerkleizationTime;
-                    BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(processedBlock, receipts));
-                }
-
-                // CommitBranch in parts if we have long running branch
-                bool isFirstInBatch = i == 0;
-                bool isLastInBatch = i == blocksCount - 1;
-                bool isNotAtTheEdge = !isFirstInBatch && !isLastInBatch;
-                bool isCommitPoint = i % MaxUncommittedBlocks == 0 && isNotAtTheEdge;
-                if (isCommitPoint && notReadOnly)
-                {
-                    if (_logger.IsInfo) _logger.Info($"Commit part of a long blocks branch {i}/{blocksCount}");
-                    previousBranchStateRoot = suggestedBlock.Header;
-                    InitBranch(suggestedBlock.Header, false);
-                }
-
-                preBlockBaseBlock = processedBlock.Header;
-                // Make sure the prewarm task is finished before we reset the state
-                preWarmTask?.GetAwaiter().GetResult();
-                preWarmTask = null;
-                _stateProvider.Reset();
-
-                // Calculate the transaction hashes in the background and release tx sequence memory
-                // Hashes will be required for PersistentReceiptStorage in ForkchoiceUpdatedHandler
-                // Though we still want to release the memory even if syncing rather than processing live
-                TxHashCalculator.CalculateInBackground(suggestedBlock);
-            }
-
-            if (options.ContainsFlag(ProcessingOptions.DoNotUpdateHead))
-            {
-                RestoreBranch(previousBranchStateRoot);
-            }
-
-            return processedBlocks;
-        }
-        catch (Exception ex) // try to restore at all cost
-        {
-            if (_logger.IsWarn) _logger.Warn($"Encountered exception {ex} while processing blocks.");
-            CancellationTokenExtensions.CancelDisposeAndClear(ref prewarmCancellation);
-            QueueClearCaches(preWarmTask);
-            preWarmTask?.GetAwaiter().GetResult();
-            RestoreBranch(previousBranchStateRoot);
-            throw;
-        }
-    }
-
-    private (CancellationTokenSource prewarmCancellation, Task preWarmTask) PreWarmTransactions(Block suggestedBlock, BlockHeader preBlockBaseBlock, IReleaseSpec spec)
-    {
-        if (preWarmer is null || suggestedBlock.Transactions.Length < 3) return (null, null);
-
-        CancellationTokenSource prewarmCancellation = new();
-        Task preWarmTask = preWarmer.PreWarmCaches(suggestedBlock,
-            preBlockBaseBlock,
-            spec,
-            prewarmCancellation.Token,
-            beaconBlockRootHandler);
-
-        return (prewarmCancellation, preWarmTask);
-    }
-
-    private void WaitForCacheClear() => _clearTask.GetAwaiter().GetResult();
-
-    private void QueueClearCaches(Task? preWarmTask)
-    {
-        if (preWarmTask is not null)
-        {
-            // Can start clearing caches in background
-            _clearTask = preWarmTask.ContinueWith(_clearCaches, TaskContinuationOptions.RunContinuationsAsynchronously);
-        }
-        else if (preWarmer is not null)
-        {
-            _clearTask = Task.Run(preWarmer.ClearCaches);
-        }
-    }
-
-    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing;
-
-    public event EventHandler<BlockEventArgs>? BlockProcessing;
-
-    // TODO: move to branch processor
-    private void InitBranch(BlockHeader? baseBlock, bool incrementReorgMetric = true)
-    {
-        /* Please note that we do not reset the state if branch state root is null.
-           That said, I do not remember in what cases we receive null here.*/
-        if (baseBlock is not null && _stateProvider.StateRoot != baseBlock.StateRoot)
-        {
-            /* Discarding the other branch data - chain reorganization.
-               We cannot use cached values any more because they may have been written
-               by blocks that are being reorganized out.*/
-
-            if (incrementReorgMetric)
-                Metrics.Reorganizations++;
-            _stateProvider.Reset();
-            _stateProvider.SetBaseBlock(baseBlock);
-        }
-    }
-
-    // TODO: move to block processing pipeline
-    private void PreCommitBlock(BlockHeader block)
-    {
-        if (_logger.IsTrace) _logger.Trace($"Committing the branch - {block.ToString(BlockHeader.Format.Short)} state root {block.StateRoot}");
-        _stateProvider.CommitTree(block.Number);
-    }
-
-    // TODO: move to branch processor
-    private void RestoreBranch(BlockHeader? branchingPointHeader)
-    {
-        if (_logger.IsTrace) _logger.Trace($"Restoring the branch checkpoint - {branchingPointHeader?.ToString(BlockHeader.Format.Short)}");
-        _stateProvider.Reset();
-        _stateProvider.SetBaseBlock(branchingPointHeader);
-        if (_logger.IsTrace) _logger.Trace($"Restored the branch checkpoint - {branchingPointHeader?.ToString(BlockHeader.Format.Short)} | {_stateProvider.StateRoot}");
-    }
-
     // TODO: block processor pipeline
-    private (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
+    public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
     {
         if (_logger.IsTrace) _logger.Trace($"Processing block {suggestedBlock.ToString(Block.Format.Short)} ({options})");
 
@@ -358,11 +160,6 @@ public partial class BlockProcessor(
 
         return receipts;
     }
-
-    /// <summary>
-    /// Builds the block context ouf the block and the release spec.
-    /// </summary>
-    protected virtual BlockExecutionContext BuildBlockContext(Block block, IReleaseSpec spec) => new(block.Header, spec);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void CalculateBlooms(TxReceipt[] receipts)
@@ -500,28 +297,6 @@ public partial class BlockProcessor(
                 UInt256 balance = _stateProvider.GetBalance(daoAccount);
                 _stateProvider.AddToBalance(withdrawAccount, balance, Dao.Instance);
                 _stateProvider.SubtractFromBalance(daoAccount, balance, Dao.Instance);
-            }
-        }
-    }
-
-    private class TxHashCalculator(Block suggestedBlock) : IThreadPoolWorkItem
-    {
-        public static void CalculateInBackground(Block suggestedBlock)
-        {
-            // Memory has been reserved on the transactions to delay calculate the hashes
-            // We calculate the hashes in the background to release that memory
-            ThreadPool.UnsafeQueueUserWorkItem(new TxHashCalculator(suggestedBlock), preferLocal: false);
-        }
-
-        void IThreadPoolWorkItem.Execute()
-        {
-            // Hashes will be required for PersistentReceiptStorage in UpdateMainChain ForkchoiceUpdatedHandler
-            // Which occurs after the block has been processed; however the block is stored in cache and picked up
-            // from there so we can calculate the hashes now for that later use.
-            foreach (Transaction tx in suggestedBlock.Transactions)
-            {
-                // Calculate the hashes to release the memory from the transactionSequence
-                tx.CalculateHashInternal();
             }
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -39,7 +39,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     public ITracerBag Tracers => _compositeBlockTracer;
 
-    private readonly IBlockProcessor _blockProcessor;
+    private readonly IBranchProcessor _branchProcessor;
     private readonly IBlockPreprocessorStep _recoveryStep;
     private readonly IStateReader _stateReader;
     private readonly Options _options;
@@ -83,27 +83,27 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     ///
     /// </summary>
     /// <param name="blockTree"></param>
-    /// <param name="blockProcessor"></param>
+    /// <param name="branchProcessor"></param>
     /// <param name="recoveryStep"></param>
     /// <param name="stateReader"></param>
     /// <param name="logManager"></param>
     /// <param name="options"></param>
     public BlockchainProcessor(
-        IBlockTree? blockTree,
-        IBlockProcessor? blockProcessor,
-        IBlockPreprocessorStep? recoveryStep,
+        IBlockTree blockTree,
+        IBranchProcessor branchProcessor,
+        IBlockPreprocessorStep recoveryStep,
         IStateReader stateReader,
-        ILogManager? logManager,
+        ILogManager logManager,
         Options options)
     {
-        _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-        _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-        _blockProcessor = blockProcessor ?? throw new ArgumentNullException(nameof(blockProcessor));
-        _recoveryStep = recoveryStep ?? throw new ArgumentNullException(nameof(recoveryStep));
-        _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
+        _logger = logManager.GetClassLogger();
+        _blockTree = blockTree;
+        _branchProcessor = branchProcessor;
+        _recoveryStep = recoveryStep;
+        _stateReader = stateReader;
         _options = options;
 
-        _stats = new ProcessingStats(stateReader, _logger);
+        _stats = new ProcessingStats(stateReader, logManager.GetClassLogger<ProcessingStats>());
         _loopCancellationSource = new CancellationTokenSource();
     }
 
@@ -515,7 +515,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         {
             try
             {
-                _blockProcessor.Process(
+                _branchProcessor.Process(
                     processingBranch.BaseBlock,
                     processingBranch.BlocksToProcess,
                     options,
@@ -551,7 +551,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         Block[]? processedBlocks;
         try
         {
-            processedBlocks = _blockProcessor.Process(
+            processedBlocks = _branchProcessor.Process(
                 processingBranch.BaseBlock,
                 processingBranch.BlocksToProcess,
                 options,

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -68,7 +68,6 @@ public class BranchProcessor(
         }
     }
 
-    // TODO: move to block processing pipeline
     private void PreCommitBlock(BlockHeader block)
     {
         if (_logger.IsTrace) _logger.Trace($"Committing the branch - {block.ToString(BlockHeader.Format.Short)} state root {block.StateRoot}");

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus.ExecutionRequests;
+using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Validators;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Logging;
+using Nethermind.State;
+using Metrics = Nethermind.Blockchain.Metrics;
+
+namespace Nethermind.Consensus.Processing;
+
+public class BranchProcessor(
+    IBlockProcessor blockProcessor,
+    ISpecProvider specProvider,
+    IWorldState stateProvider,
+    IBeaconBlockRootHandler beaconBlockRootHandler,
+    ILogManager logManager,
+    IBlockCachePreWarmer? preWarmer = null)
+    : IBranchProcessor
+{
+    private readonly ILogger _logger = logManager.GetClassLogger();
+    protected readonly WorldStateMetricsDecorator _stateProvider = new WorldStateMetricsDecorator(stateProvider);
+    private Task _clearTask = Task.CompletedTask;
+
+    private const int MaxUncommittedBlocks = 64;
+    private readonly Action<Task> _clearCaches = _ => preWarmer?.ClearCaches();
+
+    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed;
+
+    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing;
+
+    public event EventHandler<BlockEventArgs>? BlockProcessing;
+
+    public event EventHandler<TxProcessedEventArgs> TransactionProcessed
+    {
+        add => blockProcessor.TransactionProcessed += value;
+        remove => blockProcessor.TransactionProcessed -= value;
+    }
+
+    private void InitBranch(BlockHeader? baseBlock, bool incrementReorgMetric = true)
+    {
+        /* Please note that we do not reset the state if branch state root is null.
+           That said, I do not remember in what cases we receive null here.*/
+        if (baseBlock is not null && _stateProvider.StateRoot != baseBlock.StateRoot)
+        {
+            /* Discarding the other branch data - chain reorganization.
+               We cannot use cached values any more because they may have been written
+               by blocks that are being reorganized out.*/
+
+            if (incrementReorgMetric)
+                Metrics.Reorganizations++;
+            _stateProvider.Reset();
+            _stateProvider.SetBaseBlock(baseBlock);
+        }
+    }
+
+    // TODO: move to block processing pipeline
+    private void PreCommitBlock(BlockHeader block)
+    {
+        if (_logger.IsTrace) _logger.Trace($"Committing the branch - {block.ToString(BlockHeader.Format.Short)} state root {block.StateRoot}");
+        _stateProvider.CommitTree(block.Number);
+    }
+
+    private void RestoreBranch(BlockHeader? branchingPointHeader)
+    {
+        if (_logger.IsTrace) _logger.Trace($"Restoring the branch checkpoint - {branchingPointHeader?.ToString(BlockHeader.Format.Short)}");
+        _stateProvider.Reset();
+        _stateProvider.SetBaseBlock(branchingPointHeader);
+        if (_logger.IsTrace) _logger.Trace($"Restored the branch checkpoint - {branchingPointHeader?.ToString(BlockHeader.Format.Short)} | {_stateProvider.StateRoot}");
+    }
+
+    public Block[] Process(BlockHeader? baseBlock, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions options, IBlockTracer blockTracer, CancellationToken token = default)
+    {
+        if (suggestedBlocks.Count == 0) return [];
+
+        BlockHeader? previousBranchStateRoot = baseBlock;
+        InitBranch(baseBlock);
+
+        Block suggestedBlock = suggestedBlocks[0];
+        // Start prewarming as early as possible
+        WaitForCacheClear();
+        IReleaseSpec spec = specProvider.GetSpec(suggestedBlock.Header);
+        (CancellationTokenSource? prewarmCancellation, Task? preWarmTask)
+            = PreWarmTransactions(suggestedBlock, baseBlock, spec);
+
+        BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(suggestedBlocks));
+
+        BlockHeader? preBlockBaseBlock = baseBlock;
+
+        bool notReadOnly = !options.ContainsFlag(ProcessingOptions.ReadOnlyChain);
+        int blocksCount = suggestedBlocks.Count;
+        Block[] processedBlocks = new Block[blocksCount];
+        try
+        {
+            for (int i = 0; i < blocksCount; i++)
+            {
+                WaitForCacheClear();
+                suggestedBlock = suggestedBlocks[i];
+                if (i > 0)
+                {
+                    // Refresh spec
+                    spec = specProvider.GetSpec(suggestedBlock.Header);
+                }
+                // If prewarmCancellation is not null it means we are in first iteration of loop
+                // and started prewarming at method entry, so don't start it again
+                if (prewarmCancellation is null)
+                {
+                    (prewarmCancellation, preWarmTask) = PreWarmTransactions(suggestedBlock, preBlockBaseBlock, spec);
+                }
+
+                if (blocksCount > 64 && i % 8 == 0)
+                {
+                    if (_logger.IsInfo) _logger.Info($"Processing part of a long blocks branch {i}/{blocksCount}. Block: {suggestedBlock}");
+                }
+
+                if (notReadOnly)
+                {
+                    BlockProcessing?.Invoke(this, new BlockEventArgs(suggestedBlock));
+                }
+
+                Block processedBlock;
+                TxReceipt[] receipts;
+
+                if (prewarmCancellation is not null)
+                {
+                    (processedBlock, receipts) = blockProcessor.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
+                    // Block is processed, we can cancel the prewarm task
+                    CancellationTokenExtensions.CancelDisposeAndClear(ref prewarmCancellation);
+                }
+                else
+                {
+                    // Even though we skip prewarming we still need to ensure the caches are cleared
+                    CacheType result = preWarmer?.ClearCaches() ?? default;
+                    if (result != default)
+                    {
+                        if (_logger.IsWarn) _logger.Warn($"Low txs, caches {result} are not empty. Clearing them.");
+                    }
+                    (processedBlock, receipts) = blockProcessor.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
+                }
+
+                processedBlocks[i] = processedBlock;
+
+                // be cautious here as AuRa depends on processing
+                PreCommitBlock(suggestedBlock.Header);
+                QueueClearCaches(preWarmTask);
+
+                if (notReadOnly)
+                {
+                    Metrics.StateMerkleizationTime = _stateProvider.StateMerkleizationTime;
+                    BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(processedBlock, receipts));
+                }
+
+                // CommitBranch in parts if we have long running branch
+                bool isFirstInBatch = i == 0;
+                bool isLastInBatch = i == blocksCount - 1;
+                bool isNotAtTheEdge = !isFirstInBatch && !isLastInBatch;
+                bool isCommitPoint = i % MaxUncommittedBlocks == 0 && isNotAtTheEdge;
+                if (isCommitPoint && notReadOnly)
+                {
+                    if (_logger.IsInfo) _logger.Info($"Commit part of a long blocks branch {i}/{blocksCount}");
+                    previousBranchStateRoot = suggestedBlock.Header;
+                    InitBranch(suggestedBlock.Header, false);
+                }
+
+                preBlockBaseBlock = processedBlock.Header;
+                // Make sure the prewarm task is finished before we reset the state
+                preWarmTask?.GetAwaiter().GetResult();
+                preWarmTask = null;
+                _stateProvider.Reset();
+
+                // Calculate the transaction hashes in the background and release tx sequence memory
+                // Hashes will be required for PersistentReceiptStorage in ForkchoiceUpdatedHandler
+                // Though we still want to release the memory even if syncing rather than processing live
+                TxHashCalculator.CalculateInBackground(suggestedBlock);
+            }
+
+            if (options.ContainsFlag(ProcessingOptions.DoNotUpdateHead))
+            {
+                RestoreBranch(previousBranchStateRoot);
+            }
+
+            return processedBlocks;
+        }
+        catch (Exception ex) // try to restore at all cost
+        {
+            if (_logger.IsWarn) _logger.Warn($"Encountered exception {ex} while processing blocks.");
+            CancellationTokenExtensions.CancelDisposeAndClear(ref prewarmCancellation);
+            QueueClearCaches(preWarmTask);
+            preWarmTask?.GetAwaiter().GetResult();
+            RestoreBranch(previousBranchStateRoot);
+            throw;
+        }
+    }
+
+    private (CancellationTokenSource prewarmCancellation, Task preWarmTask) PreWarmTransactions(Block suggestedBlock, BlockHeader preBlockBaseBlock, IReleaseSpec spec)
+    {
+        if (preWarmer is null || suggestedBlock.Transactions.Length < 3) return (null, null);
+
+        CancellationTokenSource prewarmCancellation = new();
+        Task preWarmTask = preWarmer.PreWarmCaches(suggestedBlock,
+            preBlockBaseBlock,
+            spec,
+            prewarmCancellation.Token,
+            beaconBlockRootHandler);
+
+        return (prewarmCancellation, preWarmTask);
+    }
+
+    private void WaitForCacheClear() => _clearTask.GetAwaiter().GetResult();
+
+    private void QueueClearCaches(Task? preWarmTask)
+    {
+        if (preWarmTask is not null)
+        {
+            // Can start clearing caches in background
+            _clearTask = preWarmTask.ContinueWith(_clearCaches, TaskContinuationOptions.RunContinuationsAsynchronously);
+        }
+        else if (preWarmer is not null)
+        {
+            _clearTask = Task.Run(preWarmer.ClearCaches);
+        }
+    }
+
+    private class TxHashCalculator(Block suggestedBlock) : IThreadPoolWorkItem
+    {
+        public static void CalculateInBackground(Block suggestedBlock)
+        {
+            // Memory has been reserved on the transactions to delay calculate the hashes
+            // We calculate the hashes in the background to release that memory
+            ThreadPool.UnsafeQueueUserWorkItem(new TxHashCalculator(suggestedBlock), preferLocal: false);
+        }
+
+        void IThreadPoolWorkItem.Execute()
+        {
+            // Hashes will be required for PersistentReceiptStorage in UpdateMainChain ForkchoiceUpdatedHandler
+            // Which occurs after the block has been processed; however the block is stored in cache and picked up
+            // from there so we can calculate the hashes now for that later use.
+            foreach (Transaction tx in suggestedBlock.Transactions)
+            {
+                // Calculate the hashes to release the memory from the transactionSequence
+                tx.CalculateHashInternal();
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/CensorshipDetector/CensorshipDetector.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/CensorshipDetector/CensorshipDetector.cs
@@ -41,7 +41,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
     private readonly IBlockTree _blockTree;
     private readonly ITxPool _txPool;
     private readonly IComparer<Transaction> _betterTxComparer;
-    private readonly IBlockProcessor _blockProcessor;
+    private readonly IBranchProcessor _blockProcessor;
     private readonly ILogger _logger;
     private readonly Dictionary<AddressAsKey, Transaction?>? _bestTxPerObservedAddresses;
     private readonly LruCache<BlockNumberHash, BlockCensorshipInfo> _potentiallyCensoredBlocks;
@@ -53,7 +53,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
         IBlockTree blockTree,
         ITxPool txPool,
         IComparer<Transaction> betterTxComparer,
-        IBlockProcessor blockProcessor,
+        IBranchProcessor blockProcessor,
         ILogManager logManager,
         ICensorshipDetectorConfig censorshipDetectorConfig)
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
@@ -2,48 +2,29 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.Consensus.Processing
 {
+    /// <summary>
+    /// Works much like a <see cref="ITransactionProcessor"/> but at a block level.
+    /// Also, like <see cref="ITransactionProcessor"/>, does not prepare the world state. The world state is assumed
+    /// to be prepared ahead of time.
+    /// </summary>
     public interface IBlockProcessor
     {
-        /// <summary>
-        /// Processes a group of blocks starting with a state defined by the <paramref name="newBranchStateRoot"/>.
-        /// </summary>
-        /// <param name="baseBlock">Block where the state the processed branch to be built on top.</param>
-        /// <param name="suggestedBlocks">List of blocks to be processed.</param>
-        /// <param name="processingOptions">Options to use for processor and transaction processor.</param>
-        /// <param name="blockTracer">Block tracer to use. By default either <see cref="NullBlockTracer"/> or <see cref="BlockReceiptsTracer"/></param>
-        /// <returns>List of processed blocks.</returns>
-        Block[] Process(
-            BlockHeader? baseBlock,
-            IReadOnlyList<Block> suggestedBlocks,
-            ProcessingOptions processingOptions,
+        public (Block Block, TxReceipt[] Receipts) ProcessOne(
+            Block suggestedBlock,
+            ProcessingOptions options,
             IBlockTracer blockTracer,
-            CancellationToken token = default);
-
-        /// <summary>
-        /// Fired when a branch is being processed.
-        /// </summary>
-        event EventHandler<BlocksProcessingEventArgs> BlocksProcessing;
-
-        /// <summary>
-        /// Fired when a block is being processed.
-        /// </summary>
-        event EventHandler<BlockEventArgs> BlockProcessing;
-
-        /// <summary>
-        /// Fired after a block has been processed.
-        /// </summary>
-        event EventHandler<BlockProcessedEventArgs> BlockProcessed;
+            IReleaseSpec spec,
+            CancellationToken token);
 
         /// <summary>
         /// Fired after a transaction has been processed (even if inside the block).

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBranchProcessor.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Evm.Tracing;
+
+namespace Nethermind.Consensus.Processing;
+
+public interface IBranchProcessor
+{
+    /// <summary>
+    /// Processes a group of blocks starting with a state defined by the <paramref name="newBranchStateRoot"/>.
+    /// </summary>
+    /// <param name="baseBlock">Block where the state the processed branch to be built on top.</param>
+    /// <param name="suggestedBlocks">List of blocks to be processed.</param>
+    /// <param name="processingOptions">Options to use for processor and transaction processor.</param>
+    /// <param name="blockTracer">Block tracer to use. By default either <see cref="NullBlockTracer"/> or <see cref="BlockReceiptsTracer"/></param>
+    /// <returns>List of processed blocks.</returns>
+    //
+    Block[] Process(
+        BlockHeader? baseBlock,
+        IReadOnlyList<Block> suggestedBlocks,
+        ProcessingOptions processingOptions,
+        IBlockTracer blockTracer,
+        CancellationToken token = default);
+
+    /// <summary>
+    /// Fired after a block has been processed.
+    /// </summary>
+    event EventHandler<BlockProcessedEventArgs> BlockProcessed;
+
+    /// <summary>
+    /// Fired when a branch is being processed.
+    /// </summary>
+    event EventHandler<BlocksProcessingEventArgs> BlocksProcessing;
+
+    /// <summary>
+    /// Fired when a block is being processed.
+    /// </summary>
+    event EventHandler<BlockEventArgs> BlockProcessing;
+
+    /// <summary>
+    /// Fired after a transaction has been processed (even if inside the block).
+    /// </summary>
+    event EventHandler<TxProcessedEventArgs> TransactionProcessed;
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Consensus.Processing
@@ -20,22 +21,10 @@ namespace Nethermind.Consensus.Processing
         public Block[] Process(BlockHeader? baseBlock, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions processingOptions, IBlockTracer blockTracer, CancellationToken token) =>
             suggestedBlocks.ToArray();
 
-        public event EventHandler<BlocksProcessingEventArgs> BlocksProcessing
+        public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options,
+            IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
         {
-            add { }
-            remove { }
-        }
-
-        public event EventHandler<BlockEventArgs>? BlockProcessing
-        {
-            add { }
-            remove { }
-        }
-
-        public event EventHandler<BlockProcessedEventArgs> BlockProcessed
-        {
-            add { }
-            remove { }
+            return (suggestedBlock, []);
         }
 
         public event EventHandler<TxProcessedEventArgs> TransactionProcessed

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -60,6 +60,7 @@ public class TestBlockchain : IDisposable
     public IReadOnlyTxProcessingEnvFactory ReadOnlyTxProcessingEnvFactory => _fromContainer.ReadOnlyTxProcessingEnvFactory;
     public IShareableTxProcessorSource ShareableTxProcessorSource => _fromContainer.ShareableTxProcessorSource;
     public IBlockProcessor BlockProcessor => _fromContainer.MainProcessingContext.BlockProcessor;
+    public IBranchProcessor BranchProcessor => _fromContainer.MainProcessingContext.BranchProcessor;
     public IBlockchainProcessor BlockchainProcessor => _fromContainer.MainProcessingContext.BlockchainProcessor;
     public IBlockPreprocessorStep BlockPreprocessorStep => _fromContainer.BlockPreprocessorStep;
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/AutoMainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/AutoMainProcessingContext.cs
@@ -74,6 +74,7 @@ public record AutoMainProcessingContext : IMainProcessingContext, IAsyncDisposab
     public ILifetimeScope LifetimeScope { get; init; }
     public IBlockchainProcessor BlockchainProcessor => _mainProcessingContext.BlockchainProcessor;
     public IWorldState WorldState => _mainProcessingContext.WorldState;
+    public IBranchProcessor BranchProcessor => _mainProcessingContext.BranchProcessor;
     public IBlockProcessor BlockProcessor => _mainProcessingContext.BlockProcessor;
     public ITransactionProcessor TransactionProcessor => _mainProcessingContext.TransactionProcessor;
     public GenesisLoader GenesisLoader { get; init; }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
@@ -56,7 +56,7 @@ public class PseudoNethermindModule(ChainSpec spec, IConfigProvider configProvid
             // Environments
             .AddSingleton<ITimerFactory, TimerFactory>()
             .AddSingleton<IBackgroundTaskScheduler, IMainProcessingContext, IChainHeadInfoProvider>((blockProcessingContext, chainHeadInfoProvider) => new BackgroundTaskScheduler(
-                blockProcessingContext.BlockProcessor,
+                blockProcessingContext.BranchProcessor,
                 chainHeadInfoProvider,
                 initConfig.BackgroundTaskConcurrency,
                 initConfig.BackgroundTaskMaxNumber,

--- a/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
+++ b/src/Nethermind/Nethermind.Era.Test/Era1ModuleTests.cs
@@ -151,7 +151,7 @@ public class Era1ModuleTests
                                     .WithParent(blocks[i]).TestObject);
         }
 
-        blocks = testBlockchain.BlockProcessor.Process(genesis.Header!, blocks, ProcessingOptions.NoValidation | ProcessingOptions.StoreReceipts, new BlockReceiptsTracer()).ToList();
+        blocks = testBlockchain.BranchProcessor.Process(genesis.Header!, blocks, ProcessingOptions.NoValidation | ProcessingOptions.StoreReceipts, new BlockReceiptsTracer()).ToList();
         using EraWriter builder = new EraWriter(tmpFile.Path, testBlockchain.SpecProvider);
 
         foreach (var block in blocks)
@@ -173,7 +173,7 @@ public class Era1ModuleTests
         BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create();
         using var tmpFile = TempPath.GetTempFile();
         List<(Block, TxReceipt[])> toAddBlocks = new List<(Block, TxReceipt[])>();
-        testBlockchain.BlockProcessor.BlockProcessed += (sender, blockArgs) =>
+        testBlockchain.BranchProcessor.BlockProcessed += (sender, blockArgs) =>
         {
             toAddBlocks.Add((blockArgs.Block, blockArgs.TxReceipts));
         };
@@ -246,7 +246,7 @@ public class Era1ModuleTests
                                     .WithGasLimit(30_000_000).TestObject);
         }
 
-        testBlockchain.BlockProcessor.Process(genesis.Header!, blocks, ProcessingOptions.NoValidation, new BlockReceiptsTracer());
+        testBlockchain.BranchProcessor.Process(genesis.Header!, blocks, ProcessingOptions.NoValidation, new BlockReceiptsTracer());
 
         foreach (var block in blocks)
         {

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Blockchain.Filters
 
         public FilterManager(
             IFilterStore filterStore,
-            IBlockProcessor blockProcessor,
+            IBranchProcessor blockProcessor,
             ITxPool txPool,
             ILogManager logManager)
         {

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
@@ -137,9 +137,8 @@ public class SimulateBridgeHelper(IBlocksConfig blocksConfig, ISpecProvider spec
                 env.SimulateRequestState.Validate = payload.Validation;
                 env.SimulateRequestState.BlobBaseFeeOverride = spec.IsEip4844Enabled ? blockCall.BlockOverrides?.BlobBaseFee : null;
 
-                IBlockProcessor processor = env.BlockProcessor;
                 // Note: Weird behaviour where the call header is the same as the suggested blocks.
-                Block processedBlock = processor.Process(callHeader, suggestedBlocks, processingFlags, cancellationBlockTracer, cancellationToken)[0];
+                Block processedBlock = env.BranchProcessor.Process(callHeader, suggestedBlocks, processingFlags, cancellationBlockTracer, cancellationToken)[0];
 
                 FinalizeStateAndBlock(stateProvider, processedBlock, spec, callBlock, blockTree);
 

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -25,7 +25,7 @@ public class SimulateReadOnlyBlocksProcessingEnv(
     IBlockTree blockTree,
     IOverridableCodeInfoRepository codeInfoRepository,
     SimulateRequestState simulateState,
-    IBlockProcessor blockProcessor,
+    IBranchProcessor branchProcessor,
     BlockTreeOverlay blockTreeOverlay,
     IOverridableEnv overridableEnv,
     IReadOnlyDbProvider readOnlyDbProvider
@@ -36,7 +36,7 @@ public class SimulateReadOnlyBlocksProcessingEnv(
         blockTreeOverlay.ResetMainChain();
         IDisposable envDisposer = overridableEnv.BuildAndOverride(baseBlock, null);
         return new SimulateReadOnlyBlocksProcessingScope(
-            worldState, specProvider, blockTree, codeInfoRepository, simulateState, blockProcessor, readOnlyDbProvider, envDisposer
+            worldState, specProvider, blockTree, codeInfoRepository, simulateState, branchProcessor, readOnlyDbProvider, envDisposer
         );
     }
 }
@@ -47,7 +47,7 @@ public class SimulateReadOnlyBlocksProcessingScope(
     IBlockTree blockTree,
     IOverridableCodeInfoRepository codeInfoRepository,
     SimulateRequestState simulateState,
-    IBlockProcessor blockProcessor,
+    IBranchProcessor branchProcessor,
     IReadOnlyDbProvider readOnlyDbProvider,
     IDisposable overridableWorldStateCloser
 ) : IDisposable
@@ -57,7 +57,7 @@ public class SimulateReadOnlyBlocksProcessingScope(
     public IBlockTree BlockTree => blockTree;
     public IOverridableCodeInfoRepository CodeInfoRepository => codeInfoRepository;
     public SimulateRequestState SimulateRequestState => simulateState;
-    public IBlockProcessor BlockProcessor => blockProcessor;
+    public IBranchProcessor BranchProcessor => branchProcessor;
 
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
@@ -203,7 +203,7 @@ public class ValidateSubmissionHandler
 
         using var scope = _blockProcessorEnv.BuildAndOverride(parentHeader);
         IWorldState worldState = scope.Component.WorldState;
-        IBlockProcessor blockProcessor = scope.Component.BlockProcessor;
+        IBranchProcessor branchProcessor = scope.Component.BranchProcessor;
 
         IReleaseSpec spec = _specProvider.GetSpec(parentHeader);
 
@@ -219,7 +219,7 @@ public class ValidateSubmissionHandler
             {
                 ValidateSubmissionProcessingOptions |= ProcessingOptions.NoValidation;
             }
-            _ = blockProcessor.Process(parentHeader, suggestedBlocks, ValidateSubmissionProcessingOptions, blockReceiptsTracer)[0];
+            _ = branchProcessor.Process(parentHeader, suggestedBlocks, ValidateSubmissionProcessingOptions, blockReceiptsTracer)[0];
         }
         catch (Exception e)
         {
@@ -402,5 +402,5 @@ public class ValidateSubmissionHandler
         return true;
     }
 
-    public record ProcessingEnv(IBlockProcessor BlockProcessor, IWorldState WorldState);
+    public record ProcessingEnv(IBranchProcessor BranchProcessor, IWorldState WorldState);
 }

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -49,6 +49,7 @@ public class BlockProcessingModule(IInitConfig initConfig) : Module
             .AddScoped<IBlockhashProvider, BlockhashProvider>()
             .AddScoped<IBeaconBlockRootHandler, BeaconBlockRootHandler>()
             .AddScoped<IBlockhashStore, BlockhashStore>()
+            .AddScoped<IBranchProcessor, BranchProcessor>()
             .AddScoped<IBlockProcessor, BlockProcessor>()
             .AddScoped<IWithdrawalProcessor, WithdrawalProcessor>()
             .AddScoped<IExecutionRequestsProcessor, ExecutionRequestsProcessor>()

--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -81,7 +81,7 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
                 .AddScoped<IBlockchainBridge>((ctx) => ctx.Resolve<IBlockchainBridgeFactory>().CreateBlockchainBridge())
                     .AddSingleton<IFeeHistoryOracle, FeeHistoryOracle>()
                     .AddSingleton<IFilterStore, ITimerFactory, IJsonRpcConfig>((timerFactory, rpcConfig) => new FilterStore(timerFactory, rpcConfig.FiltersTimeout))
-                    .AddSingleton<IFilterManager, IFilterStore, IMainProcessingContext, ITxPool, ILogManager>((store, processingContext, txPool, logManager) => new FilterManager(store, processingContext.BlockProcessor, txPool, logManager))
+                    .AddSingleton<IFilterManager, IFilterStore, IMainProcessingContext, ITxPool, ILogManager>((store, processingContext, txPool, logManager) => new FilterManager(store, processingContext.BranchProcessor, txPool, logManager))
                     .AddSingleton<ISimulateReadOnlyBlocksProcessingEnvFactory, SimulateReadOnlyBlocksProcessingEnvFactory>()
 
             // Proof

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -105,10 +105,18 @@ namespace Nethermind.Init.Steps
                 : null;
 
             IBlockProcessor mainBlockProcessor = CreateBlockProcessor(preWarmer, transactionProcessor, mainWorldState);
+            IBranchProcessor mainBranchProcessor = new BranchProcessor(
+                mainBlockProcessor,
+                _api.SpecProvider!,
+                mainWorldState,
+                new BeaconBlockRootHandler(transactionProcessor, mainWorldState),
+                _api.LogManager!,
+                preWarmer
+            );
 
             BlockchainProcessor blockchainProcessor = new(
-                getApi.BlockTree,
-                mainBlockProcessor,
+                getApi.BlockTree!,
+                mainBranchProcessor,
                 _api.BlockPreprocessor,
                 stateReader,
                 getApi.LogManager,
@@ -125,6 +133,7 @@ namespace Nethermind.Init.Steps
 
             var mainProcessingContext = setApi.MainProcessingContext = new MainProcessingContext(
                 transactionProcessor,
+                mainBranchProcessor,
                 mainBlockProcessor,
                 blockchainProcessor,
                 mainWorldState);
@@ -133,7 +142,7 @@ namespace Nethermind.Init.Steps
             setApi.BlockProductionPolicy = CreateBlockProductionPolicy();
 
             BackgroundTaskScheduler backgroundTaskScheduler = new BackgroundTaskScheduler(
-                mainBlockProcessor,
+                mainBranchProcessor,
                 chainHeadInfoProvider,
                 initConfig.BackgroundTaskConcurrency,
                 initConfig.BackgroundTaskMaxNumber,
@@ -148,7 +157,7 @@ namespace Nethermind.Init.Steps
                     _api.BlockTree!,
                     txPool,
                     CreateTxPoolTxComparer(),
-                    mainBlockProcessor,
+                    mainBranchProcessor,
                     _api.LogManager,
                     censorshipDetectorConfig
                 );
@@ -240,8 +249,7 @@ namespace Nethermind.Init.Steps
                 new BlockhashStore(_api.SpecProvider!, worldState),
                 _api.LogManager,
                 new WithdrawalProcessor(worldState, _api.LogManager),
-                new ExecutionRequestsProcessor(transactionProcessor),
-                preWarmer: preWarmer);
+                new ExecutionRequestsProcessor(transactionProcessor));
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -174,7 +174,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
                     // Filter manager need the block processor, but the block processor is currently not completely DI, so need to patch it in.
                     builder.AddSingleton<IFilterManager, IFilterStore, ITxPool, ILogManager>((store, txPool, logManager) =>
-                            new FilterManager(store, _blockchain.BlockProcessor, txPool, logManager));
+                            new FilterManager(store, _blockchain.BranchProcessor, txPool, logManager));
 
                     if (_blockFinderOverride is not null) builder.AddSingleton(_blockFinderOverride);
                     if (_receiptFinderOverride is not null) builder.AddSingleton(_receiptFinderOverride);
@@ -263,7 +263,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             }
 
             // simulating restarts - we stopped the old blockchain processor and create the new one
-            _currentBlockchainProcessor = new BlockchainProcessor(BlockTree, BlockProcessor,
+            _currentBlockchainProcessor = new BlockchainProcessor(BlockTree, BranchProcessor,
                 BlockPreprocessorStep, StateReader, LimboLogs.Instance, Nethermind.Consensus.Processing.BlockchainProcessor.Options.Default);
             _currentBlockchainProcessor.Start();
         }

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
@@ -36,8 +36,7 @@ public class AuRaMergeBlockProcessor(
     IAuRaValidator? validator,
     ITxFilter? txFilter = null,
     AuRaContractGasLimitOverride? gasLimitOverride = null,
-    ContractRewriter? contractRewriter = null,
-    IBlockCachePreWarmer? preWarmer = null)
+    ContractRewriter? contractRewriter = null)
     : AuRaBlockProcessor(specProvider,
         blockValidator,
         rewardCalculator,
@@ -52,8 +51,7 @@ public class AuRaMergeBlockProcessor(
         validator,
         txFilter,
         gasLimitOverride,
-        contractRewriter,
-        preWarmer)
+        contractRewriter)
 {
     protected override TxReceipt[] ProcessBlock(Block block, IBlockTracer blockTracer, ProcessingOptions options, IReleaseSpec spec, CancellationToken token) =>
         block.IsPostMerge

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -30,9 +30,9 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
         return _auRaBlockFinalizationManager.GetFinalizationLevel(level);
     }
 
-    public void SetMainBlockProcessor(IBlockProcessor blockProcessor)
+    public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
     {
-        _auRaBlockFinalizationManager.SetMainBlockProcessor(blockProcessor);
+        _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
     }
 
     public override long LastFinalizedBlockLevel

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -187,7 +187,7 @@ public abstract partial class BaseEngineModuleTests
         public MergeTestBlockchain ThrottleBlockProcessor(int delayMs)
         {
             _blockProcessingThrottle = delayMs;
-            if (Container is not null && BlockProcessor is TestBlockProcessorInterceptor testBlockProcessor)
+            if (Container is not null && BranchProcessor is TestBranchProcessorInterceptor testBlockProcessor)
             {
                 testBlockProcessor.DelayMs = delayMs;
             }
@@ -217,7 +217,7 @@ public abstract partial class BaseEngineModuleTests
             base.ConfigureContainer(builder, configProvider)
                 .AddScoped<IWithdrawalProcessor, WithdrawalProcessor>()
                 .AddModule(new TestMergeModule(configProvider))
-                .AddDecorator<IBlockProcessor>((ctx, blockProcessor) => new TestBlockProcessorInterceptor(blockProcessor, _blockProcessingThrottle))
+                .AddDecorator<IBranchProcessor>((ctx, branchProcessor) => new TestBranchProcessorInterceptor(branchProcessor, _blockProcessingThrottle))
                 .AddDecorator<IBlockImprovementContextFactory>((ctx, factory) =>
                 {
                     if (factory is StoringBlockImprovementContextFactory) return factory;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -808,7 +808,7 @@ public partial class EngineModuleTests
 
         Block? bestBeaconBlock = bestBeaconBlockRequest.TryGetBlock().Block;
         SemaphoreSlim bestBlockProcessed = new(0);
-        chain.BlockProcessor.BlockProcessed += (s, e) =>
+        chain.BranchProcessor.BlockProcessed += (s, e) =>
         {
             if (e.Block.Hash == bestBeaconBlock!.Hash)
                 bestBlockProcessed.Release(1);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -447,7 +447,7 @@ public partial class EngineModuleTests
             .Build(new TestSingleReleaseSpecProvider(London.Instance));
         IEngineRpcModule rpc = chain.EngineRpcModule;
 
-        ((TestBlockProcessorInterceptor)chain.BlockProcessor).ExceptionToThrow =
+        ((TestBranchProcessorInterceptor)chain.BranchProcessor).ExceptionToThrow =
             new Exception("unxpected exception");
 
         ExecutionPayload executionPayload = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/TestBlockProcessorInterceptor.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/TestBlockProcessorInterceptor.Setup.cs
@@ -11,13 +11,13 @@ using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Merge.Plugin.Test;
 
-public class TestBlockProcessorInterceptor : IBlockProcessor
+public class TestBranchProcessorInterceptor : IBranchProcessor
 {
-    private readonly IBlockProcessor _blockProcessorImplementation;
+    private readonly IBranchProcessor _blockProcessorImplementation;
     public int DelayMs { get; set; }
     public Exception? ExceptionToThrow { get; set; }
 
-    public TestBlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, int delayMs)
+    public TestBranchProcessorInterceptor(IBranchProcessor baseBlockProcessor, int delayMs)
     {
         _blockProcessorImplementation = baseBlockProcessor;
         DelayMs = delayMs;

--- a/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
+++ b/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
@@ -78,8 +78,7 @@ public class InitializeBlockchainOptimism(OptimismNethermindApi api) : Initializ
             api.SpecHelper,
             contractRewriter,
             new OptimismWithdrawalProcessor(api.WorldStateManager!.GlobalWorldState, api.LogManager, api.SpecHelper),
-            new ExecutionRequestsProcessor(transactionProcessor),
-            preWarmer: preWarmer);
+            new ExecutionRequestsProcessor(transactionProcessor));
     }
 
     protected override IBlockProductionPolicy CreateBlockProductionPolicy() => AlwaysStartBlockProductionPolicy.Instance;

--- a/src/Nethermind/Nethermind.Optimism/OptimismBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBlockProcessor.cs
@@ -36,8 +36,7 @@ public class OptimismBlockProcessor : BlockProcessor
         IOptimismSpecHelper opSpecHelper,
         Create2DeployerContractRewriter contractRewriter,
         IWithdrawalProcessor withdrawalProcessor,
-        IExecutionRequestsProcessor executionRequestsProcessor,
-        IBlockCachePreWarmer? preWarmer = null)
+        IExecutionRequestsProcessor executionRequestsProcessor)
         : base(
             specProvider,
             blockValidator,
@@ -49,8 +48,7 @@ public class OptimismBlockProcessor : BlockProcessor
             blockhashStore,
             logManager,
             withdrawalProcessor,
-            executionRequestsProcessor,
-            preWarmer)
+            executionRequestsProcessor)
     {
         ArgumentNullException.ThrowIfNull(stateProvider);
         _contractRewriter = contractRewriter;

--- a/src/Nethermind/Nethermind.Taiko/InitializeBlockchainTaiko.cs
+++ b/src/Nethermind/Nethermind.Taiko/InitializeBlockchainTaiko.cs
@@ -62,8 +62,7 @@ public class InitializeBlockchainTaiko(TaikoNethermindApi api) : InitializeBlock
             new BlockhashStore(_api.SpecProvider, worldState),
             _api.LogManager,
             new WithdrawalProcessor(worldState, _api.LogManager),
-            new ExecutionRequestsProcessor(transactionProcessor),
-            preWarmer: preWarmer);
+            new ExecutionRequestsProcessor(transactionProcessor));
     }
 
     protected override IBlockProductionPolicy CreateBlockProductionPolicy() => NeverStartBlockProductionPolicy.Instance;


### PR DESCRIPTION
- Require #8959 
- Split the branch logic out of `IBlockProcessor` into `IBranchProcessor`.
- This is so that the state handling (in `BranchProcessor`) is outside, which resolve some double world scoping.
- This PR only split the class without doing further modification.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet can sync normally