### PR TITLE
perf: use bitwise checks for RpcEndpoint to avoid boxing

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -95,7 +95,7 @@ public class JsonRpcUrlCollection : Dictionary<int, JsonRpcUrl>, IJsonRpcUrlColl
             try
             {
                 JsonRpcUrl url = JsonRpcUrl.Parse(additionalRpcUrl);
-                if (!includeWebSockets && url.RpcEndpoint.HasFlag(RpcEndpoint.Ws))
+                if (!includeWebSockets && (url.RpcEndpoint & RpcEndpoint.Ws) != 0)
                 {
                     url.RpcEndpoint &= ~RpcEndpoint.Ws;
                     if (url.RpcEndpoint == RpcEndpoint.None)

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
@@ -56,7 +56,7 @@ public class JsonRpcWebSocketsModule : IWebSocketsModule
     {
         int port = context.Connection.LocalPort;
 
-        if (!_jsonRpcUrlCollection.TryGetValue(port, out JsonRpcUrl jsonRpcUrl) || !jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Ws))
+        if (!_jsonRpcUrlCollection.TryGetValue(port, out JsonRpcUrl jsonRpcUrl) || (jsonRpcUrl.RpcEndpoint & RpcEndpoint.Ws) == 0)
         {
             throw new InvalidOperationException($"WebSocket-enabled url not defined for port {port}");
         }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -129,7 +129,7 @@ public class Startup : IStartup
             app.UseWhen(ctx =>
                 ctx.WebSockets.IsWebSocketRequest &&
                 jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl jsonRpcUrl) &&
-                jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Ws),
+                (jsonRpcUrl.RpcEndpoint & RpcEndpoint.Ws) != 0,
             builder => builder.UseWebSocketsModules());
         }
 
@@ -176,7 +176,7 @@ public class Startup : IStartup
                 return;
             }
 
-            if (!jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl jsonRpcUrl) || !jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Http))
+            if (!jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl jsonRpcUrl) || (jsonRpcUrl.RpcEndpoint & RpcEndpoint.Http) == 0)
             {
                 ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return;


### PR DESCRIPTION
I made this change because Enum.HasFlag causes boxing and extra runtime checks on [Flags] enums, which creates unnecessary allocations and overhead on hot paths. This gives allocation-free, faster checks using bitwise operations while preserving identical behavior for RpcEndpoint in JsonRpcWebSocketsModule.cs, Startup.cs, and JsonRpcUrlCollection.cs.