### PR TITLE
Remove unused `_stateReader` field from SnapServer

### DIFF
--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -36,7 +36,6 @@ public class SnapServer : ISnapServer
     private readonly IReadOnlyTrieStore _store;
     private readonly TrieStoreWithReadFlags _storeWithReadFlag;
     private readonly IReadOnlyKeyValueStore _codeDb;
-    private readonly IStateReader _stateReader;
     private readonly ILogManager _logManager;
     private readonly ILogger _logger;
 


### PR DESCRIPTION
Removes the unused _stateReader field and its assignment from the SnapServer class.