### PR TITLE
perf: Avoid unnecessary base fee calculations

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Transactions/BaseFeeTxFilter.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/BaseFeeTxFilter.cs
@@ -13,11 +13,15 @@ namespace Nethermind.Consensus.Transactions
     {
         public AcceptTxResult IsAllowed(Transaction tx, BlockHeader parentHeader, IReleaseSpec spec)
         {
-            UInt256 baseFee = BaseFeeCalculator.Calculate(parentHeader, spec);
             bool isEip1559Enabled = spec.IsEip1559Enabled;
 
-            bool skipCheck = tx.IsServiceTransaction || !isEip1559Enabled;
-            bool allowed = skipCheck || tx.MaxFeePerGas >= baseFee;
+            if (!isEip1559Enabled || tx.IsServiceTransaction)
+            {
+                return AcceptTxResult.Accepted;
+            }
+
+            UInt256 baseFee = BaseFeeCalculator.Calculate(parentHeader, spec);
+            bool allowed = tx.MaxFeePerGas >= baseFee;
             return allowed
                 ? AcceptTxResult.Accepted
                 : AcceptTxResult.FeeTooLow.WithMessage(


### PR DESCRIPTION
BaseFeeTxFilter was always calling BaseFeeCalculator.Calculate, even when EIP-1559 was disabled or the transaction was marked as a service transaction. This change short-circuits those cases and only computes base fee when it is actually needed, keeping the observable behaviour of the filter unchanged while avoiding redundant work in the hot transaction filtering path.