### PR TITLE
perf: avoid extra allocation by iterating snapshot

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Core.Collections
             T[] ts = new T[Count];
             CopyTo(ts, 0);
             HashSet<T> set = other.ToHashSet();
-            foreach (T t in this.ToArray())
+            foreach (T t in ts)
             {
                 if (!set.Contains(t))
                 {


### PR DESCRIPTION
Use the already created snapshot array in IntersectWith instead of calling this.ToArray(). This removes dead code and prevents an extra allocation without changing semantics. The approach now mirrors SymmetricExceptWith, ensuring safe iteration while mutating the set.