### PR TITLE
docs: update INethermindPlugin interface in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,12 +155,15 @@ Plugins extend Nethermind functionality through the `INethermindPlugin` interfac
 public interface INethermindPlugin
 {
     string Name { get; }
-    void InitTxTypesAndRlpDecoders(INethermindApi api);
-    Task Init(INethermindApi nethermindApi);
-    Task InitNetworkProtocol();
-    Task InitRpcModules();
+    string Description { get; }
+    string Author { get; }
+    void InitTxTypesAndRlpDecoders(INethermindApi api) { }
+    Task Init(INethermindApi nethermindApi) => Task.CompletedTask;
+    Task InitNetworkProtocol() => Task.CompletedTask;
+    Task InitRpcModules() => Task.CompletedTask;
     bool MustInitialize => false;
     bool Enabled { get; }
+    IModule? Module => null;
 }
 ```
 


### PR DESCRIPTION
The plugin interface example was outdated. Added missing required properties (Description, Author) and optional Module property. Also fixed method signatures to show default implementations.