### PR TITLE
Fix `RequestPooledTransactions` generic parameter name

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -176,7 +176,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             }
         }
 
-        protected virtual void RequestPooledTransactions<TMessage>(IOwnedReadOnlyList<Hash256> hashes)
+        protected void RequestPooledTransactions<TMessage>(IOwnedReadOnlyList<Hash256> hashes)
             where TMessage : P2PMessage, INew<IOwnedReadOnlyList<Hash256>, TMessage>
         {
             AddNotifiedTransactions(hashes);


### PR DESCRIPTION
Keeps being flagged as error in Rider and just seems wrong.

## Changes

- `RequestPooledTransactions` generic parameter name.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: code analysis

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update
- [x] No

#### Requires explanation in Release Notes

- [x] No