### PR TITLE
fix: assert non-null parent; warn and return if null in InvalidChainTracker

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
@@ -123,17 +123,11 @@ public class InvalidChainTracker : IInvalidChainTracker
     {
         if (_logger.IsDebug) _logger.Debug($"OnInvalidBlock: {failedBlock} {parent}");
 
-        // TODO: This port can now be removed? We should never get null here?
+        System.Diagnostics.Debug.Assert(parent is not null, "Parent should not be null for invalid block event");
         if (parent is null)
         {
-            BlockHeader? failedBlockHeader = TryGetBlockHeaderIncludingInvalid(failedBlock);
-            if (failedBlockHeader is null)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Unable to resolve block to determine parent. Block {failedBlock}");
-                return;
-            }
-
-            parent = failedBlockHeader.ParentHash!;
+            if (_logger.IsWarn) _logger.Warn($"Invalid block parent was null for {failedBlock}. This indicates a bug in emitters.");
+            return;
         }
 
         Hash256 effectiveParent = parent;


### PR DESCRIPTION
Replace legacy null-parent resolution with a debug assertion and a guarded warn+return. Parent should always be provided by emitters; resolving it via a header lookup is dead code and can hide upstream bugs. This change enforces the contract, reduces unnecessary lookups, and surfaces issues earlier via logs/assert.