### PR TITLE
Shrink ReadToEndAsync async machine

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
@@ -29,7 +29,7 @@ public static class PipeReaderExtensions
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void AdvanceReaderToEnd(PipeReader reader, in ReadResult result)
         {
-            // Common path we don't want to read the buffer
+            // Extract buffer reading to a separate method to reduce async state machine size
             ReadOnlySequence<byte> buffer = result.Buffer;
             reader.AdvanceTo(buffer.Start, buffer.End);
         }


### PR DESCRIPTION
## Changes

- Shrink async machine
- Don't read `.Buffer` in common path

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
