### PR TITLE
feat: Avoid allocating SlicedReadOnlyList when using full request range

### DIFF
--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
@@ -61,7 +61,10 @@ public class LatencyAndMessageSizeBasedRequestSizer
         {
             long startTime = Stopwatch.GetTimestamp();
             long affectiveRequestSize = Math.Min(adjustedRequestSize, request.Count);
-            (TResponse result, long messageSize) = await func(request.Slice(0, Math.Min(adjustedRequestSize, request.Count)));
+            IReadOnlyList<TRequest> cappedRequest = affectiveRequestSize == request.Count
+                ? request
+                : request.Slice(0, (int)affectiveRequestSize);
+            (TResponse result, long messageSize) = await func(cappedRequest);
             TimeSpan duration = Stopwatch.GetElapsedTime(startTime);
             if (messageSize > _maxResponseSize)
             {


### PR DESCRIPTION
## Changes

Replace unconditional request.Slice(0, Math.Min(...)) with conditional pass-through of the original request when adjustedRequestSize >= request.Count.
Also reuse the precomputed effective size to avoid duplicated Math.Min(...) computation.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Remarks

This removes one allocation per call in common cases while preserving exact semantics.
The Slice extension returns a wrapper; when the full list is requested, wrapping is unnecessary and provides no functional benefit.
