### PR TITLE
Remove locking in RlpDecoder fast path

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -78,26 +78,49 @@ namespace Nethermind.Serialization.Rlp
 
         private static readonly Dictionary<RlpDecoderKey, IRlpDecoder> _decoderBuilder = new();
         private static FrozenDictionary<RlpDecoderKey, IRlpDecoder>? _decoders;
-        private static Lock _decoderLock = new Lock();
+        private static Lock _decoderLock = new();
         public static FrozenDictionary<RlpDecoderKey, IRlpDecoder> Decoders
         {
             get
             {
-                using Lock.Scope _ = _decoderLock.EnterScope();
-                return _decoders ??= _decoderBuilder.ToFrozenDictionary();
+                FrozenDictionary<RlpDecoderKey, IRlpDecoder> decoders = _decoders;
+                if (decoders is not null)
+                {
+                    // Already exists no need for lock
+                    return decoders;
+                }
+
+                return CreateDecoders();
             }
+        }
+
+        private static FrozenDictionary<RlpDecoderKey, IRlpDecoder> CreateDecoders()
+        {
+            using Lock.Scope _ = _decoderLock.EnterScope();
+
+            FrozenDictionary<RlpDecoderKey, IRlpDecoder> decoders = _decoders;
+            if (decoders is not null)
+            {
+                // Already been recreated
+                return decoders;
+            }
+
+            // Recreate
+            return _decoders = _decoderBuilder.ToFrozenDictionary();
         }
 
         public static void ResetDecoders()
         {
+            using Lock.Scope _ = _decoderLock.EnterScope();
             _decoderBuilder.Clear();
             _decoders = null;
             RegisterDecoders(Assembly.GetAssembly(typeof(Rlp)));
-            Rlp.RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
+            RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
         }
 
         public static void RegisterDecoder(RlpDecoderKey key, IRlpDecoder decoder)
         {
+            using Lock.Scope _ = _decoderLock.EnterScope();
             _decoderBuilder[key] = decoder;
             // Mark FrozenDictionary as null to force re-creation
             _decoders = null;
@@ -146,6 +169,7 @@ namespace Nethermind.Serialization.Rlp
 
                         void AddEncoder(RlpDecoderKey key)
                         {
+                            using Lock.Scope _ = _decoderLock.EnterScope();
                             if (!_decoderBuilder.TryGetValue(key, out IRlpDecoder? value) || canOverrideExistingDecoders)
                             {
                                 try
@@ -1921,7 +1945,9 @@ namespace Nethermind.Serialization.Rlp
 
         public bool Equals(RlpDecoderKey other) => _type.Equals(other._type) && _key.Equals(other._key);
 
-        public override int GetHashCode() => HashCode.Combine(_type, _key);
+        public override int GetHashCode() => (int)BitOperations.Crc32C(
+            (uint)_type.GetHashCode(),
+            (uint)MemoryMarshal.AsBytes(_key.AsSpan()).FastHash());
 
         public override bool Equals(object obj) => obj is RlpDecoderKey key && Equals(key);
 


### PR DESCRIPTION
## Changes

- Remove lock when looking up a decoder and `_decoders` is set as we don't need it
- Move the lock to recreating `_decoders`
- Additionally always cover changes to `_decoderBuilder` with the lock as we _**always**_ need it there (but don't always have it currently)
- Change `RlpDecoderKey` to a faster variant

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] No
