### PR TITLE
refactor(blockchain): remove unused LinearExtrapolation overload

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/KnownChainSizes.cs
+++ b/src/Nethermind/Nethermind.Blockchain/KnownChainSizes.cs
@@ -45,13 +45,6 @@ namespace Nethermind.Blockchain
                 _updateDate = updateDate;
             }
 
-            public LinearExtrapolation(long firstValue, DateTime firstDate, long secondValue, DateTime secondDate)
-            {
-                _atUpdate = firstValue;
-                _dailyGrowth = (long)((secondValue - firstValue) / (secondDate - firstDate).TotalDays);
-                _updateDate = firstDate;
-            }
-
             public long Estimate => _atUpdate + (DateTime.UtcNow - _updateDate).Days * _dailyGrowth;
         }
 


### PR DESCRIPTION
Remove the private 4-parameter constructor (long, DateTime, long, DateTime) from ChainSizes.LinearExtrapolation in 
Nethermind.Blockchain/KnownChainSizes.cs. The overload is unreferenced across the codebase and the class is private, so it cannot be used externally. Only the 3-parameter overload is used by CreateChainSizeInfo(). This reduces maintenance overhead and avoids confusion. 