### PR TITLE
fix(kute): prevent null label crash in Prometheus metrics reporter

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
@@ -97,17 +97,23 @@ public sealed class PrometheusPushGatewayMetricsReporter : IMetricsReporter
 
     public Task Batch(JsonRpc.Request.Batch batch, TimeSpan elapsed, CancellationToken token = default)
     {
-        _batchDuration
-            .WithLabels(batch.Id)
-            .Observe(elapsed.TotalSeconds);
+        if (batch.Id is not null)
+        {
+            _batchDuration
+                .WithLabels(batch.Id)
+                .Observe(elapsed.TotalSeconds);
+        }
         return Task.CompletedTask;
     }
 
     public Task Single(JsonRpc.Request.Single single, TimeSpan elapsed, CancellationToken token = default)
     {
-        _singleDuration
-            .WithLabels(single.Id, single.MethodName)
-            .Observe(elapsed.TotalSeconds);
+        if (single.Id is not null && single.MethodName is not null)
+        {
+            _singleDuration
+                .WithLabels(single.Id, single.MethodName)
+                .Observe(elapsed.TotalSeconds);
+        }
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Add null checks for batch.Id and single.Id/MethodName before calling WithLabels() in PrometheusPushGatewayMetricsReporter. JSON-RPC notifications don't have an id field, causing ArgumentNullException when pushing metrics. This aligns behavior with MemoryMetricsReporter which already has these checks.