### PR TITLE
feat: Add SuicideStorage test coverage to StateTests

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/StateTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/StateTests.cs
@@ -13,16 +13,32 @@ namespace Ethereum.Blockchain.Block.Test
     [Parallelizable(ParallelScope.All)]
     public class StateTests : BlockchainTestBase
     {
-        [Todo(Improve.TestCoverage, "SuicideStorage tests")]
         [TestCaseSource(nameof(LoadTests)), Retry(3)]
         public async Task Test(BlockchainTest test)
         {
+            if (test?.Name is not null && test.Name.Contains("SuicideStorage"))
+            {
+                Assert.Ignore("Covered by dedicated SuicideStorage tests");
+            }
+
             await RunTest(test);
         }
 
         public static IEnumerable<BlockchainTest> LoadTests()
         {
             var loader = new TestsSourceLoader(new LoadBlockchainTestsStrategy(), "bcStateTests");
+            return loader.LoadTests<BlockchainTest>();
+        }
+
+        [TestCaseSource(nameof(LoadSuicideStorageTests)), Retry(3)]
+        public async Task SuicideStorage_Tests(BlockchainTest test)
+        {
+            await RunTest(test);
+        }
+
+        public static IEnumerable<BlockchainTest> LoadSuicideStorageTests()
+        {
+            var loader = new TestsSourceLoader(new LoadBlockchainTestsStrategy(), "bcStateTests", "SuicideStorage");
             return loader.LoadTests<BlockchainTest>();
         }
     }


### PR DESCRIPTION
## Changes

- Add dedicated SuicideStorage_Tests method to StateTests class
- Implement wildcard filtering for SuicideStorage tests using TestsSourceLoader


## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The existing test infrastructure is leveraged to add SuicideStorage test coverage. The changes ensure that SuicideStorage tests run in a dedicated method while preventing duplicate execution in the main test method.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This PR resolves the TODO comment that was requesting SuicideStorage test coverage. The solution maintains backward compatibility while improving test organization and preventing test duplication.