### PR TITLE
chore: remove duplicate AddDatabase registrations in DbModule

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
@@ -70,9 +70,7 @@ public class DbModule(
             .AddDatabase(DbNames.Blocks)
             .AddDatabase(DbNames.Headers)
             .AddDatabase(DbNames.BlockInfos)
-            .AddDatabase(DbNames.BadBlocks)
             .AddDatabase(DbNames.Bloom)
-            .AddDatabase(DbNames.Metadata)
             .AddDatabase(DbNames.BlobTransactions)
 
             .AddColumnDatabase<ReceiptsColumns>(DbNames.Receipts)


### PR DESCRIPTION
The DbModule registered DbNames.BadBlocks and DbNames.Metadata twice in the same registration chain, leading to duplicate keyed registrations. Removing the later duplicates keeps a single, clear registration for each DB key and preserves the intended order for the rest of the databases, improving determinism and maintainability.


.AddDatabase(DbNames.BadBlocks) - Line 73 and 69 (73 deleted)
.AddDatabase(DbNames.Metadata) - Line 75 and 67 (75 deleted)