### PR TITLE
Revise BN254 precompile names

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254AddPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254AddPrecompile.cs
@@ -15,7 +15,7 @@ public class BN254AddPrecompile : IPrecompile<BN254AddPrecompile>
     public static Address Address { get; } = Address.FromNumber(6);
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-7910" />
-    public static string Name => "BN256_ADD";
+    public static string Name => "BN254_ADD";
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-1108" />
     public long BaseGasCost(IReleaseSpec releaseSpec) => releaseSpec.IsEip1108Enabled ? 150L : 500L;

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254MulPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254MulPrecompile.cs
@@ -15,7 +15,7 @@ public class BN254MulPrecompile : IPrecompile<BN254MulPrecompile>
     public static Address Address { get; } = Address.FromNumber(7);
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-7910" />
-    public static string Name => "BN256_MUL";
+    public static string Name => "BN254_MUL";
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-1108" />
     public long BaseGasCost(IReleaseSpec releaseSpec) => releaseSpec.IsEip1108Enabled ? 6_000L : 40_000L;

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254PairingPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254PairingPrecompile.cs
@@ -18,7 +18,7 @@ public class BN254PairingPrecompile : IPrecompile<BN254PairingPrecompile>
     public static Address Address { get; } = Address.FromNumber(8);
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-7910" />
-    public static string Name => "BN256_PAIRING";
+    public static string Name => "BN254_PAIRING";
 
     /// <see href="https://eips.ethereum.org/EIPS/eip-1108" />
     public long BaseGasCost(IReleaseSpec releaseSpec) => releaseSpec.IsEip1108Enabled ? 45_000L : 100_000L;


### PR DESCRIPTION
## Changes

Updated BN254 precompiles' names as per EIP-7910 [update](https://github.com/ethereum/EIPs/pull/10029). See [context](https://github.com/NethermindEth/nethermind/pull/8956/files#r2211016291).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
