### PR TITLE
Perf/Non blocking memory pruning

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -76,13 +76,19 @@ public class FullPruningDiskTest
             return chain;
         }
 
-        protected override ContainerBuilder ConfigureContainer(ContainerBuilder builder, IConfigProvider configProvider) =>
+        protected override ContainerBuilder
+            ConfigureContainer(ContainerBuilder builder, IConfigProvider configProvider) =>
             // Reenable rocksdb
             base.ConfigureContainer(builder, configProvider)
                 .AddSingleton<IDbFactory, RocksDbFactory>()
                 .Intercept<IInitConfig>((initConfig) =>
                 {
                     initConfig.BaseDbPath = TempDirectory.Path;
+                })
+                .Intercept<IPruningConfig>((pruningConfig) =>
+                {
+                    // Make test faster otherwise it may potentially buffer 128 block.
+                    pruningConfig.MaxBufferedCommitCount = 1;
                 });
 
         public override void Dispose()

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -246,7 +246,7 @@ public class TestBlockchain : IDisposable
 
             Block? genesis = GetGenesisBlock(WorldStateManager.GlobalWorldState);
             BlockTree.SuggestBlock(genesis);
-            await waitGenesis;
+            waitGenesis.Wait(_cts.Token);
         }
 
         if (testConfiguration.AddBlockOnStart)

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindRunner.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindRunner.cs
@@ -62,7 +62,7 @@ public class PseudoNethermindRunner(IComponentContext ctx) : IAsyncDisposable
 
         Block genesis = genesisLoader.Load();
         blockTree.SuggestBlock(genesis);
-        await newHeadTask;
+        newHeadTask.Wait();
     }
 
     public async Task StartNetwork(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Core.Test/TestRawTrieStore.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestRawTrieStore.cs
@@ -62,6 +62,11 @@ public class TestRawTrieStore(INodeStorage nodeStorage, bool isReadOnly = false)
         return nodeStorage.KeyExists(null, TreePath.Empty, stateRoot);
     }
 
+    public IDisposable BeginScope(BlockHeader? baseBlock)
+    {
+        return new Reactive.AnonymousDisposable(() => { });
+    }
+
     public IScopedTrieStore GetTrieStore(Hash256? address)
     {
         return new RawScopedTrieStore(nodeStorage, address);

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -97,4 +97,7 @@ public interface IPruningConfig : IConfig
 
     [ConfigItem(Description = "Minimum number of block worth of unpersisted state in memory. Prevent memory pruning too often due to insufficient dirty cache memory.", DefaultValue = "8")]
     long MinUnpersistedBlockCount { get; set; }
+
+    [ConfigItem(Description = "Maximum number of block in commit buffer before blocking.", DefaultValue = "128", HiddenFromDocs = true)]
+    int MaxBufferedCommitCount { get; set; }
 }

--- a/src/Nethermind/Nethermind.Db/PruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/PruningConfig.cs
@@ -62,5 +62,6 @@ namespace Nethermind.Db
         public long PrunePersistedNodeMinimumTarget { get; set; } = 50.MiB();
         public long MaxUnpersistedBlockCount { get; set; } = 300; // About 1 hour on mainnet
         public long MinUnpersistedBlockCount { get; set; } = 8; // About slightly more than 1 minute
+        public int MaxBufferedCommitCount { get; set; } = 128;
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Store.Test
         private static readonly ILogManager Logger = LimboLogs.Instance;
 
         [Test]
-        public async Task Can_ask_about_balance_in_parallel()
+        public void Can_ask_about_balance_in_parallel()
         {
             IReleaseSpec spec = MainnetSpecProvider.Instance.GetSpec((ForkActivation)MainnetSpecProvider.ConstantinopleFixBlockNumber);
             IDbProvider dbProvider = TestMemDbProvider.Init();
@@ -71,11 +71,11 @@ namespace Nethermind.Store.Test
             Task c = StartTask(reader, baseBlock2, 3);
             Task d = StartTask(reader, baseBlock3, 4);
 
-            await Task.WhenAll(a, b, c, d);
+            Task.WhenAll(a, b, c, d).Wait();
         }
 
         [Test]
-        public async Task Can_ask_about_storage_in_parallel()
+        public void Can_ask_about_storage_in_parallel()
         {
             StorageCell storageCell = new(_address1, UInt256.One);
             IReleaseSpec spec = MuirGlacier.Instance;
@@ -130,7 +130,7 @@ namespace Nethermind.Store.Test
             Task c = StartStorageTask(reader, baseBlock2, storageCell, new byte[] { 3 });
             Task d = StartStorageTask(reader, baseBlock3, storageCell, new byte[] { 4 });
 
-            await Task.WhenAll(a, b, c, d);
+            Task.WhenAll(a, b, c, d).Wait();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -246,11 +246,13 @@ namespace Nethermind.State
             if (_logger.IsTrace) _logger.Trace($"Beginning WorldState scope with baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} with stateroot {baseBlock?.StateRoot?.ToString() ?? "null"}.");
 
             StateRoot = baseBlock?.StateRoot ?? Keccak.EmptyTreeHash;
+            IDisposable trieStoreCloser = _trieStore.BeginScope(baseBlock);
 
             return new Reactive.AnonymousDisposable(() =>
             {
                 Reset();
                 StateRoot = Keccak.EmptyTreeHash;
+                trieStoreCloser.Dispose();
                 _isInScope = false;
                 if (_logger.IsTrace) _logger.Trace($"WorldState scope for baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} closed");
             });

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
@@ -8,8 +8,8 @@ using Nethermind.Trie.Pruning;
 namespace Nethermind.Trie.Test.Pruning
 {
     public class TestPruningStrategy(
-        bool deleteObsoleteKeys,
         bool shouldPrune = false,
+        bool deleteObsoleteKeys = false,
         int? pruneInterval = null)
         : IPruningStrategy
     {
@@ -18,7 +18,6 @@ namespace Nethermind.Trie.Test.Pruning
         {
             if (pruneInterval is not null && state.LatestCommittedBlock % pruneInterval == 0)
             {
-                Console.Error.WriteLine($"Prune trigger");
                 return true;
             }
             return (ShouldPruneEnabled || WithMemoryLimit is not null && state.DirtyCacheMemory > WithMemoryLimit);

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Trie.Test
             public static PruningContext ArchiveWithManualPruning
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(false, true), Persist.EveryBlock, pruningConfig: new PruningConfig()
+                get => new(new TestPruningStrategy(shouldPrune: true, deleteObsoleteKeys: false), Persist.EveryBlock, pruningConfig: new PruningConfig()
                 {
                     PruningBoundary = 0
                 });
@@ -77,7 +77,7 @@ namespace Nethermind.Trie.Test
             public static PruningContext SnapshotEveryOtherBlockWithManualPruning
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(false, pruneInterval: 2), No.Persistence, pruningConfig: new PruningConfig()
+                get => new(new TestPruningStrategy(deleteObsoleteKeys: false, pruneInterval: 2), No.Persistence, pruningConfig: new PruningConfig()
                 {
                     PruningBoundary = 1,
                     TrackPastKeys = false,
@@ -87,13 +87,13 @@ namespace Nethermind.Trie.Test
             public static PruningContext InMemory
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(true), No.Persistence);
+                get => new(new TestPruningStrategy(shouldPrune: true, deleteObsoleteKeys: false), No.Persistence);
             }
 
             public static PruningContext InMemoryWithPastKeyTracking
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(true), No.Persistence, new PruningConfig()
+                get => new(new TestPruningStrategy(shouldPrune: true, deleteObsoleteKeys: true), No.Persistence, new PruningConfig()
                 {
                     TrackPastKeys = true,
                 });
@@ -102,7 +102,7 @@ namespace Nethermind.Trie.Test
             public static PruningContext InMemoryAlwaysPrune
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(true, true), No.Persistence, new PruningConfig()
+                get => new(new TestPruningStrategy(shouldPrune: true, deleteObsoleteKeys: true), No.Persistence, new PruningConfig()
                 {
                     TrackPastKeys = true,
                 });
@@ -111,7 +111,7 @@ namespace Nethermind.Trie.Test
             public static PruningContext SetupWithPersistenceEveryEightBlocks
             {
                 [DebuggerStepThrough]
-                get => new(new TestPruningStrategy(true), new ConstantInterval(8));
+                get => new(new TestPruningStrategy(shouldPrune: true), new ConstantInterval(8));
             }
 
             public Hash256 CurrentStateRoot => _stateProvider.StateRoot;
@@ -147,11 +147,6 @@ namespace Nethermind.Trie.Test
             {
                 _pruningConfig.PruningBoundary = maxDepth;
                 return new PruningContext(_pruningStrategy, _persistenceStrategy, _pruningConfig);
-            }
-
-            public PruningContext PruneOldBlock()
-            {
-                return this;
             }
 
             public PruningContext TurnOnPrune()
@@ -211,14 +206,7 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
-            public PruningContext CommitWithRandomChange()
-            {
-                SetAccountBalance(Random.Shared.Next(), (UInt256)Random.Shared.Next());
-                Commit();
-                return this;
-            }
-
-            public PruningContext Commit()
+            public PruningContext Commit(bool waitForPruning = false)
             {
                 _stateProvider.Commit(MuirGlacier.Instance);
                 _stateProvider.CommitTree((_baseBlock?.Number ?? 0) + 1);
@@ -228,15 +216,21 @@ namespace Nethermind.Trie.Test
                 // The root hash will now be unresolved, which mean it will need to reload from trie store.
                 // `BlockProcessor.InitBranch` does this.
                 _worldStateCloser!.Dispose();
-                _worldStateCloser = _stateProvider.BeginScope(_baseBlock);
 
-                _trieStore.WaitForPruning();
-                Console.Error.WriteLine($"Commited block {_baseBlock.ToString(BlockHeader.Format.Short)} {_trieStore.CachedNodesCount} {_trieStore.PersistedNodesCount}");
+                if (waitForPruning) _trieStore.WaitForPruning();
+
+                _worldStateCloser = _stateProvider.BeginScope(_baseBlock);
                 return this;
+            }
+
+            public PruningContext CommitAndWaitForPruning()
+            {
+                return Commit(waitForPruning: true);
             }
 
             public PruningContext DisposeAndRecreate()
             {
+                _worldStateCloser!.Dispose();
                 _trieStore.Dispose();
                 _trieStore = new TrieStore(new NodeStorage(_dbProvider.StateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
                 _stateProvider = new WorldState(_trieStore, _dbProvider.CodeDb, _logManager);
@@ -244,17 +238,9 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
-            public PruningContext WaitForPruning()
+            public PruningContext CommitEmptyBlockAndWaitForPruning()
             {
-                _trieStore.WaitForPruning();
-                _trieStore.Prune();
-                _trieStore.WaitForPruning();
-                return this;
-            }
-
-            public PruningContext CommitEmptyBlock()
-            {
-                Commit(); // same, just for better test readability
+                Commit(true);
                 return this;
             }
 
@@ -372,25 +358,19 @@ namespace Nethermind.Trie.Test
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4)
                 .CreateAccount(2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(7) // not the length of the leaf path has changed
                 .DumpCache()
                 .SetStorage(2, 1)
                 .SetStorage(2, 2)
-                .Commit()
+                .CommitAndWaitForPruning()
                 .ReadStorage(1, 1)
-                .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitAndWaitForPruning()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(12);
         }
 
@@ -404,9 +384,7 @@ namespace Nethermind.Trie.Test
                 .CreateAccount(1)
                 .Commit()
                 .ReadAccountViaStateReader(1)
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(1);
         }
 
@@ -418,16 +396,12 @@ namespace Nethermind.Trie.Test
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4)
                 .DeleteStorage(1, 1)
                 .DeleteStorage(1, 2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(5);
         }
 
@@ -441,9 +415,7 @@ namespace Nethermind.Trie.Test
                 .Commit()
                 .DeleteStorage(1, 1)
                 .DeleteStorage(1, 2)
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4)
                 .VerifyCached(5);
         }
@@ -459,9 +431,7 @@ namespace Nethermind.Trie.Test
                 .SetStorage(2, 1)
                 .SetStorage(2, 2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(9)
                 .VerifyCached(9);
         }
@@ -479,9 +449,7 @@ namespace Nethermind.Trie.Test
                 .Commit()
                 .DeleteStorage(2, 1)
                 .DeleteStorage(2, 2)
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(9)
                 .VerifyCached(11);
         }
@@ -493,19 +461,15 @@ namespace Nethermind.Trie.Test
                 .CreateAccount(1)
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
-                .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitAndWaitForPruning()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4)
                 .DeleteStorage(1, 1)
                 .DeleteStorage(1, 2)
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
-                .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitAndWaitForPruning()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4);
         }
 
