### PR TITLE
fix: align BlockHashes dictionary to use nullable Hash256

### DIFF
--- a/tools/Evm/T8n/T8nBlockHashProvider.cs
+++ b/tools/Evm/T8n/T8nBlockHashProvider.cs
@@ -10,15 +10,17 @@ using Nethermind.Evm;
 
 namespace Evm.T8n;
 
-public class T8nBlockHashProvider(Dictionary<long, Hash256?> blockHashes) : IBlockhashProvider
+public class T8nBlockHashProvider(Dictionary<long, Hash256> blockHashes) : IBlockhashProvider
 {
     public Hash256? GetBlockhash(BlockHeader currentBlock, long number, IReleaseSpec? spec)
     {
         long current = currentBlock.Number;
-        return number >= current || number < current - Math.Min(current, BlockhashProvider.MaxDepth)
-            ? null
-            : blockHashes.GetValueOrDefault(number, null) ??
-              throw new T8nException($"BlockHash for block {number} not provided",
+        if (number >= current || number < current - Math.Min(current, BlockhashProvider.MaxDepth))
+            return null;
+
+        return blockHashes.TryGetValue(number, out Hash256? hash)
+            ? hash
+            : throw new T8nException($"BlockHash for block {number} not provided",
                   T8nErrorCodes.ErrorMissingBlockhash);
     }
 

--- a/tools/Evm/T8n/T8nExecutor.cs
+++ b/tools/Evm/T8n/T8nExecutor.cs
@@ -136,7 +136,7 @@ public static class T8nExecutor
     }
 
     private static IBlockhashProvider ConstructBlockHashProvider(T8nTest test) =>
-        new T8nBlockHashProvider(test.BlockHashes.ToDictionary<KeyValuePair<string, Hash256>, long, Hash256?>(kvp => long.Parse(kvp.Key), kvp => kvp.Value));
+        new T8nBlockHashProvider(test.BlockHashes.ToDictionary(kvp => long.Parse(kvp.Key), kvp => kvp.Value));
 
     private static void ApplyRewards(Block block, IWorldState stateProvider, IReleaseSpec spec, ISpecProvider specProvider)
     {


### PR DESCRIPTION
BlockHashes dictionary had inconsistent value types across the codebase:

- EnvJson and T8nTest used non-nullable Hash256
- T8nBlockHashProvider expected nullable Hash256?

Since a block hash can't semantically be null, changed `T8nBlockHashProvider` to accept non-nullable `Hash256` instead. This keeps `EnvJson` and `T8nTest` unchanged and simplifies the lookup logic.