### PR TITLE
fix: keep PeerPool commit loop running when no pending changes

### DIFF
--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Network
                     if (!_peerStorage.AnyPendingChange())
                     {
                         if (_logger.IsTrace) _logger.Trace("No changes in peer storage, skipping commit.");
-                        return;
+                        continue;
                     }
 
                     _peerStorage.Commit();


### PR DESCRIPTION
## Changes

The periodic persistence worker in PeerPool.RunPeerCommit() exited permanently on a tick with no pending changes due to an early return. This prevented future commits and could leave batches uncommitted. Switched to continue to skip the current tick while keeping the loop alive. This matches thecorrect pattern used in DiscoveryPersistenceManager.RunDiscoveryPersistenceCommit() and aligns with INetworkStorage batching semantics.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)


## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

