### PR TITLE
ReleaseSpec: get rid of Default Interface Members to speed up compilation

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -12,11 +12,13 @@ namespace Nethermind.Core.Specs
     /// </summary>
     public interface IReleaseSpec : IEip1559Spec, IReceiptSpec
     {
+        // Compiling of default interface methods/properties is very slow, therefore
+        // these methods/properties are implemented in the target classes.
         public string Name { get; }
         long MaximumExtraDataSize { get; }
         long MaxCodeSize { get; }
         //EIP-3860: Limit and meter initcode
-        long MaxInitCodeSize => 2 * MaxCodeSize;
+        long MaxInitCodeSize { get; }
         long MinGasLimit { get; }
         long MinHistoryRetentionEpochs { get; }
         long GasLimitBoundDivisor { get; }
@@ -205,7 +207,7 @@ namespace Nethermind.Core.Specs
         /// <remarks>THis is needed for SystemUser account compatibility with Parity.</remarks>
         /// <param name="address"></param>
         /// <returns></returns>
-        bool IsEip158IgnoredAccount(Address address) => false;
+        bool IsEip158IgnoredAccount(Address address);
 
         /// <summary>
         /// BaseFee opcode
@@ -276,14 +278,14 @@ namespace Nethermind.Core.Specs
         /// EIP-6110: Supply validator deposits on chain
         /// </summary>
         bool IsEip6110Enabled { get; }
-        bool DepositsEnabled => IsEip6110Enabled;
+        bool DepositsEnabled { get; }
         Address DepositContractAddress { get; }
 
         /// <summary>
         /// Execution layer triggerable exits
         /// </summary>
         bool IsEip7002Enabled { get; }
-        bool WithdrawalRequestsEnabled => IsEip7002Enabled;
+        bool WithdrawalRequestsEnabled { get; }
         Address Eip7002ContractAddress { get; }
 
 
@@ -291,7 +293,7 @@ namespace Nethermind.Core.Specs
         /// EIP-7251: triggered consolidations
         /// </summary>
         bool IsEip7251Enabled { get; }
-        bool ConsolidationRequestsEnabled => IsEip7251Enabled;
+        bool ConsolidationRequestsEnabled { get; }
         Address Eip7251ContractAddress { get; }
 
 
@@ -310,7 +312,7 @@ namespace Nethermind.Core.Specs
         /// EIP-2935 ring buffer size for historical block hash storage.
         /// Defaults to 8,191 blocks for Ethereum mainnet.
         /// </summary>
-        long Eip2935RingBufferSize => Eip2935Constants.RingBufferSize;
+        long Eip2935RingBufferSize { get; }
 
         /// <summary>
         /// SELFDESTRUCT only in same transaction
@@ -385,7 +387,7 @@ namespace Nethermind.Core.Specs
         /// Should transactions be validated against chainId.
         /// </summary>
         /// <remarks>Backward compatibility for early Kovan blocks.</remarks>
-        bool ValidateChainId => true;
+        bool ValidateChainId { get; }
 
         /// <summary>
         /// EIP-7780: Add blob schedule to EL config files
@@ -400,82 +402,82 @@ namespace Nethermind.Core.Specs
         public ulong Eip4844TransitionTimestamp { get; }
 
         // STATE related
-        public bool ClearEmptyAccountWhenTouched => IsEip158Enabled;
+        public bool ClearEmptyAccountWhenTouched { get; }
 
         // VM
-        public bool LimitCodeSize => IsEip170Enabled;
+        public bool LimitCodeSize { get; }
 
-        public bool UseHotAndColdStorage => IsEip2929Enabled;
+        public bool UseHotAndColdStorage { get; }
 
-        public bool UseTxAccessLists => IsEip2930Enabled;
+        public bool UseTxAccessLists { get; }
 
-        public bool AddCoinbaseToTxAccessList => IsEip3651Enabled;
+        public bool AddCoinbaseToTxAccessList { get; }
 
-        public bool ModExpEnabled => IsEip198Enabled;
+        public bool ModExpEnabled { get; }
 
-        public bool BN254Enabled => IsEip196Enabled && IsEip197Enabled;
+        public bool BN254Enabled { get; }
 
-        public bool BlakeEnabled => IsEip152Enabled;
+        public bool BlakeEnabled { get; }
 
-        public bool Bls381Enabled => IsEip2537Enabled;
+        public bool Bls381Enabled { get; }
 
-        public bool ChargeForTopLevelCreate => IsEip2Enabled;
+        public bool ChargeForTopLevelCreate { get; }
 
-        public bool FailOnOutOfGasCodeDeposit => IsEip2Enabled;
+        public bool FailOnOutOfGasCodeDeposit { get; }
 
-        public bool UseShanghaiDDosProtection => IsEip150Enabled;
+        public bool UseShanghaiDDosProtection { get; }
 
-        public bool UseExpDDosProtection => IsEip160Enabled;
+        public bool UseExpDDosProtection { get; }
 
-        public bool UseLargeStateDDosProtection => IsEip1884Enabled;
+        public bool UseLargeStateDDosProtection { get; }
 
-        public bool ReturnDataOpcodesEnabled => IsEip211Enabled;
+        public bool ReturnDataOpcodesEnabled { get; }
 
-        public bool ChainIdOpcodeEnabled => IsEip1344Enabled;
+        public bool ChainIdOpcodeEnabled { get; }
 
-        public bool Create2OpcodeEnabled => IsEip1014Enabled;
+        public bool Create2OpcodeEnabled { get; }
 
-        public bool DelegateCallEnabled => IsEip7Enabled;
+        public bool DelegateCallEnabled { get; }
 
-        public bool StaticCallEnabled => IsEip214Enabled;
+        public bool StaticCallEnabled { get; }
 
-        public bool ShiftOpcodesEnabled => IsEip145Enabled;
+        public bool ShiftOpcodesEnabled { get; }
 
-        public bool RevertOpcodeEnabled => IsEip140Enabled;
+        public bool RevertOpcodeEnabled { get; }
 
-        public bool ExtCodeHashOpcodeEnabled => IsEip1052Enabled;
+        public bool ExtCodeHashOpcodeEnabled { get; }
 
-        public bool SelfBalanceOpcodeEnabled => IsEip1884Enabled;
+        public bool SelfBalanceOpcodeEnabled { get; }
 
-        public bool UseConstantinopleNetGasMetering => IsEip1283Enabled;
+        public bool UseConstantinopleNetGasMetering { get; }
 
-        public bool UseIstanbulNetGasMetering => IsEip2200Enabled;
+        public bool UseIstanbulNetGasMetering { get; }
 
-        public bool UseNetGasMetering => UseConstantinopleNetGasMetering | UseIstanbulNetGasMetering;
+        public bool UseNetGasMetering { get; }
 
-        public bool UseNetGasMeteringWithAStipendFix => UseIstanbulNetGasMetering;
+        public bool UseNetGasMeteringWithAStipendFix { get; }
 
-        public bool Use63Over64Rule => UseShanghaiDDosProtection;
+        public bool Use63Over64Rule { get; }
 
-        public bool BaseFeeEnabled => IsEip3198Enabled;
+        public bool BaseFeeEnabled { get; }
 
         // EVM Related
-        public bool IncludePush0Instruction => IsEip3855Enabled;
+        public bool IncludePush0Instruction { get; }
 
-        public bool TransientStorageEnabled => IsEip1153Enabled;
+        public bool TransientStorageEnabled { get; }
 
-        public bool WithdrawalsEnabled => IsEip4895Enabled;
-        public bool SelfdestructOnlyOnSameTransaction => IsEip6780Enabled;
+        public bool WithdrawalsEnabled { get; }
+        public bool SelfdestructOnlyOnSameTransaction { get; }
 
-        public bool IsBeaconBlockRootAvailable => IsEip4788Enabled;
-        public bool IsBlockHashInStateAvailable => IsEip7709Enabled;
-        public bool MCopyIncluded => IsEip5656Enabled;
+        public bool IsBeaconBlockRootAvailable { get; }
+        public bool IsBlockHashInStateAvailable { get; }
+        public bool MCopyIncluded { get; }
 
-        public bool BlobBaseFeeEnabled => IsEip4844Enabled;
+        public bool BlobBaseFeeEnabled { get; }
 
-        bool IsAuthorizationListEnabled => IsEip7702Enabled;
+        bool IsAuthorizationListEnabled { get; }
 
-        public bool RequestsEnabled => ConsolidationRequestsEnabled || WithdrawalRequestsEnabled || DepositsEnabled;
+        public bool RequestsEnabled { get; }
 
         public bool IsEip7594Enabled { get; }
 
@@ -511,7 +513,7 @@ namespace Nethermind.Core.Specs
         /// </summary>
         /// <param name="address">The address to check for precompile status.</param>
         /// <returns>True if the address is a precompiled contract; otherwise, false.</returns>
-        bool IsPrecompile(Address address) => Precompiles.Contains(address);
+        bool IsPrecompile(Address address);
 
         /// <summary>
         /// Gets a cached set of all precompiled contract addresses for this release specification.
@@ -519,14 +521,14 @@ namespace Nethermind.Core.Specs
         /// </summary>
         FrozenSet<AddressAsKey> Precompiles { get; }
 
-        public ProofVersion BlobProofVersion => IsEip7594Enabled ? ProofVersion.V1 : ProofVersion.V0;
+        public ProofVersion BlobProofVersion { get; }
 
         /// <summary>
         /// EIP-7939 - CLZ - Count leading zeros instruction
         /// </summary>
         public bool IsEip7939Enabled { get; }
 
-        public bool CLZEnabled => IsEip7939Enabled;
+        public bool CLZEnabled { get; }
 
         /// <summary>
         /// EIP-7907: Meter Contract Code Size And Increase Limit

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Frozen;
+using Nethermind.Core;
 using Nethermind.Int256;
 
 namespace Nethermind.Core.Specs;
@@ -150,6 +151,21 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual Address? FeeCollector => spec.FeeCollector;
     public virtual UInt256? Eip1559BaseFeeMinValue => spec.Eip1559BaseFeeMinValue;
     public virtual bool ValidateReceipts => spec.ValidateReceipts;
+
+    // Forwarders for members that were previously provided as default interface members on IReleaseSpec
+    public virtual bool DepositsEnabled => spec.DepositsEnabled;
+    public virtual bool WithdrawalRequestsEnabled => spec.WithdrawalRequestsEnabled;
+    public virtual bool ConsolidationRequestsEnabled => spec.ConsolidationRequestsEnabled;
+    public virtual long Eip2935RingBufferSize => spec.Eip2935RingBufferSize;
+    public virtual bool RequestsEnabled => spec.RequestsEnabled;
+    public virtual ProofVersion BlobProofVersion => spec.BlobProofVersion;
+    public virtual bool CLZEnabled => spec.CLZEnabled;
+
+    // This member is non-public on the interface; implement explicitly.
+    bool IReleaseSpec.IsAuthorizationListEnabled => ((IReleaseSpec)spec).IsAuthorizationListEnabled;
+
+    public virtual bool IsPrecompile(Address address) => spec.IsPrecompile(address);
+
     Array? IReleaseSpec.EvmInstructionsNoTrace { get => spec.EvmInstructionsNoTrace; set => spec.EvmInstructionsNoTrace = value; }
     Array? IReleaseSpec.EvmInstructionsTraced { get => spec.EvmInstructionsTraced; set => spec.EvmInstructionsTraced = value; }
     FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -13,6 +13,9 @@ namespace Nethermind.Specs;
 
 public class ReleaseSpec : IReleaseSpec
 {
+    // Compiling of IReleaseSpec is very slow when these members are Default
+    // Interface Members, therefore, we reintroduce them as concrete members.
+
     public string Name { get; set; } = "Custom";
     public long MaximumExtraDataSize { get; set; }
     public long MaxCodeSize { get; set; }
@@ -57,6 +60,74 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip2929Enabled { get; set; }
     public bool IsEip2930Enabled { get; set; }
 
+    public long MaxInitCodeSize => 2 * MaxCodeSize;
+
+    public bool IsEip158IgnoredAccount(Address address) => false;
+
+    public bool DepositsEnabled => IsEip6110Enabled;
+    public bool WithdrawalRequestsEnabled => IsEip7002Enabled;
+    public bool ConsolidationRequestsEnabled => IsEip7251Enabled;
+
+    // STATE related
+    public bool ClearEmptyAccountWhenTouched => IsEip158Enabled;
+
+    // VM
+    public bool LimitCodeSize => IsEip170Enabled;
+    public bool UseHotAndColdStorage => IsEip2929Enabled;
+    public bool UseTxAccessLists => IsEip2930Enabled;
+    public bool AddCoinbaseToTxAccessList => IsEip3651Enabled;
+
+    public bool ModExpEnabled => IsEip198Enabled;
+    public bool BN254Enabled => IsEip196Enabled && IsEip197Enabled;
+    public bool BlakeEnabled => IsEip152Enabled;
+    public bool Bls381Enabled => IsEip2537Enabled;
+
+    public bool ChargeForTopLevelCreate => IsEip2Enabled;
+    public bool FailOnOutOfGasCodeDeposit => IsEip2Enabled;
+    public bool UseShanghaiDDosProtection => IsEip150Enabled;
+    public bool UseExpDDosProtection => IsEip160Enabled;
+    public bool UseLargeStateDDosProtection => IsEip1884Enabled;
+    public bool ReturnDataOpcodesEnabled => IsEip211Enabled;
+    public bool ChainIdOpcodeEnabled => IsEip1344Enabled;
+    public bool Create2OpcodeEnabled => IsEip1014Enabled;
+    public bool DelegateCallEnabled => IsEip7Enabled;
+    public bool StaticCallEnabled => IsEip214Enabled;
+    public bool ShiftOpcodesEnabled => IsEip145Enabled;
+    public bool RevertOpcodeEnabled => IsEip140Enabled;
+    public bool ExtCodeHashOpcodeEnabled => IsEip1052Enabled;
+    public bool SelfBalanceOpcodeEnabled => IsEip1884Enabled;
+
+    public bool UseConstantinopleNetGasMetering => IsEip1283Enabled;
+    public bool UseIstanbulNetGasMetering => IsEip2200Enabled;
+    public bool UseNetGasMetering => UseConstantinopleNetGasMetering | UseIstanbulNetGasMetering;
+    public bool UseNetGasMeteringWithAStipendFix => UseIstanbulNetGasMetering;
+    public bool Use63Over64Rule => UseShanghaiDDosProtection;
+
+    public bool BaseFeeEnabled => IsEip3198Enabled;
+
+    // EVM Related
+    public bool IncludePush0Instruction => IsEip3855Enabled;
+    public bool TransientStorageEnabled => IsEip1153Enabled;
+
+    public bool WithdrawalsEnabled => IsEip4895Enabled;
+    public bool SelfdestructOnlyOnSameTransaction => IsEip6780Enabled;
+
+    public bool IsBeaconBlockRootAvailable => IsEip4788Enabled;
+    public bool IsBlockHashInStateAvailable => IsEip7709Enabled;
+    public bool MCopyIncluded => IsEip5656Enabled;
+
+    public bool BlobBaseFeeEnabled => IsEip4844Enabled;
+
+    bool IReleaseSpec.IsAuthorizationListEnabled => IsEip7702Enabled;
+
+    public bool RequestsEnabled => ConsolidationRequestsEnabled || WithdrawalRequestsEnabled || DepositsEnabled;
+
+    public ProofVersion BlobProofVersion => IsEip7594Enabled ? ProofVersion.V1 : ProofVersion.V0;
+
+    public bool CLZEnabled => IsEip7939Enabled;
+
+    public bool IsPrecompile(Address address) => ((IReleaseSpec)this).Precompiles.Contains(address);
+
     // used only in testing
     public ReleaseSpec Clone() => (ReleaseSpec)MemberwiseClone();
 
@@ -70,7 +141,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip3529Enabled { get; set; }
     public bool IsEip3607Enabled { get; set; }
     public bool IsEip3541Enabled { get; set; }
-    public bool ValidateChainId { get; set; }
+    public bool ValidateChainId { get; set; } = true;
     public bool ValidateReceipts { get; set; }
     public long Eip1559TransitionBlock { get; set; }
     public ulong WithdrawalTimestamp { get; set; }


### PR DESCRIPTION
If Default Interface Members are used for hot path classes, ILCompiler compilation is several orders of magnitude slower.

The slowdown is in dotnet MetadataVirtualMethodAlgorithm.cs - ResolveInterfaceMethodToVirtualMethodOnTypeRecursive.

The solution is to get rid of default interface members and move the functionality to classes derived from the interface.

## Changes

- IReleaseSpec default interface members are moved to classes derived from the interface.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Everything has to be retested.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

I think it doesn't.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

We need to fix more IReleaseSpec-derived classes probably.
