### PR TITLE
Remove unused using directives in HiveCompare.Models

### DIFF
--- a/tools/HiveCompare/Models/HiveTestResult.cs
+++ b/tools/HiveCompare/Models/HiveTestResult.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace HiveCompare.Models
 {


### PR DESCRIPTION
Removed 4 unused `using` directives from `HiveTestResult.cs`: `using System;`, `using System.Linq;`, `using System.Text;`,`using System.Threading.Tasks;`