### PR TITLE
fix: CompositeTxTracer aggregates IsTracingLogs and gates ReportLog correctly

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -37,6 +37,7 @@ public class CompositeTxTracer : ITxTracer
             IsTracingStorage |= t.IsTracingStorage;
             IsTracingAccess |= t.IsTracingAccess;
             IsTracingFees |= t.IsTracingFees;
+            IsTracingLogs |= t.IsTracingLogs;
         }
     }
 
@@ -187,24 +188,12 @@ public class CompositeTxTracer : ITxTracer
         }
     }
 
-    public void ReportOperationLogs(LogEntry log)
-    {
-        for (int index = 0; index < _txTracers.Count; index++)
-        {
-            ITxTracer innerTracer = _txTracers[index];
-            if (innerTracer.IsTracingInstructions && innerTracer.IsTracingLogs)
-            {
-                innerTracer.ReportLog(log);
-            }
-        }
-    }
-
     public void ReportLog(LogEntry log)
     {
         for (int index = 0; index < _txTracers.Count; index++)
         {
             ITxTracer innerTracer = _txTracers[index];
-            if (innerTracer.IsTracingInstructions)
+            if (innerTracer.IsTracingLogs)
             {
                 innerTracer.ReportLog(log);
             }


### PR DESCRIPTION
This change aligns CompositeTxTracer with the ITxTracer contract and VM call sites by aggregating IsTracingLogs in the constructor and gating ReportLog by IsTracingLogs instead of IsTracingInstructions, which previously caused logs to be suppressed even when inner tracers enabled logging; also removed the unused public ReportOperationLogs method that is not part of the interface.