### PR TITLE
Correct docs value for Blocks.BlockProductionMaxTxKilobytes

### DIFF
--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -49,7 +49,7 @@ public interface IBlocksConfig : IConfig
     [ConfigItem(Description = "The genesis block load timeout, in milliseconds.", DefaultValue = "40000")]
     int GenesisTimeoutMs { get; set; }
 
-    [ConfigItem(Description = "The max transaction bytes to add in block production, in kilobytes.", DefaultValue = "9728")]
+    [ConfigItem(Description = "The max transaction bytes to add in block production, in kilobytes.", DefaultValue = "7936")]
     long BlockProductionMaxTxKilobytes { get; set; }
 
     [ConfigItem(Description = "The ticker that gas rewards are denominated in for processing logs", DefaultValue = "ETH", HiddenFromDocs = true)]


### PR DESCRIPTION
## Changes

- Correct docs value is `MaxBlockSizeKilobytes - MaxCLWrapperKilobytes - SafetyMarginKilobytes = 7936`

## Types of changes

#### What types of changes does your code introduce?

- [x] Documentation update

## Testing

#### Requires testing

- [x] No
