### PR TITLE
Remove unnecessary pragma suppression from SortedPool events

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.Events.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.Events.cs
@@ -7,10 +7,8 @@ namespace Nethermind.TxPool.Collections
 {
     public partial class SortedPool<TKey, TValue, TGroupKey>
     {
-#pragma warning disable 67
         public event EventHandler<SortedPoolEventArgs>? Inserted;
         public event EventHandler<SortedPoolRemovedEventArgs>? Removed;
-#pragma warning restore 67
 
         public class SortedPoolEventArgs(TKey key, TValue value)
         {


### PR DESCRIPTION
drop the redundant #pragma warning disable/restore 67 in SortedPool.Events.cs, rely on the existing event invocations to surface real unused-event warnings in future