### PR TITLE
Remove Unused Usings From AccountException

### DIFF
--- a/tools/SendBlobs/AccountException.cs
+++ b/tools/SendBlobs/AccountException.cs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SendBlobs;
 internal class AccountException : Exception


### PR DESCRIPTION
removes redundant using directives from tools/SendBlobs/AccountException.cs
leaves only the System namespace required for the base Exception
eliminates unnecessary analyzer warnings without affecting functionality
