### PR TITLE
Remove redundant branch hash lookup in EngineModuleTests V4

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -170,8 +170,7 @@ public partial class EngineModuleTests
         ExecutionRequestsProcessorMock executionRequestsProcessorMock = new();
         using MergeTestBlockchain chain = await CreateBlockchain(Prague.Instance, null, null, executionRequestsProcessorMock);
         IEngineRpcModule rpc = chain.EngineRpcModule;
-        Hash256 lastHash = (await ProduceBranchV4(rpc, chain, 10, CreateParentBlockRequestOnHead(chain.BlockTree), true, withRequests: true))
-            .LastOrDefault()?.BlockHash ?? Keccak.Zero;
+        await ProduceBranchV4(rpc, chain, 10, CreateParentBlockRequestOnHead(chain.BlockTree), true, withRequests: true);
 
         Transaction invalidSetCodeTx = Build.A.Transaction
           .WithType(TxType.SetCode)


### PR DESCRIPTION
drop the unused `lastHash` assignment in `NewPayloadV4_reject_payload_with_bad_authorization_list_rlp`, stop computing the branch hash just to discard it while keeping the branch setup side effect intact, keep test semantics unchanged while reducing needless work