### PR TITLE
fix: avoid mutating levels in header/body existence checks

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -110,7 +110,7 @@ public partial class BlockTree
 
         foreach (BlockInfo blockInfo in level.BlockInfos)
         {
-            BlockHeader? header = FindHeader(blockInfo.BlockHash, BlockTreeLookupOptions.None);
+            BlockHeader? header = FindHeader(blockInfo.BlockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
             if (header is not null)
             {
                 if (findBeacon && blockInfo.IsBeaconHeader)
@@ -138,7 +138,7 @@ public partial class BlockTree
 
         foreach (BlockInfo blockInfo in level.BlockInfos)
         {
-            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None);
+            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
             if (block is not null)
             {
                 if (findBeacon && blockInfo.IsBeaconBody)


### PR DESCRIPTION
## Changes

-  Use `TotalDifficultyNotNeeded | DoNotCreateLevelIfMissing` when calling FindHeader and FindBlock from HeaderExists and 
BodyExists. This keeps these helpers as pure existence checks and prevents them from recalculating total difficulty or creating/updating ChainLevelInfo levels during startup binary searches. The functional semantics of LoadBestKnown and 
LoadBeaconBestKnown are preserved while reducing unnecessary work and side effects on the block info database.

## Types of changes

#### What types of changes does your code introduce?


- [x] Optimization
- [x] Refactoring


