### PR TITLE
fix(txpool): race condition in NonceManager.TxWithNonceReceived

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/NonceManager.cs
+++ b/src/Nethermind/Nethermind.TxPool/NonceManager.cs
@@ -63,8 +63,9 @@ public class NonceManager : INonceManager
 
         public NonceLocker TxWithNonceReceived(UInt256 nonce)
         {
+            NonceLocker locker = new(_accountLock, TxAccepted);
             _reservedNonce = nonce;
-            return new(_accountLock, TxAccepted);
+            return locker;
         }
 
         private void ReleaseNonces(UInt256 accountNonce)


### PR DESCRIPTION
`_reservedNonce` was assigned before acquiring the semaphore lock, while `ReserveNonce` in the same class does it correctly — lock first, then assign.

Two threads calling `TxWithNonceReceived` could overwrite each other's `_reservedNonce` before either enters the critical section, causing wrong nonce to be recorded in `_usedNonces`.

Fixed by matching the pattern already used in `ReserveNonce`: create `NonceLocker` (acquires lock), then assign `_reservedNonce`.