### PR TITLE
Update Dockerfiles automatically

### DIFF
--- a/.github/workflows/update-dockerfiles.yml
+++ b/.github/workflows/update-dockerfiles.yml
@@ -31,24 +31,24 @@ jobs:
           sdk_version=$(echo "$manifest" | jq -r '."latest-sdk"')
 
           # Get the digests for the specified tags
-          runtime_chiseled_tag=$runtime_version-noble-chiseled
-          runtime_chiseled_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/aspnet:$runtime_chiseled_tag --no-tags | jq -r '.Digest')
+          runtime_chiseled_tag=${runtime_version}-noble-chiseled
+          runtime_chiseled_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/aspnet:${runtime_chiseled_tag} --no-tags | jq -r '.Digest')
 
-          runtime_tag=$runtime_version-noble
-          runtime_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/aspnet:$runtime_tag --no-tags | jq -r '.Digest')
+          runtime_tag=${runtime_version}-noble
+          runtime_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/aspnet:${runtime_tag} --no-tags | jq -r '.Digest')
 
-          sdk_tag=$sdk_version-noble
-          sdk_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/sdk:$sdk_tag --no-tags | jq -r '.Digest')
+          sdk_tag=${sdk_version}-noble
+          sdk_digest=$(skopeo inspect docker://mcr.microsoft.com/dotnet/sdk:${sdk_tag} --no-tags | jq -r '.Digest')
 
           # Update Dockerfiles
           for file in "Dockerfile" "Dockerfile.chiseled" "scripts/build/Dockerfile"; do
-            sed -i "s|\(mcr\.microsoft\.com/dotnet/sdk:\)[^[:space:]]*|\1$sdk_tag@$sdk_digest|" "$file"
+            sed -i "s|\(mcr\.microsoft\.com/dotnet/sdk:\)[^[:space:]]*|\1${sdk_tag}@${sdk_digest}|" "$file"
           done
 
           runtime_pattern="\(mcr\.microsoft\.com/dotnet/aspnet:\)[^[:space:]]*"
 
-          sed -i "s|$runtime_pattern|\1$runtime_tag@$runtime_digest|" Dockerfile
-          sed -i "s|$runtime_pattern|\1$runtime_chiseled_tag@$runtime_chiseled_digest|" Dockerfile.chiseled
+          sed -i "s|${runtime_pattern}|\1${runtime_tag}@${runtime_digest}|" Dockerfile
+          sed -i "s|${runtime_pattern}|\1${runtime_chiseled_tag}@${runtime_chiseled_digest}|" Dockerfile.chiseled
 
           # Get the number of modified files
           file_count=$(git status --porcelain | wc -l)
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           head_branch=chore/update-dockerfiles-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT
-          body=$(cat <<'EOF'
+          body=$(cat <<EOF
           Updated Dockerfiles to use the latest versions of .NET $DOTNET_VERSION SDK and runtime.
 
           To verify manually, see:


### PR DESCRIPTION
This is a follow-up to #9365. Since our Dockerfiles now have a hardcoded full version of .NET and an image digest for reproducible builds, we need a way to automate their update. Doing it manually is error-prone and prone to forgetting, which may cause unpredictable issues later.

## Changes

- Added a new workflow to update Dockerfiles with the latest digests and versions available. It creates a PR with changes, if any.
- The workflow runs automatically every midnight. Such a frequency is needed to be on par with that of GitHub Actions. If required, it can be triggered manually as well.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually
