### PR TITLE
refactor: remove unused `_pushEnabled` from MonitoringService

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -22,7 +22,6 @@ public class MonitoringService : IMonitoringService, IStoppableService
     private readonly string _exposeHost;
     private readonly int? _exposePort;
     private readonly string _nodeName;
-    private readonly bool _pushEnabled;
     private readonly string _pushGatewayUrl;
     private readonly int _intervalSeconds;
 
@@ -34,7 +33,6 @@ public class MonitoringService : IMonitoringService, IStoppableService
         int? exposePort = metricsConfig.ExposePort;
         string nodeName = metricsConfig.NodeName;
         string pushGatewayUrl = metricsConfig.PushGatewayUrl;
-        bool pushEnabled = metricsConfig.Enabled;
         int intervalSeconds = metricsConfig.IntervalSeconds;
 
         _exposeHost = exposeHost;
@@ -43,7 +41,6 @@ public class MonitoringService : IMonitoringService, IStoppableService
             ? throw new ArgumentNullException(nameof(nodeName))
             : nodeName;
         _pushGatewayUrl = pushGatewayUrl;
-        _pushEnabled = pushEnabled;
         _intervalSeconds = intervalSeconds <= 0
             ? throw new ArgumentException($"Invalid monitoring push interval: {intervalSeconds}s")
             : intervalSeconds;


### PR DESCRIPTION
`_pushEnabled` duplicated Metrics.Enabled state but was never read inside MonitoringService. The service is only constructed when metrics are enabled, so this flag was always true and effectively dead code. Removing it clarifies the monitoring configuration flow and reduces confusion around how PushGatewayUrl actually controls the Pushgateway integration.