### PR TITLE
perf: avoid eager client id formatting in ZeroNettyP2PHandler

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -121,8 +121,6 @@ public class ZeroNettyP2PHandler(ISession session, ILogManager logManager) : Sim
         }
         else if (_session?.Node?.IsStatic != true)
         {
-            string clientId = GetClientId(_session);
-            _session.InitiateDisconnect(DisconnectReason.Exception,
             _session.InitiateDisconnect(DisconnectReason.Exception, $"Error in communication with {GetClientId(_session)} ({exception.GetType().Name}): {exception.Message}");
         }
         else


### PR DESCRIPTION
`ZeroNettyP2PHandler.ExceptionCaught` was always computing clientId before checking the logger level. This violates the intended ILogger usage pattern and causes unnecessary string allocations when debug/trace logging is disabled. The clientId is now formatted only inside the guarded logging blocks and right before InitiateDisconnect, keeping the behavior intact while avoiding extra work on the hot error path.