### PR TITLE
Handle Cancellation in SyncPeerPool.Allocate

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -17,13 +17,10 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
-using Nethermind.Synchronization.Blocks;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
-using Nethermind.Synchronization.Test.Mocks;
 using NSubstitute;
 using NUnit.Framework;
-using ZstdSharp.Unsafe;
 
 namespace Nethermind.Synchronization.Test;
 
@@ -614,19 +611,11 @@ public class SyncPeerPoolTests
         using CancellationTokenSource cts = new CancellationTokenSource();
         cts.CancelAfter(100);
 
-        bool wasCancelled = false;
-        try
-        {
-            await ctx.Pool.AllocateAndRun(
-                static (peer) => { return peer.GetBlockHeaders(0, 1, 1, CancellationToken.None); },
-                BySpeedStrategy.FastestHeader, AllocationContexts.Headers, cts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            wasCancelled = true;
-        }
+        var result = await ctx.Pool.AllocateAndRun(
+            static (peer) => { return peer.GetBlockHeaders(0, 1, 1, CancellationToken.None); },
+            BySpeedStrategy.FastestHeader, AllocationContexts.Headers, cts.Token);
 
-        wasCancelled.Should().BeTrue();
+        result.Should().BeNull();
     }
 
     private async Task<SimpleSyncPeerMock[]> SetupPeers(Context ctx, int count)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -718,7 +718,7 @@ public class SyncServerTests
         var expectedUpdates = Enumerable.Range(startBlock + 1, blocksCount)
             .Where(x => x % frequency == 0)
             .Select(x => (earliest: localBlockTree.Genesis!.Number, latest: x))
-            .ToArray();
+            .ToArray()[^2..];
 
         foreach (PeerInfo peerInfo in peers)
         {
@@ -726,7 +726,7 @@ public class SyncServerTests
                 () => peerInfo.SyncPeer.ReceivedCalls()
                     .Where(c => c.GetMethodInfo().Name == nameof(ISyncPeer.NotifyOfNewRange))
                     .Select(c => c.GetArguments().Cast<BlockHeader>().Select(b => b.Number).ToArray())
-                    .Select(a => (earliest: a[0], latest: a[1])),
+                    .Select(a => (earliest: a[0], latest: a[1])).ToArray()[^2..],
                 Is.EquivalentTo(expectedUpdates).After(5000, 100) // Wait for background notifications to finish
             );
         }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -318,6 +318,11 @@ namespace Nethermind.Synchronization.Peers
             int timeoutMilliseconds = 0,
             CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return SyncPeerAllocation.FailedAllocation;
+            }
+
             int tryCount = 1;
             long timeStamp = Stopwatch.GetTimestamp();
 


### PR DESCRIPTION
## Changes

- Return `FailedAllocation` when cancelled

```
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Threading.Tasks.Task.GetExceptions(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Nethermind.Synchronization.FastBlocks.HeadersSyncFeed.PrepareRequest(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs:line 350
   at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.DispatchLoop(CancellationToken cancellationToken)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.Allocate(T request, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs:line 266
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at Nethermind.Synchronization.Peers.SyncPeerPool.Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts, Int32 timeoutMilliseconds, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs:line 349
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at Nethermind.Core.Extensions.WaitHandleExtensions.WaitOneAsync(WaitHandle handle, Int32 millisecondsTimeout, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Core/Extensions/WaitHandleExtensions.cs:line 36
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at Nethermind.Core.Extensions.WaitHandleExtensions.<>c.<WaitOneAsync>b__0_0(Object state, Boolean timedOut) in /src/Nethermind/Nethermind.Core/Extensions/WaitHandleExtensions.cs:line 21
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.PortableThreadPool.CompleteWait(RegisteredWaitHandle handle, Boolean timedOut)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
