### PR TITLE
Remove unused scg alias from gRPC generated code

### DIFF
--- a/src/Nethermind/Nethermind.Grpc/Nethermind.cs
+++ b/src/Nethermind/Nethermind.Grpc/Nethermind.cs
@@ -8,7 +8,6 @@
 using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-using scg = global::System.Collections.Generic;
 namespace Nethermind.Grpc {
 
   /// <summary>Holder for reflection information generated from src/Nethermind/Nethermind.Grpc/Nethermind.proto</summary>


### PR DESCRIPTION
Summary
- drop the unused scg alias from Nethermind gRPC generated sources
- reduce dead/useless imports in the proto-generated descriptor file