### PR TITLE
Remove redundant Directory.Exists check before CreateDirectory

### DIFF
--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -56,10 +56,7 @@ namespace Nethermind.Logging.NLog
         private static string SetupLogDirectory(string logDirectory)
         {
             logDirectory = (string.IsNullOrEmpty(logDirectory) ? DefaultFolder : logDirectory).GetApplicationResourcePath();
-            if (!Directory.Exists(logDirectory))
-            {
-                Directory.CreateDirectory(logDirectory);
-            }
+            Directory.CreateDirectory(logDirectory);
 
             return logDirectory;
         }


### PR DESCRIPTION


- Remove redundant `Directory.Exists()` check before `Directory.CreateDirectory()` in `NLogManager.SetupLogDirectory()`
- `Directory.CreateDirectory()` is idempotent and handles existing directories gracefully

