### PR TITLE
chore: remove unused block parameter

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
@@ -211,7 +211,7 @@ public class TraceStoreRpcModule : ITraceRpcModule
 
         if (TryGetBlockTraces(block.Header, out List<ParityLikeTxTrace>? traces) && traces is not null)
         {
-            ParityLikeTxTrace? trace = GetTxTrace(block, txHash, traces);
+            ParityLikeTxTrace? trace = GetTxTrace(txHash, traces);
             if (trace is not null)
             {
                 FilterTrace(trace, traceTypes);
@@ -249,7 +249,7 @@ public class TraceStoreRpcModule : ITraceRpcModule
         }
     }
 
-    private static ParityLikeTxTrace? GetTxTrace(Block block, Hash256 txHash, List<ParityLikeTxTrace> traces)
+    private static ParityLikeTxTrace? GetTxTrace(Hash256 txHash, List<ParityLikeTxTrace> traces)
     {
         int index = traces.FindIndex(t => t.TransactionHash == txHash);
         return index != -1 ? traces[index] : null;


### PR DESCRIPTION
The GetTxTrace method accepted a Block argument that was never used, while the logic relied solely on txHash and the traces list, which are already scoped to a specific block by virtue of TryGetBlockTraces reading from the store via block header hash. Removing the unused parameter simplifies the signature, eliminates confusion around intent, and aligns with actual usage where TransactionHash uniquely identifies transaction traces. This change does not affect functionality because reward traces (which have null TransactionHash) are not resolved via this path, and tests and serializers confirm that TransactionHash is always present for transaction traces. The only call site was updated accordingly and a repository search confirms no remaining references to the previous signature.