### PR TITLE
fix(tools): add missing receiverOption to reclaim command

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -254,6 +254,7 @@ internal static class SetupCli
         };
 
         command.Add(rpcUrlOption);
+        command.Add(receiverOption);
         command.Add(keyFileOption);
         command.Add(maxPriorityFeeGasOption);
         command.Add(maxFeeOption);


### PR DESCRIPTION
The `reclaim` command in SendBlobs was broken - `receiverOption` was declared with `Required = true` and used in the handler, but never added to the command. This caused a NullReferenceException when trying to create an Address from null. Other commands in the same file (SetupExecute, SetupSendFileCommand) correctly add this option.