### PR TITLE
L1Call Precompile for Surge

### DIFF
--- a/src/Nethermind/Nethermind.Core/L1CallConstants.cs
+++ b/src/Nethermind/Nethermind.Core/L1CallConstants.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Constants for L1CALL precompile operations.
+/// </summary>
+public static class L1CallConstants
+{
+    /// <summary>
+    /// Number of bytes for the gas parameter
+    /// </summary>
+    public const int GasBytes = 8;
+
+    /// <summary>
+    /// Number of bytes for the L1 contract address
+    /// </summary>
+    public const int AddressBytes = 20;
+
+    /// <summary>
+    /// Number of bytes for the value parameter
+    /// </summary>
+    public const int ValueBytes = 32;
+
+    /// <summary>
+    /// Number of bytes for the callDataSize parameter
+    /// </summary>
+    public const int CallDataSizeBytes = 8;
+
+    /// <summary>
+    /// Number of bytes for the feePerGas parameter
+    /// </summary>
+    public const int FeePerGasBytes = 32;
+
+    /// <summary>
+    /// Minimum input length for L1CALL precompile calls (fixed fields only, without call data)
+    /// </summary>
+    public const int MinInputLength = GasBytes + AddressBytes + ValueBytes + CallDataSizeBytes + FeePerGasBytes;
+
+    /// <summary>
+    /// Fixed gas cost for L1CALL precompile calls
+    /// </summary>
+    public const long FixedGasCost = 3000L;
+
+    /// <summary>
+    /// Per-call gas cost for L1CALL precompile calls
+    /// </summary>
+    public const long PerCallGasCost = 3000L;
+}

--- a/src/Nethermind/Nethermind.Core/L1SloadConstants.cs
+++ b/src/Nethermind/Nethermind.Core/L1SloadConstants.cs
@@ -4,9 +4,9 @@
 namespace Nethermind.Core;
 
 /// <summary>
-/// Shared constants for L1SLOAD/L1CALL precompile operations.
+/// Constants for L1SLOAD precompile operations.
 /// </summary>
-public static class L1PrecompileConstants
+public static class L1SloadConstants
 {
     /// <summary>
     /// Number of bytes for the L1 contract address in the input

--- a/src/Nethermind/Nethermind.Core/Precompiles/PrecompiledAddresses.cs
+++ b/src/Nethermind/Nethermind.Core/Precompiles/PrecompiledAddresses.cs
@@ -27,4 +27,5 @@ public static class PrecompiledAddresses
     public static readonly AddressAsKey Bls12Pairing = Address.FromNumber(0x11);
     public static readonly AddressAsKey P256Verify = Address.FromNumber(0x0100);
     public static readonly AddressAsKey L1Sload = Address.FromNumber(0x10001);
+    public static readonly AddressAsKey L1Call = Address.FromNumber(0x10002);
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -528,5 +528,10 @@ namespace Nethermind.Core.Specs
         /// RIP-7728: L1SLOAD precompile for reading L1 storage from L2
         /// </summary>
         public bool IsRip7728Enabled { get; }
+
+        /// <summary>
+        /// L1CALL precompile for executing calls on L1 contracts from L2
+        /// </summary>
+        public bool IsL1CallEnabled { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -155,4 +155,5 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public bool IsEip7939Enabled => spec.IsEip7939Enabled;
     public bool IsEip7907Enabled => spec.IsEip7907Enabled;
     public bool IsRip7728Enabled => spec.IsRip7728Enabled;
+    public bool IsL1CallEnabled => spec.IsL1CallEnabled;
 }

--- a/src/Nethermind/Nethermind.Evm.Precompiles/Extensions.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/Extensions.cs
@@ -62,6 +62,11 @@ public static class Extensions
             AddPrecompile<L1SloadPrecompile>();
         }
 
+        if (spec.IsL1CallEnabled)
+        {
+            AddPrecompile<L1CallPrecompile>();
+        }
+
         return precompiles;
 
         void AddPrecompile<T>() where T : IPrecompile<T> => precompiles[T.Name] = T.Address;

