### PR TITLE
fix: correct typo in regexPattern variable name

### DIFF
--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -113,10 +113,10 @@ namespace Nethermind.Logging.NLog
 
         private static void RemoveOverriddenRules(IList<LoggingRule> configurationLoggingRules, LoggingRule loggingRule)
         {
-            string reqexPattern = $"^{loggingRule.LoggerNamePattern.Replace(".", "\\.").Replace("*", ".*")}$";
+            string regexPattern = $"^{loggingRule.LoggerNamePattern.Replace(".", "\\.").Replace("*", ".*")}$";
             for (int j = 0; j < configurationLoggingRules.Count;)
             {
-                if (Regex.IsMatch(configurationLoggingRules[j].LoggerNamePattern, reqexPattern))
+                if (Regex.IsMatch(configurationLoggingRules[j].LoggerNamePattern, regexPattern))
                 {
                     configurationLoggingRules.RemoveAt(j);
                 }


### PR DESCRIPTION
## Fix

Corrects typo in variable name from `reqexPattern` to `regexPattern` in the `RemoveOverriddenRules` method.

## Changes

- Renamed variable `reqexPattern` to `regexPattern` in `NLogManager.cs` (lines 116, 119)
- Improves code readability and follows standard naming conventions