### PR TITLE
Fix Nethermind UI when the app is run from non-app directory

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
 using Nethermind.Api;
@@ -326,8 +327,12 @@ public class Startup : IStartup
 
         if (healthChecksConfig.Enabled)
         {
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
+            string executableDir = Path.GetDirectoryName(Environment.ProcessPath) ?? Directory.GetCurrentDirectory();
+            string wwwrootPath = Path.Combine(executableDir, "wwwroot");
+            PhysicalFileProvider fileProvider = new(wwwrootPath);
+
+            app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = fileProvider });
+            app.UseStaticFiles(new StaticFileOptions { FileProvider = fileProvider });
         }
     }
 


### PR DESCRIPTION
## Changes

Updates the root directory for `UseDefaultFiles` and `UseStaticFiles` middlewares to be fixed where `nethermind` executable is.

This fixes the issue when Nethermind UI returns 404 because `wwwroot` directory can't be found. This happens when user launches Nethermind from a directory other than where `nethermind` executable is - `./dir/nethermind --args` instead of `./nethermind --args`. The same issue can happen if `WorkingDirectory` is set incorrectly. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
