### PR TITLE
perf(tests): Remove redundant ToList() calls in PatriciaTreeBulkSetterTests

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeBulkSetterTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeBulkSetterTests.cs
@@ -676,17 +676,17 @@ public class PatriciaTreeBulkSetterTests
         using ArrayPoolList<PatriciaTree.BulkSetEntry> buffer = new ArrayPoolList<PatriciaTree.BulkSetEntry>(paths.Count, paths.Count);
 
         int resultMask = PatriciaTree.BucketSort16Small(items.AsSpan(), buffer.AsSpan(), nibIndex, result);
-        buffer.Select((it) => it.Path).ToList().Should().BeEquivalentTo(expectedPaths);
+        buffer.Select((it) => it.Path).Should().BeEquivalentTo(expectedPaths);
         result.ToArray().Should().BeEquivalentTo(expectedResult);
         resultMask.Should().Be(expectedMask);
 
         resultMask = PatriciaTree.BucketSort16Large(items.AsSpan(), buffer.AsSpan(), nibIndex, result);
-        buffer.Select((it) => it.Path).ToList().Should().BeEquivalentTo(expectedPaths);
+        buffer.Select((it) => it.Path).Should().BeEquivalentTo(expectedPaths);
         result.ToArray().Should().BeEquivalentTo(expectedResult);
         resultMask.Should().Be(expectedMask);
 
         resultMask = PatriciaTree.BucketSort16(items.AsSpan(), buffer.AsSpan(), nibIndex, result);
-        buffer.Select((it) => it.Path).ToList().Should().BeEquivalentTo(expectedPaths);
+        buffer.Select((it) => it.Path).Should().BeEquivalentTo(expectedPaths);
         result.ToArray().Should().BeEquivalentTo(expectedResult);
         resultMask.Should().Be(expectedMask);
     }


### PR DESCRIPTION
Removed unnecessary `.ToList()` materializations in test assertions for `PatriciaTreeBulkSetterTests.cs`