@@ -517,15 +481,11 @@ namespace Nethermind.Trie.Test
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(4)
                 .SetStorage(1, 1, 1000)
                 .Commit()
-                .CommitEmptyBlock()
-                .PruneOldBlock()
-                .PruneOldBlock()
+                .CommitEmptyBlockAndWaitForPruning()
                 .VerifyPersisted(7);
         }
 
@@ -537,7 +497,6 @@ namespace Nethermind.Trie.Test
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
                 .Commit()
-                .PruneOldBlock()
                 .VerifyPersisted(0);
         }
 
@@ -549,8 +508,7 @@ namespace Nethermind.Trie.Test
                 .CreateAccount(1)
                 .SetStorage(1, 1)
                 .SetStorage(1, 2)
-                .Commit()
-                .PruneOldBlock()
+                .CommitAndWaitForPruning()
                 .VerifyPersisted(4);  // account leaf, storage branch, 2x storage leaf
         }
 
@@ -560,8 +518,7 @@ namespace Nethermind.Trie.Test
             PruningContext.ArchiveWithManualPruning
                 .CreateAccount(1)
                 .CreateAccount(2)
-                .Commit()
-                .PruneOldBlock()
+                .CommitAndWaitForPruning()
                 .VerifyPersisted(3); // branch and two leaves
         }
 
@@ -669,7 +626,7 @@ namespace Nethermind.Trie.Test
         }
 
         [Test]
