### PR TITLE
fix(network): shutdown rlpx executor group

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -168,7 +168,10 @@ namespace Nethermind.Network.Rlpx
                 // Replacing to prevent double dispose which hangs
                 var bossGroup = Interlocked.Exchange(ref _bossGroup, null);
                 var workerGroup = Interlocked.Exchange(ref _workerGroup, null);
-                await Task.WhenAll(bossGroup?.ShutdownGracefullyAsync() ?? Task.CompletedTask, workerGroup?.ShutdownGracefullyAsync() ?? Task.CompletedTask);
+                await Task.WhenAll(
+                    bossGroup?.ShutdownGracefullyAsync() ?? Task.CompletedTask,
+                    workerGroup?.ShutdownGracefullyAsync() ?? Task.CompletedTask,
+                    _group.ShutdownGracefullyAsync(_shutdownQuietPeriod, _shutdownCloseTimeout));
                 throw;
             }
         }
@@ -289,7 +292,8 @@ namespace Nethermind.Network.Rlpx
 
             Task closingTask = Task.WhenAll(
                 _bossGroup is not null ? _bossGroup.ShutdownGracefullyAsync(_shutdownQuietPeriod, _shutdownCloseTimeout) : Task.CompletedTask,
-                _workerGroup is not null ? _workerGroup.ShutdownGracefullyAsync(_shutdownCloseTimeout, _shutdownCloseTimeout) : Task.CompletedTask);
+                _workerGroup is not null ? _workerGroup.ShutdownGracefullyAsync(_shutdownCloseTimeout, _shutdownCloseTimeout) : Task.CompletedTask,
+                _group.ShutdownGracefullyAsync(_shutdownQuietPeriod, _shutdownCloseTimeout));
 
             // below comment may arise from not understanding the quiet period but the resolution is correct
             // we need to add additional timeout on our side as netty is not executing internal timeout properly, often it just hangs forever on closing


### PR DESCRIPTION
## Changes

Ensure the shared IEventExecutorGroup used by RlpxHost is shut down when the host fails to initialize or is explicitly stopped. This prevents leaking DotNetty event loop threads across RlpxHost lifecycles by calling ShutdownGracefullyAsync for the executor group alongside the boss and worker groups.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

