### PR TITLE
fix(blockchain): avoid per-node allocation

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -81,7 +81,7 @@ namespace Nethermind.Blockchain.FullPruning
             if (node.Keccak is not null)
             {
                 // simple copy of nodes RLP
-                _concurrentWriteBatcher.Set(storage, path, node.Keccak, node.FullRlp.ToArray(), _writeFlags);
+                _concurrentWriteBatcher.Set(storage, path, node.Keccak, node.FullRlp.Span, _writeFlags);
                 Interlocked.Increment(ref _persistedNodes);
 
                 // log message every 1 mln nodes


### PR DESCRIPTION
Replace node.FullRlp.ToArray() with node.FullRlp.Span in CopyTreeVisitor.PersistNode to eliminate a heap allocation on every persisted trie node during full pruning. The storage stack accepts ReadOnlySpan (INodeStorage.Set and IWriteBatch.Set) and synchronously copies into RocksDB via Put, so no span is retained past the call. SpanSource.Span provides a non-allocating view of the RLP. Other ToArray usages in proof builders remain unchanged because they intentionally materialize byte[] for later serialization. This change reduces GC pressure and improves pruning throughput without altering behavior.