### PR TITLE
fix: Use correct round for grandParent block in CommitBlock

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
@@ -106,7 +106,7 @@ internal class QuorumCertificateManager : IQuorumCertificateManager
         if (_context.HighestCommitBlock is not null && (_context.HighestCommitBlock.Round >= parentHeader.ExtraConsensusData.BlockRound || _context.HighestCommitBlock.BlockNumber > grandParentHeader.Number))
             return false;
 
-        _context.HighestCommitBlock = new BlockRoundInfo(grandParentHeader.Hash, parentHeader.ExtraConsensusData.BlockRound, grandParentHeader.Number);
+        _context.HighestCommitBlock = new BlockRoundInfo(grandParentHeader.Hash, grandParentHeader.ExtraConsensusData.BlockRound, grandParentHeader.Number);
 
         //Finalize the grand parent
         _blockTree.ForkChoiceUpdated(grandParentHeader.Hash, grandParentHeader.Hash);


### PR DESCRIPTION
Fixed bug in QuorumCertificateManager.CommitBlock() where BlockRoundInfo for grandParent block was created with wrong round value from parent instead of grandParent.

This caused HighestCommitBlock.Round to be set to (proposedRound - 1) instead of (proposedRound - 2), making the check on line 106 always return false on subsequent calls with same parent round. Block won't commit when it should.

Changed to use grandParentHeader.ExtraConsensusData.BlockRound to match the other fields (hash and number) which already reference grandParent correctly.