### PR TITLE
Refactor/Nicer IWorldStateScopeProvider interface

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip1283Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1283Tests.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2200Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2200Tests.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
 using Nethermind.Specs;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2935Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2935Tests.cs
@@ -6,6 +6,7 @@ using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Specs;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip3529RefundsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip3529RefundsTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Blockchain.Tracing.ParityStyle;
+using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
 using Nethermind.Specs;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
@@ -26,6 +26,7 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Core.Crypto;
 using System;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.Evm.Test

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Blockchain.Tracing.Proofs;
+using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -130,9 +130,6 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     void SetNonce(Address address, in UInt256 nonce);
 
     /* snapshots */
-
-    void Commit(IReleaseSpec releaseSpec, bool isGenesis = false, bool commitRoots = true);
-
     void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false, bool commitRoots = true);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing.State;
 
 namespace Nethermind.Evm.State;
 
@@ -15,5 +16,10 @@ public static class WorldStateExtensions
     {
         ValueHash256 codeHash = code.Length == 0 ? ValueKeccak.OfAnEmptyString : ValueKeccak.Compute(code.Span);
         worldState.InsertCode(address, codeHash, code, spec, isGenesis);
+    }
+
+    public static void Commit(this IWorldState worldState, IReleaseSpec releaseSpec, bool isGenesis = false, bool commitRoots = true)
+    {
+        worldState.Commit(releaseSpec, NullStateTracer.Instance, isGenesis, commitRoots);
     }
 }

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -140,14 +140,6 @@ namespace Nethermind.State
 
         }
 
-        /// <summary>
-        /// Commit persistent storage
-        /// </summary>
-        public void Commit(bool commitRoots = true)
-        {
-            Commit(NullStateTracer.Instance, commitRoots);
-        }
-
         protected struct ChangeTrace
         {
             public static readonly ChangeTrace _zeroBytes = new(StorageTree.ZeroBytes, StorageTree.ZeroBytes);
@@ -175,7 +167,7 @@ namespace Nethermind.State
         /// Commit persistent storage
         /// </summary>
         /// <param name="stateTracer">State tracer</param>
-        public void Commit(IStorageTracer tracer, bool commitRoots = true)
+        public void Commit(IStorageTracer tracer)
         {
             if (_changes.Count == 0)
             {
@@ -185,16 +177,6 @@ namespace Nethermind.State
             {
                 CommitCore(tracer);
             }
-
-            if (commitRoots)
-            {
-                CommitStorageRoots();
-            }
-        }
-
-        protected virtual void CommitStorageRoots()
-        {
-            // Commit storage roots
         }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -237,7 +238,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
         }
     }
 
-    protected override void CommitStorageRoots()
+    internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {
         if (_toUpdateRoots.Count == 0)
         {
@@ -267,19 +268,22 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
                 }
 
                 PerContractState contractState = kvp.Value;
-                (int writes, int skipped) = contractState.ProcessStorageChanges();
+                (int writes, int skipped) = contractState.ProcessStorageChanges(writeBatch.CreateStorageWriteBatch(kvp.Key, kvp.Value.EstimatedChanges));
                 ReportMetrics(writes, skipped);
-                if (writes > 0)
-                {
-                    _stateProvider.UpdateStorageRoot(address: kvp.Key, contractState.RootHash);
-                }
             }
         }
 
         void UpdateRootHashesMultiThread()
         {
             // We can recalculate the roots in parallel as they are all independent tries
-            using var storages = _storages.ToPooledList();
+            using ArrayPoolList<(AddressAsKey Key, PerContractState ContractState, IWorldStateScopeProvider.IStorageWriteBatch WriteBatch)> storages = _storages
+                .Select((kv) => (
+                    kv.Key,
+                    kv.Value,
+                    writeBatch.CreateStorageWriteBatch(kv.Key, kv.Value.EstimatedChanges)
+                ))
+                .ToPooledList(_storages.Count);
+
             ParallelUnbalancedWork.For(
                 0,
                 storages.Count,
@@ -294,7 +298,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
                         return state;
                     }
 
-                    (int writes, int skipped) = kvp.Value.ProcessStorageChanges();
+                    (int writes, int skipped) = kvp.ContractState.ProcessStorageChanges(kvp.WriteBatch);
                     if (writes == 0)
                     {
                         // Mark as no changes; we set as false rather than removing so
@@ -311,19 +315,6 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
                     return state;
                 },
                 (state) => ReportMetrics(state.writes, state.skips));
