### PR TITLE
fix: SyncDispatcher leak by disposing CountdownEvent

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -334,6 +334,7 @@ namespace Nethermind.Synchronization.ParallelSync
             {
                 if (Logger.IsWarn) Logger.Warn($"Timeout on waiting for active tasks for feed {Feed.GetType().Name} {_activeTasks.CurrentCount}");
             }
+            _activeTasks.Dispose();
             _cancellationTokenSource.Dispose();
             _concurrentProcessingSemaphore.Dispose();
         }


### PR DESCRIPTION
`CountdownEvent` owns a wait handle and the .NET documentation explicitly recommends disposing it when the owning component is finished. `SyncDispatcher` was already disposing its CancellationTokenSource and SemaphoreSlim but left _activeTasks undisposed, relying on finalization. This change disposes _activeTasks after waiting for active tasks in DisposeAsync, so the wait handle is released together with the other synchronization primitives