### PR TITLE
Don't process gossiped txs during block processing

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/NotProcessingBlocksGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/NotProcessingBlocksGossipPolicyTests.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Processing;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Consensus.Test;
+public class NotProcessingBlocksGossipPolicyTests
+{
+    [TestCase(true, ExpectedResult = false)]
+    [TestCase(false, ExpectedResult = true)]
+    public bool can_listen_gossip(bool isProcessing)
+    {
+        var processor = Substitute.For<IBlockchainProcessor>();
+        processor.IsProcessingBlock.Returns(isProcessing);
+
+        return ((ITxGossipPolicy)new NotProcessingBlocksGossipPolicy(processor)).ShouldListenToGossipedTransactions;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/NotProcessingBlocksGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Consensus/NotProcessingBlocksGossipPolicy.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Processing;
+using Nethermind.TxPool;
+
+namespace Nethermind.Consensus;
+public class NotProcessingBlocksGossipPolicy(IBlockchainProcessor processor) : ITxGossipPolicy
+{
+    public bool ShouldListenToGossipedTransactions => !processor.IsProcessingBlock;
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -307,7 +307,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
     }
 
-    private bool IsProcessingBlock { get => _isProcessingBlock; set { _isProcessingBlock = value; _blockTree.IsProcessingBlock = value; } }
+    public bool IsProcessingBlock { get => _isProcessingBlock; set { _isProcessingBlock = value; _blockTree.IsProcessingBlock = value; } }
 
     private async Task RunProcessingLoop()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockchainProcessor.cs
@@ -21,6 +21,7 @@ namespace Nethermind.Consensus.Processing
         Block? Process(Block block, ProcessingOptions options, IBlockTracer tracer, CancellationToken token = default);
 
         bool IsProcessingBlocks(ulong? maxProcessingInterval);
+        bool IsProcessingBlock { get; }
 
         event EventHandler<InvalidBlockEventArgs> InvalidBlock;
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/OneTimeProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/OneTimeProcessor.cs
@@ -44,10 +44,10 @@ namespace Nethermind.Consensus.Processing
             }
         }
 
+        public bool IsProcessingBlock => _processor.IsProcessingBlock;
+
         public bool IsProcessingBlocks(ulong? maxProcessingInterval)
-        {
-            return _processor.IsProcessingBlocks(maxProcessingInterval);
-        }
+            => _processor.IsProcessingBlocks(maxProcessingInterval);
 
 #pragma warning disable 67
         public event EventHandler<BlockProcessedEventArgs> BlockProcessed;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -120,6 +120,7 @@ namespace Nethermind.Init.Steps
             };
 
             getApi.DisposeStack.Push(blockchainProcessor);
+            _api.TxGossipPolicy.Policies.Add(new NotProcessingBlocksGossipPolicy(blockchainProcessor));
 
             var mainProcessingContext = setApi.MainProcessingContext = new MainProcessingContext(
                 transactionProcessor,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -121,7 +121,7 @@ public class InitializeNetwork : IStep
         int maxPeersCount = _networkConfig.ActivePeersMaxCount;
         Network.Metrics.PeerLimit = maxPeersCount;
 
-        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
+        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector, () => _api.BlockTree.IsProcessingBlock));
 
         if (cancellationToken.IsCancellationRequested)
         {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -121,7 +121,7 @@ public class InitializeNetwork : IStep
         int maxPeersCount = _networkConfig.ActivePeersMaxCount;
         Network.Metrics.PeerLimit = maxPeersCount;
 
-        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector, () => _api.BlockTree.IsProcessingBlock));
+        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
 
         if (cancellationToken.IsCancellationRequested)
         {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -276,6 +276,7 @@ public class InitializeNetwork : IStep
             _networkConfig,
             _api.LogManager);
         PooledTxsRequestor pooledTxsRequestor = new(_api.TxPool!, _api.Config<ITxPoolConfig>(), _api.SpecProvider);
