### PR TITLE
test: fix gas price calculation comment in EIP-1559 test

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.GasPrice.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.GasPrice.cs
@@ -104,7 +104,7 @@ public partial class EthRpcModuleTests
         ).TestObject;
 
         Block secondBlock = Build.A.Block.WithNumber(1).WithParentHash(firstBlock.Hash!).WithBaseFeePerGas(3).WithTransactions(
-            Build.A.Transaction.WithMaxFeePerGas(3).WithMaxPriorityFeePerGas(3).SignedAndResolved(TestItem.PrivateKeyC).WithNonce(0).WithType(TxType.EIP1559).TestObject, //Min(3, 2 + 3) = 3
+            Build.A.Transaction.WithMaxFeePerGas(3).WithMaxPriorityFeePerGas(3).SignedAndResolved(TestItem.PrivateKeyC).WithNonce(0).WithType(TxType.EIP1559).TestObject, //Min(3, 3 + 3) = 3
             Build.A.Transaction.WithMaxFeePerGas(4).WithMaxPriorityFeePerGas(0).SignedAndResolved(TestItem.PrivateKeyD).WithNonce(0).WithType(TxType.EIP1559).TestObject  //Min(4, 0 + 3) = 3
         ).TestObject;
 


### PR DESCRIPTION
Corrected the comment on line 107 in GetThreeTestBlocksWith1559Tx() method. The transaction uses WithMaxPriorityFeePerGas(3), but the comment incorrectly stated "Min(3, 2 + 3) = 3". Updated to "Min(3, 3 + 3) = 3" to match the actual code parameters.