### PR TITLE
fix: use ArgumentNullException.ThrowIfNull in EthStatsClient

### DIFF
--- a/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
+++ b/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
@@ -29,10 +29,13 @@ namespace Nethermind.EthStats.Clients
             IMessageSender? messageSender,
             ILogManager? logManager)
         {
-            _urlFromConfig = urlFromConfig ?? throw new ArgumentNullException(nameof(urlFromConfig));
+            ArgumentNullException.ThrowIfNull(urlFromConfig);
+            _urlFromConfig = urlFromConfig;
             _reconnectionInterval = reconnectionInterval;
-            _messageSender = messageSender ?? throw new ArgumentNullException(nameof(messageSender));
-            _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
+            ArgumentNullException.ThrowIfNull(messageSender);
+            _messageSender = messageSender;
+            ArgumentNullException.ThrowIfNull(logManager);
+            _logger = logManager.GetClassLogger();
         }
 
         internal string BuildUrl()


### PR DESCRIPTION
Replace null-coalescing throw pattern with ArgumentNullException.ThrowIfNull
in EthStatsClient constructor to align with project coding guidelines.

The change applies to urlFromConfig, messageSender, and logManager parameters,
following the same pattern used in other parts of the codebase.