### PR TITLE
Use lighter GetBlockNumber for OnForkChoiceUpdated

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1758,8 +1758,8 @@ namespace Nethermind.Blockchain
                 this,
                 new(
                     Head,
-                    FindHeader(safeBlockHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing)?.Number ?? 0,
-                    FindHeader(FinalizedHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing)?.Number ?? 0)
+                    _headerStore.GetBlockNumber(safeBlockHash) ?? 0,
+                    _headerStore.GetBlockNumber(FinalizedHash) ?? 0)
                 );
         }
 


### PR DESCRIPTION
## Changes

- Use lighter `GetBlockNumber` than `FindHeader`

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
