### PR TITLE
Fix higher than expected pruning cache memory during forward sync.

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -598,7 +598,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             await Task.Delay(pruneDelayMs);
         }
 
-        using (var _ = _pruningLock.EnterScope())
+        using (_pruningLock.EnterScope())
         {
             // Skip triggering GC while pruning so they don't fight each other causing pruning to take longer
             GCScheduler.Instance.SkipNextGC();


### PR DESCRIPTION
- Fix pruning cache did not prune during forward sync.
- The _pruningTask.IsCompleted should prevent multiple prune attempt already.

<img width="1599" height="1798" alt="Screenshot_2026-01-27_21-51-57" src="https://github.com/user-attachments/assets/211d3a73-d9be-4db8-843e-94c2f5304457" />

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- tested manually.