### PR TITLE
Remove unused imports and add missing license headers

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/LoadPyspecTestsStrategy.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/LoadPyspecTestsStrategy.cs
@@ -48,8 +48,7 @@ public class LoadPyspecTestsStrategy : ITestLoadStrategy
         using Stream contentStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
         using GZipStream gzStream = new(contentStream, CompressionMode.Decompress);
 
-        if (!Directory.Exists(testsDirectoryName))
-            Directory.CreateDirectory(testsDirectoryName);
+        Directory.CreateDirectory(testsDirectoryName);
 
         TarFile.ExtractToDirectory(gzStream, testsDirectoryName, true);
     }

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ParisBlockChainTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ParisBlockChainTests.cs
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
 using NUnit.Framework;

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueBlockChainTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueBlockChainTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
 using NUnit.Framework;
@@ -19,6 +18,6 @@ public class PragueBlockChainTests : BlockchainTestBase
     private static IEnumerable<BlockchainTest> LoadTests()
     {
         TestsSourceLoader loader = new(new LoadPyspecTestsStrategy(), $"fixtures/blockchain_tests/prague");
-        return loader.LoadTests().OfType<BlockchainTest>();
+        return loader.LoadTests<BlockchainTest>();
     }
 }

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueStateTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueStateTests.cs
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
 using System.Collections.Generic;
-using System.Linq;
 using Ethereum.Test.Base;
 using FluentAssertions;
 using NUnit.Framework;


### PR DESCRIPTION
Remove unused imports and redundant code in Ethereum.Blockchain.Pyspec.Test