### PR TITLE
Restrict IPC socket to owner-only mode if set

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -53,7 +53,7 @@ public interface IJsonRpcConfig : IConfig
     [ConfigItem(Description = "The path to connect a UNIX domain socket over.")]
     string IpcUnixDomainSocketPath { get; set; }
 
-    [ConfigItem(Description = "Should Owner-only access be applied to IPC socket.", DefaultValue = "true")]
+    [ConfigItem(Description = "Should Owner-only 600 (rw-------) access be applied to IPC socket file path.", DefaultValue = "true")]
     bool RestrictIpcSocketPermissions { get; set; }
 
     [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -53,7 +53,7 @@ public interface IJsonRpcConfig : IConfig
     [ConfigItem(Description = "The path to connect a UNIX domain socket over.")]
     string IpcUnixDomainSocketPath { get; set; }
 
-    [ConfigItem(Description = "Should Owner-only 600 (rw-------) access be applied to IPC socket file path.", DefaultValue = "true")]
+    [ConfigItem(Description = "Whether to set the IPC socket UNIX file permissions to owner-only (600).", DefaultValue = "true")]
     bool RestrictIpcSocketPermissions { get; set; }
 
     [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -53,6 +53,9 @@ public interface IJsonRpcConfig : IConfig
     [ConfigItem(Description = "The path to connect a UNIX domain socket over.")]
     string IpcUnixDomainSocketPath { get; set; }
 
+    [ConfigItem(Description = "Should Owner-only access be applied to IPC socket.", DefaultValue = "true")]
+    bool RestrictIpcSocketPermissions { get; set; }
+
     [ConfigItem(
         Description = """
             An array of JSON-RPC namespaces to enable. For instance, `[debug,eth]`.

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -31,6 +31,8 @@ public class JsonRpcConfig : IJsonRpcConfig
 
     public string? IpcUnixDomainSocketPath { get; set; } = null;
 
+    public bool RestrictIpcSocketPermissions { get; set; } = true;
+
     public string[] EnabledModules
     {
         get => _enabledModules;

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -115,7 +115,7 @@ namespace Nethermind.Runner.JsonRpc
             }
             catch (Exception ex)
             {
-                if (_logger.IsWarn) _logger.Warn($"Failed to set restrictive permissions on IPC socket at {path}: {ex.Message}");
+                if (_logger.IsWarn) _logger.Warn($"Failed to set restrictive permissions on IPC socket at {path}: {ex}");
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -106,7 +106,7 @@ namespace Nethermind.Runner.JsonRpc
                 }
                 else if (OperatingSystem.IsWindows())
                 {
-                    if (_logger.IsTrace) _logger.Trace("IPC socket on Windows uses named pipes with OS-level access control; skipping Unix permission setting.");
+                    if (_logger.IsTrace) _logger.Trace("IPC socket on Windows does not support Unix file permission bits; skipping permission restriction.");
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Runner.JsonRpc
             {
                 if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
                 {
-                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); // 600 (rw-------)
+                    _fileSystem.File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); // 600 (rw-------)
 
                     if (_logger.IsTrace) _logger.Trace($"Restricted IPC socket permissions to 600 at {path}.");
                 }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -92,7 +92,7 @@ namespace Nethermind.Runner.JsonRpc
         {
             if (!_jsonRpcConfig.RestrictIpcSocketPermissions)
             {
-                if (_logger.IsTrace) _logger.Trace("IPC socket permission restriction disabled by configuration.");
+                if (_logger.IsWarn) _logger.Warn("IPC socket permission restriction is disabled by configuration. Any local user can connect to the IPC socket.");
                 return;
             }
 


### PR DESCRIPTION
## Changes

- Adds owner-only mode restriction for IPC socket for better safety. Makes it configurable so other users process can access IPC if needed.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Other: security hardening

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

## Documentation

#### Requires documentation update

- [x] Yes

#### Requires explanation in Release Notes

- [x] Yes

We are changing default behavior so only owner of Nethermind process has IPC access. This can be changed with `JsonRpc.RestrictIpcSocketPermissions false` flag to bring back previous behavior where any process on the machine can interact with Nethermind process through IPC.

## Remarks

If multiple users share the same machine (e.g., in shared hosting, CI/CD, or containerized environments), another user could:
- Open the socket directly,
- Call JSON-RPC methods like personal_listAccounts or admin_*,
- Potentially control the node or extract sensitive data.

Restricting the socket’s permissions ensures that only the node’s owner process (and root) can connect.