### PR TITLE
fix: remove dead code in BlockchainTestBase static constructor

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -49,7 +49,6 @@ public abstract class BlockchainTestBase
     static BlockchainTestBase()
     {
         DifficultyCalculator = new DifficultyCalculatorWrapper();
-        _logManager ??= LimboLogs.Instance;
         _logger = _logManager.GetClassLogger();
     }
 


### PR DESCRIPTION
Remove useless null check for _logManager. The field is already initialized as readonly, so the ??= operator never runs. Looks like leftover code.