-
-            // Update the storage roots in the main thread not in parallel,
-            // as can't update the StateTrie in parallel.
-            foreach (ref var kvp in storages.AsSpan())
-            {
-                if (!_toUpdateRoots.TryGetValue(kvp.Key, out bool hasChanges) || !hasChanges)
-                {
-                    continue;
-                }
-
-                // Update the storage root for the Account
-                _stateProvider.UpdateStorageRoot(address: kvp.Key, kvp.Value.RootHash);
-            }
         }
 
         static void ReportMetrics(int writes, int skipped)
@@ -415,7 +406,8 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
     {
         private bool _missingAreDefault;
         private readonly Dictionary<UInt256, ChangeTrace> _dictionary = new(Comparer.Instance);
-        public int EstimatedSize => _dictionary.Count;
+        public int EstimatedSize => _dictionary.Count + (_missingAreDefault ? 1 : 0);
+        public bool HasClear => _missingAreDefault;
 
         public void ClearAndSetMissingAsDefault()
         {
@@ -459,6 +451,11 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
             public int GetHashCode([DisallowNull] UInt256 obj)
                 => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in obj, 1)).FastHash();
         }
+
+        public void UnmarkClear()
+        {
+            _missingAreDefault = false;
+        }
     }
 
     private sealed class PerContractState
@@ -478,13 +475,15 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
             _loadFromTreeStorageFunc = LoadFromTreeStorage;
         }
 
+        public int EstimatedChanges => BlockChange.EstimatedSize;
+
         internal void EnsureStorageTree()
         {
             if (_backend is not null) return;
 
             _backend = _provider._currentScope.CreateStorageTree(_address);
 
-            bool isEmpty = _backend.RootHash == Keccak.EmptyTreeHash;
+            bool isEmpty = _backend.WasEmptyTree;
             if (isEmpty && !_wasWritten)
             {
                 // Slight optimization that skips the tree
@@ -492,19 +491,9 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
             }
         }
 
-        public Hash256 RootHash
-        {
-            get
-            {
-                EnsureStorageTree();
-                return _backend.RootHash;
-            }
-        }
-
         public void Clear()
         {
             EnsureStorageTree();
-            _backend.Clear();
             BlockChange.ClearAndSetMissingAsDefault();
         }
 
@@ -581,53 +570,35 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
                 : _backend.Get(storageCell.Hash);
         }
 
