### PR TITLE
fix: remove duplicate EIP-7702 transaction counting in TxPool

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -404,11 +404,6 @@ namespace Nethermind.TxPool
                     }
                 }
 
-                if (blockTx.Type == TxType.SetCode)
-                {
-                    eip7702Txs++;
-                }
-
                 bool isKnown = IsKnown(txHash);
                 if (!isKnown)
                 {


### PR DESCRIPTION
EIP-7702 (SetCode) transactions were counted twice in RemoveProcessedTransactions.

The code incremented eip7702Txs both when checking SupportsAuthorizationList and when checking Type == TxType.SetCode. These conditions are identical - SupportsAuthorizationList just returns Type == TxType.SetCode.

This caused Metrics.Eip7702TransactionsInBlock to report double the actual count.

Removed the redundant Type == TxType.SetCode check.