### PR TITLE
fix: correct NSubstitute argument types in AuraWithdrawalProcessorTests

### DIFF
--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuraWithdrawalProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuraWithdrawalProcessorTests.cs
@@ -79,7 +79,7 @@ public class AuraWithdrawalProcessorTests
             .ExecuteWithdrawals(
                 Arg.Any<BlockHeader>(),
                 Arg.Any<UInt256>(),
-                Arg.Any<ulong[]>(),
-                Arg.Any<Address[]>());
+                Arg.Any<IList<ulong>>(),
+                Arg.Any<IList<Address>>());
     }
 }


### PR DESCRIPTION
### What
Fix type mismatch in AuraWithdrawalProcessorTests: change Arg.Any<ulong[]>() and Arg.Any<Address[]>() to Arg.Any<IList<ulong>>() and Arg.Any<IList<Address>>() in the Received(0) assertion.
### Why
The ExecuteWithdrawals method signature expects IList<ulong> and IList<Address>, not arrays. Using the correct types ensures NSubstitute matches calls correctly and keeps the test consistent with the other test method in the same file.