### PR TITLE
chore(merkle): remove unused RootOfNull field

### DIFF
--- a/src/Nethermind/Nethermind.Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Merkleization/Merkle.cs
@@ -28,12 +28,9 @@ public static partial class Merkle
         }
     }
 
-    private static readonly UInt256 RootOfNull;
-
     static Merkle()
     {
         BuildZeroHashes();
-        RootOfNull = new UInt256(new Root(SHA256.HashData([])).AsSpan().ToArray());
     }
 
     public static ulong NextPowerOfTwo(uint v)


### PR DESCRIPTION
## Changes

Removed the unused field and its initialization
RootOfNull was only assigned in the Merkle static constructor and never read anywhere in the codebase or tests
Initializing it incurred extra SHA256 allocations at type load time without affecting any observable behavior


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

