### PR TITLE
fix(shutter): use Debug() instead of Error() when IsDebug check

### DIFF
--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -84,7 +84,7 @@ public class ShutterKeyValidator(
 
         if (decryptionKeys.Keys.Count == 0)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Invalid Shutter decryption keys received: expected placeholder key.");
+            if (_logger.IsDebug) _logger.Debug("Invalid Shutter decryption keys received: expected placeholder key.");
             return false;
         }
 
@@ -102,7 +102,7 @@ public class ShutterKeyValidator(
             }
             catch (Bls.BlsException e)
             {
-                if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Invalid Shutter decryption keys received.", e);
+                if (_logger.IsDebug) _logger.Debug("Invalid Shutter decryption keys received.", e);
                 return false;
             }
 


### PR DESCRIPTION
Fixed logger level mismatch in ShutterKeyValidator. Code was checking IsDebug but calling Error() method. The original messages even contained "DEBUG/ERROR" marker indicating unfinished refactoring. Changed to use Debug() consistently with the IsDebug guard.