### PR TITLE
Fix incorrect BlockRangeUpdateMessage.EarliestBlock in some edge cases

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -292,7 +292,6 @@ public class InitializeNetwork : IStep
             _forkInfo,
             _api.GossipPolicy,
             _api.WorldStateManager!,
-            _api.BlockTree,
             _api.LogManager,
             _api.TxGossipPolicy);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -229,7 +229,6 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Container.Resolve<IForkInfo>(),
                 Substitute.For<IGossipPolicy>(),
                 WorldStateManager,
-                Substitute.For<IBlockFinder>(),
                 LimboLogs.Instance,
                 Substitute.For<ITxGossipPolicy>()
             );

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
@@ -54,7 +54,6 @@ public class Eth69ProtocolHandlerTests
     private Eth69ProtocolHandler _handler = null!;
     private ITxGossipPolicy _txGossipPolicy = null!;
     private ITimerFactory _timerFactory = null!;
-    private IBlockFinder _blockFinder = null!;
 
     [SetUp]
     public void Setup()
@@ -72,13 +71,12 @@ public class Eth69ProtocolHandlerTests
         _genesisBlock = Build.A.Block.Genesis.TestObject;
         _syncManager.Head.Returns(_genesisBlock.Header);
         _syncManager.Genesis.Returns(_genesisBlock.Header);
+        _syncManager.LowestBlock.Returns(0);
         _timerFactory = Substitute.For<ITimerFactory>();
         _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
         _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(true);
         _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
         _svc = Build.A.SerializationService().WithEth69(_specProvider).TestObject;
-        _blockFinder = Substitute.For<IBlockFinder>();
-        _blockFinder.GetLowestBlock().Returns(3);
         _handler = new Eth69ProtocolHandler(
             _session,
             _svc,
@@ -89,7 +87,6 @@ public class Eth69ProtocolHandlerTests
             _pooledTxsRequestor,
             _gossipPolicy,
             new ForkInfo(_specProvider, _syncManager),
-            _blockFinder,
             LimboLogs.Instance,
             _txGossipPolicy);
         _handler.Init();
@@ -280,7 +277,7 @@ public class Eth69ProtocolHandlerTests
             && m.Protocol == Protocol.Eth
             && m.GenesisHash == _genesisBlock.Hash
             && m.LatestBlockHash == _genesisBlock.Hash
-            && m.EarliestBlock == 3));
+            && m.EarliestBlock == 0));
     }
 
     private void HandleIncomingStatusMessage()

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -129,7 +129,6 @@ public class ProtocolsManagerTests
                 forkInfo,
                 _gossipPolicy,
                 Substitute.For<IWorldStateManager>(),
-                _blockTree,
                 LimboLogs.Instance);
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
-
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
@@ -38,7 +36,6 @@ public class Eth69ProtocolHandler(
     IPooledTxsRequestor pooledTxsRequestor,
     IGossipPolicy gossipPolicy,
     IForkInfo forkInfo,
-    IBlockFinder blockFinder,
     ILogManager logManager,
     ITxGossipPolicy? transactionsGossipPolicy = null)
     : Eth68ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool,
@@ -153,7 +150,7 @@ public class Eth69ProtocolHandler(
             NetworkId = SyncServer.NetworkId,
             GenesisHash = SyncServer.Genesis.Hash!,
             ForkId = _forkInfo.GetForkId(head.Number, head.Timestamp),
-            EarliestBlock = blockFinder.GetLowestBlock(),
+            EarliestBlock = SyncServer.LowestBlock,
             LatestBlock = head.Number,
             LatestBlockHash = head.Hash!
         };

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Autofac.Features.AttributeFilters;
-using Nethermind.Blockchain.Find;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Scheduler;
@@ -73,7 +72,6 @@ namespace Nethermind.Network
         private readonly HashSet<Capability> _capabilities = DefaultCapabilities.ToHashSet();
         private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
         private readonly ISnapServer? _snapServer;
-        private readonly IBlockFinder _blockFinder;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -90,7 +88,6 @@ namespace Nethermind.Network
             IForkInfo forkInfo,
             IGossipPolicy gossipPolicy,
             IWorldStateManager worldStateManager,
-            IBlockFinder blockFinder,
             ILogManager logManager,
             ITxGossipPolicy? transactionsGossipPolicy = null)
         {
@@ -110,7 +107,6 @@ namespace Nethermind.Network
             _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _snapServer = worldStateManager.SnapServer;
-            _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
             _logger = _logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
             _protocolFactories = GetProtocolFactories();
@@ -227,7 +223,7 @@ namespace Nethermind.Network
                         66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
                         67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
                         68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
-                        69 => new Eth69ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _blockFinder, _logManager, _txGossipPolicy),
+                        69 => new Eth69ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
                         _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
                     };
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -777,6 +777,14 @@ public class SyncServerTests
         ctx.SyncServer.GetNodeData(new[] { nodeKey }, CancellationToken.None, NodeDataType.All).Should().BeEquivalentTo(new[] { TestItem.KeccakB.BytesToArray() });
     }
 
+    [Test]
+    public void Correctly_clips_lowestBlock()
+    {
+        Context ctx = new();
+        ctx.BlockTree.GetLowestBlock().Returns(5);
+        ctx.SyncServer.LowestBlock.Should().Be(0);
+    }
+
     private class Context
     {
         public Context()

--- a/src/Nethermind/Nethermind.Synchronization/ISyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ISyncServer.cs
@@ -26,5 +26,6 @@ namespace Nethermind.Synchronization
         ulong NetworkId { get; }
         BlockHeader Genesis { get; }
         BlockHeader? Head { get; }
+        long LowestBlock { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -124,6 +124,8 @@ namespace Nethermind.Synchronization
             }
         }
 
+        public long LowestBlock => Math.Min(Head?.Number ?? 0, _blockTree.GetLowestBlock());
+
         public int GetPeerCount() => _pool.PeerCount;
 
         private readonly Guid _sealValidatorUserGuid = Guid.NewGuid();


### PR DESCRIPTION
## Changes

- Fix incorrect BlockRangeUpdateMessage.EarliestBlock in some edge cases
- Issue comes from #9409

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes