### PR TITLE
Feature/adjust rocksdb config by memory

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -8,6 +8,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Consensus;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Db;
@@ -117,6 +118,8 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
                 pruningConfig.DirtyNodeShardBit = 1;
                 return pruningConfig;
             })
+
+            .AddSingleton<IHardwareInfo>(new TestHardwareInfo(1.GiB()))
             ;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/TestHardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestHardwareInfo.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Test;
+
+public class TestHardwareInfo(long availableMemory = 10000000) : IHardwareInfo
+{
+    public long AvailableMemoryBytes => availableMemory;
+}

--- a/src/Nethermind/Nethermind.Core/HardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Core/HardwareInfo.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Core;
+
+public class HardwareInfo : IHardwareInfo
+{
+    public long AvailableMemoryBytes { get; }
+
+    public HardwareInfo()
+    {
+        AvailableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/HardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Core/HardwareInfo.cs
@@ -11,6 +11,8 @@ public class HardwareInfo : IHardwareInfo
 
     public HardwareInfo()
     {
+        // Note: Not the same as memory capacity. This take into account current system memory pressure such as
+        // other process as well as OS level limit such as rlimit. Eh, its good enough.
         AvailableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
     }
 }

--- a/src/Nethermind/Nethermind.Core/IHardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Core/IHardwareInfo.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core;
+
+public interface IHardwareInfo
+{
+    long AvailableMemoryBytes { get; }
+}

--- a/src/Nethermind/Nethermind.Core/IHardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Core/IHardwareInfo.cs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Extensions;
+
 namespace Nethermind.Core;
 
 public interface IHardwareInfo
 {
+    public static readonly long StateDbLargerMemoryThreshold = 32.GiB();
     long AvailableMemoryBytes { get; }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -17,8 +17,8 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
 {
     private readonly IDictionary<T, ColumnDb> _columnDbs = new Dictionary<T, ColumnDb>();
 
-    public ColumnsDb(string basePath, DbSettings settings, IDbConfig dbConfig, ILogManager logManager, IReadOnlyList<T> keys, IntPtr? sharedCache = null)
-        : base(basePath, settings, dbConfig, logManager, GetEnumKeys(keys).Select(static (key) => key.ToString()).ToList(), sharedCache: sharedCache)
+    public ColumnsDb(string basePath, DbSettings settings, IDbConfig dbConfig, IRocksDbConfigFactory rocksDbConfigFactory, ILogManager logManager, IReadOnlyList<T> keys, IntPtr? sharedCache = null)
+        : base(basePath, settings, dbConfig, rocksDbConfigFactory, logManager, GetEnumKeys(keys).Select(static (key) => key.ToString()).ToList(), sharedCache: sharedCache)
     {
         keys = GetEnumKeys(keys);
 
@@ -61,7 +61,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         return keys;
     }
 
-    protected override void BuildOptions<O>(PerTableDbConfig dbConfig, Options<O> options, IntPtr? sharedCache)
+    protected override void BuildOptions<O>(IRocksDbConfig dbConfig, Options<O> options, IntPtr? sharedCache)
     {
         base.BuildOptions(dbConfig, options, sharedCache);
         options.SetCreateMissingColumnFamilies();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
@@ -3,7 +3,7 @@
 
 namespace Nethermind.Db.Rocks.Config;
 
-public class MemoryAdjustedRocksdbConfig(
+public class AdjustedRocksdbConfig(
     IRocksDbConfig baseConfig,
     string additionalRocksDbOptions,
     ulong writeBufferSize

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -235,10 +235,30 @@ public class DbConfig : IDbConfig
 
         "";
 
-    public string StateDbLargeMemoryAdditionalRocksDbOptions { get; set; } =
+    public string StateDbLargeMemoryRocksDbOptions { get; set; } =
         "block_based_table_factory={index_type=kBinarySearch;partition_filters=0;};";
 
+    public string StateDbArchiveModeRocksDbOptions { get; set; } =
+        // For archive mode, we lowers back the level multiplier as very large database causes very high write amp.
+        "max_bytes_for_level_multiplier=10;" +
+        "max_bytes_for_level_base=350000000;" +
+
+        // Change back file size multiplier as we dont want ridiculous file size, making compaction uneven,
+        // but set high base size. This mean a lot of file, but you are using archive mode, so this should be expected.
+        "target_file_size_multiplier=1;" +
+        "target_file_size_base=256000000;" +
+
+        // Change back restart interval for (probably slight) database size reduction
+        "block_based_table_factory.block_restart_interval=16;" +
+
+        // slight adjustment to util ratio
+        "block_based_table_factory.data_block_hash_table_util_ratio=0.8;" +
+
+        // slight adjustment to block size
+        "block_based_table_factory.block_size=64000;";
+
     public ulong StateDbLargeMemoryWriteBufferSize { get; set; } = (ulong)128.MiB();
+    public ulong StateDbArchiveModeWriteBufferSize { get; set; } = (ulong)256.MiB();
 
     public string? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -236,10 +236,15 @@ public class DbConfig : IDbConfig
         "";
 
     public string StateDbLargeMemoryRocksDbOptions { get; set; } =
+        // In large memory, we disable the partitioned block index. This took around additional 2GB of memory, but
+        // pretty reasonable reduction in latency especially when blocks are already cached.
+        // Note: Not for archive mode as the index size is proportional to db size.
         "block_based_table_factory={index_type=kBinarySearch;partition_filters=0;};";
 
     public string StateDbArchiveModeRocksDbOptions { get; set; } =
-        // For archive mode, we lowers back the level multiplier as very large database causes very high write amp.
+        // For archive mode, we are mainly concerned with write amplification due to very large database.
+
+        // Lowers back the level multiplier as very large database causes very high write amp.
         "max_bytes_for_level_multiplier=10;" +
         "max_bytes_for_level_base=350000000;" +
 
@@ -251,10 +256,10 @@ public class DbConfig : IDbConfig
         // Change back restart interval for (probably slight) database size reduction
         "block_based_table_factory.block_restart_interval=16;" +
 
-        // slight adjustment to util ratio
+        // slight adjustment to util ratio, for db size.
         "block_based_table_factory.data_block_hash_table_util_ratio=0.8;" +
 
-        // slight adjustment to block size
+        // slight adjustment to block size, for potentially better db size.
         "block_based_table_factory.block_size=64000;";
 
     public ulong StateDbLargeMemoryWriteBufferSize { get; set; } = (ulong)128.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -158,7 +158,7 @@ public class DbConfig : IDbConfig
 
     public ulong? CodeDbRowCacheSize { get; set; } = (ulong)16.MiB();
     public string CodeDbRocksDbOptions { get; set; } =
-        "write_buffer_size=4000000;" +
+        "write_buffer_size=16000000;" +
         "block_based_table_factory.block_cache=16000000;" +
         "optimize_filters_for_hits=false;" +
         "prefix_extractor=capped:8;" +
@@ -234,6 +234,12 @@ public class DbConfig : IDbConfig
         "max_write_batch_group_size_bytes=4000000;" +
 
         "";
+
+    public string StateDbLargeMemoryAdditionalRocksDbOptions { get; set; } =
+        "block_based_table_factory={index_type=kBinarySearch;partition_filters=0;};";
+
+    public ulong StateDbLargeMemoryWriteBufferSize { get; set; } = (ulong)128.MiB();
+
     public string? StateDbAdditionalRocksDbOptions { get; set; }
 
     public string L1OriginDbRocksDbOptions { get; set; } = "";

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -93,8 +93,10 @@ public interface IDbConfig : IConfig
     double StateDbCompressibilityHint { get; set; }
     string StateDbRocksDbOptions { get; set; }
     string? StateDbAdditionalRocksDbOptions { get; set; }
-    string StateDbLargeMemoryAdditionalRocksDbOptions { get; set; }
+    string StateDbLargeMemoryRocksDbOptions { get; set; }
+    string StateDbArchiveModeRocksDbOptions { get; set; }
     ulong StateDbLargeMemoryWriteBufferSize { get; set; }
+    ulong StateDbArchiveModeWriteBufferSize { get; set; }
 
 
     string L1OriginDbRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -93,6 +93,8 @@ public interface IDbConfig : IConfig
     double StateDbCompressibilityHint { get; set; }
     string StateDbRocksDbOptions { get; set; }
     string? StateDbAdditionalRocksDbOptions { get; set; }
+    string StateDbLargeMemoryAdditionalRocksDbOptions { get; set; }
+    ulong StateDbLargeMemoryWriteBufferSize { get; set; }
 
 
     string L1OriginDbRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.Rocks.Config;
+
+public interface IRocksDbConfig
+{
+    ulong? WriteBufferSize { get; }
+    ulong? WriteBufferNumber { get; }
+    string RocksDbOptions { get; }
+    string AdditionalRocksDbOptions { get; }
+    int? MaxOpenFiles { get; }
+    bool WriteAheadLogSync { get; }
+    ulong? ReadAheadSize { get; }
+    bool EnableDbStatistics { get; }
+    uint StatsDumpPeriodSec { get; }
+    bool? VerifyChecksum { get; }
+    ulong? RowCacheSize { get; }
+    bool EnableFileWarmer { get; }
+    double CompressibilityHint { get; }
+    bool FlushOnExit { get; }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfigFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfigFactory.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.Rocks.Config;
+
+public interface IRocksDbConfigFactory
+{
+    IRocksDbConfig GetForDatabase(string databaseName, string? columnName);
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/MemoryAdjustedRocksdbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/MemoryAdjustedRocksdbConfig.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.Rocks.Config;
+
+public class MemoryAdjustedRocksdbConfig(
+    IRocksDbConfig baseConfig,
+    string additionalRocksDbOptions,
+    ulong writeBufferSize
+) : IRocksDbConfig
+{
+    public ulong? WriteBufferSize => writeBufferSize;
+
+    public ulong? WriteBufferNumber => baseConfig.WriteBufferNumber;
+
+    // Note: not AdditionalRocksDbOptions so that user can still override option.
+    public string RocksDbOptions => baseConfig.RocksDbOptions + additionalRocksDbOptions;
+
+    public string AdditionalRocksDbOptions => baseConfig.AdditionalRocksDbOptions;
+
+    public int? MaxOpenFiles => baseConfig.MaxOpenFiles;
+
+    public bool WriteAheadLogSync => baseConfig.WriteAheadLogSync;
+
+    public ulong? ReadAheadSize => baseConfig.ReadAheadSize;
+
+    public bool EnableDbStatistics => baseConfig.EnableDbStatistics;
+
+    public uint StatsDumpPeriodSec => baseConfig.StatsDumpPeriodSec;
+
+    public bool? VerifyChecksum => baseConfig.VerifyChecksum;
+
+    public ulong? RowCacheSize => baseConfig.RowCacheSize;
+
+    public bool EnableFileWarmer => baseConfig.EnableFileWarmer;
+
+    public double CompressibilityHint => baseConfig.CompressibilityHint;
+
+    public bool FlushOnExit => baseConfig.FlushOnExit;
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -10,20 +10,18 @@ using Nethermind.Core.Extensions;
 
 namespace Nethermind.Db.Rocks.Config;
 
-public class PerTableDbConfig
+public class PerTableDbConfig: IRocksDbConfig
 {
     private readonly string _tableName;
     private readonly string? _columnName;
     private readonly IDbConfig _dbConfig;
-    private readonly DbSettings _settings;
     private readonly string[] _prefixes;
     private readonly string[] _reversedPrefixes;
 
-    public PerTableDbConfig(IDbConfig dbConfig, DbSettings dbSettings, string? columnName = null)
+    public PerTableDbConfig(IDbConfig dbConfig, string dbName, string? columnName = null)
     {
         _dbConfig = dbConfig;
-        _settings = dbSettings;
-        _tableName = _settings.DbName;
+        _tableName = dbName;
         _columnName = columnName;
         _prefixes = GetPrefixes();
         _reversedPrefixes = _prefixes.Reverse().ToArray();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
@@ -23,25 +24,44 @@ public class RocksDbConfigFactory(IDbConfig dbConfig, IPruningConfig pruningConf
                 ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
                 if (writeBufferSize < dbConfig.StateDbArchiveModeWriteBufferSize) writeBufferSize = dbConfig.StateDbArchiveModeWriteBufferSize;
 
-                rocksDbConfig = new MemoryAdjustedRocksdbConfig(
+                rocksDbConfig = new AdjustedRocksdbConfig(
                     rocksDbConfig,
                     dbConfig.StateDbArchiveModeRocksDbOptions!,
                     writeBufferSize
                 );
             }
-            else if (hardwareInfo.AvailableMemoryBytes > IHardwareInfo.StateDbLargerMemoryThreshold)
+            else if (hardwareInfo.AvailableMemoryBytes >= IHardwareInfo.StateDbLargerMemoryThreshold)
             {
                 if (_logger.IsInfo) _logger.Info($"Detected {hardwareInfo.AvailableMemoryBytes / 1.GiB()} GB of available memory. Applying large memory State Db config.");
 
                 ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
                 if (writeBufferSize < dbConfig.StateDbLargeMemoryWriteBufferSize) writeBufferSize = dbConfig.StateDbLargeMemoryWriteBufferSize;
 
-                rocksDbConfig = new MemoryAdjustedRocksdbConfig(
+                rocksDbConfig = new AdjustedRocksdbConfig(
                     rocksDbConfig,
                     dbConfig.StateDbLargeMemoryRocksDbOptions!,
                     writeBufferSize
                 );
             }
+
+            if (pruningConfig.Mode.IsMemory())
+            {
+                ulong totalWriteBufferMb = rocksDbConfig.WriteBufferNumber!.Value * rocksDbConfig.WriteBufferSize!.Value / (ulong)1.MB();
+                double minimumWriteBufferMb = 0.2 * pruningConfig.DirtyCacheMb;
+                if (totalWriteBufferMb < minimumWriteBufferMb)
+                {
+                    ulong minimumWriteBufferSize = (uint)Math.Ceiling((minimumWriteBufferMb * 1.MB()) / rocksDbConfig.WriteBufferNumber!.Value);
+
+                    if (_logger.IsInfo) _logger.Info($"Adjust state DB write buffer size to {minimumWriteBufferSize / (ulong)1.MB()} MB to account for pruning cache.");
+
+                    rocksDbConfig = new AdjustedRocksdbConfig(
+                        rocksDbConfig,
+                        "",
+                        minimumWriteBufferSize
+                    );
+                }
+            }
+
         }
 
         return rocksDbConfig;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
@@ -1,12 +1,37 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Logging;
+
 namespace Nethermind.Db.Rocks.Config;
 
-public class RocksDbConfigFactory(IDbConfig dbConfig) : IRocksDbConfigFactory
+public class RocksDbConfigFactory(IDbConfig dbConfig, IHardwareInfo hardwareInfo, ILogManager logManager) : IRocksDbConfigFactory
 {
+    private readonly ILogger _logger = logManager.GetClassLogger<IRocksDbConfigFactory>();
+    private readonly long StateDbLargerMemoryThreshold = 32.GiB();
+
     public IRocksDbConfig GetForDatabase(string databaseName, string? columnName)
     {
-        return new PerTableDbConfig(dbConfig, databaseName, columnName);
+        IRocksDbConfig rocksDbConfig = new PerTableDbConfig(dbConfig, databaseName, columnName);
+        if (databaseName.StartsWith("State") && hardwareInfo.AvailableMemoryBytes > StateDbLargerMemoryThreshold)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Detected {hardwareInfo.AvailableMemoryBytes / 1.GiB()} GB of available memory. Applying large memory State Db config.");
+
+            ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
+            if (writeBufferSize < dbConfig.StateDbLargeMemoryWriteBufferSize)
+            {
+                writeBufferSize = dbConfig.StateDbLargeMemoryWriteBufferSize;
+            }
+
+            rocksDbConfig = new MemoryAdjustedRocksdbConfig(
+                rocksDbConfig,
+                dbConfig.StateDbLargeMemoryAdditionalRocksDbOptions!,
+                writeBufferSize
+            );
+        }
+
+        return rocksDbConfig;
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
@@ -7,29 +7,41 @@ using Nethermind.Logging;
 
 namespace Nethermind.Db.Rocks.Config;
 
-public class RocksDbConfigFactory(IDbConfig dbConfig, IHardwareInfo hardwareInfo, ILogManager logManager) : IRocksDbConfigFactory
+public class RocksDbConfigFactory(IDbConfig dbConfig, IPruningConfig pruningConfig, IHardwareInfo hardwareInfo, ILogManager logManager) : IRocksDbConfigFactory
 {
     private readonly ILogger _logger = logManager.GetClassLogger<IRocksDbConfigFactory>();
-    private readonly long StateDbLargerMemoryThreshold = 32.GiB();
 
     public IRocksDbConfig GetForDatabase(string databaseName, string? columnName)
     {
         IRocksDbConfig rocksDbConfig = new PerTableDbConfig(dbConfig, databaseName, columnName);
-        if (databaseName.StartsWith("State") && hardwareInfo.AvailableMemoryBytes > StateDbLargerMemoryThreshold)
+        if (databaseName.StartsWith("State"))
         {
-            if (_logger.IsDebug) _logger.Debug($"Detected {hardwareInfo.AvailableMemoryBytes / 1.GiB()} GB of available memory. Applying large memory State Db config.");
-
-            ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
-            if (writeBufferSize < dbConfig.StateDbLargeMemoryWriteBufferSize)
+            if (!pruningConfig.Mode.IsMemory())
             {
-                writeBufferSize = dbConfig.StateDbLargeMemoryWriteBufferSize;
-            }
+                if (_logger.IsInfo) _logger.Info($"Using archive mode State Db config.");
 
-            rocksDbConfig = new MemoryAdjustedRocksdbConfig(
-                rocksDbConfig,
-                dbConfig.StateDbLargeMemoryAdditionalRocksDbOptions!,
-                writeBufferSize
-            );
+                ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
+                if (writeBufferSize < dbConfig.StateDbArchiveModeWriteBufferSize) writeBufferSize = dbConfig.StateDbArchiveModeWriteBufferSize;
+
+                rocksDbConfig = new MemoryAdjustedRocksdbConfig(
+                    rocksDbConfig,
+                    dbConfig.StateDbArchiveModeRocksDbOptions!,
+                    writeBufferSize
+                );
+            }
+            else if (hardwareInfo.AvailableMemoryBytes > IHardwareInfo.StateDbLargerMemoryThreshold)
+            {
+                if (_logger.IsInfo) _logger.Info($"Detected {hardwareInfo.AvailableMemoryBytes / 1.GiB()} GB of available memory. Applying large memory State Db config.");
+
+                ulong writeBufferSize = rocksDbConfig.WriteBufferSize ?? 0;
+                if (writeBufferSize < dbConfig.StateDbLargeMemoryWriteBufferSize) writeBufferSize = dbConfig.StateDbLargeMemoryWriteBufferSize;
+
+                rocksDbConfig = new MemoryAdjustedRocksdbConfig(
+                    rocksDbConfig,
+                    dbConfig.StateDbLargeMemoryRocksDbOptions!,
+                    writeBufferSize
+                );
+            }
         }
 
         return rocksDbConfig;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/RocksDbConfigFactory.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.Rocks.Config;
+
+public class RocksDbConfigFactory(IDbConfig dbConfig) : IRocksDbConfigFactory
+{
+    public IRocksDbConfig GetForDatabase(string databaseName, string? columnName)
+    {
+        return new PerTableDbConfig(dbConfig, databaseName, columnName);
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -54,6 +54,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     internal ReadOptions? _readAheadReadOptions = null;
 
     internal DbOptions? DbOptions { get; private set; }
+    private readonly IRocksDbConfigFactory _rocksDbConfigFactory;
 
     public string Name { get; }
 
@@ -65,7 +66,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly DbSettings _settings;
 
-    private readonly PerTableDbConfig _perTableDbConfig;
+    private readonly IRocksDbConfig _perTableDbConfig;
     private ulong _maxBytesForLevelBase;
     private ulong _targetFileSizeBase;
     private int _minWriteBufferToMerge;
@@ -92,6 +93,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         string basePath,
         DbSettings dbSettings,
         IDbConfig dbConfig,
+        IRocksDbConfigFactory rocksDbConfigFactory,
         ILogManager logManager,
         IList<string>? columnFamilies = null,
         RocksDbSharp.Native? rocksDbNative = null,
@@ -103,7 +105,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         Name = _settings.DbName;
         _fileSystem = fileSystem ?? new FileSystem();
         _rocksDbNative = rocksDbNative ?? RocksDbSharp.Native.Instance;
-        _perTableDbConfig = new PerTableDbConfig(dbConfig, _settings);
+        _rocksDbConfigFactory = rocksDbConfigFactory;
+        _perTableDbConfig = rocksDbConfigFactory.GetForDatabase(Name, null);
         _db = Init(basePath, dbSettings.DbPath, dbConfig, logManager, columnFamilies, dbSettings.DeleteOnStart, sharedCache);
         _iteratorManager = new IteratorManager(_db, null, _readAheadReadOptions);
     }
@@ -151,7 +154,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     string columnFamily = enumColumnName;
 
                     ColumnFamilyOptions options = new();
-                    BuildOptions(new PerTableDbConfig(dbConfig, _settings, columnFamily), options, sharedCache);
+                    IRocksDbConfig columnConfig = _rocksDbConfigFactory.GetForDatabase(Name, columnFamily);
+                    BuildOptions(columnConfig, options, sharedCache);
 
                     // "default" is a special column name with rocksdb, which is what previously not specifying column goes to
                     if (columnFamily == "Default") columnFamily = "default";
@@ -430,7 +434,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         return asDict;
     }
 
-    protected virtual void BuildOptions<T>(PerTableDbConfig dbConfig, Options<T> options, IntPtr? sharedCache) where T : Options<T>
+    protected virtual void BuildOptions<T>(IRocksDbConfig dbConfig, Options<T> options, IntPtr? sharedCache) where T : Options<T>
     {
         // This section is about the table factory.. and block cache apparently.
         // This effect the format of the SST files and usually require resync to take effect.
@@ -563,6 +567,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         #endregion
 
         #region read-write options
+        // TODO: These are not applied to column family
         WriteOptions = CreateWriteOptions(dbConfig);
 
         _noWalWrite = CreateWriteOptions(dbConfig);
@@ -597,7 +602,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         #endregion
     }
 
-    private static WriteOptions CreateWriteOptions(PerTableDbConfig dbConfig)
+    private static WriteOptions CreateWriteOptions(IRocksDbConfig dbConfig)
     {
         WriteOptions options = new();
         // potential fix for corruption on hard process termination, may cause performance degradation

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
@@ -17,15 +17,17 @@ public class RocksDbFactory : IDbFactory
     private readonly string _basePath;
 
     private readonly IntPtr _sharedCache;
+    private readonly IRocksDbConfigFactory _rocksDbConfigFactory;
 
-    public RocksDbFactory(IDbConfig dbConfig, IInitConfig initConfig, ILogManager logManager)
-        : this(dbConfig, logManager, initConfig.BaseDbPath)
+    public RocksDbFactory(IRocksDbConfigFactory rocksDbConfigFactory, IDbConfig dbConfig, IInitConfig initConfig, ILogManager logManager)
+        : this(rocksDbConfigFactory, dbConfig, logManager, initConfig.BaseDbPath)
     {
 
     }
 
-    public RocksDbFactory(IDbConfig dbConfig, ILogManager logManager, string basePath)
+    public RocksDbFactory(IRocksDbConfigFactory rocksDbConfigFactory, IDbConfig dbConfig, ILogManager logManager, string basePath)
     {
+        _rocksDbConfigFactory = rocksDbConfigFactory;
         _dbConfig = dbConfig;
         _logManager = logManager;
         _basePath = basePath;
@@ -41,10 +43,10 @@ public class RocksDbFactory : IDbFactory
     }
 
     public IDb CreateDb(DbSettings dbSettings) =>
-        new DbOnTheRocks(_basePath, dbSettings, _dbConfig, _logManager, sharedCache: _sharedCache);
+        new DbOnTheRocks(_basePath, dbSettings, _dbConfig, _rocksDbConfigFactory, _logManager, sharedCache: _sharedCache);
 
     public IColumnsDb<T> CreateColumnsDb<T>(DbSettings dbSettings) where T : struct, Enum =>
-        new ColumnsDb<T>(_basePath, dbSettings, _dbConfig, _logManager, Array.Empty<T>(), sharedCache: _sharedCache);
+        new ColumnsDb<T>(_basePath, dbSettings, _dbConfig, _rocksDbConfigFactory, _logManager, Array.Empty<T>(), sharedCache: _sharedCache);
 
     public string GetFullDbPath(DbSettings dbSettings) => DbOnTheRocks.GetFullDbPath(dbSettings.DbPath, _basePath);
 }

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
@@ -34,6 +35,7 @@ public class ColumnsDbTests
                 DeleteOnStart = true,
             },
             new DbConfig(),
+            new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance),
             LimboLogs.Instance,
             Enum.GetValues<ReceiptsColumns>()
         );

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -31,7 +31,7 @@ public class PerTableDbConfigTests
 
         foreach (string table in tables)
         {
-            PerTableDbConfig config = new PerTableDbConfig(dbConfig, new DbSettings(table, ""));
+            PerTableDbConfig config = new PerTableDbConfig(dbConfig, table);
 
             object _ = config.RocksDbOptions;
             _ = config.AdditionalRocksDbOptions;
@@ -49,7 +49,7 @@ public class PerTableDbConfigTests
         dbConfig.ReceiptsDbRocksDbOptions = "some_option=2;";
         dbConfig.ReceiptsBlocksDbRocksDbOptions = "some_option=3;";
 
-        PerTableDbConfig config = new PerTableDbConfig(dbConfig, new DbSettings(DbNames.Receipts, ""), "Blocks");
+        PerTableDbConfig config = new PerTableDbConfig(dbConfig, DbNames.Receipts, "Blocks");
         config.RocksDbOptions.Should().Be("some_option=1;some_option=2;some_option=3;");
     }
 
@@ -61,7 +61,7 @@ public class PerTableDbConfigTests
         dbConfig.ReceiptsDbRocksDbOptions = "some_option=2;";
         dbConfig.ReceiptsBlocksDbRocksDbOptions = "some_option=3;";
 
-        PerTableDbConfig config = new PerTableDbConfig(dbConfig, new DbSettings(DbNames.Receipts, ""));
+        PerTableDbConfig config = new PerTableDbConfig(dbConfig, DbNames.Receipts);
         config.RocksDbOptions.Should().Be("some_option=1;some_option=2;");
     }
 
@@ -71,7 +71,7 @@ public class PerTableDbConfigTests
         DbConfig dbConfig = new DbConfig();
         dbConfig.MaxOpenFiles = 2;
 
-        PerTableDbConfig config = new PerTableDbConfig(dbConfig, new DbSettings(DbNames.Receipts, ""));
+        PerTableDbConfig config = new PerTableDbConfig(dbConfig, DbNames.Receipts);
         config.MaxOpenFiles.Should().Be(2);
     }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Logging;
@@ -29,12 +30,15 @@ namespace Nethermind.Db.Test
     [Parallelizable(ParallelScope.None)]
     public class DbOnTheRocksTests
     {
+        private RocksDbConfigFactory _rocksdbConfigFactory;
         string DbPath => "testdb/" + TestContext.CurrentContext.Test.Name;
+
 
         [SetUp]
         public void Setup()
         {
             Directory.CreateDirectory(DbPath);
+            _rocksdbConfigFactory = new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(1.GiB()), LimboLogs.Instance);
         }
 
         [TearDown]
@@ -47,7 +51,7 @@ namespace Nethermind.Db.Test
         public void WriteOptions_is_correct()
         {
             IDbConfig config = new DbConfig();
-            using DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
+            using DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, _rocksdbConfigFactory, LimboLogs.Instance);
 
             WriteOptions? options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority);
             Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
@@ -66,7 +70,7 @@ namespace Nethermind.Db.Test
         public async Task Dispose_while_writing_does_not_cause_access_violation_exception()
         {
             IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("testDispose1", GetRocksDbSettings("testDispose1", "TestDispose1"), config, LimboLogs.Instance);
+            DbOnTheRocks db = new("testDispose1", GetRocksDbSettings("testDispose1", "TestDispose1"), config, _rocksdbConfigFactory, LimboLogs.Instance);
 
             CancellationTokenSource cancelSource = new();
             ManualResetEventSlim firstWriteWait = new();
@@ -108,7 +112,7 @@ namespace Nethermind.Db.Test
         public void Dispose_wont_cause_ObjectDisposedException_when_batch_is_still_open()
         {
             IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("testDispose2", GetRocksDbSettings("testDispose2", "TestDispose2"), config, LimboLogs.Instance);
+            DbOnTheRocks db = new("testDispose2", GetRocksDbSettings("testDispose2", "TestDispose2"), config, _rocksdbConfigFactory, LimboLogs.Instance);
             _ = db.StartWriteBatch();
             db.Dispose();
         }
@@ -119,7 +123,7 @@ namespace Nethermind.Db.Test
             IDbConfig config = new DbConfig();
             config.EnableFileWarmer = true;
             {
-                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, _rocksdbConfigFactory, LimboLogs.Instance);
                 for (int i = 0; i < 1000; i++)
                 {
                     db[i.ToBigEndianByteArray()] = i.ToBigEndianByteArray();
@@ -127,7 +131,7 @@ namespace Nethermind.Db.Test
             }
 
             {
-                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, _rocksdbConfigFactory, LimboLogs.Instance);
             }
         }
 
@@ -141,7 +145,8 @@ namespace Nethermind.Db.Test
 
             Action act = () =>
             {
-                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+                var configFactory = new RocksDbConfigFactory(config, new PruningConfig(), new TestHardwareInfo(1.GiB()), LimboLogs.Instance);
+                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, configFactory, LimboLogs.Instance);
             };
 
             if (success)
@@ -167,6 +172,7 @@ namespace Nethermind.Db.Test
             try
             {
                 CorruptedDbOnTheRocks db = new("test", GetRocksDbSettings("test", "test"), config,
+                    _rocksdbConfigFactory,
                     LimboLogs.Instance,
                     fileSystem: fileSystem);
             }
@@ -195,7 +201,7 @@ namespace Nethermind.Db.Test
 
             try
             {
-                DbOnTheRocks db = new(Path.Join(Path.GetTempPath(), "test"), GetRocksDbSettings("test", "test"), config,
+                DbOnTheRocks db = new(Path.Join(Path.GetTempPath(), "test"), GetRocksDbSettings("test", "test"), config, _rocksdbConfigFactory,
                     LimboLogs.Instance,
                     fileSystem: fileSystem,
                     rocksDbNative: native);
@@ -235,6 +241,8 @@ namespace Nethermind.Db.Test
         [SetUp]
         public void Setup()
         {
+            RocksDbConfigFactory rocksdbConfigFactory = new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(1.GiB()), LimboLogs.Instance);
+
             if (Directory.Exists(DbPath))
             {
                 Directory.Delete(DbPath, true);
@@ -244,7 +252,7 @@ namespace Nethermind.Db.Test
             if (_useColumnDb)
             {
                 IDbConfig config = new DbConfig();
-                ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config,
+                ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, rocksdbConfigFactory,
                     LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
                 _dbDisposable = columnsDb;
 
@@ -253,7 +261,7 @@ namespace Nethermind.Db.Test
             else
             {
                 IDbConfig config = new DbConfig();
-                _db = new DbOnTheRocks(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
+                _db = new DbOnTheRocks(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, rocksdbConfigFactory, LimboLogs.Instance);
                 _dbDisposable = _db;
             }
         }
@@ -397,11 +405,12 @@ namespace Nethermind.Db.Test
             string basePath,
             DbSettings dbSettings,
             IDbConfig dbConfig,
+            IRocksDbConfigFactory rocksDbConfigFactory,
             ILogManager logManager,
             IList<string>? columnFamilies = null,
             RocksDbSharp.Native? rocksDbNative = null,
             IFileSystem? fileSystem = null
-        ) : base(basePath, dbSettings, dbConfig, logManager, columnFamilies, rocksDbNative, fileSystem)
+        ) : base(basePath, dbSettings, dbConfig, rocksDbConfigFactory, logManager, columnFamilies, rocksDbNative, fileSystem)
         {
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/RocksDbConfigFactoryTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/RocksDbConfigFactoryTests.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Logging;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Db.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class RocksDbConfigFactoryTests
+{
+    [Test]
+    public void CanFetchNormally()
+    {
+        var dbConfig = new DbConfig();
+        var factory = new RocksDbConfigFactory(dbConfig, new PruningConfig(), new TestHardwareInfo(0), LimboLogs.Instance);
+        IRocksDbConfig config = factory.GetForDatabase("State0", null);
+        Console.Error.WriteLine(config.RocksDbOptions);
+        config.RocksDbOptions.Should().Be(dbConfig.RocksDbOptions + dbConfig.StateDbRocksDbOptions);
+    }
+
+    [Test]
+    public void WillOverrideStateConfigOnArchiveMode()
+    {
+        var dbConfig = new DbConfig();
+        var pruningConfig = new PruningConfig();
+        pruningConfig.Mode = PruningMode.Full;
+        var factory = new RocksDbConfigFactory(dbConfig, pruningConfig, new TestHardwareInfo(0), LimboLogs.Instance);
+        IRocksDbConfig config = factory.GetForDatabase("State0", null);
+        config.RocksDbOptions.Should().Be(dbConfig.RocksDbOptions + dbConfig.StateDbRocksDbOptions + dbConfig.StateDbArchiveModeRocksDbOptions);
+    }
+
+    [Test]
+    public void WillOverrideStateConfigWhenMemoryIsHigh()
+    {
+        var dbConfig = new DbConfig();
+        var factory = new RocksDbConfigFactory(dbConfig, new PruningConfig(), new TestHardwareInfo(100.GiB()), LimboLogs.Instance);
+        IRocksDbConfig config = factory.GetForDatabase("State0", null);
+        config.RocksDbOptions.Should().Be(dbConfig.RocksDbOptions + dbConfig.StateDbRocksDbOptions + dbConfig.StateDbLargeMemoryRocksDbOptions);
+    }
+
+    [Test]
+    public void WillOverrideStateConfigWhenDirtyCachesTooHigh()
+    {
+        var dbConfig = new DbConfig();
+        var pruningConfig = new PruningConfig();
+        pruningConfig.CacheMb = 20000;
+        pruningConfig.DirtyCacheMb = 10000;
+        var factory = new RocksDbConfigFactory(dbConfig, pruningConfig, new TestHardwareInfo(0), LimboLogs.Instance);
+        IRocksDbConfig config = factory.GetForDatabase("State0", null);
+        config.WriteBufferSize.Should().Be((ulong)500.MB());
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Api;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Db;
 using Nethermind.Db.FullPruning;
 using Nethermind.Db.Rocks;
@@ -90,10 +91,12 @@ namespace Nethermind.Db.Test
                     DownloadReceiptsInFastSync = useReceipts
                 }))
                 .AddModule(new WorldStateModule(initConfig)) // For the full pruning db
+                .AddSingleton<IPruningConfig>(new PruningConfig())
                 .AddSingleton<IDbConfig>(new DbConfig())
                 .AddSingleton<IInitConfig>(initConfig)
                 .AddSingleton<ILogManager>(LimboLogs.Instance)
                 .AddSingleton<IFileSystem, FileSystem>()
+                .AddSingleton<IHardwareInfo>(new TestHardwareInfo(1))
                 .AddSingleton<IDbProvider, ContainerOwningDbProvider>()
                 .Build();
 

--- a/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
@@ -9,6 +9,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
 using Nethermind.Db.Rpc;
 using Nethermind.JsonRpc.Client;
 using Nethermind.Logging;
@@ -35,6 +36,7 @@ public class DbModule(
     protected override void Load(ContainerBuilder builder)
     {
         builder
+            .AddSingleton<IRocksDbConfigFactory, RocksDbConfigFactory>()
             .AddSingleton<IDbFactory, RocksDbFactory>()
             .AddSingleton<IDbProvider, DbProvider>()
             .AddScoped<IReadOnlyDbProvider, IDbProvider>((dbProvider) => dbProvider.AsReadOnly(false))

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -70,6 +70,8 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             .AddSingleton<IChainHeadSpecProvider, ChainHeadSpecProvider>()
             .AddSingleton<IChainHeadInfoProvider, ChainHeadInfoProvider>()
             .Add<IDisposableStack, AutofacDisposableStack>() // Not a singleton so that dispose is registered to correct lifetime
+
+            .AddSingleton<IHardwareInfo, HardwareInfo>()
             ;
 
         if (!configProvider.GetConfig<ITxPoolConfig>().BlobsSupport.IsPersistentStorage())

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -34,7 +34,6 @@ public class PruningTrieStateFactory(
     IInitConfig initConfig,
     IPruningConfig pruningConfig,
     IBlocksConfig blockConfig,
-    IDbConfig dbConfig,
     IDbProvider dbProvider,
     IBlockTree blockTree,
     IFileSystem fileSystem,
@@ -53,8 +52,6 @@ public class PruningTrieStateFactory(
     public (IWorldStateManager, IPruningTrieStateAdminRpcModule) Build()
     {
         CompositePruningTrigger compositePruningTrigger = new CompositePruningTrigger();
-
-        AdviseConfig();
 
         IPruningTrieStore trieStore = mainPruningTrieStoreFactory.PruningTrieStore;
         ITrieStore mainWorldTrieStore = trieStore;
@@ -123,36 +120,6 @@ public class PruningTrieStateFactory(
         return (stateManager, adminRpcModule);
     }
 
-    private void AdviseConfig()
-    {
-        // On a 7950x (32 logical coree), assuming write buffer is large enough, the pruning time is about 3 second
-        // with 8GB of pruning cache. Lets assume that this is a safe estimate as the ssd can be a limitation also.
-        long maximumCacheMb = Environment.ProcessorCount * 250;
-        // It must be at least 1GB as on mainnet at least 500MB will remain to support snap sync. So pruning cache only drop to about 500MB after pruning.
-        maximumCacheMb = Math.Max(1000, maximumCacheMb);
-        if (pruningConfig.CacheMb > maximumCacheMb)
-        {
-            // The user can also change `--Db.StateDbWriteBufferSize`.
-            // Which may or may not be better as each read will need to go through eacch write buffer.
-            // So having less of them is probably better..
-            if (_logger.IsWarn) _logger.Warn($"Detected {pruningConfig.CacheMb}MB of pruning cache config. Pruning cache more than {maximumCacheMb}MB is not recommended with {Environment.ProcessorCount} logical core as it may cause long memory pruning time which affect attestation.");
-        }
-
-        var totalWriteBufferMb = dbConfig.StateDbWriteBufferNumber * dbConfig.StateDbWriteBufferSize / (ulong)1.MB();
-        var minimumWriteBufferMb = 0.2 * pruningConfig.CacheMb;
-        if (totalWriteBufferMb < minimumWriteBufferMb)
-        {
-            long minimumWriteBufferSize = (int)Math.Ceiling((minimumWriteBufferMb * 1.MB()) / dbConfig.StateDbWriteBufferNumber);
-
-            if (_logger.IsWarn) _logger.Warn($"Detected {totalWriteBufferMb}MB of maximum write buffer size. Write buffer size should be at least 20% of pruning cache MB or memory pruning may slow down. Try setting `--Db.{nameof(dbConfig.StateDbWriteBufferSize)} {minimumWriteBufferSize}`.");
-        }
-
-        if (pruningConfig.CacheMb <= pruningConfig.DirtyCacheMb)
-        {
-            throw new InvalidConfigurationException("Dirty pruning cache size must be less than persisted pruning cache size.", -1);
-        }
-    }
-
     private void InitializeFullPruning(IDb stateDb,
         IStateReader stateReader,
         INodeStorage mainNodeStorage,
@@ -215,12 +182,14 @@ public class MainPruningTrieStoreFactory
         IPruningConfig pruningConfig,
         IDbProvider dbProvider,
         INodeStorageFactory nodeStorageFactory,
-        IBlockTree blockTree,
-        IDisposableStack disposeStack,
+        IDbConfig dbConfig,
+        IHardwareInfo hardwareInfo,
         ILogManager logManager
-        )
+    )
     {
         _logger = logManager.GetClassLogger<MainPruningTrieStoreFactory>();
+
+        AdviseConfig(pruningConfig, dbConfig, hardwareInfo);
 
         if (syncConfig.SnapServingEnabled == true && pruningConfig.PruningBoundary < 128)
         {
@@ -273,6 +242,38 @@ public class MainPruningTrieStoreFactory
             persistenceStrategy,
             pruningConfig,
             logManager);
+    }
+
+    private void AdviseConfig(IPruningConfig pruningConfig, IDbConfig dbConfig, IHardwareInfo hardwareInfo)
+    {
+        if (hardwareInfo.AvailableMemoryBytes >= IHardwareInfo.StateDbLargerMemoryThreshold)
+        {
+            // Default is 1280 MB, which translate to 280 MB of persisted cache memory (dirty node cache is 1000 MB).
+            // So this actually increase it from 280 MB to 1000 MB, reducing dirty node load at DB by 50%.
+            if (pruningConfig.CacheMb < 2000)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Increasing pruning cache to 2 GB due to available additional memory.");
+                pruningConfig.CacheMb = 2000;
+            }
+        }
+
+        // On a 7950x (32 logical coree), assuming write buffer is large enough, the pruning time is about 3 second
+        // with 8GB of pruning cache. Lets assume that this is a safe estimate as the ssd can be a limitation also.
+        long maximumDirtyCacheMb = Environment.ProcessorCount * 250;
+        // It must be at least 1GB as on mainnet at least 500MB will remain to support snap sync. So pruning cache only drop to about 500MB after pruning.
+        maximumDirtyCacheMb = Math.Max(1000, maximumDirtyCacheMb);
+        if (pruningConfig.DirtyCacheMb > maximumDirtyCacheMb)
+        {
+            // The user can also change `--Db.StateDbWriteBufferSize`.
+            // Which may or may not be better as each read will need to go through eacch write buffer.
+            // So having less of them is probably better..
+            if (_logger.IsWarn) _logger.Warn($"Detected {pruningConfig.DirtyCacheMb}MB of dirty pruning cache config. Dirty cache more than {maximumDirtyCacheMb}MB is not recommended with {Environment.ProcessorCount} logical core as it may cause long memory pruning time which affect attestation.");
+        }
+
+        if (pruningConfig.CacheMb <= pruningConfig.DirtyCacheMb)
+        {
+            throw new InvalidConfigurationException("Dirty pruning cache size must be less than persisted pruning cache size.", -1);
+        }
     }
 
     public IPruningTrieStore PruningTrieStore { get; }

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -228,9 +228,6 @@ public class MainPruningTrieStoreFactory
 
         if (stateDb is IFullPruningDb fullPruningDb)
         {
-            // PruningTriggerPersistenceStrategy triggerPersistenceStrategy = new(fullPruningDb, logManager);
-            // disposeStack.Push(triggerPersistenceStrategy);
-            // persistenceStrategy = persistenceStrategy.Or(triggerPersistenceStrategy);
             pruningStrategy = new PruningTriggerPruningStrategy(fullPruningDb, pruningStrategy);
         }
 


### PR DESCRIPTION
Require #8997 

- Modified the rocksdb config depending on the pruning config and available memory.
- When available memory is more than 32GB, partitioned index is disabled and write buffer is increased.
- When archive mode is on, level multiplier is set to 10, and write buffer is increased again, to reduce write amplification.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [X] Mainnet sync ok
- [X] Index size increased accordingly.
- [X] Available memory respond to cgroup limit.