### PR TITLE
refactor(AuRa): remove redundant Create override

### DIFF
--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaPostMergeBlockProducerFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaPostMergeBlockProducerFactory.cs
@@ -29,25 +29,5 @@ namespace Nethermind.Merge.AuRa
                 gasLimitCalculator)
         {
         }
-
-        public override PostMergeBlockProducer Create(
-            IBlockProducerEnv producerEnv,
-            ITxSource? txSource = null)
-        {
-            TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator =
-                new(_specProvider, _blocksConfig);
-
-            return new PostMergeBlockProducer(
-                txSource ?? producerEnv.TxSource,
-                producerEnv.ChainProcessor,
-                producerEnv.BlockTree,
-                producerEnv.ReadOnlyStateProvider,
-                _gasLimitCalculator ?? targetAdjustedGasLimitCalculator,
-                _sealEngine,
-                _timestamper,
-                _specProvider,
-                _logManager,
-                _blocksConfig);
-        }
     }
 }


### PR DESCRIPTION
`AuRaPostMergeBlockProducerFactory` was overriding `Create` with logic identical to the base `PostMergeBlockProducerFactory`. This duplication added an unnecessary `TargetAdjustedGasLimitCalculator` allocation when a custom `IGasLimitCalculator` was already provided. The override has been removed so that AuRa uses the base implementation without changing behavior while avoiding redundant code and extra allocations.