### PR TITLE
Fixes #9577: resolve race condition in StateSyncFeedTests.Big_test

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -124,9 +124,9 @@ public abstract class StateSyncFeedTestsBase(int defaultPeerCount = 1, int defau
             .AddSingleton<INodeStorage>(dbContext.LocalNodeStorage)
 
             // Use factory function to make it lazy in case test need to replace IBlockTree
-            // Use unique ID per test to avoid cache collisions during parallel execution
+            // Cache key includes type name so different inherited test classes don't share the same blocktree
             .AddSingleton<IBlockTree>((ctx) => CachedBlockTreeBuilder.BuildCached(
-                $"{GetType().Name}{dbContext.RemoteStateTree.RootHash}{TestChainLength}{Guid.NewGuid()}",
+                $"{GetType().Name}{dbContext.RemoteStateTree.RootHash}{TestChainLength}",
                 () => Build.A.BlockTree().WithStateRoot(dbContext.RemoteStateTree.RootHash).OfChainLength(TestChainLength)))
 
             .Add<SafeContext>();


### PR DESCRIPTION
Fixes #9577

## Changes

- Remove static `BlockTree` field in `StateSyncFeedTestsBase` that was shared across parallel test fixtures
- Add `TestChainLength` constant (100) to replace the shared state dependency
- Add per-test `_blockTree` field and `SetBlockTree()` method to `SyncPeerMock`
- Update `GetHeadBlockHeader()` to use the per-test block tree instance


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Verified by running `Big_test` 100 times with 4 parallel workers:

| Execution | Workers | Iterations | Passed | Failed |
|-----------|---------|------------|--------|--------|
| Before fix | 4 | 100 | ~81 | ~19 (19% failure rate) |
| After fix | 4 | 100 | 100 | 0 |

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The root cause was `SyncPeerMock.GetHeadBlockHeader()` referencing a static `BlockTree` field shared across all parallel test fixtures. When tests ran concurrently and modified their block trees, they interfered with each other through this shared state.

To reproduce the issue and the fix run
`docker build -f Dockerfile.big-test --build-arg REPEAT_COUNT=100 -t big-test-verify . && docker run --rm --cpus=4 --memory=3g big-test-verify`

> FROM mcr.microsoft.com/dotnet/nightly/sdk:10.0-preview
> 
> ARG REPEAT_COUNT=100
> ARG TEST_WORKERS=4
> 
> ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
> ENV DOTNET_NOLOGO=1
> ENV TEST_WORKERS=${TEST_WORKERS}
> 
> WORKDIR /nethermind
> 
> COPY src/Nethermind src/Nethermind
> COPY Directory.*.props .
> COPY global.json .
> COPY nuget.config .
> 
> RUN echo '{"sdk":{"rollForward":"latestMajor","allowPrerelease":true}}' > global.json && \
>     sed -i '/<RuntimeIdentifiers>/d' src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj && \
>     sed -i 's/<TreatWarningsAsErrors>true<\/TreatWarningsAsErrors>/<TreatWarningsAsErrors>false<\/TreatWarningsAsErrors>/g' Directory.Build.props && \
>     sed -i "s/private const int TestRepeatCount = [0-9]*;/private const int TestRepeatCount = ${REPEAT_COUNT};/" \
>         src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
> 
> WORKDIR /nethermind/src/Nethermind
> 
> RUN dotnet restore Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj && \
>     dotnet build Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj -c Release --no-restore
> 
> CMD dotnet test Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj \
>     -c Release --no-build --filter "FullyQualifiedName~Big_test" \
>     --logger "console;verbosity=normal" -- NUnit.NumberOfTestWorkers=${TEST_WORKERS}
