### PR TITLE
fix: Remove redundant BlockHeader field reassignments in StatelessExecution

### DIFF
--- a/tools/StatelessExecution/SetupCli.cs
+++ b/tools/StatelessExecution/SetupCli.cs
@@ -110,10 +110,6 @@ internal static class SetupCli
             MixHash = suggestedBlockForRpc.MixHash,
             BaseFeePerGas = suggestedBlockForRpc.BaseFeePerGas!.Value,
             WithdrawalsRoot = suggestedBlockForRpc.WithdrawalsRoot,
-            ParentBeaconBlockRoot = suggestedBlockForRpc.ParentBeaconBlockRoot,
-            RequestsHash = suggestedBlockForRpc.RequestsHash,
-            BlobGasUsed = suggestedBlockForRpc.BlobGasUsed,
-            ExcessBlobGas = suggestedBlockForRpc.ExcessBlobGas,
             Hash = suggestedBlockForRpc.Hash,
         };
 


### PR DESCRIPTION
Delete duplicate property assignments in `ReadData` initializer for `BlockHeader` since constructor already sets these fields, reducing noise and future divergence risk.

