### PR TITLE
fix: correct ParentHash assignment and unsafe cast in L1Block

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/CL/L1Block.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/L1Block.cs
@@ -51,11 +51,13 @@ public sealed record L1BlockRef
 
     public static L1BlockRef From(L1BlockInfo blockInfo)
     {
+        // Note: L1BlockInfo doesn't contain ParentHash information
+        // ParentHash should be obtained separately or set to Zero for incomplete data
         return new L1BlockRef
         {
             Hash = blockInfo.BlockHash,
             Number = blockInfo.Number,
-            ParentHash = blockInfo.BlockHash,
+            ParentHash = Hash256.Zero, // Fixed: Cannot use current block hash as parent hash
             Timestamp = blockInfo.Timestamp
         };
     }
@@ -67,7 +69,7 @@ public sealed record L1BlockRef
             Hash = block.Value.Hash,
             Number = block.Value.Number,
             ParentHash = block.Value.ParentHash,
-            Timestamp = (ulong)block.Value.Timestamp // TODO: Potential unsafe cast
+            Timestamp = block.Value.Timestamp.ToUInt64(null) // Fixed: Use safe conversion method
         };
     }
 }


### PR DESCRIPTION
1. ParentHash was incorrectly set to current block hash instead of actual parent
2. Replaced unsafe (ulong) cast with safe ToUInt64() method for timestamps

The From(L1BlockInfo) method was setting ParentHash = blockInfo.BlockHash which makes no sense - a block can't be its own parent. Changed to Hash256.Zero since L1BlockInfo doesn't contain parent hash data.

Also fixed the TODO about unsafe casting by using the same ToUInt64(null) pattern already used elsewhere in the codebase.