### PR TITLE
ethstats: report newPayload processing time to stats server

### DIFF
--- a/src/Nethermind/Nethermind.Api/INewPayloadEventSource.cs
+++ b/src/Nethermind/Nethermind.Api/INewPayloadEventSource.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Api
+{
+    /// <summary>
+    /// Event arguments for when an engine_newPayloadVX call successfully processes a block.
+    /// </summary>
+    public class NewPayloadProcessedEventArgs(Hash256 hash, long number, TimeSpan processingTime) : EventArgs
+    {
+        public Hash256 Hash { get; } = hash;
+        public long Number { get; } = number;
+        public TimeSpan ProcessingTime { get; } = processingTime;
+    }
+
+    /// <summary>
+    /// Provides events for engine API newPayload processing.
+    /// </summary>
+    public interface INewPayloadEventSource
+    {
+        /// <summary>
+        /// Raised when a new payload has been successfully processed with a Valid result.
+        /// </summary>
+        event EventHandler<NewPayloadProcessedEventArgs>? NewPayloadProcessed;
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
@@ -27,7 +27,7 @@ using Nethermind.TxPool;
 
 namespace Nethermind.EthStats;
 
-[RunnerStepDependencies(typeof(InitializeBlockchain))]
+[RunnerStepDependencies(typeof(RegisterRpcModules))]
 public class EthStatsStep(
     ISpecProvider specProvider,
     ITxPool txPool,
@@ -40,7 +40,8 @@ public class EthStatsStep(
     INetworkConfig networkConfig,
     IInitConfig initConfig,
     IMiningConfig miningConfig,
-    ILogManager logManager
+    ILogManager logManager,
+    INewPayloadEventSource? newPayloadEventSource = null
 ) : IStep, IAsyncDisposable
 {
     private readonly ILogger _logger = logManager.GetClassLogger<EthStatsStep>();
@@ -98,7 +99,8 @@ public class EthStatsStep(
             ethSyncingInfo!,
             miningConfig.Enabled,
             TimeSpan.FromSeconds(ethStatsConfig.SendInterval),
-            logManager);
+            logManager,
+            newPayloadEventSource);
 
         await _ethStatsIntegration.InitAsync();
     }

--- a/src/Nethermind/Nethermind.EthStats/Messages/Models/NewPayloadBlock.cs
+++ b/src/Nethermind/Nethermind.EthStats/Messages/Models/NewPayloadBlock.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.EthStats.Messages.Models
+{
+    public class NewPayloadBlock
+    {
+        public long Number { get; }
+        public string Hash { get; }
+        public long ProcessingTime { get; }
+
+        public NewPayloadBlock(long number, string hash, long processingTime)
+        {
+            Number = number;
+            Hash = hash;
+            ProcessingTime = processingTime;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/Messages/NewPayloadMessage.cs
+++ b/src/Nethermind/Nethermind.EthStats/Messages/NewPayloadMessage.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.EthStats.Messages.Models;
+
+namespace Nethermind.EthStats.Messages
+{
+    public class NewPayloadMessage : IMessage
+    {
+        public string? Id { get; set; }
+        public NewPayloadBlock Block { get; }
+
+        public NewPayloadMessage(NewPayloadBlock block)
+        {
+            Block = block;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -323,6 +323,7 @@ public class BaseMergePluginModule : Module
                 .AddSingleton<IAsyncHandler<byte[], GetPayloadV4Result?>, GetPayloadV4Handler>()
                 .AddSingleton<IAsyncHandler<byte[], GetPayloadV5Result?>, GetPayloadV5Handler>()
                 .AddSingleton<IAsyncHandler<ExecutionPayload, PayloadStatusV1>, NewPayloadHandler>()
+                    .Bind<INewPayloadEventSource, NewPayloadHandler>()
                 .AddSingleton<IForkchoiceUpdatedHandler, ForkchoiceUpdatedHandler>()
                 .AddSingleton<IHandler<IReadOnlyList<Hash256>, IEnumerable<ExecutionPayloadBodyV1Result?>>, GetPayloadBodiesByHashV1Handler>()
                 .AddSingleton<IGetPayloadBodiesByRangeV1Handler, GetPayloadBodiesByRangeV1Handler>()


### PR DESCRIPTION
## Changes

- Add `INewPayloadEventSource` interface for publishing new payload events
- Add `NewPayloadBlock` model to capture block details and processing time
- Add `NewPayloadMessage` for sending new payload events to ethstats server
- Update `NewPayloadHandler` to track processing time and emit events
- Update `MergePlugin` to implement `INewPayloadEventSource`
- Update `EthStatsIntegration` to subscribe to new payload events and send them to the stats server

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Adds support for reporting `newPayload` processing times to ethstats server, enabling monitoring of block processing performance via the Engine API.

## Remarks

Related to go-ethereum implementation: https://github.com/ethereum/go-ethereum/pull/33395

See also: https://notes.ethereum.org/@savid/block-observability