### PR TITLE
XDC: enforce end-of-sequence checks

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
@@ -36,6 +36,10 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
         }
 
         ulong gap = decoderContext.DecodeULong();
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
+        {
+            decoderContext.Check(endPosition);
+        }
         return new QuorumCertificate(blockInfo, signatures, gap);
     }
 
@@ -61,6 +65,10 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
         }
 
         ulong gap = rlpStream.DecodeULong();
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
+        {
+            rlpStream.Check(endPosition);
+        }
         return new QuorumCertificate(blockInfo, signatures, gap);
     }
 


### PR DESCRIPTION
Added strict end-of-sequence validations to QuorumCertificateDecoder and XdcBlockInfoDecoder in both RlpStream and ValueDecoderContext decode paths, guarded by the absence of AllowExtraBytes. This aligns these decoders with the prevailing RLP decoding pattern used across XDC types (VoteDecoder, TimeoutDecoder, TimeoutCertificateDecoder, ExtraConsensusDataDecoder) and with the canonical BlockInfoDecoder in the RLP library. Previously, both decoders computed endPosition but did not consume or verify it, allowing extra trailing bytes inside nested sequences to be silently accepted and leaving endPosition as dead code. Enforcing boundary checks ensures that each decoder consumes exactly its declared sequence, failing fast on malformed payloads and eliminating the dead-code scenario.