### PR TITLE
fix: missing reader.Read() in BlockParameterConverter for blockHash property

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -171,6 +171,7 @@ namespace Nethermind.JsonRpc.Data
                     }
                     else if (reader.ValueTextEquals("blockHash"u8))
                     {
+                        reader.Read();
                         blockHash = JsonSerializer.Deserialize<Hash256>(ref reader, options);
                     }
                 }


### PR DESCRIPTION
Add missing reader.Read() call before deserializing blockHash property in 
BlockParameterConverter.Read() method. This aligns with the established 
pattern used throughout the codebase where all JSON converters explicitly 
advance the reader from property name to property value before calling 
JsonSerializer.Deserialize().
