### PR TITLE
proper fix for key property in storage proof for rpc-compat

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Json/ValueHash256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ValueHash256Converter.cs
@@ -32,6 +32,6 @@ public class ValueHash256Converter : JsonConverter<ValueHash256>
         ValueHash256 keccak,
         JsonSerializerOptions options)
     {
-        ByteArrayConverter.Convert(writer, keccak.Bytes, skipLeadingZeros: true);
+        ByteArrayConverter.Convert(writer, keccak.Bytes, skipLeadingZeros: false);
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -307,8 +307,8 @@ namespace Nethermind.Store.Test.Proofs
             AccountProofCollector accountProofCollector = new(TestItem.AddressA, new[] { Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000001") });
             tree.Accept(accountProofCollector, tree.RootHash);
             AccountProof proof = accountProofCollector.BuildResult();
-            Assert.That(proof.StorageProofs![0].Key!.Value.ToString(true), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
-            Assert.That(proof.StorageProofs![1].Key!.Value.ToString(true), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000001"));
+            Assert.That(proof.StorageProofs![0].Key!, Is.EqualTo("0x0"));
+            Assert.That(proof.StorageProofs![1].Key!, Is.EqualTo("0x1"));
         }
 
         [Test]
@@ -750,7 +750,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
                 {
                     byte[] indexBytes = new byte[32];
                     addressesWithStorage[i].StorageCells[j].Index.ToBigEndian(indexBytes.AsSpan());
-                    accountProof.StorageProofs[j].Key!.Value.ToString(false).Should().Be(indexBytes.ToHexString(), $"{i} {j}");
+                    accountProof.StorageProofs[j].Key!.Should().Be(indexBytes.ToHexString(true, true), $"{i} {j}");
 
                     TrieNode node = new(NodeType.Unknown, accountProof.StorageProofs[j].Proof.Last());
                     node.ResolveNode(null, TreePath.Empty);

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -82,7 +82,7 @@ namespace Nethermind.State.Proofs
                     _accountProof.StorageProofs[i] = new StorageProof
                     {
                         // we don't know the key (index)
-                        Key = storageKeys is not null ? new ValueHash256(storageKeys[i]) : null,
+                        Key = storageKeys?[i].ToHexString(true, true),
                         Value = Bytes.ZeroByte
                     };
 

--- a/src/Nethermind/Nethermind.State/Proofs/StorageProof.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/StorageProof.cs
@@ -13,7 +13,7 @@ namespace Nethermind.State.Proofs;
 /// </summary>
 public class StorageProof
 {
-    public ValueHash256? Key { get; set; }
+    public string? Key { get; set; }
     public byte[][]? Proof { get; set; }
 
     [JsonConverter(typeof(ProofStorageValueConverter))]

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoExtendedEthModuleTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoExtendedEthModuleTests.cs
@@ -84,11 +84,11 @@ public class TaikoExtendedEthModuleTests
     {
         IL1OriginStore originStore = Substitute.For<IL1OriginStore>();
         TaikoExtendedEthModule rpc = new TaikoExtendedEthModule(new SyncConfig(), originStore);
-        int expectedLengthInChars = Hash256.Size * 2 + 2;
+        int expectedLengthInChars = ValueHash256.Length * 2 + 2;
 
         // Create odd length hash values
-        var l2BlockHash = new Hash256("0x35a48c5b3ee5b1b2a365fcd1aa68c738d1c06474578087a78fa79dd45de6214");
-        var l1BlockHash = new Hash256("0x2daf7e4b06ca2d3a82c775d9e9ad0c973545a608684146cda0df5f7d71188a5");
+        var l2BlockHash = new ValueHash256("0x35a48c5b3ee5b1b2a365fcd1aa68c738d1c06474578087a78fa79dd45de6214");
+        var l1BlockHash = new ValueHash256("0x2daf7e4b06ca2d3a82c775d9e9ad0c973545a608684146cda0df5f7d71188a5");
 
         L1Origin origin = new L1Origin(0, l2BlockHash, 1, l1BlockHash, null);
         originStore.ReadL1Origin((UInt256)0).Returns(origin);

--- a/src/Nethermind/Nethermind.Taiko/L1Origin.cs
+++ b/src/Nethermind/Nethermind.Taiko/L1Origin.cs
@@ -6,18 +6,18 @@ using Nethermind.Int256;
 
 namespace Nethermind.Taiko;
 
-public class L1Origin(UInt256 blockId, Hash256? l2BlockHash, long l1BlockHeight, Hash256 l1BlockHash, int[]? buildPayloadArgsId)
+public class L1Origin(UInt256 blockId, ValueHash256? l2BlockHash, long l1BlockHeight, ValueHash256 l1BlockHash, int[]? buildPayloadArgsId)
 {
     public UInt256 BlockId { get; set; } = blockId;
-    public Hash256? L2BlockHash { get; set; } = l2BlockHash;
+    public ValueHash256? L2BlockHash { get; set; } = l2BlockHash;
     public long L1BlockHeight { get; set; } = l1BlockHeight;
-    public Hash256 L1BlockHash { get; set; } = l1BlockHash;
+    public ValueHash256 L1BlockHash { get; set; } = l1BlockHash;
 
     // Taiko uses int-like serializer
     public int[]? BuildPayloadArgsId { get; set; } = buildPayloadArgsId;
 
     /// <summary>
     /// IsPreconfBlock returns true if the L1Origin is for a preconfirmation block.
-    /// </summary>    
+    /// </summary>
     public bool IsPreconfBlock => L1BlockHeight == 0;
 }


### PR DESCRIPTION
## Changes

- proper fix for key property in storage proof.
- revert change to ValueHash256Converter.cs to always return leading zeros.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No