### PR TITLE
fix eth_config missing checks

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -819,7 +819,7 @@ public partial class EthRpcModule(
 
         static ForkConfig? GetForkConfig(Fork? fork, ISpecProvider specProvider)
         {
-            if (fork is null || fork.Value.Activation.Timestamp is null)
+            if (fork is null)
             {
                 return null;
             }


### PR DESCRIPTION
## Changes

- Added check that sets `Last` to `null` if `Next` is unavailable, according to the [specs](https://github.com/ethereum/EIPs/blob/90a2b6fb5c84efdf0079b65a7f1ecab254562ff9/EIPS/eip-7910.md?plain=1#L54):
> "next" and "last" will be `null` if the client is not configured to support a future fork.
- Added a check that ensures `Activation.Timestamp` to be non-null according to the [specs](https://github.com/ethereum/EIPs/blob/90a2b6fb5c84efdf0079b65a7f1ecab254562ff9/EIPS/eip-7910.md?plain=1#L66C88-L66C204)
> If the fork is not scheduled to be activated or its activation time is unknown, it should not be in the RPC results.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No


