### PR TITLE
Override default CLI option alias

### DIFF
--- a/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
@@ -3,25 +3,22 @@
 
 using System;
 
-namespace Nethermind.Config
+namespace Nethermind.Config;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class ConfigItemAttribute : Attribute
 {
-    public class ConfigItemAttribute : Attribute
-    {
-        public string Description { get; set; }
+    public string Description { get; set; }
 
-        public string DefaultValue { get; set; }
+    public string DefaultValue { get; set; }
 
-        public bool HiddenFromDocs { get; set; }
+    public bool HiddenFromDocs { get; set; }
 
-        public bool DisabledForCli { get; set; }
+    public bool DisabledForCli { get; set; }
 
-        public string EnvironmentVariable { get; set; }
+    public string EnvironmentVariable { get; set; }
 
-        public bool IsPortOption { get; set; }
+    public bool IsPortOption { get; set; }
 
-        /// <summary>
-        /// Overrides the auto-generated kebab-case CLI option name.
-        /// </summary>
-        public string CliOptionName { get; set; }
-    }
+    public string CliOptionAlias { get; set; }
 }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -213,10 +213,13 @@ async Task<int> RunAsync(ParseResult parseResult, PluginLoader pluginLoader, Can
 
 void AddConfigurationOptions(Command command)
 {
-    static Option CreateOption<T>(string name, Type configType, string? cliOptionName) =>
-        new Option<T>(
-            $"--{ConfigExtensions.GetCategoryName(configType)}.{name}",
-            cliOptionName is not null ? cliOptionName : $"--{ConfigExtensions.GetCategoryName(configType)}-{name}".ToLowerInvariant());
+    static Option CreateOption<T>(Type configType, string name, string? alias)
+    {
+        var category = ConfigExtensions.GetCategoryName(configType);
+        alias = string.IsNullOrWhiteSpace(alias) ? name : alias;
+
+        return new Option<T>($"--{category}.{name}", $"--{category}-{alias}".ToLowerInvariant());
+    }
 
     IEnumerable<Type> configTypes = TypeDiscovery
         .FindNethermindBasedTypes(typeof(IConfig))
@@ -238,19 +241,19 @@ void AddConfigurationOptions(Command command)
         foreach (PropertyInfo prop in
             configType.GetProperties(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.Name))
         {
-            ConfigItemAttribute? configItemAttribute = prop.GetCustomAttribute<ConfigItemAttribute>();
+            ConfigItemAttribute? configItemAttr = prop.GetCustomAttribute<ConfigItemAttribute>();
 
-            if (configItemAttribute?.DisabledForCli != true)
+            if (configItemAttr?.DisabledForCli != true)
             {
                 Option option = prop.PropertyType == typeof(bool)
-                    ? CreateOption<bool>(prop.Name, configType, configItemAttribute?.CliOptionName)
-                    : CreateOption<string>(prop.Name, configType, configItemAttribute?.CliOptionName);
+                    ? CreateOption<bool>(configType, prop.Name, configItemAttr?.CliOptionAlias)
+                    : CreateOption<string>(configType, prop.Name, configItemAttr?.CliOptionAlias);
 
-                string? description = configItemAttribute?.Description;
+                string? description = configItemAttr?.Description;
 
-                if (!string.IsNullOrEmpty(configItemAttribute?.DefaultValue))
+                if (!string.IsNullOrEmpty(configItemAttr?.DefaultValue))
                 {
-                    string defaultValue = $"Defaults to `{configItemAttribute.DefaultValue}`.";
+                    string defaultValue = $"Defaults to `{configItemAttr.DefaultValue}`.";
 
                     description = string.IsNullOrEmpty(description)
                         ? defaultValue
@@ -259,12 +262,12 @@ void AddConfigurationOptions(Command command)
 
                 option.Description = description;
                 option.HelpName = "value";
-                option.Hidden = categoryHidden || configItemAttribute?.HiddenFromDocs == true;
+                option.Hidden = categoryHidden || configItemAttr?.HiddenFromDocs == true;
 
                 command.Add(option);
             }
 
-            if (configItemAttribute?.IsPortOption == true)
+            if (configItemAttr?.IsPortOption == true)
                 ConfigExtensions.AddPortOptionName(configType, prop.Name);
         }
     }


### PR DESCRIPTION
Resolves #10147

## Changes

- Implemented additional property on ConfigItemAttribute, that allows to override default lowercase CLI option with provided one.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

Not sure, probably not?

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

Probably would be good to mention this in plugin development docs, not sure.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No