### PR TITLE
feat(core-test): auto-create EthereumEcdsa in SignedAndResolved when null

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
@@ -248,10 +248,11 @@ namespace Nethermind.Core.Test.Builders
             return Signed(ecdsa, privateKey, isEip155Enabled);
         }
 
-        // TODO: auto create ecdsa here
-        public TransactionBuilder<T> SignedAndResolved(IEthereumEcdsa ecdsa, PrivateKey privateKey, bool isEip155Enabled = true)
+        // Auto-create ecdsa if not provided
+        public TransactionBuilder<T> SignedAndResolved(IEthereumEcdsa? ecdsa, PrivateKey privateKey, bool isEip155Enabled = true)
         {
             // make sure that you do not change anything in the tx after signing as this will lead to a different recovered address
+            ecdsa ??= new EthereumEcdsa(TestObjectInternal.ChainId ?? TestBlockchainIds.ChainId);
             ecdsa.Sign(privateKey, TestObjectInternal, isEip155Enabled);
             TestObjectInternal.SenderAddress = privateKey.Address;
             return this;


### PR DESCRIPTION
## Changes

- Implemented the TODO to auto-create an EthereumEcdsa instance in TransactionBuilder<T>.SignedAndResolved when the provided IEthereumEcdsa is null.
- Mirrors existing behavior in other overloads by using TestObjectInternal.ChainId ?? TestBlockchainIds.ChainId.
- Updated method signature to accept IEthereumEcdsa? and kept signing and SenderAddress resolution unchanged.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [ ] Yes
- [x] No


