### PR TITLE
Fix Taiko Chains Default Config

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
@@ -10,11 +10,11 @@
     "BlobsSupport": "Disabled"
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
-    "PivotNumber": 460269,
-    "PivotHash": "0xc22ad6f4c1fecab96fa084dad303b4482c552d1d07f0c63b87a1b318b022378f",
-    "PivotTotalDifficulty": 0
+    "FastSync": false,
+    "SnapSync": false
+  },
+  "Pruning": {
+    "PruningBoundary": 1000
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/taiko-hekla.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-hekla.json
@@ -10,11 +10,11 @@
     "BlobsSupport": "Disabled"
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
-    "PivotNumber": 882786,
-    "PivotHash": "0x76e654042380ab94b86398fdb3515d7e699c7c070ffbbf6a49e581eb2b8f3f00",
-    "PivotTotalDifficulty": 0
+    "FastSync": false,
+    "SnapSync": false
+  },
+  "Pruning": {
+    "PruningBoundary": 1000
   },
   "JsonRpc": {
     "Enabled": true,


### PR DESCRIPTION
Fixes 
https://github.com/NethermindEth/nethermind/issues/9280

Taiko can no longer snap sync, since the older state is required to process bigger batches (100-200+ L2 blocks), which is not present when performing snap sync. Modify the default config to not use snap/fast sync and ensure the pruning boundary is big enough to cover the blocks for one batch.

## Changes
- Remove fast/snap sync
- Add Pruning.PruningBoundary

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No