### PR TITLE
refactor: Add BuildBlock overload to reduce parameter count

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksWhenRequested.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksWhenRequested.cs
@@ -13,6 +13,12 @@ namespace Nethermind.Consensus.Producers
     {
         public event EventHandler<BlockProductionEventArgs>? TriggerBlockProduction;
 
+        public Task<Block?> BuildBlock(BlockProductionEventArgs args)
+        {
+            TriggerBlockProduction?.Invoke(this, args);
+            return args.BlockProductionTask;
+        }
+
         public Task<Block?> BuildBlock(
             BlockHeader? parentHeader = null,
             CancellationToken? cancellationToken = null,
@@ -20,8 +26,7 @@ namespace Nethermind.Consensus.Producers
             PayloadAttributes payloadAttributes = null)
         {
             BlockProductionEventArgs args = new(parentHeader, cancellationToken, blockTracer, payloadAttributes);
-            TriggerBlockProduction?.Invoke(this, args);
-            return args.BlockProductionTask;
+            return BuildBlock(args);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/IManualBlockProductionTrigger.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/IManualBlockProductionTrigger.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
@@ -10,7 +11,16 @@ namespace Nethermind.Consensus.Producers
 {
     public interface IManualBlockProductionTrigger : IBlockProductionTrigger
     {
-        // TODO: too many parameters
+        /// <summary>
+        /// Triggers building a block using the provided <see cref="BlockProductionEventArgs"/>.
+        /// Prefer this overload to avoid multiple optional parameters.
+        /// </summary>
+        public Task<Block?> BuildBlock(BlockProductionEventArgs args);
+
+        /// <summary>
+        /// Triggers building a block. Prefer using <see cref="BuildBlock(BlockProductionEventArgs)"/>.
+        /// </summary>
+        [Obsolete("Use BuildBlock(BlockProductionEventArgs args) to reduce parameter count and improve readability.")]
         public Task<Block?> BuildBlock(
             BlockHeader? parentHeader = null,
             CancellationToken? cancellationToken = null,


### PR DESCRIPTION
- Introduce single-argument overload BuildBlock(BlockProductionEventArgs) in IManualBlockProductionTrigger to encapsulate inputs and address “too many parameters”.
- Implement overload in BuildBlocksWhenRequested and delegate existing multi-parameter method to the new one.
- Keep the original signature for backward compatibility; no changes required at call sites.