### PR TITLE
Disable `Flashbots` module by default

### DIFF
--- a/src/Nethermind/Nethermind.Flashbots/Flashbots.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Flashbots.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Nethermind.Api.Extensions;
@@ -29,7 +27,6 @@ public class FlashbotsModule(IFlashbotsConfig flashbotsConfig, IJsonRpcConfig js
     protected override void Load(ContainerBuilder builder)
     {
         base.Load(builder);
-        jsonRpcConfig.EnabledModules = jsonRpcConfig.EnabledModules.Append(ModuleType.Flashbots).ToArray();
 
         builder
             .RegisterSingletonJsonRpcModule<IRbuilderRpcModule, RbuilderRpcModule>()

--- a/src/Nethermind/Nethermind.Flashbots/FlashbotsConfig.cs
+++ b/src/Nethermind/Nethermind.Flashbots/FlashbotsConfig.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Flashbots;
 
 public class FlashbotsConfig : IFlashbotsConfig
 {
-    public bool Enabled { get; set; } = true;
+    public bool Enabled { get; set; } = false;
     public bool UseBalanceDiffProfit { get; set; } = false;
 
     public bool ExcludeWithdrawals { get; set; } = false;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
@@ -31,33 +31,6 @@ namespace Nethermind.JsonRpc.Modules
         public const string Rpc = nameof(Rpc);
         public const string Rbuilder = nameof(Rbuilder);
 
-        public static IEnumerable<string> AllBuiltInModules { get; } = new List<string>()
-        {
-            Admin,
-            Clique,
-            Engine,
-            Db,
-            Debug,
-            Erc20,
-            Eth,
-            Evm,
-            Flashbots,
-            Net,
-            Nft,
-            Parity,
-            Personal,
-            Proof,
-            Subscribe,
-            Trace,
-            TxPool,
-            Web3,
-            Vault,
-            Deposit,
-            Health,
-            Rpc,
-            Rbuilder,
-        };
-
         public static IEnumerable<string> DefaultModules { get; } = new List<string>()
         {
             Eth,


### PR DESCRIPTION
## Changes

- Disable the Flashbots module and it's associated RPC endpoints (`flashbots`, `rbuilder`) by default. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested a couple of configs to verify that the module is not being loaded or any RPC method is added.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

We should not need to update anything since the docs are generated from configuration attributes, which listed the Flashbot module as disabled by default (this was actually not the case though).

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Despite the config listing Flashbots as a disabled module by default, our code actually enabled it. This PR disables the plugin by default.

To explicitly enable the plugin include the flag `--Flashbots.Enabled=true`. Also, to enable the RPC endpoints include `--JsonRpc.EnabledModules=flashbots,rbuilder,...` as appropriate (it could be argued that enabling the plugin should automatically include the RPC endpoints though).