### PR TITLE
Check for 0 in MOD opcode

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
@@ -165,7 +165,17 @@ internal static partial class EvmInstructions
     {
         public static long GasCost => GasCostOf.Low;
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result)
-            => UInt256.Mod(in a, in b, out result);
+        {
+            if (b.IsZeroOrOne)
+            {
+                // Modulo with 0 or 1 yields zero.
+                result = default;
+            }
+            else
+            {
+                UInt256.Mod(in a, in b, out result);
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- In `MOD` don't rely on `UInt256` not to throw division by zero; and follow `DIV`,`SDIV`,`SMOD`,`ADDMOD`,`MULMOD` code and precheck


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
