### PR TITLE
Add -y flag to Windows zip archive and quote variables in archive.sh

### DIFF
--- a/scripts/build/archive.sh
+++ b/scripts/build/archive.sh
@@ -6,15 +6,15 @@ set -e
 
 echo "Archiving Nethermind packages"
 
-cd $GITHUB_WORKSPACE
-mkdir $PACKAGE_DIR
-cd $PUB_DIR
+cd "$GITHUB_WORKSPACE"
+mkdir "$PACKAGE_DIR"
+cd "$PUB_DIR"
 
-cd linux-x64 && zip -r -y $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-linux-x64.zip . && cd ..
-cd linux-arm64 && zip -r -y $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-linux-arm64.zip . && cd ..
-cd win-x64 && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-windows-x64.zip . && cd ..
-cd osx-x64 && zip -r -y $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-x64.zip . && cd ..
-cd osx-arm64 && zip -r -y $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-arm64.zip . && cd ..
-cd ref && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-ref-assemblies.zip . && cd ..
+cd linux-x64 && zip -r -y "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-linux-x64.zip" . && cd ..
+cd linux-arm64 && zip -r -y "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-linux-arm64.zip" . && cd ..
+cd win-x64 && zip -r -y "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-windows-x64.zip" . && cd ..
+cd osx-x64 && zip -r -y "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-x64.zip" . && cd ..
+cd osx-arm64 && zip -r -y "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-arm64.zip" . && cd ..
+cd ref && zip -r "$GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-ref-assemblies.zip" . && cd ..
 
 echo "Archiving completed"


### PR DESCRIPTION
- Adds the -y flag to the zip command for the Windows (win-x64) archive, ensuring symbolic links are handled consistently across all platforms.
- Wraps all variable references in double quotes in cd, mkdir, and zip commands to prevent issues with paths containing spaces.