### PR TITLE
fix: normalize discovery bootnodes merge from chainspec

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
@@ -81,7 +81,7 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
                     discoveryConfig.Bootnodes = string.Join(",", chainSpec.Bootnodes.Select(static bn => bn.ToString()));
                 }
 
-                if (networkConfig.DiscoveryDns == null)
+                if (networkConfig.DiscoveryDns is null)
                 {
                     string chainName = BlockchainIds.GetBlockchainName(chainSpec!.NetworkId).ToLowerInvariant();
                     networkConfig.DiscoveryDns = $"all.{chainName}.ethdisco.net";


### PR DESCRIPTION
DiscoveryConfig.Bootnodes could be null and was concatenated using '+=' with chainspec bootnodes, producing a leading comma in the final enode list. At the same time the code tried to guard against a null ChainSpec.Bootnodes array using 'is not null', even though the array is always initialized by the chainspec loader.

Normalized discovery bootnodes handling by treating null and empty as the same state using string.IsNullOrEmpty and by relying on ChainSpec.Bootnodes.Length != 0 instead of a misleading null check. As a result, the merged bootnodes string is well-formed and better matches the actual contracts of both configs.