### PR TITLE
Fix crash on after db dispose and concurrent full pruning start

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -340,6 +340,18 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false)
     {
+        if (_isDisposed)
+        {
+            return new IDbMeta.DbMetric()
+            {
+                Size = 0,
+                CacheSize = 0,
+                IndexSize = 0,
+                MemtableSize = 0,
+                TotalReads = _totalReads,
+                TotalWrites = _totalWrites,
+            };
+        }
         return new IDbMeta.DbMetric()
         {
             Size = GetSize(),
@@ -907,8 +919,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         fixed (byte* ptr = &MemoryMarshal.GetReference(key))
         {
             slice = cf is null
-                        ? Native.Instance.rocksdb_get_pinned(db, read_options, ptr, skLength, out errPtr)
-                        : Native.Instance.rocksdb_get_pinned_cf(db, read_options, cf.Handle, ptr, skLength, out errPtr);
+                ? Native.Instance.rocksdb_get_pinned(db, read_options, ptr, skLength, out errPtr)
+                : Native.Instance.rocksdb_get_pinned_cf(db, read_options, cf.Handle, ptr, skLength, out errPtr);
         }
 
         if (errPtr != IntPtr.Zero) ThrowRocksDbException(errPtr);

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -397,6 +397,13 @@ namespace Nethermind.Db.Test
             parsedOptions["optimize_filters_for_hits"].Should().Be("false");
             parsedOptions["memtable_whole_key_filtering"].Should().Be("true");
         }
+
+        [Test]
+        public void Can_GetMetric_AfterDispose()
+        {
+            _db.Dispose();
+            _db.GatherMetric().Size.Should().Be(0);
+        }
     }
 
     class CorruptedDbOnTheRocks : DbOnTheRocks


### PR DESCRIPTION
- Fix segmentation fault after db dispose such as after full pruning due to metric trying to get rocksdb property.
- Fix concurrent full pruning start when rpc is called multiple time quickly due to slow db creation.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Can continuously prune and reprune and so on.