### PR TITLE
Use baseblock for tree visitor

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
@@ -93,18 +93,19 @@ public class CopyTreeVisitorTests
         // Use TestWorldStateFactory.CreateForTest() with the custom DbProvider
         (IWorldState worldState, IStateReader stateReader) = TestWorldStateFactory.CreateForTestWithStateReader(dbProvider, logManager);
 
+        BlockHeader? baseBlock = Build.A.BlockHeader.WithStateRoot(trie.RootHash).TestObject;
         if (_keyScheme == INodeStorage.KeyScheme.Hash)
         {
             NodeStorage nodeStorage = new NodeStorage(pruningContext, _keyScheme);
             using CopyTreeVisitor<NoopTreePathContextWithStorage> copyTreeVisitor = new(nodeStorage, writeFlags, logManager, cancellationToken);
-            stateReader.RunTreeVisitor(copyTreeVisitor, trie.RootHash, visitingOptions);
+            stateReader.RunTreeVisitor(copyTreeVisitor, baseBlock, visitingOptions);
             copyTreeVisitor.Finish();
         }
         else
         {
             NodeStorage nodeStorage = new NodeStorage(pruningContext, _keyScheme);
             using CopyTreeVisitor<TreePathContextWithStorage> copyTreeVisitor = new(nodeStorage, writeFlags, logManager, cancellationToken);
-            stateReader.RunTreeVisitor(copyTreeVisitor, trie.RootHash, visitingOptions);
+            stateReader.RunTreeVisitor(copyTreeVisitor, baseBlock, visitingOptions);
             copyTreeVisitor.Finish();
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -180,7 +180,7 @@ namespace Nethermind.Blockchain.FullPruning
             }
 
             if (_logger.IsInfo) _logger.Info($"Full Pruning Ready to start: pruning garbage before state {stateToCopy} with root {header.StateRoot}");
-            await CopyTrie(pruningContext, header.StateRoot!, cancellationToken);
+            await CopyTrie(pruningContext, header, cancellationToken);
         }
 
         private bool CanStartNewPruning() => _fullPruningDb.CanStartPruning;
@@ -220,7 +220,7 @@ namespace Nethermind.Blockchain.FullPruning
             }
         }
 
