### PR TITLE
Refactor: prune unused usings in HiveCompare models

### DIFF
--- a/tools/HiveCompare/Models/HiveTestResult.cs
+++ b/tools/HiveCompare/Models/HiveTestResult.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace HiveCompare.Models
 {


### PR DESCRIPTION
Drop unused using directives from tools/HiveCompare/Models/HiveTestResult.cs to keep the model clean and warning-free
