### PR TITLE
Remove unused System.Collections import from XdcHotStuff.cs

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
@@ -13,7 +13,6 @@ using Nethermind.Logging;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;


### PR DESCRIPTION
Removes unused `using System.Collections;` import from `XdcHotStuff.cs` to clean up unnecessary dependencies.