-        private Task CopyTrie(IPruningContext pruning, Hash256 stateRoot, CancellationToken cancellationToken)
+        private Task CopyTrie(IPruningContext pruning, BlockHeader? baseBlock, CancellationToken cancellationToken)
         {
             INodeStorage.KeyScheme originalKeyScheme = _nodeStorage.Scheme;
             ICopyTreeVisitor visitor = null;
@@ -265,8 +265,8 @@ namespace Nethermind.Blockchain.FullPruning
                 if (_logger.IsInfo) _logger.Info($"Full pruning started with MaxDegreeOfParallelism: {visitingOptions.MaxDegreeOfParallelism} and FullScanMemoryBudget: {visitingOptions.FullScanMemoryBudget}");
 
                 visitor = targetNodeStorage.Scheme == INodeStorage.KeyScheme.Hash
-                    ? CopyTree<NoopTreePathContextWithStorage>(stateRoot, targetNodeStorage, writeFlags, visitingOptions, cancellationToken)
-                    : CopyTree<TreePathContextWithStorage>(stateRoot, targetNodeStorage, writeFlags, visitingOptions, cancellationToken);
+                    ? CopyTree<NoopTreePathContextWithStorage>(baseBlock, targetNodeStorage, writeFlags, visitingOptions, cancellationToken)
+                    : CopyTree<TreePathContextWithStorage>(baseBlock, targetNodeStorage, writeFlags, visitingOptions, cancellationToken);
 
                 if (!cancellationToken.IsCancellationRequested)
                 {
@@ -296,7 +296,7 @@ namespace Nethermind.Blockchain.FullPruning
         }
 
         private ICopyTreeVisitor CopyTree<TContext>(
-            Hash256 stateRoot,
+            BlockHeader? baseBlock,
             INodeStorage targetNodeStorage,
             WriteFlags writeFlags,
             VisitingOptions visitingOptions,
@@ -304,7 +304,7 @@ namespace Nethermind.Blockchain.FullPruning
         ) where TContext : struct, ITreePathContextWithStorage, INodeContext<TContext>
         {
             CopyTreeVisitor<TContext> copyTreeVisitor = new(targetNodeStorage, writeFlags, _logManager, cancellationToken);
-            _stateReader.RunTreeVisitor(copyTreeVisitor, stateRoot, visitingOptions);
+            _stateReader.RunTreeVisitor(copyTreeVisitor, baseBlock, visitingOptions);
             return copyTreeVisitor;
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -31,17 +31,7 @@ namespace Nethermind.Blockchain
 
         public byte[]? GetCode(in ValueHash256 codeHash) => _stateReader.GetCode(in codeHash);
 
-        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot, VisitingOptions? visitingOptions) where TCtx : struct, INodeContext<TCtx>
-        {
-            _stateReader.RunTreeVisitor(visitor, stateRoot, visitingOptions);
-        }
-
         public bool AccountExists(Address address) => _stateReader.TryGetAccount(BaseBlock, address, out _);
-
-        [SkipLocalsInit]
-        public bool IsEmptyAccount(Address address) => TryGetAccount(address, out AccountStruct account) && account.IsEmpty;
-
-        public bool HasStateForBlock(BlockHeader? header) => _stateReader.HasStateForBlock(header);
 
         [SkipLocalsInit]
         public bool IsDeadAccount(Address address) => !TryGetAccount(address, out AccountStruct account) || account.IsEmpty;

--- a/src/Nethermind/Nethermind.Consensus/Processing/GenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/GenesisLoader.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Consensus.Processing
         {
             if (expectedGenesisHash is not null && genesis.Hash != expectedGenesisHash)
             {
-                if (_logger.IsTrace) _logger.Trace(stateReader.DumpState(genesis.StateRoot!));
+                if (_logger.IsTrace) _logger.Trace(stateReader.DumpState(genesis));
                 if (_logger.IsWarn) _logger.Warn(genesis.ToString(BlockHeader.Format.Full));
                 if (_logger.IsError) _logger.Error($"Unexpected genesis hash, expected {expectedGenesisHash}, but was {genesis.Hash}");
             }

--- a/src/Nethermind/Nethermind.Consensus/Tracing/ITracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/ITracer.cs
@@ -27,6 +27,6 @@ namespace Nethermind.Consensus.Tracing
         /// <param name="tracer">Trace to act on block processing events.</param>
         void Execute(Block block, IBlockTracer tracer);
 
-        void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>;
+        void Accept<TCtx>(ITreeVisitor<TCtx> visitor, BlockHeader? baseBlock) where TCtx : struct, INodeContext<TCtx>;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Tracing/Tracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/Tracer.cs
@@ -33,12 +33,12 @@ namespace Nethermind.Consensus.Tracing
 
         public void Execute(Block block, IBlockTracer tracer) => Process(block, tracer, executeProcessor, executeOptions);
 
-        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>
+        public void Accept<TCtx>(ITreeVisitor<TCtx> visitor, BlockHeader? baseBlock) where TCtx : struct, INodeContext<TCtx>
         {
             ArgumentNullException.ThrowIfNull(visitor);
-            ArgumentNullException.ThrowIfNull(stateRoot);
+            ArgumentNullException.ThrowIfNull(baseBlock);
 
-            stateReader.RunTreeVisitor(visitor, stateRoot);
+            stateReader.RunTreeVisitor(visitor, baseBlock);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -378,9 +378,9 @@ namespace Nethermind.Facade
 
         public Address? RecoverTxSender(Transaction tx) => ecdsa.RecoverAddress(tx);
 
-        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>
+        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock) where TCtx : struct, INodeContext<TCtx>
         {
-            stateReader.RunTreeVisitor(treeVisitor, stateRoot);
+            stateReader.RunTreeVisitor(treeVisitor, baseBlock);
         }
 
         public bool HasStateForBlock(BlockHeader baseBlock)

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -48,7 +48,7 @@ namespace Nethermind.Facade
         IEnumerable<FilterLog> GetLogs(BlockParameter fromBlock, BlockParameter toBlock, AddressAsKey[]? addresses = null, IEnumerable<Hash256[]?>? topics = null, CancellationToken cancellationToken = default);
 
         bool TryGetLogs(int filterId, out IEnumerable<FilterLog> filterLogs, CancellationToken cancellationToken = default);
-        void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot) where TCtx : struct, INodeContext<TCtx>;
+        void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock) where TCtx : struct, INodeContext<TCtx>;
         bool HasStateForBlock(BlockHeader? baseBlock);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -684,7 +684,7 @@ public partial class EthRpcModule(
         }
 
         AccountProofCollector accountProofCollector = new(accountAddress, storageKeys);
