### PR TITLE
Fix #10068 regression

### DIFF
--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -166,8 +166,8 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeDataCopyGas(ref EthereumGasPolicy gas, bool isExternalCode, long baseCost, long dataCost)
-        => UpdateGas(ref gas, baseCost + dataCost);
+    public static void ConsumeDataCopyGas(ref EthereumGasPolicy gas, bool isExternalCode, long baseCost, long dataCost)
+        => Consume(ref gas, baseCost + dataCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy Max(in EthereumGasPolicy a, in EthereumGasPolicy b) =>

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -214,6 +214,5 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     /// <param name="isExternalCode">True for EXTCODECOPY (external account code).</param>
     /// <param name="baseCost">Fixed opcode cost.</param>
     /// <param name="dataCost">Per-word copy cost.</param>
-    /// <returns>True if sufficient gas available.</returns>
-    static abstract bool ConsumeDataCopyGas(ref TSelf gas, bool isExternalCode, long baseCost, long dataCost);
+    static abstract void ConsumeDataCopyGas(ref TSelf gas, bool isExternalCode, long baseCost, long dataCost);
 }


### PR DESCRIPTION
  Fixes NethermindEth/nethermind#10068 regression

  ## Changes

  - Changed `ConsumeDataCopyGas` in `EthereumGasPolicy` to use `Consume` instead of `UpdateGas`
  - Changed return type from `bool` to `void` to match actual usage pattern
  - Updated `IGasPolicy<TSelf>` interface signature to reflect `void` return type

  ## Root Cause

  PR #10068 introduced `ConsumeDataCopyGas` using `UpdateGas`, which returns `bool` indicating whether there was sufficient gas.

  ## Types of changes

  #### What types of changes does your code introduce?

  - [x] Bugfix (a non-breaking change that fixes an issue)
  - [ ] New feature (a non-breaking change that adds functionality)
  - [ ] Breaking change (a change that causes existing functionality not to work as expected)
  - [ ] Optimization
  - [ ] Refactoring
  - [ ] Documentation update
  - [ ] Build-related changes
  - [ ] Other: _Description_

  ## Testing

  #### Requires testing

  - [x] Yes
  - [ ] No

  #### If yes, did you write tests?

  - [ ] Yes
  - [x] No

  #### Notes on testing

  Verified using test `00672500-naive-79.json` via `Nethermind.Test.Runner`. The test now produces the same result as before NethermindEth/nethermind#10068.

  ## Documentation

  #### Requires documentation update

  - [ ] Yes
  - [x] No

  #### Requires explanation in Release Notes

  - [ ] Yes
  - [x] No
