### PR TITLE
perf: Remove redundant allocations in NettyDiscoveryHandlerTests

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -137,7 +138,7 @@ namespace Nethermind.Network.Discovery.Test
         [Test]
         public async Task NeighborsSentReceivedTest()
         {
-            NeighborsMsg msg = new(_privateKey2.PublicKey, Timestamper.Default.UnixTime.SecondsLong + 1200, new List<Node>().ToArray())
+            NeighborsMsg msg = new(_privateKey2.PublicKey, Timestamper.Default.UnixTime.SecondsLong + 1200, Array.Empty<Node>())
             {
                 FarAddress = _address2
             };
@@ -146,7 +147,7 @@ namespace Nethermind.Network.Discovery.Test
             await SleepWhileWaiting();
             _discoveryManagersMocks[1].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(static x => x.MsgType == MsgType.Neighbors));
 
-            NeighborsMsg msg2 = new(_privateKey.PublicKey, Timestamper.Default.UnixTime.SecondsLong + 1200, new List<Node>().ToArray())
+            NeighborsMsg msg2 = new(_privateKey.PublicKey, Timestamper.Default.UnixTime.SecondsLong + 1200, Array.Empty<Node>())
             {
                 FarAddress = _address,
             };


### PR DESCRIPTION
Eliminates unnecessary memory allocations in test setup by replacing `new List<Node>().ToArray()` with `Array.Empty<Node>()`.