### PR TITLE
Optimize ColumnDb MultiGet allocations

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using RocksDbSharp;
@@ -68,7 +67,6 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore
         {
             ColumnFamilyHandle[] columnFamilies = new ColumnFamilyHandle[keys.Length];
             Array.Fill(columnFamilies, _columnFamily);
-
             return _rocksDb.MultiGet(keys, columnFamilies);
         }
     }


### PR DESCRIPTION
replace the LINQ Select(...).ToArray() in ColumnDb’s indexer with a direct Array.Fill, eliminate the per-call delegate and enumerable allocations while keeping the returned data unchanged