### PR TITLE
Refactor/further isolate prewarmer

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -5,7 +5,6 @@ using System;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.State;
@@ -17,19 +16,6 @@ public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, I
     public IReadOnlyTxProcessorSource Create()
     {
         IWorldStateScopeProvider worldState = worldStateManager.CreateResettableWorldState();
-        ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
-        {
-            builder
-                .AddSingleton<IWorldStateScopeProvider>(worldState)
-                .AddSingleton<AutoReadOnlyTxProcessingEnv>();
-        });
-
-        return childScope.Resolve<AutoReadOnlyTxProcessingEnv>();
-    }
-
-    public IReadOnlyTxProcessorSource CreateForWarmingUp(IWorldStateScopeProvider worldStateToWarmUp)
-    {
-        IWorldStateScopeProvider worldState = worldStateManager.CreateWorldStateForWarmingUp(worldStateToWarmUp);
         ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
         {
             builder

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -25,30 +25,30 @@ using Nethermind.Trie;
 namespace Nethermind.Consensus.Processing;
 
 public sealed class BlockCachePreWarmer(
-    IReadOnlyTxProcessingEnvFactory envFactory,
-    IWorldStateScopeProvider worldStateToWarmup,
+    PrewarmerEnvFactory envFactory,
     int concurrency,
-    ILogManager logManager,
-    PreBlockCaches? preBlockCaches = null
+    NodeStorageCache nodeStorageCache,
+    PreBlockCaches preBlockCaches,
+    ILogManager logManager
 ) : IBlockCachePreWarmer
 {
     private int _concurrencyLevel = (concurrency == 0 ? Math.Min(Environment.ProcessorCount - 1, 16) : concurrency);
-    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory, worldStateToWarmup), Environment.ProcessorCount * 2);
+    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory, preBlockCaches), Environment.ProcessorCount * 2);
     private readonly ILogger _logger = logManager.GetClassLogger<BlockCachePreWarmer>();
     private BlockStateSource? _currentBlockState = null;
 
     public BlockCachePreWarmer(
-        IReadOnlyTxProcessingEnvFactory envFactory,
-        IWorldStateScopeProvider worldStateToWarmup,
+        PrewarmerEnvFactory envFactory,
         IBlocksConfig blocksConfig,
-        ILogManager logManager,
-        PreBlockCaches? preBlockCaches = null
+        NodeStorageCache nodeStorageCache,
+        PreBlockCaches preBlockCaches,
+        ILogManager logManager
     ) : this(
         envFactory,
-        worldStateToWarmup,
         blocksConfig.PreWarmStateConcurrency,
-        logManager,
-        preBlockCaches)
+        nodeStorageCache,
+        preBlockCaches,
+        logManager)
     {
     }
 
