### PR TITLE
Remove redundant `File.Delete` after `File.Move`

### DIFF
--- a/tools/DocGen/ConfigGenerator.cs
+++ b/tools/DocGen/ConfigGenerator.cs
@@ -68,7 +68,6 @@ internal static class ConfigGenerator
         writeStream.Close();
 
         File.Move(tempFileName, fileName, true);
-        File.Delete(tempFileName);
 
         AnsiConsole.MarkupLine($"[green]Updated[/] {fileName}");
     }


### PR DESCRIPTION
File.Move already moves the temp file to destination, so calling File.Delete on the same path afterwards does nothing - the file is no longer there. Removed the unnecessary call.