### PR TITLE
chore: remove dead IsSyncing field and its assignment

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
@@ -61,7 +61,6 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 if (_logger.IsTrace) _logger.Trace($"Syncing subscription {Id} changed syncing status from {_lastIsSyncing} to {isSyncing}");
 
                 _lastIsSyncing = isSyncing;
-                JsonRpcResult result;
 
                 using (JsonRpcResult result = !isSyncing
                            ? CreateSubscriptionMessage(false)
@@ -74,7 +73,6 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 {
                     await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 }
-
 
                 _logger.Trace($"Syncing subscription {Id} printed SyncingResult object.");
             });


### PR DESCRIPTION
Removed the IsSyncing property from SubscriptionSyncingResult and the corresponding assignment in the object initializer. The field was marked with JsonIgnore and never consumed, resulting in a dead write and unnecessary allocation during message creation. Tests and the eth_subscribe syncing contract expect either a boolean false or an object with startingBlock, currentBlock, and highestBlock only, with no isSyncing field included. The SyncingResult converter governs this shape, so carrying IsSyncing in the wrapper type was redundant