### PR TITLE
Fix Blockhash Cache to Handle Empty Values

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
@@ -42,10 +42,15 @@ namespace Nethermind.Blockchain
             }
 
             Hash256[]? hashes = _hashes;
-            return hashes is not null
-                ? hashes[depth]
-                : blockhashCache.GetHash(currentBlock, (int)depth)
-                  ?? throw new InvalidDataException("Hash cannot be found when executing BLOCKHASH operation");
+
+            // Use prefetched hashes if available and depth is within bounds.
+            if (hashes is not null && depth < hashes.Length)
+            {
+                return hashes[depth];
+            }
+
+            return blockhashCache.GetHash(currentBlock, (int)depth)
+                ?? throw new InvalidDataException("Hash cannot be found when executing BLOCKHASH operation");
         }
 
         public async Task Prefetch(BlockHeader currentBlock, CancellationToken token)


### PR DESCRIPTION
Fixes issue possibly due to changes in https://github.com/NethermindEth/nethermind/pull/9725

During block production `blockHeader.Hash` is `null`, since it is calculated post-processing https://github.com/NethermindEth/nethermind/blob/18b5b62aa3a61248893d14e42cf8fe0246283f80/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs#L144 But the block cache does not handle empty values and could end up inserting hashes with null key.

We started seeing this issue with Taiko chain, even though the anchor transaction was generated:
```
03 Dec 05:33:00 | Encountered exception System.ArgumentException: Block must contain at least the anchor transaction
   at Nethermind.Taiko.BlockTransactionExecutors.BlockInvalidTxExecutor.ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token) in /nethermind/src/Nethermind/Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs:line 35
   at Nethermind.Consensus.Processing.BlockProcessor.ProcessBlock(Block block, IBlockTracer blockTracer, ProcessingOptions options, IReleaseSpec spec, CancellationToken token) in /nethermind/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs:line 106
   at Nethermind.Consensus.Processing.BlockProcessor.ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token) in /nethermind/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs:line 62
   at Nethermind.Consensus.Processing.BranchProcessor.Process(BlockHeader baseBlock, IReadOnlyList`1 suggestedBlocks, ProcessingOptions options, IBlockTracer blockTracer, CancellationToken token) in /nethermind/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs:line 136 while processing blocks. 
```


Extra debugging logs showed the anchor transaction was being rejected due to cache lookup faliure:
```
03 Dec 05:33:00 | BlockInvalidTxExecutor ProcessTransactions: BlockNumber=2, Transactions.Length=1, IsGenesis=False 
03 Dec 05:33:00 | BlockInvalidTxExecutor: Processing tx[0] Hash=0x0b3a9e595b604140c918eb0c6045fdf36d36184a8552e07d41d500786baff903, Type=EIP1559, IsAnchorTx=True 
03 Dec 05:33:00 | BlockInvalidTxExecutor: tx[0] threw exception: IndexOutOfRangeException: Index was outside the bounds of the array. 
03 Dec 05:33:00 | BlockInvalidTxExecutor: Processing complete. correctTransactions.Count=0, original=1 
```


## Changes
- Handle null key
- Add new test

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
