### PR TITLE
Schedule largest storage changes first

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -275,6 +275,8 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
         {
             // We can recalculate the roots in parallel as they are all independent tries
             using ArrayPoolList<(AddressAsKey Key, PerContractState ContractState, IWorldStateScopeProvider.IStorageWriteBatch WriteBatch)> storages = _storages
+                // Only consider contracts that actually have pending changes
+                .Where(kv => _toUpdateRoots.TryGetValue(kv.Key, out bool hasChanges) && hasChanges)
                 // Schedule larger changes first to help balance the work
                 .OrderByDescending(kv => kv.Value.EstimatedChanges)
                 .Select((kv) => (
@@ -292,12 +294,6 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
                 static (i, state) =>
                 {
                     ref var kvp = ref state.storages.GetRef(i);
-                    if (!state.toUpdateRoots.TryGetValue(kvp.Key, out bool hasChanges) || !hasChanges)
-                    {
-                        // Wasn't updated don't recalculate
-                        return state;
-                    }
-
                     (int writes, int skipped) = kvp.ContractState.ProcessStorageChanges(kvp.WriteBatch);
                     if (writes == 0)
                     {


### PR DESCRIPTION
## Changes

- Schedule largest storage tries first for saving so parallel waiting is reduced (e.g. if largest is last, then main thread will have to wait longest time)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
