### PR TITLE
fix: add missing string interpolation

### DIFF
--- a/tools/Evm/T8n/T8nInputReader.cs
+++ b/tools/Evm/T8n/T8nInputReader.cs
@@ -63,7 +63,7 @@ public static class T8nInputReader
         }
         catch (FileNotFoundException e)
         {
-            throw new T8nException(e, "failed reading {filePath} file: {description}", T8nErrorCodes.ErrorIO);
+            throw new T8nException(e, $"failed reading {filePath} file: {description}", T8nErrorCodes.ErrorIO);
         }
         catch (JsonException e)
         {


### PR DESCRIPTION
FileNotFoundException handler was missing the $ prefix for string interpolation. The error message displayed literal "{filePath}" text instead of actual file path.

The correct interpolation was already used in JsonException handler below.
