### PR TITLE
 fix: unsubscribe NodeRemoved on shutdown

### DIFF
--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -294,6 +294,7 @@ namespace Nethermind.Network
             _cancellationTokenSource.Cancel();
 
             StopTimers();
+            _nodeSource.NodeRemoved -= NodeSourceOnNodeRemoved;
 
             Task storageCloseTask = Task.CompletedTask;
             if (_storageCommitTask is not null)


### PR DESCRIPTION
Unsubscribe PeerPool from NodeRemoved during shutdown to avoid handling node events after the service stops and prevent dangling event references that can mutate state post-stop.