### PR TITLE
perf: Remove redundant ClearPreHash call in Transaction.PoolPolicy.Return

### DIFF
--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -283,7 +283,6 @@ namespace Nethermind.Core
                 if (obj.GetType() != typeof(Transaction))
                     return false;
 
-                obj.ClearPreHash();
                 obj.Hash = default;
                 obj.ChainId = default;
                 obj.Type = default;


### PR DESCRIPTION
Removes redundant `ClearPreHash()` call in `Transaction.PoolPolicy.Return` method.