### PR TITLE
Add JWT expiration to Kute auth tokens

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/Auth/JwtAuth.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Auth/JwtAuth.cs
@@ -36,6 +36,7 @@ public sealed class JwtAuth : IAuth
         return handler.CreateToken(new SecurityTokenDescriptor
         {
             IssuedAt = _clock.UtcNow.UtcDateTime,
+            Expires = _clock.UtcNow.UtcDateTime.AddMinutes(5),
             SigningCredentials = new(_key, SecurityAlgorithms.HmacSha256)
         });
     }


### PR DESCRIPTION
Set explicit `Expires` when generating JWTs to avoid perpetual tokens.


