### PR TITLE
Optimize pivot total difficulty parsing in sync-settings

### DIFF
--- a/scripts/sync-settings.py
+++ b/scripts/sync-settings.py
@@ -129,13 +129,13 @@ def fastBlocksSettings(configuration, apiUrl, blockReduced, multiplierRequiremen
     pivot = json.loads(response.text)
 
     pivotHash = pivot['result']['hash']
-    pivotTotalDifficulty = int(pivot['result'].get('totalDifficulty', '0x0'), 16)
 
     print(configuration + ' LatestBlock: ' + str(latestBlock))
     print(configuration + ' PivotNumber: ' + str(baseBlock))
     print(configuration + ' PivotHash: ' + str(pivotHash))
     if not isPoS:
-      print(configuration + ' PivotTotalDifficulty: ' + str(pivotTotalDifficulty))
+        pivotTotalDifficulty = int(pivot['result'].get('totalDifficulty', '0x0'), 16)
+        print(configuration + ' PivotTotalDifficulty: ' + str(pivotTotalDifficulty))
 
     with open(f'{CONFIGS_PATH}/{configuration}.json', 'r') as mainnetCfg:
         data = json.load(mainnetCfg)


### PR DESCRIPTION
Remove redundant parsing of totalDifficulty for PoS chains; the value was computed but never used. Keep behavior identical: PoS chains still skip printing/writing total difficulty, non-PoS chains still parse, print, and persist it. Result: less needless work per run, zero functional change or risk.