### PR TITLE
fix: correct header range logging in PoW forward sync

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -73,7 +73,7 @@ public class PowForwardHeaderProvider(
             IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
             if (headers is not null)
             {
-                if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headers[0].ToString(BlockHeader.Format.Short)} to {headers[1].ToString(BlockHeader.Format.Short)}");
+                if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headers[0].ToString(BlockHeader.Format.Short)} to {headers[^1].ToString(BlockHeader.Format.Short)}");
                 return headers;
             }
 


### PR DESCRIPTION

## Changes

Fix incorrect array index in trace logging for PoW header synchronization. The log message claims to show the range "from first to last" header, but uses `headers[1]` (second element) instead of `headers[^1]` (last element).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
