### PR TITLE
refactor(rocksdb): rename ColumnsDbWriteBatch to ColumnDbWriteBatch in ColumnDb

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -80,15 +80,15 @@ public class ColumnDb : IDb
 
     public IWriteBatch StartWriteBatch()
     {
-        return new ColumnsDbWriteBatch(this, (DbOnTheRocks.RocksDbWriteBatch)_mainDb.StartWriteBatch());
+        return new ColumnDbWriteBatch(this, (DbOnTheRocks.RocksDbWriteBatch)_mainDb.StartWriteBatch());
     }
 
-    private class ColumnsDbWriteBatch : IWriteBatch
+    private class ColumnDbWriteBatch : IWriteBatch
     {
         private readonly ColumnDb _columnDb;
         private readonly DbOnTheRocks.RocksDbWriteBatch _underlyingWriteBatch;
 
-        public ColumnsDbWriteBatch(ColumnDb columnDb, DbOnTheRocks.RocksDbWriteBatch underlyingWriteBatch)
+        public ColumnDbWriteBatch(ColumnDb columnDb, DbOnTheRocks.RocksDbWriteBatch underlyingWriteBatch)
         {
             _columnDb = columnDb;
             _underlyingWriteBatch = underlyingWriteBatch;


### PR DESCRIPTION
Renamed the inner write batch class in ColumnDb from plural to singular to match its single-column scope: ColumnsDbWriteBatch → ColumnDbWriteBatch. This aligns naming with the established pattern in ColumnsDb<T> (RocksColumnsWriteBatch for multi-column vs RocksColumnWriteBatch for single-column) and avoids confusion. Updated the constructor and instantiation in StartWriteBatch. No functional changes; improves API clarity and maintainability.