### PR TITLE
fix: remove duplicate transaction processor adapter registration

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -45,7 +45,6 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
                 // These are main block processing specific
                 .AddSingleton<IWorldStateScopeProvider>(worldState)
                 .AddModule(blockValidationModules)
-                .AddScoped<ITransactionProcessorAdapter, ExecuteTransactionProcessorAdapter>()
                 .AddSingleton<BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler>(this)
                 .AddModule(mainProcessingModules)
 


### PR DESCRIPTION
`MainProcessingContext` was registering `ITransactionProcessorAdapter` as `ExecuteTransactionProcessorAdapter` even though the same adapter is already registered in `StandardBlockValidationModule` via `IBlockValidationModule`. This extra AddScoped call did not change the default behavior but polluted the container and effectively prevented plugins from overriding the adapter through their own IBlockValidationModule implementations. The redundant registration was removed