### PR TITLE
fix: prevent UInt256 overflow in HexConvert.ToUInt256

### DIFF
--- a/tools/SendBlobs/HexConvert.cs
+++ b/tools/SendBlobs/HexConvert.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
 namespace SendBlobs;
@@ -8,7 +9,7 @@ internal static class HexConvert
 {
     public static UInt256 ToUInt256(string s)
     {
-        return (UInt256)ToUInt64(s);
+        return new UInt256(Bytes.FromHexString(s), isBigEndian: true);
     }
 
     public static ulong ToUInt64(string s)


### PR DESCRIPTION
The ToUInt256 method was casting through ulong, which silently truncates values larger than 64 bits. This could cause incorrect gas price calculations when dealing with large hex values from RPC responses. Fixed by parsing the hex string directly into UInt256.