### PR TITLE
Remove unused using directives from HiveTestResult.cs

### DIFF
--- a/tools/HiveCompare/Models/HiveTestResult.cs
+++ b/tools/HiveCompare/Models/HiveTestResult.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace HiveCompare.Models
 {


### PR DESCRIPTION
Removes 4 unused `using` directives from `HiveTestResult.cs` to improve code cleanliness and reduce namespace pollution.