### PR TITLE
Remove unsupported Rlpx channel option

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -126,7 +126,6 @@ namespace Nethermind.Network.Rlpx
                     .ChannelFactory(() => _channelFactory?.CreateServer() ?? new TcpServerSocketChannel())
                     .Option(ChannelOption.Allocator, NethermindBuffers.RlpxAllocator)
                     .Option(ChannelOption.SoBacklog, 100)
-                    .Option(ChannelOption.SoTimeout, (int)(_connectTimeout.TotalMilliseconds * 1.5))
                     .ChildOption(ChannelOption.Allocator, NethermindBuffers.RlpxAllocator)
                     .ChildOption(ChannelOption.TcpNodelay, true)
                     .ChildOption(ChannelOption.SoKeepalive, true)


### PR DESCRIPTION
## Changes

- Remove unsupported Rlpx channel option

```
Unknown channel option 'SO_TIMEOUT' for channel '[id: 0x20cbce6e]'
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
