### PR TITLE
chore(sync): remove redundant await in peer refresh loop

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -446,7 +446,6 @@ namespace Nethermind.Synchronization.Peers
             }
 
             if (_logger.IsInfo) _logger.Info("Exiting sync peer refresh loop");
-            await Task.CompletedTask;
         }
 
         private void StartUpgradeTimer()


### PR DESCRIPTION
drop the no-op await Task.CompletedTask; at the end of RunRefreshPeerLoop, reduce generated state machine work while keeping the loop’s behavior unchanged