### PR TITLE
fix: replace unused mock logger with LimboTraceLogger in EnrDiscoveryTests

### DIFF
--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryTests.cs
@@ -48,7 +48,7 @@ public class EnrDiscoveryTests
 
         NodeRecordSigner singer = new(new Ecdsa(), TestItem.PrivateKeyA);
         EnrRecordParser parser = new(singer);
-        EnrTreeCrawler crawler = new(new(Substitute.For<InterfaceLogger>()));
+        EnrTreeCrawler crawler = new(LimboTraceLogger.Instance);
         int verified = 0;
         await foreach (string record in crawler.SearchTree("all.mainnet.ethdisco.net", default))
         {


### PR DESCRIPTION
Replaced Substitute.For<InterfaceLogger>() with LimboTraceLogger.Instance in Test_enr_discovery2. 
The mock was created but never verified, and the  logger isn't called in this test scenario. 
Using the standard test logger follows project conventions and simplifies the code.