### PR TITLE
Make ExecutePrecompile overridable instead of RunPrecompile

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -763,7 +763,7 @@ public unsafe partial class VirtualMachine(
     /// A <see cref="CallResult"/> containing the results of the precompile execution. In case of a failure,
     /// returns the default value of <see cref="CallResult"/>.
     /// </returns>
-    protected CallResult ExecutePrecompile(EvmState currentState, bool isTracingActions, out Exception? failure)
+    protected virtual CallResult ExecutePrecompile(EvmState currentState, bool isTracingActions, out Exception? failure)
     {
         // Report the precompile action if tracing is enabled.
         if (isTracingActions)
@@ -971,7 +971,7 @@ public unsafe partial class VirtualMachine(
         SSTORE
     }
 
-    protected virtual CallResult RunPrecompile(EvmState state)
+    private CallResult RunPrecompile(EvmState state)
     {
         ReadOnlyMemory<byte> callData = state.Env.InputData;
         UInt256 transferValue = state.Env.TransferValue;


### PR DESCRIPTION
For Arbitrum, we actually want to override `ExecutePrecompile()` because precompiles can both revert and fail (without reverting) impacting any returned output as well as any gas refund (to sender if top-level, or to calling contract if nested call).

See [Arbitrum PR](https://github.com/NethermindEth/nethermind-arbitrum/pull/279)

For example, one case where the base implementation of `ExecutePrecompile()` does not work for Arbitrum: anytime a precompile reverts (not an ungraceful failure). The base implem will either set the result as a failure (not a revert) or will set the gas left as 0 (no refund).

I guess it's normal behaviour for Ethereum as it's been working so far, but i thought reverting ethereum precompiles would refund caller..?

Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
