### PR TITLE
fix: NameError in `fastBlocksSettings` by passing API key

### DIFF
--- a/scripts/sync-settings.py
+++ b/scripts/sync-settings.py
@@ -98,7 +98,7 @@ configs = {
     }
 }
 
-def fastBlocksSettings(configuration, apiUrl, blockReduced, multiplierRequirement, isPoS):
+def fastBlocksSettings(configuration, apiUrl, blockReduced, multiplierRequirement, isPoS, key):
     if "etherscan" in apiUrl:
         params = {
             'module': 'proxy',
@@ -163,4 +163,4 @@ if __name__ == "__main__":
             continue
 
         print(emoji.emojize(f"{config.capitalize()} section                                     :white_check_mark: "))
-        fastBlocksSettings(config, value['url'], value['blockReduced'], value['multiplierRequirement'], value['isPoS'])
+        fastBlocksSettings(config, value['url'], value['blockReduced'], value['multiplierRequirement'], value['isPoS'], key)


### PR DESCRIPTION
## Changes

* Added `key` parameter to `fastBlocksSettings` function:

```python
def fastBlocksSettings(configuration, apiUrl, blockReduced, multiplierRequirement, isPoS, key):
```

* Updated call in `main` to pass the `key` argument:

```python
fastBlocksSettings(config, value['url'], value['blockReduced'], value['multiplierRequirement'], value['isPoS'], key)
```

* Fixes a `NameError` that occurred because `key` was previously out of scope.

## Types of changes

#### What types of changes does your code introduce?

* [x] Bugfix (a non-breaking change that fixes an issue)
* [ ] New feature (a non-breaking change that adds functionality)
* [ ] Breaking change (a change that causes existing functionality not to work as expected)
* [ ] Optimization
* [ ] Refactoring
* [ ] Documentation update
* [ ] Build-related changes
* [ ] Other: *Description*

## Testing

#### Requires testing

* [ ] Yes
* [x] No

#### If yes, did you write tests?

* [ ] Yes
* [ ] No

#### Notes on testing

*No additional testing needed; this is a straightforward scope fix.*

## Documentation

#### Requires documentation update

* [ ] Yes
* [x] No

#### Requires explanation in Release Notes

* [x] Yes
* [ ] No

*Added `key` parameter to `fastBlocksSettings` to prevent runtime `NameError`.*

## Remarks

*This change ensures that the API key is properly passed to the function and resolves potential crashes when interacting with Etherscan.*

