### PR TITLE
cleanup: remove redundant null-forgiving operator in BlobSender

### DIFF
--- a/tools/SendBlobs/BlobSender.cs
+++ b/tools/SendBlobs/BlobSender.cs
@@ -258,7 +258,7 @@ internal class BlobSender
             return;
         }
 
-        (UInt256 maxGasPrice, UInt256 maxPriorityFeePerGas, UInt256 maxFeePerBlobGas) = await GetGasPrices(null, maxPriorityFeeGasArgs, maxFeePerBlobGasArgs, blockResult!, 1, spec);
+        (UInt256 maxGasPrice, UInt256 maxPriorityFeePerGas, UInt256 maxFeePerBlobGas) = await GetGasPrices(null, maxPriorityFeeGasArgs, maxFeePerBlobGasArgs, blockResult, 1, spec);
 
         maxPriorityFeePerGas *= feeMultiplier;
         maxGasPrice *= feeMultiplier;


### PR DESCRIPTION
Removed unnecessary `!` operator on `blockResult` since the null check and early return on lines 255-259 already guarantees it's not null at that point.