### PR TITLE
chore: remove debug-only keccak keys from proof call storage test

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -843,19 +843,6 @@ public class ProofRpcModuleTests(bool createZeroAccount, bool useNonZeroGasPrice
         CallResultWithProof callResultWithProof = _proofRpcModule.proof_call(tx, new BlockParameter(blockOnTop.Number)).Data;
         Assert.That(callResultWithProof.Accounts.Length, Is.GreaterThan(0));
 
-        // just the keys for debugging
-        byte[] span = new byte[32];
-        new UInt256(0).ToBigEndian(span);
-        _ = Keccak.Compute(span);
-
-        // just the keys for debugging
-        new UInt256(1).ToBigEndian(span);
-        _ = Keccak.Compute(span);
-
-        // just the keys for debugging
-        new UInt256(2).ToBigEndian(span);
-        _ = Keccak.Compute(span);
-
         foreach (AccountProof accountProof in callResultWithProof.Accounts)
         {
             // this is here for diagnostics - so you can read what happens in the test


### PR DESCRIPTION
Removed the temporary diagnostic code in TestCallWithStorageAndCode that was computing keccak hashes for three UInt256 keys and discarding the result. This block did not affect test assertions or proof verification and only added unnecessary allocations and CPU work, so the test logic remains unchanged while the code is now cleaner and cheaper to run.