### PR TITLE
refactor: remove unused Destroy change type from storage provider

### DIFF
--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -270,7 +270,6 @@ namespace Nethermind.State
             Null = 0,
             JustCache,
             Update,
-            Destroy,
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -171,12 +171,6 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
             }
 
             _committedThisRound.Add(change.StorageCell);
-
-            if (change.ChangeType == ChangeType.Destroy)
-            {
-                continue;
-            }
-
             int forAssertion = _intraBlockCache[change.StorageCell].Pop();
             if (forAssertion != currentPosition - i)
             {


### PR DESCRIPTION
## Changes

- The Destroy value in PartialStorageProviderBase.ChangeType was never used anywhere in the codebase. No Change instances are created with this type, so the special handling branch in PersistentStorageProvider.CommitCore was also effectively dead code. This change removes the Destroy enum value and the unreachable branch in CommitCore to simplify the storage commit logic and avoid confusion about a non-existent destroy semantics for storage changes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring


