### PR TITLE
Enable ProofRpcModuleTests fixture with non-zero gas price and system account

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -41,7 +41,7 @@ using NSubstitute;
 namespace Nethermind.JsonRpc.Test.Modules.Proof;
 
 [Parallelizable(ParallelScope.None)]
-// [TestFixture(true, true)] TODO fix or remove test?
+[TestFixture(true, true)]
 [TestFixture(true, false)]
 [TestFixture(false, false)]
 public class ProofRpcModuleTests


### PR DESCRIPTION
This PR enables the previously disabled TestFixture(true, true) in ProofRpcModuleTests to cover the scenario with a pre-created system account and non-zero gas price. The existing tests already account for the miner/system account inclusion in the collected accounts, so no additional logic changes were required. Enabling this fixture increases test coverage for proof_call behavior under paid gas conditions while keeping expectations aligned with current tracer and proof collection behavior.