### PR TITLE
Extra validation in case `IForwardHeaderProvider` skip header.

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -221,9 +221,9 @@ public partial class BlockDownloaderTests
             .Returns(Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(headers));
 
         await using IContainer node = CreateNode(configProvider: new ConfigProvider(new SyncConfig()
-            {
-                FastSync = true
-            }),
+        {
+            FastSync = true
+        }),
             configurer: (builder) => builder.AddSingleton<IForwardHeaderProvider>(mockForwardHeaderProvider));
 
         Context ctx = node.Resolve<Context>();

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -210,6 +210,31 @@ public partial class BlockDownloaderTests
     }
 
     [Test]
+    public async Task Return_Null_On_InConsistentHeaderSequence()
+    {
+        using ArrayPoolList<BlockHeader?> headers = new ArrayPoolList<BlockHeader?>(1);
+        headers.Add(Build.A.EmptyBlockHeader);
+        headers.Add(Build.A.EmptyBlockHeader);
+
+        IForwardHeaderProvider mockForwardHeaderProvider = Substitute.For<IForwardHeaderProvider>();
+        mockForwardHeaderProvider.GetBlockHeaders(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(headers));
+
+        await using IContainer node = CreateNode(configProvider: new ConfigProvider(new SyncConfig()
+            {
+                FastSync = true
+            }),
+            configurer: (builder) => builder.AddSingleton<IForwardHeaderProvider>(mockForwardHeaderProvider));
+
+        Context ctx = node.Resolve<Context>();
+        BlocksRequest? res = await ctx.FastSyncFeedComponent.BlockDownloader.PrepareRequest(
+            DownloaderOptions.Insert,
+            0,
+            CancellationToken.None);
+        res.Should().BeNull();
+    }
+
+    [Test]
     public async Task Skit_spawning_request_when_block_processing_queue_is_high()
     {
         IForwardHeaderProvider mockForwardHeaderProvider = Substitute.For<IForwardHeaderProvider>();

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -169,6 +169,22 @@ namespace Nethermind.Synchronization.Blocks
                     if (_logger.IsDebug) _logger.Debug($"Forward header starting block number did not changed from {previousStartingHeaderNumber}.");
                     return null;
                 }
+
+                for (int i = 1; i < headers.Count; i++)
+                {
+                    if (headers[i].Number - 1 != headers[i - 1].Number)
+                    {
+                        if (_logger.IsWarn) _logger.Warn($"Non consecutive header sequence from forward header provider. {headers[i].Number} vs {headers[i - 1].Number + 1}");
+                        return null;
+                    }
+
+                    if (headers[i].ParentHash != headers[i - 1].Hash)
+                    {
+                        if (_logger.IsWarn) _logger.Warn($"Unexpected parent hash from forward header provider {headers[i].ParentHash} vs {headers[i - 1].Hash}");
+                        return null;
+                    }
+                }
+
                 previousStartingHeaderNumber = headers[0].Number;
 
                 (bool shouldProcess, bool downloadReceipts) = ReceiptEdgeCase(bestProcessedBlock, headers[1].Number, originalShouldProcess, originalDownloadReceiptOpts);


### PR DESCRIPTION
- Add extra validation in case `IForwardHeaderProvider` return non consecutive block headers.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [ ] Mainnet can sync normally