### PR TITLE
fix: use IN tag for incoming trace logs

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -172,7 +172,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected void ReportIn(string messageInfo, int size)
         {
             if (Logger.IsTrace)
-                Logger.Trace($"OUT {Counter:D5} {messageInfo}");
+                Logger.Trace($"IN {Counter:D5} {messageInfo}");
 
             if (NetworkDiagTracer.IsEnabled)
                 NetworkDiagTracer.ReportIncomingMessage(Session?.Node?.Address, Name, messageInfo, size);


### PR DESCRIPTION
## Changes

corrected direction tag in incoming trace logs within ProtocolHandlerBase.ReportIn(string, int), replacing “OUT” with “IN” to align with the established semantics used across the codebase and with NetworkDiagTracer which already reports incoming messages via ReportIncomingMessage. Outgoing logs in send paths (e.g., SyncPeerProtocolHandlerBase and ETH protocol handlers) consistently use “OUT”, and no other occurrences were found where incoming paths used “OUT”, indicating this was an isolated inconsistency rather than an intentional convention.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: small change




