### PR TITLE
Remove unused System import from OneLoggerLogManager

### DIFF
--- a/src/Nethermind/Nethermind.Logging/OneLoggerLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/OneLoggerLogManager.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging


### PR DESCRIPTION
drop the using System; directive in OneLoggerLogManager, as the file relies only on System.Runtime.CompilerServices keep the logging helper lean by avoiding unnecessary framework references