### PR TITLE
Remove Linq from Block Processing

### DIFF
--- a/src/Nethermind/Nethermind.Core/BlockInfo.cs
+++ b/src/Nethermind/Nethermind.Core/BlockInfo.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Core
         BeaconMainChain = 16
     }
 
-    public class BlockInfo
+    public class BlockInfo : IEquatable<BlockInfo>
     {
         public BlockInfo(Hash256 blockHash, in UInt256 totalDifficulty, BlockMetadata metadata = BlockMetadata.None)
         {
@@ -84,5 +84,14 @@ namespace Nethermind.Core
             && BlockHash.Equals(other.BlockHash)
             && Metadata == other.Metadata
             && BlockNumber == other.BlockNumber;
+
+        public bool Equals(BlockInfo? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return EqualsIgnoringWasProcessed(other) &&
+                   WasProcessed == other.WasProcessed;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Collections/IHashSetEnumerableCollection.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/IHashSetEnumerableCollection.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+
+namespace Nethermind.Core.Collections;
+
+public interface IHashSetEnumerableCollection<T> : IReadOnlyCollection<T>
+{
+    new HashSet<T>.Enumerator GetEnumerator();
+}

--- a/src/Nethermind/Nethermind.Core/Collections/IToArrayCollection.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/IToArrayCollection.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Nethermind.Core.Collections;
+
+public interface IToArrayCollection<T> : IReadOnlyCollection<T>
+{
+    T[] ToArray();
+}

--- a/src/Nethermind/Nethermind.Core/Collections/JournalCollection.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/JournalCollection.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Core.Collections
     /// </summary>
     /// <typeparam name="T">Item type.</typeparam>
     /// <remarks>Due to snapshots <see cref="Remove"/> is not supported.</remarks>
-    public sealed class JournalCollection<T> : ICollection<T>, IReadOnlyCollection<T>, IJournal<int>
+    public sealed class JournalCollection<T> : IToArrayCollection<T>, ICollection<T>, IJournal<int>
     {
         private readonly List<T> _list = new();
         public int TakeSnapshot() => Count - 1;
@@ -42,6 +42,7 @@ namespace Nethermind.Core.Collections
         public bool Contains(T item) => _list.Contains(item);
         public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
         public bool Remove(T item) => throw new NotSupportedException("Cannot remove from Journal, use Restore(int snapshot) instead.");
+        public T[] ToArray() => _list.ToArray();
         public int Count => _list.Count;
         public bool IsReadOnly => false;
     }

--- a/src/Nethermind/Nethermind.Core/Collections/JournalSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/JournalSet.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Core.Collections
     /// </summary>
     /// <typeparam name="T">Item type.</typeparam>
     /// <remarks>Due to snapshots <see cref="Remove"/> is not supported.</remarks>
-    public sealed class JournalSet<T> : IReadOnlyCollection<T>, ICollection<T>, IJournal<int>
+    public sealed class JournalSet<T> : IHashSetEnumerableCollection<T>, ICollection<T>, IJournal<int>
     {
         private readonly List<T> _items = [];
         private readonly HashSet<T> _set = [];
@@ -63,7 +63,8 @@ namespace Nethermind.Core.Collections
             _set.Clear();
         }
 
-        public IEnumerator<T> GetEnumerator() => _set.GetEnumerator();
+        public HashSet<T>.Enumerator GetEnumerator() => _set.GetEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         public bool Remove(T item) => throw new NotSupportedException("Cannot remove from Journal, use Restore(int snapshot) instead.");
         public int Count => _set.Count;

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.CodeAnalysis;
 using NUnit.Framework;
@@ -29,8 +30,8 @@ namespace Nethermind.Evm.Test
             ReadOnlyMemory<byte> readOnlyMemory = new(data);
             TransactionSubstate transactionSubstate = new((CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
             transactionSubstate.Error.Should().Be("\u0005\u0006\u0007\u0008\t");
@@ -43,8 +44,8 @@ namespace Nethermind.Evm.Test
             ReadOnlyMemory<byte> readOnlyMemory = new(data);
             TransactionSubstate transactionSubstate = new((CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
             transactionSubstate.Error.Should().Be("\u0005\u0006\u0007\u0008\t");
@@ -57,8 +58,8 @@ namespace Nethermind.Evm.Test
             ReadOnlyMemory<byte> readOnlyMemory = new(data);
             TransactionSubstate transactionSubstate = new((CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
             transactionSubstate.Error.Should().Be("0x08c379a000000001000000000000000000000000000000000000000012a9d65e7d180cfcf3601b6d00000000000000000000000000000000000000000000000000000001000276a400000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000006a000000000300000000000115859c410282f6600012efb47fcfcad4f96c83d4ca676842fb03ef20a4770000000015f762bdaa80f6d9dc5518ff64cb7ba5717a10dabc4be3a41acd2c2f95ee22000012a9d65e7d180cfcf3601b6df0000000000000185594dac7eb0828ff000000000000000000000000");
@@ -77,8 +78,8 @@ namespace Nethermind.Evm.Test
             TransactionSubstate transactionSubstate = new(
                 (CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
             transactionSubstate.Error.Should().Be("0x220266b600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001741413231206469646e2774207061792070726566756e64000000000000000000");
@@ -150,8 +151,8 @@ namespace Nethermind.Evm.Test
             TransactionSubstate transactionSubstate = new(
                 (CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
 
@@ -174,8 +175,8 @@ namespace Nethermind.Evm.Test
             TransactionSubstate transactionSubstate = new(
                 (CodeInfo.Empty, readOnlyMemory),
                 0,
-                new ArraySegment<Address>(),
-                Array.Empty<LogEntry>(),
+                new JournalSet<Address>(),
+                new JournalCollection<LogEntry>(),
                 true,
                 true);
             transactionSubstate.Error.Should().Be("0x41413231206469646e2774207061792070726566756e64");

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -9,6 +9,7 @@ using System.Text.Unicode;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Collections;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -18,8 +19,8 @@ namespace Nethermind.Evm;
 public readonly ref struct TransactionSubstate
 {
     private readonly ILogger _logger;
-    private static readonly List<Address> _emptyDestroyList = new(0);
-    private static readonly List<LogEntry> _emptyLogs = new(0);
+    private static readonly IHashSetEnumerableCollection<Address> _emptyDestroyList = new JournalSet<Address>();
+    private static readonly IToArrayCollection<LogEntry> _emptyLogs = new JournalCollection<LogEntry>();
 
     private const string SomeError = "error";
     public const string Revert = "revert";
@@ -44,16 +45,16 @@ public readonly ref struct TransactionSubstate
         { 0x51, "uninitialized function" },
     }.ToFrozenDictionary();
 
-    private readonly IReadOnlyCollection<Address>? _destroyList;
-    private readonly IReadOnlyCollection<LogEntry>? _logs;
+    private readonly IHashSetEnumerableCollection<Address>? _destroyList;
+    private readonly IToArrayCollection<LogEntry>? _logs;
 
     public bool IsError => Error is not null && !ShouldRevert;
     public string? Error { get; }
     public (ICodeInfo DeployCode, ReadOnlyMemory<byte> Bytes) Output { get; }
     public bool ShouldRevert { get; }
     public long Refund { get; }
-    public IReadOnlyCollection<LogEntry> Logs => _logs ?? _emptyLogs;
-    public IReadOnlyCollection<Address> DestroyList => _destroyList ?? _emptyDestroyList;
+    public IToArrayCollection<LogEntry> Logs => _logs ?? _emptyLogs;
+    public IHashSetEnumerableCollection<Address> DestroyList => _destroyList ?? _emptyDestroyList;
 
     public TransactionSubstate(EvmExceptionType exceptionType, bool isTracerConnected)
     {
@@ -77,8 +78,8 @@ public readonly ref struct TransactionSubstate
 
     public TransactionSubstate((ICodeInfo eofDeployCode, ReadOnlyMemory<byte> bytes) output,
         long refund,
-        IReadOnlyCollection<Address> destroyList,
-        IReadOnlyCollection<LogEntry> logs,
+        IHashSetEnumerableCollection<Address> destroyList,
+        IToArrayCollection<LogEntry> logs,
         bool shouldRevert,
         bool isTracerConnected,
         ILogger logger = default)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -19,7 +19,7 @@ namespace Nethermind.JsonRpc
             Host = host;
             Port = port;
             RpcEndpoint = rpcEndpoint;
-            EnabledModules = new HashSet<string>(enabledModules, StringComparer.InvariantCultureIgnoreCase);
+            EnabledModules = new HashSet<string>(enabledModules, StringComparer.OrdinalIgnoreCase);
             IsAuthenticated = isAuthenticated;
             MaxRequestBodySize = maxRequestBodySize;
         }
@@ -82,7 +82,7 @@ namespace Nethermind.JsonRpc
         public string Host { get; set; }
         public int Port { get; set; }
         public RpcEndpoint RpcEndpoint { get; set; }
-        public IReadOnlyCollection<string> EnabledModules { get; set; }
+        public IReadOnlySet<string> EnabledModules { get; set; }
 
         public bool IsModuleEnabled(string moduleName) =>
             EnabledModules.Any(m => StringComparer.InvariantCultureIgnoreCase.Equals(m, moduleName));

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -84,8 +84,7 @@ namespace Nethermind.JsonRpc
         public RpcEndpoint RpcEndpoint { get; set; }
         public IReadOnlySet<string> EnabledModules { get; set; }
 
-        public bool IsModuleEnabled(string moduleName) =>
-            EnabledModules.Any(m => StringComparer.InvariantCultureIgnoreCase.Equals(m, moduleName));
+        public bool IsModuleEnabled(string moduleName) => EnabledModules.Contains(moduleName);
 
         public bool Equals(JsonRpcUrl other)
         {
@@ -101,7 +100,7 @@ namespace Nethermind.JsonRpc
                    RpcEndpoint == other.RpcEndpoint &&
                    IsAuthenticated == other.IsAuthenticated &&
                    EnabledModules.OrderBy(static t => t).SequenceEqual(other.EnabledModules.OrderBy(static t => t),
-                       StringComparer.InvariantCultureIgnoreCase);
+                       StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object other)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -152,7 +152,7 @@ namespace Nethermind.JsonRpc.Modules
 
             if (context.Url is not null)
             {
-                return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.OrdinalIgnoreCase)
+                return context.Url.EnabledModules.Contains(result.ModuleType)
                     ? ModuleResolution.Enabled
                     : ModuleResolution.Disabled;
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
@@ -56,9 +56,9 @@ namespace Nethermind.Serialization.Rlp
                 return;
             }
 
-            if (item.BlockInfos.Any(static t => t is null))
+            if (item.BlockInfos.AsSpan().Contains(null))
             {
-                throw new InvalidOperationException($"{nameof(BlockInfo)} is null when encoding {nameof(ChainLevelInfo)}");
+                ThrowHasNull();
             }
 
             int contentLength = GetContentLength(item, rlpBehaviors);
@@ -70,6 +70,9 @@ namespace Nethermind.Serialization.Rlp
             {
                 stream.Encode(blockInfo);
             }
+
+            static void ThrowHasNull()
+                => throw new InvalidOperationException($"{nameof(BlockInfo)} is null when encoding {nameof(ChainLevelInfo)}");
         }
 
         public ChainLevelInfo? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Nethermind.Core;
 
@@ -71,6 +73,7 @@ namespace Nethermind.Serialization.Rlp
                 stream.Encode(blockInfo);
             }
 
+            [StackTraceHidden, DoesNotReturn]
             static void ThrowHasNull()
                 => throw new InvalidOperationException($"{nameof(BlockInfo)} is null when encoding {nameof(ChainLevelInfo)}");
         }


### PR DESCRIPTION
## Changes

- Use faster direct `.ToArray()`
- Use faster `ReadOnlySpan.Contains(null)`

<img width="1329" height="421" alt="image" src="https://github.com/user-attachments/assets/8585f0a3-06c1-45fd-9d53-43e3da750cb0" />

- Use faster direct `HashSet<T>.Enumerator`
- Validate JsonRpc url with `IReadOnlySet` rather than `IEnumerable`

<img width="1074" height="160" alt="image" src="https://github.com/user-attachments/assets/55c1832c-b122-4f2f-a4e7-b55e67632acc" />



## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
