### PR TITLE
Remove redundant Math.Min call in SnapServer storage guard

### DIFF
--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -226,7 +226,7 @@ public class SnapServer : ISnapServer
                 break;
             }
 
-            if (responseSize > 1 && (Math.Min(byteLimit, HardResponseByteLimit) - responseSize) < 10000)
+            if (responseSize > 1 && (byteLimit - responseSize) < 10000)
             {
                 break;
             }


### PR DESCRIPTION
drop the extra Math.Min(byteLimit, HardResponseByteLimit) call in SnapServer.GetStorageRanges, rely on the earlier clamp of byteLimit, keeping logic identical while removing needless recalculation