### PR TITLE
fix(xdc-tests): Add proper disposal and prevent parallel execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -439,6 +439,9 @@ FodyWeavers.xsd
 .claude/
 .gemini/
 
+# Worktrees
+.worktrees/
+
 ## Nethermind
 keystore/
 /.githooks

--- a/src/Nethermind/Nethermind.Xdc.Test/BlockInfoTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/BlockInfoTests.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 internal class BlockInfoTests
 {
     [Test]
     public async Task VerifyGenesisV2Block()
     {
-        XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
+        using XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
         XdcBlockHeader genesisBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.FindHeader(xdcTestBlockchain.BlockTree.Genesis!.Number + 1)!;
 
         BlockRoundInfo blockInfo = new BlockRoundInfo(genesisBlock.Hash!, 1, genesisBlock.Number);
@@ -27,7 +27,7 @@ internal class BlockInfoTests
     [Test]
     public async Task RoundMismatch_Fails()
     {
-        XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
+        using XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
         XdcBlockHeader headBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.Head!.Header!;
 
         BlockRoundInfo blockInfo = new BlockRoundInfo(headBlock.Hash!, headBlock.ExtraConsensusData!.BlockRound - 1, headBlock.Number);
@@ -41,7 +41,7 @@ internal class BlockInfoTests
     [Test]
     public async Task HashMismatch_Fails()
     {
-        XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
+        using XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
         XdcBlockHeader headBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.Head!.Header!;
         XdcBlockHeader parentBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.FindHeader(headBlock.ParentHash!)!;
 
@@ -56,7 +56,7 @@ internal class BlockInfoTests
     [Test]
     public async Task NumberMismatch_Fails()
     {
-        XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
+        using XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
         XdcBlockHeader headBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.Head!.Header!;
         XdcBlockHeader parentBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.FindHeader(headBlock.ParentHash!)!;
 
@@ -71,7 +71,7 @@ internal class BlockInfoTests
     [Test]
     public async Task NoMismatch_Pass()
     {
-        XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
+        using XdcTestBlockchain xdcTestBlockchain = await XdcTestBlockchain.Create();
         XdcBlockHeader headBlock = (XdcBlockHeader)xdcTestBlockchain.BlockTree.Head!.Header!;
 
         BlockRoundInfo blockInfo = new BlockRoundInfo(headBlock.Hash!, headBlock.ExtraConsensusData!.BlockRound, headBlock.Number);

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/HeaderVerificationTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/HeaderVerificationTests.cs
@@ -22,6 +22,7 @@ using ISigner = Nethermind.Consensus.ISigner;
 
 namespace Nethermind.Xdc.Test.ModuleTests;
 
+[NonParallelizable]
 internal class HeaderVerificationTests
 {
     private XdcTestBlockchain xdcTestBlockchain;
@@ -36,6 +37,12 @@ internal class HeaderVerificationTests
         xdcHeaderValidator = xdcTestBlockchain.Container.Resolve<IHeaderValidator>();
         xdcSigner = xdcTestBlockchain.Container.Resolve<ISigner>();
         extraConsensusDataDecoder = new();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        xdcTestBlockchain?.Dispose();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/MineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/MineModuleTests.cs
@@ -21,21 +21,14 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test.ModuleTests;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 internal class MineModuleTests
 {
-    public async Task<(XdcTestBlockchain, XdcBlockTree)> Setup()
-    {
-        var blockchain = await XdcTestBlockchain.Create(useHotStuffModule: true);
-        var tree = (XdcBlockTree)blockchain.BlockTree;
-
-        return (blockchain, tree);
-    }
-
     [Test]
     public async Task TestUpdateMultipleMasterNodes()
     {
-        var (blockchain, tree) = await Setup();
+        using var blockchain = await XdcTestBlockchain.Create(useHotStuffModule: true);
+        var tree = (XdcBlockTree)blockchain.BlockTree;
 
         // this test is basically an emulation because our block producer test setup does not support saving snapshots yet
         // add blocks until the next gap block
@@ -72,7 +65,8 @@ internal class MineModuleTests
     [Test]
     public async Task TestShouldMineOncePerRound()
     {
-        var (xdcBlockchain, tree) = await Setup();
+        using var xdcBlockchain = await XdcTestBlockchain.Create(useHotStuffModule: true);
+        var tree = (XdcBlockTree)xdcBlockchain.BlockTree;
 
         var _hotstuff = (XdcHotStuff)xdcBlockchain.BlockProducerRunner;
 
@@ -108,7 +102,8 @@ internal class MineModuleTests
     [Test]
     public async Task TestUpdateMasterNodes()
     {
-        var (blockchain, tree) = await Setup();
+        using var blockchain = await XdcTestBlockchain.Create(useHotStuffModule: true);
+        var tree = (XdcBlockTree)blockchain.BlockTree;
 
         blockchain.ChangeReleaseSpec((spec) =>
         {

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/ProposedBlockTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/ProposedBlockTests.cs
@@ -13,13 +13,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 internal class ProposedBlockTests
 {
     [Test]
     public async Task TestShouldSendVoteMsgAndCommitGreatGrandparentBlockAsync()
     {
-        var blockChain = await XdcTestBlockchain.Create(2, true);
+        using var blockChain = await XdcTestBlockchain.Create(2, true);
 
         await blockChain.AddBlockWithoutCommitQc();
 
@@ -66,7 +66,7 @@ internal class ProposedBlockTests
     [Test]
     public async Task TestShouldNotCommitIfRoundsNotContinousFor3Rounds()
     {
-        var blockChain = await XdcTestBlockchain.Create(2, true);
+        using var blockChain = await XdcTestBlockchain.Create(2, true);
 
         await blockChain.AddBlock();
 
@@ -93,7 +93,7 @@ internal class ProposedBlockTests
     [Test]
     public async Task TestProposedBlockMessageHandlerSuccessfullyGenerateVote()
     {
-        var blockChain = await XdcTestBlockchain.Create(2, true);
+        using var blockChain = await XdcTestBlockchain.Create(2, true);
 
         await blockChain.AddBlockWithoutCommitQc();
 
@@ -143,7 +143,7 @@ internal class ProposedBlockTests
     [TestCase(30)]
     public async Task CanBuildAFinalizedChain(int count)
     {
-        var blockChain = await XdcTestBlockchain.Create(0, true);
+        using var blockChain = await XdcTestBlockchain.Create(0, true);
         blockChain.ChangeReleaseSpec((s) =>
         {
             s.EpochLength = 90;
@@ -168,7 +168,7 @@ internal class ProposedBlockTests
     [Test]
     public async Task TestProposedBlockMessageHandlerNotGenerateVoteIfSignerNotInMNlist()
     {
-        var blockChain = await XdcTestBlockchain.Create(2, true);
+        using var blockChain = await XdcTestBlockchain.Create(2, true);
 
         await blockChain.AddBlockWithoutCommitQc();
 

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RewardTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RewardTests.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test.ModuleTests;
 
+[NonParallelizable]
 public class RewardTests
 {
     // Test ported from XDC reward_test :
@@ -29,7 +30,7 @@ public class RewardTests
     [Test]
     public async Task TestHookRewardV2()
     {
-        var chain = await XdcTestBlockchain.Create();
+        using var chain = await XdcTestBlockchain.Create();
         var masternodeVotingContract = Substitute.For<IMasternodeVotingContract>();
         var rc = new XdcRewardCalculator(
             chain.EpochSwitchManager,
@@ -129,7 +130,7 @@ public class RewardTests
     [Test]
     public async Task TestHookRewardV2SplitReward()
     {
-        var chain = await XdcTestBlockchain.Create();
+        using var chain = await XdcTestBlockchain.Create();
         var masternodeVotingContract = Substitute.For<IMasternodeVotingContract>();
         var rc = new XdcRewardCalculator(
             chain.EpochSwitchManager,

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/TimeoutTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/TimeoutTests.cs
@@ -13,12 +13,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
+[NonParallelizable]
 public class TimeoutTests
 {
     [Test]
     public async Task TestCountdownTimeoutToSendTimeoutMessage()
     {
-        var blockchain = await XdcTestBlockchain.Create();
+        using var blockchain = await XdcTestBlockchain.Create();
         var tcManager = blockchain.TimeoutCertificateManager;
         var ctx = blockchain.XdcContext;
         tcManager.OnCountdownTimer();
@@ -32,7 +33,7 @@ public class TimeoutTests
     [Test]
     public async Task TestCountdownTimeoutNotToSendTimeoutMessageIfNotInMasternodeList()
     {
-        var blockchain = await XdcTestBlockchain.Create();
+        using var blockchain = await XdcTestBlockchain.Create();
         // Create TCManager with a signer not in the Masternode list
         var extraKey = blockchain.RandomKeys.First();
 
@@ -47,7 +48,7 @@ public class TimeoutTests
     [Test]
     public async Task TestTimeoutMessageHandlerSuccessfullyGenerateTC()
     {
-        var blockchain = await XdcTestBlockchain.Create();
+        using var blockchain = await XdcTestBlockchain.Create();
 
         var ctx = blockchain.XdcContext;
         var head = (XdcBlockHeader)blockchain.BlockTree.Head!.Header;

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/VoteTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/VoteTests.cs
@@ -13,12 +13,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
+[NonParallelizable]
 public class VoteTests
 {
     [Test]
     public async Task HandleVote_SuccessfullyGenerateAndProcessQc()
     {
-        var blockchain = await XdcTestBlockchain.Create();
+        using var blockchain = await XdcTestBlockchain.Create();
         var votesManager = CreateVotesManager(blockchain);
         IXdcConsensusContext ctx = blockchain.XdcContext;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcReorgModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcReorgModuleTests.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 internal class XdcReorgModuleTests
 {
     [Test]
     public async Task TestNormalReorgWhenNotInvolveCommittedBlock()
     {
-        var blockChain = await XdcTestBlockchain.Create();
+        using var blockChain = await XdcTestBlockchain.Create();
         var startRound = blockChain.XdcContext.CurrentRound;
         await blockChain.AddBlocks(3);
         // Simulate timeout to make block rounds non-consecutive preventing finalization
@@ -33,7 +33,7 @@ internal class XdcReorgModuleTests
     [Test]
     public async Task BuildAValidForkOnFinalizedBlockAndAssertForkBecomesCanonical()
     {
-        var blockChain = await XdcTestBlockchain.Create(3);
+        using var blockChain = await XdcTestBlockchain.Create(3);
         var startRound = blockChain.XdcContext.CurrentRound;
         await blockChain.AddBlocks(10);
 
@@ -73,7 +73,7 @@ internal class XdcReorgModuleTests
     [TestCase(901)]
     public async Task TestShouldNotReorgCommittedBlock(int number)
     {
-        var blockChain = await XdcTestBlockchain.Create();
+        using var blockChain = await XdcTestBlockchain.Create();
         var startRound = blockChain.XdcContext.CurrentRound;
         await blockChain.AddBlocks(number);
         var finalizedBlockInfo = blockChain.XdcContext.HighestCommitBlock;

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcTestBlockchainTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcTestBlockchainTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Xdc.Test;
 
+[NonParallelizable]
 internal class XdcTestBlockchainTests
 {
     private XdcTestBlockchain _blockchain;


### PR DESCRIPTION
## Summary
- Add `using` declarations to all `XdcTestBlockchain` instances for proper resource cleanup
- Add `[NonParallelizable]` attribute to test classes that use `XdcTestBlockchain` to prevent race conditions
- Add `[TearDown]` method to `HeaderVerificationTests` to dispose the blockchain field
- Remove `Setup()` helper in `MineModuleTests`, inline with `using` in each test

## Test plan
- [x] Verified 33 tests pass: XdcTestBlockchainTests, TimeoutTests, VoteTests, HeaderVerificationTests, BlockInfoTests, RewardTests
- [ ] Note: Some tests in MineModuleTests, ProposedBlockTests, and XdcReorgModuleTests have pre-existing hang issues related to `useHotStuffModule: true` that require separate investigation

🤖 Generated with [Claude Code](https://claude.ai/code)