### PR TITLE
test: add edge case tests for zero value handling in StorageTree

### DIFF
--- a/src/Nethermind/Ethereum.Trie.Test/StorageTrieTests.cs
+++ b/src/Nethermind/Ethereum.Trie.Test/StorageTrieTests.cs
@@ -54,5 +54,41 @@ namespace Ethereum.Trie.Test
             Hash256 rootAfter = tree.RootHash;
             Assert.That(rootAfter, Is.EqualTo(rootBefore));
         }
+
+        [Test]
+        public void Storage_trie_set_reset_with_32_byte_zero()
+        {
+            StorageTree tree = CreateStorageTrie();
+            Hash256 rootBefore = tree.RootHash;
+            tree.Set(1, new byte[] { 1 });
+            tree.Set(1, new byte[32]); // Standard Ethereum storage size, all zeros
+            tree.UpdateRootHash();
+            Hash256 rootAfter = tree.RootHash;
+            Assert.That(rootAfter, Is.EqualTo(rootBefore));
+        }
+
+        [Test]
+        public void Storage_trie_set_reset_with_leading_zeros_and_nonzero()
+        {
+            StorageTree tree = CreateStorageTrie();
+            Hash256 rootBefore = tree.RootHash;
+            tree.Set(1, new byte[] { 1 });
+            tree.Set(1, new byte[] { 0, 0, 1 }); // Leading zeros but has non-zero byte
+            tree.UpdateRootHash();
+            Hash256 rootAfter = tree.RootHash;
+            Assert.That(rootAfter, Is.Not.EqualTo(rootBefore), "Value with non-zero bytes should not reset to empty tree");
+        }
+
+        [Test]
+        public void Storage_trie_set_reset_with_zeros_in_middle()
+        {
+            StorageTree tree = CreateStorageTrie();
+            Hash256 rootBefore = tree.RootHash;
+            tree.Set(1, new byte[] { 1 });
+            tree.Set(1, new byte[] { 1, 0, 0, 1 }); // Zeros in middle but has non-zero bytes
+            tree.UpdateRootHash();
+            Hash256 rootAfter = tree.RootHash;
+            Assert.That(rootAfter, Is.Not.EqualTo(rootBefore), "Value with non-zero bytes should not reset to empty tree");
+        }
     }
 }


### PR DESCRIPTION
Adds three test cases to cover different zero value representations in storage trie operations. Tests verify that 32-byte zero arrays are treated as zero values, while arrays with non-zero bytes (even with leading zeros or zeros in the middle) are correctly preserved and don't reset the tree to empty state.
