### PR TITLE
refactor: Remove redundant try-catch in SszProperty.StaticLength

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszProperty.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszProperty.cs
@@ -81,6 +81,7 @@ class SszProperty
             {
                 return 4;
             }
+
             return Kind switch
             {
                 Kind.Vector => Length!.Value * Type.StaticLength,


### PR DESCRIPTION
Removes an empty try-catch block in `SszProperty.StaticLength` property that was catching and immediately re-throwing exceptions without any additional handling.