### PR TITLE
Switch active History pruning off by default

### DIFF
--- a/src/Nethermind/Nethermind.Config/HistoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/HistoryConfig.cs
@@ -7,6 +7,6 @@ public class HistoryConfig : IHistoryConfig
 {
     public bool Enabled => Pruning != PruningModes.Disabled;
 
-    public PruningModes Pruning { get; set; } = PruningModes.UseAncientBarriers;
+    public PruningModes Pruning { get; set; } = PruningModes.Disabled;
     public long RetentionEpochs { get; set; } = 82125;
 }

--- a/src/Nethermind/Nethermind.Config/IHistoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IHistoryConfig.cs
@@ -11,7 +11,7 @@ public interface IHistoryConfig : IConfig
 
     [ConfigItem(
         Description = "Pruning mode.",
-        DefaultValue = "UseAncientBarriers")]
+        DefaultValue = "Disabled")]
     PruningModes Pruning { get; set; }
 
     // For EIP-4444 should be 82125


### PR DESCRIPTION
## Changes

- Switch active History pruning off by default; will be released as experimental feature that can be switched on

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No