### PR TITLE
Improve deposit request fields validation

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs
@@ -4,6 +4,7 @@
 
 using Nethermind.Abi;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Consensus.Messages;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -11,13 +12,11 @@ using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm;
-using Nethermind.Evm.Tracing;
+using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using System;
 using System.Linq;
-using Nethermind.Blockchain.Tracing;
-using Nethermind.Evm.State;
 
 namespace Nethermind.Consensus.ExecutionRequests;
 
@@ -120,6 +119,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
         try
         {
             result = _abiEncoder.Decode(AbiEncodingStyle.None, DepositEventAbi, log.Data);
+            ValidateLayout(result, block);
         }
         catch (Exception e) when (e is AbiException or OverflowException)
         {
@@ -135,16 +135,28 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                 byteArray.CopyTo(buffer.Slice(offset, byteArray.Length));
                 offset += byteArray.Length;
             }
-            else
-            {
-                throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout("Decoded ABI result contains non-byte array elements."));
-            }
         }
+    }
 
-        // make sure the flattened result is of the correct size
-        if (offset != ExecutionRequestExtensions.DepositRequestsBytesSize)
+    private static void ValidateLayout(object[] result, Block block)
+    {
+        Validate(block, result[0], "pubkey", ExecutionRequestExtensions.PublicKeySize);
+        Validate(block, result[1], "withdrawalCredentials", ExecutionRequestExtensions.WithdrawalCredentialsSize);
+        Validate(block, result[2], "amount", ExecutionRequestExtensions.AmountSize);
+        Validate(block, result[3], "signature", ExecutionRequestExtensions.SignatureSize);
+        Validate(block, result[4], "index", ExecutionRequestExtensions.IndexSize);
+
+        static void Validate(Block block, object obj, string name, int expectedSize)
         {
-            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Decoded ABI result has incorrect size. Expected {ExecutionRequestExtensions.DepositRequestsBytesSize} bytes, got {offset} bytes."));
+            if (obj is not byte[] byteArray)
+            {
+                throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Decoded ABI result contains {name} as non-byte array element."));
+            }
+
+            if (byteArray.Length != expectedSize)
+            {
+                throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Decoded ABI result contains invalid {name} element, size does not match, expected {expectedSize}, got {byteArray.Length}."));
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequestExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequestExtensions.cs
@@ -13,11 +13,18 @@ namespace Nethermind.Core.ExecutionRequest;
 
 public static class ExecutionRequestExtensions
 {
-    public const int DepositRequestsBytesSize = PublicKeySize /*pubkey: Bytes48 */ + Hash256.Size /*withdrawal_credentials: Bytes32 */ + sizeof(ulong) /*amount: uint64*/ + 96 /*signature: Bytes96*/ + sizeof(ulong) /*index: uint64*/;
+    public const int PublicKeySize = 48;
+    public const int WithdrawalCredentialsSize = Hash256.Size;
+    public const int AmountSize = sizeof(ulong);
+    public const int SignatureSize = 96;
+    public const int IndexSize = sizeof(ulong);
+    public const int DepositRequestsBytesSize = PublicKeySize + WithdrawalCredentialsSize + AmountSize + SignatureSize + IndexSize;
+
     public const int WithdrawalRequestsBytesSize = Address.Size + PublicKeySize /*validator_pubkey: Bytes48*/ + sizeof(ulong) /*amount: uint64*/;
     public const int ConsolidationRequestsBytesSize = Address.Size + PublicKeySize /*source_pubkey: Bytes48*/ + PublicKeySize /*target_pubkey: Bytes48*/;
     public const int MaxRequestsCount = 3;
-    private const int PublicKeySize = 48;
+
+
 
     public static readonly byte[][] EmptyRequests = [];
     public static readonly Hash256 EmptyRequestsHash = CalculateHashFromFlatEncodedRequests(EmptyRequests);


### PR DESCRIPTION
The PR adds fixed lengths validation. It did not work because we decode as dynamic arrays instead of uints of fixed size https://github.com/NethermindEth/nethermind/blob/70d17f27412c70254e67af10dcdb654f2519342c/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestProcessor.cs?plain=1#L25 which is kinda OK, because simplifies further copying into deposit request. But we missed length validation.

## Changes

- Add length of fields validation

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
