### PR TITLE
Fix redundant allocation in IXdcHeaderStore.BulkInsert

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/IXdcHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/IXdcHeaderStore.cs
@@ -5,14 +5,13 @@ using Nethermind.Blockchain.Headers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nethermind.Xdc;
 
 internal interface IXdcHeaderStore : IHeaderStore
 {
     void Insert(XdcBlockHeader header) => ((IHeaderStore)this).Insert(header);
-    void BulkInsert(IReadOnlyList<XdcBlockHeader> headers) => BulkInsert(headers.Cast<BlockHeader>().ToList());
+    void BulkInsert(IReadOnlyList<XdcBlockHeader> headers) => ((IHeaderStore)this).BulkInsert(headers);
     new XdcBlockHeader? Get(Hash256 blockHash, bool shouldCache, long? blockNumber = null) => ((IHeaderStore)this).Get(blockHash, shouldCache, blockNumber) as XdcBlockHeader;
 
     void Cache(XdcBlockHeader header) => ((IHeaderStore)this).Cache(header);


### PR DESCRIPTION
call the base IHeaderStore.BulkInsert from the XDC default implementation, drop the Cast().ToList() copy that was duplicating header collections, remove the now-unused System.Linq import