### PR TITLE
fix: invert post-merge difficulty validation logic in T8n tool

### DIFF
--- a/tools/Evm/T8n/T8nValidator.cs
+++ b/tools/Evm/T8n/T8nValidator.cs
@@ -68,7 +68,7 @@ public static class T8nValidator
             if (env.CurrentRandom is null)
                 throw new T8nException("post-merge requires currentRandom to be defined in env",
                     T8nErrorCodes.ErrorConfig);
-            if (env.CurrentDifficulty?.IsZero ?? false)
+            if (env.CurrentDifficulty is not null && !env.CurrentDifficulty.Value.IsZero)
                 throw new T8nException("post-merge difficulty must be zero (or omitted) in env",
                     T8nErrorCodes.ErrorConfig);
             return;


### PR DESCRIPTION
The condition for validating post-merge difficulty was inverted.

Original code threw an exception when difficulty was zero, but allowed non-zero values - the exact opposite of what the error message states and what EIP-3675 requires.

Post-merge blocks must have difficulty = 0 or omitted. The fix now correctly rejects non-zero difficulty values while accepting zero and null.