### PR TITLE
fix: include IsAuthenticated and modules in JsonRpcUrl.GetHashCode

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -14,18 +14,17 @@ namespace Nethermind.JsonRpc
     public class JsonRpcUrl : IEquatable<JsonRpcUrl>, ICloneable
     {
         private int? _hashCode;
-        private string _scheme = null!;
-        private string _host = null!;
-        private int _port;
-        private RpcEndpoint _rpcEndpoint;
-        private IReadOnlySet<string> _enabledModules = null!;
         public JsonRpcUrl(string scheme, string host, int port, RpcEndpoint rpcEndpoint, bool isAuthenticated, string[] enabledModules, long? maxRequestBodySize = null)
         {
+            string[] sortedModules = enabledModules
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
             Scheme = scheme;
             Host = host;
             Port = port;
             RpcEndpoint = rpcEndpoint;
-            EnabledModules = new HashSet<string>(enabledModules, StringComparer.OrdinalIgnoreCase);
+            EnabledModules = new HashSet<string>(sortedModules, StringComparer.OrdinalIgnoreCase);
             IsAuthenticated = isAuthenticated;
             MaxRequestBodySize = maxRequestBodySize;
         }
@@ -84,11 +83,11 @@ namespace Nethermind.JsonRpc
 
         public long? MaxRequestBodySize { get; }
         public bool IsAuthenticated { get; }
-        public string Scheme { get => _scheme; set { _scheme = value; _hashCode = null; } }
-        public string Host { get => _host; set { _host = value; _hashCode = null; } }
-        public int Port { get => _port; set { _port = value; _hashCode = null; } }
-        public RpcEndpoint RpcEndpoint { get => _rpcEndpoint; set { _rpcEndpoint = value; _hashCode = null; } }
-        public IReadOnlySet<string> EnabledModules { get => _enabledModules; set { _enabledModules = new HashSet<string>(value, StringComparer.OrdinalIgnoreCase); _hashCode = null; } }
+        public string Scheme { get; }
+        public string Host { get; }
+        public int Port { get; }
+        public RpcEndpoint RpcEndpoint { get; }
+        public IReadOnlySet<string> EnabledModules { get; }
 
         public bool IsModuleEnabled(string moduleName) => EnabledModules.Contains(moduleName);
 
@@ -123,7 +122,7 @@ namespace Nethermind.JsonRpc
             if (_hashCode.HasValue) return _hashCode.Value;
 
             int modulesHash = 0;
-            foreach (string m in EnabledModules.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+            foreach (string m in EnabledModules)
             {
                 modulesHash = HashCode.Combine(modulesHash, StringComparer.OrdinalIgnoreCase.GetHashCode(m));
             }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -113,8 +113,16 @@ namespace Nethermind.JsonRpc
 
             return other is JsonRpcUrl url && Equals(url);
         }
+        public override int GetHashCode()
+        {
+            int modulesHash = 0;
+            foreach (string m in EnabledModules.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+            {
+                modulesHash = HashCode.Combine(modulesHash, StringComparer.OrdinalIgnoreCase.GetHashCode(m));
+            }
 
-        public override int GetHashCode() => HashCode.Combine(Scheme, Host, Port, RpcEndpoint, EnabledModules as IStructuralEquatable);
+            return HashCode.Combine(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, modulesHash);
+        }
         public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, EnabledModules.ToArray());
         public override string ToString() => $"{Scheme}://{Host}:{Port}";
     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -128,9 +128,7 @@ namespace Nethermind.JsonRpc
                 modulesHash = HashCode.Combine(modulesHash, StringComparer.OrdinalIgnoreCase.GetHashCode(m));
             }
 
-            int computed = HashCode.Combine(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, modulesHash);
-            _hashCode = computed;
-            return computed;
+            return _hashCode = HashCode.Combine(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, modulesHash);
         }
         public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, EnabledModules.ToArray());
         public override string ToString() => $"{Scheme}://{Host}:{Port}";

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -128,7 +128,9 @@ namespace Nethermind.JsonRpc
                 modulesHash = HashCode.Combine(modulesHash, StringComparer.OrdinalIgnoreCase.GetHashCode(m));
             }
 
-            return _hashCode = HashCode.Combine(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, modulesHash);
+            int hash = HashCode.Combine(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, modulesHash);
+            _hashCode = hash;
+            return hash;
         }
         public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, IsAuthenticated, EnabledModules.ToArray());
         public override string ToString() => $"{Scheme}://{Host}:{Port}";


### PR DESCRIPTION
JsonRpcUrl.Equals compares IsAuthenticated and EnabledModules (case-insensitive set), but GetHashCode previously ignored both by casting EnabledModules to IStructuralEquatable (which HashSet<string> doesn’t implement) and not including IsAuthenticated. This could break hash-based collections when equal instances produce different hashes. The fix adds IsAuthenticated to the hash and computes a stable, case-/order-insensitive hash for EnabledModules to preserve the equals/hash code contract.