### PR TITLE
feat: Make spec provider get specs overridable

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestNethermindModule.cs
@@ -33,6 +33,6 @@ public class TestNethermindModule(IConfigProvider configProvider) : Module
         builder
             .AddModule(new PseudoNethermindModule(new ChainSpec(), configProvider, LimboLogs.Instance))
             .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, Random.Shared.Next().ToString()))
-            .AddSingleton<ISpecProvider>(new TestSpecProvider(Cancun.Instance));
+            .AddSingleton<ISpecProvider>(_ => new TestSpecProvider(Cancun.Instance));
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
@@ -43,7 +43,7 @@ public abstract class SpecProviderBase
 
     public IReleaseSpec GenesisSpec { get; private set; }
 
-    public IReleaseSpec GetSpec(ForkActivation activation)
+    public virtual IReleaseSpec GetSpec(ForkActivation activation)
     {
         static int CompareTransitionOnActivation(ForkActivation activation, (ForkActivation Activation, IReleaseSpec Spec) transition) =>
            activation.CompareTo(transition.Activation);


### PR DESCRIPTION
Arbitrum spec provider uses some state value for its release spec, see the [arbitrum PR](https://github.com/NethermindEth/nethermind-arbitrum/pull/143)

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
