### PR TITLE
fix: remove redundant LINQ sorting and enforce ordinal key ordering

### DIFF
--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
@@ -22,7 +22,7 @@ public class NodeRecord
 
     private Hash256? _contentHash;
 
-    private SortedDictionary<string, EnrContentEntry> Entries { get; } = new();
+    private SortedDictionary<string, EnrContentEntry> Entries { get; } = new(System.StringComparer.Ordinal);
 
     /// <summary>
     /// This field is used when this <see cref="NodeRecord"/> is deserialized and an unknown entry is encountered.
@@ -185,7 +185,7 @@ public class NodeRecord
         int contentLength = GetContentLengthWithoutSignature();
         rlpStream.StartSequence(contentLength);
         rlpStream.Encode(EnrSequence);
-        foreach ((_, EnrContentEntry contentEntry) in Entries.OrderBy(static e => e.Key))
+        foreach ((_, EnrContentEntry contentEntry) in Entries)
         {
             contentEntry.Encode(rlpStream);
         }
@@ -216,7 +216,7 @@ public class NodeRecord
         rlpStream.StartSequence(contentLength);
         rlpStream.Encode(Signature!.Bytes);
         rlpStream.Encode(EnrSequence); // a different sequence here (not RLP sequence)
-        foreach ((_, EnrContentEntry contentEntry) in Entries.OrderBy(static e => e.Key))
+        foreach ((_, EnrContentEntry contentEntry) in Entries)
         {
             contentEntry.Encode(rlpStream);
         }


### PR DESCRIPTION
Removed redundant LINQ sorting in NodeRecord.EncodeContent and NodeRecord.Encode by iterating the existing SortedDictionary directly, and enforces deterministic ENR key ordering by initializing the dictionary with StringComparer.Ordinal. The ENR spec requires keys to be sorted, and protocol data must be culture-invariant; relying on default culture-sensitive comparisons risks non-deterministic ordering, which affects content hashes and signatures. Using ordinal sorting guarantees byte-wise ASCII order and removes LINQ allocations and extra CPU work during encoding. RLP length calculations and semantics remain the same; the only behavioral difference is culture invariance in key order, which is the correct interpretation of the specification.