-        public void Should_persist_all_block_of_same_level_on_dispose()
+        public void Should_persist_reorg_depth_block_on_dispose()
         {
             PruningContext.InMemory
                 .WithMaxDepth(4)
@@ -855,11 +812,9 @@ namespace Nethermind.Trie.Test
             {
                 ctx
                     .SetAccountBalance(0, (UInt256)i)
-                    .Commit();
+                    .CommitAndWaitForPruning();
                 stateRoots.Add(ctx.CurrentStateRoot);
             }
-
-            ctx.WaitForPruning();
 
             for (int i = 0; i < 256; i++)
             {
@@ -909,8 +864,7 @@ namespace Nethermind.Trie.Test
             {
                 ctx
                     .SetAccountBalance(i, (UInt256)i)
-                    .Commit()
-                    .WaitForPruning();
+                    .CommitAndWaitForPruning();
             }
 
             ctx
@@ -930,8 +884,7 @@ namespace Nethermind.Trie.Test
 
             ctx
                 .SetAccountBalance(0, (UInt256)1)
-                .Commit()
-                .WaitForPruning()
+                .CommitAndWaitForPruning()
                 .AssertThatDirtyNodeCountIs(1)
                 .AssertThatCachedNodeCountIs(1);
 
@@ -939,8 +892,7 @@ namespace Nethermind.Trie.Test
             {
                 ctx
                     .SetAccountBalance(0, (UInt256)(i + 1))
-                    .Commit()
-                    .WaitForPruning();
+                    .CommitAndWaitForPruning();
             }
 
             ctx
@@ -964,8 +916,7 @@ namespace Nethermind.Trie.Test
             {
                 ctx
                     .SetAccountBalance(i, (UInt256)i)
-                    .Commit()
-                    .WaitForPruning();
+                    .CommitAndWaitForPruning();
 
                 if (thresholdReached)
                 {
@@ -980,6 +931,30 @@ namespace Nethermind.Trie.Test
             ctx
                 .AssertThatDirtyNodeCountIs(9)
                 .AssertThatCachedNodeCountMoreThan(280);
+        }
+
+        [TestCase(10)]
+        [TestCase(64)]
+        [TestCase(100)]
+        public void Can_ContinueCommittingEvenWhenPruning(int maxDepth)
+        {
+            PruningContext ctx = PruningContext.InMemory
+                .WithMaxDepth(maxDepth)
+                .TurnOnPrune();
+
+            using ArrayPoolList<Hash256> stateRoots = new ArrayPoolList<Hash256>(256);
+            for (int i = 0; i < 256; i++)
+            {
+                ctx
+                    .SetAccountBalance(0, (UInt256)i)
+                    .CommitAndWaitForPruning();
+                stateRoots.Add(ctx.CurrentStateRoot);
+            }
+
+            for (int i = 0; i < 256; i++)
+            {
+                ctx.VerifyNodeInCache(stateRoots[i], i >= 255 - maxDepth);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -581,7 +581,7 @@ namespace Nethermind.Trie.Test
                 .Commit()
 
                 // Storage root actually never got pruned even-though another parallel branch get persisted. This
-                // is because the condition `LastSeen < LastPersistedBlock` never turn to true.
+                // is because the condition `LastCommit < LastPersistedBlock` never turn to true.
                 .VerifyStorageValue(3, 1, 999);
         }
 
@@ -740,7 +740,7 @@ namespace Nethermind.Trie.Test
                 .Commit()
                 .SaveBranchingPoint("main")
 
-                // The storage root will now get reset at a lower LastSeen
+                // The storage root will now get reset at a lower LastCommit
                 .RestoreBranchingPoint("revert_main")
                 .CreateAccount(3)
                 .SetStorage(3, 1, 999)
@@ -779,7 +779,7 @@ namespace Nethermind.Trie.Test
                 .Commit()
                 .SaveBranchingPoint("main")
 
-                // This will result in the same state root, but it's `LastSeen` reduced.
+                // This will result in the same state root, but it's `LastCommit` reduced.
                 .RestoreBranchingPoint("revert_main")
                 .SetAccountBalance(1, 10)
                 .SetAccountBalance(2, 101)

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -4,13 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Db;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -36,7 +38,9 @@ namespace Nethermind.Trie.Test
         {
             private BlockHeader? _baseBlock = Build.A.EmptyBlockHeader;
             private readonly Dictionary<string, BlockHeader?> _branchingPoints = new();
-            private readonly IDbProvider _dbProvider;
+            private readonly ManualResetEvent _stateDbBlocker = new ManualResetEvent(true);
+            private readonly TestMemDb _stateDb;
+            private readonly TestMemDb _codeDb;
             private IDisposable? _worldStateCloser = null;
             private IWorldState _stateProvider;
             private IStateReader _stateReader;
@@ -51,16 +55,22 @@ namespace Nethermind.Trie.Test
             private PruningContext(TestPruningStrategy pruningStrategy, IPersistenceStrategy persistenceStrategy, IPruningConfig? pruningConfig = null)
             {
                 _logManager = LimboLogs.Instance;
-                //new TestLogManager(LogLevel.Trace);
                 _logger = _logManager.GetClassLogger();
-                _dbProvider = TestMemDbProvider.Init();
+                _stateDb = new TestMemDb();
+                _stateDb.WriteFunc = (k, v) =>
+                {
+                    _stateDbBlocker.WaitOne();
+                    return true;
+                };
+
+                _codeDb = new TestMemDb();
                 _persistenceStrategy = persistenceStrategy;
                 _pruningStrategy = pruningStrategy;
 
                 _pruningConfig = pruningConfig ?? new PruningConfig() { TrackPastKeys = false };
-                _trieStore = new TrieStore(new NodeStorage(_dbProvider.StateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
-                _stateProvider = new WorldState(_trieStore, _dbProvider.CodeDb, _logManager);
-                _stateReader = new StateReader(_trieStore, _dbProvider.CodeDb, _logManager);
+                _trieStore = new TrieStore(new NodeStorage(_stateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
+                _stateProvider = new WorldState(_trieStore, _codeDb, _logManager);
+                _stateReader = new StateReader(_trieStore, _codeDb, _logManager);
                 _worldStateCloser = _stateProvider.BeginScope(null);
             }
 
@@ -134,6 +144,11 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
+            public UInt256 GetAccountBalance(int accountIndex)
+            {
+                return _stateProvider.GetBalance(Address.FromNumber((UInt256)accountIndex));
+            }
+
             public PruningContext SetManyAccountWithSameBalance(int startNum, int numOfAccount, UInt256 balance)
             {
                 for (int i = 0; i < numOfAccount; i++)
@@ -145,7 +160,12 @@ namespace Nethermind.Trie.Test
 
             public PruningContext WithMaxDepth(int maxDepth)
             {
-                _pruningConfig.PruningBoundary = maxDepth;
+                return WithPruningConfig((cfg) => cfg.PruningBoundary = maxDepth);
+            }
+
+            public PruningContext WithPruningConfig(Action<IPruningConfig> configurer)
+            {
+                configurer(_pruningConfig);
                 return new PruningContext(_pruningStrategy, _persistenceStrategy, _pruningConfig);
             }
 
@@ -223,6 +243,18 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
+            public PruningContext ExitScope()
+            {
+                _worldStateCloser.Dispose();
+                return this;
+            }
+
+            public PruningContext EnterScope()
+            {
+                _worldStateCloser = _stateProvider.BeginScope(_baseBlock);
+                return this;
+            }
+
             public PruningContext CommitAndWaitForPruning()
             {
                 return Commit(waitForPruning: true);
@@ -232,9 +264,9 @@ namespace Nethermind.Trie.Test
             {
                 _worldStateCloser!.Dispose();
                 _trieStore.Dispose();
-                _trieStore = new TrieStore(new NodeStorage(_dbProvider.StateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
-                _stateProvider = new WorldState(_trieStore, _dbProvider.CodeDb, _logManager);
-                _stateReader = new StateReader(_trieStore, _dbProvider.CodeDb, _logManager);
+                _trieStore = new TrieStore(new NodeStorage(_stateDb), _pruningStrategy, _persistenceStrategy, _pruningConfig, _logManager);
+                _stateProvider = new WorldState(_trieStore, _codeDb, _logManager);
+                _stateReader = new StateReader(_trieStore, _codeDb, _logManager);
                 return this;
             }
 
@@ -335,6 +367,18 @@ namespace Nethermind.Trie.Test
             public void AssertThatTotalMemoryUsedIsNoLessThan(long memoryUsage)
             {
                 _trieStore.MemoryUsedByDirtyCache.Should().BeGreaterThan(memoryUsage);
+            }
+
+            public PruningContext BlockDatabase()
+            {
+                _stateDbBlocker.Reset();
+                return this;
+            }
+
+            public PruningContext UnblockDatabase()
+            {
+                _stateDbBlocker.Set();
+                return this;
             }
         }
 
@@ -955,6 +999,54 @@ namespace Nethermind.Trie.Test
             {
                 ctx.VerifyNodeInCache(stateRoots[i], i >= 255 - maxDepth);
             }
+        }
+
+        [TestCase(100, 50, false)]
+        [TestCase(100, 150, true)]
+        public async Task Can_ContinueEvenWhenPruningIsBlocked(int maxBufferedCommit, int blockCount, bool isBlocked)
+        {
+            PruningContext ctx = PruningContext.InMemory
+                .TurnOnPrune()
+                .WithPruningConfig((cfg) =>
+                {
+                    cfg.PruningBoundary = 2;
+                    cfg.MaxBufferedCommitCount = maxBufferedCommit;
+                })
+                .BlockDatabase()
+                .ExitScope()
+                ;
+
+            Task blockTask = Task.Run(() =>
+            {
+                ctx.EnterScope();
+                for (int i = 0; i < blockCount; i++)
+                {
+                    ctx
+                        .SetAccountBalance(i, (UInt256)i)
+                        .Commit();
+                }
+
+                for (int i = 0; i < blockCount; i++)
+                {
+                    ctx.GetAccountBalance(i).Should().Be((UInt256)i);
+                }
+                ctx.ExitScope();
+            });
+
+            if (!isBlocked)
+            {
+                await blockTask;
+            }
+            else
+            {
+                await Task.Delay(1000);
+                blockTask.IsCompleted.Should().BeFalse();
+
+                ctx.UnblockDatabase();
+
+                await blockTask;
+            }
+
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
@@ -53,6 +53,8 @@ public class PreCachedTrieStore : ITrieStore
 
     public bool HasRoot(Hash256 stateRoot) => _inner.HasRoot(stateRoot);
 
+    public IDisposable BeginScope(BlockHeader? baseBlock) => _inner.BeginScope(baseBlock);
+
     public IScopedTrieStore GetTrieStore(Hash256? address) => new ScopedTrieStore(this, address);
 
     public TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256 hash) => _inner.FindCachedOrUnknown(address, in path, hash);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Trie.Pruning
     {
         bool HasRoot(Hash256 stateRoot);
 
+        IDisposable BeginScope(BlockHeader? baseBlock);
+
         IScopedTrieStore GetTrieStore(Hash256? address);
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Trie/Pruning/OverlayTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/OverlayTrieStore.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -39,6 +40,8 @@ public class OverlayTrieStore(IKeyValueStoreWithBatching keyValueStore, IReadOnl
     public bool IsPersisted(Hash256? address, in TreePath path, in ValueHash256 keccak) => _nodeStorage.Get(address, in path, in keccak) is not null || baseStore.IsPersisted(address, in path, in keccak);
 
     public bool HasRoot(Hash256 stateRoot) => _nodeStorage.Get(null, TreePath.Empty, stateRoot) is not null || baseStore.HasRoot(stateRoot);
+
+    public IDisposable BeginScope(BlockHeader? baseBlock) => baseStore.BeginScope(baseBlock);
 
     public IScopedTrieStore GetTrieStore(Hash256? address) => new ScopedTrieStore(this, address);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Trie.Pruning
             return NullCommitter.Instance;
         }
 
-        public IReadOnlyKeyValueStore TrieNodeRlpStore => _trieStore.TrieNodeRlpStore;
+        public IDisposable BeginScope(BlockHeader? baseBlock) => new Reactive.AnonymousDisposable(() => { }); // Noop
 
         public IScopedTrieStore GetTrieStore(Hash256? address) => new ScopedReadOnlyTrieStore(this, address);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -459,11 +459,14 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         // Commit buffer mode would use the
         if (IsInCommitBufferMode)
+        {
             _commitBuffer.EnqueueCommitSet(set);
+        }
         else
+        {
             PushToMainCommitSetQueue(set);
-
-        Prune();
+            Prune();
+        }
     }
 
     private void PushToMainCommitSetQueue(BlockCommitSet set)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -439,13 +439,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         if (_currentBlockCommitter is not null) throw new InvalidOperationException("Cannot start a new block commit when an existing one is still not closed");
 
+        if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
         VerifyNewCommitSet(blockNumber);
 
-        BlockCommitSet commitSet = IsInCommitBufferMode
-            ? _commitBuffer.CreateCommitSet(blockNumber)
-            : CreateCommitSet(blockNumber);
-
-        _lastCommitSet = commitSet;
+        BlockCommitSet commitSet = new BlockCommitSet(blockNumber);
 
         _currentBlockCommitter = new BlockCommitter(this, commitSet);
         return _currentBlockCommitter;
@@ -458,8 +455,22 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         set.Prune();
 
         _currentBlockCommitter = null;
+        _lastCommitSet = set;
+
+        // Commit buffer mode would use the
+        if (IsInCommitBufferMode)
+            _commitBuffer.EnqueueCommitSet(set);
+        else
+            PushToMainCommitSetQueue(set);
 
         Prune();
+    }
+
+    private void PushToMainCommitSetQueue(BlockCommitSet set)
+    {
+        _commitSetQueue.Enqueue(set);
+        LatestCommittedBlockNumber = Math.Max(set.BlockNumber, LatestCommittedBlockNumber);
+        AnnounceReorgBoundaries();
     }
 
     public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
@@ -900,21 +911,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 if (_logger.IsInfo) _logger.Info($"Non consecutive block commit. This is likely a reorg. Last block commit: {_lastCommitSet.BlockNumber}. New block commit: {blockNumber}.");
             }
         }
-    }
-
-    private BlockCommitSet CreateCommitSet(long blockNumber)
-    {
-        if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
-
-        BlockCommitSet commitSet = new(blockNumber);
-        _commitSetQueue.Enqueue(commitSet);
-
-        LatestCommittedBlockNumber = Math.Max(blockNumber, LatestCommittedBlockNumber);
-        // Why are we announcing **before** committing next block??
-        // Should it be after commit?
-        AnnounceReorgBoundaries();
-
-        return commitSet;
     }
 
     /// <summary>
@@ -1436,11 +1432,9 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             }
         }
 
-        public BlockCommitSet CreateCommitSet(long blockNumber)
+        public void EnqueueCommitSet(BlockCommitSet set)
         {
-            BlockCommitSet commitSet = new(blockNumber);
-            _commitSetQueueBuffer.Enqueue(commitSet);
-            return commitSet;
+            _commitSetQueueBuffer.Enqueue(set);
         }
 
         public void FlushToDirtyNodes()
@@ -1456,6 +1450,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             while (_commitSetQueueBuffer.TryDequeue(out BlockCommitSet commitSet))
             {
                 _trieStore._commitSetQueue.Enqueue(commitSet);
+                _trieStore.PushToMainCommitSetQueue(commitSet);
                 count++;
             }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -28,6 +28,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 {
     private readonly int _shardedDirtyNodeCount = 256;
     private readonly int _shardBit = 8;
+    private readonly int _maxBufferedCommitCount;
     private readonly int _maxDepth;
     private readonly double _prunePersistedNodePortion;
     private readonly long _prunePersistedNodeMinimumTarget;
@@ -41,8 +42,21 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     private readonly Action<TreePath, Hash256?, TrieNode> _persistedNodeRecorderNoop;
     private readonly Task[] _disposeTasks = new Task[RuntimeInformation.PhysicalCoreCount];
 
-    // This seems to attempt prevent multiple block processing at the same time and along with pruning at the same time.
-    private readonly object _dirtyNodesLock = new object();
+    // Is created when _scopeLock was acquired but _dirtyNodesLock was not, meaning _dirtyNodes is being used,
+    // likely by memory pruning. Read and commit will get redirected to _commitBuffer in this case.
+    private CommitBuffer? _commitBuffer = null;
+
+    // Small optimization to not re-create CommitBuffer
+    private CommitBuffer? _commitBufferUnused = null;
+
+    private bool IsInCommitBufferMode => _commitBuffer is not null;
+
+    // Only one scope can be active at the same time. Any mutation to trieStore as part of block processing need to
+    // acquire _scopeLock.
+    private readonly Lock _scopeLock = new Lock();
+
+    // Protect _dirtyNodes from mutation. Used during memory pruning or WorldState scope.
+    private readonly Lock _pruningLock = new Lock();
 
     private readonly bool _deleteOldNodes = false;
     private readonly bool _pastKeyTrackingEnabled = false;
@@ -68,6 +82,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         _maxDepth = pruningConfig.PruningBoundary;
         _prunePersistedNodePortion = pruningConfig.PrunePersistedNodePortion;
         _prunePersistedNodeMinimumTarget = pruningConfig.PrunePersistedNodeMinimumTarget;
+        _maxBufferedCommitCount = pruningConfig.MaxBufferedCommitCount;
 
         _shardBit = pruningConfig.DirtyNodeShardBit;
         _shardedDirtyNodeCount = 1 << _shardBit;
@@ -206,7 +221,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 ThrowUnknownHash(node);
             }
 
-            SaveOrReplaceInDirtyNodesCache(address, ref path, nodeCommitInfo, node, blockNumber);
+            if (IsInCommitBufferMode)
+                _commitBuffer.SaveOrReplaceInDirtyNodesCache(address, ref path, nodeCommitInfo, blockNumber);
+            else
+                SaveOrReplaceInDirtyNodesCache(address, ref path, nodeCommitInfo, blockNumber);
 
             IncrementCommittedNodesCount();
         }
@@ -232,9 +250,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         return (int)(hashCode % _shardedDirtyNodeCount);
     }
 
-    private int GetNodeShardIdx(in TrieStoreDirtyNodesCache.Key key) => GetNodeShardIdx(key.Path, key.Keccak);
-
-    private TrieStoreDirtyNodesCache GetDirtyNodeShard(in TrieStoreDirtyNodesCache.Key key) => _dirtyNodes[GetNodeShardIdx(key)];
+    private TrieStoreDirtyNodesCache GetDirtyNodeShard(in TrieStoreDirtyNodesCache.Key key) => _dirtyNodes[GetNodeShardIdx(key.Path, key.Keccak)];
 
     private long NodesCount()
     {
@@ -256,14 +272,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         return count;
     }
 
-    private TrieNode DirtyNodesGetOrAdd(in TrieStoreDirtyNodesCache.Key key, TrieNode node, long blockNumber) =>
-        GetDirtyNodeShard(key).GetOrAdd(key, new TrieStoreDirtyNodesCache.NodeRecord(node, blockNumber)).Node;
-
     private bool DirtyNodesTryGetValue(in TrieStoreDirtyNodesCache.Key key, out TrieNode? node) =>
         GetDirtyNodeShard(key).TryGetValue(key, out node);
-
-    private void DirtyNodesIncrementMemory(in TrieStoreDirtyNodesCache.Key key, TrieNode node) =>
-        GetDirtyNodeShard(key).IncrementMemory(node);
 
     private bool DirtyNodesIsNodeCached(TrieStoreDirtyNodesCache.Key key) =>
         GetDirtyNodeShard(key).IsNodeCached(key);
@@ -274,10 +284,27 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     private TrieNode DirtyNodesFindCachedOrUnknown(TrieStoreDirtyNodesCache.Key key) =>
         GetDirtyNodeShard(key).FindCachedOrUnknown(key);
 
-    private void SaveOrReplaceInDirtyNodesCache(Hash256? address, ref TreePath path, NodeCommitInfo nodeCommitInfo, TrieNode node, long blockNumber)
+    private void SaveOrReplaceInDirtyNodesCache(
+        Hash256? address,
+        ref TreePath path,
+        NodeCommitInfo nodeCommitInfo,
+        long blockNumber)
     {
+        TrieStoreDirtyNodesCache shard = _dirtyNodes[GetNodeShardIdx(path, nodeCommitInfo.Node.Keccak)];
+        SaveOrReplaceInDirtyNodesCache(shard, address, ref path, nodeCommitInfo, blockNumber);
+    }
+
+    private void SaveOrReplaceInDirtyNodesCache(
+        TrieStoreDirtyNodesCache shard,
+        Hash256? address,
+        ref TreePath path,
+        NodeCommitInfo nodeCommitInfo,
+        long blockNumber
+    )
+    {
+        TrieNode node = nodeCommitInfo.Node;
         TrieStoreDirtyNodesCache.Key key = new(address, path, node.Keccak);
-        TrieNode cachedNodeCopy = DirtyNodesGetOrAdd(in key, node, blockNumber);
+        TrieNode cachedNodeCopy = shard.GetOrAdd(in key, new TrieStoreDirtyNodesCache.NodeRecord(node, blockNumber)).Node;
         if (!ReferenceEquals(cachedNodeCopy, node))
         {
             // So what happen here is that the patricia trie was modified in a way that some of the trie nodes
@@ -303,7 +330,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
         else
         {
-            DirtyNodesIncrementMemory(key, node);
+            shard.IncrementMemory(node);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -317,7 +344,92 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             throw new InvalidOperationException($"The hash of replacement node {cachedNodeCopy} is not the same as the original {node}.");
     }
 
-    public ICommitter BeginCommit(Hash256? address, TrieNode? root, WriteFlags writeFlags)
+    public IDisposable BeginScope(BlockHeader? baseBlock)
+    {
+        _scopeLock.Enter();
+        if (_pruningLock.TryEnter())
+        {
+            // When in non commit buffer mode, FindCachedOrUnknown can also modify the dirty cache which has
+            // a notable performance benefit. So we try to clear the buffer before.
+            FlushCommitBufferNoLock();
+
+            return new Reactive.AnonymousDisposable(() =>
+            {
+                _pruningLock.Exit();
+                _scopeLock.Exit();
+            });
+        }
+
+        // _dirtyNodesLock was not acquired, likely due to memory pruning.
+        // Will continue with commit buffer.
+        if (_commitBuffer is null) _commitBuffer = _commitBufferUnused ?? new CommitBuffer(this);
+        if (_commitBuffer.CommitCount > _maxBufferedCommitCount)
+        {
+            // Prevent commit buffer from becoming too large.
+            // This only happen if dirty cache size is very large and during forward sync.
+            if (_logger.IsDebug) _logger.Debug("Commit buffer too large. Flushing first.");
+
+            // Blocks until memory pruning is finished
+
+            while (!_pruningLock.TryEnter(TimeSpan.FromSeconds(10)))
+            {
+                if (_logger.IsInfo) _logger.Info("Commit buffer full. Waiting for state to be unlocked.");
+            }
+
+            FlushCommitBufferNoLock();
+
+            return new Reactive.AnonymousDisposable(() =>
+            {
+                _pruningLock.Exit();
+                _scopeLock.Exit();
+            });
+        }
+
+        return new Reactive.AnonymousDisposable(() =>
+        {
+            _scopeLock.Exit();
+
+            // Try exit and flush async
+            Task.Factory.StartNew(TryExitCommitBufferMode);
+        });
+    }
+
+    private void TryExitCommitBufferMode()
+    {
+        if (!IsInCommitBufferMode) return;
+
+        if (_scopeLock.TryEnter())
+        {
+            try
+            {
+                if (_pruningLock.TryEnter())
+                {
+                    try
+                    {
+                        FlushCommitBufferNoLock();
+                    }
+                    finally
+                    {
+                        _pruningLock.Exit();
+                    }
+                }
+            }
+            finally
+            {
+                _scopeLock.Exit();
+            }
+        }
+    }
+
+    private void FlushCommitBufferNoLock()
+    {
+        if (!IsInCommitBufferMode) return;
+        _commitBuffer.FlushToDirtyNodes();
+        _commitBufferUnused = _commitBuffer;
+        _commitBuffer = null;
+    }
+
+    ICommitter IScopableTrieStore.BeginCommit(Hash256? address, TrieNode? root, WriteFlags writeFlags)
     {
         if (_currentBlockCommitter is null) throw new InvalidOperationException($"With pruning triestore, {nameof(BeginBlockCommit)} must be called.");
         return _currentBlockCommitter.GetTrieCommitter(address, root, writeFlags);
@@ -325,17 +437,17 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
     public IBlockCommitter BeginBlockCommit(long blockNumber)
     {
-        while (!Monitor.TryEnter(_dirtyNodesLock, TimeSpan.FromSeconds(10)))
-        {
-            if (_logger.IsInfo) _logger.Info("Waiting for state to be unlocked.");
-        }
+        if (_currentBlockCommitter is not null) throw new InvalidOperationException("Cannot start a new block commit when an existing one is still not closed");
 
-        if (_currentBlockCommitter is not null)
-        {
-            throw new InvalidOperationException("Cannot start a new block commit when an existing one is still not closed");
-        }
+        VerifyNewCommitSet(blockNumber);
 
-        _currentBlockCommitter = new BlockCommitter(this, CreateCommitSet(blockNumber));
+        BlockCommitSet commitSet = IsInCommitBufferMode
+            ? _commitBuffer.CreateCommitSet(blockNumber)
+            : CreateCommitSet(blockNumber);
+
+        _lastCommitSet = commitSet;
+
+        _currentBlockCommitter = new BlockCommitter(this, commitSet);
         return _currentBlockCommitter;
     }
 
@@ -346,8 +458,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         set.Prune();
 
         _currentBlockCommitter = null;
-
-        Monitor.Exit(_dirtyNodesLock);
 
         Prune();
     }
@@ -414,7 +524,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         ArgumentNullException.ThrowIfNull(hash);
 
         TrieStoreDirtyNodesCache.Key key = new TrieStoreDirtyNodesCache.Key(address, path, hash);
-        return FindCachedOrUnknown(key, isReadOnly);
+        return IsInCommitBufferMode ? _commitBuffer.FindCachedOrUnknown(key, isReadOnly) : FindCachedOrUnknown(key, isReadOnly);
     }
 
     private TrieNode FindCachedOrUnknown(TrieStoreDirtyNodesCache.Key key, bool isReadOnly)
@@ -444,7 +554,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         {
             _pruningTask = Task.Run(() =>
             {
-                lock (_dirtyNodesLock)
+                using (var _ = _pruningLock.EnterScope())
                 {
                     if (_pruningStrategy.ShouldPruneDirtyNode(CaptureCurrentState()))
                     {
@@ -456,6 +566,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                         PrunePersistedNodes();
                     }
                 }
+
+                TryExitCommitBufferMode();
             });
         }
     }
@@ -464,13 +576,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         try
         {
-            // Flush ahead of time so that memtable is empty which prevent stalling when writing nodes.
-            // Note, the WriteBufferSize * WriteBufferNumber need to be more than about 20% of pruning cache
-            // otherwise, it may not fit the whole dirty cache.
-            // Additionally, if (WriteBufferSize * (WriteBufferNumber - 1)) is already more than 20% of pruning
-            // cache, it is likely that there are enough space for it on most time, except for syncing maybe.
-            _nodeStorage.Flush(onlyWal: false);
-
             long start = Stopwatch.GetTimestamp();
             if (_logger.IsDebug) _logger.Debug($"Locked {nameof(TrieStore)} for pruning.");
 
@@ -730,20 +835,23 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         Metrics.DirtyNodesCount = totalDirtyNodes;
     }
 
-    public void ClearCache()
-    {
-        foreach (TrieStoreDirtyNodesCache dirtyNode in _dirtyNodes)
-        {
-            dirtyNode.Clear();
-        }
-    }
-
     public void Dispose()
     {
         if (_logger.IsDebug) _logger.Debug("Disposing trie");
         _pruningTaskCancellationTokenSource.Cancel();
         _pruningTask.Wait();
+        FlushNonBlockingBuffer();
         PersistOnShutdown();
+    }
+
+    private void FlushNonBlockingBuffer()
+    {
+        using var _ = _scopeLock.EnterScope();
+        if (_commitBuffer is null) return;
+
+        using var _2 = _pruningLock.EnterScope();
+
+        FlushCommitBufferNoLock();
     }
 
     public void WaitForPruning()
@@ -798,12 +906,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
 
-        VerifyNewCommitSet(blockNumber);
-
         BlockCommitSet commitSet = new(blockNumber);
         _commitSetQueue.Enqueue(commitSet);
-
-        _lastCommitSet = commitSet;
 
         LatestCommittedBlockNumber = Math.Max(blockNumber, LatestCommittedBlockNumber);
         // Why are we announcing **before** committing next block??
@@ -1028,71 +1132,69 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     public void PersistCache(CancellationToken cancellationToken)
     {
         if (_logger.IsInfo) _logger.Info("Full Pruning Persist Cache started.");
+        using var _ = _pruningLock.EnterScope();
 
-        lock (_dirtyNodesLock)
+        long start = Stopwatch.GetTimestamp();
+        int commitSetCount = 0;
+        // We persist all sealed Commitset causing PruneCache to almost completely clear the cache. Any new block that
+        // need existing node will have to read back from db causing copy-on-read mechanism to copy the node.
+        ConcurrentQueue<BlockCommitSet> commitSetQueue = _commitSetQueue;
+
+        void ClearCommitSetQueue()
         {
-            long start = Stopwatch.GetTimestamp();
-            int commitSetCount = 0;
-            // We persist all sealed Commitset causing PruneCache to almost completely clear the cache. Any new block that
-            // need existing node will have to read back from db causing copy-on-read mechanism to copy the node.
-            ConcurrentQueue<BlockCommitSet> commitSetQueue = _commitSetQueue;
-
-            void ClearCommitSetQueue()
+            while (commitSetQueue.TryPeek(out BlockCommitSet commitSet) && commitSet.IsSealed)
             {
-                while (commitSetQueue.TryPeek(out BlockCommitSet commitSet) && commitSet.IsSealed)
+                if (!commitSetQueue.TryDequeue(out commitSet)) break;
+                if (!commitSet.IsSealed)
                 {
-                    if (!commitSetQueue.TryDequeue(out commitSet)) break;
-                    if (!commitSet.IsSealed)
-                    {
-                        // Oops
-                        commitSetQueue.Enqueue(commitSet);
-                        break;
-                    }
-
-                    commitSetCount++;
-                    ParallelPersistBlockCommitSet(commitSet, _persistedNodeRecorderNoop);
+                    // Oops
+                    commitSetQueue.Enqueue(commitSet);
+                    break;
                 }
+
+                commitSetCount++;
+                ParallelPersistBlockCommitSet(commitSet, _persistedNodeRecorderNoop);
             }
-
-            if (_logger.IsInfo) _logger.Info($"Saving all commit set took {Stopwatch.GetElapsedTime(start)} for {commitSetCount} commit sets.");
-
-            start = Stopwatch.GetTimestamp();
-
-            // Double check
-            ClearCommitSetQueue();
-            if (cancellationToken.IsCancellationRequested) return;
-
-            // All persisted node including recommitted nodes between head and reorg depth must be removed so that
-            // it will be re-persisted or at least re-read in order to be cloned.
-            // This should clear most nodes. For some reason, not all.
-            PruneCache(prunePersisted: true, dontRemoveNodes: true, forceRemovePersistedNodes: true);
-            if (cancellationToken.IsCancellationRequested) return;
-
-            int totalPersistedCount = 0;
-            for (int index = 0; index < _dirtyNodes.Length; index++)
-            {
-                TrieStoreDirtyNodesCache dirtyNode = _dirtyNodes[index];
-                _dirtyNodesTasks[index] = Task.Run(() =>
-                {
-                    int persistedCount = dirtyNode.PersistAll(_nodeStorage, cancellationToken);
-                    totalPersistedCount += persistedCount;
-                });
-            }
-
-            Task.WaitAll(_dirtyNodesTasks);
-
-            if (cancellationToken.IsCancellationRequested) return;
-
-            PruneCache(prunePersisted: true, dontRemoveNodes: true, forceRemovePersistedNodes: true);
-
-            long nodesCount = NodesCount();
-            if (nodesCount != 0)
-            {
-                if (_logger.IsWarn) _logger.Warn($"{nodesCount} cache entry remains. {DirtyCachedNodesCount} dirty, total persistec count is {totalPersistedCount}.");
-            }
-
-            if (_logger.IsInfo) _logger.Info($"Clear cache took {Stopwatch.GetElapsedTime(start)}.");
         }
+
+        if (_logger.IsInfo) _logger.Info($"Saving all commit set took {Stopwatch.GetElapsedTime(start)} for {commitSetCount} commit sets.");
+
+        start = Stopwatch.GetTimestamp();
+
+        // Double check
+        ClearCommitSetQueue();
+        if (cancellationToken.IsCancellationRequested) return;
+
+        // All persisted node including recommitted nodes between head and reorg depth must be removed so that
+        // it will be re-persisted or at least re-read in order to be cloned.
+        // This should clear most nodes. For some reason, not all.
+        PruneCache(prunePersisted: true, dontRemoveNodes: true, forceRemovePersistedNodes: true);
+        if (cancellationToken.IsCancellationRequested) return;
+
+        int totalPersistedCount = 0;
+        for (int index = 0; index < _dirtyNodes.Length; index++)
+        {
+            TrieStoreDirtyNodesCache dirtyNode = _dirtyNodes[index];
+            _dirtyNodesTasks[index] = Task.Run(() =>
+            {
+                int persistedCount = dirtyNode.PersistAll(_nodeStorage, cancellationToken);
+                totalPersistedCount += persistedCount;
+            });
+        }
+
+        Task.WaitAll(_dirtyNodesTasks);
+
+        if (cancellationToken.IsCancellationRequested) return;
+
+        PruneCache(prunePersisted: true, dontRemoveNodes: true, forceRemovePersistedNodes: true);
+
+        long nodesCount = NodesCount();
+        if (nodesCount != 0)
+        {
+            if (_logger.IsWarn) _logger.Warn($"{nodesCount} cache entry remains. {DirtyCachedNodesCount} dirty, total persistec count is {totalPersistedCount}.");
+        }
+
+        if (_logger.IsInfo) _logger.Info($"Clear cache took {Stopwatch.GetElapsedTime(start)}.");
     }
 
     // Used to serve node by hash
@@ -1176,7 +1278,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 // During commit it PatriciaTrie, the root may get resolved to an existing node (same keccak).
                 // This ensure that the root that we use here is the same.
                 // This is only needed for state tree as the root need to be put in the block commit set.
-                if (address == null) blockCommitter.StateRoot = trieStore.FindCachedOrUnknown(address, TreePath.Empty, root?.Keccak);
+                if (address == null) blockCommitter.StateRoot = ((IScopableTrieStore)trieStore).FindCachedOrUnknown(address, TreePath.Empty, root?.Keccak);
             }
         }
 
@@ -1312,5 +1414,85 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             5999471,
             7199369
         ];
