### PR TITLE
Fix cross-block state leak of `_parityTouchBugAccount.ShouldDelete` flag in VirtualMachine

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -146,6 +146,9 @@ public unsafe partial class VirtualMachine(
         _txTracer = txTracer;
         _worldState = worldState;
 
+        // Reset Parity touch bug state to prevent cross-transaction leakage.
+        _parityTouchBugAccount.ShouldDelete = false;
+
         // Prepare the specification and opcode mapping based on the current block header.
         IReleaseSpec spec = BlockExecutionContext.Spec;
         PrepareOpcodes<TTracingInst>(spec);


### PR DESCRIPTION
  ## Problem

  The `_parityTouchBugAccount.ShouldDelete` flag is set to `true` when calling the RIPEMD-160
  precompile (0x03) with zero value transfer. This flag is only reset to `false` inside
  `RevertParityTouchBugAccount()`, which is called during failure/revert handling.

  If a transaction successfully calls RIPEMD-160 and completes without reverting, the flag
  remains `true`. When the same VirtualMachine instance processes a subsequent block where
  a transaction fails, `RevertParityTouchBugAccount()` is called, which then:
  1. Calls `AccountExists(0x03)` - adding RIPEMD-160 to the BAL
  2. Calls `AddToBalance(0x03, 0, spec)`

  This incorrectly adds RIPEMD-160 to the Block Access List (BAL) for blocks that never
  touched the precompile.

  ## Scenario

  Block N:   TX calls RIPEMD-160 → ShouldDelete = true → TX succeeds (no revert)
             → ShouldDelete remains TRUE

  Block N+1: TX fails/reverts → RevertParityTouchBugAccount() called
             → AccountExists(0x03) adds RIPEMD-160 to BAL (BUG!)

  ## Fix

  Reset `_parityTouchBugAccount.ShouldDelete = false` in `SetBlockExecutionContext()`,
  which is called at the start of each block's processing.