### PR TITLE
fix culture-dependent metric name generation

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
@@ -119,7 +119,7 @@ public sealed class PrometheusPushGatewayMetricsReporter : IMetricsReporter
 
     private static string GetMetricName(string name)
     {
-        var lowerName = name.ToLower();
+        var lowerName = name.ToLowerInvariant();
         var sanitizedName = lowerName.Replace(" ", "_").Replace("-", "_");
         return $"{JobName}_{sanitizedName}";
     }


### PR DESCRIPTION


## Description

**Problem**: The `GetMetricName` method uses `ToLower()` without specifying culture, which can produce inconsistent metric names across different locales (e.g., Turkish "i" handling).

**Solution**: Replace `ToLower()` with `ToLowerInvariant()` to ensure deterministic metric name generation regardless of system culture.

