### PR TITLE
Fix inconsistent test.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.BaseFee.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.BaseFee.cs
@@ -182,7 +182,7 @@ public partial class BlockProducerBaseTests
                 params Transaction[] transactions)
             {
                 await ExecuteAntecedentIfNeeded();
-                await _testRpcBlockchain.AddBlock(transactions);
+                await _testRpcBlockchain.AddBlock(TestBlockchainUtil.AddBlockFlags.MayHaveExtraTx, transactions);
                 IBlockTree blockTree = _testRpcBlockchain.BlockTree;
                 Block headBlock = blockTree.Head!;
                 Assert.That(headBlock.Header.BaseFeePerGas, Is.EqualTo(expectedBaseFee));

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.BaseFee.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.BaseFee.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.IO;
 using System.Security;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Container;
 using Nethermind.Evm;
@@ -168,7 +170,7 @@ public partial class BlockProducerBaseTests
                 Assert.That(startingBlock.Header.BaseFeePerGas, Is.EqualTo(UInt256.Zero));
                 for (long i = startingBlock.Number; i < _eip1559TransitionBlock - 1; ++i)
                 {
-                    await _testRpcBlockchain.AddBlock();
+                    await _testRpcBlockchain.AddBlock(TestBlockchainUtil.AddBlockFlags.MayHaveExtraTx);
                     Block currentBlock = blockTree.Head!;
                     Assert.That(currentBlock.Header.BaseFeePerGas, Is.EqualTo(UInt256.Zero));
                 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.FeeCollector.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerBaseTests.FeeCollector.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using NUnit.Framework;
@@ -34,7 +35,7 @@ public partial class BlockProducerBaseTests
             {
                 await ExecuteAntecedentIfNeeded();
                 UInt256 balanceBefore = _testRpcBlockchain.ReadOnlyState.GetBalance(_feeCollector);
-                await _testRpcBlockchain.AddBlock(transactions);
+                await _testRpcBlockchain.AddBlock(TestBlockchainUtil.AddBlockFlags.MayHaveExtraTx, transactions);
                 UInt256 balanceAfter = _testRpcBlockchain.ReadOnlyState.GetBalance(_feeCollector);
                 Assert.That(balanceAfter - balanceBefore, Is.EqualTo(expectedFeeCollected));
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/InvalidBlockDetector.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/InvalidBlockDetector.cs
@@ -13,19 +13,14 @@ namespace Nethermind.Core.Test.Blockchain;
 
 public class InvalidBlockDetector
 {
-    public event EventHandler<InvalidBlockEventArgs>? OnInvalidBlock;
+    public event EventHandler<IBlockchainProcessor.InvalidBlockEventArgs>? OnInvalidBlock;
 
     private void TriggerOnInvalidBlock(Block invalidBlock)
     {
-        OnInvalidBlock?.Invoke(this, new InvalidBlockEventArgs()
+        OnInvalidBlock?.Invoke(this, new IBlockchainProcessor.InvalidBlockEventArgs()
         {
             InvalidBlock = invalidBlock
         });
-    }
-
-    public class InvalidBlockEventArgs : EventArgs
-    {
-        public Block InvalidBlock { get; init; } = null!;
     }
 
     internal class BlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, InvalidBlockDetector invalidBlockDetector) : IBlockProcessor

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/InvalidBlockDetector.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/InvalidBlockDetector.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
+
+namespace Nethermind.Core.Test.Blockchain;
+
+public class InvalidBlockDetector
+{
+    public event EventHandler<InvalidBlockEventArgs>? OnInvalidBlock;
+
+    private void TriggerOnInvalidBlock(Block invalidBlock)
+    {
+        OnInvalidBlock?.Invoke(this, new InvalidBlockEventArgs()
+        {
+            InvalidBlock = invalidBlock
+        });
+    }
+
+    public class InvalidBlockEventArgs : EventArgs
+    {
+        public Block InvalidBlock { get; init; } = null!;
+    }
+
+    internal class BlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, InvalidBlockDetector invalidBlockDetector) : IBlockProcessor
+    {
+        public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options,
+            IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token = default)
+        {
+            try
+            {
+                return baseBlockProcessor.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
+            }
+            catch (InvalidBlockException)
+            {
+                invalidBlockDetector.TriggerOnInvalidBlock(suggestedBlock);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -223,7 +223,13 @@ public class TestBlockchain : IDisposable
 
         _cts = AutoCancelTokenSource.ThatCancelAfter(Debugger.IsAttached ? TimeSpan.FromMilliseconds(-1) : TimeSpan.FromMilliseconds(TestTimout));
 
-        if (testConfiguration.SuggestGenesisOnStart) MainProcessingContext.GenesisLoader.Load();
+        if (testConfiguration.SuggestGenesisOnStart)
+        {
+            // The block added event is not waited by genesis, but its needed to wait here so that `AddBlock` wait correctly.
+            Task newBlockWaiter = BlockTree.WaitForNewBlock(this.CancellationToken);
+            MainProcessingContext.GenesisLoader.Load();
+            await newBlockWaiter;
+        }
 
         if (testConfiguration.AddBlockOnStart)
             await AddBlocksOnStart();

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -390,6 +390,13 @@ public class TestBlockchain : IDisposable
         await AddBlock();
         await AddBlock(CreateTransactionBuilder().WithNonce(0).TestObject);
         await AddBlock(CreateTransactionBuilder().WithNonce(1).TestObject, CreateTransactionBuilder().WithNonce(2).TestObject);
+
+        while (true)
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+            if (BlockTree.Head?.Number == 3) return;
+            await Task.Delay(1, CancellationToken);
+        }
     }
 
     private TransactionBuilder<Transaction> CreateTransactionBuilder()

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using FluentAssertions;
 using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
@@ -103,8 +104,8 @@ public class TestBlockchain : IDisposable
     protected AutoCancelTokenSource _cts;
     public CancellationToken CancellationToken => _cts.Token;
 
-    private TestBlockchainUtil TestUtil => _fromContainer.TestBlockchainUtil.Value;
-    private PoWTestBlockchainUtil PoWTestUtil => _fromContainer.PoWTestBlockchainUtil.Value;
+    private TestBlockchainUtil TestUtil => _fromContainer.TestBlockchainUtil;
+    private PoWTestBlockchainUtil PoWTestUtil => _fromContainer.PoWTestBlockchainUtil;
     private IManualBlockProductionTrigger BlockProductionTrigger => _fromContainer.BlockProductionTrigger;
 
     public ManualTimestamper Timestamper => _fromContainer.ManualTimestamper;
@@ -126,37 +127,65 @@ public class TestBlockchain : IDisposable
 
     // Resolving all these component at once is faster.
     private FromContainer _fromContainer = null!;
-    private record FromContainer(
-        IStateReader StateReader,
-        IEthereumEcdsa EthereumEcdsa,
-        INonceManager NonceManager,
-        IReceiptStorage ReceiptStorage,
-        ITxPool TxPool,
-        IWorldStateManager WorldStateManager,
-        IBlockPreprocessorStep BlockPreprocessorStep,
-        IBlockTree BlockTree,
-        IBlockFinder BlockFinder,
-        ILogFinder LogFinder,
-        IChainHeadInfoProvider ChainHeadInfoProvider,
-        IDbProvider DbProvider,
-        ISpecProvider SpecProvider,
-        ISealEngine SealEngine,
-        ITransactionComparerProvider TransactionComparerProvider,
-        IPoSSwitcher PoSSwitcher,
-        IChainLevelInfoRepository ChainLevelInfoRepository,
-        IMainProcessingContext MainProcessingContext,
-        IReadOnlyTxProcessingEnvFactory ReadOnlyTxProcessingEnvFactory,
-        IBlockProducerEnvFactory BlockProducerEnvFactory,
-        Configuration Configuration,
-        Lazy<TestBlockchainUtil> TestBlockchainUtil,
-        Lazy<PoWTestBlockchainUtil> PoWTestBlockchainUtil,
-        ManualTimestamper ManualTimestamper,
-        IManualBlockProductionTrigger BlockProductionTrigger,
-        IShareableTxProcessorSource ShareableTxProcessorSource,
-        ISealer Sealer,
-        IForkInfo ForkInfo
+    public class FromContainer(
+        Lazy<IStateReader> stateReader,
+        Lazy<IEthereumEcdsa> ethereumEcdsa,
+        Lazy<INonceManager> nonceManager,
+        Lazy<IReceiptStorage> receiptStorage,
+        Lazy<ITxPool> txPool,
+        Lazy<IWorldStateManager> worldStateManager,
+        Lazy<IBlockPreprocessorStep> blockPreprocessorStep,
+        Lazy<IBlockTree> blockTree,
+        Lazy<IBlockFinder> blockFinder,
+        Lazy<ILogFinder> logFinder,
+        Lazy<IChainHeadInfoProvider> chainHeadInfoProvider,
+        Lazy<IDbProvider> dbProvider,
+        Lazy<ISpecProvider> specProvider,
+        Lazy<ISealEngine> sealEngine,
+        Lazy<ITransactionComparerProvider> transactionComparerProvider,
+        Lazy<IPoSSwitcher> poSSwitcher,
+        Lazy<IChainLevelInfoRepository> chainLevelInfoRepository,
+        Lazy<IMainProcessingContext> mainProcessingContext,
+        Lazy<IReadOnlyTxProcessingEnvFactory> readOnlyTxProcessingEnvFactory,
+        Lazy<IBlockProducerEnvFactory> blockProducerEnvFactory,
+        Lazy<Configuration> configuration,
+        Lazy<TestBlockchainUtil> testBlockchainUtil,
+        Lazy<PoWTestBlockchainUtil> poWTestBlockchainUtil,
+        Lazy<ManualTimestamper> manualTimestamper,
+        Lazy<IManualBlockProductionTrigger> blockProductionTrigger,
+        Lazy<IShareableTxProcessorSource> shareableTxProcessorSource,
+        Lazy<ISealer> sealer,
+        Lazy<IForkInfo> forkInfo
     )
     {
+        public IStateReader StateReader => stateReader.Value;
+        public IEthereumEcdsa EthereumEcdsa => ethereumEcdsa.Value;
+        public INonceManager NonceManager => nonceManager.Value;
+        public IReceiptStorage ReceiptStorage => receiptStorage.Value;
+        public ITxPool TxPool => txPool.Value;
+        public IWorldStateManager WorldStateManager => worldStateManager.Value;
+        public IBlockPreprocessorStep BlockPreprocessorStep => blockPreprocessorStep.Value;
+        public IBlockTree BlockTree => blockTree.Value;
+        public IBlockFinder BlockFinder => blockFinder.Value;
+        public ILogFinder LogFinder => logFinder.Value;
+        public IChainHeadInfoProvider ChainHeadInfoProvider => chainHeadInfoProvider.Value;
+        public IDbProvider DbProvider => dbProvider.Value;
+        public ISpecProvider SpecProvider => specProvider.Value;
+        public ISealEngine SealEngine => sealEngine.Value;
+        public ITransactionComparerProvider TransactionComparerProvider => transactionComparerProvider.Value;
+        public IPoSSwitcher PoSSwitcher => poSSwitcher.Value;
+        public IChainLevelInfoRepository ChainLevelInfoRepository => chainLevelInfoRepository.Value;
+        public IMainProcessingContext MainProcessingContext => mainProcessingContext.Value;
+        public IReadOnlyTxProcessingEnvFactory ReadOnlyTxProcessingEnvFactory => readOnlyTxProcessingEnvFactory.Value;
+        public IBlockProducerEnvFactory BlockProducerEnvFactory => blockProducerEnvFactory.Value;
+        public Configuration Configuration => configuration.Value;
+        public TestBlockchainUtil TestBlockchainUtil => testBlockchainUtil.Value;
+        public PoWTestBlockchainUtil PoWTestBlockchainUtil => poWTestBlockchainUtil.Value;
+        public ManualTimestamper ManualTimestamper => manualTimestamper.Value;
+        public IManualBlockProductionTrigger BlockProductionTrigger => blockProductionTrigger.Value;
+        public IShareableTxProcessorSource ShareableTxProcessorSource => shareableTxProcessorSource.Value;
+        public ISealer Sealer => sealer.Value;
+        public IForkInfo ForkInfo => forkInfo.Value;
     }
 
     public class Configuration
@@ -401,6 +430,11 @@ public class TestBlockchain : IDisposable
     public virtual async Task AddBlock(params Transaction[] transactions)
     {
         await TestUtil.AddBlockAndWaitForHead(false, _cts.Token, transactions);
+    }
+
+    public async Task AddBlock(TestBlockchainUtil.AddBlockFlags flags, params Transaction[] transactions)
+    {
+        await TestUtil.AddBlock(flags, _cts.Token, transactions);
     }
 
     public async Task AddBlockMayMissTx(params Transaction[] transactions)

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
@@ -66,7 +66,7 @@ public class TestBlockchainUtil(
                 bool hasExtraTx = expectedHashes.Count > matchingHashes;
                 if (hasExtraTx && mayHaveExtraTx) break;
 
-                bool hasExactlyTheRightTx = expectedHashes.Count == matchingHashes;
+                bool hasExactlyTheRightTx = expectedHashes.Count == blockTxs.Count;
                 if (hasExactlyTheRightTx) break;
             }
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
 using Nethermind.Core.Test.Builders;
@@ -44,7 +45,7 @@ public class TestBlockchainUtil(
                 b => true);
 
         Block? invalidBlock = null;
-        void OnInvalidBlock(object? sender, InvalidBlockDetector.InvalidBlockEventArgs e)
+        void OnInvalidBlock(object? sender, IBlockchainProcessor.InvalidBlockEventArgs e)
         {
             invalidBlock = e.InvalidBlock;
         }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -8,6 +8,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Consensus;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Blockchain;
@@ -48,7 +49,9 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
 
             .AddSingleton<PseudoNethermindRunner>()
             .AddSingleton<TestBlockchainUtil>()
-            .AddSingleton<TestBlockchainUtil.Config>()
+                .AddSingleton<TestBlockchainUtil.Config>()
+                .AddSingleton<InvalidBlockDetector>()
+                .AddDecorator<IBlockProcessor, InvalidBlockDetector.BlockProcessorInterceptor>()
 
             .AddSingleton<ISealer>(new NethDevSealEngine(nodeKey.Address))
             .AddSingleton<ITimestamper, ManualTimestamper>()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -27,6 +27,7 @@ using NUnit.Framework;
 namespace Nethermind.JsonRpc.Test;
 
 [TestFixture]
+[Parallelizable(ParallelScope.Children)]
 public class JsonRpcSocketsClientTests
 {
     public class UsingIpc

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
@@ -13,6 +14,7 @@ using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.FourByte;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Prestate;
 using Nethermind.Serialization.Rlp;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Nethermind.JsonRpc.Test.Modules;
@@ -30,10 +32,7 @@ public partial class DebugRpcModuleTests
 
         var response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransaction", transaction.Hash, options);
 
-        Assert.That(JsonElement.DeepEquals(
-            JsonDocument.Parse(response).RootElement,
-            JsonDocument.Parse(expected).RootElement),
-            response);
+        JToken.Parse(response).Should().BeEquivalentTo(JToken.Parse(expected));
     }
 
     [TestCaseSource(nameof(TraceTransactionTransferSource))]
@@ -48,10 +47,7 @@ public partial class DebugRpcModuleTests
         var blockNumber = context.Blockchain.BlockTree.Head!.Number;
         var response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransactionByBlockAndIndex", blockNumber, 0, options);
 
-        Assert.That(JsonElement.DeepEquals(
-            JsonDocument.Parse(response).RootElement,
-            JsonDocument.Parse(expected).RootElement),
-            response);
+        JToken.Parse(response).Should().BeEquivalentTo(JToken.Parse(expected));
     }
 
     [TestCaseSource(nameof(TraceTransactionTransferSource))]
@@ -66,10 +62,7 @@ public partial class DebugRpcModuleTests
         var blockHash = context.Blockchain.BlockTree.Head!.Hash;
         var response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransactionByBlockhashAndIndex", blockHash, 0, options);
 
-        Assert.That(JsonElement.DeepEquals(
-            JsonDocument.Parse(response).RootElement,
-            JsonDocument.Parse(expected).RootElement),
-            response);
+        JToken.Parse(response).Should().BeEquivalentTo(JToken.Parse(expected));
     }
 
     [TestCaseSource(nameof(TraceTransactionTransferSource))]
@@ -84,10 +77,7 @@ public partial class DebugRpcModuleTests
         var blockRlp = Rlp.Encode(context.Blockchain.BlockTree.Head!).ToString();
         var response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransactionInBlockByHash", blockRlp, transaction.Hash, options);
 
-        Assert.That(JsonElement.DeepEquals(
-            JsonDocument.Parse(response).RootElement,
-            JsonDocument.Parse(expected).RootElement),
-            response);
+        JToken.Parse(response).Should().BeEquivalentTo(JToken.Parse(expected));
     }
 
     [TestCaseSource(nameof(TraceTransactionTransferSource))]
@@ -102,10 +92,7 @@ public partial class DebugRpcModuleTests
         var blockRlp = Rlp.Encode(context.Blockchain.BlockTree.Head!).ToString();
         var response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransactionInBlockByIndex", blockRlp, 0, options);
 
-        Assert.That(JsonElement.DeepEquals(
-            JsonDocument.Parse(response).RootElement,
-            JsonDocument.Parse(expected).RootElement),
-            response);
+        JToken.Parse(response).Should().BeEquivalentTo(JToken.Parse(expected));
     }
 
     private static IEnumerable<TestCaseData> TraceTransactionTransferSource()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1653,11 +1653,11 @@ public partial class EthRpcModuleTests
 
             return Task.FromResult(new Context
             {
-                // Did it make... both? all the time?
-                TestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+                Test = TestRpcBlockchain.ForTest(SealEngineType.NethDev)
                     .WithBlockchainBridge(blockchainBridge!)
                     .WithConfig(new JsonRpcConfig() { EstimateErrorMargin = 0 })
                     .Build(wrappedConfigurer).Result,
+
                 AuraTestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.AuRa)
                     .Build(configurer: builder =>
                     {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1676,7 +1676,7 @@ public partial class EthRpcModuleTests
         public void Dispose()
         {
             _testCtx?.Dispose();
-            _testCtx?.Dispose();
+            _auraCtx?.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1643,7 +1643,7 @@ public partial class EthRpcModuleTests
             });
         }
 
-        public static Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
+        public static async Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
         {
             Action<ContainerBuilder> wrappedConfigurer = builder =>
             {
@@ -1651,12 +1651,12 @@ public partial class EthRpcModuleTests
                 configurer?.Invoke(builder);
             };
 
-            return Task.FromResult(new Context
+            return new Context
             {
-                Test = TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+                Test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
                     .WithBlockchainBridge(blockchainBridge!)
                     .WithConfig(new JsonRpcConfig() { EstimateErrorMargin = 0 })
-                    .Build(wrappedConfigurer).Result,
+                    .Build(wrappedConfigurer),
 
                 AuraTestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.AuRa)
                     .Build(configurer: builder =>
@@ -1670,7 +1670,7 @@ public partial class EthRpcModuleTests
                             );
                         wrappedConfigurer(builder);
                     }).Result
-            });
+            };
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -167,7 +167,7 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.Create();
         string serialized = await ctx.Test.TestEthRpc("eth_getBlockReceipts", "latest");
         string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":[{\"transactionHash\":\"0x681c2b6f99e37fd6fe6046db8b51ec3460d699cacd6a376143fd5842ac50621f\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x29f141925d2d8e357ae5b6040c97aa12d7ac6dfcbe2b20e7b616d8907ac8e1f3\",\"blockNumber\":\"0x3\",\"cumulativeGasUsed\":\"0x5208\",\"gasUsed\":\"0x5208\",\"effectiveGasPrice\":\"0x1\",\"from\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"to\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"contractAddress\":null,\"logs\":[],\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"status\":\"0x1\",\"type\":\"0x0\"},{\"transactionHash\":\"0x7126cf20a0ad8bd51634837d9049615c34c1bff5e1a54e5663f7e23109bff48b\",\"transactionIndex\":\"0x1\",\"blockHash\":\"0x29f141925d2d8e357ae5b6040c97aa12d7ac6dfcbe2b20e7b616d8907ac8e1f3\",\"blockNumber\":\"0x3\",\"cumulativeGasUsed\":\"0xa410\",\"gasUsed\":\"0x5208\",\"effectiveGasPrice\":\"0x1\",\"from\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"to\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"contractAddress\":null,\"logs\":[],\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"status\":\"0x1\",\"type\":\"0x0\"}],\"id\":67}";
