### PR TITLE
Correctly typed interface for XDC header decoder

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -7,9 +7,9 @@ using Nethermind.Core;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public class BlockDecoder(IHeaderDecoder headerDecoder) : IRlpValueDecoder<Block>, IRlpStreamDecoder<Block>
+    public class BlockDecoder(IHeaderDecoder<BlockHeader> headerDecoder) : IRlpValueDecoder<Block>, IRlpStreamDecoder<Block>
     {
-        private readonly IHeaderDecoder _headerDecoder = headerDecoder ?? throw new ArgumentNullException(nameof(headerDecoder));
+        private readonly IHeaderDecoder<BlockHeader> _headerDecoder = headerDecoder ?? throw new ArgumentNullException(nameof(headerDecoder));
         private readonly BlockBodyDecoder _blockBodyDecoder = BlockBodyDecoder.Instance;
 
         public BlockDecoder() : this(new HeaderDecoder()) { }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -8,9 +8,9 @@ using Nethermind.Int256;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public interface IHeaderDecoder : IRlpValueDecoder<BlockHeader>, IRlpStreamDecoder<BlockHeader> { }
+    public interface IHeaderDecoder<THeader> : IRlpValueDecoder<THeader>, IRlpStreamDecoder<THeader> { }
 
-    public class HeaderDecoder : IHeaderDecoder
+    public class HeaderDecoder : IHeaderDecoder<BlockHeader>
     {
         public const int NonceLength = 8;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderDecoderTests.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Xdc.Test
         {
             var decoder = new XdcHeaderDecoder();
 
-            BlockHeader? unencoded = decoder.Decode(new RlpStream(Bytes.FromHexString(hexRlp)));
+            XdcBlockHeader? unencoded = decoder.Decode(new RlpStream(Bytes.FromHexString(hexRlp)));
 
             string encoded = decoder.Encode(unencoded).ToString();
 

--- a/src/Nethermind/Nethermind.Xdc/RLP/XdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/XdcHeaderDecoder.cs
@@ -7,11 +7,11 @@ using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 namespace Nethermind.Xdc;
-public sealed class XdcHeaderDecoder : IHeaderDecoder
+public sealed class XdcHeaderDecoder : IHeaderDecoder<XdcBlockHeader>
 {
     private const int NonceLength = 8;
 
-    public BlockHeader? Decode(ref Rlp.ValueDecoderContext decoderContext,
+    public XdcBlockHeader? Decode(ref Rlp.ValueDecoderContext decoderContext,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemNull())
@@ -75,7 +75,7 @@ public sealed class XdcHeaderDecoder : IHeaderDecoder
         return blockHeader;
     }
 
-    public BlockHeader? Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public XdcBlockHeader? Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (rlpStream.IsNextItemNull())
         {
@@ -139,7 +139,7 @@ public sealed class XdcHeaderDecoder : IHeaderDecoder
         return blockHeader;
     }
 
-    public void Encode(RlpStream rlpStream, BlockHeader? header, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public void Encode(RlpStream rlpStream, XdcBlockHeader? header, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (header is null)
         {
@@ -177,7 +177,7 @@ public sealed class XdcHeaderDecoder : IHeaderDecoder
 
     }
 
-    public Rlp Encode(BlockHeader? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(XdcBlockHeader? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -226,7 +226,7 @@ public sealed class XdcHeaderDecoder : IHeaderDecoder
         return contentLength;
     }
 
-    public int GetLength(BlockHeader? item, RlpBehaviors rlpBehaviors)
+    public int GetLength(XdcBlockHeader? item, RlpBehaviors rlpBehaviors)
     {
         if (item is not XdcBlockHeader header)
             throw new ArgumentException("XdcHeaderRlpCodec expects XdcBlockHeader.", nameof(header));


### PR DESCRIPTION
just gives Xdc header decoder correct return types and args.