### PR TITLE
fix: handle missing 'abi' property in contract JSON

### DIFF
--- a/src/Nethermind/Nethermind.Abi/AbiDefinitionConverter.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiDefinitionConverter.cs
@@ -37,7 +37,10 @@ public class AbiDefinitionConverter : JsonConverter<AbiDefinition>
         JsonElement topLevelToken = document.RootElement;
         if (topLevelToken.ValueKind == JsonValueKind.Object)
         {
-            abiToken = topLevelToken.GetProperty("abi"u8);
+            if (!topLevelToken.TryGetProperty("abi"u8, out abiToken))
+            {
+                throw new JsonException("Contract JSON object must contain an 'abi' property.");
+            }
             if (topLevelToken.TryGetProperty("bytecode"u8, out JsonElement bytecodeBase64))
             {
                 value.SetBytecode(Bytes.FromHexString(bytecodeBase64.GetString()!));


### PR DESCRIPTION
## Changes

- Replace `GetProperty("abi"u8)` with `TryGetProperty("abi"u8, out abiToken)` in `AbiDefinitionConverter.Read()` method
- Add explicit error handling when 'abi' property is missing from contract JSON object
- Throw `JsonException` with clear error message when required 'abi' property is absent

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

All existing tests pass (170 tests in `Nethermind.Abi.Test`). The fix prevents a potential `KeyNotFoundException` when contract JSON objects are missing the 'abi' property. Current test coverage validates the converter functionality with valid JSON structures.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

This change improves error handling robustness by preventing `KeyNotFoundException` when parsing contract JSON objects that are missing the required 'abi' property. Instead of crashing, the converter now throws a descriptive `JsonException` that clearly indicates the issue. The fix follows the existing pattern used for optional properties like 'bytecode' and 'deployedBytecode'.