-        public (int writes, int skipped) ProcessStorageChanges()
+        public (int writes, int skipped) ProcessStorageChanges(IWorldStateScopeProvider.IStorageWriteBatch storageWriteBatch)
         {
             EnsureStorageTree();
 
+            using IWorldStateScopeProvider.IStorageWriteBatch _ = storageWriteBatch;
+
             int writes = 0;
             int skipped = 0;
-            if (BlockChange.EstimatedSize < PatriciaTree.MinEntriesToParallelizeThreshold)
-            {
-                foreach (var kvp in BlockChange)
-                {
-                    byte[] after = kvp.Value.After;
-                    if (!Bytes.AreEqual(kvp.Value.Before, after) || kvp.Value.IsInitialValue)
-                    {
-                        BlockChange[kvp.Key] = new(after, after);
-                        _backend.Set(kvp.Key, after);
-                        writes++;
-                    }
-                    else
-                    {
-                        skipped++;
-                    }
-                }
-            }
-            else
-            {
-                using IWorldStateScopeProvider.IStorageSetter setter = _backend.BeginSet(BlockChange.EstimatedSize);
 
-                foreach (var kvp in BlockChange)
-                {
-                    byte[] after = kvp.Value.After;
-                    if (!Bytes.AreEqual(kvp.Value.Before, after) || kvp.Value.IsInitialValue)
-                    {
-                        BlockChange[kvp.Key] = new(after, after);
-                        setter.Set(kvp.Key, after);
-
-                        writes++;
-                    }
-                    else
-                    {
-                        skipped++;
-                    }
-                }
+            if (BlockChange.HasClear)
+            {
+                storageWriteBatch.Clear();
+                BlockChange.UnmarkClear(); // Note: Until the storage write batch is disposed, this BlockCache will pass read through the uncleared storage tree
             }
 
-            if (writes > 0)
+            foreach (var kvp in BlockChange)
             {
-                _backend.UpdateRootHash(canBeParallel: writes > 64);
+                byte[] after = kvp.Value.After;
+                if (!Bytes.AreEqual(kvp.Value.Before, after) || kvp.Value.IsInitialValue)
+                {
+                    BlockChange[kvp.Key] = new(after, after);
+                    storageWriteBatch.Set(kvp.Key, after);
+
+                    writes++;
+                }
+                else
+                {
+                    skipped++;
+                }
             }
 
             return (writes, skipped);

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -606,7 +606,7 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
 
         public void RemoveStorageTree()
         {
-            StorageTree = null;
+            _backend = null;
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -571,63 +571,63 @@ namespace Nethermind.State
                         break;
                     case ChangeType.Touch:
                     case ChangeType.Update:
-                    {
-                        if (releaseSpec.IsEip158Enabled && change.Account.IsEmpty && !isGenesis)
                         {
-                            if (isTracing) TraceRemoveEmpty(change);
-                            SetState(change.Address, null);
-                            trace?.AddToTrace(change.Address, null);
-                        }
-                        else
-                        {
-                            if (isTracing) TraceUpdate(change);
-                            SetState(change.Address, change.Account);
-                            trace?.AddToTrace(change.Address, change.Account);
-                        }
+                            if (releaseSpec.IsEip158Enabled && change.Account.IsEmpty && !isGenesis)
+                            {
+                                if (isTracing) TraceRemoveEmpty(change);
+                                SetState(change.Address, null);
+                                trace?.AddToTrace(change.Address, null);
+                            }
+                            else
+                            {
+                                if (isTracing) TraceUpdate(change);
+                                SetState(change.Address, change.Account);
+                                trace?.AddToTrace(change.Address, change.Account);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case ChangeType.New:
-                    {
-                        if (!releaseSpec.IsEip158Enabled || !change.Account.IsEmpty || isGenesis)
+                        {
+                            if (!releaseSpec.IsEip158Enabled || !change.Account.IsEmpty || isGenesis)
+                            {
+                                if (isTracing) TraceCreate(change);
+                                SetState(change.Address, change.Account);
+                                trace?.AddToTrace(change.Address, change.Account);
+                            }
+
+                            break;
+                        }
+                    case ChangeType.RecreateEmpty:
                         {
                             if (isTracing) TraceCreate(change);
                             SetState(change.Address, change.Account);
                             trace?.AddToTrace(change.Address, change.Account);
+
+                            break;
                         }
-
-                        break;
-                    }
-                    case ChangeType.RecreateEmpty:
-                    {
-                        if (isTracing) TraceCreate(change);
-                        SetState(change.Address, change.Account);
-                        trace?.AddToTrace(change.Address, change.Account);
-
-                        break;
-                    }
                     case ChangeType.Delete:
-                    {
-                        if (isTracing) TraceRemove(change);
-                        bool wasItCreatedNow = false;
-                        while (stack.Count > 0)
                         {
-                            int previousOne = stack.Pop();
-                            wasItCreatedNow |= _changes[previousOne].ChangeType == ChangeType.New;
-                            if (wasItCreatedNow)
+                            if (isTracing) TraceRemove(change);
+                            bool wasItCreatedNow = false;
+                            while (stack.Count > 0)
                             {
-                                break;
+                                int previousOne = stack.Pop();
+                                wasItCreatedNow |= _changes[previousOne].ChangeType == ChangeType.New;
+                                if (wasItCreatedNow)
+                                {
+                                    break;
+                                }
                             }
-                        }
 
-                        if (!wasItCreatedNow)
-                        {
-                            SetState(change.Address, null);
-                            trace?.AddToTrace(change.Address, null);
-                        }
+                            if (!wasItCreatedNow)
+                            {
+                                SetState(change.Address, null);
+                                trace?.AddToTrace(change.Address, null);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     default:
                         ThrowUnknownChangeType();
                         break;

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -8,7 +8,6 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
-using Nethermind.Evm.State;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie;
@@ -16,7 +15,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State
 {
-    public class StateTree : PatriciaTree, IWorldStateScopeProvider.IStateTree
+    public class StateTree : PatriciaTree
     {
         private readonly AccountDecoder _decoder = new();
 
@@ -75,12 +74,12 @@ namespace Nethermind.State
             Set(keccak.BytesAsSpan, account is null ? null : account.IsTotallyEmpty ? EmptyAccountRlp : Rlp.Encode(account));
         }
 
-        public IWorldStateScopeProvider.IStateSetter BeginSet(int estimatedEntries)
+        public StateTreeBulkSetter BeginSet(int estimatedEntries)
         {
             return new StateTreeBulkSetter(estimatedEntries, this);
         }
 
-        private class StateTreeBulkSetter(int estimatedEntries, StateTree tree) : IWorldStateScopeProvider.IStateSetter
+        public class StateTreeBulkSetter(int estimatedEntries, StateTree tree) : IDisposable
         {
             ArrayPoolList<PatriciaTree.BulkSetEntry> _bulkWrite = new(estimatedEntries);
 

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -137,6 +137,8 @@ namespace Nethermind.State
             RootHash = EmptyTreeHash;
         }
 
+        public bool WasEmptyTree => RootHash == EmptyTreeHash;
+
         public byte[] Get(in UInt256 index)
         {
             return Get(index, null);
@@ -165,29 +167,6 @@ namespace Nethermind.State
                 Span<byte> key = stackalloc byte[32];
                 ComputeKey(index, key);
                 SetInternal(key, value);
-            }
-        }
-
-        public IWorldStateScopeProvider.IStorageSetter BeginSet(int estimatedEntries)
-        {
-            return new StorageTreeBulkSetter(estimatedEntries, this);
-        }
-
-        private class StorageTreeBulkSetter(int estimatedEntries, StorageTree storageTree) : IWorldStateScopeProvider.IStorageSetter
-        {
-            ArrayPoolList<PatriciaTree.BulkSetEntry> _bulkWrite = new(estimatedEntries);
-            private ValueHash256 _keyBuff = new ValueHash256();
-
-            public void Set(in UInt256 index, byte[] value)
-            {
-                StorageTree.ComputeKeyWithLookup(index, _keyBuff.BytesAsSpan);
-                _bulkWrite.Add(StorageTree.CreateBulkSetEntry(_keyBuff, value));
-            }
-
-            public void Dispose()
-            {
-                storageTree.BulkSet(_bulkWrite);
-                _bulkWrite.Dispose();
             }
         }
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -2,15 +2,22 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.State;
+using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
+using NonBlocking;
 
 namespace Nethermind.State;
 
@@ -19,7 +26,6 @@ public class TrieStoreScopeProvider : IWorldStateScopeProvider
     private readonly ITrieStore _trieStore;
     private readonly ILogManager _logManager;
     protected StateTree _backingStateTree;
-    private readonly Dictionary<AddressAsKey, StorageTree> _storages = new();
     private readonly KeyValueWithBatchingBackedCodeDb _codeDb;
 
     public TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatching codeDb, ILogManager logManager)
@@ -46,13 +52,7 @@ public class TrieStoreScopeProvider : IWorldStateScopeProvider
         var trieStoreCloser = _trieStore.BeginScope(baseBlock);
         _backingStateTree.RootHash = baseBlock?.StateRoot ?? Keccak.EmptyTreeHash;
 
-        return new TrieStoreWorldStateBackendScope(_backingStateTree, this, _codeDb, trieStoreCloser);
-    }
-
-    private void Reset()
-    {
-        _backingStateTree.RootHash = Keccak.EmptyTreeHash;
-        _storages.Clear();
+        return new TrieStoreWorldStateBackendScope(_backingStateTree, this, _codeDb, trieStoreCloser, _logManager);
     }
 
     protected virtual StorageTree CreateStorageTree(Address address)
@@ -61,68 +61,185 @@ public class TrieStoreScopeProvider : IWorldStateScopeProvider
         return new StorageTree(_trieStore.GetTrieStore(address), storageRoot, _logManager);
     }
 
-    private IWorldStateScopeProvider.IStorageTree CreateAndTrackStorageTree(Address address)
-    {
-        if (_storages.TryGetValue(address, out var storageTree))
-        {
-            return storageTree;
-        }
-
-        storageTree = CreateStorageTree(address);
-        _storages[address] = storageTree;
-        return storageTree;
-    }
-
-    private void Commit(long blockNumber)
-    {
-        using var blockCommitter = _trieStore.BeginBlockCommit(blockNumber);
-
-        // Note: These all runs in about 0.4ms. So the little overhead like attempting to sort the tasks
-        // may make it worst. Always check on mainnet.
-        using ArrayPoolList<Task> commitTask = new ArrayPoolList<Task>(_storages.Count);
-        foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
-        {
-            if (blockCommitter.TryRequestConcurrencyQuota())
-            {
-                commitTask.Add(Task.Factory.StartNew((ctx) =>
-                {
-                    StorageTree st = (StorageTree)ctx;
-                    st.Commit();
-                    blockCommitter.ReturnConcurrencyQuota();
-                }, storage.Value));
-            }
-            else
-            {
-                storage.Value.Commit();
-            }
-        }
-
-        Task.WaitAll(commitTask.AsSpan());
-        _backingStateTree.Commit();
-
-        _storages.Clear();
-    }
-
-    private class TrieStoreWorldStateBackendScope(StateTree backingStateTree, TrieStoreScopeProvider scopeProvider, IWorldStateScopeProvider.ICodeDb codeDb, IDisposable trieStoreCloser) : IWorldStateScopeProvider.IScope
+    private class TrieStoreWorldStateBackendScope : IWorldStateScopeProvider.IScope
     {
         public void Dispose()
         {
-            trieStoreCloser.Dispose();
-            scopeProvider.Reset();
+            _trieStoreCloser.Dispose();
+            _backingStateTree.RootHash = Keccak.EmptyTreeHash;
+            _storages.Clear();
         }
 
-        public IWorldStateScopeProvider.IStateTree StateTree => backingStateTree;
+        public Hash256 RootHash => _backingStateTree.RootHash;
+        public void UpdateRootHash() => _backingStateTree.UpdateRootHash();
+        public Account? Get(Address address) => _backingStateTree.Get(address);
 
-        public IWorldStateScopeProvider.ICodeDb CodeDb => codeDb;
+        public IWorldStateScopeProvider.ICodeDb CodeDb => _codeDb1;
 
-        public IWorldStateScopeProvider.IStorageTree CreateStorageTree(Address address)
+        internal StateTree _backingStateTree;
+        private readonly Dictionary<AddressAsKey, StorageTree> _storages = new();
+        private readonly TrieStoreScopeProvider _scopeProvider;
+        private readonly IWorldStateScopeProvider.ICodeDb _codeDb1;
+        private readonly IDisposable _trieStoreCloser;
+        private readonly ILogManager _logManager;
+
+        public TrieStoreWorldStateBackendScope(StateTree backingStateTree, TrieStoreScopeProvider scopeProvider, IWorldStateScopeProvider.ICodeDb codeDb, IDisposable trieStoreCloser, ILogManager logManager)
         {
-            return scopeProvider.CreateAndTrackStorageTree(address);
+            _backingStateTree = backingStateTree;
+            _logManager = logManager;
+            _scopeProvider = scopeProvider;
+            _codeDb1 = codeDb;
+            _trieStoreCloser = trieStoreCloser;
+        }
+
+        public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNumber, Action<Address, Account> onAccountUpdated)
+        {
+            return new WorldStateWriteBatch(this, estimatedAccountNumber, onAccountUpdated, _logManager.GetClassLogger<WorldStateWriteBatch>());
         }
 
         public void Commit(long blockNumber)
         {
-            scopeProvider.Commit(blockNumber);
+            using var blockCommitter = _scopeProvider._trieStore.BeginBlockCommit(blockNumber);
+
+            // Note: These all runs in about 0.4ms. So the little overhead like attempting to sort the tasks
+            // may make it worst. Always check on mainnet.
+            using ArrayPoolList<Task> commitTask = new ArrayPoolList<Task>(_storages.Count);
+            foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
+            {
+                if (blockCommitter.TryRequestConcurrencyQuota())
+                {
+                    commitTask.Add(Task.Factory.StartNew((ctx) =>
+                    {
+                        StorageTree st = (StorageTree)ctx;
+                        st.Commit();
+                        blockCommitter.ReturnConcurrencyQuota();
+                    }, storage.Value));
+                }
+                else
+                {
+                    storage.Value.Commit();
+                }
+            }
+
+            Task.WaitAll(commitTask.AsSpan());
+            _backingStateTree.Commit();
+            _storages.Clear();
+        }
+
+        internal StorageTree LookupStorageTree(Address address)
+        {
+            if (_storages.TryGetValue(address, out var storageTree))
+            {
+                return storageTree;
+            }
+
+            storageTree = _scopeProvider.CreateStorageTree(address);
+            _storages[address] = storageTree;
+            return storageTree;
+        }
+
+        public IWorldStateScopeProvider.IStorageTree CreateStorageTree(Address address)
+        {
+            return LookupStorageTree(address);
+        }
+    }
+
+    private class WorldStateWriteBatch(
+        TrieStoreWorldStateBackendScope scope,
+        int estimatedAccountCount,
+        Action<Address, Account>? onAccountUpdated,
+        ILogger logger) : IWorldStateScopeProvider.IWorldStateWriteBatch
+    {
+        private readonly Dictionary<AddressAsKey, Account?> _dirtyAccounts = new(estimatedAccountCount);
+        private readonly ConcurrentQueue<(AddressAsKey, Hash256)> _dirtyStorageTree = new();
+
+        public void Set(Address key, Account? account)
+        {
+            _dirtyAccounts[key] = account;
+        }
+
+        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address address, int estimatedEntries)
+        {
+            return new StorageTreeBulkWriteBatch(estimatedEntries, scope.LookupStorageTree(address), this, address);
+        }
+
+        public void MarkDirty(AddressAsKey address, Hash256 storageTreeRootHash)
+        {
+            _dirtyStorageTree.Enqueue((address, storageTreeRootHash));
+        }
+
+        public void Dispose()
+        {
+            while (_dirtyStorageTree.TryDequeue(out var entry))
+            {
+                (AddressAsKey key, Hash256 storageRoot) = entry;
+                Account account = _dirtyAccounts.GetValueOrDefault(key)
+                                  ?? scope.Get(key)
+                                  ?? ThrowNullAccount(key);
+
+                account = account!.WithChangedStorageRoot(storageRoot);
+                _dirtyAccounts[key] = account;
+                onAccountUpdated?.Invoke(key, account);
+                Trace(key, storageRoot, account);
+            }
+
+            using (var stateSetter = scope._backingStateTree.BeginSet(_dirtyAccounts.Count))
+            {
+                foreach (var kv in _dirtyAccounts)
+                {
+                    stateSetter.Set(kv.Key, kv.Value);
+                }
+            }
+
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Trace(Address address, Hash256 storageRoot, Account account)
+                => logger.Trace($"Update {address} S {account.StorageRoot} -> {storageRoot}");
+
+            [DoesNotReturn, StackTraceHidden]
+            static Account ThrowNullAccount(Address address)
+                => throw new InvalidOperationException($"Account {address} is null when updating storage hash");
+        }
+    }
+
+    private class StorageTreeBulkWriteBatch(int estimatedEntries, StorageTree storageTree, WorldStateWriteBatch worldStateWriteBatch, AddressAsKey address) : IWorldStateScopeProvider.IStorageWriteBatch
+    {
+        private bool _hasSelfDestruct;
+        private bool _wasSetCalled = false;
+
+        ArrayPoolList<PatriciaTree.BulkSetEntry> _bulkWrite = new(estimatedEntries);
+        private ValueHash256 _keyBuff = new ValueHash256();
+
+        public void Set(in UInt256 index, byte[] value)
+        {
+            StorageTree.ComputeKeyWithLookup(index, _keyBuff.BytesAsSpan);
+            _bulkWrite.Add(StorageTree.CreateBulkSetEntry(_keyBuff, value));
+        }
+
+        public void Clear()
+        {
+            if (_wasSetCalled) throw new InvalidOperationException("Must call clear first in a storage write batch");
+            _hasSelfDestruct = false;
+        }
+
+        public void Dispose()
+        {
+            bool hasSet = false;
+            if (_hasSelfDestruct)
+            {
+                hasSet = true;
+                storageTree.RootHash = Keccak.EmptyTreeHash;
+            }
+            storageTree.BulkSet(_bulkWrite);
+            if (_bulkWrite.Count > 0) hasSet = true;
+
+            if (hasSet)
+            {
+                storageTree.UpdateRootHash(_bulkWrite.Count > 64);
+                worldStateWriteBatch.MarkDirty(address, storageTree.RootHash);
+            }
+
+            _bulkWrite.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -1109,7 +1109,7 @@ namespace Nethermind.Trie.Test
                 }
                 else
                 {
-                    accounts[i] = TestItem.GenerateRandomAccount();
+                    accounts[i] = TestItem.GenerateRandomAccount(_random);
                 }
 
                 addresses[i] = TestItem.GetRandomAddress(_random);


### PR DESCRIPTION
Require #9089 

- Make the interface nicer and more future proof.
- Remove `IStateTree`, storage root and update storage root. 
- Comes at a downside of an additional dictionary and concurrent queue. 
- All set goes through a single write batch. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- [x] Mainnet can sync
- [ ] Sepolia era replay
- [ ] Mainnet era replay.