### PR TITLE
refactor: remove redundant StreamWriter extension in Kute metrics formatter

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/PrettyMetricsReportFormatter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/PrettyMetricsReportFormatter.cs
@@ -8,37 +8,29 @@ public sealed class PrettyMetricsReportFormatter : IMetricsReportFormatter
     public async Task WriteAsync(Stream stream, MetricsReport report, CancellationToken token = default)
     {
         await using var writer = new StreamWriter(stream);
-        await writer.WriteLineAsync("=== Report ===", token);
-        await writer.WriteLineAsync($"Total Time: {report.TotalTime.TotalSeconds} s", token);
-        await writer.WriteLineAsync($"Total Messages: {report.TotalMessages}\n", token);
-        await writer.WriteLineAsync($"Succeeded: {report.Succeeded}", token);
-        await writer.WriteLineAsync($"Failed: {report.Failed}", token);
-        await writer.WriteLineAsync($"Ignored: {report.Ignored}", token);
-        await writer.WriteLineAsync($"Responses: {report.Responses}\n", token);
-        await writer.WriteLineAsync("Singles:", token);
+        await writer.WriteLineAsync("=== Report ===".AsMemory(), token);
+        await writer.WriteLineAsync($"Total Time: {report.TotalTime.TotalSeconds} s".AsMemory(), token);
+        await writer.WriteLineAsync($"Total Messages: {report.TotalMessages}\n".AsMemory(), token);
+        await writer.WriteLineAsync($"Succeeded: {report.Succeeded}".AsMemory(), token);
+        await writer.WriteLineAsync($"Failed: {report.Failed}".AsMemory(), token);
+        await writer.WriteLineAsync($"Ignored: {report.Ignored}".AsMemory(), token);
+        await writer.WriteLineAsync($"Responses: {report.Responses}\n".AsMemory(), token);
+        await writer.WriteLineAsync("Singles:".AsMemory(), token);
         foreach ((var methodName, var metrics) in report.SinglesMetrics)
         {
-            await writer.WriteLineAsync($"  {methodName}:", token);
-            await writer.WriteLineAsync($"    Count: {report.Singles[methodName].Count}", token);
-            await writer.WriteLineAsync($"    Max: {metrics.Max.TotalMilliseconds} ms", token);
-            await writer.WriteLineAsync($"    Average: {metrics.Average.TotalMilliseconds} ms", token);
-            await writer.WriteLineAsync($"    Min: {metrics.Min.TotalMilliseconds} ms", token);
-            await writer.WriteLineAsync($"    Stddev: {metrics.StandardDeviation.TotalMilliseconds} ms", token);
+            await writer.WriteLineAsync($"  {methodName}:".AsMemory(), token);
+            await writer.WriteLineAsync($"    Count: {report.Singles[methodName].Count}".AsMemory(), token);
+            await writer.WriteLineAsync($"    Max: {metrics.Max.TotalMilliseconds} ms".AsMemory(), token);
+            await writer.WriteLineAsync($"    Average: {metrics.Average.TotalMilliseconds} ms".AsMemory(), token);
+            await writer.WriteLineAsync($"    Min: {metrics.Min.TotalMilliseconds} ms".AsMemory(), token);
+            await writer.WriteLineAsync($"    Stddev: {metrics.StandardDeviation.TotalMilliseconds} ms".AsMemory(), token);
         }
 
-        await writer.WriteLineAsync("Batches:", token);
-        await writer.WriteLineAsync($"  Count: {report.Batches.Count}", token);
-        await writer.WriteLineAsync($"  Max: {report.BatchesMetrics.Max.TotalMilliseconds} ms", token);
-        await writer.WriteLineAsync($"  Average: {report.BatchesMetrics.Average.TotalMilliseconds} ms", token);
-        await writer.WriteLineAsync($"  Min: {report.BatchesMetrics.Min.TotalMilliseconds} ms", token);
-        await writer.WriteLineAsync($"  Stddev: {report.BatchesMetrics.StandardDeviation.TotalMilliseconds} ms", token);
-    }
-}
-
-internal static class StreamWriterExt
-{
-    public static async Task WriteLineAsync(this StreamWriter writer, string value, CancellationToken token)
-    {
-        await writer.WriteLineAsync(value.AsMemory(), token);
+        await writer.WriteLineAsync("Batches:".AsMemory(), token);
+        await writer.WriteLineAsync($"  Count: {report.Batches.Count}".AsMemory(), token);
+        await writer.WriteLineAsync($"  Max: {report.BatchesMetrics.Max.TotalMilliseconds} ms".AsMemory(), token);
+        await writer.WriteLineAsync($"  Average: {report.BatchesMetrics.Average.TotalMilliseconds} ms".AsMemory(), token);
+        await writer.WriteLineAsync($"  Min: {report.BatchesMetrics.Min.TotalMilliseconds} ms".AsMemory(), token);
+        await writer.WriteLineAsync($"  Stddev: {report.BatchesMetrics.StandardDeviation.TotalMilliseconds} ms".AsMemory(), token);
     }
 }


### PR DESCRIPTION


Removes the unnecessary `StreamWriterExt` extension class that duplicated built-in .NET 9.0 API functionality in the Kute metrics formatter.

