### PR TITLE
fix: add Ethereum Signed Message prefix to address recovery test

### DIFF
--- a/src/Nethermind/Ethereum.KeyAddress.Test/KeyAddressTests.cs
+++ b/src/Nethermind/Ethereum.KeyAddress.Test/KeyAddressTests.cs
@@ -51,12 +51,11 @@ namespace Ethereum.KeyAddress.Test
         [TestCase("0x36d85Dc3683156e63Bf880A9fAb7788CF8143a27", "Christopher Pearce", "0x34ff4b97a0ec8f735f781f250dcd3070a72ddb640072dd39553407d0320db79939e3b080ecaa2e9f248214c6f0811fb4b4ba05b7bcff254c053e47d8513e82091b")]
         public void Recovered_address_as_expected(string addressHex, string message, string sigHex)
         {
-            Hash256 messageHash = Keccak.Compute(message);
+            Hash256 messageHash = Keccak.Compute($"\u0019Ethereum Signed Message:\n{message.Length}{message}");
             Signature sig = new Signature(sigHex);
             Address recovered = _ecdsa.RecoverAddress(sig, messageHash);
             Address address = new Address(addressHex);
 
-            // TODO: check - at the moment they are failing when running in the test mode but not in Debug
             Assert.That(recovered, Is.EqualTo(address));
         }
 


### PR DESCRIPTION
The test was failing because it computed the message hash without the Ethereum Signed Message prefix, while the signatures were created with the prefix. This caused address recovery to fail in test mode.

Added the standard prefix "\u0019Ethereum Signed Message:\n{length}{message}" when computing the message hash, matching the format used in PersonalRpcModule and other parts of the codebase.