-        _blockchainBridge.RunTreeVisitor(accountProofCollector, header!.StateRoot!);
+        _blockchainBridge.RunTreeVisitor(accountProofCollector, header!);
         return ResultWrapper<AccountProof>.Success(accountProofCollector.BuildResult());
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -88,7 +88,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
             // we collect proofs from before execution (after learning which addresses will be touched)
             // if we wanted to collect post execution proofs then we would need to use BeforeRestore on the tracer
-            callResultWithProof.Accounts = CollectAccountProofs(scope.Component, sourceHeader.StateRoot, proofTxTracer);
+            callResultWithProof.Accounts = CollectAccountProofs(scope.Component, sourceHeader, proofTxTracer);
 
             return ResultWrapper<CallResultWithProof>.Success(callResultWithProof);
         }
@@ -165,7 +165,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
             return ResultWrapper<ReceiptWithProof>.Success(receiptWithProof);
         }
 
-        private AccountProof[] CollectAccountProofs(ITracer tracer, Hash256 stateRoot, ProofTxTracer proofTxTracer)
+        private AccountProof[] CollectAccountProofs(ITracer tracer, BlockHeader? baseBlock, ProofTxTracer proofTxTracer)
         {
             List<AccountProof> accountProofs = new();
             foreach (Address address in proofTxTracer.Accounts)
@@ -174,7 +174,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
                     .Where(s => s.Address == address)
                     .Select(s => s.Index).ToArray());
 
-                tracer.Accept(collector, stateRoot);
+                tracer.Accept(collector, baseBlock);
                 accountProofs.Add(collector.BuildResult());
             }
 

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -249,7 +249,7 @@ namespace Nethermind.Store.Test
                 stateRoot = provider.StateRoot;
             }
 
-            var stats = stateReader.CollectStats(stateRoot, new MemDb(), Logger);
+            var stats = stateReader.CollectStats(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject, new MemDb(), Logger);
             stats.AccountCount.Should().Be(1);
         }
 
@@ -382,7 +382,7 @@ namespace Nethermind.Store.Test
             }
 
             TrieStatsCollector visitor = new(new MemDb(), LimboLogs.Instance);
-            reader.RunTreeVisitor(visitor, stateRoot);
+            reader.RunTreeVisitor(visitor, Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject);
         }
 
         [Test]
@@ -399,7 +399,7 @@ namespace Nethermind.Store.Test
                 stateRoot = provider.StateRoot;
             }
 
-            string state = reader.DumpState(stateRoot);
+            string state = reader.DumpState(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject);
             state.Should().NotBeEmpty();
         }
     }

--- a/src/Nethermind/Nethermind.State.Test/StatsCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StatsCollectorTests.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Store.Test
             TestRawTrieStore trieStore = new(nodeStorage);
             WorldState stateProvider = new(new TrieStoreScopeProvider(trieStore, codeDb, LimboLogs.Instance), LimboLogs.Instance);
             StateReader stateReader = new StateReader(trieStore, codeDb, LimboLogs.Instance);
-            Hash256 stateRoot;
+            BlockHeader baseBlock;
 
             using (var _ = stateProvider.BeginScope(IWorldState.PreGenesis))
             {
@@ -50,7 +50,7 @@ namespace Nethermind.Store.Test
 
                 stateProvider.CommitTree(0);
                 stateProvider.CommitTree(1);
-                stateRoot = stateProvider.StateRoot;
+                baseBlock = Build.A.BlockHeader.WithNumber(1).WithStateRoot(stateProvider.StateRoot).TestObject;
             }
 
             codeDb.Delete(Keccak.Compute(new byte[] { 1, 2, 3, 4 })); // missing code
