### PR TITLE
Fix: ArrayPool buffer leak in PatriciaTree Get methods

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -478,10 +478,10 @@ namespace Nethermind.Trie
 
             _writeBeforeCommit++;
 
+            byte[]? array = null;
             try
             {
                 int nibblesCount = 2 * rawKey.Length;
-                byte[] array = null;
                 Span<byte> nibbles = (rawKey.Length <= MaxKeyStackAlloc
                         ? stackalloc byte[MaxKeyStackAlloc] // Fixed size stack allocation
                         : array = ArrayPool<byte>.Shared.Rent(nibblesCount))
@@ -495,11 +495,11 @@ namespace Nethermind.Trie
                 TreePath empty = TreePath.Empty;
                 RootRef = SetNew(_traverseStack, nibbles, value, ref empty, RootRef);
 
-                if (array is not null) ArrayPool<byte>.Shared.Return(array);
             }
             finally
             {
                 Volatile.Write(ref _isWriteInProgress, 0);
+                if (array is not null) ArrayPool<byte>.Shared.Return(array);
             }
 
             void Trace(in ReadOnlySpan<byte> rawKey, SpanSource value)


### PR DESCRIPTION
## Changes

- Fixed `ArrayPool` buffer leak in `Get()` method - Moved `ArrayPool<byte>.Shared.Return(array)` from try block to finally block to ensure cleanup even when `TrieException` is thrown
- Fixed ArrayPool buffer leak in `GetNodeByKey()` method - Moved `ArrayPool<byte>.Shared.Return(array)` from try block to finally block to ensure cleanup even when `TrieException` is thrown

To give a little bit more detail about the why, the `Get()` and `GetNodeByKey()` methods in PatriciaTree rent buffers from `ArrayPool` but only returned them in the success path.

When `GetNew()` throws a `TrieException`, the rented buffers weren't returned to the pool, it could've cause gradual memory pressure under sustained load (even if the array get GC'ed at some point).

This was only affecting RPC endpoints when handling requests with keys larger than the 64byte stack allocation min.
For the p2p path, the peer would be banned before causing any significant harm.

