### PR TITLE
fix: Remove invalid eth_getTransactionByHash call

### DIFF
--- a/tools/SendBlobs/BlobSender.cs
+++ b/tools/SendBlobs/BlobSender.cs
@@ -362,8 +362,6 @@ internal class BlobSender
 
                 if (txHash is not null && blockResult.Transactions.Contains(txHash))
                 {
-                    string? receipt = await rpcClient.Post<string>("eth_getTransactionByHash", txHash.ToString(), true);
-
                     Console.WriteLine($"Found blob transaction in block {blockResult.Number}");
                     return;
                 }


### PR DESCRIPTION
Removed an incorrect and unnecessary JSON-RPC call in tools/SendBlobs/BlobSender.cs within WaitForBlobInclusion(). The code was calling eth_getTransactionByHash with two parameters—the transaction hash and a boolean—while the Ethereum JSON-RPC specification mandates exactly one parameter (the hash) for this method and does not accept a boolean, which is only applicable to block retrieval methods like eth_getBlockByNumber or eth_getBlockByHash. Additionally, the call attempted to deserialize the result as a string even though the method returns a transaction object, and the returned value was not used, causing redundant network traffic and potential deserialization logs without any functional effect. Since inclusion is already reliably determined by checking whether the current block’s transaction list contains the hash, the RPC call served no purpose. Removing it aligns the implementation with the spec, avoids unnecessary RPCs, and eliminates dead code without changing the tool’s behavior.