### PR TITLE
OOG if not enough gas for self-destruct

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -211,7 +211,8 @@ internal static partial class EvmInstructions
         // If Shanghai DDoS protection is active, charge the appropriate gas cost.
         if (spec.UseShanghaiDDosProtection)
         {
-            gasAvailable -= GasCostOf.SelfDestructEip150;
+            if (!EvmCalculations.UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable))
+                goto OutOfGas;
         }
 
         // Pop the inheritor address from the stack; signal underflow if missing.


### PR DESCRIPTION
## Changes

- OOG if not enough gas for self-destruct. This prevents reaching into state unnecessarily on new account gas check.

I believe this is directly related to the latest issues on devnet 1 where the BAL generated by Nethermind did not agree with all other clients by touching state unnecessarily with OOG on selfdestruct check.

I think this line is quite relevant [here](https://github.com/NethermindEth/nethermind/blob/bal-devnet-1/src/Nethermind/Nethermind.Evm/Instructions/EvmCalculations.cs#L62). Since this was a precompile, it did not charge any gas for access and moved on. This may have actually executed the selfdestruct successfully if we don't hit any other checks on `availableGas` in the logic here even though there wasn't enough gas for selfdestruct (we deducted it from `availableGas` but never performed any other "successful" check on the value where it would have triggered the OOG). On the devnet this may have happened on the parent call somewhere, not quite sure. Either way we need to OOG early to keep with consensus for BALs if there is not enough gas.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

I saw there weren't a lot of tests for instructions that revolve around these. If one is desired I can include it here or feel free to push to my branch.

- `ethereum/execution-specs` tests: I will make sure we add new test cases for selfdestruct to precompiles as this seems like it was a unique code path that was triggered, related to precompile as beneficiary.
    - ^ update: OOG test scenarios for selfdestruct to precompiles updated in [this PR](https://github.com/ethereum/execution-specs/pull/1954). I confirmed on hive that Nethermind indeed does not pass the `oog_before_state_access` cases in this PR.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Happy to close this or update here if there is a better option. Thanks.
