### PR TITLE
Fix for RISC-V

### DIFF
--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -82,6 +82,10 @@ namespace Nethermind.Trie
                     Unsafe.Add(ref output, i * 2 + 1) = upper0;
                 }
             }
+            else
+            {
+                length = 0;
+            }
 
             // Process any remaining bytes that were not handled by SIMD.
             for (int i = length; i < bytes.Length; i++)


### PR DESCRIPTION
## Changes

- Risc-v doesn't support 128bit vectors

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