--- a/src/Nethermind/Nethermind.Evm.Precompiles/IL1CallProvider.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/IL1CallProvider.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.Precompiles;
+
+/// <summary>
+/// Interface for L1 call providers that can execute calls on L1 contracts.
+/// </summary>
+public interface IL1CallProvider
+{
+    /// <summary>
+    /// Executes a call on an L1 contract.
+    /// </summary>
+    /// <param name="contractAddress">The L1 contract address to call</param>
+    /// <param name="gas">The gas limit for the call</param>
+    /// <param name="value">The value to send with the call</param>
+    /// <param name="callData">The call data (function selector + ABI-encoded parameters), or null/empty if no call data</param>
+    /// <param name="feePerGas">The fee the user is willing to pay for executing this call on L1</param>
+    /// <returns>The return data from the L1 call, or null if the call fails</returns>
+    byte[]? ExecuteCall(Address contractAddress, ulong gas, UInt256 value, byte[]? callData, UInt256 feePerGas);
+}

--- a/src/Nethermind/Nethermind.Evm.Precompiles/L1CallPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/L1CallPrecompile.cs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.Precompiles;
+
+/// <summary>
+/// L1CALL precompile - execute calls on L1 contracts (RIP-7728).
+///
+/// The input to the L1CALL precompile consists of:
+///
+/// | Byte range                    | Name          | Description                     |
+/// | ----------------------------- | ------------- | ------------------------------- |
+/// | [0: 7] (8 bytes)              | gas           | The gas limit for the call      |
+/// | [8: 27] (20 bytes)            | address       | The L1 contract address         |
+/// | [28: 59] (32 bytes)           | value         | The value to send with the call |
+/// | [60: 67] (8 bytes)            | callDataSize  | Size of call data in bytes      |
+/// | [68: 99] (32 bytes)           | feePerGas     | Fee per gas for L1 call         |
+/// | [100: 99+callDataSize]        | callData      | Call data (variable length)     |
+///
+/// Output:
+/// - Return data from the L1 call
+/// </summary>
+public class L1CallPrecompile : IPrecompile<L1CallPrecompile>
+{
+    public static readonly L1CallPrecompile Instance = new();
+
+    private L1CallPrecompile()
+    {
+    }
+
+    public static Address Address { get; } = Address.FromNumber(0x10002);
+    public static string Name => "L1CALL";
+    public static IL1CallProvider? L1CallProvider { get; set; }
+
+    public long BaseGasCost(IReleaseSpec releaseSpec) => L1CallConstants.FixedGasCost;
+
+    public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
+    {
+        return inputData.Length < L1CallConstants.MinInputLength ? 0L : L1CallConstants.PerCallGasCost;
+    }
+
+    public (byte[], bool) Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
+    {
+        if (inputData.Length < L1CallConstants.MinInputLength)
+        {
+            return IPrecompile.Failure;
+        }
+
+        ReadOnlySpan<byte> span = inputData.Span;
+        int offset = 0;
+
+        // Parse fixed parameters
+        ulong gas = BitConverter.ToUInt64(span.Slice(offset, L1CallConstants.GasBytes));
+        offset += L1CallConstants.GasBytes;
+
+        Address contractAddress = new Address(span.Slice(offset, L1CallConstants.AddressBytes));
+        offset += L1CallConstants.AddressBytes;
+
+        UInt256 value = new UInt256(span.Slice(offset, L1CallConstants.ValueBytes), isBigEndian: true);
+        offset += L1CallConstants.ValueBytes;
+
+        ulong callDataSize = BitConverter.ToUInt64(span.Slice(offset, L1CallConstants.CallDataSizeBytes));
+        offset += L1CallConstants.CallDataSizeBytes;
+
+        UInt256 feePerGas = new UInt256(span.Slice(offset, L1CallConstants.FeePerGasBytes), isBigEndian: true);
+        offset += L1CallConstants.FeePerGasBytes;
+
+        // Validate total input length (all fixed fields + call data)
+        ulong expectedLength = L1CallConstants.MinInputLength + callDataSize;
+        if (inputData.Length < (int)expectedLength)
+        {
+            return IPrecompile.Failure;
+        }
+
+        // Extract call data (variable length)
+        byte[]? callData = null;
+        if (callDataSize > 0)
+        {
+            callData = span.Slice(offset, (int)callDataSize).ToArray();
+        }
+
+        byte[]? returnData = ExecuteL1Call(contractAddress, gas, value, callData, feePerGas);
+        if (returnData == null)
+        {
+            return IPrecompile.Failure; // L1 call execution failed
+        }
+
+        return (returnData, true);
+    }
+
+    /// <summary>
+    /// Executes an L1 call for the specified parameters.
+    /// </summary>
+    /// <param name="contractAddress">The L1 contract address to call</param>
+    /// <param name="gas">The gas limit for the call</param>
+    /// <param name="value">The value to send with the call</param>
+    /// <param name="callData">The call data (function selector + parameters), or null/empty if no call data</param>
+    /// <param name="feePerGas">The fee the user is willing to pay for executing this call on L1</param>
+    /// <returns>The return data from the L1 call, or null if the call fails</returns>
+    private byte[]? ExecuteL1Call(Address contractAddress, ulong gas, UInt256 value, byte[]? callData, UInt256 feePerGas)
+    {
+        try
+        {
+            return L1CallProvider?.ExecuteCall(contractAddress, gas, value, callData, feePerGas);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Precompiles/L1SloadPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/L1SloadPrecompile.cs
@@ -2,13 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Threading.Tasks;
 using Nethermind.Core;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
-using Nethermind.Logging;
 
 namespace Nethermind.Evm.Precompiles;
 
@@ -38,28 +34,28 @@ public class L1SloadPrecompile : IPrecompile<L1SloadPrecompile>
     public static string Name => "L1SLOAD";
     public static IL1StorageProvider? L1StorageProvider { get; set; }
 
-    public long BaseGasCost(IReleaseSpec releaseSpec) => L1PrecompileConstants.FixedGasCost;
+    public long BaseGasCost(IReleaseSpec releaseSpec) => L1SloadConstants.FixedGasCost;
 
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
     {
-        if (inputData.Length != L1PrecompileConstants.ExpectedInputLength)
+        if (inputData.Length != L1SloadConstants.ExpectedInputLength)
         {
             return 0L;
         }
 
-        return L1PrecompileConstants.PerLoadGasCost;
+        return L1SloadConstants.PerLoadGasCost;
     }
 
     public (byte[], bool) Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
     {
-        if (inputData.Length != L1PrecompileConstants.ExpectedInputLength)
+        if (inputData.Length != L1SloadConstants.ExpectedInputLength)
         {
             return IPrecompile.Failure;
         }
 
-        Address contractAddress = new Address(inputData.Span[..L1PrecompileConstants.AddressBytes]);
-        UInt256 storageKey = new UInt256(inputData.Span[L1PrecompileConstants.AddressBytes..(L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes)], isBigEndian: true);
-        UInt256 blockNumber = new UInt256(inputData.Span[(L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes)..], isBigEndian: true);
+        Address contractAddress = new Address(inputData.Span[..L1SloadConstants.AddressBytes]);
+        UInt256 storageKey = new UInt256(inputData.Span[L1SloadConstants.AddressBytes..(L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes)], isBigEndian: true);
+        UInt256 blockNumber = new UInt256(inputData.Span[(L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes)..], isBigEndian: true);
 
         UInt256? storageValue = GetL1StorageValue(contractAddress, storageKey, blockNumber);
         if (storageValue == null)

--- a/src/Nethermind/Nethermind.Evm.Test/L1CallPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/L1CallPrecompileTests.cs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+[TestFixture]
+public class L1CallPrecompileTests
+{
+    private L1CallPrecompile _precompile = null!;
+    private IReleaseSpec _spec = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _precompile = L1CallPrecompile.Instance;
+        _spec = new ReleaseSpec { IsL1CallEnabled = true };
+    }
+
+    [Test]
+    public void BaseGasCost_Should_Return_FixedGasCost()
+    {
+        Assert.That(_precompile.BaseGasCost(_spec), Is.EqualTo(L1CallConstants.FixedGasCost));
+    }
+
+    [Test]
+    public void DataGasCost_With_Invalid_Input_Length_Should_Return_0()
+    {
+        // Input too short
+        var input = new byte[L1CallConstants.AddressBytes]; // Only address
+        Assert.That(_precompile.DataGasCost(input, _spec), Is.EqualTo(0L));
+
+        // Input with invalid callDataSize (too long)
+        var longInput = new byte[L1CallConstants.MinInputLength + 1000];
+        Assert.That(_precompile.DataGasCost(longInput, _spec), Is.EqualTo(L1CallConstants.PerCallGasCost));
+    }
+
+    [Test]
+    public void DataGasCost_With_Valid_Input_Should_Calculate_Correctly()
+    {
+        var input = CreateValidInput(Address.FromNumber(123), 1000000, (UInt256)0, null, (UInt256)20000000000);
+        Assert.That(_precompile.DataGasCost(input, _spec), Is.EqualTo(L1CallConstants.PerCallGasCost));
+    }
+
+    [Test]
+    public void Run_With_Invalid_Input_Length_Should_Fail()
+    {
+        // Input too short
+        var input = new byte[L1CallConstants.AddressBytes];
+        var (result, success) = _precompile.Run(input, _spec);
+
+        Assert.That(success, Is.False);
+        Assert.That(result, Is.Empty);
+
+        // Input with callDataSize that exceeds available data
+        var invalidInput = new byte[L1CallConstants.MinInputLength];
+        // Set callDataSize to 100 but we only have MinInputLength bytes
+        BitConverter.GetBytes(100UL).CopyTo(invalidInput.AsSpan(L1CallConstants.GasBytes + L1CallConstants.AddressBytes + L1CallConstants.ValueBytes, L1CallConstants.CallDataSizeBytes));
+        (result, success) = _precompile.Run(invalidInput, _spec);
+
+        Assert.That(success, Is.False);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void Run_With_Valid_Input_Should_Succeed()
+    {
+        // Setup mock L1 call provider
+        var expectedReturnData = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        L1CallPrecompile.L1CallProvider = MockL1CallProvider.Returning(expectedReturnData);
+
+        try
+        {
+            var input = CreateValidInput(Address.FromNumber(123), 1000000, (UInt256)0, null, (UInt256)20000000000);
+
+            var (result, success) = _precompile.Run(input, _spec);
+
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.EqualTo(expectedReturnData));
+        }
+        finally
+        {
+            L1CallPrecompile.L1CallProvider = null;
+        }
+    }
+
+    [Test]
+    public void Run_With_Disabled_Spec_Should_Fail()
+    {
+        var disabledSpec = new ReleaseSpec { IsL1CallEnabled = false };
+
+        var input = CreateValidInput(Address.FromNumber(123), 1000000, (UInt256)0, null, (UInt256)20000000000);
+
+        var (result, success) = _precompile.Run(input, disabledSpec);
+
+        Assert.That(success, Is.False);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void Run_With_No_Provider_Should_Fail()
+    {
+        L1CallPrecompile.L1CallProvider = null;
+        var input = CreateValidInput(Address.FromNumber(123), 1000000, (UInt256)0, null, (UInt256)20000000000);
+
+        var (result, success) = _precompile.Run(input, _spec);
+
+        Assert.That(success, Is.False);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void Run_With_Provider_Returning_Null_Should_Fail()
+    {
+        L1CallPrecompile.L1CallProvider = MockL1CallProvider.ReturningNull();
+
+        try
+        {
+            var input = CreateValidInput(Address.FromNumber(123), 1000000, (UInt256)0, null, (UInt256)20000000000);
+
+            var (result, success) = _precompile.Run(input, _spec);
+
+            Assert.That(success, Is.False);
+            Assert.That(result, Is.Empty);
+        }
+        finally
+        {
+            L1CallPrecompile.L1CallProvider = null;
+        }
+    }
+
+    [Test]
+    public void IsPrecompile_Active_With_L1Call()
+    {
+        IReleaseSpec enabledSpec = new ReleaseSpec { IsL1CallEnabled = true };
+        IReleaseSpec disabledSpec = new ReleaseSpec { IsL1CallEnabled = false };
+
+        Address? precompileAddress = L1CallPrecompile.Address;
+
+        Assert.That(enabledSpec.IsPrecompile(precompileAddress), Is.True,
+            "L1CallPrecompile address should be identified as precompile when L1Call is enabled");
+
+        Assert.That(disabledSpec.IsPrecompile(precompileAddress), Is.False,
+            "L1CallPrecompile address should not be identified as precompile when L1Call is disabled");
+    }
+
+    private static byte[] CreateValidInput(Address contractAddress, ulong gas, UInt256 value, byte[]? callData, UInt256 feePerGas)
+    {
+        ulong callDataSize = callData == null ? 0UL : (ulong)callData.Length;
+        int totalLength = L1CallConstants.MinInputLength + (int)callDataSize;
+        var input = new byte[totalLength];
+
+        int offset = 0;
+
+        // Copy gas (8 bytes)
+        BitConverter.GetBytes(gas).CopyTo(input.AsSpan(offset, L1CallConstants.GasBytes));
+        offset += L1CallConstants.GasBytes;
+
+        // Copy address (20 bytes)
+        contractAddress.Bytes.CopyTo(input.AsSpan(offset, L1CallConstants.AddressBytes));
+        offset += L1CallConstants.AddressBytes;
+
+        // Copy value (32 bytes)
+        value.ToBigEndian().CopyTo(input.AsSpan(offset, L1CallConstants.ValueBytes));
+        offset += L1CallConstants.ValueBytes;
+
+        // Copy callDataSize (8 bytes)
+        BitConverter.GetBytes(callDataSize).CopyTo(input.AsSpan(offset, L1CallConstants.CallDataSizeBytes));
+        offset += L1CallConstants.CallDataSizeBytes;
+
+        // Copy feePerGas (32 bytes)
+        feePerGas.ToBigEndian().CopyTo(input.AsSpan(offset, L1CallConstants.FeePerGasBytes));
+        offset += L1CallConstants.FeePerGasBytes;
+
+        // Copy callData (variable length, at the end)
+        if (callData != null && callData.Length > 0)
+        {
+            callData.CopyTo(input.AsSpan(offset, callData.Length));
+        }
+
+        return input;
+    }
+
+    private sealed class MockL1CallProvider : IL1CallProvider
+    {
+        private readonly byte[]? _returnData;
+
+        private MockL1CallProvider(byte[]? returnData)
+        {
+            _returnData = returnData;
+        }
+
+        public byte[]? ExecuteCall(Address contractAddress, ulong gas, UInt256 value, byte[]? callData, UInt256 feePerGas) => _returnData;
+
+        // Static factory methods for different scenarios
+        public static MockL1CallProvider Returning(byte[] returnData) => new(returnData);
+        public static MockL1CallProvider ReturningNull() => new(null);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/L1SloadPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/L1SloadPrecompileTests.cs
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
-using Nethermind.Logging;
 using Nethermind.Specs;
 using NUnit.Framework;
 
@@ -30,18 +27,18 @@ public class L1SloadPrecompileTests
     [Test]
     public void BaseGasCost_Should_Return_FixedGasCost()
     {
-        Assert.That(_precompile.BaseGasCost(_spec), Is.EqualTo(L1PrecompileConstants.FixedGasCost));
+        Assert.That(_precompile.BaseGasCost(_spec), Is.EqualTo(L1SloadConstants.FixedGasCost));
     }
 
     [Test]
     public void DataGasCost_With_Invalid_Input_Length_Should_Return_0()
     {
         // Input too short
-        var input = new byte[L1PrecompileConstants.AddressBytes]; // Only address
+        var input = new byte[L1SloadConstants.AddressBytes]; // Only address
         Assert.That(_precompile.DataGasCost(input, _spec), Is.EqualTo(0L));
 
         // Input too long
-        var expectedLength = L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes + L1PrecompileConstants.BlockNumberBytes;
+        var expectedLength = L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes + L1SloadConstants.BlockNumberBytes;
         var longInput = new byte[expectedLength + 32]; // Extra 32 bytes
         Assert.That(_precompile.DataGasCost(longInput, _spec), Is.EqualTo(0L));
     }
@@ -50,21 +47,21 @@ public class L1SloadPrecompileTests
     public void DataGasCost_With_Valid_Input_Should_Calculate_Correctly()
     {
         var input = CreateValidInput(Address.FromNumber(123), (UInt256)1, (UInt256)1000);
-        Assert.That(_precompile.DataGasCost(input, _spec), Is.EqualTo(L1PrecompileConstants.PerLoadGasCost));
+        Assert.That(_precompile.DataGasCost(input, _spec), Is.EqualTo(L1SloadConstants.PerLoadGasCost));
     }
 
     [Test]
     public void Run_With_Invalid_Input_Length_Should_Fail()
     {
         // Input too short
-        var input = new byte[L1PrecompileConstants.AddressBytes];
+        var input = new byte[L1SloadConstants.AddressBytes];
         var (result, success) = _precompile.Run(input, _spec);
 
         Assert.That(success, Is.False);
         Assert.That(result, Is.Empty);
 
         // Input too long
-        var expectedLength = L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes + L1PrecompileConstants.BlockNumberBytes;
+        var expectedLength = L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes + L1SloadConstants.BlockNumberBytes;
         var longInput = new byte[expectedLength + 32];
         (result, success) = _precompile.Run(longInput, _spec);
 
@@ -159,11 +156,11 @@ public class L1SloadPrecompileTests
 
     private static byte[] CreateValidInput(Address contractAddress, UInt256 storageKey, UInt256 blockNumber)
     {
-        var input = new byte[L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes + L1PrecompileConstants.BlockNumberBytes];
+        var input = new byte[L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes + L1SloadConstants.BlockNumberBytes];
 
-        contractAddress.Bytes.CopyTo(input.AsSpan(0, L1PrecompileConstants.AddressBytes));
-        storageKey.ToBigEndian().CopyTo(input.AsSpan(L1PrecompileConstants.AddressBytes, L1PrecompileConstants.StorageKeyBytes));
-        blockNumber.ToBigEndian().CopyTo(input.AsSpan(L1PrecompileConstants.AddressBytes + L1PrecompileConstants.StorageKeyBytes, L1PrecompileConstants.BlockNumberBytes));
+        contractAddress.Bytes.CopyTo(input.AsSpan(0, L1SloadConstants.AddressBytes));
+        storageKey.ToBigEndian().CopyTo(input.AsSpan(L1SloadConstants.AddressBytes, L1SloadConstants.StorageKeyBytes));
+        blockNumber.ToBigEndian().CopyTo(input.AsSpan(L1SloadConstants.AddressBytes + L1SloadConstants.StorageKeyBytes, L1SloadConstants.BlockNumberBytes));
 
         return input;
     }

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -199,6 +199,7 @@ namespace Nethermind.Specs.Test
         public bool IsEip7939Enabled => spec.IsEip7939Enabled;
         public bool IsEip7907Enabled => spec.IsEip7907Enabled;
         public bool IsRip7728Enabled => spec.IsRip7728Enabled;
+        public bool IsL1CallEnabled => spec.IsL1CallEnabled;
         FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -173,4 +173,5 @@ public class ChainParameters
     #endregion
 
     public ulong? Rip7728TransitionTimestamp { get; set; }
+    public ulong? L1CallTransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -292,6 +292,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip7939Enabled = (chainSpec.Parameters.Eip7939TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             releaseSpec.IsRip7728Enabled = (chainSpec.Parameters.Rip7728TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsL1CallEnabled = (chainSpec.Parameters.L1CallTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -196,6 +196,7 @@ public class ChainSpecLoader(IJsonSerializer serializer) : IChainSpecLoader
             Eip7934MaxRlpBlockSize = chainSpecJson.Params.Eip7934MaxRlpBlockSize ?? Eip7934Constants.DefaultMaxRlpBlockSize,
 
             Rip7728TransitionTimestamp = chainSpecJson.Params.Rip7728TransitionTimestamp,
+            L1CallTransitionTimestamp = chainSpecJson.Params.L1CallTransitionTimestamp,
         };
 
         chainSpec.Parameters.Eip152Transition ??= GetTransitionForExpectedPricing("blake2_f", "price.blake2_f.gas_per_round", 1);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -177,4 +177,5 @@ public class ChainSpecParamsJson
     public ulong? Eip7594TransitionTimestamp { get; set; }
     public ulong? Eip7939TransitionTimestamp { get; set; }
     public ulong? Rip7728TransitionTimestamp { get; set; }
+    public ulong? L1CallTransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -163,6 +163,7 @@ namespace Nethermind.Specs
         Array? IReleaseSpec.EvmInstructionsTraced { get; set; }
         public bool IsEip7939Enabled { get; set; }
         public bool IsRip7728Enabled { get; set; }
+        public bool IsL1CallEnabled { get; set; }
 
         private FrozenSet<AddressAsKey>? _precompiles;
         FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompilesCache();
@@ -197,6 +198,7 @@ namespace Nethermind.Specs
             }
             if (IsRip7212Enabled || IsEip7951Enabled) cache.Add(PrecompiledAddresses.P256Verify);
             if (IsRip7728Enabled) cache.Add(PrecompiledAddresses.L1Sload);
+            if (IsL1CallEnabled) cache.Add(PrecompiledAddresses.L1Call);
 
             return cache.ToFrozenSet();
         }

--- a/src/Nethermind/Nethermind.Taiko/JsonRpcL1CallProvider.cs
+++ b/src/Nethermind/Nethermind.Taiko/JsonRpcL1CallProvider.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Int256;
+using Nethermind.JsonRpc.Client;
+using Nethermind.Logging;
+using Nethermind.Serialization.Json;
+using Nethermind.Evm.Precompiles;
+
+namespace Nethermind.Taiko;
+
+/// <summary>
+/// JsonRpc-based implementation of IL1CallProvider that uses eth_call
+/// RPC to execute calls on L1 contracts.
+/// </summary>
+public class JsonRpcL1CallProvider : IL1CallProvider
+{
+    private readonly IJsonRpcClient _rpcClient;
+    private readonly ILogger _logger;
+
+    public JsonRpcL1CallProvider(string l1EthApiEndpoint, IJsonSerializer jsonSerializer, ILogManager logManager)
+    {
+        _rpcClient = new BasicJsonRpcClient(new Uri(l1EthApiEndpoint), jsonSerializer, logManager);
+        _logger = logManager.GetClassLogger<JsonRpcL1CallProvider>();
+    }
+
+    public byte[]? ExecuteCall(Address contractAddress, ulong gas, UInt256 value, byte[]? callData, UInt256 feePerGas)
+    {
+        try
+        {
+            string callDataHex = callData == null || callData.Length == 0 ? "0x" : callData.ToHexString(true);
+            string? valueHex = value.IsZero ? null : value.ToHexString(true);
+
+            string? response = _rpcClient.Post<string>("eth_call", new
+            {
+                to = contractAddress.ToString(),
+                data = callDataHex,
+                value = valueHex,
+                gas = gas == 0 ? null : $"0x{gas:x}"
+            }, "latest").GetAwaiter().GetResult();
+
+            if (response == null)
+            {
+                _logger.Warn($"L1 call failed: contract={contractAddress}, gas={gas}, value={value}");
+                return null;
+            }
+
+            // Parse the hex response
+            return Bytes.FromHexString(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"L1 call execution failed: {ex.Message}");
+            return null;
+        }
+    }
+}
+


### PR DESCRIPTION
New feature for Surge https://github.com/NethermindEth/Surge/issues/135

## Changes

- Adds new precompile for L1Call
- JsonRpcL1Call implementation to allow L2s to call `eth_call` via JsonRpc
- Precompile can be activated/deactivated by  `L1CallTransitionTimestamp` in the chainspec

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No