### PR TITLE
Remove unused using directive in SendBlobs/SetupCli

### DIFF
--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus;
 using Nethermind.Crypto;
 using Nethermind.Logging;
 using System.CommandLine;


### PR DESCRIPTION
Removes unused using Nethermind.Consensus; directive from SetupCli.cs in the SendBlobs tool.