### PR TITLE
docs: Remove obsolete canParallelize parameter from BulkSet documentation

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
@@ -106,7 +106,6 @@ public partial class PatriciaTree
     /// <param name="path"></param>
     /// <param name="node"></param>
     /// <param name="flipCount">Flip count, for parallelism.</param>
-    /// <param name="canParallelize"></param>
     /// <param name="flags"></param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>


### PR DESCRIPTION
Remove outdated XML documentation reference to non-existent `canParallelize` parameter in the `PatriciaTree.BulkSet` method.
