### PR TITLE
fix: remove duplicate gRPC host validation in GrpcClient

### DIFF
--- a/src/Nethermind/Nethermind.Grpc/Clients/GrpcClient.cs
+++ b/src/Nethermind/Nethermind.Grpc/Clients/GrpcClient.cs
@@ -38,9 +38,7 @@ namespace Nethermind.Grpc.Clients
                     nameof(reconnectionInterval));
             }
 
-            _address = string.IsNullOrWhiteSpace(host)
-                ? throw new ArgumentException("Missing gRPC host", nameof(host))
-                : $"{host}:{port}";
+            _address = $"{host}:{port}";
             _reconnectionInterval = reconnectionInterval;
             _logger = logManager.GetClassLogger();
         }


### PR DESCRIPTION
## Changes

The constructor of GrpcClient validated the host argument twice with the same condition, first via an explicit guard clause and then again in the _address assignment using a ternary with throw. Because the first check always throws for invalid input, the second one was effectively dead code and only added noise and inconsistency in exception messages. This change keeps the explicit guard clause as the single source of validation and simplifies _address initialization to a direct interpolation of host and port.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring


