### PR TITLE
chore(init): remove unused StateReader assignment in InitializeBlockchain

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -53,8 +53,6 @@ namespace Nethermind.Init.Steps
                 blocksConfig.ExtraData :
                 "- binary data -");
 
-            IStateReader stateReader = setApi.StateReader!;
-
             _api.TxGossipPolicy.Policies.Add(new SpecDrivenTxGossipPolicy(chainHeadInfoProvider));
 
             ITxPool txPool = _api.TxPool = CreateTxPool(chainHeadInfoProvider);


### PR DESCRIPTION
Removed an unused local assignment to StateReader in InitBlockchain. The property getter simply resolves the service from DI and the value was never used, so keeping it only forces an unnecessary resolution at startup. This eliminates dead code without changing behavior.