### PR TITLE
fix: END 3 assertion index in GethLikeTxMemoryTracerTests

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
@@ -213,7 +213,7 @@ public class GethLikeTxMemoryTracerTests : VirtualMachineTestsBase
         Assert.That(trace.Entries[9].Stack.Count, Is.EqualTo(0), "BEGIN 2");
         Assert.That(trace.Entries[19].Stack.Count, Is.EqualTo(4), "CREATE FROM 2");
         Assert.That(trace.Entries[20].Stack.Count, Is.EqualTo(0), "BEGIN 3");
-        Assert.That(trace.Entries[2].Stack.Count, Is.EqualTo(2), "END 3");
+        Assert.That(trace.Entries[25].Stack.Count, Is.EqualTo(2), "END 3");
         Assert.That(trace.Entries[26].Stack.Count, Is.EqualTo(2), "END 2");
         Assert.That(trace.Entries[27].Stack.Count, Is.EqualTo(2), "END 1");
     }


### PR DESCRIPTION
comment states:
` 1, 1, 1, 1, 1, 1, 1, 1, 1, // SAMPLE STACK + STACK FOR CALL [0..8]`
` 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 // SAMPLE STACK + CALL [9..19`
` 3, 3, 3, 3, 3, 3, // CREATE [20..25]`

                              
so i think 2 is like a typo here and should be 25
too low impact but maybe im lucky