### PR TITLE
Optimize ModExp

### DIFF
--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -14,6 +14,7 @@
     <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
+    <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />
     <Project Path="Nethermind.Init\Nethermind.Init.csproj" />

--- a/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
@@ -56,18 +56,23 @@ namespace Nethermind.Core.Extensions
             return slice;
         }
 
-        public static byte[] SliceWithZeroPaddingEmptyOnError(this ReadOnlySpan<byte> bytes, int startIndex, int length)
+        public static ReadOnlySpan<byte> SliceWithZeroPaddingEmptyOnError(this ReadOnlySpan<byte> bytes, int startIndex, int length)
         {
             int copiedFragmentLength = Math.Min(bytes.Length - startIndex, length);
             if (copiedFragmentLength <= 0)
             {
-                return [];
+                return default;
             }
 
-            byte[] slice = new byte[length];
+            ReadOnlySpan<byte> sliced = bytes.Slice(startIndex, copiedFragmentLength);
+            if (copiedFragmentLength < length)
+            {
+                byte[] extended = new byte[length];
+                sliced.CopyTo(extended);
+                sliced = extended;
+            }
 
-            bytes.Slice(startIndex, copiedFragmentLength).CopyTo(slice.AsSpan(0, copiedFragmentLength));
-            return slice;
+            return sliced;
         }
 
     }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -182,7 +182,7 @@ namespace Nethermind.Core.Extensions
             return bytes.IndexOfAnyExcept((byte)0) < 0;
         }
 
