### PR TITLE
perf: Remove redundant ToArray() allocation in TrieStore warning log

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -785,7 +785,11 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             {
                 // This is a hang. It should recover itself as new finalized block is set. But it will hang if we for some reason
                 // does not process in the finalized branch at all.
-                if (_logger.IsWarn) _logger.Warn($"Unable to determine finalized state root at block {effectiveFinalizedBlockNumber}. Available state roots {string.Join(", ", commitSetsAtFinalizedBlock.Select(c => c.StateRoot.ToString()))}");
+                if (_logger.IsWarn)
+                {
+                    using ArrayPoolListRef<string> roots = commitSetsAtFinalizedBlock.Select(c => c.StateRoot.ToString());
+                    _logger.Warn($"Unable to determine finalized state root at block {effectiveFinalizedBlockNumber}. Available state roots {string.Join(", ", roots.AsSpan())}");
+                }
                 return (candidateSets, null);
             }
 


### PR DESCRIPTION
Removes unnecessary `ToArray()` call in TrieStore's finalized state root warning log, eliminating redundant heap allocation.