### PR TITLE
Fix redundant null check in EthereumStepsManager constructor

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Init.Steps
             _logger = logManager?.GetClassLogger<EthereumStepsManager>()
                       ?? throw new ArgumentNullException(nameof(logManager));
 
-            _loader = loader ?? throw new ArgumentNullException(nameof(loader));
+            _loader = loader;
         }
 
         public async Task InitializeAll(CancellationToken cancellationToken)


### PR DESCRIPTION
Removed the unreachable `?? throw` assignment in `EthereumStepsManager` since the preceding `ThrowIfNull` already guarantees a non-null loader.

