### PR TITLE
perf: avoid rlp encode-decode in simulate receipt recovery

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -53,14 +53,10 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
         return readonlyBaseBlockStore.GetRlp(blockNumber, blockHash);
     }
 
-    public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash)
-    {
-        if (_blockNumDict.TryGetValue(blockNumber, out Block block))
-        {
-            return new ReceiptRecoveryBlock(block);
-        }
-        return readonlyBaseBlockStore.GetReceiptRecoveryBlock(blockNumber, blockHash);
-    }
+    public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash) =>
+        _blockNumDict.TryGetValue(blockNumber, out Block block)
+            ? new ReceiptRecoveryBlock(block)
+            : readonlyBaseBlockStore.GetReceiptRecoveryBlock(blockNumber, blockHash);
 
     public void Cache(Block block)
         => Insert(block);


### PR DESCRIPTION
## Changes

When a block is served from the in-memory simulate dictionary we already have the full Block with all transactions available. In this case we can construct ReceiptRecoveryBlock directly from the Block instead of re-encoding it to RLP and decoding it back again. This removes unnecessary CPU work and allocations while keeping the same behavior as other parts of the codebase that use ReceiptRecoveryBlock(Block) for in-memory blocks.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

