### PR TITLE
fix: RlpxHost.Init guard to reference RlpxHost instead of PeerManager

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -105,7 +105,7 @@ namespace Nethermind.Network.Rlpx
         {
             if (_isInitialized)
             {
-                throw new InvalidOperationException($"{nameof(PeerManager)} already initialized.");
+                throw new InvalidOperationException($"{nameof(RlpxHost)} already initialized.");
             }
 
             _isInitialized = true;


### PR DESCRIPTION
The initialization guard in RlpxHost.Init() threw InvalidOperationException using nameof(PeerManager), which is misleading because the guard protects the initialization state of RlpxHost itself. Searching the codebase shows no intentional cross-component reference and other components use their own class names in similar guards (e.g., BlockchainProcessor uses nameof(BlockchainProcessor) for “already started”). Therefore, this was a copy/paste mistake and the exception message is corrected to use nameof(RlpxHost) to provide accurate diagnostics and maintain consistency.