### PR TITLE
chore: streamline nullability suppression in LruCache

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -53,10 +53,7 @@ namespace Nethermind.Core.Caching
                 return value;
             }
 
-#pragma warning disable 8603
-            // fixed C# 9
-            return default;
-#pragma warning restore 8603
+            return default!;
         }
 
         public bool TryGet(TKey key, out TValue value)
@@ -70,10 +67,7 @@ namespace Nethermind.Core.Caching
                 return true;
             }
 
-#pragma warning disable 8601
-            // fixed C# 9
-            value = default;
-#pragma warning restore 8601
+            value = default!;
             return false;
         }
 


### PR DESCRIPTION
 return/assign the existing default values with default!, keeping behavior identical while removing the broad warning suppression.