### PR TITLE
fix: map ExecutionType.TXCREATE to Instruction.EOFCREATE

### DIFF
--- a/src/Nethermind/Nethermind.Evm/ExecutionType.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionType.cs
@@ -42,6 +42,7 @@ namespace Nethermind.Evm
                 ExecutionType.CREATE => Instruction.CREATE,
                 ExecutionType.CREATE2 => Instruction.CREATE2,
                 ExecutionType.EOFCREATE => Instruction.EOFCREATE,
+                ExecutionType.TXCREATE => Instruction.EOFCREATE,
                 ExecutionType.EOFCALL => Instruction.EXTCALL,
                 ExecutionType.EOFSTATICCALL => Instruction.EXTSTATICCALL,
                 ExecutionType.EOFDELEGATECALL => Instruction.EXTDELEGATECALL,


### PR DESCRIPTION
TXCREATE is used as the top-level execution type for EOF contract creation in TransactionProcessor, but 
ExecutionTypeExtensions.ToInstruction() did not handle it, causing a NotSupportedException during tracing when 
NativeCallTracer.ReportAction() converts the execution type to an opcode. Mapping TXCREATE to EOFCREATE aligns with how TRANSACTION maps to CALL and with the semantics of EOF creation where the corresponding instruction is EOFCREATE. 