### PR TITLE
Remove redundant ToArray() call in EngineModuleTests.V4

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -259,7 +259,7 @@ public partial class EngineModuleTests
         last!.IsGenesis.Should().BeTrue();
 
         Block? head = chain.BlockTree.Head;
-        head!.ExecutionRequests!.ToArray().Length.Should().Be(ExecutionRequestsProcessorMock.Requests.Length);
+        head!.ExecutionRequests!.Length.Should().Be(ExecutionRequestsProcessorMock.Requests.Length);
     }
 
     private async Task<IReadOnlyList<ExecutionPayload>> ProduceBranchV4(IEngineRpcModule rpc,


### PR DESCRIPTION
Remove unnecessary `ToArray()` call when accessing array length in test assertion.
