### PR TITLE
Optimize Ripemd

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RipemdTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RipemdTests.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Core.Test
     [TestFixture]
     public class RipemdTests
     {
-        public const string RipemdOfEmptyString = "9c1185a5c5e9fc54612808977ee8f548b2258d31";
+        public const string RipemdOfEmptyString = "0000000000000000000000009c1185a5c5e9fc54612808977ee8f548b2258d31";
 
         [Test]
         public void Empty_byte_array()

--- a/src/Nethermind/Nethermind.Crypto/Ripemd.cs
+++ b/src/Nethermind/Nethermind.Crypto/Ripemd.cs
@@ -1,25 +1,29 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core.Extensions;
 using Org.BouncyCastle.Crypto.Digests;
 
-namespace Nethermind.Crypto
-{
-    public static class Ripemd
-    {
-        public static byte[] Compute(byte[] input)
-        {
-            var digest = new RipeMD160Digest();
-            digest.BlockUpdate(input, 0, input.Length);
-            var result = new byte[digest.GetDigestSize()];
-            digest.DoFinal(result, 0);
-            return result;
-        }
+namespace Nethermind.Crypto;
 
-        public static string ComputeString(byte[] input)
-        {
-            return Compute(input).ToHexString(false);
-        }
+public static class Ripemd
+{
+    const int HashOutputLength = 32;
+
+    public static byte[] Compute(ReadOnlySpan<byte> input)
+    {
+        RipeMD160Digest digest = new();
+        digest.BlockUpdate(input);
+        byte[] result = new byte[HashOutputLength];
+        int length = digest.GetDigestSize();
+        Span<byte> span = result.AsSpan(HashOutputLength - length, length);
+        digest.DoFinal(span);
+        return result;
+    }
+
+    public static string ComputeString(ReadOnlySpan<byte> input)
+    {
+        return Compute(input).ToHexString(false);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Precompiles/Ripemd160Precompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/Ripemd160Precompile.cs
@@ -38,6 +38,6 @@ public class Ripemd160Precompile : IPrecompile<Ripemd160Precompile>
     {
         Metrics.Ripemd160Precompile++;
 
-        return (Ripemd.Compute(inputData.ToArray()).PadLeft(32), true);
+        return (Ripemd.Compute(inputData.Span), true);
     }
 }


### PR DESCRIPTION
## Changes

- Use original input rather than copying to array first (by using span overloads)
- Output directly to expected sized array rather than 20 bytes and then reallalocating/copying to 32 bytes

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] Yes - updated one
