### PR TITLE
perf(clique): eliminate redundant cache lookup in GetBlockSealer

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -53,7 +53,8 @@ namespace Nethermind.Consensus.Clique
         {
             if (header.Author is not null) return header.Author;
             if (header.Number == 0) return Address.Zero;
-            if (_signatures.Get(header.Hash) is not null) return _signatures.Get(header.Hash);
+            Address? cached = _signatures.Get(header.Hash);
+            if (cached is not null) return cached;
 
             int extraSeal = 65;
 


### PR DESCRIPTION
Optimizes SnapshotManager.GetBlockSealer() by eliminating a redundant LruCache.Get() call, reducing lock contention and potential race conditions.