### PR TITLE
fix: Correct DistributeFunds method spelling

### DIFF
--- a/tools/SendBlobs/FundsDistributor.cs
+++ b/tools/SendBlobs/FundsDistributor.cs
@@ -36,7 +36,7 @@ internal class FundsDistributor
     /// <param name="maxPriorityFee"></param>
     /// <returns><see cref="IEnumerable{string}"/> containing all the executed tx hashes.</returns>
     /// <exception cref="AccountException"></exception>
-    public async Task<IEnumerable<string>> DitributeFunds(Signer distributeFrom, uint keysToMake, UInt256 maxFee, UInt256 maxPriorityFee)
+    public async Task<IEnumerable<string>> DistributeFunds(Signer distributeFrom, uint keysToMake, UInt256 maxFee, UInt256 maxPriorityFee)
     {
         if (keysToMake == 0)
             throw new ArgumentException("keysToMake must be greater than zero.", nameof(keysToMake));

--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -209,7 +209,7 @@ internal static class SetupCli
 
             FundsDistributor distributor = new(
                 rpcClient, chainId, parseResult.GetValue(keyFileOption), SimpleConsoleLogManager.Instance);
-            await distributor.DitributeFunds(
+            await distributor.DistributeFunds(
                 signer,
                 parseResult.GetValue(keyNumberOption),
                 parseResult.GetValue(maxFeeOption),


### PR DESCRIPTION
 Corrected method name from DitributeFunds to DistributeFunds in FundsDistributor and updated the call in SetupCli.