### PR TITLE
Fix Chainspec for Taiko-Hoodi

### DIFF
--- a/src/Nethermind/Chains/taiko-hoodi.json
+++ b/src/Nethermind/Chains/taiko-hoodi.json
@@ -3,8 +3,8 @@
   "dataDir": "taiko-hoodi",
   "engine": {
     "Taiko": {
-      "ontakeTransition": "0xcd340",
-      "pacayaTransition": "0x13d5b0",
+      "ontakeTransition": "0x0",
+      "pacayaTransition": "0x0",
       "taikoL2Address": "0x1670130000000000000000000000000000010001"
     }
   },


### PR DESCRIPTION
Fix taiko hoodi chainspec to match taiko-geth genesis values for hard-fork transitions: https://github.com/taikoxyz/taiko-geth/blob/5812bdf697ac516fcfa22b2945209a7138483f1c/core/taiko_genesis.go#L22

The actual issue which was shown in the logs was invalid block on taiko-hoodi (since pacaya fork was not activated):
```
sedge-execution-taiko-client        | 13 Nov 10:43:52 | Received New Block:  878885 (0x64a54a...3d500f)      | limit   241,000,000    | Hex: 0x000000000000000000000000000000000000000000000000000000000000004b 
sedge-execution-taiko-client        | 13 Nov 10:43:52 | Rejected invalid block 878885 (0x64a54adbf922264d184828dff3555e857bbcf9728b2df4ea9607e552a53d500f),  ExtraData: K, reason: orphaned block is invalid: Anchor transaction must have correct gas limit 
```

## Changes
- Chainspec fix

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

Tested locally:
```
sedge-execution-taiko-client        | 13 Nov 11:15:03 | Received ForkChoice: 0x34a20d7f2690e48ab18c203b14140bc4e49c75911b1826fc9051c39efcd7d17d, Safe: 0x0000000000000000000000000000000000000000000000000000000000000000, Finalized: 0x0000000000000000000000000000000000000000000000000000000000000000 
sedge-execution-taiko-client        | 13 Nov 11:15:03 | New beacon pivot: 879911 (0x34a20d7f2690e48ab18c203b14140bc4e49c75911b1826fc9051c39efcd7d17d) 
sedge-execution-taiko-client        | 13 Nov 11:15:03 | Start a new sync process, Request: ForkChoice: 0x34a20d7f2690e48ab18c203b14140bc4e49c75911b1826fc9051c39efcd7d17d, Safe: 0x0000000000000000000000000000000000000000000000000000000000000000, Finalized: 0x0000000000000000000000000000000000000000000000000000000000000000. 
```

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No