### PR TITLE
Optimize success response of engine_getBlobsV2 (and slow down non-success)

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -77,22 +77,6 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         return false;
     }
 
-    public int GetBlobCounts(byte[][] requestedBlobVersionedHashes)
-    {
-        using var lockRelease = Lock.Acquire();
-        int count = 0;
-
-        foreach (byte[] requestedBlobVersionedHash in requestedBlobVersionedHashes)
-        {
-            if (BlobIndex.ContainsKey(requestedBlobVersionedHash))
-            {
-                count += 1;
-            }
-        }
-
-        return count;
-    }
-
     protected override bool InsertCore(ValueHash256 key, Transaction value, AddressAsKey groupKey)
     {
         if (base.InsertCore(key, value, groupKey))

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -53,7 +53,6 @@ namespace Nethermind.TxPool
         bool TryGetBlobAndProofV1(byte[] blobVersionedHash,
             [NotNullWhen(true)] out byte[]? blob,
             [NotNullWhen(true)] out byte[][]? cellProofs);
-        int GetBlobCounts(byte[][] blobVersionedHashes);
         UInt256 GetLatestPendingNonce(Address address);
         event EventHandler<TxEventArgs> NewDiscovered;
         event EventHandler<TxEventArgs> NewPending;

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -83,8 +83,6 @@ namespace Nethermind.TxPool
             return false;
         }
 
-        public int GetBlobCounts(byte[][] blobVersionedHashes) => 0;
-
         public UInt256 GetLatestPendingNonce(Address address) => 0;
 
         public AnnounceResult NoitifyAboutTx(Hash256 txhash, IMessageHandler<PooledTransactionRequestMessage> retryHandler) => AnnounceResult.RequestRequired;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -225,9 +225,6 @@ namespace Nethermind.TxPool
             [NotNullWhen(true)] out byte[][]? cellProofs)
             => _blobTransactions.TryGetBlobAndProofV1(blobVersionedHash, out blob, out cellProofs);
 
-        public int GetBlobCounts(byte[][] blobVersionedHashes)
-            => _blobTransactions.GetBlobCounts(blobVersionedHashes);
-
         private void OnRemovedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolRemovedEventArgs args)
         {
             RemovePendingDelegations(args.Value);


### PR DESCRIPTION
## Changes

- remove the logic for checking number of available blobs and quick failing if not all blobs available
It will slow our response down a lot if some blob is missing (and we return empty), but success responses should be slightly faster

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No