### PR TITLE
fix: tie readonly DB provider to env lifetime and clear per-scope buffers

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -62,6 +62,6 @@ public class SimulateReadOnlyBlocksProcessingScope(
     public void Dispose()
     {
         overridableWorldStateCloser.Dispose();
-        readOnlyDbProvider.Dispose(); // For blocktree. The read only db has a buffer that need to be cleared.
+        readOnlyDbProvider.ClearTempChanges(); // For blocktree. The read only db has a buffer that need to be cleared.
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -44,6 +44,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
 
         ILifetimeScope envLifetimeScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
             .AddModule(overridableEnv) // worldstate related override here
+            .AddSingleton<IReadOnlyDbProvider>(editableDbProvider)
             .AddSingleton<IBlockTree>(overrideBlockTree)
             .AddSingleton<BlockTreeOverlay>(overrideBlockTree)
             .AddSingleton<IHeaderStore>(tmpHeaderStore)
@@ -60,6 +61,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
             .AddScoped<SimulateRequestState>()
             .AddScoped<SimulateReadOnlyBlocksProcessingEnv>());
 
+        envLifetimeScope.Disposer.AddInstanceForDisposal(editableDbProvider);
         rootLifetimeScope.Disposer.AddInstanceForAsyncDisposal(envLifetimeScope);
         return envLifetimeScope.Resolve<SimulateReadOnlyBlocksProcessingEnv>();
     }


### PR DESCRIPTION
The simulate BlockTree was built on a locally created ReadOnlyDbProvider while the scope disposed a different DI-provided instance. This leaked the actual in-memory buffers and risked disposing an unrelated provider. Register the factory-created provider in the env lifetime and bind its disposal to the env scope. Switch per-scope cleanup to ClearTempChanges() to drop temp writes without tearing down the provider, aligning with the reusable env contract.