### PR TITLE
Fix StatelessExecution tool build

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -24,13 +24,15 @@ jobs:
           - Kute/Kute.slnx
           # - SchemaGenerator/SchemaGenerator.slnx
           - SendBlobs/SendBlobs.slnx
-          - TxParser/TxParser.slnx
           - StatelessExecution/StatelessExecution.slnx
+          - TxParser/TxParser.slnx
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+
       - name: Build ${{ matrix.project }}
         working-directory: tools
         run: dotnet build ./${{ matrix.project }} -c ${{ matrix.config }}

--- a/tools/StatelessExecution/StatelessExecution.csproj
+++ b/tools/StatelessExecution/StatelessExecution.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

- Removed target framework moniker from the project file. It must be taken from the Directory.Builds.props. Otherwise, build fails on framework upgrade.
- Reordered projects in workflow to be alphabetical

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