+    }
+
+    private class CommitBuffer
+    {
+        private readonly ConcurrentQueue<BlockCommitSet> _commitSetQueueBuffer = new();
+        private readonly TrieStoreDirtyNodesCache[] _dirtyNodesBuffer;
+        private readonly TrieStore _trieStore;
+        private readonly ILogger _logger;
+
+        public int CommitCount => _commitSetQueueBuffer.Count;
+
+        public CommitBuffer(TrieStore trieStore)
+        {
+            _trieStore = trieStore;
+            _logger = trieStore._logger;
+            _dirtyNodesBuffer = new TrieStoreDirtyNodesCache[trieStore._dirtyNodes.Length];
+            for (int i = 0; i < trieStore._shardedDirtyNodeCount; i++)
+            {
+                _dirtyNodesBuffer[i] = new TrieStoreDirtyNodesCache(trieStore, !trieStore._nodeStorage.RequirePath, trieStore._logger);
+            }
+        }
+
+        public BlockCommitSet CreateCommitSet(long blockNumber)
+        {
+            BlockCommitSet commitSet = new(blockNumber);
+            _commitSetQueueBuffer.Enqueue(commitSet);
+            return commitSet;
+        }
+
+        public void FlushToDirtyNodes()
+        {
+            if (_logger.IsDebug) _logger.Debug("Flushing commit buffer");
+            long startTime = Stopwatch.GetTimestamp();
+            Parallel.For(0, _trieStore._shardedDirtyNodeCount, (i) =>
+            {
+                _dirtyNodesBuffer[i].CopyTo(_trieStore._dirtyNodes[i]);
+            });
+
+            int count = 0;
+            while (_commitSetQueueBuffer.TryDequeue(out BlockCommitSet commitSet))
+            {
+                _trieStore._commitSetQueue.Enqueue(commitSet);
+                count++;
+            }
+
+            TimeSpan elapsed = Stopwatch.GetElapsedTime(startTime);
+            if (_logger.IsDebug) _logger.Debug($"Flushed {count} commit buffers in {elapsed.Milliseconds}ms");
+        }
+
+        private TrieStoreDirtyNodesCache GetDirtyNodeShard(in TreePath path, Hash256 keccak) => _dirtyNodesBuffer[_trieStore.GetNodeShardIdx(path, keccak)];
+
+        public void SaveOrReplaceInDirtyNodesCache(Hash256? address, ref TreePath path, in NodeCommitInfo nodeCommitInfo, long blockNumber)
+        {
+            TrieNode node = nodeCommitInfo.Node;
+            // Change the shard to the one from commit buffer.
+            TrieStoreDirtyNodesCache shard = GetDirtyNodeShard(path, node.Keccak);
+            _trieStore.SaveOrReplaceInDirtyNodesCache(shard, address, ref path, nodeCommitInfo, blockNumber);
+        }
+
+        public TrieNode FindCachedOrUnknown(TrieStoreDirtyNodesCache.Key key, bool isReadOnly)
+        {
+            int shardIdx = _trieStore.GetNodeShardIdx(key.Path, key.Keccak);
+            TrieStoreDirtyNodesCache bufferShard = _dirtyNodesBuffer[shardIdx];
+            TrieStoreDirtyNodesCache mainShard = _trieStore._dirtyNodes[shardIdx];
+
+            var hasInBuffer = bufferShard.TryGetValue(key, out TrieNode bufferNode);
+            if (!hasInBuffer && mainShard.TryGetValue(key, out TrieNode mainNode))
+            {
+                // Need to migrate the shard
+                bufferShard.GetOrAdd(key, new TrieStoreDirtyNodesCache.NodeRecord(mainNode, -1));
+                if (!isReadOnly) return mainNode;
+            }
+
+            if (!isReadOnly && hasInBuffer)
+            {
+                return bufferNode;
+            }
+
+            return isReadOnly ? bufferShard.FromCachedRlpOrUnknown(key) : bufferShard.FindCachedOrUnknown(key);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -1032,11 +1032,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         if (currentNode.Keccak is not null)
         {
-            // Note that the LastSeen value here can be 'in the future' (greater than block number
-            // if we replaced a newly added node with an older copy and updated the LastSeen value.
-            // Here we reach it from the old root so it appears to be out of place but it is correct as we need
-            // to prevent it from being removed from cache and also want to have it persisted.
-
             if (_logger.IsTrace) _logger.Trace($"Persisting {nameof(TrieNode)} {currentNode}.");
             writeBatch.Set(address, path, currentNode.Keccak, currentNode.FullRlp.Span, writeFlags);
             currentNode.IsPersisted = true;
@@ -1049,10 +1044,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
     }
 
-    public bool IsNoLongerNeeded(long lastSeen)
+    public bool IsNoLongerNeeded(long lastCommit)
     {
-        return lastSeen < LastPersistedBlockNumber
-               && lastSeen < LatestCommittedBlockNumber - _maxDepth;
+        return lastCommit < LastPersistedBlockNumber
+               && lastCommit < LatestCommittedBlockNumber - _maxDepth;
     }
 
     private void AnnounceReorgBoundaries()

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -206,13 +206,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 ThrowUnknownHash(node);
             }
 
-            if (node.LastSeen >= 0)
-            {
-                ThrowNodeHasBeenSeen(blockNumber, node);
-            }
-
-            node = SaveOrReplaceInDirtyNodesCache(address, ref path, nodeCommitInfo, node);
-            node.LastSeen = Math.Max(blockNumber, node.LastSeen);
+            SaveOrReplaceInDirtyNodesCache(address, ref path, nodeCommitInfo, node, blockNumber);
 
             IncrementCommittedNodesCount();
         }