@@ -58,6 +58,8 @@ public sealed class BlockCachePreWarmer(
         {
             _currentBlockState = new(this, suggestedBlock, parent, spec);
             CacheType result = preBlockCaches.ClearCaches();
+            result |= nodeStorageCache.ClearCaches() ? CacheType.Rlp : CacheType.None;
+            nodeStorageCache.Enabled = true;
             if (result != default)
             {
                 if (_logger.IsWarn) _logger.Warn($"Caches {result} are not empty. Clearing them.");
@@ -82,8 +84,10 @@ public sealed class BlockCachePreWarmer(
     {
         if (_logger.IsDebug) _logger.Debug("Clearing caches");
         CacheType cachesCleared = preBlockCaches?.ClearCaches() ?? default;
-        if (_logger.IsDebug) _logger.Debug($"Cleared caches: {cachesCleared}");
 
+        nodeStorageCache.Enabled = false;
+        cachesCleared |= nodeStorageCache.ClearCaches() ? CacheType.Rlp : CacheType.None;
+        if (_logger.IsDebug) _logger.Debug($"Cleared caches: {cachesCleared}");
         return cachesCleared;
     }
 
@@ -373,9 +377,9 @@ public sealed class BlockCachePreWarmer(
         private static void DisposeThreadState(AddressWarmingState state) => state.Dispose();
     }
 
-    private class ReadOnlyTxProcessingEnvPooledObjectPolicy(IReadOnlyTxProcessingEnvFactory envFactory, IWorldStateScopeProvider worldStateToWarmUp) : IPooledObjectPolicy<IReadOnlyTxProcessorSource>
+    private class ReadOnlyTxProcessingEnvPooledObjectPolicy(PrewarmerEnvFactory envFactory, PreBlockCaches preBlockCaches) : IPooledObjectPolicy<IReadOnlyTxProcessorSource>
     {
-        public IReadOnlyTxProcessorSource Create() => envFactory.CreateForWarmingUp(worldStateToWarmUp);
+        public IReadOnlyTxProcessorSource Create() => envFactory.Create(preBlockCaches);
         public bool Return(IReadOnlyTxProcessorSource obj) => true;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/IReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IReadOnlyTxProcessingEnvFactory.cs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Blockchain;
-using Nethermind.Evm.State;
 
 namespace Nethermind.Consensus.Processing;
 
 public interface IReadOnlyTxProcessingEnvFactory
 {
     public IReadOnlyTxProcessorSource Create();
-    public IReadOnlyTxProcessorSource CreateForWarmingUp(IWorldStateScopeProvider worldState);
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Evm.State;
+using Nethermind.State;
+
+namespace Nethermind.Consensus.Processing;
+
+public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILifetimeScope parentLifetime)
+{
+    public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches)
+    {
+        var worldState = new PrewarmerScopeProvider(
+            worldStateManager.CreateResettableWorldState(),
+            preBlockCaches,
+            populatePreBlockCache: true
+        );
+
+        ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
+        {
+            builder
+                .AddSingleton<IWorldStateScopeProvider>(worldState)
+                .AddSingleton<AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv>();
+        });
+
+        return childScope.Resolve<AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv>();
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using Nethermind.Api;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Db;

--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -24,14 +24,12 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
     public MainProcessingContext(
         ILifetimeScope rootLifetimeScope,
         IReceiptConfig receiptConfig,
-        IBlocksConfig blocksConfig,
         IInitConfig initConfig,
         IBlockValidationModule[] blockValidationModules,
         IMainProcessingModule[] mainProcessingModules,
         IWorldStateManager worldStateManager,
         CompositeBlockPreprocessorStep compositeBlockPreprocessorStep,
         IBlockTree blockTree,
-        IPrecompileProvider precompileProvider,
         ILogManager logManager)
     {
 
@@ -64,20 +62,6 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
                 // And finally, to wrap things up.
                 .AddScoped<Components>()
                 ;
-
-            if (blocksConfig.PreWarmStateOnBlockProcessing)
-            {
-                builder
-                    .AddScoped<PreBlockCaches>((mainWorldState as IPreBlockCaches)!.Caches)
-                    .AddScoped<IBlockCachePreWarmer, BlockCachePreWarmer>()
-                    .AddDecorator<ICodeInfoRepository>((ctx, originalCodeInfoRepository) =>
-                    {
-                        PreBlockCaches preBlockCaches = ctx.Resolve<PreBlockCaches>();
-                        // Note: The use of FrozenDictionary means that this cannot be used for other processing env also due to risk of memory leak.
-                        return new CachedCodeInfoRepository(precompileProvider, originalCodeInfoRepository, preBlockCaches?.PrecompileCache);
-                    })
-                    ;
-            }
         });
 
         _components = innerScope.Resolve<Components>();

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -49,6 +49,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
                 configProvider.GetConfig<ISyncConfig>()
             ))
             .AddModule(new WorldStateModule(configProvider.GetConfig<IInitConfig>()))
+            .AddModule(new PrewarmerModule(configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BuiltInStepsModule())
             .AddModule(new RpcModules(configProvider.GetConfig<IJsonRpcConfig>()))
             .AddModule(new EraModule())

--- a/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Container;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.State;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Init.Modules;
+
+public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        if (blocksConfig.PreWarmStateOnBlockProcessing)
+        {
+            builder
+
+                // Note: There is a special logic for this in `PruningTrieStateFactory`.
+                .AddSingleton<NodeStorageCache>()
+
+                // Note: Need a small modification to have this work on all branch processor due to the shared
+                // NodeStorageCache and the FrozenDictionary and the fact that some processing does not have
+                // branch processor, and use block processor instead.
+                .AddSingleton<IMainProcessingModule, PrewarmerMainProcessingModule>();
+        }
+    }
+
+    public class PrewarmerMainProcessingModule : Module, IMainProcessingModule
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder
+                .AddSingleton<PreBlockCaches>() // Singleton so that all child env share the same caches
+                .AddScoped<IBlockCachePreWarmer, BlockCachePreWarmer>()
+                .Add<PrewarmerEnvFactory>()
+
+                // These are the actual decorated component that provide cached result
+                .AddDecorator<IWorldStateScopeProvider>((ctx, worldStateScopeProvider) => new PrewarmerScopeProvider(
+                    worldStateScopeProvider,
+                    ctx.Resolve<PreBlockCaches>(),
+                    populatePreBlockCache: false
+                ))
+                .AddDecorator<ICodeInfoRepository>((ctx, originalCodeInfoRepository) =>
+                {
+                    PreBlockCaches preBlockCaches = ctx.Resolve<PreBlockCaches>();
+                    IPrecompileProvider precompileProvider = ctx.Resolve<IPrecompileProvider>();
+                    // Note: The use of FrozenDictionary means that this cannot be used for other processing env also due to risk of memory leak.
+                    return new CachedCodeInfoRepository(precompileProvider, originalCodeInfoRepository,
+                        preBlockCaches?.PrecompileCache);
+                });
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
@@ -43,11 +43,15 @@ public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
                 .Add<PrewarmerEnvFactory>()
 
                 // These are the actual decorated component that provide cached result
-                .AddDecorator<IWorldStateScopeProvider>((ctx, worldStateScopeProvider) => new PrewarmerScopeProvider(
-                    worldStateScopeProvider,
-                    ctx.Resolve<PreBlockCaches>(),
-                    populatePreBlockCache: false
-                ))
+                .AddDecorator<IWorldStateScopeProvider>((ctx, worldStateScopeProvider) =>
+                {
+                    if (worldStateScopeProvider is PrewarmerScopeProvider) return worldStateScopeProvider; // Inner world state
+                    return new PrewarmerScopeProvider(
+                        worldStateScopeProvider,
+                        ctx.Resolve<PreBlockCaches>(),
+                        populatePreBlockCache: false
+                    );
+                })
                 .AddDecorator<ICodeInfoRepository>((ctx, originalCodeInfoRepository) =>
                 {
                     PreBlockCaches preBlockCaches = ctx.Resolve<PreBlockCaches>();

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -7,7 +7,6 @@ using Autofac;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
-using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Db.FullPruning;

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -11,7 +11,6 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Utils;
 using Nethermind.Config;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Timers;
@@ -33,7 +32,6 @@ public class PruningTrieStateFactory(
     ISyncConfig syncConfig,
     IInitConfig initConfig,
     IPruningConfig pruningConfig,
-    IBlocksConfig blockConfig,
     IDbProvider dbProvider,
     IBlockTree blockTree,
     IFileSystem fileSystem,
@@ -45,7 +43,8 @@ public class PruningTrieStateFactory(
     ChainSpec chainSpec,
     IDisposableStack disposeStack,
     Lazy<IPathRecovery> pathRecovery,
-    ILogManager logManager
+    ILogManager logManager,
+    NodeStorageCache? nodeStorageCache = null
 )
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PruningTrieStateFactory>();
@@ -55,12 +54,12 @@ public class PruningTrieStateFactory(
         CompositePruningTrigger compositePruningTrigger = new CompositePruningTrigger();
 
         IPruningTrieStore trieStore = mainPruningTrieStoreFactory.PruningTrieStore;
+
         ITrieStore mainWorldTrieStore = trieStore;
-        PreBlockCaches? preBlockCaches = null;
-        if (blockConfig.PreWarmStateOnBlockProcessing)
+
+        if (nodeStorageCache is not null)
         {
-            preBlockCaches = new PreBlockCaches();
-            mainWorldTrieStore = new PreCachedTrieStore(trieStore, preBlockCaches.RlpCache);
+            mainWorldTrieStore = new PreCachedTrieStore(mainWorldTrieStore, nodeStorageCache);
         }
 
         IKeyValueStoreWithBatching codeDb = dbProvider.CodeDb;
@@ -75,11 +74,6 @@ public class PruningTrieStateFactory(
                 mainWorldTrieStore,
                 codeDb,
                 logManager);
-
-        if (blockConfig.PreWarmStateOnBlockProcessing)
-        {
-            scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches!, false);
-        }
 
         IWorldStateManager stateManager = new WorldStateManager(
             scopeProvider,
@@ -101,8 +95,7 @@ public class PruningTrieStateFactory(
             mainNodeStorage,
             nodeStorageFactory,
             trieStore,
-            compositePruningTrigger,
-            preBlockCaches
+            compositePruningTrigger
         );
 
         var verifyTrieStarter = new VerifyTrieStarter(stateManager, processExit!, logManager);
@@ -123,8 +116,7 @@ public class PruningTrieStateFactory(
         INodeStorage mainNodeStorage,
         INodeStorageFactory nodeStorageFactory,
         IPruningTrieStore trieStore,
-        CompositePruningTrigger compositePruningTrigger,
-        PreBlockCaches? preBlockCaches)
+        CompositePruningTrigger compositePruningTrigger)
     {
         IPruningTrigger? CreateAutomaticTrigger(string dbPath)
         {

--- a/src/Nethermind/Nethermind.State/IWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateManager.cs
@@ -24,13 +24,6 @@ public interface IWorldStateManager
     /// <returns></returns>
     IWorldStateScopeProvider CreateResettableWorldState();
 
-    /// <summary>
-    /// Create a read only world state to warm up another world state
-    /// </summary>
-    /// <param name="forWarmup">Specify a world state to warm up by the returned world state.</param>
-    /// <returns></returns>
-    IWorldStateScopeProvider CreateWorldStateForWarmingUp(IWorldStateScopeProvider forWarmup);
-
     event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
     IOverridableWorldScope CreateOverridableWorldScope();

--- a/src/Nethermind/Nethermind.State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.State/PreBlockCaches.cs
@@ -22,7 +22,6 @@ public class PreBlockCaches
 
     private readonly ConcurrentDictionary<StorageCell, byte[]> _storageCache = new(LockPartitions, InitialCapacity);
     private readonly ConcurrentDictionary<AddressAsKey, Account> _stateCache = new(LockPartitions, InitialCapacity);
-    private readonly ConcurrentDictionary<NodeKey, byte[]?> _rlpCache = new(LockPartitions, InitialCapacity);
     private readonly ConcurrentDictionary<PrecompileCacheKey, (byte[], bool)> _precompileCache = new(LockPartitions, InitialCapacity);
 
     public PreBlockCaches()
@@ -31,14 +30,12 @@ public class PreBlockCaches
         [
             () => _storageCache.NoResizeClear() ? CacheType.Storage : CacheType.None,
             () => _stateCache.NoResizeClear() ? CacheType.State : CacheType.None,
-            () => _rlpCache.NoResizeClear() ? CacheType.Rlp : CacheType.None,
             () => _precompileCache.NoResizeClear() ? CacheType.Precompile : CacheType.None
         ];
     }
 
     public ConcurrentDictionary<StorageCell, byte[]> StorageCache => _storageCache;
     public ConcurrentDictionary<AddressAsKey, Account> StateCache => _stateCache;
-    public ConcurrentDictionary<NodeKey, byte[]?> RlpCache => _rlpCache;
     public ConcurrentDictionary<PrecompileCacheKey, (byte[], bool)> PrecompileCache => _precompileCache;
 
     public CacheType ClearCaches()

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -15,7 +15,7 @@ public class PrewarmerScopeProvider(
     IWorldStateScopeProvider baseProvider,
     PreBlockCaches preBlockCaches,
     bool populatePreBlockCache = true
-): IWorldStateScopeProvider , IPreBlockCaches
+) : IWorldStateScopeProvider, IPreBlockCaches
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -66,21 +66,6 @@ public class WorldStateManager : IWorldStateManager
         return new TrieStoreScopeProvider(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager);
     }
 
-    public IWorldStateScopeProvider CreateWorldStateForWarmingUp(IWorldStateScopeProvider forWarmup)
-    {
-        if (forWarmup is IPreBlockCaches preBlockCaches)
-        {
-            return new PrewarmerScopeProvider(
-                new TrieStoreScopeProvider(new PreCachedTrieStore(_readOnlyTrieStore, preBlockCaches.Caches.RlpCache),
-                    _readaOnlyCodeCb, _logManager),
-                preBlockCaches.Caches,
-                populatePreBlockCache: true
-            );
-        }
-
-        return CreateResettableWorldState();
-    }
-
     public IOverridableWorldScope CreateOverridableWorldScope()
     {
         return new OverridableWorldStateManager(_dbProvider, _readOnlyTrieStore, _logManager);

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using Nethermind.Core.Collections;
+
+namespace Nethermind.Trie;
+
+public sealed class NodeStorageCache
+{
+    private ConcurrentDictionary<NodeKey, byte[]> _cache = new();
+
+    private bool _enabled = false;
+
+    public bool Enabled
+    {
+        get => _enabled;
+        set => _enabled = value;
+    }
+
+    public byte[]? GetOrAdd(NodeKey nodeKey, Func<NodeKey, byte[]> tryLoadRlp)
+    {
+        if (!_enabled)
+        {
+            return tryLoadRlp(nodeKey);
+        }
+        return _cache.GetOrAdd(nodeKey, tryLoadRlp);
+    }
+
+    public bool ClearCaches()
+    {
+        return _cache.NoResizeClear();
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
 using System.Numerics;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -10,18 +9,17 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Trie;
 
-public class PreCachedTrieStore : ITrieStore
+public sealed class PreCachedTrieStore : ITrieStore
 {
     private readonly ITrieStore _inner;
-    private readonly ConcurrentDictionary<NodeKey, byte[]?> _preBlockCache;
+    private readonly NodeStorageCache _preBlockCache;
     private readonly Func<NodeKey, byte[]> _loadRlp;
     private readonly Func<NodeKey, byte[]> _tryLoadRlp;
 
-    public PreCachedTrieStore(ITrieStore inner,
-        ConcurrentDictionary<NodeKey, byte[]?> preBlockCache)
+    public PreCachedTrieStore(ITrieStore inner, NodeStorageCache cache)
     {
         _inner = inner;
-        _preBlockCache = preBlockCache;
+        _preBlockCache = cache;
 
         // Capture the delegate once for default path to avoid the allocation of the lambda per call
         _loadRlp = (NodeKey key) => _inner.LoadRlp(key.Address, in key.Path, key.Hash, flags: ReadFlags.None);


### PR DESCRIPTION
Require #9306 

- The prewarmer is around 85% effective and during that 85% its a single concurrent dictionary lookup. In another word, any state db change need to run behind the prewarmer or it will be slower.
- This PR further isolate prewarmer so that it runs as a decorator independent of StateDb layout, except for rlp cache, which is made separate so that it can be stubbed.
- Removed `IWorldStateManager.CreateWorldStateForWarmingUp` and `IReadOnlyTxProcessingEnvFactory.CreateForWarmingUp`. 
  - This make it easier to simply decorate the `IWorldStateScopeProvider` without having to unwrap the decorator in `IWorldStateManager.CreateWorldStateForWarmingUp`
- Move prewarmer setup in its own module.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No: Runner test should run all module.

#### Notes on testing

- [x] Mainnet can start with prewarmer.
- [x] Mainnet can start without prewarmer.
