### PR TITLE
fix: map EOF call execution types to callType strings

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -81,9 +81,9 @@ public class ParityLikeTxTracer : TxTracer
         {
             ExecutionType.CREATE or ExecutionType.CREATE2 or ExecutionType.EOFCREATE
                 or ExecutionType.TXCREATE => "create",
-            ExecutionType.CALL or ExecutionType.TRANSACTION => "call",
-            ExecutionType.DELEGATECALL => "delegatecall",
-            ExecutionType.STATICCALL => "staticcall",
+            ExecutionType.CALL or ExecutionType.TRANSACTION or ExecutionType.EOFCALL => "call",
+            ExecutionType.DELEGATECALL or ExecutionType.EOFDELEGATECALL => "delegatecall",
+            ExecutionType.STATICCALL or ExecutionType.EOFSTATICCALL => "staticcall",
             ExecutionType.CALLCODE => "callcode",
             _ => throw new NotSupportedException($"Parity trace call type is undefined for {executionType}")
         };


### PR DESCRIPTION
Extend GetCallType in ParityLikeTxTracer to support EOFCALL, EOFSTATICCALL, and EOFDELEGATECALL by mapping them to the same callType strings as legacy calls. This avoids NotSupportedException during parity-style tracing when EOF call opcodes are executed and ensures output remains parity-compatible for clients expecting canonical call/staticcall/delegatecall labels.