### PR TITLE
Remove unused variable in LruCacheTests

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -301,7 +301,7 @@ namespace Nethermind.Core.Test.Caching
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 {
-                    LruCache<int, int> unused = new(maxCapacity, "test");
+                    new LruCache<int, int>(maxCapacity, "test");
                 });
 
         }


### PR DESCRIPTION
Removed unused local variable `unused` in `Wrong_capacity_number_at_constructor` test. Changed from `LruCache<int, int> unused = new(maxCapacity, "test")` to `new LruCache<int, int>(maxCapacity, "test")`