### PR TITLE
Use Array.Empty for zero-length signature in XdcSealValidatorTests

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcSealValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcSealValidatorTests.cs
@@ -65,7 +65,7 @@ internal class XdcSealValidatorTests
             Build.A.XdcBlockHeader()
             .TestObject;
         header.Beneficiary = TestItem.AddressA;
-        yield return new TestCaseData(header, new byte[0]);
+        yield return new TestCaseData(header, Array.Empty<byte>());
         yield return new TestCaseData(header, new byte[65]);
         yield return new TestCaseData(header, new byte[66]);
         byte[] extraLongSignature = new byte[66];


### PR DESCRIPTION
Replace new byte[0] with Array.Empty<byte>() in the invalid-signature test case to drop redundant allocations while keeping semantics identical.