### PR TITLE
refactor: Remove unused GasLimit constant from SystemTransaction

### DIFF
--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -283,7 +283,6 @@ namespace Nethermind.Core
                 if (obj.GetType() != typeof(Transaction))
                     return false;
 
-                obj.ClearPreHash();
                 obj.Hash = default;
                 obj.ChainId = default;
                 obj.Type = default;


### PR DESCRIPTION
Removes dead code: an unused private constant GasLimit from the SystemTransaction class that served no purpose.