### PR TITLE
refactor: remove unused BindingFlags.GetProperty from GetProperties call

### DIFF
--- a/src/Nethermind/Nethermind.Core/Container/FallbackToFieldFromApi.cs
+++ b/src/Nethermind/Nethermind.Core/Container/FallbackToFieldFromApi.cs
@@ -27,7 +27,7 @@ public class FallbackToFieldFromApi<TApi> : IRegistrationSource where TApi : not
 
         Type tApi = typeof(TApi);
 
-        BindingFlags flag = BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public;
+        BindingFlags flag = BindingFlags.Instance | BindingFlags.Public;
         if (directlyDeclaredOnly)
             flag |= BindingFlags.DeclaredOnly;
 


### PR DESCRIPTION
Use only the BindingFlags values that are actually honored by Type.GetProperties: Instance, Public and optionally DeclaredOnly. BindingFlags.GetProperty is intended for InvokeMember to select a property getter and is ignored by GetProperties, so keeping it here is misleading and suggests a non-existent behavior.