### PR TITLE
Fix `PathUtils` for JetBrains Rider

### DIFF
--- a/src/Nethermind/Nethermind.Logging/PathUtils.cs
+++ b/src/Nethermind/Nethermind.Logging/PathUtils.cs
@@ -17,7 +17,7 @@ public static class PathUtils
             || processName.Equals("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)
             // A workaround for tests in JetBrains Rider ignoring MTP:
             // https://youtrack.jetbrains.com/projects/RIDER/issues/RIDER-131530
-            ? AppContext.BaseDirectory 
+            ? AppContext.BaseDirectory
             : Path.GetDirectoryName(Environment.ProcessPath);
     }
 


### PR DESCRIPTION
## Changes

Since JetBrains Rider [doesn't respect](https://youtrack.jetbrains.com/projects/RIDER/issues/RIDER-131530) MTP configuration with NUnit, failing the logic of `PathUtils`, added a process name detection to work around the issue. The process path detection doesn't use `System.Diagnostics.Process` as previously but a much lighter API.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Needs manual testing in JetBrains Rider
