### PR TITLE
Fix: do not decompress keys in CompressingDb.GetAllKeys

### DIFF
--- a/src/Nethermind/Nethermind.Db/CompressingDb.cs
+++ b/src/Nethermind/Nethermind.Db/CompressingDb.cs
@@ -128,7 +128,7 @@ namespace Nethermind.Db
                 .Select(static kvp => new KeyValuePair<byte[], byte[]>(kvp.Key, Decompress(kvp.Value)));
 
             public IEnumerable<byte[]> GetAllKeys(bool ordered = false) =>
-                _wrapped.GetAllKeys(ordered).Select(Decompress);
+                _wrapped.GetAllKeys(ordered);
 
             public IEnumerable<byte[]> GetAllValues(bool ordered = false) =>
                 _wrapped.GetAllValues(ordered).Select(Decompress);


### PR DESCRIPTION
Problem: GetAllKeys applied Decompress to keys, but key compression is not part of the EOA compression wrapper; only values are compressed. This could introduce nulls into a method that must return non-nullable keys and corrupt key iteration semantics.