### PR TITLE
Allow precompile cache to be switched off by config

### DIFF
--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -58,6 +58,9 @@ namespace Nethermind.Config
         public ulong SecondsPerSlot { get; set; } = 12;
 
         public bool PreWarmStateOnBlockProcessing { get; set; } = true;
+
+        public bool CachePrecompilesOnBlockProcessing { get; set; } = true;
+
         public int PreWarmStateConcurrency { get; set; } = 0;
 
         public int BlockProductionTimeoutMs { get; set; } = 4_000;

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -40,6 +40,9 @@ public interface IBlocksConfig : IConfig
     [ConfigItem(Description = "Whether to pre-warm the state when processing blocks. This can lead to an up to 2x speed-up in the main loop block processing.", DefaultValue = "True")]
     bool PreWarmStateOnBlockProcessing { get; set; }
 
+    [ConfigItem(Description = "Whether to cache precompile results when processing blocks.", DefaultValue = "True", HiddenFromDocs = true)]
+    bool CachePrecompilesOnBlockProcessing { get; set; }
+
     [ConfigItem(Description = "Specify pre-warm state concurrency. Default is logical processor - 1.", DefaultValue = "0", HiddenFromDocs = true)]
     int PreWarmStateConcurrency { get; set; }
 

--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -75,7 +75,7 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
                     {
                         PreBlockCaches preBlockCaches = ctx.Resolve<PreBlockCaches>();
                         // Note: The use of FrozenDictionary means that this cannot be used for other processing env also due to risk of memory leak.
-                        return new CachedCodeInfoRepository(precompileProvider, originalCodeInfoRepository, preBlockCaches?.PrecompileCache);
+                        return new CachedCodeInfoRepository(precompileProvider, originalCodeInfoRepository, blocksConfig.CachePrecompilesOnBlockProcessing ? preBlockCaches?.PrecompileCache : null);
                     })
                     ;
             }


### PR DESCRIPTION
## Changes

- Allow precompile cache to be switched off by config for benchmark testing

`--Blocks.CachePrecompilesOnBlockProcessing=false`

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No
