### PR TITLE
feat: Make `GenerateOpCodes` and `ExecuteTransaction` overridable in VM

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Warmup.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Warmup.cs
@@ -75,7 +75,7 @@ public unsafe partial class VirtualMachineBase
     {
         const int WarmUpIterations = 30;
 
-        OpCode[] opcodes = EvmInstructions.GenerateOpCodes<TTracingInst>(spec);
+        OpCode[] opcodes = vm.GenerateOpCodes<TTracingInst>(spec);
         ITxTracer txTracer = new FeesTracer();
         vm._txTracer = txTracer;
         EvmStack stack = new(0, txTracer, evmState.DataStack);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -137,7 +137,7 @@ public unsafe partial class VirtualMachineBase(
     /// <exception cref="EvmException">
     /// Thrown when an EVM-specific error occurs during execution.
     /// </exception>
-    public TransactionSubstate ExecuteTransaction<TTracingInst>(
+    public virtual TransactionSubstate ExecuteTransaction<TTracingInst>(
         EvmState evmState,
         IWorldState worldState,
         ITxTracer txTracer)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -88,7 +88,7 @@ public unsafe partial class VirtualMachineBase(
 
     private ICodeInfoRepository _codeInfoRepository;
 
-    private OpCode[] _opcodeMethods;
+    protected OpCode[] _opcodeMethods;
     private static long _txCount;
 
     private EvmState _currentState;
@@ -833,7 +833,7 @@ public unsafe partial class VirtualMachineBase(
     /// <returns>
     /// The prepared <see cref="IReleaseSpec"/> instance, with its associated opcode methods cached for execution.
     /// </returns>
-    private IReleaseSpec PrepareSpecAndOpcodes<TTracingInst>(BlockHeader header)
+    protected virtual IReleaseSpec PrepareSpecAndOpcodes<TTracingInst>(BlockHeader header)
         where TTracingInst : struct, IFlag
     {
         // Retrieve the release specification based on the block's number and timestamp.

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -854,20 +854,24 @@ public unsafe partial class VirtualMachineBase(
                     _logger.Debug("Refreshing EVM instruction cache");
                 }
                 // Regenerate the non-traced opcode set to pick up any updated PGO optimized methods.
-                spec.EvmInstructionsNoTrace = EvmInstructions.GenerateOpCodes<TTracingInst>(spec);
+                spec.EvmInstructionsNoTrace = GenerateOpCodes<TTracingInst>(spec);
             }
             // Ensure the non-traced opcode set is generated and assign it to the _opcodeMethods field.
-            _opcodeMethods = (OpCode[])(spec.EvmInstructionsNoTrace ??= EvmInstructions.GenerateOpCodes<TTracingInst>(spec));
+            _opcodeMethods = (OpCode[])(spec.EvmInstructionsNoTrace ??= GenerateOpCodes<TTracingInst>(spec));
         }
         else
         {
             // For tracing-enabled execution, generate (if necessary) and cache the traced opcode set.
-            _opcodeMethods = (OpCode[])(spec.EvmInstructionsTraced ??= EvmInstructions.GenerateOpCodes<TTracingInst>(spec));
+            _opcodeMethods = (OpCode[])(spec.EvmInstructionsTraced ??= GenerateOpCodes<TTracingInst>(spec));
         }
 
         // Store the spec in field for future access and return it.
         return (_spec = spec);
     }
+
+    protected virtual OpCode[] GenerateOpCodes<TTracingInst>(IReleaseSpec spec)
+        where TTracingInst : struct, IFlag
+        => EvmInstructions.GenerateOpCodes<TTracingInst>(spec);
 
     /// <summary>
     /// Reports the final outcome of a transaction action to the transaction tracer, taking into account

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -88,7 +88,7 @@ public unsafe partial class VirtualMachineBase(
 
     private ICodeInfoRepository _codeInfoRepository;
 
-    protected OpCode[] _opcodeMethods;
+    private OpCode[] _opcodeMethods;
     private static long _txCount;
 
     private EvmState _currentState;
@@ -833,7 +833,7 @@ public unsafe partial class VirtualMachineBase(
     /// <returns>
     /// The prepared <see cref="IReleaseSpec"/> instance, with its associated opcode methods cached for execution.
     /// </returns>
-    protected virtual IReleaseSpec PrepareSpecAndOpcodes<TTracingInst>(BlockHeader header)
+    private IReleaseSpec PrepareSpecAndOpcodes<TTracingInst>(BlockHeader header)
         where TTracingInst : struct, IFlag
     {
         // Retrieve the release specification based on the block's number and timestamp.


### PR DESCRIPTION
Arbitrum has its own custom implementation for `GasPrice` opcode.
See [Arbitrum's PR](https://github.com/NethermindEth/nethermind-arbitrum/pull/127).

In my suggested modifications here, the virtual machine warmup `RunOpCodes` will not have the updated GasPrice opcode. To have it, I would need to override the whole `VirtualMachine.WarmUpEvmInstructions();`, which seems a bit overkill. Let me know it's still better to have the update there too.

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
