### PR TITLE
Route ColumnDb.Remove through Set(null) to use wrapper semantics

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -134,8 +134,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore
 
     public void Remove(ReadOnlySpan<byte> key)
     {
-        // TODO: this does not participate in batching?
-        _rocksDb.Remove(key, _columnFamily, _mainDb.WriteOptions);
+        Set(key, null);
     }
 
     public bool KeyExists(ReadOnlySpan<byte> key)


### PR DESCRIPTION
Replace direct RocksDB delete in ColumnDb.Remove with Set(key, null) so deletes go through DbOnTheRocks.SetWithColumnFamily(...).
This aligns Remove with batching support, write metrics updates, disposal state checks, and corruption marker handling that are present in other write paths.
Previously, Remove bypassed batching, did not update metrics, lacked disposal guards, and did not process RocksDB corruption exceptions.