### PR TITLE
Fix error on exit

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Container/KeyedMapperRegistrationSourceTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Container/KeyedMapperRegistrationSourceTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using FluentAssertions;
 using NUnit.Framework;
@@ -20,6 +21,40 @@ public class KeyedMapperRegistrationSourceTests
         cont.ResolveKeyed<ClassB>("Key").Property.Should().Be("Property1");
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TestDisposeWhenNotOwned(bool shouldDispose)
+    {
+        bool adapterWasDisposed = false;
+
+        var builder = new ContainerBuilder()
+            .AddKeyedSingleton<ClassA>("Key", new ClassA("Property1"));
+
+        if (shouldDispose)
+        {
+            builder.AddKeyedAdapterWithNewService<ClassB, ClassA>((a) => new ClassB(a.Property, () => adapterWasDisposed = true));
+        }
+        else
+        {
+            builder.AddKeyedAdapter<ClassB, ClassA>((a) => new ClassB(a.Property, () => adapterWasDisposed = true));
+        }
+
+        IContainer cont = builder.Build();
+
+        cont.ResolveKeyed<ClassB>("Key").Property.Should().Be("Property1");
+
+        cont.Dispose();
+
+        adapterWasDisposed.Should().Be(shouldDispose);
+    }
+
     private record ClassA(string Property);
-    private record ClassB(string Property);
+
+    private record ClassB(string Property, Action? onDispose = null) : IDisposable
+    {
+        public void Dispose()
+        {
+            onDispose?.Invoke();
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Core/Container/KeyedMapperRegistrationSource.cs
+++ b/src/Nethermind/Nethermind.Core/Container/KeyedMapperRegistrationSource.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Core.Container;
 /// <param name="mapper"></param>
 /// <typeparam name="TFrom"></typeparam>
 /// <typeparam name="TTo"></typeparam>
-public class KeyedMapperRegistrationSource<TFrom, TTo>(Func<TFrom, TTo> mapper) : IRegistrationSource where TFrom : notnull
+public class KeyedMapperRegistrationSource<TFrom, TTo>(Func<TFrom, TTo> mapper, bool isNewObject) : IRegistrationSource where TFrom : notnull
 {
     public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<ServiceRegistration>> registrationAccessor)
     {
@@ -37,8 +37,8 @@ public class KeyedMapperRegistrationSource<TFrom, TTo>(Func<TFrom, TTo> mapper) 
             }),
             new RootScopeLifetime(),
             InstanceSharing.Shared,
-            InstanceOwnership.OwnedByLifetimeScope,
-            new[] { service },
+            isNewObject ? InstanceOwnership.OwnedByLifetimeScope : InstanceOwnership.ExternallyOwned,
+            [service],
             new Dictionary<string, object?>());
 
         return [registration];

--- a/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
@@ -489,7 +489,12 @@ public static class ContainerBuilderExtensions
 
     public static ContainerBuilder AddKeyedAdapter<TTo, TFrom>(this ContainerBuilder builder, Func<TFrom, TTo> mapper) where TFrom : notnull
     {
-        return builder.AddSource(new KeyedMapperRegistrationSource<TFrom, TTo>(mapper));
+        return builder.AddSource(new KeyedMapperRegistrationSource<TFrom, TTo>(mapper, false));
+    }
+
+    public static ContainerBuilder AddKeyedAdapterWithNewService<TTo, TFrom>(this ContainerBuilder builder, Func<TFrom, TTo> mapper) where TFrom : notnull
+    {
+        return builder.AddSource(new KeyedMapperRegistrationSource<TFrom, TTo>(mapper, true));
     }
 }
 


### PR DESCRIPTION
- Fix error on exit as the keyed mapper used to resolved derived type for database assume the object is new it which then attempt to dispose out of order.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Reproducable locally.