### PR TITLE
Cleanup/Remove unnecessary SetBaseBlock

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -490,8 +490,6 @@ public class CliqueBlockProducer : IBlockProducer
         header.MixHash = Keccak.Zero;
         header.WithdrawalsRoot = spec.WithdrawalsEnabled ? Keccak.EmptyTreeHash : null;
 
-        _stateProvider.SetBaseBlock(parentHeader);
-
         IEnumerable<Transaction> selectedTxs = _txSource.GetTransactions(parentHeader, header.GasLimit, null, filterSource: true);
         Block block = new BlockToProduce(
             header,

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -132,7 +132,7 @@ namespace Nethermind.Consensus.Producers
 
         private Task<Block?> ProduceNewBlock(BlockHeader parent, CancellationToken token, IBlockTracer? blockTracer, PayloadAttributes? payloadAttributes = null, IBlockProducer.Flags flags = IBlockProducer.Flags.None)
         {
-            if (TrySetState(parent))
+            if (StateProvider.HasStateForBlock(parent))
             {
                 Block block = PrepareBlock(parent, payloadAttributes, flags);
                 if (PreparedBlockCanBeMined(block))
@@ -184,23 +184,6 @@ namespace Nethermind.Consensus.Producers
             }
 
             return Task.FromResult((Block?)null);
-        }
-
-        /// <summary>
-        /// Sets the state to produce block on
-        /// </summary>
-        /// <param name="parentStateRoot">Parent block state</param>
-        /// <returns>True if succeeded, false otherwise</returns>
-        /// <remarks>Should be called inside <see cref="_producingBlockLock"/> lock.</remarks>
-        protected bool TrySetState(BlockHeader? parent)
-        {
-            if (parent is not null && StateProvider.HasStateForBlock(parent))
-            {
-                StateProvider.SetBaseBlock(parent);
-                return true;
-            }
-
-            return false;
         }
 
         protected virtual Task<Block> SealBlock(Block block, BlockHeader parent, CancellationToken token) =>

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -172,7 +172,6 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
         }
 
         BlockExecutionContext blkCtx = new(blockHeader, _specProvider.GetSpec(blockHeader));
-        worldState.SetBaseBlock(blockHeader);
 
         Batch batch = new(maxBytesPerTxList, txSource.Length, txDecoder);
 

--- a/src/Nethermind/Nethermind.Taiko/TaikoPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoPayloadPreparationService.cs
@@ -81,8 +81,6 @@ public class TaikoPayloadPreparationService(
             {
                 if (worldState.HasStateForBlock(parent))
                 {
-                    worldState.SetBaseBlock(parent);
-
                     return processor.Process(block, ProcessingOptions.ProducingBlock, NullBlockTracer.Instance, token)
                         ?? throw new InvalidOperationException("Block processing failed");
                 }


### PR DESCRIPTION
- Remove unnecessary `SetBaseBlock` to make it clearer the code that manage worldstate lifecycle.
- These are mainly noop.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- [ ] Mainnet simulate block production works fine.