### PR TITLE
Rollback - Precompiles Mutability

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Frozen;
+using System.Collections.Generic;
 using Nethermind.Int256;
 
 namespace Nethermind.Core.Specs
@@ -508,7 +508,7 @@ namespace Nethermind.Core.Specs
         /// Gets a cached set of all precompiled contract addresses for this release specification.
         /// Chain-specific implementations can override this to include their own precompiled contracts.
         /// </summary>
-        FrozenSet<AddressAsKey> Precompiles { get; }
+        HashSet<AddressAsKey> Precompiles { get; }
 
         public ProofVersion BlobProofVersion => IsEip7594Enabled ? ProofVersion.V1 : ProofVersion.V0;
 

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Frozen;
+using System.Collections.Generic;
 using Nethermind.Int256;
 
 namespace Nethermind.Core.Specs;
@@ -151,7 +151,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool ValidateReceipts => spec.ValidateReceipts;
     Array? IReleaseSpec.EvmInstructionsNoTrace { get => spec.EvmInstructionsNoTrace; set => spec.EvmInstructionsNoTrace = value; }
     Array? IReleaseSpec.EvmInstructionsTraced { get => spec.EvmInstructionsTraced; set => spec.EvmInstructionsTraced = value; }
-    FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
+    HashSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
     public bool IsEip7939Enabled => spec.IsEip7939Enabled;
     public bool IsEip7907Enabled => spec.IsEip7907Enabled;
     public bool IsRip7728Enabled => spec.IsRip7728Enabled;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Frozen;
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
@@ -199,6 +199,6 @@ namespace Nethermind.Specs.Test
         public bool IsEip7939Enabled => spec.IsEip7939Enabled;
         public bool IsEip7907Enabled => spec.IsEip7907Enabled;
         public bool IsRip7728Enabled => spec.IsRip7728Enabled;
-        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
+        HashSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Precompiles;
@@ -164,10 +163,10 @@ namespace Nethermind.Specs
         public bool IsEip7939Enabled { get; set; }
         public bool IsRip7728Enabled { get; set; }
 
-        private FrozenSet<AddressAsKey>? _precompiles;
-        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompilesCache();
+        private HashSet<AddressAsKey>? _precompiles;
+        HashSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompilesCache();
 
-        public virtual FrozenSet<AddressAsKey> BuildPrecompilesCache()
+        public virtual HashSet<AddressAsKey> BuildPrecompilesCache()
         {
             HashSet<AddressAsKey> cache = new();
 
@@ -198,7 +197,7 @@ namespace Nethermind.Specs
             if (IsRip7212Enabled || IsEip7951Enabled) cache.Add(PrecompiledAddresses.P256Verify);
             if (IsRip7728Enabled) cache.Add(PrecompiledAddresses.L1Sload);
 
-            return cache.ToFrozenSet();
+            return cache;
         }
     }
 }


### PR DESCRIPTION
Revert Precompiles back to `HashSet` from `FrozenSet` because it blocks our override in Arbitrum through `SpecProviderDecorator`.

The change was introduced on this PR https://github.com/NethermindEth/nethermind/pull/9274 and after discussing with @deffrian there is no issue with reverting this back.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [X] Other: Rollback

## Testing

#### Requires testing

- [ ] Yes
- [X] No
