### PR TITLE
Remove console log from FileTestsSource

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/FileTestsSource.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FileTestsSource.cs
@@ -28,7 +28,6 @@ namespace Ethereum.Test.Base
                     return [];
                 }
 
-                Console.WriteLine("Loading test " + _fileName);
                 string json = File.ReadAllText(_fileName, Encoding.Default);
 
                 return testType switch


### PR DESCRIPTION
Reported by protocol security team.
Breaks compatibility:

```
The reason is that goevmlab expects a json output after a state test is run but now it sees

Loading test ...
[ Json ]
```

## Changes

- Removed console log for loading test file.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
