### PR TITLE
fix: dispose IEraStore when EraImporter.Import fails early

### DIFF
--- a/src/Nethermind/Nethermind.Era1/EraImporter.cs
+++ b/src/Nethermind/Nethermind.Era1/EraImporter.cs
@@ -49,7 +49,7 @@ public class EraImporter(
             trustedAccumulators = (await fileSystem.File.ReadAllLinesAsync(accumulatorFile, cancellation)).Select(EraPathUtils.ExtractHashFromAccumulatorAndCheckSumEntry).ToHashSet();
         }
 
-        IEraStore eraStore = eraStoreFactory.Create(src, trustedAccumulators);
+        using IEraStore eraStore = eraStoreFactory.Create(src, trustedAccumulators);
 
         long lastBlockInStore = eraStore.LastBlock;
         if (to == 0) to = long.MaxValue;


### PR DESCRIPTION
EraImporter.Import was creating an IEraStore and using it to read FirstBlock/LastBlock before entering ImportInternal, but the store was only disposed inside ImportInternal. Any exception during parameter validation or archive boundary checks could leave EraStore open and leak underlying EraReader/E2StoreReader file handles until GC finalization. Wrapping the IEraStore creation in a using declaration ensures deterministic disposal on all exit paths from Import, including early failures.