### PR TITLE
feat(merkle): remove unused RootOfNull to avoid dead code and startup allocation

### DIFF
--- a/src/Nethermind/Nethermind.Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Merkleization/Merkle.cs
@@ -28,12 +28,9 @@ public static partial class Merkle
         }
     }
 
-    private static readonly UInt256 RootOfNull;
-
     static Merkle()
     {
         BuildZeroHashes();
-        RootOfNull = new UInt256(new Root(SHA256.HashData([])).AsSpan().ToArray());
     }
 
     public static ulong NextPowerOfTwo(uint v)


### PR DESCRIPTION
RootOfNull was never referenced in the codebase. Keeping it caused unnecessary SHA-256 computation and heap allocation during static initialization of Merkle. Removing it eliminates dead code and avoids cold-start overhead without affecting behavior.