-        public static int LeadingZerosCount(this Span<byte> bytes, int startIndex = 0)
+        public static int LeadingZerosCount(this ReadOnlySpan<byte> bytes, int startIndex = 0)
         {
             int nonZeroIndex = bytes[startIndex..].IndexOfAnyExcept((byte)0);
             return nonZeroIndex < 0 ? bytes.Length - startIndex : nonZeroIndex;

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -244,7 +244,7 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
         if (modulusDataSpan.Length > 0)
         {
             fixed (byte* modulusData = &MemoryMarshal.GetReference(modulusDataSpan))
-                Gmp.mpz_import(modulusInt, (nuint)modulusLength, 1, 1, 1, nuint.Zero, (nint)modulusData);
+                Gmp.mpz_import(modulusInt, modulusLength, 1, 1, 1, nuint.Zero, (nint)modulusData);
         }
 
         if (Gmp.mpz_sgn(modulusInt) == 0)
@@ -258,20 +258,20 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
         if (baseDataSpan.Length > 0)
         {
             fixed (byte* baseData = &MemoryMarshal.GetReference(baseDataSpan))
-                Gmp.mpz_import(baseInt, (nuint)baseLength, 1, 1, 1, nuint.Zero, (nint)baseData);
+                Gmp.mpz_import(baseInt, baseLength, 1, 1, 1, nuint.Zero, (nint)baseData);
         }
 
         ReadOnlySpan<byte> expDataSpan = inputSpan.SliceWithZeroPaddingEmptyOnError(96 + (int)baseLength, (int)expLength);
         if (expDataSpan.Length > 0)
         {
             fixed (byte* expData = &MemoryMarshal.GetReference(expDataSpan))
-                Gmp.mpz_import(expInt, (nuint)expLength, 1, 1, 1, nuint.Zero, (nint)expData);
+                Gmp.mpz_import(expInt, expLength, 1, 1, 1, nuint.Zero, (nint)expData);
         }
 
         Gmp.mpz_powm(powmResult, baseInt, expInt, modulusInt);
 
         nint powmResultLen = (nint)(Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
-        nint offset = (nint)(int)modulusLength - powmResultLen;
+        nint offset = (int)modulusLength - powmResultLen;
 
         byte[] result = new byte[modulusLength];
         fixed (byte* ptr = &MemoryMarshal.GetArrayDataReference(result))

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -271,7 +271,7 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
         Gmp.mpz_powm(powmResult, baseInt, expInt, modulusInt);
 
         nint powmResultLen = (nint)(Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
-        nint offset = (nint)modulusLength - powmResultLen;
+        nint offset = (nint)(int)modulusLength - powmResultLen;
 
         byte[] result = new byte[modulusLength];
         fixed (byte* ptr = &MemoryMarshal.GetArrayDataReference(result))

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -270,8 +270,8 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
 
         Gmp.mpz_powm(powmResult, baseInt, expInt, modulusInt);
 
-        uint powmResultLen = (uint)(Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
-        uint offset = modulusLength - powmResultLen;
+        nuint powmResultLen = (Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
+        nuint offset = modulusLength - powmResultLen;
 
         byte[] result = new byte[modulusLength];
         fixed (byte* ptr = &MemoryMarshal.GetArrayDataReference(result))

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -270,8 +270,8 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
 
         Gmp.mpz_powm(powmResult, baseInt, expInt, modulusInt);
 
-        nuint powmResultLen = (Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
-        nuint offset = modulusLength - powmResultLen;
+        nint powmResultLen = (nint)(Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;
+        nint offset = (nint)modulusLength - powmResultLen;
 
         byte[] result = new byte[modulusLength];
         fixed (byte* ptr = &MemoryMarshal.GetArrayDataReference(result))

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -26,7 +26,7 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
     /// This constant defines the upper limit for the size of the input data that can be processed.
     /// For more details, see: https://eips.ethereum.org/EIPS/eip-7823
     /// </summary>
-    public const int ModExpMaxInputSizeEip7823 = 1024;
+    public const uint ModExpMaxInputSizeEip7823 = 1024;
 
     private const int LengthSize = 32;
     private const int StartBaseLength = 0;
@@ -112,8 +112,8 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
     private static bool ExceedsMaxInputSize(IReleaseSpec releaseSpec, uint baseLength, uint expLength, uint modulusLength)
     {
         return releaseSpec.IsEip7823Enabled
-            ? baseLength > ModExpMaxInputSizeEip7823 | expLength > ModExpMaxInputSizeEip7823 | modulusLength > ModExpMaxInputSizeEip7823
-            : baseLength > int.MaxValue | modulusLength > int.MaxValue;
+            ? (baseLength > ModExpMaxInputSizeEip7823 | expLength > ModExpMaxInputSizeEip7823 | modulusLength > ModExpMaxInputSizeEip7823)
+            : (baseLength | modulusLength) > int.MaxValue;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -112,8 +112,8 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
     private static bool ExceedsMaxInputSize(IReleaseSpec releaseSpec, uint baseLength, uint expLength, uint modulusLength)
     {
         return releaseSpec.IsEip7823Enabled
-            ? baseLength > ModExpMaxInputSizeEip7823 || expLength > ModExpMaxInputSizeEip7823 || modulusLength > ModExpMaxInputSizeEip7823
-            : baseLength == int.MaxValue || modulusLength == int.MaxValue;
+            ? baseLength > ModExpMaxInputSizeEip7823 | expLength > ModExpMaxInputSizeEip7823 | modulusLength > ModExpMaxInputSizeEip7823
+            : baseLength > int.MaxValue | modulusLength > int.MaxValue;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompilePreEip2565.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompilePreEip2565.cs
@@ -6,7 +6,6 @@ using System.Numerics;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
 
 namespace Nethermind.Evm.Precompiles;
@@ -62,7 +61,7 @@ public class ModExpPrecompilePreEip2565 : IPrecompile<ModExpPrecompilePreEip2565
 
         UInt256 complexity = MultComplexity(UInt256.Max(baseLength, modulusLength));
 
-        byte[] expSignificantBytes =
+        ReadOnlySpan<byte> expSignificantBytes =
             inputData.Span.SliceWithZeroPaddingEmptyOnError(96 + (int)baseLength, (int)UInt256.Min(expLength, 32));
 
         UInt256 lengthOver32 = expLength <= 32 ? 0 : expLength - 32;
@@ -109,13 +108,13 @@ public class ModExpPrecompilePreEip2565 : IPrecompile<ModExpPrecompilePreEip2565
         return adjustedExponentLength * adjustedExponentLength / 16 + 480 * adjustedExponentLength - 199680;
     }
 
-    private static UInt256 AdjustedExponentLength(in UInt256 lengthOver32, byte[] exponent)
+    private static UInt256 AdjustedExponentLength(in UInt256 lengthOver32, ReadOnlySpan<byte> exponent)
     {
         bool overflow = false;
         bool underflow = false;
         UInt256 result;
 
-        int leadingZeros = exponent.AsSpan().LeadingZerosCount();
+        int leadingZeros = exponent.LeadingZerosCount();
         if (leadingZeros == exponent.Length)
         {
             overflow |= UInt256.MultiplyOverflow(lengthOver32, Eight, out result);

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2565Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2565Tests.cs
@@ -25,13 +25,14 @@ namespace Nethermind.Evm.Test
             string randomInput = string.Format("{0}{0}{0}{1}", Length64, data.ToHexString());
 
             Prepare input = Prepare.EvmCode.FromCode(randomInput);
+            byte[] inputData = input.Done.ToArray();
 
-            (ReadOnlyMemory<byte>, bool) gmpPair = ModExpPrecompile.Instance.Run(input.Done.ToArray(), Berlin.Instance);
+            (ReadOnlyMemory<byte>, bool) gmpPair = ModExpPrecompile.Instance.Run(inputData, Berlin.Instance);
 #pragma warning disable 618
-            (ReadOnlyMemory<byte>, bool) bigIntPair = ModExpPrecompile.OldRun(input.Done.ToArray());
+            (ReadOnlyMemory<byte>, bool) bigIntPair = ModExpPrecompile.OldRun(inputData);
 #pragma warning restore 618
 
-            Assert.That(bigIntPair.Item1.ToArray(), Is.EqualTo(gmpPair.Item1.ToArray()));
+            Assert.That(gmpPair.Item1.ToArray(), Is.EqualTo(bigIntPair.Item1.ToArray()));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2565Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2565Tests.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Linq;
+using System.Numerics;
 using FluentAssertions;
 using MathNet.Numerics.Random;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.Precompiles;
+using Nethermind.Int256;
 using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
@@ -28,9 +30,7 @@ namespace Nethermind.Evm.Test
             byte[] inputData = input.Done.ToArray();
 
             (ReadOnlyMemory<byte>, bool) gmpPair = ModExpPrecompile.Instance.Run(inputData, Berlin.Instance);
-#pragma warning disable 618
-            (ReadOnlyMemory<byte>, bool) bigIntPair = ModExpPrecompile.OldRun(inputData);
-#pragma warning restore 618
+            (ReadOnlyMemory<byte>, bool) bigIntPair = BigIntegerModExp(inputData);
 
             Assert.That(gmpPair.Item1.ToArray(), Is.EqualTo(bigIntPair.Item1.ToArray()));
         }
@@ -51,6 +51,38 @@ namespace Nethermind.Evm.Test
             Assert.DoesNotThrow(() => ModExpPrecompile.Instance.Run(input.Done.ToArray(), London.Instance));
             long gas = ModExpPrecompile.Instance.DataGasCost(input.Done, London.Instance);
             gas.Should().Be(200);
+        }
+
+        private static (byte[], bool) BigIntegerModExp(byte[] inputData)
+        {
+            (int baseLength, int expLength, int modulusLength) = GetInputLengths(inputData);
+
+            BigInteger modulusInt = inputData
+                .SliceWithZeroPaddingEmptyOnError(96 + baseLength + expLength, modulusLength).ToUnsignedBigInteger();
+
+            if (modulusInt.IsZero)
+            {
+                return (new byte[modulusLength], true);
+            }
+
+            BigInteger baseInt = inputData.SliceWithZeroPaddingEmptyOnError(96, baseLength).ToUnsignedBigInteger();
+            BigInteger expInt = inputData.SliceWithZeroPaddingEmptyOnError(96 + baseLength, expLength)
+                .ToUnsignedBigInteger();
+            return (BigInteger.ModPow(baseInt, expInt, modulusInt).ToBigEndianByteArray(modulusLength), true);
+        }
+
+        private static (int baseLength, int expLength, int modulusLength) GetInputLengths(ReadOnlySpan<byte> inputData)
+        {
+            Span<byte> extendedInput = stackalloc byte[96];
+            inputData[..Math.Min(96, inputData.Length)]
+                .CopyTo(extendedInput[..Math.Min(96, inputData.Length)]);
+
+            int baseLength = (int)new UInt256(extendedInput[..32], true);
+            UInt256 expLengthUint256 = new(extendedInput.Slice(32, 32), true);
+            int expLength = expLengthUint256 > Array.MaxLength ? Array.MaxLength : (int)expLengthUint256;
+            int modulusLength = (int)new UInt256(extendedInput.Slice(64, 32), true);
+
+            return (baseLength, expLength, modulusLength);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7823Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7823Tests.cs
@@ -60,7 +60,7 @@ public class Eip7823Tests
 
         byte[] input = Bytes.FromHexString(inputHex);
 
-        Assert.Throws<OverflowException>(() => TestSuccess(input, specDisabled));
+        Assert.That(TestSuccess(input, specDisabled), Is.EqualTo(false));
         Assert.That(TestSuccess(input, specEnabled), Is.EqualTo(false));
 
         Assert.That(TestGas(input, specDisabled), Is.EqualTo(long.MaxValue));

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7823Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7823Tests.cs
@@ -61,7 +61,7 @@ public class Eip7823Tests
         byte[] input = Bytes.FromHexString(inputHex);
 
         Assert.Throws<OverflowException>(() => TestSuccess(input, specDisabled));
-        Assert.Throws<OverflowException>(() => TestSuccess(input, specEnabled));
+        Assert.That(TestSuccess(input, specEnabled), Is.EqualTo(false));
 
         Assert.That(TestGas(input, specDisabled), Is.EqualTo(long.MaxValue));
         Assert.That(TestGas(input, specEnabled), Is.EqualTo(long.MaxValue));

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
@@ -269,7 +269,7 @@ internal static partial class EvmInstructions
             goto StackUnderflow;
 
         // Pop the exponent as a 256-bit word.
-        Span<byte> bytes = stack.PopWord256();
+        ReadOnlySpan<byte> bytes = stack.PopWord256();
 
         // Determine the effective byte-length of the exponent.
         int leadingZeros = bytes.LeadingZerosCount();

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/ModExpBenchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/ModExpBenchmark.cs
@@ -3,22 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using BenchmarkDotNet.Attributes;
 using Nethermind.Evm.Precompiles;
 
-namespace Nethermind.Precompiles.Benchmark
-{
-    public class ModExpBenchmark : PrecompileBenchmarkBase
-    {
-        protected override IEnumerable<IPrecompile> Precompiles => new[] { ModExpPrecompile.Instance };
-        protected override string InputsDirectory => "modexp";
+namespace Nethermind.Precompiles.Benchmark;
 
-        [Benchmark]
-        public (ReadOnlyMemory<byte>, bool) BigInt()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            return ModExpPrecompile.OldRun(Input.Bytes);
-#pragma warning restore CS0618 // Type or member is obsolete
-        }
-    }
+public class ModExpBenchmark : PrecompileBenchmarkBase
+{
+    protected override IEnumerable<IPrecompile> Precompiles => new[] { ModExpPrecompile.Instance };
+    protected override string InputsDirectory => "modexp";
 }


### PR DESCRIPTION
## Changes

- Do more maths in 64/32 bit space than 256 bit
- Vectorize overflow checks
- Don't allocate input arrays unless completely needed
- Don't throw and catch exception for overflow
- Don't try catch in `CalculateIterationCount`

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
