### PR TITLE
fix: dispose JsonDocument for batch JSON-RPC requests

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -184,6 +184,8 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                 }
                 catch (Exception ex)
                 {
+                    jsonDocument?.Dispose();
+                    collection?.Dispose();
                     deserializationFailureResult = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
                 }
 
@@ -225,7 +227,6 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                         break;
                     }
                     JsonRpcBatchResult jsonRpcBatchResult = new((e, c) => IterateRequest(collection, context, e).GetAsyncEnumerator(c));
-                    jsonRpcBatchResult.AddDisposable(() => collection.Dispose());
                     jsonRpcBatchResult.AddDisposable(() => jsonDocument.Dispose());
                     yield return JsonRpcResult.Collection(jsonRpcBatchResult);
                 }


### PR DESCRIPTION
Previously, successful batch JSON-RPC requests never disposed the JsonDocument instance created during parsing. Single requests and error/limit paths correctly attached JsonDocument.Dispose() via JsonRpcResponse.AddDisposable, but the normal batch path only registered disposal for the ArrayPoolList of requests. As a result, the pooled JsonDocument buffers were effectively leaked, increasing GC and memory pressure under sustained batch load. This change attaches JsonDocument.Dispose() to the JsonRpcBatchResult lifetime so that the document is released when the batch result is disposed