### PR TITLE
fix leak in NettyDiscoveryBaseHandler

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryBaseHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryBaseHandler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using DotNetty.Common.Utilities;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using Nethermind.Logging;
@@ -18,7 +19,10 @@ public abstract class NettyDiscoveryBaseHandler(ILogManager? logManager) : Simpl
     public override void ChannelRead(IChannelHandlerContext ctx, object msg)
     {
         if (msg is DatagramPacket packet && AcceptInboundMessage(packet) && !ValidatePacket(packet))
+        {
+            ReferenceCountUtil.Release(msg);
             return;
+        }
 
         base.ChannelRead(ctx, msg);
     }


### PR DESCRIPTION
> ChannelRead override reject invalid DatagramPacket by returning early but without realeasing the ByteBuf reference. If invalid > (0 byte or oversized packets), base.ChannelRead(ctx, msg) (have an automatic cleanup) would never be reached. I’ve found no > wrapper handler that release the buffers and nothing in the discovery handler. Other handler inherit from SimpleChannelInboundHandler, only NettyDiscoveryBaseHandler has this pattern


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No