### PR TITLE
fix: unsubscribe from IHistoryPruner.NewOldestBlock in SyncServer.Dispose

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -558,6 +558,7 @@ namespace Nethermind.Synchronization
         private void StopNotifyingPeersAboutBlockRangeUpdates()
         {
             _blockTree.NewHeadBlock -= OnNewRange;
+            _historyPruner.NewOldestBlock -= OnNewRange;
         }
 
         public void Dispose()


### PR DESCRIPTION
The SyncServer constructor subscribes to IHistoryPruner.NewOldestBlock to broadcast range updates when the pruning oldest block advances, but Dispose only detached the OnNewRange handler from IBlockTree.NewHeadBlock and did not unsubscribe from IHistoryPruner.NewOldestBlock. Because NewOldestBlock is a standard strong event, the HistoryPruner keeps a reference to the SyncServer via the delegate, causing the SyncServer to remain alive past disposal and allowing OnNewRange to be invoked after the server is torn down. This can lead to memory/lifecycle leaks and unexpected background broadcasts being scheduled against disposed state. This change adds the missing _historyPruner.NewOldestBlock -= OnNewRange unsubscription in StopNotifyingPeersAboutBlockRangeUpdates so that Dispose fully detaches SyncServer from all event sources it subscribed to, aligning with the existing pattern for NewHeadBlock and preventing dangling handlers.