### PR TITLE
chore: fix branch check in `bump_version` for macOS bash

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -145,7 +145,7 @@ bump_version() {
         return 1
     fi
     
-    if [[ ! $branch_name =~ ^refs/heads/release/[0-9]+\.[0-9]+\.0$ ]]; then
+    if ! echo "$branch_name" | grep -Eq '^refs/heads/release/[0-9]+\.[0-9]+\.0$'; then
         echo "error: Invalid branch name format. Expected: refs/heads/release/X.Y.0" >&2
         return 1
     fi


### PR DESCRIPTION
## Changes

* replaced `[[ ... =~ ... ]]` with `grep -Eq` in `bump_version`
* prevented false branch validation errors on older Bash versions (e.g. macOS)

---

## Types of changes

#### What types of changes does your code introduce?

* [x] Bugfix (a non-breaking change that fixes an issue)
* [ ] New feature (a non-breaking change that adds functionality)
* [ ] Breaking change (a change that causes existing functionality not to work as expected)
* [ ] Optimization
* [ ] Refactoring
* [ ] Documentation update
* [ ] Build-related changes
* [ ] Other: *Description*

---

## Testing

#### Requires testing

* [ ] Yes
* [x] No

#### If yes, did you write tests?

* [ ] Yes
* [ ] No

#### Notes on testing

No tests needed — shell behavior manually verified on macOS and Linux.

---

## Documentation

#### Requires documentation update

* [ ] Yes
* [x] No

#### Requires explanation in Release Notes

* [ ] Yes
* [x] No