### PR TITLE
fix(SendBlobs): add missing receiverOption to reclaim command

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -254,6 +254,7 @@ internal static class SetupCli
         };
 
         command.Add(rpcUrlOption);
+        command.Add(receiverOption);
         command.Add(keyFileOption);
         command.Add(maxPriorityFeeGasOption);
         command.Add(maxFeeOption);


### PR DESCRIPTION
The reclaim command defined --receiveraddress option with Required = true but never added it to the command parser. This meant the option was silently ignored and parseResult.GetValue() would return null, breaking the command entirely.