### PR TITLE
Remove redundant `--lock-file-path` option

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -34,9 +34,7 @@ jobs:
           cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Install dependencies
-        run: |
-          dotnet restore src/Nethermind/${{ matrix.solution }}.slnx --locked-mode \
-            --lock-file-path src/Nethermind/Nethermind.Runner/packages.lock.json
+        run: dotnet restore src/Nethermind/${{ matrix.solution }}.slnx --locked-mode
 
       - name: Build ${{ matrix.solution }}.slnx
         run: dotnet build src/Nethermind/${{ matrix.solution }}.slnx -c ${{ matrix.config }} --no-restore


### PR DESCRIPTION
## Changes

Removed the `--lock-file-path` option introduced in #9365 to fix the dependency restoration behavior in the solutions build tests.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Tested manually
