### PR TITLE
fix: return correct count when no peer was dropped in DropWorstPeer

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -539,7 +539,12 @@ namespace Nethermind.Synchronization.Peers
                 }
             }
 
-            worstPeer?.SyncPeer.Disconnect(DisconnectReason.DropWorstPeer, $"PEER REVIEW / {worstReason}");
+            if (worstPeer is null)
+            {
+                return 0;
+            }
+
+            worstPeer.SyncPeer.Disconnect(DisconnectReason.DropWorstPeer, $"PEER REVIEW / {worstReason}");
             return 1;
         }
 


### PR DESCRIPTION
DropWorstPeer() was always returning 1 even when worstPeer was null and no peer was actually disconnected. This happens when all peers in the pool are static or all are priority peers below the limit. The null-conditional operator on Disconnect() silently did nothing, but the method still returned 1, causing misleading "Dropped 1 useless peers" log messages. Now it properly returns 0 when no peer is found to drop.