### PR TITLE
Handle static/trusted nodes old location

### DIFF
--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -30,7 +30,7 @@ public abstract class NodesManager(string path, ILogger logger)
         }
         else // For backward compatibility. To be removed in future versions.
         {
-            string oldPath = Path.GetFullPath(string.Empty.GetApplicationResourcePath($"Data/{resource}"));
+            string oldPath = Path.GetFullPath($"Data/{resource}".GetApplicationResourcePath());
 
             if (File.Exists(oldPath))
             {

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -486,9 +486,9 @@ void ResolveDataDirectory(string? path, IInitConfig initConfig, IKeyStoreConfig 
 {
     if (string.IsNullOrWhiteSpace(path))
     {
-        initConfig.BaseDbPath ??= string.Empty.GetApplicationResourcePath("db");
-        initConfig.LogDirectory ??= string.Empty.GetApplicationResourcePath("logs");
-        keyStoreConfig.KeyStoreDirectory ??= string.Empty.GetApplicationResourcePath("keystore");
+        initConfig.BaseDbPath ??= "db".GetApplicationResourcePath();
+        initConfig.LogDirectory ??= "logs".GetApplicationResourcePath();
+        keyStoreConfig.KeyStoreDirectory ??= "keystore".GetApplicationResourcePath();
     }
     else
     {


### PR DESCRIPTION
This is a follow-up to #9477 

## Changes

- Implemented backward compatibility so that if the static nodes' path is not defined explicitly, Nethermind looks for the old location in the Data directory and copies the file to the new location if it exists. This keeps the current settings.
- Revised `GetApplicationResourcePath()` usage

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Improvement

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually
