### PR TITLE
XDC: stream Signature as spans to eliminate per-call 65B allocations

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
@@ -105,8 +105,10 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
                 stream.StartSequence(signatureContentLength);
                 foreach (var sig in item.Signatures)
                 {
-                    //TODO Signature class should be optimized to store full 65 bytes
-                    stream.Encode(sig.BytesWithRecovery);
+                    stream.StartByteArray(65, false);
+                    stream.Write(sig.RAsSpan);
+                    stream.Write(sig.SAsSpan);
+                    stream.WriteByte(sig.RecoveryId);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
@@ -104,7 +104,12 @@ public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertifica
         {
             stream.StartSequence(SignaturesLength(item));
             foreach (Signature sig in item.Signatures)
-                stream.Encode(sig.BytesWithRecovery);
+            {
+                stream.StartByteArray(65, false);
+                stream.Write(sig.RAsSpan);
+                stream.Write(sig.SAsSpan);
+                stream.WriteByte(sig.RecoveryId);
+            }
         }
 
         stream.Encode(item.GapNumber);

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutDecoder.cs
@@ -90,9 +90,16 @@ public sealed class TimeoutDecoder : RlpValueDecoder<Timeout>
         if ((rlpBehaviors & RlpBehaviors.ForSealing) != RlpBehaviors.ForSealing)
         {
             if (item.Signature is null)
+            {
                 stream.EncodeNullObject();
+            }
             else
-                stream.Encode(item.Signature.BytesWithRecovery);
+            {
+                stream.StartByteArray(65, false);
+                stream.Write(item.Signature.RAsSpan);
+                stream.Write(item.Signature.SAsSpan);
+                stream.WriteByte(item.Signature.RecoveryId);
+            }
         }
 
         stream.Encode(item.GapNumber);

--- a/src/Nethermind/Nethermind.Xdc/RLP/VoteDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/VoteDecoder.cs
@@ -70,7 +70,12 @@ public sealed class VoteDecoder : RlpValueDecoder<Vote>
         stream.StartSequence(GetContentLength(item, rlpBehaviors));
         _xdcBlockInfoDecoder.Encode(stream, item.ProposedBlockInfo, rlpBehaviors);
         if ((rlpBehaviors & RlpBehaviors.ForSealing) != RlpBehaviors.ForSealing)
-            stream.Encode(item.Signature.BytesWithRecovery);
+        {
+            stream.StartByteArray(65, false);
+            stream.Write(item.Signature.RAsSpan);
+            stream.Write(item.Signature.SAsSpan);
+            stream.WriteByte(item.Signature.RecoveryId);
+        }
         stream.Encode(item.GapNumber);
     }
 


### PR DESCRIPTION
## Changes

Replaced all uses of Signature.BytesWithRecovery in XDC RLP encoders with direct streaming via StartByteArray, Write of R/S spans and WriteByte for recovery id. This preserves exact RLP output while removing a byte[65] allocation from each encode call on hot serialization paths such as quorum and timeout certificates. RlpStream already exposes span-based APIs, so no API changes to Signature are required and we retain its Vector512-based storage. Other areas where a byte[] is truly required (e.g., header fields and tests) are left intact to maintain existing data model contracts. This change reduces GC pressure and improves throughput

#### What types of changes does your code introduce?

- [x] Optimization

