### PR TITLE
fix: replace null-forgiving operator with OfType in DiscoveryV5App

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/DiscoveryV5App.cs
@@ -90,7 +90,7 @@ public class DiscoveryV5App : IDiscoveryApp
                         return null;
                     }
                 })
-                .Where(enr => enr != null)!
+                .OfType<Lantern.Discv5.Enr.Enr>()
             ];
 
         EnrBuilder enrBuilder = new EnrBuilder()


### PR DESCRIPTION
Replace unsafe null-forgiving operator with OfType<T>() when filtering null ENR records from database. 

This ensures type safety and properly handles nullable reference types without suppressing compiler warnings.
