### PR TITLE
fix: remove unused variable in BlobSender.SendData

### DIFF
--- a/tools/SendBlobs/BlobSender.cs
+++ b/tools/SendBlobs/BlobSender.cs
@@ -204,9 +204,8 @@ internal class BlobSender
         bool waitForInclusion,
         IReleaseSpec spec)
     {
-        int n = 0;
         data = data
-            .Select((s, i) => (i + n) % 32 != 0 ? [s] : (s < 0x73 ? new byte[] { s } : [(byte)(32), s]))
+            .Select((s, i) => i % 32 != 0 ? [s] : (s < 0x73 ? new byte[] { s } : [(byte)(32), s]))
             .SelectMany(b => b).ToArray();
 
         if (waitForInclusion)


### PR DESCRIPTION
Remove dead code in SendData method.

Variable `n` was declared and initialized to 0 but never modified,making `(i + n) % 32` equivalent to just `i % 32`. Cleaned up the unused variable to make the code clearer.