### PR TITLE
fix: remove unused Nethermind.Logging import from TransactionTests

### DIFF
--- a/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/TransactionTests.cs
@@ -13,7 +13,6 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Crypto;
 using Nethermind.Int256;
-using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 


### PR DESCRIPTION
Removed unused `using Nethermind.Logging;` directive from TransactionTests.cs.

The import was not referenced anywhere in the file and violates IDE0005 code style rule.