@@ -225,9 +219,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowUnknownHash(TrieNode node) => throw new TrieStoreException($"The hash of {node} should be known at the time of committing.");
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowNodeHasBeenSeen(long blockNumber, TrieNode node) => throw new TrieStoreException($"{nameof(TrieNode.LastSeen)} set on {node} committed at {blockNumber}.");
     }
 
     private int GetNodeShardIdx(in TreePath path, Hash256 hash)
@@ -265,11 +256,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         return count;
     }
 
-    private TrieNode DirtyNodesGetOrAdd(in TrieStoreDirtyNodesCache.Key key, TrieNode node) =>
-        GetDirtyNodeShard(key).GetOrAdd(key, node);
-
-    private void DirtyNodesReplace(in TrieStoreDirtyNodesCache.Key key, TrieNode node) =>
-        GetDirtyNodeShard(key).Replace(key, node);
+    private TrieNode DirtyNodesGetOrAdd(in TrieStoreDirtyNodesCache.Key key, TrieNode node, long blockNumber) =>
+        GetDirtyNodeShard(key).GetOrAdd(key, new TrieStoreDirtyNodesCache.NodeRecord(node, blockNumber)).Node;
 
     private bool DirtyNodesTryGetValue(in TrieStoreDirtyNodesCache.Key key, out TrieNode? node) =>
         GetDirtyNodeShard(key).TryGetValue(key, out node);
