### PR TITLE
Fast path JwtAuthentication

### DIFF
--- a/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
+++ b/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
@@ -36,7 +36,7 @@ public sealed partial class JwtAuthentication : IRpcAuthentication
 
     private JwtAuthentication(byte[] secret, ITimestamper timestamper, ILogger logger)
     {
-        Debug.Assert(secret is not null);
+        ArgumentNullException.ThrowIfNull(secret);
         ArgumentNullException.ThrowIfNull(timestamper);
 
         _securityKey = new SymmetricSecurityKey(secret);
@@ -260,12 +260,12 @@ public sealed partial class JwtAuthentication : IRpcAuthentication
         if (Math.Abs(entry.IssuedAtUnixSeconds - nowUnixSeconds) > JwtTokenTtl)
         {
             // Token lifetime exceeded - drop the cached entry and force a fresh validation
-            Volatile.Write(ref _lastToken, null);
+            Interlocked.CompareExchange(ref _lastToken, null, entry);
             return false;
         }
 
         // Same token, within TTL, recently validated:
-        // Accept as valid without re running JWT parsing and crypto checks
+        // Accept as valid without rerunning JWT parsing and crypto checks
         return true;
     }
 


### PR DESCRIPTION
## Changes

- The same Jwt token is used for a number of requests in a row e.g. newPayload, getBlobs, forkChoice; so if we have already validated and within validation period we can skip the full checks which are more time consuming and allocating

<img  src="https://github.com/user-attachments/assets/c9a479b6-b01a-4fbb-afa8-f497baa541b5" />

<img  src="https://github.com/user-attachments/assets/981a8447-be0f-4c5f-bd28-65c1b5f4c41a" />

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
