### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/build-nethermind-packages.yml
+++ b/.github/workflows/build-nethermind-packages.yml
@@ -14,7 +14,7 @@ jobs:
       SCRIPTS_PATH: ${{ github.workspace }}/scripts/build
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
       - name: Build Nethermind.Runner

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -22,7 +22,7 @@ jobs:
           large-packages: false
           tool-cache: false
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: ${{ matrix.solution == 'EthereumTests' }}
       - name: Set up .NET

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -27,7 +27,7 @@ jobs:
           - TxParser/TxParser.slnx
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
       - name: Build ${{ matrix.project }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Bump up the version
         id: version

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
       - name: Format

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
         language: ['csharp', 'actions']
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Dependency review
         uses: actions/dependency-review-action@v4
         with:

--- a/.github/workflows/hive-consensus-tests.yml
+++ b/.github/workflows/hive-consensus-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
@@ -117,7 +117,7 @@ jobs:
     needs: [create_docker_image]
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: nethermind
           submodules: "recursive"
@@ -146,7 +146,7 @@ jobs:
           echo "PARALLELISM=${{ github.event.inputs.parallelism || '8' }}" >> $GITHUB_ENV
 
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: nethermind
 
@@ -161,7 +161,7 @@ jobs:
           go-version: '>=1.17.0'
 
       - name: Check out Hive repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ethereum/hive
           ref: master

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -59,7 +59,7 @@ jobs:
           echo "HIVE_BRANCH=${{ github.event.inputs.hive-branch || 'master' }}" >> $GITHUB_ENV
           echo "BUILDARG=${{ github.event.inputs.buildarg || '' }}" >> $GITHUB_ENV
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: nethermind
       - name: Set up Docker Buildx
@@ -74,7 +74,7 @@ jobs:
           tags: nethermind:test-${{ github.sha }}
           outputs: type=docker,dest=/tmp/image.tar
       - name: Check out Hive repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.HIVE_REPO }}
           ref: ${{ env.HIVE_BRANCH }}

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -93,7 +93,7 @@ jobs:
           - Nethermind.Wallet.Test
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: ${{ startsWith(matrix.project, 'Ethereum.') && 'recursive' || 'false' }}
     - name: Set up .NET

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Set up .NET

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Set up GPG
@@ -112,7 +112,7 @@ jobs:
           repositories: "homebrew-nethermind"
 
       - name: Check out homebrew-nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: NethermindEth/homebrew-nethermind
           token: ${{ steps.gh-app.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       prerelease: ${{ steps.build.outputs.prerelease }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
       - name: Build Nethermind.Runner
@@ -100,7 +100,7 @@ jobs:
     needs: [approval, build]
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Authenticate App
         id: gh-app
         uses: actions/create-github-app-token@v1
@@ -129,7 +129,7 @@ jobs:
     if: needs.build.outputs.prerelease == 'false'
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -155,7 +155,7 @@ jobs:
     needs: [approval, build]
     steps:
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Authenticate App
         id: gh-app
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -183,7 +183,7 @@ jobs:
     if: always() && needs.aggregate_rpcs.result == 'success'
     timeout-minutes: 1440
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Wait for the nodes to sync
         timeout-minutes: 1440
@@ -320,7 +320,7 @@ jobs:
     needs: [wait_for_node_to_sync, aggregate_rpcs]
     if: always() && needs.aggregate_rpcs.result == 'success' && needs.wait_for_node_to_sync.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install flood
         run: pip install --force-reinstall --no-deps git+https://github.com/kamilchodola/flood.git
         

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -161,7 +161,7 @@ jobs:
       base_tag: ${{ steps.set-base-tag.outputs.base_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -32,7 +32,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: nethermind
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name || 'master' }}
@@ -105,13 +105,13 @@ jobs:
           repositories: "nethermind,post-merge-smoke-tests"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: true
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name || 'master' }}
 
       - name: Checkout tests repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: NethermindEth/post-merge-smoke-tests
           path: tests

--- a/.github/workflows/test-assertoor.yml
+++ b/.github/workflows/test-assertoor.yml
@@ -21,12 +21,12 @@ jobs:
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         
     - name: Checkout this repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: main-repo
 
     - name: Checkout assertoor-test repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: kamilchodola/assertoor-test
         path: assertoor-test

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -25,12 +25,12 @@ jobs:
             nethermind
             docs
       - name: Check out Nethermind repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           path: n
       - name: Check out Nethermind docs repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: NethermindEth/docs
           path: d

--- a/.github/workflows/update-fast-sync.yml
+++ b/.github/workflows/update-fast-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install dependencies

--- a/.github/workflows/update-no-op-plugin.yml
+++ b/.github/workflows/update-no-op-plugin.yml
@@ -22,7 +22,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           token: ${{ steps.gh-app.outputs.token }}

--- a/.github/workflows/update-poa-bootnodes.yml
+++ b/.github/workflows/update-poa-bootnodes.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out Nethermind repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Check out poa-chain-spec repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: 'poanetwork/poa-chain-spec'
         path: poa-chain-spec

--- a/.github/workflows/update-superchain.yml
+++ b/.github/workflows/update-superchain.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0