### PR TITLE
Use RawTrieStore in StatelessEnv

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -41,8 +41,7 @@ public class StatelessBlockProcessingEnv(
     public IWorldState WorldState
     {
         get => _worldState ??= new WorldState(
-            new TrieStore(witness.NodeStorage, NoPruning.Instance, NoPersistence.Instance, new PruningConfig(),
-                logManager),
+            new RawTrieStore(witness.NodeStorage),
             witness.CodeDb, logManager);
     }
 

--- a/src/Nethermind/Nethermind.Trie.Test/RawTrieStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/RawTrieStoreTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+public class RawTrieStoreTests
+{
+    [Test]
+    public void SmokeTest()
+    {
+        MemDb db = new MemDb();
+        PatriciaTree patriciaTree = new PatriciaTree(new RawTrieStore(db).GetTrieStore(null), LimboLogs.Instance);
+
+        patriciaTree.Set(TestItem.KeccakA.Bytes, TestItem.KeccakA.BytesToArray());
+        patriciaTree.Set(TestItem.KeccakB.Bytes, TestItem.KeccakB.BytesToArray());
+        patriciaTree.Set(TestItem.KeccakC.Bytes, TestItem.KeccakC.BytesToArray());
+
+        patriciaTree.Commit();
+        patriciaTree.RootHash.Should().NotBe(Keccak.EmptyTreeHash);
+
+        Hash256 rootHash = patriciaTree.RootHash;
+
+        // Recreate
+        patriciaTree = new PatriciaTree(new RawTrieStore(db).GetTrieStore(null), LimboLogs.Instance);
+        patriciaTree.RootHash = rootHash;
+
+        patriciaTree.Get(TestItem.KeccakA.Bytes).ToArray().Should().BeEquivalentTo(TestItem.KeccakA.BytesToArray());
+        patriciaTree.Get(TestItem.KeccakB.Bytes).ToArray().Should().BeEquivalentTo(TestItem.KeccakB.BytesToArray());
+        patriciaTree.Get(TestItem.KeccakC.Bytes).ToArray().Should().BeEquivalentTo(TestItem.KeccakC.BytesToArray());
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/RawTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/RawTrieStore.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Trie;
+
+/// <summary>
+/// Expose <see cref="ITrieStore"/> interface directly backed by <see cref="INodeStorage"/> without any pruning
+/// or buffering.
+/// </summary>
+/// <param name="nodeStorage"></param>
+public class RawTrieStore(INodeStorage nodeStorage) : IReadOnlyTrieStore
+{
+    public RawTrieStore(IKeyValueStoreWithBatching kv) : this(new NodeStorage(kv))
+    {
+    }
+
+    void IDisposable.Dispose()
+    {
+    }
+
+    public virtual ICommitter BeginCommit(Hash256? address, TrieNode? root, WriteFlags writeFlags)
+    {
+        return new RawScopedTrieStore.Committer(nodeStorage, address, writeFlags);
+    }
+
+    public TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256 hash)
+    {
+        return new TrieNode(NodeType.Unknown, hash);
+    }
+
+    public byte[]? LoadRlp(Hash256? address, in TreePath path, Hash256 hash, ReadFlags flags)
+    {
+        byte[]? ret = nodeStorage.Get(address, path, hash, flags);
+        if (ret is null) throw new MissingTrieNodeException("Node missing", address, path, hash);
+        return ret;
+    }
+
+    public byte[]? TryLoadRlp(Hash256? address, in TreePath path, Hash256 hash, ReadFlags flags)
+    {
+        return nodeStorage.Get(address, path, hash, flags);
+    }
+
+    public bool IsPersisted(Hash256? address, in TreePath path, in ValueHash256 keccak)
+    {
+        return nodeStorage.KeyExists(address, path, keccak);
+    }
+
+    public INodeStorage.KeyScheme Scheme { get; } = nodeStorage.Scheme;
+
+    public bool HasRoot(Hash256 stateRoot)
+    {
+        return nodeStorage.KeyExists(null, TreePath.Empty, stateRoot);
+    }
+
+    public IDisposable BeginScope(BlockHeader? baseBlock)
+    {
+        return new Reactive.AnonymousDisposable(() => { });
+    }
+
+    public IScopedTrieStore GetTrieStore(Hash256? address)
+    {
+        return new RawScopedTrieStore(nodeStorage, address);
+    }
+
+    public IBlockCommitter BeginBlockCommit(long blockNumber)
+    {
+        return NullCommitter.Instance;
+    }
+}


### PR DESCRIPTION
- Move TestRawTrieStore from test to prod.
- Use it for `StatelessBlockProcessingEnv`.
- This make it easy to modify triestore.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [X] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
