### PR TITLE
Remove redundant Interlocked.MemoryBarrier calls

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -75,7 +75,6 @@ public class McsLock
         }
 
         node.State = (nuint)LockState.Acquired;
-        Interlocked.MemoryBarrier();
     }
 
     private static void WaitForSignal(ThreadNode node)
@@ -134,7 +133,6 @@ public class McsLock
             next.State = (nuint)LockState.ReadyToAcquire;
 
             // Give the next thread a chance to acquire the lock before checking.
-            Interlocked.MemoryBarrier();
 
             if (next.State == (nuint)LockState.ReadyToAcquire)
             {


### PR DESCRIPTION
Remove two Interlocked.MemoryBarrier() calls in McsLock
- After setting State = Acquired in  WaitForUnlock() 
- After setting next.State = ReadyToAcquire in  Disposable.Dispose()

Rely on .NET volatile semantics (acquire/release) for ThreadNode.State and monitor semantics (Monitor.Wait/Pulse) to ensure correct memory ordering and visibility.