### PR TITLE
Remove redundant TxDecoder allocation in BlobSender

### DIFF
--- a/tools/SendBlobs/BlobSender.cs
+++ b/tools/SendBlobs/BlobSender.cs
@@ -92,7 +92,6 @@ internal class BlobSender
             signers.Add(new(new Signer(chainId, privateKey, _logManager), nonce));
         }
 
-        TxDecoder txDecoder = TxDecoder.Instance;
         Random random = new();
 
         int signerIndex = -1;


### PR DESCRIPTION
Drop the unused local TxDecoder instance so SendRandomBlobs relies on the existing static field reduce noise and silence analyzer warnings without touching runtime flow