### PR TITLE
Remove redundant Close() calls on using-managed streams

### DIFF
--- a/tools/DocGen/MetricsGenerator.cs
+++ b/tools/DocGen/MetricsGenerator.cs
@@ -66,8 +66,7 @@ internal static partial class MetricsGenerator
             writeStream.WriteLine(line);
         }
 
-        readStream.Close();
-        writeStream.Close();
+        // 'using' ensures streams are disposed; explicit Close() is unnecessary
 
         File.Move(tempFileName, fileName, true);
         File.Delete(tempFileName);


### PR DESCRIPTION
Explicit `Close()` calls on streams that are already managed by `using` statements create redundancy and potential issues.
Removed unnecessary `Close()` calls since `using` blocks automatically handle stream disposal.

