### PR TITLE
Remove unused using directives in XdcContractData

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/Contracts/XdcContractData.cs
+++ b/src/Nethermind/Nethermind.Xdc/Contracts/XdcContractData.cs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Contracts;
 


### PR DESCRIPTION
Removes unnecessary using directives from `XdcContractData.cs` that are not referenced in the file.