### PR TITLE
Remove storage cell hash representation

### DIFF
--- a/src/Nethermind/Nethermind.Core/StorageCell.cs
+++ b/src/Nethermind/Nethermind.Core/StorageCell.cs
@@ -16,20 +16,8 @@ namespace Nethermind.Core
     public readonly struct StorageCell : IEquatable<StorageCell>
     {
         private readonly UInt256 _index;
-        private readonly bool _isHash;
-
         public Address Address { get; }
-        public bool IsHash => _isHash;
         public UInt256 Index => _index;
-
-        public ValueHash256 Hash => _isHash ? Unsafe.As<UInt256, ValueHash256>(ref Unsafe.AsRef(in _index)) : GetHash();
-
-        private ValueHash256 GetHash()
-        {
-            Span<byte> key = stackalloc byte[32];
-            Index.ToBigEndian(key);
-            return KeccakCache.Compute(key);
-        }
 
         public StorageCell(Address address, in UInt256 index)
         {
@@ -41,11 +29,9 @@ namespace Nethermind.Core
         {
             Address = address;
             _index = Unsafe.As<ValueHash256, UInt256>(ref hash);
-            _isHash = true;
         }
 
         public bool Equals(StorageCell other) =>
-            _isHash == other._isHash &&
             Unsafe.As<UInt256, Vector256<byte>>(ref Unsafe.AsRef(in _index)) == Unsafe.As<UInt256, Vector256<byte>>(ref Unsafe.AsRef(in other._index)) &&
             Address.Equals(other.Address);
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -472,7 +471,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
             Db.Metrics.IncrementStorageTreeCache();
         }
 
-        if (!storageCell.IsHash) PushToRegistryOnly(storageCell, valueChange.After);
+        PushToRegistryOnly(storageCell, valueChange.After);
         return valueChange.After;
     }
 
@@ -516,7 +515,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
         }
 
         Db.Metrics.IncrementStorageTreeReads();
-        return !storageCell.IsHash ? tree.Get(storageCell.Index) : tree.GetArray(storageCell.Hash.Bytes);
+        return tree.Get(storageCell.Index);
     }
 
     private void PushToRegistryOnly(in StorageCell cell, byte[] value)


### PR DESCRIPTION
- Remove `StorageCell` has representation. It always represent slot now.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No