### PR TITLE
Optimize AddCapabilityMessageSerializer lowercase handling

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
@@ -17,12 +17,13 @@ namespace Nethermind.Network.P2P.Messages
 
         public void Serialize(IByteBuffer byteBuffer, AddCapabilityMessage msg)
         {
-            int totalLength = GetLength(msg, out int contentLength);
+            string protocolCode = msg.Capability.ProtocolCode.ToLowerInvariant();
+            int totalLength = GetLength(protocolCode, msg.Capability.Version, out int contentLength);
             byteBuffer.EnsureWritable(totalLength);
 
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);
-            stream.Encode(msg.Capability.ProtocolCode.ToLowerInvariant());
+            stream.Encode(protocolCode);
             stream.Encode(msg.Capability.Version);
         }
 
@@ -35,10 +36,10 @@ namespace Nethermind.Network.P2P.Messages
 
             return new AddCapabilityMessage(new Capability(protocolCode, version));
         }
-        private static int GetLength(AddCapabilityMessage msg, out int contentLength)
+        private static int GetLength(string protocolCode, int version, out int contentLength)
         {
-            contentLength = Rlp.LengthOf(msg.Capability.ProtocolCode.ToLowerInvariant());
-            contentLength += Rlp.LengthOf(msg.Capability.Version);
+            contentLength = Rlp.LengthOf(protocolCode);
+            contentLength += Rlp.LengthOf(version);
 
             return Rlp.LengthOfSequence(contentLength);
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
@@ -17,13 +17,13 @@ namespace Nethermind.Network.P2P.Messages
 
         public void Serialize(IByteBuffer byteBuffer, AddCapabilityMessage msg)
         {
-            string protocolCode = msg.Capability.ProtocolCode.ToLowerInvariant();
+            string protocolCode = msg.Capability.ProtocolCode;
             int totalLength = GetLength(protocolCode, msg.Capability.Version, out int contentLength);
             byteBuffer.EnsureWritable(totalLength);
 
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);
-            stream.Encode(protocolCode);
+            stream.EncodeAsciiLowercase(protocolCode);
             stream.Encode(msg.Capability.Version);
         }
 


### PR DESCRIPTION
Compute the lowercase protocol code once in AddCapabilityMessageSerializer.Serialize and pass it into GetLength instead of calling ToLowerInvariant twice. This removes a redundant string allocation and duplicate work on serialization path