### PR TITLE
cleanup: Remove unused imports from AccountException

### DIFF
--- a/tools/SendBlobs/AccountException.cs
+++ b/tools/SendBlobs/AccountException.cs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SendBlobs;
 internal class AccountException : Exception


### PR DESCRIPTION
## Changes

- Remove unused `using` statements from `AccountException.cs` in SendBlobs tool
- Clean up `System.Runtime.Serialization` import left after serialization constructor removal in PR #7579
- Remove dead imports that were never used: `System.Collections.Generic`, `System.Linq`, `System.Text`, `System.Threading.Tasks`
- Keep only required `System` import for `Exception` base class

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization  
- [x] Refactoring

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No