### PR TITLE
Fail fast on Db corruption

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -292,7 +292,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             _fileSystem.File.WriteAllText(CorruptMarkerPath, "marker");
 
             // Don't kill tests checking corruption response
-            if (rocksDbException.Message != "Corruption: test corruption")
+            if (!rocksDbException.Message.Equals("Corruption: test corruption", StringComparison.Ordinal))
             {
                 Environment.FailFast("Fast shutdown due to DB corruption. Please restart.");
             }


### PR DESCRIPTION
Resolves #8220

## Changes

- Fail fast on Db corruption rather than continuing to run which may compound the error further and make the db more corrupt

<img width="2548" height="1265" alt="image" src="https://github.com/user-attachments/assets/87396988-acfd-4235-9dfc-0b1b8496c7d3" />

Continuing leads to missing trienodes after repair etc

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
