### PR TITLE
fix: correct EOFCREATE error message

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
@@ -1473,7 +1473,7 @@ internal class Eof1 : IEofVersionHandler
         if (eofContainer.Header.ContainerSections is null || initCodeSectionId >= eofContainer.Header.ContainerSections.Value.Count)
         {
             if (Logger.IsTrace)
-                Logger.Trace($"EOF: Eof{VERSION}, {Instruction.EOFCREATE}'s immediate must fall within the Containers' range available, i.e.: {eofContainer.Header.CodeSections.Count}");
+                Logger.Trace($"EOF: Eof{VERSION}, {Instruction.EOFCREATE}'s immediate must fall within the Containers' range available, i.e.: {eofContainer.Header.ContainerSections?.Count}");
             return false;
         }
 


### PR DESCRIPTION
The EOFCREATE validation message incorrectly referenced CodeSections.Count while the bounds check validated against Header.ContainerSections. Per EIP‑7620, EOFCREATE immediates index container subcontainers; the message now prints Header.ContainerSections?.Count for accurate diagnostics.