### PR TITLE
Fix resource leak in HttpJsonRpcSubmitter

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcSubmitter/HttpJsonRpcSubmitter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcSubmitter/HttpJsonRpcSubmitter.cs
@@ -29,7 +29,7 @@ public sealed class HttpJsonRpcSubmitter : IJsonRpcSubmitter
             Content = new StringContent(rpc.ToJsonString(), Encoding.UTF8, MediaTypeNames.Application.Json),
         };
 
-        var httpResponse = await _httpClient.SendAsync(request, token);
+        using HttpResponseMessage httpResponse = await _httpClient.SendAsync(request, token);
         return await JsonRpc.Response.FromHttpResponseAsync(httpResponse, token);
     }
 }


### PR DESCRIPTION
## Changes

- Dispose `HttpResponseMessage` in `HttpJsonRpcSubmitter.Submit` method using `using` statement

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

The fix ensures proper disposal of HTTP response resources. Existing functionality remains unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `HttpResponseMessage` returned by `HttpClient.SendAsync` implements `IDisposable` and must be disposed to release underlying network resources and socket connections. Without proper disposal, connections remain in the connection pool until garbage collection, which can lead to socket exhaustion and connection pool depletion under high load scenarios.
