### PR TITLE
refactor: remove unused finalization manager field in Optimism plugin

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -55,8 +55,6 @@ public class OptimismPlugin(ChainSpec chainSpec) : IConsensusPlugin
 
     private OptimismNethermindApi? _api;
     private ILogger _logger;
-    private ManualBlockFinalizationManager? _blockFinalizationManager;
-
     private OptimismCL? _cl;
     public bool Enabled => chainSpec.SealEngineType == SealEngineType;
 
@@ -108,7 +106,7 @@ public class OptimismPlugin(ChainSpec chainSpec) : IConsensusPlugin
 
         ArgumentNullException.ThrowIfNull(_api.SpecProvider);
 
-        _api.FinalizationManager = _blockFinalizationManager = new ManualBlockFinalizationManager();
+        _api.FinalizationManager = new ManualBlockFinalizationManager();
 
         _api.GossipPolicy = ShouldNotGossip.Instance;
 
@@ -127,7 +125,7 @@ public class OptimismPlugin(ChainSpec chainSpec) : IConsensusPlugin
         ArgumentNullException.ThrowIfNull(_api.RpcModuleProvider);
         ArgumentNullException.ThrowIfNull(_api.BlockProducer);
 
-        ArgumentNullException.ThrowIfNull(_blockFinalizationManager);
+        ArgumentNullException.ThrowIfNull(_api.FinalizationManager);
 
         IEngineRpcModule engineRpcModule = _api.Context.Resolve<IEngineRpcModule>();
 


### PR DESCRIPTION
## Changes

- Removed redundant field, assigned the ManualBlockFinalizationManager directly to FinalizationManager in Init, and updated InitRpcModules to validate _api.FinalizationManager instead. OptimismPlugin was keeping a private ManualBlockFinalizationManager field that was only used as a null-check marker in InitRpcModules, while the actual finalization manager is exposed via the NethermindApi.FinalizationManager property.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [x] No

