### PR TITLE
 refactor(trie): remove redundant condition check in IsValidWithOneNodeLess

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -230,7 +230,12 @@ namespace Nethermind.Trie
                 int nonEmptyNodes = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    if (!IsChildNull(i) && ++nonEmptyNodes > 2)
+                    if (!IsChildNull(i))
+                    {
+                        nonEmptyNodes++;
+                    }
+
+                    if (nonEmptyNodes > 2)
                     {
                         return true;
                     }


### PR DESCRIPTION
Eliminates duplicate logic in `TrieNode.IsValidWithOneNodeLess` property getter.