### PR TITLE
fix: remove duplicate HasSignedRecently checks in sealer clique

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealer.cs
@@ -101,15 +101,6 @@ namespace Nethermind.Consensus.Clique
                 return false;
             }
 
-            if (_snapshotManager.HasSignedRecently(snapshot, blockNumber, _signer.Address))
-            {
-                if (_snapshotManager.HasSignedRecently(snapshot, blockNumber, _signer.Address))
-                {
-                    if (_logger.IsTrace) _logger.Trace("Signed recently");
-                    return false;
-                }
-            }
-
             // If we're amongst the recent signers, wait for the next block
             if (_snapshotManager.HasSignedRecently(snapshot, blockNumber, _signer.Address))
             {


### PR DESCRIPTION
CanSeal was calling HasSignedRecently up to three times in a row with the same arguments, with the inner and trailing checks being redundant. HasSignedRecently is a pure read-only check on the snapshot, so multiple consecutive calls cannot change the result and only add noise and overhead. This change replaces the duplicated block with a single check that logs "Signed recently" and returns false, keeping the existing behavior and comment while simplifying the control flow.