### PR TITLE
fix: correct gas limit change calculation for non-sequential blocks in NewPayloadHandler

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -125,7 +125,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         string requestStr = $"New Block:  {request}";
         if (_logger.IsInfo)
         {
-            _logger.Info($"Received {requestStr}      | limit {block.Header.GasLimit,13:N0} {GetGasChange(block.Number == _lastBlockNumber + 1 ? block.Header.GasLimit : _lastBlockGasLimit)} | {block.ParsedExtraData()}");
+            _logger.Info($"Received {requestStr} | limit {block.Header.GasLimit,13:N0} {GetGasChange(block.Header.GasLimit)} | {block.ParsedExtraData()}");
             _lastBlockNumber = block.Number;
             _lastBlockGasLimit = block.Header.GasLimit;
         }


### PR DESCRIPTION

## Changes

Fix incorrect gas limit change display in `NewPayloadHandler` logging where non-sequential blocks always show zero gas change due to passing the wrong variable to `GetGasChange()`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_