-        Assert.That(serialized, Is.EqualTo(expectedResult));
+        JToken.Parse(serialized).Should().BeEquivalentTo(expectedResult);
     }
 
     [Test]
@@ -1592,8 +1592,23 @@ public partial class EthRpcModuleTests
 
     protected class Context : IDisposable
     {
-        public TestRpcBlockchain Test { get; set; } = null!;
-        public TestRpcBlockchain AuraTest { get; set; } = null!;
+        private TestRpcBlockchain? _testCtx;
+        private TestRpcBlockchain? _auraCtx;
+
+        public Func<TestRpcBlockchain> TestFactory { get; set; } = null!;
+        public Func<TestRpcBlockchain> AuraTestFactory { get; set; } = null!;
+
+        public TestRpcBlockchain Test
+        {
+            get => _testCtx ??= TestFactory();
+            set => _testCtx = value;
+        }
+
+        public TestRpcBlockchain AuraTest
+        {
+            get => _auraCtx ??= AuraTestFactory();
+            set => _auraCtx = value;
+        }
 
         private Context() { }
 
@@ -1628,7 +1643,7 @@ public partial class EthRpcModuleTests
             });
         }
 
-        public static async Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
+        public static Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
         {
             Action<ContainerBuilder> wrappedConfigurer = builder =>
             {
@@ -1636,14 +1651,14 @@ public partial class EthRpcModuleTests
                 configurer?.Invoke(builder);
             };
 
-            return new Context
+            return Task.FromResult(new Context
             {
                 // Did it make... both? all the time?
-                Test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+                TestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.NethDev)
                     .WithBlockchainBridge(blockchainBridge!)
                     .WithConfig(new JsonRpcConfig() { EstimateErrorMargin = 0 })
-                    .Build(wrappedConfigurer),
-                AuraTest = await TestRpcBlockchain.ForTest(SealEngineType.AuRa)
+                    .Build(wrappedConfigurer).Result,
+                AuraTestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.AuRa)
                     .Build(configurer: builder =>
                     {
                         builder
@@ -1654,14 +1669,14 @@ public partial class EthRpcModuleTests
                                 }
                             );
                         wrappedConfigurer(builder);
-                    })
-            };
+                    }).Result
+            });
         }
 
         public void Dispose()
         {
-            Test?.Dispose();
-            AuraTest?.Dispose();
+            _testCtx?.Dispose();
+            _testCtx?.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1643,7 +1643,7 @@ public partial class EthRpcModuleTests
             });
         }
 
