### PR TITLE
Reduce use of storage root slightly

### DIFF
--- a/src/Nethermind/Nethermind.Core/Account.cs
+++ b/src/Nethermind/Nethermind.Core/Account.cs
@@ -165,9 +165,10 @@ namespace Nethermind.Core
         public UInt256 Nonce => _nonce;
         public UInt256 Balance => _balance;
         public ValueHash256 StorageRoot => _storageRoot;
-        public bool IsTotallyEmpty => IsEmpty && _storageRoot == Keccak.EmptyTreeHash.ValueHash256;
+        public bool IsTotallyEmpty => IsEmpty && IsStorageEmpty;
         public bool IsEmpty => Balance.IsZero && Nonce.IsZero && CodeHash == Keccak.OfAnEmptyString.ValueHash256;
         public bool IsContract => CodeHash != Keccak.OfAnEmptyString.ValueHash256;
+        public bool IsStorageEmpty => _storageRoot == Keccak.EmptyTreeHash.ValueHash256;
         public bool IsNull
         {
             get
@@ -204,7 +205,7 @@ namespace Nethermind.Core
             return _nonce == other.Nonce &&
                    _balance == other.Balance &&
                    CodeHash == other.CodeHash &&
-                   StorageRoot == other.StorageRoot;
+                   _storageRoot == other._storageRoot;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/IAccountStateProvider.cs
+++ b/src/Nethermind/Nethermind.Core/IAccountStateProvider.cs
@@ -26,10 +26,10 @@ namespace Nethermind.Core
         }
 
         [SkipLocalsInit]
-        ValueHash256 GetStorageRoot(Address address)
+        bool IsStorageEmpty(Address address)
         {
             TryGetAccount(address, out AccountStruct account);
-            return account.StorageRoot;
+            return account.IsStorageEmpty;
         }
 
         [SkipLocalsInit]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
@@ -109,8 +109,7 @@ namespace Nethermind.Evm.Test
             TestState.Commit(Spec);
             TestState.CommitTree(0);
 
-            ValueHash256 storageRoot = TestState.GetStorageRoot(expectedAddress);
-            storageRoot.Should().NotBe(PatriciaTree.EmptyTreeHash);
+            TestState.IsStorageEmpty(expectedAddress).Should().BeFalse();
 
             TestState.CreateAccount(TestItem.AddressC, 1.Ether());
 
@@ -124,7 +123,6 @@ namespace Nethermind.Evm.Test
 
             TestState.TryGetAccount(expectedAddress, out AccountStruct account).Should().BeTrue();
             account.Balance.Should().Be(1.Ether());
-            account.StorageRoot.Should().Be(storageRoot);
             AssertEip1014(expectedAddress, []);
         }
 

--- a/src/Nethermind/Nethermind.Evm/AddressExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/AddressExtensions.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Evm
         {
             return codeInfoRepository.GetCachedCodeInfo(state, contractAddress, spec).CodeSpan.Length != 0 ||
                    state.GetNonce(contractAddress) != 0 ||
-                   state.GetStorageRoot(contractAddress) != Keccak.EmptyTreeHash;
+                   !state.IsStorageEmpty(contractAddress);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -117,8 +117,6 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     void SubtractFromBalance(Address address, in UInt256 balanceChange, IReleaseSpec spec);
 
-    void UpdateStorageRoot(Address address, Hash256 storageRoot);
-
     void IncrementNonce(Address address, UInt256 delta);
 
     void DecrementNonce(Address address, UInt256 delta);

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -169,12 +169,7 @@ public class StateProviderTests
         provider.AddToBalance(_address1, 1, Frontier.Instance);
         provider.IncrementNonce(_address1);
         provider.InsertCode(_address1, new byte[] { 1 }, Frontier.Instance, false);
-        provider.UpdateStorageRoot(_address1, Hash2);
 
-        Assert.That(provider.GetNonce(_address1), Is.EqualTo(UInt256.One));
-        Assert.That(provider.GetBalance(_address1), Is.EqualTo(UInt256.One + 1));
-        Assert.That(provider.GetCode(_address1), Is.EqualTo(code));
-        provider.Restore(new Snapshot(Snapshot.Storage.Empty, 4));
         Assert.That(provider.GetNonce(_address1), Is.EqualTo(UInt256.One));
         Assert.That(provider.GetBalance(_address1), Is.EqualTo(UInt256.One + 1));
         Assert.That(provider.GetCode(_address1), Is.EqualTo(code));

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -266,12 +266,6 @@ namespace Nethermind.State
             return ref _stateProvider.GetBalance(address);
         }
 
-        UInt256 IAccountStateProvider.GetBalance(Address address)
-        {
-            DebugGuardInScope();
-            return _stateProvider.GetBalance(address);
-        }
-
         public ValueHash256 GetStorageRoot(Address address)
         {
             DebugGuardInScope();

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsDecorator.cs
@@ -74,9 +74,6 @@ public class WorldStateMetricsDecorator(IWorldState innerState) : IWorldState
     public void SubtractFromBalance(Address address, in UInt256 balanceChange, IReleaseSpec spec) =>
         innerState.SubtractFromBalance(address, in balanceChange, spec);
 
-    public void UpdateStorageRoot(Address address, Hash256 storageRoot)
-        => innerState.UpdateStorageRoot(address, storageRoot);
-
     public void IncrementNonce(Address address, UInt256 delta) => innerState.IncrementNonce(address, delta);
 
     public void DecrementNonce(Address address, UInt256 delta) => innerState.DecrementNonce(address, delta);


### PR DESCRIPTION
- Slightly reduce use of storage root from `IWorldState` POV.
- Storage root may not be accessable from alternate state layout or with verkle/btree.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- [x] Mainnet start and run normally.