### PR TITLE
Hive to load blocks before RPC start

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -11,6 +11,7 @@ using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Core;
 using Nethermind.Core.Authentication;
+using Nethermind.Hive;
 using Nethermind.Init.Steps;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
@@ -22,7 +23,7 @@ using Nethermind.Sockets;
 
 namespace Nethermind.Runner.Ethereum.Steps;
 
-[RunnerStepDependencies(typeof(InitializeNetwork), typeof(RegisterRpcModules), typeof(RegisterPluginRpcModules))]
+[RunnerStepDependencies(typeof(InitializeNetwork), typeof(RegisterRpcModules), typeof(RegisterPluginRpcModules), typeof(HiveStep))]
 public class StartRpc(INethermindApi api, IJsonRpcServiceConfigurer[] serviceConfigurers, IWebSocketsManager webSocketsManager) : IStep
 {
     public async Task Execute(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes fusaka-devnet-5 consume rlp hive tests

Step are now loading in parallel and RPC may return just genesis instead of the 1st block later loaded by hive

<img width="809" height="392" alt="hive blocks, then rpc" src="https://github.com/user-attachments/assets/9b048a60-1046-47d8-8a5f-f6cb6b5b2f6f" />

## Changes

- Wait hive blocks before start of RPC

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
