### PR TITLE
refactor: remove redundant TxGasInfo parameterless constructor

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
@@ -41,8 +41,6 @@ namespace Nethermind.Evm
 
     public readonly struct TxGasInfo
     {
-        public TxGasInfo() { }
-
         public TxGasInfo(UInt256? effectiveGasPrice, UInt256? feePerBlobGas, ulong? blobGasUsed)
         {
             EffectiveGasPrice = effectiveGasPrice;


### PR DESCRIPTION
## Changes

- `TxGasInfo` had an explicit public parameterless constructor that didn’t add any custom initialization and behaved the same as the implicit default constructor. It wasn’t used anywhere in the codebase and didn’t encode any special invariants. Removing it  avoids suggesting that new TxGasInfo() has semantics different from default(TxGasInfo), while keeping all existing usages and behavior unchanged.

## Types of changes

#### What types of changes does your code introduce?


- [x] Refactoring

