### PR TITLE
fix: use parameter name in BloomStorage null check

### DIFF
--- a/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Db.Blooms
             long Get(Hash256 key, long defaultValue) => bloomDb.Get(key)?.ToLongFromBigEndianByteArrayWithoutLeadingZeros() ?? defaultValue;
 
             _config = config ?? throw new ArgumentNullException(nameof(config));
-            _bloomInfoDb = bloomDb ?? throw new ArgumentNullException(nameof(_bloomInfoDb));
+            _bloomInfoDb = bloomDb ?? throw new ArgumentNullException(nameof(bloomDb));
             _fileStoreFactory = fileStoreFactory;
             _storageLevels = CreateStorageLevels(config);
             Levels = (byte)_storageLevels.Length;


### PR DESCRIPTION
## Description

Fixes ArgumentNullException to use parameter name instead of field name in BloomStorage constructor null check.

## Changes

- Changed `nameof(_bloomInfoDb)` to `nameof(bloomDb)` in line 71 of `BloomStorage.cs`
- Ensures error messages reference the actual parameter name when null is passed
- Aligns with project conventions where parameter names are used in ArgumentNullException