### PR TITLE
refactor(tracing): centralize gas cost guard

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
@@ -108,6 +108,7 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer
 
     public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
+        base.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
         _log.pc = pc + env.CodeInfo.PcOffset();
         _log.op = new Log.Opcode(opcode);
         _log.gas = gas;
@@ -118,7 +119,7 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer
         // skip functionDepth
     }
 
-    public override void ReportOperationRemainingGas(long gas)
+    protected override void OnOperationRemainingGas(long gas)
     {
         _log.gasCost ??= _log.gas - gas;
         if (_functions.HasFlag(TracerFunctions.postStep))

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -122,9 +122,8 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         callFrame.Logs.Add(callLog);
     }
 
-    public override void ReportOperationRemainingGas(long gas)
+    protected override void OnOperationRemainingGas(long gas)
     {
-        base.ReportOperationRemainingGas(gas);
         _remainingGas = gas > 0 ? gas : 0;
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
@@ -66,6 +66,7 @@ public sealed class Native4ByteTracer : GethLikeNativeTxTracer
 
     public override void StartOperation(int pc, Instruction opcode, long gas, in ExecutionEnvironment env, int codeSection = 0, int functionDepth = 0)
     {
+        base.StartOperation(pc, opcode, gas, env, codeSection, functionDepth);
         _op = opcode;
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/GethLikeNativeTracerFactory.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/GethLikeNativeTracerFactory.cs
@@ -36,6 +36,11 @@ public static class GethLikeNativeTracerFactory
         _tracers.Add(tracerName, tracerDelegate);
     }
 
+    public static void RegisterExternalTracer(string tracerName, GethLikeNativeTracerFactoryDelegate tracerDelegate)
+    {
+        _tracers.TryAdd(tracerName, tracerDelegate);
+    }
+
     public static GethLikeNativeTxTracer CreateTracer(GethTraceOptions options, Block block, Transaction transaction, IWorldState worldState) =>
         _tracers.TryGetValue(options.Tracer, out GethLikeNativeTracerFactoryDelegate tracerDelegate)
             ? tracerDelegate(options, block, transaction, worldState)

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Tracing.GethStyle;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.Tracing;
+
+public class GethLikeTxTracerTests
+{
+    [Test]
+    public void ReportOperationRemainingGas_CalledMultipleTimes_OnOperationRemainingGasCalledOnce()
+    {
+        CountingTracer tracer = new(GethTraceOptions.Default);
+
+        tracer.StartOperation(0, Instruction.ADD, 100, default);
+        tracer.ReportOperationRemainingGas(97);
+        tracer.ReportOperationRemainingGas(97);
+        tracer.ReportOperationRemainingGas(97);
+
+        Assert.That(tracer.OnOperationRemainingGasCallCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void StartOperation_ResetsGuard_AllowsNewGasReport()
+    {
+        CountingTracer tracer = new(GethTraceOptions.Default);
+
+        tracer.StartOperation(0, Instruction.ADD, 100, default);
+        tracer.ReportOperationRemainingGas(97);
+
+        tracer.StartOperation(1, Instruction.MUL, 97, default);
+        tracer.ReportOperationRemainingGas(92);
+
+        Assert.That(tracer.OnOperationRemainingGasCallCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void OnOperationRemainingGas_ReceivesCorrectGasValue()
+    {
+        CountingTracer tracer = new(GethTraceOptions.Default);
+
+        tracer.StartOperation(0, Instruction.ADD, 100, default);
+        tracer.ReportOperationRemainingGas(97);
+
+        Assert.That(tracer.LastReportedGas, Is.EqualTo(97));
+    }
+
+    private sealed class CountingTracer : GethLikeTxTracer
+    {
+        public int OnOperationRemainingGasCallCount { get; private set; }
+        public long LastReportedGas { get; private set; }
+
+        public CountingTracer(GethTraceOptions options) : base(options) { }
+
+        protected override void OnOperationRemainingGas(long gas)
+        {
+            OnOperationRemainingGasCallCount++;
+            LastReportedGas = gas;
+        }
+    }
+}


### PR DESCRIPTION
  ## Changes

  - Centralize `_gasCostAlreadySetForCurrentOp` guard in `GethLikeTxTracer` base class
  - Make `ReportOperationRemainingGas` sealed, add protected virtual `OnOperationRemainingGas` callback
  - Update `GethLikeTxTracer<TEntry>`, `GethLikeJavaScriptTxTracer`, and `NativeCallTracer` to use `OnOperationRemainingGas`
  - Add `RegisterExternalTracer` method to `GethLikeNativeTracerFactory` for plugin tracer registration

  ## Types of changes

  #### What types of changes does your code introduce?

  - [ ] Bugfix (a non-breaking change that fixes an issue)
  - [ ] New feature (a non-breaking change that adds functionality)
  - [ ] Breaking change (a change that causes existing functionality not to work as expected)
  - [ ] Optimization
  - [x] Refactoring
  - [ ] Documentation update
  - [ ] Build-related changes
  - [ ] Other: _Description_

  ## Testing

  #### Requires testing

  - [x] Yes
  - [ ] No

  #### If yes, did you write tests?

  - [x] Yes
  - [ ] No

  ## Documentation

  #### Requires documentation update

  - [ ] Yes
  - [x] No

  #### Requires explanation in Release Notes

  - [ ] Yes
  - [x] No