### PR TITLE
chore(xdc): remove unused usings in XdcBlockS

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcBlockSuggester.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockSuggester.cs
@@ -4,12 +4,6 @@
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
-using Nethermind.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nethermind.Xdc;
 


### PR DESCRIPTION
 delete the six unused namespace imports from `Nethermind.Xdc/XdcBlockSuggester.cs`, keep only the dependencies required by the class to reduce noise and avoid needless warnings