### PR TITLE
Remove redundant WithAttributeFiltering() in PseudoNetworkModule

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNetworkModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNetworkModule.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac;
-using Autofac.Features.AttributeFilters;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Logging;


### PR DESCRIPTION
The AddAdvance() helper already applies CommonNethermindConfig(), which includes .WithAttributeFiltering(). The extra .WithAttributeFiltering() on ProtocolsManager  registration in PseudoNetworkModule.cs was redundant and removed.