### PR TITLE
Fix disk space errors on GitHub runners

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -17,7 +17,7 @@ jobs:
         solution: [Nethermind, EthereumTests, Benchmarks]
     steps:
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           large-packages: false
           tool-cache: false

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,6 +30,12 @@ jobs:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
+          tool-cache: false
+
       - name: Check out repository
         uses: actions/checkout@v5
 


### PR DESCRIPTION
## Changes

Fixed "no disk space left" errors when building the diagnostics Docker image.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually
