### PR TITLE
Fix snap sync edge case due to unnecessary proof

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -6,9 +6,11 @@
 using System;
 using System.Linq;
 using Autofac;
+using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -18,6 +20,8 @@ using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.SnapSync
@@ -159,6 +163,32 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Assert.That(result1, Is.EqualTo(AddRangeResult.OK));
             Assert.That(result2, Is.EqualTo(AddRangeResult.DifferentRootHash));
             Assert.That(result3, Is.EqualTo(AddRangeResult.OK));
+        }
+
+        [Test]
+        public void AddStorageRange_WhereProofIsTheSameAsAllKey_ShouldStillStore()
+        {
+            Hash256 account = TestItem.KeccakA;
+            TestMemDb testMemDb = new();
+            var rawTrieStore = new RawScopedTrieStore(new NodeStorage(testMemDb), account);
+            StorageTree tree = new(rawTrieStore, LimboLogs.Instance);
+
+            (AddRangeResult result, bool moreChildrenToRight) = SnapProviderHelper.AddStorageRange(
+                tree,
+                new PathWithAccount(account, new Account(1, 1, new Hash256("0xeb8594ba5b3314111518b584bbd3801fb3aed5970bd8b47fd9ff744505fe101c"), TestItem.KeccakA)),
+                [
+                    new PathWithStorageSlot(new ValueHash256("0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"), Bytes.FromHexString("94654f75e491acf8c380d2a6906e67e2e56813665e")),
+                ],
+                Keccak.Zero,
+                null,
+                proofs: [
+                    Bytes.FromHexString("f838a120290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5639594654f75e491acf8c380d2a6906e67e2e56813665e"),
+                    Bytes.FromHexString("f838a120290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5639594654f75e491acf8c380d2a6906e67e2e56813665e"),
+                ]);
+
+            result.Should().Be(AddRangeResult.OK);
+            moreChildrenToRight.Should().BeFalse();
+            testMemDb.WritesCount.Should().Be(1);
         }
 
         private static StorageRange PrepareStorageRequest(ValueHash256 accountPath, Hash256 storageRoot, ValueHash256 startingHash)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -204,6 +204,17 @@ namespace Nethermind.Synchronization.SnapSync
                 return (AddRangeResult.MissingRootHashInProofs, null, true);
             }
 
+            if (dict.Count == 1 && root.IsLeaf)
+            {
+                // Special case with some server sending proof where the root is the same as the only path.
+                // Without this the proof's IsBoundaryNode flag will cause the key to not get saved.
+                var rootPath = TreePath.FromNibble(root.Key);
+                if (rootPath.Length == 64 && rootPath.Path.Equals(endHash))
+                {
+                    return (AddRangeResult.OK, null, false);
+                }
+            }
+
             TreePath leftBoundaryPath = TreePath.FromPath(effectiveStartingHAsh.Bytes);
             TreePath rightBoundaryPath = TreePath.FromPath(endHash.Bytes);
             TreePath rightLimitPath = TreePath.FromPath(limitHash.Bytes);


### PR DESCRIPTION
- Fix snap sync edge case where sometimes the server give unnecessary proof where the proof given is the same as the only slot which causes the proof node marked as `IsBoundaryProof` to not be saved.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Running some more sync.