### PR TITLE
Fix ColumnsDb constructor recursion and reuse resolved keys

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -22,7 +22,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
     {
     }
 
-        private ColumnsDb(string basePath, DbSettings settings, IDbConfig dbConfig, IRocksDbConfigFactory rocksDbConfigFactory, ILogManager logManager, (IReadOnlyList<T> Keys, IList<string> ColumnNames) keyInfo, IntPtr? sharedCache)
+    private ColumnsDb(string basePath, DbSettings settings, IDbConfig dbConfig, IRocksDbConfigFactory rocksDbConfigFactory, ILogManager logManager, (IReadOnlyList<T> Keys, IList<string> ColumnNames) keyInfo, IntPtr? sharedCache)
         : base(basePath, settings, dbConfig, rocksDbConfigFactory, logManager, keyInfo.ColumnNames, sharedCache: sharedCache)
     {
         foreach (T key in keyInfo.Keys)


### PR DESCRIPTION
redirect ColumnsDb’s public ctor to a private overload that accepts both the resolved keys and their string column names, compute enum fallbacks and ToString() names exactly once via ResolveKeys, keep the existing fallback to enumerate T when no keys are provided. І also reopened the pull request with these updated changes.