### PR TITLE
perf: avoid redundant Hash256 allocation

### DIFF
--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
@@ -71,7 +71,7 @@ public class ValidateSubmissionHandler
             return FlashbotsResult.Invalid("Parent beacon block root must be set in the request");
         }
 
-        payload.ParentBeaconBlockRoot = new Hash256(request.ParentBeaconBlockRoot);
+        payload.ParentBeaconBlockRoot = request.ParentBeaconBlockRoot;
 
         BlobsBundleV1 blobsBundle = request.BlobsBundle;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -101,7 +101,7 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
             return ValidationResult.Fail;
         }
 
-        executionPayload.ParentBeaconBlockRoot = new Hash256(parentBeaconBlockRoot);
+        executionPayload.ParentBeaconBlockRoot = parentBeaconBlockRoot;
 
         error = null;
         return ValidationResult.Success;


### PR DESCRIPTION
Removed unnecessary Hash256 construction, replaced with direct nullable Hash256 assignments in ValidateBuilderSubmissionHandler and ExecutionPayloadParams. Both properties are typed as Hash256?, so reference assignment is safe and avoids allocating a new Hash256 object. Hash256 is treated as immutable, and ExecutionPayloadV3.TryGetBlock only forwards the value into BlockHeader without mutation. The codebase elsewhere (e.g., ExecutionPayloadV3.Create) uses direct assignment for the same field, so this aligns with established patterns. RExecutionPayloadV3 does not carry parent_beacon_block_root, which is expected to be set separately; removing the constructor call preserves behavior while eliminating needless allocations.