### PR TITLE
fix: ensure eth_getBlockByNumber enforces canonical block retrieval

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Blockchain.Find
 
         public Hash256? BlockHash { get; }
 
-        public bool RequireCanonical { get; set; }
+        public bool RequireCanonical { get; }
 
         public BlockParameter(BlockParameterType type)
         {
@@ -45,6 +45,7 @@ namespace Nethermind.Blockchain.Find
 
         public BlockParameter(long number)
         {
+            RequireCanonical = true;
             Type = BlockParameterType.BlockNumber;
             BlockNumber = number;
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
@@ -35,22 +35,14 @@ namespace Nethermind.JsonRpc.Modules
 
             blockParameter ??= BlockParameter.Latest;
 
-            BlockHeader header;
-            if (blockParameter.RequireCanonical)
+            BlockHeader header = blockFinder.FindHeader(blockParameter);
+            if (blockParameter.RequireCanonical && header is null && !allowNulls && blockParameter.BlockHash is not null)
             {
-                header = blockFinder.FindHeader(blockParameter.BlockHash, BlockTreeLookupOptions.RequireCanonical);
-                if (header is null && !allowNulls)
+                header = blockFinder.FindHeader(blockParameter.BlockHash);
+                if (header is not null)
                 {
-                    header = blockFinder.FindHeader(blockParameter.BlockHash);
-                    if (header is not null)
-                    {
-                        return new SearchResult<BlockHeader>($"{blockParameter.BlockHash} block is not canonical", ErrorCodes.InvalidInput);
-                    }
+                    return new SearchResult<BlockHeader>($"{blockParameter.BlockHash} block is not canonical", ErrorCodes.InvalidInput);
                 }
-            }
-            else
-            {
-                header = blockFinder.FindHeader(blockParameter);
             }
 
             return header is null && !allowNulls
@@ -62,23 +54,14 @@ namespace Nethermind.JsonRpc.Modules
         {
             blockParameter ??= BlockParameter.Latest;
 
-            Block block;
-            if (blockParameter.RequireCanonical &&
-                (blockParameter.BlockHash is not null || blockParameter.BlockNumber is not null))
+            Block block = blockFinder.FindBlock(blockParameter);
+            if (blockParameter.RequireCanonical && block is null && !allowNulls && blockParameter.BlockHash is not null)
             {
-                block = blockFinder.FindBlock(blockParameter);
-                if (block is null && !allowNulls)
+                BlockHeader? header = blockFinder.FindHeader(blockParameter.BlockHash);
+                if (header is not null)
                 {
-                    BlockHeader? header = blockFinder.FindHeader(blockParameter.BlockHash);
-                    if (header is not null)
-                    {
-                        return new SearchResult<Block>($"{blockParameter.BlockHash} block is not canonical", ErrorCodes.InvalidInput);
-                    }
+                    return new SearchResult<Block>($"{blockParameter.BlockHash} block is not canonical", ErrorCodes.InvalidInput);
                 }
-            }
-            else
-            {
-                block = blockFinder.FindBlock(blockParameter);
             }
 
             if (block is null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -364,8 +364,6 @@ public partial class EthRpcModule(
     public ResultWrapper<BlockForRpc> eth_getBlockByNumber(BlockParameter blockParameter,
         bool returnFullTransactionObjects)
     {
-        if (blockParameter.BlockNumber is not null)
-            blockParameter.RequireCanonical = true;
         return GetBlock(blockParameter, returnFullTransactionObjects);
     }
 


### PR DESCRIPTION
## Changes

- ensure eth_getBlockByNumber enforces canonical block retrieval. this matches geth bahavior as seen below
https://github.com/ethereum/go-ethereum/blob/27b3a6087e23a477b74e617641ff2378faf2a970/core/blockchain_reader.go#L196

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Change in behavior of eth_getBlockByNumber to only return canonical blocks
