### PR TITLE
fix: RpcDb.Name to return actual database name

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Db.Rpc
         public long GetIndexSize() => 0;
         public long GetMemtableSize() => 0;
 
-        public string Name { get; } = "RpcDb";
+        public string Name => _dbName;
 
         public byte[] this[ReadOnlySpan<byte> key]
         {


### PR DESCRIPTION
Replace the hardcoded RpcDb.Name value with the actual database name passed via constructor so that logs and diagnostics accurately reflect the underlying DB or column being accessed; this removes ambiguity when multiple databases are in use, aligns with how DbTracker and metrics identify DBs by configured names, and is safe because no code relies on the literal “RpcDb” name while metrics continue to use DbSettings-based keys, resulting in improved observability without functional changes.