### PR TITLE
Skip creating precompile error string if no error

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CallResult.cs
+++ b/src/Nethermind/Nethermind.Evm/CallResult.cs
@@ -6,7 +6,7 @@ using Nethermind.Evm.CodeAnalysis;
 
 namespace Nethermind.Evm;
 
-public unsafe partial class VirtualMachine
+public partial class VirtualMachine
 {
     protected readonly ref struct CallResult
     {

--- a/src/Nethermind/Nethermind.Evm/ICodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfo.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Evm.CodeAnalysis;
 
@@ -34,6 +35,7 @@ public interface ICodeInfo
     /// By default, this returns <c>false</c>.
     /// </summary>
     bool IsPrecompile => false;
+    IPrecompile? Precompile => null;
 
     /// <summary>
     /// Gets the code section. 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -979,33 +979,34 @@ public unsafe partial class VirtualMachine(
         UInt256 transferValue = state.Env.TransferValue;
         long gasAvailable = state.GasAvailable;
 
-        IPrecompile precompile = ((PrecompileInfo)state.Env.CodeInfo).Precompile!;
+        IPrecompile precompile = state.Env.CodeInfo.Precompile!;
 
         IReleaseSpec spec = BlockExecutionContext.Spec;
         long baseGasCost = precompile.BaseGasCost(spec);
         long dataGasCost = precompile.DataGasCost(callData, spec);
 
-        bool wasCreated = _worldState.AddToBalanceAndCreateIfNotExists(state.Env.ExecutingAccount, transferValue, spec);
+        bool wasCreated = _worldState.AddToBalanceAndCreateIfNotExists(state.Env.ExecutingAccount, in transferValue, spec);
 
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
         // An additional issue was found in Parity,
         // where the Parity client incorrectly failed
         // to revert empty account deletions in a more limited set of contexts
         // involving out-of-gas calls to precompiled contracts;
-        // the new Geth behavior matches Parity’s,
+        // the new Geth behavior matches Parity's,
         // and empty accounts will cease to be a source of concern in general
         // in about one week once the state clearing process finishes.
-        if (state.Env.ExecutingAccount.Equals(_parityTouchBugAccount.Address)
-            && !wasCreated
-            && transferValue.IsZero
-            && spec.ClearEmptyAccountWhenTouched)
+        if (!wasCreated &&
+            transferValue.IsZero &&
+            spec.ClearEmptyAccountWhenTouched &&
+            state.Env.ExecutingAccount.Equals(_parityTouchBugAccount.Address))
         {
             _parityTouchBugAccount.ShouldDelete = true;
         }
 
-        if (!UpdateGas(checked(baseGasCost + dataGasCost), ref gasAvailable))
+        if ((ulong)baseGasCost + (ulong)dataGasCost > (ulong)long.MaxValue ||
+            !UpdateGas(baseGasCost + dataGasCost, ref gasAvailable))
         {
-            return new(default, false, 0, true, EvmExceptionType.OutOfGas);
+            return new(output: default, precompileSuccess: false, fromVersion: 0, shouldRevert: true, EvmExceptionType.OutOfGas);
         }
 
         state.GasAvailable = gasAvailable;
@@ -1022,19 +1023,31 @@ public unsafe partial class VirtualMachine(
                 exceptionType: !success ? EvmExceptionType.PrecompileFailure : EvmExceptionType.None
             )
             {
-                SubstateError = $"Precompile {precompile.GetStaticName()} failed with error: {output.Error}"
+                SubstateError = success ? null : GetErrorString(precompile, output.Error)
             };
         }
         catch (DllNotFoundException exception)
         {
-            if (_logger.IsError) _logger.Error($"Failed to load one of the dependencies of {precompile.GetType()} precompile", exception);
+            if (_logger.IsError) LogMissingDependency(precompile, exception);
             throw;
         }
         catch (Exception exception)
         {
-            if (_logger.IsError) _logger.Error($"Precompiled contract ({precompile.GetType()}) execution exception", exception);
+            if (_logger.IsError) LogExecutionException(precompile, exception);
             return new(output: default, precompileSuccess: false, fromVersion: 0, shouldRevert: true);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void LogExecutionException(IPrecompile precompile, Exception exception)
+            => _logger.Error($"Precompiled contract ({precompile.GetType()}) execution exception", exception);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void LogMissingDependency(IPrecompile precompile, DllNotFoundException exception)
+            => _logger.Error($"Failed to load one of the dependencies of {precompile.GetType()} precompile", exception);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string GetErrorString(IPrecompile precompile, string? error)
+            => $"Precompile {precompile.GetStaticName()} failed with error: {error}";
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- Only create error string for precompiles when there is an error
- Remove the CodeInfo cast for precompiles
- Start lazy `&&` checks with lightest
- Check for overflow and use appropriate error rather than `checked` exception throwing
- Move unlikely logging string construction out of main method (Total bytes of code: 1807 => 1113)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No