### PR TITLE
Remove unused ComponentModel import from PeerManager

### DIFF
--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;


### PR DESCRIPTION
Drop the unused System.ComponentModel namespace from PeerManager. Keep the file’s dependencies limited to what the code actually calls