### PR TITLE
fix: correct exception type in Either<T1,T2>.To methods

### DIFF
--- a/src/Nethermind/Nethermind.Core/Either.cs
+++ b/src/Nethermind/Nethermind.Core/Either.cs
@@ -40,7 +40,7 @@ public readonly struct Either<T1, T2>
         return value2 is not null;
     }
 
-    public void To(out T1 val) => val = value1 ?? throw new ArgumentException(nameof(T1));
+    public void To(out T1 val) => val = value1 ?? throw new InvalidOperationException($"Either does not contain {nameof(T1)}");
 
-    public void To(out T2 val) => val = value2 ?? throw new ArgumentException(nameof(T2));
+    public void To(out T2 val) => val = value2 ?? throw new InvalidOperationException($"Either does not contain {nameof(T2)}");
 }


### PR DESCRIPTION
Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

Replace `ArgumentException` with `InvalidOperationException` in `Either<T1, T2>.To` methods.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
