### PR TITLE
Refactor HexConvert to use shared hex parsing logic

### DIFF
--- a/tools/SendBlobs/HexConvert.cs
+++ b/tools/SendBlobs/HexConvert.cs
@@ -1,11 +1,38 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Core.Extensions;
+
 namespace SendBlobs;
 internal static class HexConvert
 {
     public static ulong ToUInt64(string s)
     {
-        return Convert.ToUInt64(s, s.StartsWith("0x") ? 16 : 10);
+        // Prefer Nethermind's shared hex parsing logic to avoid duplicating subtle rules.
+        if (s.StartsWith("0x", StringComparison.Ordinal))
+        {
+            ReadOnlySpan<char> hex = s.AsSpan(2);
+            if (hex.IsEmpty)
+            {
+                throw new FormatException("Empty hex value.");
+            }
+
+            // Compute decoded byte length (supports odd-length quantities like "0x1").
+            int byteLength = (hex.Length >> 1) + (hex.Length & 1);
+            if (byteLength > sizeof(ulong))
+            {
+                throw new OverflowException("Value does not fit into UInt64.");
+            }
+
+            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+            bytes.Clear();
+
+            Span<byte> target = bytes[^byteLength..];
+            Bytes.FromHexString(s.AsSpan(), target);
+            return bytes.ReadEthUInt64();
+        }
+
+        return Convert.ToUInt64(s, 10);
     }
 }


### PR DESCRIPTION

- Replace custom hex parsing in `HexConvert.ToUInt64` with `Nethermind.Core.Extensions.Bytes.FromHexString` and `ReadEthUInt64`
- Remove code duplication by reusing the existing, tested hex parsing implementation
- Add explicit validation for empty hex values and overflow cases

