### PR TITLE
fix: remove redundant ExtraData assignment

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
@@ -42,7 +42,6 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         {
             BlockHeader blockHeader = base.PrepareBlockHeader(parent, payloadAttributes);
 
-            blockHeader.ExtraData = _blocksConfig.GetExtraDataBytes();
             blockHeader.IsPostMerge = true;
             IReleaseSpec spec = _specProvider.GetSpec(blockHeader);
 


### PR DESCRIPTION
Assigning `blockHeader.ExtraData` in `PostMergeBlockProducer.PrepareBlockHeader()` is redundant.
The base method already sets ExtraData from `_blocksConfig.GetExtraDataBytes()`