### PR TITLE
fix: remove unused IHttpContextFactory resolution in StartAsync

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/WebHost.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/WebHost.cs
@@ -82,7 +82,6 @@ internal sealed partial class WebHost : IHost, IAsyncDisposable
 
         _applicationLifetime = _applicationServices.GetRequiredService<ApplicationLifetime>();
 
-        _applicationServices.GetRequiredService<IHttpContextFactory>();
         var httpContextFactory = new HttpContextFactory(Services);
         var hostingApp = new HostingApplication(application, _logManager, httpContextFactory);
 


### PR DESCRIPTION
Removed an unused IHttpContextFactory resolution in WebHost.StartAsync(). The hosting pipeline uses the custom JsonRpc.HttpContextFactory via HostingApplication, so resolving the framework factory had no effect and introduced an unnecessary allocation.