### PR TITLE
Add support for block producer based on global world state instance.

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Consensus.Producers
     /// </summary>
     public abstract class BlockProducerBase : IBlockProducer
     {
-        private IBlockchainProcessor Processor { get; }
+        protected IBlockchainProcessor Processor { get; }
         protected IBlockTree BlockTree { get; }
         private ITimestamper Timestamper { get; }
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.State;
+
+namespace Nethermind.Consensus.Producers
+{
+    /// <summary>
+    /// Block producer environment factory that uses the global world state and stores receipts by default.
+    /// It will not trigger suggesting produced blocks.
+    /// </summary>
+    /// <param name="rootLifetime"></param>
+    /// <param name="worldStateManager"></param>
+    /// <param name="txSourceFactory"></param>
+    public class GlobalWorldStateBlockProducerEnvFactory(
+        ILifetimeScope rootLifetime,
+        IWorldStateManager worldStateManager,
+        IBlockProducerTxSourceFactory txSourceFactory)
+        : IBlockProducerEnvFactory
+    {
+        protected virtual ContainerBuilder ConfigureBuilder(ContainerBuilder builder) => builder
+            .AddScoped<ITxSource>(txSourceFactory.Create())
+            .AddScoped(BlockchainProcessor.Options.Default)
+            .AddScoped<ITransactionProcessorAdapter, BuildUpTransactionProcessorAdapter>()
+            .AddScoped<IBlockProcessor.IBlockTransactionsExecutor, BlockProcessor.BlockProductionTransactionsExecutor>()
+            .AddDecorator<IWithdrawalProcessor, BlockProductionWithdrawalProcessor>()
+            .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
+            .AddScoped<IProducedBlockSuggester, NoOpProducedBlockSuggester>()
+
+            .AddScoped<IBlockProducerEnv, BlockProducerEnv>();
+
+        public virtual IBlockProducerEnv Create()
+        {
+            ILifetimeScope lifetimeScope = rootLifetime.BeginLifetimeScope(builder =>
+                ConfigureBuilder(builder)
+                    .AddScoped(worldStateManager.GlobalWorldState));
+
+            rootLifetime.Disposer.AddInstanceForAsyncDisposal(lifetimeScope);
+            return lifetimeScope.Resolve<IBlockProducerEnv>();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Producers/IProducedBlockSuggester.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/IProducedBlockSuggester.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Consensus.Producers;
+
+public interface IProducedBlockSuggester : IDisposable
+{
+    // Just a marker interface to support DI
+}

--- a/src/Nethermind/Nethermind.Consensus/Producers/NoOpProducedBlockSuggester.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/NoOpProducedBlockSuggester.cs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Consensus.Producers;
+public class NoOpProducedBlockSuggester : IProducedBlockSuggester
+{
+    public void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.Consensus/Producers/ProducedBlockSuggester.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/ProducedBlockSuggester.cs
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 
 namespace Nethermind.Consensus.Producers
 {
-    public class ProducedBlockSuggester : IDisposable
+    public class ProducedBlockSuggester : IProducedBlockSuggester
     {
         private readonly IBlockTree _blockTree;
         private readonly IBlockProducerRunner _blockProducerRunner;

--- a/src/Nethermind/Nethermind.Init/Steps/StartBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartBlockProducer.cs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Threading;
-using System.Threading.Tasks;
+using Autofac;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Consensus.Producers;
 using Nethermind.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nethermind.Init.Steps
 {
@@ -30,8 +31,7 @@ namespace Nethermind.Init.Steps
 
                 ILogger logger = _api.LogManager.GetClassLogger();
                 if (logger.IsInfo) logger.Info($"Starting {_api.SealEngineType} block producer & sealer");
-                ProducedBlockSuggester suggester = new(_api.BlockTree, _api.BlockProducerRunner);
-                _api.DisposeStack.Push(suggester);
+                _api.Context.ResolveOptional<IProducedBlockSuggester>();
                 _api.BlockProducerRunner.Start();
             }
 


### PR DESCRIPTION
Fixes Closes Resolves #

## Changes

Adds support for block producer based on global world state instance. Assumptions are:
- block producing on `GlobalWorldState`
- receipts are stored on default storage (persistent instead on `NullReceiptStorage`)
- Block production doesn't trigger block being suggested to block tree (and subsequently validated) for pre-merge chains

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
