### PR TITLE
perf: avoid extra allocation in optimism deposit RPC input

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core.Crypto;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using System.Text.Json.Serialization;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -57,7 +58,7 @@ public class DepositTransactionForRpc : TransactionForRpc, IFromTransaction<Depo
         Value = transaction.Value;
         Gas = transaction.GasLimit;
         IsSystemTx = transaction.IsOPSystemTransaction;
-        Input = transaction.Data.ToArray();
+        Input = transaction.Data.AsArray();
         Nonce = receipt?.DepositNonce ?? 0;
 
         DepositReceiptVersion = receipt?.DepositReceiptVersion;


### PR DESCRIPTION
## Changes

Replaced transaction.Data.ToArray() with transaction.Data.AsArray() in DepositTransactionForRpc and add the missing Nethermind.Core.Extensions import. Other RPC transaction types already use AsArray() to reuse the underlying ReadOnlyMemory<byte> buffer when possible and only copy when necessary. Aligning the deposit RPC path with this pattern removes an unnecessary array allocation on a hot conversion path without changing the observable semantics of the input field.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [x] No - 

#### If yes, did you write tests?

- [ ] Yes
- [x] No
