### PR TITLE
fix fullPrunning referencing wrong dbFolder

### DIFF
--- a/src/Nethermind/Nethermind.Db/DbTracker.cs
+++ b/src/Nethermind/Nethermind.Db/DbTracker.cs
@@ -42,5 +42,7 @@ public class DbTracker
             }
             return db;
         }
+
+        public string GetFullDbPath(DbSettings dbSettings) => baseFactory.GetFullDbPath(dbSettings); 
     }
 }


### PR DESCRIPTION
Fixes Closes Resolves #

## Changes

- fixes trieException introduced after running full pruning
- fixes wrong db Folder reference in init of Db

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
