### PR TITLE
Remove `eth_sendRawTransaction/send-blob-tx` as passing

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -3,7 +3,6 @@
 eth_getStorageAt/get-storage-invalid-key (nethermind)
 eth_getStorageAt/get-storage-invalid-key-too-large (nethermind)
 eth_createAccessList/create-al-abi-revert (nethermind)
-eth_sendRawTransaction/send-blob-tx (nethermind)
 eth_simulateV1/ethSimulate-instrict-gas-38013 (nethermind)
 eth_simulateV1/ethSimulate-two-blocks-with-complete-eth-sends (nethermind)
 eth_simulateV1/ethSimulate-use-as-many-features-as-possible (nethermind)


### PR DESCRIPTION
## Changes

Since `eth_sendRawTransaction/send-blob-tx` is now passing in Hive tests, it has been removed from known failures.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Hive tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Already been tested
