### PR TITLE
perf: avoid LINQ allocations in GetStorageRangesMessageSerializer

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
@@ -16,7 +16,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
 
             rlpStream.Encode(message.RequestId);
             rlpStream.Encode(message.StorageRange.RootHash);
-            rlpStream.Encode(message.StorageRange.Accounts.Select(static a => a.Path).ToArray()); // TODO: optimize this
+            var accounts = message.StorageRange.Accounts;
+            int accountsCount = accounts.Count;
+            int accountsPathsContentLength = accountsCount * Rlp.LengthOfKeccakRlp;
+            rlpStream.StartSequence(accountsPathsContentLength);
+            for (int i = 0; i < accountsCount; i++)
+            {
+                rlpStream.Encode(accounts[i].Path);
+            }
             rlpStream.Encode(message.StorageRange.StartingHash);
             rlpStream.Encode(message.StorageRange.LimitHash);
             rlpStream.Encode(message.ResponseBytes);
@@ -48,7 +55,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         {
             contentLength = Rlp.LengthOf(message.RequestId);
             contentLength += Rlp.LengthOf(message.StorageRange.RootHash);
-            contentLength += Rlp.LengthOf(message.StorageRange.Accounts.Select(static a => a.Path).ToArray(), true); // TODO: optimize this
+            int accountsCount = message.StorageRange.Accounts.Count;
+            int accountsPathsContentLength = accountsCount * Rlp.LengthOfKeccakRlp;
+            contentLength += Rlp.LengthOfSequence(accountsPathsContentLength);
             contentLength += Rlp.LengthOf(message.StorageRange.StartingHash);
             contentLength += Rlp.LengthOf(message.StorageRange.LimitHash);
             contentLength += Rlp.LengthOf(message.ResponseBytes);


### PR DESCRIPTION
## Changes

- Replaced `Accounts.Select(a => a.Path).ToArray()` in GetStorageRangesMessageSerializer with RLP sequence over account paths. The sequence content length is now computed from `Accounts.Count * Rlp.LengthOfKeccakRlp`, and paths are encoded in a simple for-loop. This removes redundant enumeration of Accounts and avoids allocating intermediate ValueHash256[] arrays on the SNAP hot path 

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

