### PR TITLE
refactor: remove unused imports in XdcSealValidator

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcSealValidator.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcSealValidator.cs
@@ -10,10 +10,6 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 using static Nethermind.Xdc.XdcExtensions;


### PR DESCRIPTION
Removed unused collection imports that weren't being used anywhere in the code. The file only uses SequenceEqual from System.Linq, so the extra System.Collections.* imports (Frozen, Immutable, ObjectModel, Generic) weren't needed.