### PR TITLE
Refactor ColumnsDb constructor to avoid redundant enum enumeration

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -21,6 +21,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         : this(basePath, settings, dbConfig, rocksDbConfigFactory, logManager, GetEnumKeys(keys), sharedCache)
     {
     }
+
     private ColumnsDb(string basePath, DbSettings settings, IDbConfig dbConfig, IRocksDbConfigFactory rocksDbConfigFactory, ILogManager logManager, IReadOnlyList<T> keys, IntPtr? sharedCache)
         : base(basePath, settings, dbConfig, rocksDbConfigFactory, logManager, keys.Select(static key => key.ToString()).ToList(), sharedCache: sharedCache)
     {


### PR DESCRIPTION
Deduplicate the GetEnumKeys call by delegating the public constructor to a private overload. Ensure enum keys are materialized once before passing them to the base class and column initialization.