### PR TITLE
fix: remove redundant blockInfosDb assertions

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1050,10 +1050,6 @@ public class BlockTreeTests
         Assert.That(blockInfosDb.Get(2), Is.Not.Null, "level 2");
         Assert.That(blockInfosDb.Get(3), Is.Not.Null, "level 3");
 
-        Assert.That(blockInfosDb.Get(1), Is.Not.Null, "level 1b");
-        Assert.That(blockInfosDb.Get(2), Is.Not.Null, "level 2b");
-        Assert.That(blockInfosDb.Get(3), Is.Not.Null, "level 3b");
-
         repository.LoadLevel(1)!.BlockInfos.Length.Should().Be(1);
         repository.LoadLevel(2)!.BlockInfos.Length.Should().Be(1);
         repository.LoadLevel(3)!.BlockInfos.Length.Should().Be(1);


### PR DESCRIPTION
## Changes

Remove redundant duplicate assertions (lines 1053-1055) that incorrectly attempt to verify branch-specific level info, but actually check the same database keys as lines 1049-1051.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