+        _api.DisposeStack.Push(pooledTxsRequestor);
 
         _api.ProtocolsManager = new ProtocolsManager(
             _api.SyncPeerPool!,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -95,6 +95,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _session?.Dispose();
             _syncManager?.Dispose();
             _disposables.Dispose();
+            _pooledTxsRequestor?.Dispose();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
@@ -27,6 +27,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         [TearDown]
         public void TearDown()
         {
+            _requestor?.Dispose();
             _response?.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -102,6 +102,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         [TearDown]
         public void TearDown()
         {
+            _pooledTxsRequestor?.Dispose();
             _handler?.Dispose();
             _session?.Dispose();
             _syncManager?.Dispose();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
@@ -81,6 +81,7 @@ public class Eth67ProtocolHandlerTests
     [TearDown]
     public void TearDown()
     {
+        _pooledTxsRequestor?.Dispose();
         _handler?.Dispose();
         _session?.Dispose();
         _syncManager?.Dispose();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -92,6 +92,7 @@ public class Eth68ProtocolHandlerTests
     [TearDown]
     public void TearDown()
     {
+        _pooledTxsRequestor?.Dispose();
         _handler?.Dispose();
         _session?.Dispose();
         _syncManager?.Dispose();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
@@ -92,6 +92,7 @@ public class Eth69ProtocolHandlerTests
     [TearDown]
     public void TearDown()
     {
+        _pooledTxsRequestor?.Dispose();
         // Dispose received messages
         _session?.ReceivedCalls()
             .Where(c => c.GetMethodInfo().Name == nameof(_session.DeliverMessage))

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/IPooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/IPooledTxsRequestor.cs
@@ -8,7 +8,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth
 {
-    public interface IPooledTxsRequestor
+    public interface IPooledTxsRequestor : IDisposable
     {
         void RequestTransactions(Action<GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes);
         void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashes);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -25,5 +25,5 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
     [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), () => true)).ShouldListenToGossipedTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), isProcessing: () => false)).ShouldListenToGossipedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -25,5 +25,5 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
     [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode))).ShouldListenToGossipedTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), () => true)).ShouldListenToGossipedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -25,5 +25,5 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
     [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), isProcessing: () => false)).ShouldListenToGossipedTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), isProcessingBlock: () => false)).ShouldListenToGossipedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -25,5 +25,5 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
     [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode), isProcessingBlock: () => false)).ShouldListenToGossipedTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode))).ShouldListenToGossipedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -9,13 +9,11 @@ namespace Nethermind.Synchronization.ParallelSync;
 public class SyncedTxGossipPolicy : ITxGossipPolicy
 {
     private readonly ISyncModeSelector _syncModeSelector;
-    private readonly Func<bool> _isProcessingBlock;
 
-    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector, Func<bool> isProcessingBlock)
+    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector)
     {
         _syncModeSelector = syncModeSelector;
-        _isProcessingBlock = isProcessingBlock;
     }
 
-    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0 && !_isProcessingBlock();
+    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -9,13 +9,13 @@ namespace Nethermind.Synchronization.ParallelSync;
 public class SyncedTxGossipPolicy : ITxGossipPolicy
 {
     private readonly ISyncModeSelector _syncModeSelector;
-    private readonly Func<bool> _isProcessing;
+    private readonly Func<bool> _isProcessingBlock;
 
-    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector, Func<bool> isProcessing)
+    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector, Func<bool> isProcessingBlock)
     {
         _syncModeSelector = syncModeSelector;
-        _isProcessing = isProcessing;
+        _isProcessingBlock = isProcessingBlock;
     }
 
-    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0 && !_isProcessing();
+    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0 && !_isProcessingBlock();
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.TxPool;
 
 namespace Nethermind.Synchronization.ParallelSync;
@@ -8,11 +9,13 @@ namespace Nethermind.Synchronization.ParallelSync;
 public class SyncedTxGossipPolicy : ITxGossipPolicy
 {
     private readonly ISyncModeSelector _syncModeSelector;
+    private readonly Func<bool> _isProcessing;
 
-    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector)
+    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector, Func<bool> isProcessing)
     {
         _syncModeSelector = syncModeSelector;
+        _isProcessing = isProcessing;
     }
 
-    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
+    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0 && !_isProcessing();
 }

--- a/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
@@ -7,5 +7,6 @@ namespace Nethermind.TxPool
     {
         public static int MemPoolSize { get; set; } = 2_048;
         public static int TxHashCacheSize { get; set; } = 131_072;
+        public static int RequestedTxHashCacheSize { get; set; } = MemPoolSize * 2;
     }
 }


### PR DESCRIPTION
## Changes

- Remove a source of unpredictability from block processing
- Can both be very heavy on memory allocations (with blob txs) and the head is just about to change; will get them after
- Reduces WorldState access from the txPool during block processing
- Clear the pending requests on each txPool head (to allow re-requesting)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
