### PR TITLE
fix: StateSyncDownloader error logging guard

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDownloader.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Synchronization.StateSync
             }
             catch (Exception e)
             {
-                if (Logger.IsTrace) Logger.Error("DEBUG/ERROR Error after dispatching the state sync request", e);
+                Logger.Error("DEBUG/ERROR Error after dispatching the state sync request", e);
             }
         }
 


### PR DESCRIPTION
Previously, errors thrown during StateSyncDownloader.Dispatch were logged only when the Trace level was enabled because Logger.Error was guarded by Logger.IsTrace. In typical production configurations Trace is disabled while Error is enabled, which caused all dispatch failures to be silently dropped from the logs. This change removes the Trace guard and calls Logger.Error directly, relying on ILogger’s internal IsError check, so state sync dispatch failures are always logged when the error level is enabled and the behavior matches the rest of the logging patterns in the codebase.