### PR TITLE
fix(sync,trie): Handle timeout exceptions and empty trie sealing in PoW sync

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -175,6 +175,12 @@ public class PowForwardHeaderProvider(
                 syncPeerPool.ReportWeakPeer(bestPeer, AllocationContexts.ForwardHeader);
                 return null;
             }
+            catch (OperationCanceledException) when (!cancellation.IsCancellationRequested)
+            {
+                // Request was cancelled due to timeout in protocol handler, not because the sync was cancelled
+                syncPeerPool.ReportWeakPeer(bestPeer, AllocationContexts.ForwardHeader);
+                return null;
+            }
             catch (EthSyncException e)
             {
                 if (_logger.IsDebug) _logger.Debug($"Failed to download forward header from {bestPeer}, {e}");

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1610,7 +1610,7 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void BlockCommitSet_IsSealed_after_Seal_with_null_root()
         {
-            // This test verifies the fix for networks like Mordor that have an empty genesis state.
+            // This test verifies the fix for networks that have an empty genesis state.
             // When the state trie is empty, the root is null, but the commit set should still be sealed.
             BlockCommitSet commitSet = new(0);
 
@@ -1625,11 +1625,11 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Consecutive_block_commits_work_when_first_has_null_root()
         {
-            // This test simulates the Mordor scenario where the genesis block has an empty state (no allocations).
+            // This test simulates a scenario where the genesis block has an empty state (no allocations).
             // Block 0 commits with null root, then block 1 should be able to commit without assertion failure.
             using TrieStore fullTrieStore = CreateTrieStore();
 
-            // Block 0: empty state (like Mordor genesis with no allocations)
+            // Block 0: empty state (genesis with no allocations)
             using (ICommitter _ = fullTrieStore.BeginStateBlockCommit(0, null)) { }
 
             // Block 1: should not throw or assert, even though previous block had null root

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1606,5 +1606,40 @@ namespace Nethermind.Trie.Test.Pruning
                 }
             }
         }
+
+        [Test]
+        public void BlockCommitSet_IsSealed_after_Seal_with_null_root()
+        {
+            // This test verifies the fix for networks like Mordor that have an empty genesis state.
+            // When the state trie is empty, the root is null, but the commit set should still be sealed.
+            BlockCommitSet commitSet = new(0);
+
+            commitSet.IsSealed.Should().BeFalse();
+
+            commitSet.Seal(null);
+
+            commitSet.IsSealed.Should().BeTrue();
+            commitSet.StateRoot.Should().Be(Keccak.EmptyTreeHash);
+        }
+
+        [Test]
+        public void Consecutive_block_commits_work_when_first_has_null_root()
+        {
+            // This test simulates the Mordor scenario where the genesis block has an empty state (no allocations).
+            // Block 0 commits with null root, then block 1 should be able to commit without assertion failure.
+            using TrieStore fullTrieStore = CreateTrieStore();
+
+            // Block 0: empty state (like Mordor genesis with no allocations)
+            using (ICommitter _ = fullTrieStore.BeginStateBlockCommit(0, null)) { }
+
+            // Block 1: should not throw or assert, even though previous block had null root
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
+            Action commitBlock1 = () =>
+            {
+                using (ICommitter _ = fullTrieStore.BeginStateBlockCommit(1, trieNode)) { }
+            };
+
+            commitBlock1.Should().NotThrow();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/BlockCommitPackage.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/BlockCommitPackage.cs
@@ -14,11 +14,18 @@ namespace Nethermind.Trie.Pruning
         public TrieNode? Root { get; private set; }
         public Hash256 StateRoot => Root?.Keccak ?? Keccak.EmptyTreeHash;
 
-        public bool IsSealed => Root is not null;
+        private bool _isSealed;
+
+        /// <summary>
+        /// A commit set is sealed once <see cref="Seal"/> has been called, regardless of whether the root is null.
+        /// A null root is valid for an empty state trie (e.g., genesis blocks with no allocations).
+        /// </summary>
+        public bool IsSealed => _isSealed;
 
         public void Seal(TrieNode? root)
         {
             Root = root;
+            _isSealed = true;
         }
 
         public override string ToString() => $"{BlockNumber}({Root})";

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -463,7 +463,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     private void FinishBlockCommit(BlockCommitSet set, TrieNode? root)
     {
         if (_logger.IsTrace) _logger.Trace($"Enqueued blocks {_commitSetQueue.Count}");
-        // Note: root is null when the state trie is empty. It will therefore make the block commit set not sealed.
+        // Note: root can be null when the state trie is empty (e.g., genesis with no allocations).
         set.Seal(root);
         set.Prune();
 


### PR DESCRIPTION
## Changes

- **fix(sync)**: Handle `OperationCanceledException` as timeout in `PowForwardHeaderProvider` - After commit cc56a0333f changed timeout handling to use cancellation instead of `TimeoutException`, PoW sync would stop completely on timeout.
- **fix(trie)**: Mark `BlockCommitSet` as sealed even when root is null - Empty state tries with `Keccak.EmptyTreeHash` are valid (e.g., genesis blocks with no allocations), but `IsSealed` returned false causing assertion failures.

These issues were discovered during Ethereum Classic sync testing using the [Nethermind ETC Plugin](https://github.com/ETCCooperative/nethermind-etc-plugin).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added test for `PowForwardHeaderProvider` timeout handling via `OperationCanceledException`
- Added test for `BlockCommitSet` sealing with null root

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Both fixes affect PoW chain synchronization. Without these fixes, sync does not progress on PoW chains like Ethereum Classic.