### PR TITLE
fix: delegate raw converters read to base converters

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Json/LongConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/LongConverter.cs
@@ -79,10 +79,7 @@ namespace Nethermind.Serialization.Json
             throw new JsonException("hex to long");
         }
 
-        public override long Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
+        internal static long ReadCore(ref Utf8JsonReader reader)
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
@@ -101,6 +98,14 @@ namespace Nethermind.Serialization.Json
             }
 
             throw new JsonException();
+        }
+
+        public override long Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            return ReadCore(ref reader);
         }
 
         [SkipLocalsInit]

--- a/src/Nethermind/Nethermind.Serialization.Json/LongRawJsonConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/LongRawJsonConverter.cs
@@ -10,14 +10,12 @@ namespace Nethermind.Serialization.Json;
 
 public class LongRawJsonConverter : JsonConverter<long>
 {
-    private readonly LongConverter _converter = new();
-
     public override long Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
         JsonSerializerOptions options)
     {
-        return _converter.Read(ref reader, typeToConvert, options);
+        return LongConverter.ReadCore(ref reader);
     }
 
     public override void Write(

--- a/src/Nethermind/Nethermind.Serialization.Json/ULongConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ULongConverter.cs
@@ -78,10 +78,7 @@ namespace Nethermind.Serialization.Json
             }
         }
 
-        public override ulong Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
+        internal static ulong ReadCore(ref Utf8JsonReader reader)
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
@@ -100,6 +97,14 @@ namespace Nethermind.Serialization.Json
             }
 
             throw new JsonException();
+        }
+
+        public override ulong Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            return ReadCore(ref reader);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/ULongRawJsonConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ULongRawJsonConverter.cs
@@ -10,14 +10,12 @@ namespace Nethermind.Serialization.Json;
 
 public class ULongRawJsonConverter : JsonConverter<ulong>
 {
-    private readonly ULongConverter _converter = new();
-
     public override ulong Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
         JsonSerializerOptions options)
     {
-        return _converter.Read(ref reader, typeToConvert, options);
+        return ULongConverter.ReadCore(ref reader);
     }
 
     public override void Write(


### PR DESCRIPTION
Removed duplicated parsing logic from LongRawJsonConverter and ULongRawJsonConverter by delegating their Read methods to LongConverter and ULongConverter. It keeps the existing Write behavior (always writing numeric JSON values) while ensuring that any future adjustments to number parsing in the base converters are automatically reflected in the raw variants.