### PR TITLE
fix: Replace mutable TxReceipt.SkipStateAndStatusInRlp with constructor-based approach

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsExtensions.cs
@@ -12,13 +12,6 @@ namespace Nethermind.Blockchain.Receipts
         public static TxReceipt ForTransaction(this TxReceipt[] receipts, Hash256 txHash)
             => receipts.FirstOrDefault(r => r.TxHash == txHash);
 
-        public static void SetSkipStateAndStatusInRlp(this TxReceipt[] receipts, bool value)
-        {
-            for (int i = 0; i < receipts.Length; i++)
-            {
-                receipts[i].SkipStateAndStatusInRlp = value;
-            }
-        }
 
         public static int GetBlockLogFirstIndex(this TxReceipt[] receipts, int receiptIndex)
         {

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Core
             Bloom = other.Bloom;
             Logs = other.Logs;
             Error = other.Error;
-            SkipStateAndStatusInRlp = other.SkipStateAndStatusInRlp;
         }
 
         /// <summary>
@@ -66,11 +65,6 @@ namespace Nethermind.Core
         public LogEntry[]? Logs { get; set; }
         public string? Error { get; set; }
 
-        /// <summary>
-        /// Ignores receipt output on RLP serialization.
-        /// Output is either StateRoot or StatusCode depending on eip configuration.
-        /// </summary>
-        public bool SkipStateAndStatusInRlp { get; set; }
 
         public Bloom CalculateBloom()
             => _boom = Logs?.Length == 0 ? Bloom.Empty : new Bloom(Logs);

--- a/src/Nethermind/Nethermind.Optimism/OptimismReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismReceiptMessageDecoder.cs
@@ -14,8 +14,9 @@ namespace Nethermind.Optimism;
 public class OptimismReceiptTrieDecoder() : OptimismReceiptMessageDecoder(true);
 
 [Rlp.Decoder]
-public class OptimismReceiptMessageDecoder(bool isEncodedForTrie = false) : IRlpStreamDecoder<TxReceipt>
+public class OptimismReceiptMessageDecoder(bool isEncodedForTrie = false, bool skipStateAndStatus = false) : IRlpStreamDecoder<TxReceipt>
 {
+    private readonly bool _skipStateAndStatus = skipStateAndStatus;
     public OptimismTxReceipt Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         OptimismTxReceipt txReceipt = new();
@@ -36,7 +37,6 @@ public class OptimismReceiptMessageDecoder(bool isEncodedForTrie = false) : IRlp
         else if (firstItem.Length is >= 1 and <= 4)
         {
             txReceipt.GasUsedTotal = (long)firstItem.ToUnsignedBigInteger();
-            txReceipt.SkipStateAndStatusInRlp = true;
         }
         else
         {
@@ -88,7 +88,7 @@ public class OptimismReceiptMessageDecoder(bool isEncodedForTrie = false) : IRlp
 
         bool isEip658Receipts = (rlpBehaviors & RlpBehaviors.Eip658Receipts) == RlpBehaviors.Eip658Receipts;
 
-        if (!item.SkipStateAndStatusInRlp)
+        if (!_skipStateAndStatus)
         {
             contentLength += isEip658Receipts
                 ? Rlp.LengthOf(item.StatusCode)
@@ -161,7 +161,7 @@ public class OptimismReceiptMessageDecoder(bool isEncodedForTrie = false) : IRlp
         }
 
         rlpStream.StartSequence(totalContentLength);
-        if (!item.SkipStateAndStatusInRlp)
+        if (!_skipStateAndStatus)
         {
             rlpStream.Encode(item.StatusCode);
         }


### PR DESCRIPTION
Fixes #8588

## Changes

Resolves thread safety issues in receipt serialization by eliminating shared mutable state.

Changes:
* Replace mutable property with constructor parameters across all receipt decoders
* Use dedicated static decoder instances in ReceiptsRootCalculator

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
