### PR TITLE
fix: remove redundant BindingFlags.GetProperty from GetProperties

### DIFF
--- a/src/Nethermind/Nethermind.Core/Container/FallbackToFieldFromApi.cs
+++ b/src/Nethermind/Nethermind.Core/Container/FallbackToFieldFromApi.cs
@@ -27,7 +27,7 @@ public class FallbackToFieldFromApi<TApi> : IRegistrationSource where TApi : not
 
         Type tApi = typeof(TApi);
 
-        BindingFlags flag = BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public;
+        BindingFlags flag = BindingFlags.Instance | BindingFlags.Public;
         if (directlyDeclaredOnly)
             flag |= BindingFlags.DeclaredOnly;
 


### PR DESCRIPTION
Type.GetProperties(BindingFlags) ignores BindingFlags.GetProperty, which is only meaningful for InvokeMember. Dropped it to avoid confusion and reflect the intended filter set.