### PR TITLE
Limit deleted block on invalid block

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1001,6 +1001,22 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public void When_deleting_invalid_block_deletes_its_descendant_up_to_a_limit()
+    {
+        BlockStore blockStore = new(new MemDb());
+        MemDb blockInfosDb = new();
+        BlockTree tree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithBlockInfoDb(blockInfosDb)
+            .WithBlockStore(blockStore)
+            .OfChainLength(1000)
+            .TestObject;
+
+        tree.DeleteInvalidBlock(tree.FindBlock(1, BlockTreeLookupOptions.None)!);
+        blockInfosDb.Count.Should().Be(1000 - BlockTree.MaxInvalidBlockToDelete + 2);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void When_deleting_invalid_block_deletes_its_descendants_even_if_not_first()
     {
         BlockStore blockStore = new(new MemDb());


### PR DESCRIPTION
- When an invalid block happen during forward sync from genesis, it will try to delete millions of block which overwrites existing logs making debugging very hard.
- Limit deleted blocks on invalid block to 256 block, which should be a reasonably large size in case of long invalid reorg.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Testing...