### PR TITLE
Fix/unable to download all receipts

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -176,29 +176,8 @@ public class BodiesSyncFeedTests
     }
 
     [TestCase(1, 99, false, null, false)]
-    [TestCase(1, 11051474, false, null, true)]
-    [TestCase(1, 11052984, false, null, true)]
-    [TestCase(1, 11052985, false, null, false)]
-    [TestCase(11051474, 11052984, false, null, false)]
-    [TestCase(11051474, 11051474, false, null, true)]
-    [TestCase(1, 99, false, 11052984, false)]
-    [TestCase(1, 11051474, false, 11052984, true)]
-    [TestCase(1, 11052984, false, 11052984, true)]
-    [TestCase(1, 11052985, false, 11052984, false)]
-    [TestCase(11051474, 11052984, false, 11052984, false)]
-    [TestCase(11051474, 11051474, false, 11052984, true)]
     [TestCase(1, 99, true, null, false)]
-    [TestCase(1, 11051474, true, null, false)]
-    [TestCase(1, 11052984, true, null, false)]
-    [TestCase(1, 11052985, true, null, false)]
-    [TestCase(11051474, 11052984, true, null, false)]
-    [TestCase(11051474, 11051474, true, null, true)]
     [TestCase(1, 99, false, 0, false)]
-    [TestCase(1, 11051474, false, 0, false)]
-    [TestCase(1, 11052984, false, 0, false)]
-    [TestCase(1, 11052985, false, 0, false)]
-    [TestCase(11051474, 11052984, false, 0, false)]
-    [TestCase(11051474, 11051474, false, 0, true)]
     public void When_finished_sync_with_old_default_barrier_then_finishes_imedietely(
             long AncientBarrierInConfig,
             long lowestInsertedBlockNumber,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -244,29 +244,8 @@ public class ReceiptsSyncFeedTests
     }
 
     [TestCase(1, 1024, false, null, false)]
-    [TestCase(1, 11051474, false, null, true)]
-    [TestCase(1, 11052984, false, null, true)]
-    [TestCase(11051474, 11052984, false, null, false)]
-    [TestCase(11051474, 11051474, false, null, true)]
-    [TestCase(1, 11052985, false, null, false)]
-    [TestCase(1, 1024, false, 11052984, false)]
-    [TestCase(1, 11051474, false, 11052984, true)]
-    [TestCase(1, 11052984, false, 11052984, true)]
-    [TestCase(11051474, 11052984, false, 11052984, false)]
-    [TestCase(11051474, 11051474, false, 11052984, true)]
-    [TestCase(1, 11052985, false, 11052984, false)]
     [TestCase(1, 1024, true, null, false)]
-    [TestCase(1, 11051474, true, null, false)]
-    [TestCase(1, 11052984, true, null, false)]
-    [TestCase(11051474, 11052984, true, null, false)]
-    [TestCase(11051474, 11051474, true, null, true)]
-    [TestCase(1, 11052985, true, null, false)]
     [TestCase(1, 1024, false, 0, false)]
