### PR TITLE
Fix PayloadAttributes version mismatch and slot number validation

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -198,8 +198,8 @@ public static class PayloadAttributesExtensions
 
 public static class PayloadAttributesVersions
 {
-    public const int Paris = 1;
-    public const int Shanghai = 2;
-    public const int Cancun = 3;
-    public const int Amsterdam = 4;
+    public const int Paris = EngineApiVersions.Paris;
+    public const int Shanghai = EngineApiVersions.Shanghai;
+    public const int Cancun = EngineApiVersions.Cancun;
+    public const int Amsterdam = EngineApiVersions.Amsterdam;
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -398,11 +398,12 @@ namespace Nethermind.Consensus.Validators
                     return false;
                 }
 
-                // how to validate at fork boundary?
-                if (parent.SlotNumber is not null && parent.SlotNumber != 0 && header.SlotNumber != parent.SlotNumber + 1)
+                // Slot numbers must be strictly increasing but NOT necessarily consecutive
+                // (missed slots are valid in Ethereum - no block is produced for empty slots)
+                if (parent.SlotNumber is not null && parent.SlotNumber != 0 && header.SlotNumber <= parent.SlotNumber)
                 {
                     error = BlockErrorMessages.InvalidSlotNumber;
-                    if (_logger.IsWarn) _logger.Warn($"Invalid slot number ({header.SlotNumber}) - slot number does not increment parent ({parent.SlotNumber})");
+                    if (_logger.IsWarn) _logger.Warn($"Invalid slot number ({header.SlotNumber}) - slot number must be greater than parent ({parent.SlotNumber})");
                     return false;
                 }
             }


### PR DESCRIPTION
Two bugs preventing Nethermind from syncing past the Gloas fork:

1. PayloadAttributesVersions.Amsterdam was hardcoded to 4, while EngineApiVersions.Amsterdam is 6 (includes Prague=4, Osaka=5). This caused engine_forkchoiceUpdatedV4 to return -38003 "PayloadAttributesV6 expected". Fixed by referencing EngineApiVersions constants directly.

2. ValidateSlotNumber required header.SlotNumber == parent.SlotNumber + 1, but Ethereum allows missed slots (no block produced). A block at slot 13 with parent at slot 8 is valid. Changed to require strictly increasing slot numbers (header.SlotNumber > parent.SlotNumber) instead of consecutive.