### PR TITLE
perf(facade): optimize SimulateDictionaryHeaderStore.Get for cache hits

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
@@ -36,16 +36,12 @@ public class SimulateDictionaryHeaderStore(IHeaderStore readonlyBaseHeaderStore)
 
     public BlockHeader? Get(Hash256 blockHash, bool shouldCache = false, long? blockNumber = null)
     {
-        blockNumber ??= GetBlockNumber(blockHash);
-
-        if (blockNumber.HasValue && _headerDict.TryGetValue(blockHash, out BlockHeader? header))
+        if (_headerDict.TryGetValue(blockHash, out BlockHeader? header))
         {
-            if (shouldCache)
-            {
-                Cache(header!);
-            }
             return header;
         }
+
+        blockNumber ??= GetBlockNumber(blockHash);
 
         header = readonlyBaseHeaderStore.Get(blockHash, false, blockNumber);
         if (header is not null && shouldCache)


### PR DESCRIPTION
In SimulateDictionaryHeaderStore.Get we first queried block number via GetBlockNumber and only then checked the local header dictionary. On cache hits this caused unnecessary lookups and potential base store calls, contradicting the class’ performance goal. Now we check the in-memory cache first and return immediately. Only on miss we resolve blockNumber and consult the base store, caching the result if requested.