### PR TITLE
Revert "Set default pruning boundary to 128 (#8863)"

### DIFF
--- a/src/Nethermind/Nethermind.Core/Reorganization.cs
+++ b/src/Nethermind/Nethermind.Core/Reorganization.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Core
 {
     public static class Reorganization
     {
-        public static long MaxDepth = 128;
+        public static long MaxDepth = 64;
         public const long PersistenceInterval = 8192;
     }
 }

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -80,7 +80,7 @@ public interface IPruningConfig : IConfig
     [ConfigItem(Description = "Enable tracking of past key to reduce database and pruning cache growth", DefaultValue = "true")]
     bool TrackPastKeys { get; set; }
 
-    [ConfigItem(Description = "The number of past states before the state gets pruned. Used to determine how old of a state to keep from the head.", DefaultValue = "128")]
+    [ConfigItem(Description = "The number of past states before the state gets pruned. Used to determine how old of a state to keep from the head.", DefaultValue = "64")]
     int PruningBoundary { get; set; }
 
     [ConfigItem(Description = "Dirty node shard count", DefaultValue = "8")]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
@@ -47,7 +47,7 @@ public class BeaconPivotTests
     }
 
     [TestCase(0, 1001)]
-    [TestCase(500, 372)]
+    [TestCase(500, 436)]
     public void Beacon_pivot_set_to_pivot_when_set(int processedBlocks, int expectedPivotDestinationNumber)
     {
         IBlockTree blockTree = Build.A.BlockTree()

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/StartingSyncPivotUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/StartingSyncPivotUpdaterTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NSubstitute;
@@ -44,15 +43,15 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
             specProvider.TerminalTotalDifficulty = 0;
             _externalPeerBlockTree = Build.A.BlockTree(genesisBlock, specProvider)
                 .WithoutSettingHead
-                .OfChainLength(128 + 64)
+                .OfChainLength(100)
                 .TestObject;
 
             ISyncPeer? fakePeer = Substitute.For<ISyncPeer>();
             fakePeer.GetHeadBlockHeader(default, default).ReturnsForAnyArgs(x => _externalPeerBlockTree!.Head!.Header);
 
             // for unsafe pivot updator
-            Hash256 pivotHash = _externalPeerBlockTree!.FindLevel(63)!.BlockInfos[0].BlockHash;
-            fakePeer.GetBlockHeaders(65, 1, 0, default).ReturnsForAnyArgs(x => _externalPeerBlockTree!.FindHeaders(pivotHash, 1, 0, default));
+            Hash256 pivotHash = _externalPeerBlockTree!.FindLevel(35)!.BlockInfos[0].BlockHash;
+            fakePeer.GetBlockHeaders(35, 1, 0, default).ReturnsForAnyArgs(x => _externalPeerBlockTree!.FindHeaders(pivotHash, 1, 0, default));
 
             NetworkNode node = new(TestItem.PublicKeyA, "127.0.0.1", 30303, 100L);
             fakePeer.Node.Returns(new Node(node));
@@ -103,7 +102,7 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
         }
 
         [Test]
-        public void TrySetFreshPivot_for_unsafe_updator_saves_pivot_N_blocks_behind_HeadBlockHash_in_db()
+        public void TrySetFreshPivot_for_unsafe_updator_saves_pivot_64_blocks_behind_HeadBlockHash_in_db()
         {
             _ = new UnsafeStartingSyncPivotUpdater(
                 _blockTree!,
@@ -117,7 +116,7 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
 
             SyncModeChangedEventArgs args = new(SyncMode.FastSync, SyncMode.UpdatingPivot);
             Hash256 expectedHeadBlockHash = _externalPeerBlockTree!.HeadHash;
-            long expectedPivotBlockNumber = _externalPeerBlockTree!.Head!.Number - Reorganization.MaxDepth;
+            long expectedPivotBlockNumber = _externalPeerBlockTree!.Head!.Number - 64;
             Hash256 expectedPivotBlockHash = _externalPeerBlockTree!.FindLevel(expectedPivotBlockNumber)!.BlockInfos[0].BlockHash;
             _beaconSyncStrategy!.GetHeadBlockHash().Returns(expectedHeadBlockHash);
 


### PR DESCRIPTION
This reverts commit 845095d56ad07867ce4267c159db4e1d53c85668.

Resolves #9031

## Changes

- Revert pruning boundary changes

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No