### PR TITLE
fix(txpool): remove redundant hasBeenRemoved check in RemoveTransaction

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -903,18 +903,15 @@ namespace Nethermind.TxPool
                 return false;
             }
 
-            if (hasBeenRemoved)
-            {
-                RemovedPending?.Invoke(this, new TxEventArgs(transaction));
+            RemovedPending?.Invoke(this, new TxEventArgs(transaction));
 
-                RemovePendingDelegations(transaction);
-            }
+            RemovePendingDelegations(transaction);
 
             _broadcaster.StopBroadcast(hash);
 
             if (_logger.IsTrace) _logger.Trace($"Removed a transaction: {hash}");
 
-            return hasBeenRemoved;
+            return true;
         }
 
         public bool ContainsTx(Hash256 hash, TxType txType) => txType == TxType.Blob


### PR DESCRIPTION
The `if (hasBeenRemoved)` check on line 906 was always true because we already return early on line 901-903 when `!hasBeenRemoved`. Removed the dead code and changed `return hasBeenRemoved` to `return true` since we can only reach that point when the transaction was successfully removed.