### PR TITLE
fix: DataFeed constructor null checks

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
@@ -57,7 +57,7 @@ public class DataFeed
         CancellationToken lifetime)
     {
         ArgumentNullException.ThrowIfNull(txPool);
-        ArgumentNullException.ThrowIfNull(syncPeerPool);
+        ArgumentNullException.ThrowIfNull(specProvider);
         ArgumentNullException.ThrowIfNull(receiptFinder);
         ArgumentNullException.ThrowIfNull(blockTree);
         ArgumentNullException.ThrowIfNull(syncPeerPool);


### PR DESCRIPTION
## Changes

- DataFeed constructor was checking ISyncPeerPool for null twice and never validating ISpecProvider, even though specProvider is used later in OnForkChoiceUpdated. Replace the duplicated syncPeerPool check with a specProvider null check to prevent a potential NullReferenceException and keep the argument validation consistent with how the dependencies are used.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

