### PR TITLE
chore(schema-generator): drop unused collections import

### DIFF
--- a/tools/SchemaGenerator/Program.cs
+++ b/tools/SchemaGenerator/Program.cs
@@ -3,7 +3,6 @@ using NJsonSchema;
 using System.Reflection;
 using System.Reflection.Emit;
 using Nethermind.Config;
-using Nethermind.Core.Collections;
 
 Type iConfigType = typeof(IConfig);
 


### PR DESCRIPTION
remove the stale using Nethermind.Core.Collections; from tools/SchemaGenerator/Program.cs keeps SchemaGenerator’s dependencies minimal and silences the unused-import warning