### PR TITLE
More graceful shutdown logs

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -28,6 +28,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
     private (Hash256 headBlockhash, Hash256 headParentBlockhash, Hash256 finalizedBlockhash) _lastBlockhashes = (Keccak.Zero, Keccak.Zero, Keccak.Zero);
     private readonly ITimer _refreshTimer;
     private readonly ILogger _logger;
+    private bool _disposed;
 
     public PeerRefresher(IPeerDifficultyRefreshPool syncPeerPool, ITimerFactory timerFactory, ILogManager logManager)
     {
@@ -40,6 +41,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
 
     public void RefreshPeers(Hash256 headBlockhash, Hash256 headParentBlockhash, Hash256 finalizedBlockhash)
     {
+        if (_disposed) return;
         _lastBlockhashes = (headBlockhash, headParentBlockhash, finalizedBlockhash);
         TimeSpan timePassed = DateTime.UtcNow - _lastRefresh;
         if (timePassed > _minRefreshDelay)
@@ -78,6 +80,10 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         try
         {
             await RefreshPeerForFcu(syncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash, delaySource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Peer refresh timed out.");
         }
         catch (Exception exception)
         {
@@ -199,7 +205,11 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
-        _refreshTimer.Dispose();
+        if (!_disposed)
+        {
+            _disposed = true;
+            _refreshTimer.Dispose();
+        }
         return default;
     }
 }

--- a/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
+++ b/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
@@ -43,7 +43,7 @@ public class VerifyTrieStarter(IWorldStateManager worldStateManager, IProcessExi
             }
             catch (OperationCanceledException)
             {
-                if (_logger.IsError) _logger.Error($"Verify trie cancelled");
+                if (_logger.IsInfo) _logger.Info($"Verify trie cancelled");
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
@@ -46,6 +46,10 @@ namespace Nethermind.Synchronization.SnapSync
                         batch.AccountsToRefreshResponse = await handler.GetTrieNodes(batch.AccountsToRefreshRequest, cancellationToken);
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    if (Logger.IsDebug) Logger.Debug($"Snap sync request cancelled. Request: {batch}");
+                }
                 catch (Exception e)
                 {
                     if (Logger.IsDebug)


### PR DESCRIPTION
## Changes

- Fuzzer rapidly cycling though instances so triggering lots of areas where we aren't handling shutdown gracefully, handle this better

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Other: logging

## Testing

#### Requires testing

- [x] No