### PR TITLE
Update trivy.yml

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,13 +24,13 @@ jobs:
       IMAGE_TAG: nethermind:${{ github.sha }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 #v4.2.1
+        uses: actions/checkout@v4
 
       - name: Build Docker image
         run: docker build -t $IMAGE_TAG .
       
       - name: Scan
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 #v0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: ${{ env.IMAGE_TAG }}
           format: template
@@ -41,6 +41,6 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload scan results
-        uses: github/codeql-action/upload-sarif@cf5b0a9041d3c1d336516f1944c96d96598193cc #v2.19.1
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION


## Summary
Clean up GitHub Actions versions in Trivy security scanner workflow.

## Changes
- Remove commit hash pins from actions
- Standardize to semantic versioning
- Update CodeQL action to latest version

