### PR TITLE
Fix: Correct memory access validation in TrySaveByte for MSTORE8 operation

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -45,7 +45,7 @@ public struct EvmPooledMemory : IEvmMemory
 
     public bool TrySaveByte(in UInt256 location, byte value)
     {
-        CheckMemoryAccessViolation(in location, 1, out _, out bool isViolation);
+        CheckMemoryAccessViolation(in location, 1, out ulong newLength, out bool isViolation);
         if (isViolation) return false;
 
         UpdateSize(newLength);


### PR DESCRIPTION
Fixes memory access validation in `EvmPooledMemory.TrySaveByte` to check for 1-byte access instead of 32-byte word access.