@@ -286,10 +274,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     private TrieNode DirtyNodesFindCachedOrUnknown(TrieStoreDirtyNodesCache.Key key) =>
         GetDirtyNodeShard(key).FindCachedOrUnknown(key);
 
-    private TrieNode SaveOrReplaceInDirtyNodesCache(Hash256? address, ref TreePath path, NodeCommitInfo nodeCommitInfo, TrieNode node)
+    private void SaveOrReplaceInDirtyNodesCache(Hash256? address, ref TreePath path, NodeCommitInfo nodeCommitInfo, TrieNode node, long blockNumber)
     {
         TrieStoreDirtyNodesCache.Key key = new(address, path, node.Keccak);
-        TrieNode cachedNodeCopy = DirtyNodesGetOrAdd(in key, node);
+        TrieNode cachedNodeCopy = DirtyNodesGetOrAdd(in key, node, blockNumber);
         if (!ReferenceEquals(cachedNodeCopy, node))
         {
             // So what happen here is that the patricia trie was modified in a way that some of the trie nodes
@@ -297,44 +285,26 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             // This happen about 2.5% of the time at 4GB dirty cache and 16GB total cache.
 
             Metrics.LoadedFromCacheNodesCount++;
-            if (cachedNodeCopy.IsPersisted)
+            // If the cached not is not persisted, we try to replace it in its parent to reduce duplicated
+            // nodes.
+            if (_logger.IsTrace) Trace(node, cachedNodeCopy);
+            cachedNodeCopy.ResolveKey(GetTrieStore(address), ref path, nodeCommitInfo.IsRoot);
+            if (node.Keccak != cachedNodeCopy.Keccak)
             {
-                // This code path happens around 0.8% of the time at 4GB of dirty cache and 16GB total cache.
-                //
-                // If the cache node is persisted, we replace it completely.
-                // This is because although very rare, it is possible that this node is persisted, but its child is not
-                // persisted. This can happen when a path is not replaced with another node, but its child is and hence,
-                // the child is removed, but the parent is not and remain in the cache as persisted node.
-                // Additionally, it may hold a reference to its child which is marked as persisted eventhough it was
-                // deleted from the cached map.
-                DirtyNodesReplace(in key, node);
+                ThrowNodeIsNotSame(node, cachedNodeCopy);
             }
-            else
+
+            if (!nodeCommitInfo.IsRoot)
             {
-                // If the cached not is not persisted, we try to replace it in its parent to reduce duplicated
-                // nodes.
-                if (_logger.IsTrace) Trace(node, cachedNodeCopy);
-                cachedNodeCopy.ResolveKey(GetTrieStore(address), ref path, nodeCommitInfo.IsRoot);
-                if (node.Keccak != cachedNodeCopy.Keccak)
-                {
-                    ThrowNodeIsNotSame(node, cachedNodeCopy);
-                }
-
-                if (!nodeCommitInfo.IsRoot)
-                {
-                    nodeCommitInfo.NodeParent!.ReplaceChildRef(nodeCommitInfo.ChildPositionAtParent, cachedNodeCopy);
-                }
-
-                node = cachedNodeCopy;
+                nodeCommitInfo.NodeParent!.ReplaceChildRef(nodeCommitInfo.ChildPositionAtParent, cachedNodeCopy);
             }
+
             Metrics.ReplacedNodesCount++;
         }
         else
         {
             DirtyNodesIncrementMemory(key, node);
         }
-
-        return node;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void Trace(TrieNode node, TrieNode cachedNodeCopy)
@@ -976,14 +946,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
     }
 
