### PR TITLE
fix: BlockReceiptsTracer not forwarding stateRoot to inner tracers

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -45,8 +45,7 @@ public class BlockReceiptsTracer : IBlockTracer, ITxTracer, IJournal<int>, ITxTr
 
         if (_currentTxTracer.IsTracingReceipt)
         {
-            // TODO: is no stateRoot a bug?
-            _currentTxTracer.MarkAsSuccess(recipient, gasSpent, output, logs);
+            _currentTxTracer.MarkAsSuccess(recipient, gasSpent, output, logs, stateRoot);
         }
     }
 
@@ -62,8 +61,7 @@ public class BlockReceiptsTracer : IBlockTracer, ITxTracer, IJournal<int>, ITxTr
 
         if (_currentTxTracer.IsTracingReceipt)
         {
-            // TODO: is no stateRoot a bug?
-            _currentTxTracer.MarkAsFailed(recipient, gasSpent, output, error, null);
+            _currentTxTracer.MarkAsFailed(recipient, gasSpent, output, error, stateRoot);
         }
     }
 


### PR DESCRIPTION
## Changes

- Forward stateRoot to inner tracer in BlockReceiptsTracer.MarkAsSuccess/MarkAsFailed
- Remove stale TODO comment
- Align behavior with ITxTracer contract and CompositeTxTracer
- Preserve EIP-658 semantics (stateRoot remains null on post-Byzantium networks); enable proper stateRoot propagation on pre-EIP-658 runs


#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing
 Requires testing

[ ] Yes
[x] No


#### Notes on testing

Existing tests cover receipt stateRoot assignment. Change only affects forwarding to inner tracers and is a no-op on EIP-658 networks.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

Ensures tracers relying on stateRoot (pre-EIP-658 or specific test harnesses) receive it consistently.
