### PR TITLE
fix(shutter): use Debug instead of Warn for IsDebug guard

### DIFF
--- a/src/Nethermind/Nethermind.Shutter/ShutterBlockHandler.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterBlockHandler.cs
@@ -185,7 +185,7 @@ public class ShutterBlockHandler : IShutterBlockHandler
         }
         else if (_logger.IsDebug)
         {
-            _logger.Warn($"Shutter block handler not running, outdated block {head.Number}");
+            _logger.Debug($"Shutter block handler not running, outdated block {head.Number}");
         }
     }
 


### PR DESCRIPTION
Fix logging level mismatch in ShutterBlockHandler.OnNewHeadBlock method. The condition checks `_logger.IsDebug` but was calling `_logger.Warn()`.
Changed to `_logger.Debug()` to match the guard condition and align with the informational nature of the message (outdated block is expected behavior, not a warning condition).