### PR TITLE
fix: Correct NullSigner.CanSign to return false

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Blockchain.Test.Consensus
         {
             NullSigner signer = NullSigner.Instance;
             signer.Address.Should().Be(Address.Zero);
-            signer.CanSign.Should().BeTrue();
+            signer.CanSign.Should().BeFalse();
         }
 
         [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Consensus/NullSigner.cs
+++ b/src/Nethermind/Nethermind.Consensus/NullSigner.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Consensus
 
         public Signature Sign(in ValueHash256 message) { return new(new byte[65]); }
 
-        public bool CanSign { get; } = true; // TODO: why true?
+        public bool CanSign { get; } = false;
 
         public PrivateKey? Key { get; } = null;
 


### PR DESCRIPTION
NullSigner is a null object pattern implementation that represents a signer without any signing capability (no private key). The CanSign property was incorrectly returning true, which contradicts the class purpose and the fact that Key is null.

This brings NullSigner in line with the real Signer class behavior where CanSign => _key is not null. Consensus sealers (Clique, AuRa) check CanSign before attempting to seal blocks, so this fix ensures nodes without mining enabled won't incorrectly report they can sign.