-    public bool IsNoLongerNeeded(TrieNode node)
+    public bool IsNoLongerNeeded(long lastSeen)
     {
-        return IsNoLongerNeeded(node.LastSeen);
-    }
-
-    private bool IsNoLongerNeeded(long lastSeen)
-    {
-        Debug.Assert(lastSeen >= 0, $"Any node that is cache should have {nameof(TrieNode.LastSeen)} set.");
         return lastSeen < LastPersistedBlockNumber
                && lastSeen < LatestCommittedBlockNumber - _maxDepth;
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -26,8 +26,8 @@ internal class TrieStoreDirtyNodesCache
     private long _totalDirtyMemory = 0;
     private readonly ILogger _logger;
     private readonly bool _storeByHash;
-    private readonly ConcurrentDictionary<Key, TrieNode> _byKeyObjectCache;
-    private readonly ConcurrentDictionary<Hash256AsKey, TrieNode> _byHashObjectCache;
+    private readonly ConcurrentDictionary<Key, NodeRecord> _byKeyObjectCache;
+    private readonly ConcurrentDictionary<Hash256AsKey, NodeRecord> _byHashObjectCache;
 
     public long Count => _count;
     public long DirtyCount => _dirtyCount;
@@ -63,17 +63,17 @@ internal class TrieStoreDirtyNodesCache
 
     public TrieNode FindCachedOrUnknown(in Key key)
     {
-        TrieNode trieNode = GetOrAdd(in key, this);
-        if (trieNode.NodeType != NodeType.Unknown)
+        NodeRecord nodeRecord = GetOrAdd(in key, this);
+        if (nodeRecord.Node.NodeType != NodeType.Unknown)
         {
             Metrics.LoadedFromCacheNodesCount++;
         }
         else
         {
-            if (_logger.IsTrace) Trace(trieNode);
+            if (_logger.IsTrace) Trace(nodeRecord.Node);
         }
 
-        return trieNode;
+        return nodeRecord.Node;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void Trace(TrieNode trieNode)
@@ -122,52 +122,94 @@ internal class TrieStoreDirtyNodesCache
         return _byKeyObjectCache.ContainsKey(key);
     }
 
-    public IEnumerable<KeyValuePair<Key, TrieNode>> AllNodes
+    public readonly struct NodeRecord(TrieNode node, long lastSeen)
+    {
+        public readonly TrieNode Node = node;
+        public readonly long LastSeen = lastSeen;
+    }
+
+    public IEnumerable<KeyValuePair<Key, NodeRecord>> AllNodes
     {
         get
         {
             if (_storeByHash)
             {
                 return _byHashObjectCache.Select(
-                    static pair => new KeyValuePair<Key, TrieNode>(new Key(null, TreePath.Empty, pair.Key.Value), pair.Value));
+                    static pair => new KeyValuePair<Key, NodeRecord>(new Key(null, TreePath.Empty, pair.Key.Value), pair.Value));
             }
 
             return _byKeyObjectCache;
         }
     }
 
-    public bool TryGetValue(in Key key, out TrieNode node) => _storeByHash
-        ? _byHashObjectCache.TryGetValue(key.Keccak, out node)
-        : _byKeyObjectCache.TryGetValue(key, out node);
+    public bool TryGetValue(in Key key, out TrieNode node)
+    {
+        NodeRecord nodeRecord;
+        bool ok = _storeByHash
+            ? _byHashObjectCache.TryGetValue(key.Keccak, out nodeRecord)
+            : _byKeyObjectCache.TryGetValue(key, out nodeRecord);
 
-    private TrieNode GetOrAdd(in Key key, TrieStoreDirtyNodesCache cache) => _storeByHash
+        if (ok)
+        {
+            node = nodeRecord.Node;
+            return true;
+        }
+
+        node = null;
+        return false;
+    }
+
+    private NodeRecord GetOrAdd(in Key key, TrieStoreDirtyNodesCache cache) => _storeByHash
         ? _byHashObjectCache.GetOrAdd(key.Keccak, static (keccak, cache) =>
         {
             TrieNode trieNode = new(NodeType.Unknown, keccak);
             cache.IncrementMemory(trieNode);
-            return trieNode;
+            return new NodeRecord(trieNode, -1);
         }, cache)
         : _byKeyObjectCache.GetOrAdd(key, static (key, cache) =>
         {
             TrieNode trieNode = new(NodeType.Unknown, key.Keccak);
             cache.IncrementMemory(trieNode);
-            return trieNode;
+            return new NodeRecord(trieNode, -1);
         }, cache);
 
-    public TrieNode GetOrAdd(in Key key, TrieNode node) => _storeByHash
-        ? _byHashObjectCache.GetOrAdd(key.Keccak, node)
-        : _byKeyObjectCache.GetOrAdd(key, node);
-
-    public void Replace(in Key key, TrieNode node)
+    public NodeRecord GetOrAdd(in Key key, NodeRecord record)
     {
-        if (_storeByHash)
+        return _storeByHash
+            ? _byHashObjectCache.AddOrUpdate(key.Keccak, static (key, arg) => arg,
+                RecordReplacementLogic, record)
+            : _byKeyObjectCache.AddOrUpdate(key, static (key, arg) => arg,
+                RecordReplacementLogic, record);
+    }
+
+    private static NodeRecord RecordReplacementLogic(Key key, NodeRecord current, NodeRecord arg)
+    {
+        return RecordReplacementLogic(null, current, arg);
+    }
+
+    private static NodeRecord RecordReplacementLogic(Hash256AsKey keyHash, NodeRecord current, NodeRecord arg)
+    {
+        long lastSeen = current.LastSeen;
+        if (arg.LastSeen > lastSeen)
         {
-            _byHashObjectCache[key.Keccak] = node;
+            lastSeen = arg.LastSeen;
         }
-        else
+
+        TrieNode node = current.Node;
+        if (node.IsPersisted && !arg.Node.IsPersisted)
         {
-            _byKeyObjectCache[key] = node;
+            // This code path happens around 0.8% of the time at 4GB of dirty cache and 16GB total cache.
+            //
+            // If the cache node is persisted, we replace it completely.
+            // This is because although very rare, it is possible that this node is persisted, but its child is not
+            // persisted. This can happen when a path is not replaced with another node, but its child is and hence,
+            // the child is removed, but the parent is not and remain in the cache as persisted node.
+            // Additionally, it may hold a reference to its child which is marked as persisted eventhough it was
+            // deleted from the cached map.
+            node = arg.Node;
         }
+
+        return new NodeRecord(node, lastSeen);
     }
 
     public void IncrementMemory(TrieNode node)
@@ -200,16 +242,16 @@ internal class TrieStoreDirtyNodesCache
     {
         if (_storeByHash)
         {
-            if (_byHashObjectCache.Remove(key.Keccak, out TrieNode node))
+            if (_byHashObjectCache.Remove(key.Keccak, out NodeRecord nodeRecord))
             {
-                DecrementMemory(node);
+                DecrementMemory(nodeRecord.Node);
             }
 
             return;
         }
-        if (_byKeyObjectCache.Remove<Key, TrieNode>(key, out TrieNode node2))
+        if (_byKeyObjectCache.Remove(key, out NodeRecord nodeRecord2))
         {
-            DecrementMemory(node2);
+            DecrementMemory(nodeRecord2.Node);
         }
     }
 
@@ -226,7 +268,7 @@ internal class TrieStoreDirtyNodesCache
         return new MapLock()
         {
             _storeByHash = _storeByHash,
-            _byKeyLock = _byKeyObjectCache.AcquireLock<Key, TrieNode>()
+            _byKeyLock = _byKeyObjectCache.AcquireLock()
         };
     }
 
@@ -269,8 +311,10 @@ internal class TrieStoreDirtyNodesCache
         long dirtyMemory = 0;
         long totalNode = 0;
         long dirtyNode = 0;