-    [TestCase(1, 11051474, false, 0, false)]
-    [TestCase(1, 11052984, false, 0, false)]
-    [TestCase(11051474, 11052984, false, 0, false)]
-    [TestCase(11051474, 11051474, false, 0, true)]
-    [TestCase(1, 11052985, false, 0, false)]
     public void When_finished_sync_with_old_default_barrier_then_finishes_imedietely(
         long AncientBarrierInConfig,
         long? lowestInsertedReceiptBlockNumber,

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
@@ -13,9 +13,6 @@ namespace Nethermind.Synchronization.FastBlocks;
 
 public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
 {
-    internal const int DepositContractBarrier = 11052984;
-    internal const int OldBarrierDefaultExtraRange = 64_000;
-
     protected abstract long? LowestInsertedNumber { get; }
     protected abstract int BarrierWhenStartedMetadataDbKey { get; }
     protected abstract long SyncConfigBarrierCalc { get; }
@@ -28,13 +25,6 @@ public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
     protected long? _barrierWhenStarted;
 
     protected readonly IDb _metadataDb;
-
-    // This property was introduced when we switched defaults of barriers on mainnet from 11052984 to 0 to not disturb existing node operators
-    protected bool WithinOldBarrierDefault => _specProvider.ChainId == BlockchainIds.Mainnet
-        && _barrier == 1
-        && _barrierWhenStarted == DepositContractBarrier
-        && LowestInsertedNumber <= DepositContractBarrier
-        && LowestInsertedNumber > DepositContractBarrier - OldBarrierDefaultExtraRange; // this is intentional. this is a magic number as to the amount of possible blocks that had been synced. We noticed on previous versions that the client synced a bit below the default barrier by more than just the GethRequest limit (128).
 
     public BarrierSyncFeed(IDb metadataDb, ISpecProvider specProvider, ILogger logger)
     {
@@ -53,12 +43,6 @@ public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
         else if (_metadataDb.KeyExists(BarrierWhenStartedMetadataDbKey))
         {
             _barrierWhenStarted = _metadataDb.Get(BarrierWhenStartedMetadataDbKey).ToLongFromBigEndianByteArrayWithoutLeadingZeros();
-        }
-        else if (_specProvider.ChainId == BlockchainIds.Mainnet)
-        {
-            // Assume the  barrier was the previous default (deposit contract barrier) only for mainnet
-            _barrierWhenStarted = DepositContractBarrier;
-            _metadataDb.Set(BarrierWhenStartedMetadataDbKey, _barrierWhenStarted.Value.ToBigEndianByteArrayWithoutLeadingZeros());
         }
         else
         {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -45,8 +45,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private SyncStatusList _syncStatusList;
 
         private bool ShouldFinish => !_syncConfig.DownloadBodiesInFastSync || AllDownloaded;
-        private bool AllDownloaded => (_syncPointers.LowestInsertedBodyNumber ?? long.MaxValue) <= _barrier
-            || WithinOldBarrierDefault;
+        private bool AllDownloaded => (_syncPointers.LowestInsertedBodyNumber ?? long.MaxValue) <= _barrier;
 
         public override bool IsFinished => AllDownloaded;
         public override string FeedName => nameof(BodiesSyncFeed);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -48,8 +48,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private SyncStatusList _syncStatusList;
 
         private bool ShouldFinish => !_syncConfig.DownloadReceiptsInFastSync || AllDownloaded;
-        private bool AllDownloaded => (_syncPointers.LowestInsertedReceiptBlockNumber ?? long.MaxValue) <= _barrier
-            || WithinOldBarrierDefault;
+        private bool AllDownloaded => (_syncPointers.LowestInsertedReceiptBlockNumber ?? long.MaxValue) <= _barrier;
 
         public override bool IsFinished => AllDownloaded;
         public override string FeedName => nameof(ReceiptsSyncFeed);

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -88,7 +88,14 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public bool IsFastBlocksBodiesFinished() => !IsFastBlocks() || !_syncConfig.DownloadBodiesInFastSync || _bodiesSyncFeed.IsFinished;
 
-        public bool IsFastBlocksReceiptsFinished() => !IsFastBlocks() || !_syncConfig.DownloadReceiptsInFastSync || _receiptsSyncFeed.IsFinished;
+        public bool IsFastBlocksReceiptsFinished()
+        {
+            bool cond = !IsFastBlocks() || !_syncConfig.DownloadReceiptsInFastSync || _receiptsSyncFeed.IsFinished;
+
+            Console.Error.WriteLine($"The barrier is {_syncConfig.AncientReceiptsBarrier}, is it finished {_receiptsSyncFeed.IsFinished}");
+
+            return cond;
+        }
 
         public bool IsSnapGetRangesFinished() => _snapSyncFeed?.IsFinished ?? true;
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -88,14 +88,7 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public bool IsFastBlocksBodiesFinished() => !IsFastBlocks() || !_syncConfig.DownloadBodiesInFastSync || _bodiesSyncFeed.IsFinished;
 
-        public bool IsFastBlocksReceiptsFinished()
-        {
-            bool cond = !IsFastBlocks() || !_syncConfig.DownloadReceiptsInFastSync || _receiptsSyncFeed.IsFinished;
-
-            Console.Error.WriteLine($"The barrier is {_syncConfig.AncientReceiptsBarrier}, is it finished {_receiptsSyncFeed.IsFinished}");
-
-            return cond;
-        }
+        public bool IsFastBlocksReceiptsFinished() => !IsFastBlocks() || !_syncConfig.DownloadReceiptsInFastSync || _receiptsSyncFeed.IsFinished;
 
         public bool IsSnapGetRangesFinished() => _snapSyncFeed?.IsFinished ?? true;
 


### PR DESCRIPTION
- Fix cannot download all receipts when barrier already set to 0.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Receipt download now continue