### PR TITLE
refactor: extract duplicate chain ID retrieval logic in SendBlobs CLI

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -201,8 +201,7 @@ internal static class SetupCli
                 parseResult.GetValue(rpcUrlOption)!,
                 SimpleConsoleLogManager.Instance.GetClassLogger());
 
-            string? chainIdString = await rpcClient.Post<string>("eth_chainId") ?? "1";
-            ulong chainId = HexConvert.ToUInt64(chainIdString);
+            ulong chainId = await GetChainIdAsync(rpcClient);
 
             Signer signer = new(chainId, new PrivateKey(parseResult.GetValue(privateKeyOption)!),
                 SimpleConsoleLogManager.Instance);
@@ -263,8 +262,7 @@ internal static class SetupCli
                 parseResult.GetValue(rpcUrlOption)!,
                 SimpleConsoleLogManager.Instance.GetClassLogger());
 
-            string? chainIdString = await rpcClient.Post<string>("eth_chainId") ?? "1";
-            ulong chainId = HexConvert.ToUInt64(chainIdString);
+            ulong chainId = await GetChainIdAsync(rpcClient);
 
             FundsDistributor distributor = new(rpcClient, chainId, parseResult.GetValue(keyFileOption), SimpleConsoleLogManager.Instance);
             await distributor.ReclaimFunds(
@@ -273,6 +271,12 @@ internal static class SetupCli
                 parseResult.GetValue(maxPriorityFeeGasOption));
         });
         root.Add(command);
+    }
+
+    private static async Task<ulong> GetChainIdAsync(IJsonRpcClient rpcClient)
+    {
+        string? chainIdString = await rpcClient.Post<string>("eth_chainId") ?? "1";
+        return HexConvert.ToUInt64(chainIdString);
     }
 
     public static IJsonRpcClient InitRpcClient(string rpcUrl, ILogger logger) =>


### PR DESCRIPTION


Removed code duplication by extracting the repeated chain ID retrieval logic into a reusable helper method.

