### PR TITLE
Сhore(xdc): remove unused imports from XdcBlockHeader

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcBlockHeader.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockHeader.cs
@@ -10,12 +10,7 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.RLP;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nethermind.Xdc;
 public class XdcBlockHeader : BlockHeader, IHashResolver


### PR DESCRIPTION
Drop unused System usings from XdcBlockHeader keep only System.Collections.Immutable, which the file actually needs