### PR TITLE
fix: map InvalidBlockRangeUpdate to BreachOfProtocol

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
@@ -92,7 +92,7 @@ public static class DisconnectReasonExtension
             DisconnectReason.ForwardSyncFailed => EthDisconnectReason.DisconnectRequested,
             DisconnectReason.GossipingInPoS => EthDisconnectReason.BreachOfProtocol,
             DisconnectReason.AppClosing => EthDisconnectReason.ClientQuitting,
-            DisconnectReason.InvalidTxOrUncle or DisconnectReason.HeaderResponseTooLong or DisconnectReason.InconsistentHeaderBatch or DisconnectReason.UnexpectedHeaderHash or DisconnectReason.HeaderBatchOnDifferentBranch or DisconnectReason.UnexpectedParentHeader or DisconnectReason.InvalidHeader or DisconnectReason.InvalidReceiptRoot or DisconnectReason.EthSyncException => EthDisconnectReason.BreachOfProtocol,
+            DisconnectReason.InvalidTxOrUncle or DisconnectReason.HeaderResponseTooLong or DisconnectReason.InconsistentHeaderBatch or DisconnectReason.UnexpectedHeaderHash or DisconnectReason.HeaderBatchOnDifferentBranch or DisconnectReason.UnexpectedParentHeader or DisconnectReason.InvalidHeader or DisconnectReason.InvalidReceiptRoot or DisconnectReason.EthSyncException or DisconnectReason.InvalidBlockRangeUpdate => EthDisconnectReason.BreachOfProtocol,
             DisconnectReason.EthDisconnectRequested => EthDisconnectReason.DisconnectRequested,
             DisconnectReason.TcpSubSystemError => EthDisconnectReason.TcpSubSystemError,
             DisconnectReason.BreachOfProtocol => EthDisconnectReason.BreachOfProtocol,


### PR DESCRIPTION
Previously DisconnectReason.InvalidBlockRangeUpdate was not handled explicitly in 
DisconnectReasonExtension.ToEthDisconnectReason and therefore fell through to EthDisconnectReason.Other. This meant that invalid BlockRangeUpdate messages in Eth69ProtocolHandler were reported on the wire as a generic “Other” disconnect instead of a protocol breach, and static peers sending such invalid updates were treated more leniently than other sync-related protocol violations. This change maps InvalidBlockRangeUpdate to EthDisconnectReason.BreachOfProtocol, aligning it with the rest of the sync validation errors, improving disconnect diagnostics and ensuring consistent handling for both regular and static peers.