### PR TITLE
Make AuthorizationListForRpc.JsonConverter public for attribute-based activation

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
@@ -79,7 +79,7 @@ public class AuthorizationListForRpc : IEnumerable<RpcAuthTuple>
         return GetEnumerator();
     }
 
-    private class JsonConverter : JsonConverter<AuthorizationListForRpc>
+    public class JsonConverter : JsonConverter<AuthorizationListForRpc>
     {
         public override AuthorizationListForRpc? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {


### PR DESCRIPTION
System.Text.Json requires converter types referenced by [JsonConverter(typeof(...))] to be instantiable via reflection with a public parameterless constructor. A private nested converter prevents the runtime from creating the instance, risking deserialization failures. Aligning with the pattern used in AccessListForRpc, this change sets the nested converter to public to guarantee proper discovery and activation.