@@ -67,7 +67,7 @@ namespace Nethermind.Store.Test
                 MaxDegreeOfParallelism = parallel ? 0 : 1
             };
 
-            stateReader.RunTreeVisitor(statsCollector, stateRoot, visitingOptions);
+            stateReader.RunTreeVisitor(statsCollector, baseBlock, visitingOptions);
             var stats = statsCollector.Stats;
 
             stats.CodeCount.Should().Be(1);

--- a/src/Nethermind/Nethermind.State/BlockingVerifyTrie.cs
+++ b/src/Nethermind/Nethermind.State/BlockingVerifyTrie.cs
@@ -47,8 +47,7 @@ public class BlockingVerifyTrie
         // This is to block processing as with halfpath old nodes will be removed
         using IDisposable _ = _trieStore.BeginScope(stateAtBlock);
 
-        Hash256 rootNode = stateAtBlock.StateRoot;
-        TrieStats stats = _stateReader.CollectStats(rootNode, _codeDb, _logManager, cancellationToken);
+        TrieStats stats = _stateReader.CollectStats(stateAtBlock, _codeDb, _logManager, cancellationToken);
         if (stats.MissingNodes > 0)
         {
             if (_logger.IsError) _logger.Error($"Missing node found!");

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -15,7 +15,7 @@ namespace Nethermind.State
         ReadOnlySpan<byte> GetStorage(BlockHeader? baseBlock, Address address, in UInt256 index);
         byte[]? GetCode(Hash256 codeHash);
         byte[]? GetCode(in ValueHash256 codeHash);
-        void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>;
+        void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>;
         bool HasStateForBlock(BlockHeader? baseBlock);
     }
 }

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -41,9 +41,9 @@ namespace Nethermind.State
 
         public byte[]? GetCode(Hash256 codeHash) => codeHash == Keccak.OfAnEmptyString ? [] : _codeDb[codeHash.Bytes];
 
-        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>
+        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? header, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>
         {
-            _state.Accept(treeVisitor, stateRoot, visitingOptions);
+            _state.Accept(treeVisitor, header?.StateRoot ?? Keccak.EmptyTreeHash, visitingOptions);
         }
 
         public bool HasStateForBlock(BlockHeader? baseBlock) => trieStore.HasRoot(baseBlock?.StateRoot ?? Keccak.EmptyTreeHash);

--- a/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
@@ -44,10 +44,10 @@ namespace Nethermind.State
             return account.CodeHash;
         }
 
-        public static TrieStats CollectStats(this IStateReader stateProvider, Hash256 root, IKeyValueStore codeStorage, ILogManager logManager, CancellationToken cancellationToken = default)
+        public static TrieStats CollectStats(this IStateReader stateProvider, BlockHeader? baseBlock, IKeyValueStore codeStorage, ILogManager logManager, CancellationToken cancellationToken = default)
         {
             TrieStatsCollector collector = new(codeStorage, logManager, cancellationToken);
-            stateProvider.RunTreeVisitor(collector, root, new VisitingOptions
+            stateProvider.RunTreeVisitor(collector, baseBlock, new VisitingOptions
             {
                 MaxDegreeOfParallelism = Environment.ProcessorCount,
                 FullScanMemoryBudget = 16.GiB(), // Gonna guess that if you are running this, you have a decent setup.
@@ -55,10 +55,10 @@ namespace Nethermind.State
             return collector.Stats;
         }
 
-        public static string DumpState(this IStateReader stateReader, Hash256 root)
+        public static string DumpState(this IStateReader stateReader, BlockHeader? baseBlock)
         {
             TreeDumper dumper = new();
-            stateReader.RunTreeVisitor(dumper, root);
+            stateReader.RunTreeVisitor(dumper, baseBlock);
             return dumper.ToString();
         }
     }


### PR DESCRIPTION
- Previously state was addressed with just stateroot. This was changed too use BlockHeader to make it simpler for flat. But `IStateReader.Accept` method was missed.
- This changes it so that `IStateReader.Accept` also take `BlockHeader` instead of just state root.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- [X] Mainnet run normally.