### PR TITLE
Set Ethereum mainnet default gaslimit to 60M

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -349,7 +349,7 @@ public class ConfigFilesTests : ConfigFileTestsBase
 
     [TestCase("chiado", 17_000_000L, 5UL, 3000)]
     [TestCase("gnosis", 17_000_000L, 5UL, 3000)]
-    [TestCase("mainnet", 45_000_000L)]
+    [TestCase("mainnet", 60_000_000L)]
     [TestCase("sepolia", 60_000_000L)]
     [TestCase("holesky", 60_000_000L)]
     [TestCase("^chiado ^gnosis ^mainnet ^sepolia ^holesky")]

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.json
@@ -24,7 +24,7 @@
     "NodeName": "Mainnet"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 45000000
+    "TargetBlockGasLimit": 60000000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.json
@@ -18,7 +18,7 @@
     "NodeName": "Mainnet Archive"
   },
   "Blocks": {
-    "TargetBlockGasLimit": 45000000
+    "TargetBlockGasLimit": 60000000
   },
   "Receipt": {
     "TxLookupLimit": 0


### PR DESCRIPTION
## Changes

- Set Ethereum mainnet default gaslimit to 60M

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No
