### PR TITLE
Fix `taiko_lastBlockIDByBatchID` to return raw decimal instead of hex string

### DIFF
--- a/src/Nethermind/Nethermind.Taiko/Rpc/ITaikoExtendedEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/ITaikoExtendedEthRpcModule.cs
@@ -39,5 +39,5 @@ public interface ITaikoExtendedEthRpcModule : IRpcModule
         Description = "Returns the ID of the last block for the given batch.",
         IsSharable = true,
         IsImplemented = true)]
-    Task<ResultWrapper<UInt256?>> taiko_lastBlockIDByBatchID(UInt256 batchId);
+    Task<ResultWrapper<BlockId?>> taiko_lastBlockIDByBatchID(UInt256 batchId);
 }


### PR DESCRIPTION
Fixes https://github.com/NethermindEth/nethermind/issues/10074

## Changes

- Add `BlockId` record struct with custom JSON converter that serializes as raw decimal number
- Update `taiko_lastBlockIDByBatchID` return type from `UInt256` to `BlockId?`
- The new converter uses `WriteNumberValue()` to output `2` instead of `"0x2"`

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Verified by running taiko-client integration tests against Nethermind:

```bash
cd ~/code/surge-taiko-mono/packages/taiko-client
L2_NODE=l2_nmc PACKAGE=prover make test
```

- Before fix: `TestProverTestSuite/TestOnBatchProposed` fails with unmarshaling error
- After fix: All prover tests pass

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
