### PR TITLE
 remove unused variable in XdcHeaderDecoder.Decode method

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/RLP/XdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/XdcHeaderDecoder.cs
@@ -21,7 +21,6 @@ public sealed class XdcHeaderDecoder : IHeaderDecoder
         ReadOnlySpan<byte> headerRlp = decoderContext.PeekNextItem();
         int headerSequenceLength = decoderContext.ReadSequenceLength();
         int headerCheck = decoderContext.Position + headerSequenceLength;
-        var x = new BlockDecoder(new XdcHeaderDecoder());
         Hash256? parentHash = decoderContext.DecodeKeccak();
         Hash256? unclesHash = decoderContext.DecodeKeccak();
         Address? beneficiary = decoderContext.DecodeAddress();


### PR DESCRIPTION
## Changes

- Remove unused `BlockDecoder` variable in `XdcHeaderDecoder.Decode()` method

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring
- [x] Optimization

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No