### PR TITLE
Fix excess blob gas

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
@@ -286,7 +286,7 @@ public class SimulateBridgeHelper(IBlocksConfig blocksConfig, ISpecProvider spec
             result.BaseFeePerGas = 0;
         }
 
-        result.ExcessBlobGas = spec.IsEip4844Enabled ? BlobGasCalculator.CalculateExcessBlobGas(parent, spec) : (ulong?)0;
+        result.ExcessBlobGas = spec.IsEip4844Enabled ? BlobGasCalculator.CalculateExcessBlobGas(parent, spec) : null;
 
         block.BlockOverrides?.ApplyOverrides(result);
 


### PR DESCRIPTION
Fixes Closes Resolves #
`eth_simulateV1/ethSimulate-empty-with-block-num-set-firstblock (nethermind)`

It was supposed to lend in #9406, but I accidentally reverted it 
#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
