### PR TITLE
Adjust tx flood control to keep Besu as peer more

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/AcceptTxResultAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/AcceptTxResultAuRa.cs
@@ -10,6 +10,6 @@ namespace Nethermind.Consensus.AuRa.Transactions
         /// <summary>
         /// Permission denied for this tx type.
         /// </summary>
-        public static readonly AcceptTxResult PermissionDenied = new(100, nameof(PermissionDenied));
+        public static readonly AcceptTxResult PermissionDenied = new(TxResultCode.PermissionDenied, nameof(PermissionDenied));
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
@@ -69,6 +69,7 @@ public enum DisconnectReason : byte
     MultipleHeaderDependencies,
 
     // Try not to use this. Instead, create a new one.
+    InvalidTx,
     Other,
 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -38,7 +38,8 @@ internal class TxFloodController(Eth62ProtocolHandler protocolHandler, ITimestam
             }
 
             if (accepted is
-                { Id:
+                {
+                    Id:
                     TxResultCode.Invalid or
                     TxResultCode.GasLimitExceeded or
                     TxResultCode.MaxTxSizeExceeded or

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -1,72 +1,92 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Logging;
 using Nethermind.Stats.Model;
 using Nethermind.TxPool;
-using System;
 
-namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
+namespace Nethermind.Network.P2P.Subprotocols.Eth.V62;
+
+internal class TxFloodController(Eth62ProtocolHandler protocolHandler, ITimestamper timestamper, ILogger logger)
 {
-    internal class TxFloodController(Eth62ProtocolHandler protocolHandler, ITimestamper timestamper, ILogger logger)
+    // Late with one block
+    private const int DegradeRatePerMinute = 250;
+    // Late with 5 blocks (and has all included txs in their pool)
+    private const int DisconnectRatePerMinute = 750;
+
+    private DateTime _checkpoint = DateTime.UtcNow;
+    private readonly Eth62ProtocolHandler _protocolHandler = protocolHandler ?? throw new ArgumentNullException(nameof(protocolHandler));
+    private readonly ITimestamper _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
+    private readonly TimeSpan _checkInterval = TimeSpan.FromSeconds(60);
+    private long _notAcceptedSinceLastCheck;
+    private readonly Random _random = new();
+
+    internal bool IsDowngraded { get; private set; }
+
+    public void Report(in AcceptTxResult accepted)
     {
-        private DateTime _checkpoint = DateTime.UtcNow;
-        private readonly Eth62ProtocolHandler _protocolHandler = protocolHandler ?? throw new ArgumentNullException(nameof(protocolHandler));
-        private readonly ITimestamper _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
-        private readonly TimeSpan _checkInterval = TimeSpan.FromSeconds(60);
-        private long _notAcceptedSinceLastCheck;
-        private readonly Random _random = new();
+        TryReset();
 
-        internal bool IsDowngraded { get; private set; }
-
-        public void Report(AcceptTxResult accepted)
+        if (!accepted)
         {
-            TryReset();
-
-            if (!accepted)
+            if (accepted.Id == TxResultCode.Syncing)
             {
-                if (accepted == AcceptTxResult.Invalid)
-                {
-                    if (logger.IsDebug) logger.Debug($"Disconnecting {_protocolHandler} due to invalid tx received");
-                    _protocolHandler.Disconnect(DisconnectReason.Other, $"invalid tx");
-                    return;
-                }
+                // Do not count rejections while we are syncing
+                return;
+            }
 
-                _notAcceptedSinceLastCheck++;
-                if (!IsDowngraded && _notAcceptedSinceLastCheck / _checkInterval.TotalSeconds > 10)
-                {
-                    if (logger.IsDebug) logger.Debug($"Downgrading {_protocolHandler} due to tx flooding");
-                    IsDowngraded = true;
-                }
-                else if (_notAcceptedSinceLastCheck / _checkInterval.TotalSeconds > 100)
-                {
-                    if (logger.IsDebug) logger.Debug($"Disconnecting {_protocolHandler} due to tx flooding");
-                    _protocolHandler.Disconnect(
-                        DisconnectReason.TxFlooding,
-                        $"tx flooding {_notAcceptedSinceLastCheck}/{_checkInterval.TotalSeconds > 100}");
-                }
+            if (accepted is
+                { Id:
+                    TxResultCode.Invalid or
+                    TxResultCode.GasLimitExceeded or
+                    TxResultCode.MaxTxSizeExceeded or
+                    TxResultCode.Int256Overflow or
+                    TxResultCode.SenderIsContract or
+                    TxResultCode.FailedToResolveSender or
+                    TxResultCode.NotSupportedTxType
+                })
+            {
+                if (logger.IsDebug) logger.Debug($"Disconnecting {_protocolHandler} due to invalid tx received");
+                _protocolHandler.Disconnect(DisconnectReason.InvalidTx, accepted.Id.ToString());
+                return;
+            }
+
+            TimeSpan timeDiff = _timestamper.UtcNow - _checkpoint;
+            double rejectRatePerMinute = _notAcceptedSinceLastCheck / _checkInterval.TotalSeconds;
+            _notAcceptedSinceLastCheck++;
+            if (!IsDowngraded && rejectRatePerMinute > DegradeRatePerMinute)
+            {
+                if (logger.IsDebug) logger.Debug($"Downgrading {_protocolHandler} due to tx flooding");
+                IsDowngraded = true;
+            }
+            else if (rejectRatePerMinute > DisconnectRatePerMinute)
+            {
+                if (logger.IsDebug) logger.Debug($"Disconnecting {_protocolHandler} due to tx flooding");
+                _protocolHandler.Disconnect(
+                    DisconnectReason.TxFlooding,
+                    $"Tx flooding: Rejected {_notAcceptedSinceLastCheck} in {timeDiff.TotalSeconds:f3}sec");
             }
         }
-
-        private void TryReset()
-        {
-            DateTime now = _timestamper.UtcNow;
-            if (now >= _checkpoint + _checkInterval)
-            {
-                _checkpoint = now;
-                _notAcceptedSinceLastCheck = 0;
-                IsDowngraded = false;
-
-            }
-        }
-
-        public bool IsAllowed()
-        {
-            TryReset();
-            return !(IsEnabled && IsDowngraded && 10 < _random.Next(0, 99));
-        }
-
-        public bool IsEnabled { get; set; } = true;
     }
+
+    private void TryReset()
+    {
+        DateTime now = _timestamper.UtcNow;
+        if (now >= _checkpoint + _checkInterval)
+        {
+            _notAcceptedSinceLastCheck = 0;
+            _checkpoint = now;
+            IsDowngraded = false;
+        }
+    }
+
+    public bool IsAllowed()
+    {
+        TryReset();
+        return !(IsEnabled && IsDowngraded && 10 < _random.Next(0, 99));
+    }
+
+    public bool IsEnabled { get; set; } = true;
 }


### PR DESCRIPTION
## Changes

- After looking to why I never have Besu peers; turns out they send too many txs with old nonces; which could just be them lagging/sending tx while verifying blocks (which are then included) etc. e.g. @LukaszRozmej has Besu peers but his machine is slow
- Also don't count rejected txs as a disconnect reason when syncing

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No