### PR TITLE
fix: handle full UInt256 range in HexConvert.ToUInt256

### DIFF
--- a/tools/SendBlobs/HexConvert.cs
+++ b/tools/SendBlobs/HexConvert.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
 namespace SendBlobs;
@@ -8,7 +9,7 @@ internal static class HexConvert
 {
     public static UInt256 ToUInt256(string s)
     {
-        return (UInt256)ToUInt64(s);
+        return new UInt256(Bytes.FromHexString(s), isBigEndian: true);
     }
 
     public static ulong ToUInt64(string s)


### PR DESCRIPTION
ToUInt256 was converting via ulong, limiting values to 2^64.
Now correctly parses hex strings to full UInt256 range using Bytes.FromHexString.