### PR TITLE
Fix `reclaim` CLI command missing receiver option

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -254,6 +254,7 @@ internal static class SetupCli
         };
 
         command.Add(rpcUrlOption);
+        command.Add(receiverOption);
         command.Add(keyFileOption);
         command.Add(maxPriorityFeeGasOption);
         command.Add(maxFeeOption);


### PR DESCRIPTION
Register the mandatory `--receiveraddress` option in `SetupReclaimCommand`, enabling users to pass the receiver address without hitting null references.

