### PR TITLE
fix: resource cleanup in BeaconHeadersSyncFeed

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -112,19 +112,6 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         FallAsleep();
         PostFinishCleanUp();
     }
-
-    protected override void PostFinishCleanUp()
-    {
-        HeadersSyncProgressLoggerReport.Update(TotalBlocks);
-        HeadersSyncProgressLoggerReport.CurrentQueued = 0;
-        HeadersSyncProgressLoggerReport.MarkEnd();
-        ClearDependencies(); // there may be some dependencies from wrong branches
-        _pending.DisposeItems();
-        _pending.Clear(); // there may be pending wrong branches
-        _sent.DisposeItems();
-        _sent.Clear(); // we my still be waiting for some bad branches
-    }
-
     public override Task<HeadersSyncBatch?> PrepareRequest(CancellationToken cancellationToken = default)
     {
         if (_pivotNumber != ExpectedPivotNumber)


### PR DESCRIPTION
BeaconHeadersSyncFeed.PostFinishCleanUp was only clearing the _pending and _sent collections without disposing the underlying HeadersSyncBatch instances. This meant that any owned response lists kept their buffers until the feed itself was disposed, which is inconsistent with the base HeadersSyncFeed behavior. The cleanup now matches the fast headers implementation by disposing pending and sent batches and resetting the headers progress queue, preventing unnecessary resource retention across beacon sync cycles.