-        public static async Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
+        public static Task<Context> Create(ISpecProvider? specProvider = null, IBlockchainBridge? blockchainBridge = null, Action<ContainerBuilder>? configurer = null)
         {
             Action<ContainerBuilder> wrappedConfigurer = builder =>
             {
@@ -1651,12 +1651,12 @@ public partial class EthRpcModuleTests
                 configurer?.Invoke(builder);
             };
 
-            return new Context
+            return Task.FromResult(new Context
             {
-                Test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+                TestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.NethDev)
                     .WithBlockchainBridge(blockchainBridge!)
                     .WithConfig(new JsonRpcConfig() { EstimateErrorMargin = 0 })
-                    .Build(wrappedConfigurer),
+                    .Build(wrappedConfigurer).Result,
 
                 AuraTestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.AuRa)
                     .Build(configurer: builder =>
@@ -1670,7 +1670,7 @@ public partial class EthRpcModuleTests
                             );
                         wrappedConfigurer(builder);
                     }).Result
-            };
+            });
         }
 
         public void Dispose()


### PR DESCRIPTION
- Fix randomly failing test due to genesis loader waiting for `NewHead` event while `AddBlock` wait for `BlockAdded` event.
- Ensure that the head after the context init is of the right block number.
- Ensure TX pool tx removed at end of `AddBlock`.
- Make components lazy to make unit test run faster.
- Do not allow additional tx in the created block unless explicitly allowed.
- Fail test when invalid block is detected in `AddBlock`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Waiting....