### PR TITLE
fix: use GaugeMetric for PeerCandidateCount

### DIFF
--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Network
         [KeyIsLabel("protocol", "message")]
         public static NonBlocking.ConcurrentDictionary<P2PMessageKey, long> IncomingP2PMessageBytes { get; } = new();
 
-        [CounterMetric]
+        [GaugeMetric]
         [Description("Number of candidate peers in peer manager")]
         [DetailedMetric]
         public static int PeerCandidateCount { get; set; }


### PR DESCRIPTION
PeerCandidateCount represents the current number of candidate peers in the peer manager and is updated via assignment from _peerPool.PeerCount. This is snapshot semantics and the value can go up and down over time, which matches a gauge, not a counter.