### PR TITLE
Bump default pruning cache by 512MB for larger mainnet blocks

### DIFF
--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -16,10 +16,10 @@ public interface IPruningConfig : IConfig
     [ConfigItem(Description = "The pruning mode.", DefaultValue = "Hybrid")]
     PruningMode Mode { get; set; }
 
-    [ConfigItem(Description = "The in-memory cache size, in MB. Bigger size tend to improve performance.", DefaultValue = "1280")]
+    [ConfigItem(Description = "The in-memory cache size, in MB. Bigger size tend to improve performance.", DefaultValue = "1792")]
     long CacheMb { get; set; }
 
-    [ConfigItem(Description = "The in-memory cache size for dirty nodes, in MB. Increasing this reduces pruning interval but cause increased pruning time.", DefaultValue = "1024")]
+    [ConfigItem(Description = "The in-memory cache size for dirty nodes, in MB. Increasing this reduces pruning interval but cause increased pruning time.", DefaultValue = "1536")]
     long DirtyCacheMb { get; set; }
 
     [ConfigItem(

--- a/src/Nethermind/Nethermind.Db/PruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/PruningConfig.cs
@@ -26,8 +26,8 @@ namespace Nethermind.Db
         }
 
         public PruningMode Mode { get; set; } = PruningMode.Hybrid;
-        public long CacheMb { get; set; } = 1280;
-        public long DirtyCacheMb { get; set; } = 1024;
+        public long CacheMb { get; set; } = 1792;
+        public long DirtyCacheMb { get; set; } = 1536;
         public long PersistenceInterval { get; set; } = 1;
         public long FullPruningThresholdMb { get; set; } = 256000;
         public FullPruningTrigger FullPruningTrigger { get; set; } = FullPruningTrigger.Manual;


### PR DESCRIPTION
## Changes

- Larger mainnet blocks means unpruned is around 766MB; bump up the cache sizes by 512MB to add safety margin so as not to prune too frequently as blocks get bigger (+512MB would mean pruning when memory x2; atm is pruning when adds +1/3)
- Does take a bunch longer; but also is between blocks so should be ok
Before

<img width="937" height="151" alt="image" src="https://github.com/user-attachments/assets/bc63171b-abe3-4e4e-bed3-e6d89a7bdc3b" />

After

<img width="979" height="235" alt="image" src="https://github.com/user-attachments/assets/ebd8879d-d6b7-4576-9026-8bc7929d43da" />


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