-        foreach ((Key key, TrieNode node) in AllNodes)
+        foreach ((Key key, NodeRecord nodeRecord) in AllNodes)
         {
+            var node = nodeRecord.Node;
+            var lastSeen = nodeRecord.LastSeen;
             if (node.IsPersisted)
             {
                 // Remove persisted node based on `persistedHashes` if available.
@@ -279,7 +323,7 @@ internal class TrieStoreDirtyNodesCache
                     HashAndTinyPath tinyKey = new(key.Address, new TinyTreePath(key.Path));
                     if (persistedHashes.TryGetValue(tinyKey, out Hash256? lastPersistedHash))
                     {
-                        if (CanDelete(key, lastPersistedHash))
+                        if (CanDelete(key, lastSeen, lastPersistedHash))
                         {
                             Delete(key, writeBatcher);
                             continue;
@@ -291,7 +335,7 @@ internal class TrieStoreDirtyNodesCache
                 {
                     // If its persisted and has last seen meaning it was recommitted,
                     // we keep it to prevent key removal from removing it from DB.
-                    if (node.LastSeen == -1 || forceRemovePersistedNodes)
+                    if (lastSeen == -1 || forceRemovePersistedNodes)
                     {
                         if (_logger.IsTrace) LogPersistedNodeRemoval(node);
 
@@ -300,14 +344,14 @@ internal class TrieStoreDirtyNodesCache
                         continue;
                     }
 
-                    if (_trieStore.IsNoLongerNeeded(node))
+                    if (_trieStore.IsNoLongerNeeded(lastSeen))
                     {
                         RemoveNodeFromCache(key, node, ref Metrics.PrunedPersistedNodesCount);
                         continue;
                     }
                 }
             }
-            else if (_trieStore.IsNoLongerNeeded(node))
+            else if (_trieStore.IsNoLongerNeeded(lastSeen))
             {
                 RemoveNodeFromCache(key, node, ref Metrics.DeepPrunedPersistedNodesCount);
                 continue;
@@ -374,7 +418,7 @@ internal class TrieStoreDirtyNodesCache
         writeBatch?.Set(key.Address, key.Path, key.Keccak, default, WriteFlags.DisableWAL);
     }
 
-    bool CanDelete(in Key key, Hash256? currentlyPersistingKeccak)
+    bool CanDelete(in Key key, long lastSeen, Hash256? currentlyPersistingKeccak)
     {
         // Multiple current hash that we don't keep track for simplicity. Just ignore this case.
         if (currentlyPersistingKeccak is null) return false;
@@ -383,8 +427,7 @@ internal class TrieStoreDirtyNodesCache
         if (currentlyPersistingKeccak == key.Keccak) return false;
 
         // We have it in cache and it is still needed.
-        if (TryGetValue(in key, out TrieNode node) &&
-            !_trieStore.IsNoLongerNeeded(node)) return false;
+        if (!_trieStore.IsNoLongerNeeded(lastSeen)) return false;
 
         return true;
     }
@@ -409,13 +452,13 @@ internal class TrieStoreDirtyNodesCache
 
         using (AcquireMapLock())
         {
-            foreach (KeyValuePair<Key, TrieNode> kv in AllNodes)
+            foreach (KeyValuePair<Key, NodeRecord> kv in AllNodes)
             {
                 if (cancellationToken.IsCancellationRequested) return persistedCount;
                 Key key = kv.Key;
                 TreePath path = key.Path;
                 Hash256? address = key.Address;
-                kv.Value.CallRecursively(PersistNode, address, ref path, _trieStore.GetTrieStore(address), false, _logger, resolveStorageRoot: false);
+                kv.Value.Node.CallRecursively(PersistNode, address, ref path, _trieStore.GetTrieStore(address), false, _logger, resolveStorageRoot: false);
             }
         }
 
@@ -427,7 +470,7 @@ internal class TrieStoreDirtyNodesCache
         if (_logger.IsTrace)
         {
             _logger.Trace($"Trie node dirty cache ({Count})");
-            foreach (KeyValuePair<Key, TrieNode> keyValuePair in AllNodes)
+            foreach (KeyValuePair<Key, NodeRecord> keyValuePair in AllNodes)
             {
                 _logger.Trace($"  {keyValuePair.Value}");
             }
@@ -437,7 +480,7 @@ internal class TrieStoreDirtyNodesCache
     public void Clear()
     {
         _byHashObjectCache.NoResizeClear();
-        _byKeyObjectCache.NoResizeClear<Key, TrieNode>();
+        _byKeyObjectCache.NoResizeClear();
         Interlocked.Exchange(ref _count, 0);
         _trieStore.MemoryUsedByDirtyCache = 0;
     }
@@ -484,8 +527,8 @@ internal class TrieStoreDirtyNodesCache
     internal ref struct MapLock
     {
         public bool _storeByHash;
-        public ConcurrentDictionaryLock<Hash256AsKey, TrieNode>.Lock _byHashLock;
-        public ConcurrentDictionaryLock<Key, TrieNode>.Lock _byKeyLock;
+        public ConcurrentDictionaryLock<Hash256AsKey, NodeRecord>.Lock _byHashLock;
+        public ConcurrentDictionaryLock<Key, NodeRecord>.Lock _byKeyLock;
 
         public readonly void Dispose()
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -288,10 +288,7 @@ internal class TrieStoreDirtyNodesCache
             ? new ConcurrentNodeWriteBatcher(nodeStorage, 256) : null;
 
         long totalMemory, dirtyMemory, totalNode, dirtyNode;
-        using (AcquireMapLock())
-        {
-            (totalMemory, dirtyMemory, totalNode, dirtyNode) = PruneCacheUnlocked(prunePersisted, forceRemovePersistedNodes, persistedHashes, writeBatcher);
-        }
+        (totalMemory, dirtyMemory, totalNode, dirtyNode) = PruneCacheUnlocked(prunePersisted, forceRemovePersistedNodes, persistedHashes, writeBatcher);
 
         writeBatcher?.Dispose();
 
@@ -482,7 +479,6 @@ internal class TrieStoreDirtyNodesCache
         _byHashObjectCache.NoResizeClear();
         _byKeyObjectCache.NoResizeClear();
         Interlocked.Exchange(ref _count, 0);
-        _trieStore.MemoryUsedByDirtyCache = 0;
     }
 
     internal readonly struct Key : IEquatable<Key>
@@ -541,5 +537,11 @@ internal class TrieStoreDirtyNodesCache
                 _byKeyLock.Dispose();
             }
         }
+    }
+
+    public void CopyTo(TrieStoreDirtyNodesCache otherCache)
+    {
+        foreach (var kv in AllNodes) otherCache.GetOrAdd(kv.Key, kv.Value);
+        Clear();
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -321,7 +321,7 @@ namespace Nethermind.Trie
 #if DEBUG
             return
                 $"[{NodeType}({(FullRlp.IsNotNullOrEmpty ? FullRlp.Length : 0)}){(FullRlp.IsNotNullOrEmpty && FullRlp.Length < 32 ? $"{FullRlp.Span.ToHexString()}" : "")}" +
-                $"|{Id}|{Keccak}|{LastSeen}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
+                $"|{Id}|{Keccak}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
 #else
             return $"[{NodeType}({(FullRlp.IsNotNullOrEmpty ? FullRlp.Length : 0)})|{Keccak?.ToShortString()}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
 #endif

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -38,14 +38,11 @@ namespace Nethermind.Trie
         private static readonly Action<TrieNode, Hash256?, TreePath> _markPersisted = static (tn, _, _) =>
             tn.IsPersisted = true;
 
-        private const long _dirtyMask = 0b001;
-        private const long _persistedMask = 0b010;
-        private const long _boundaryProof = 0b100;
-        private const long _flagsMask = 0b111;
-        private const long _blockMask = ~_flagsMask;
-        private const int _blockShift = 3;
+        private const byte _dirtyMask = 0b001;
+        private const byte _persistedMask = 0b010;
+        private const byte _boundaryProof = 0b100;
 
-        private long _blockAndFlags = -1L & _blockMask;
+        private byte _blockAndFlags = 0;
         private SpanSource _rlp;
         private INodeData? _nodeData;
 
@@ -59,12 +56,12 @@ namespace Nethermind.Trie
             get => (Volatile.Read(ref _blockAndFlags) & _persistedMask) != 0;
             set
             {
-                long previousValue = Volatile.Read(ref _blockAndFlags);
-                long currentValue;
+                byte previousValue = Volatile.Read(ref _blockAndFlags);
+                byte currentValue;
                 do
                 {
                     currentValue = previousValue;
-                    long newValue = value ? (currentValue | _persistedMask) : (currentValue & ~_persistedMask);
+                    byte newValue = (byte)(value ? (currentValue | _persistedMask) : (currentValue & ~_persistedMask));
                     previousValue = Interlocked.CompareExchange(ref _blockAndFlags, newValue, currentValue);
                 } while (previousValue != currentValue);
             }
@@ -75,12 +72,12 @@ namespace Nethermind.Trie
             get => (Volatile.Read(ref _blockAndFlags) & _boundaryProof) != 0;
             set
             {
-                long previousValue = Volatile.Read(ref _blockAndFlags);
-                long currentValue;
+                byte previousValue = Volatile.Read(ref _blockAndFlags);
+                byte currentValue;
                 do
                 {
                     currentValue = previousValue;
-                    long newValue = value ? (currentValue | _boundaryProof) : (currentValue & ~_boundaryProof);
+                    byte newValue = (byte)(value ? (currentValue | _boundaryProof) : (currentValue & ~_boundaryProof));
                     previousValue = Interlocked.CompareExchange(ref _blockAndFlags, newValue, currentValue);
                 } while (previousValue != currentValue);
             }
@@ -93,8 +90,8 @@ namespace Nethermind.Trie
         /// </summary>
         public void Seal()
         {
-            long previousValue = Volatile.Read(ref _blockAndFlags);
-            long currentValue;
+            byte previousValue = Volatile.Read(ref _blockAndFlags);
+            byte currentValue;
             do
             {
                 if ((previousValue & _dirtyMask) == 0)
@@ -103,7 +100,7 @@ namespace Nethermind.Trie
                 }
 
                 currentValue = previousValue;
-                long newValue = currentValue & ~_dirtyMask;
+                byte newValue = (byte)(currentValue & ~_dirtyMask);
                 previousValue = Interlocked.CompareExchange(ref _blockAndFlags, newValue, currentValue);
             } while (previousValue != currentValue);
 
@@ -250,19 +247,19 @@ namespace Nethermind.Trie
 
         private TrieNode(TrieNode node)
         {
-            _blockAndFlags |= _dirtyMask;
+            _blockAndFlags = _dirtyMask;
             _nodeData = node._nodeData?.Clone();
         }
 
         public TrieNode(NodeType nodeType)
         {
-            _blockAndFlags |= _dirtyMask;
+            _blockAndFlags = _dirtyMask;
             _nodeData = CreateNodeData(nodeType);
         }
 
         public TrieNode(INodeData nodeData)
         {
-            _blockAndFlags |= _dirtyMask;
+            _blockAndFlags = _dirtyMask;
             _nodeData = nodeData;
         }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -54,22 +54,6 @@ namespace Nethermind.Trie
         /// </summary>
         public bool IsSealed => !IsDirty;
 
-        public long LastSeen
-        {
-            get => (Volatile.Read(ref _blockAndFlags) >> _blockShift);
-            set
-            {
-                long previousValue = Volatile.Read(ref _blockAndFlags);
-                long currentValue;
-                do
-                {
-                    currentValue = previousValue;
-                    long newValue = (currentValue & _flagsMask) | (value << _blockShift);
-                    previousValue = Interlocked.CompareExchange(ref _blockAndFlags, newValue, currentValue);
-                } while (previousValue != currentValue);
-            }
-        }
-
         public bool IsPersisted
         {
             get => (Volatile.Read(ref _blockAndFlags) & _persistedMask) != 0;
@@ -342,7 +326,7 @@ namespace Nethermind.Trie
                 $"[{NodeType}({(FullRlp.IsNotNullOrEmpty ? FullRlp.Length : 0)}){(FullRlp.IsNotNullOrEmpty && FullRlp.Length < 32 ? $"{FullRlp.Span.ToHexString()}" : "")}" +
                 $"|{Id}|{Keccak}|{LastSeen}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
 #else
-            return $"[{NodeType}({(FullRlp.IsNotNullOrEmpty ? FullRlp.Length : 0)})|{Keccak?.ToShortString()}|{LastSeen}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
+            return $"[{NodeType}({(FullRlp.IsNotNullOrEmpty ? FullRlp.Length : 0)})|{Keccak?.ToShortString()}|D:{IsDirty}|S:{IsSealed}|P:{IsPersisted}|";
 #endif
         }
 


### PR DESCRIPTION
- Requires #9028 
- One of the blocker for nethermind to run very short slot time is the blocking memory prune where occationally nethermind will need to save the in-memory dirty nodes cache and prune unused nodes along with deleting obsolete nodes. 
  - This process locks the dirty nodes cache and prevent further block processing until it is finished.
  - On mainnet under default config, this happens about every 30 minute or so, and it take around 1 second. 
  - This is a problem for network with under 1 second slot time for weaker client as some block will get delayed.
- This PR adds a `CommitBuffer` where during memory pruning, further read and commit will operate on top of the buffer. 
- Multiple blocks can be added to the buffer up to a configurable limit `--Pruning.MaxBufferedCommit` set to 128 by default to prevent unexpected memory exhaustion.
- After memory pruning is complete, the `CommitBuffer` is flushed to the standard dirty nodes cache.

## Changes

- Move `TrieNode.LastSeen` to dirty nodes cache to not have issue with out of sync last seen number.
- Added `BeginScope` to `ITrieStore` to make it easy to switch between buffered or unbuffered mode.
 
## Types of changes

#### What types of changes does your code introduce?,

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Removed code for parallel pruning, resulting in very slow memory pruning. Confirmed via custom logs that a block processing is not blocked during prune cache.