### PR TITLE
chore(xdc): remove unused using directives from genesis builder

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcGenesisBuilder.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcGenesisBuilder.cs
@@ -2,20 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Crypto;
-using Nethermind.Evm;
-using Nethermind.Evm.State;
-using Nethermind.Evm.TransactionProcessing;
-using Nethermind.Int256;
-using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Xdc.Spec;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nethermind.Xdc;
 


### PR DESCRIPTION
Remove unused `using` directives in `XdcGenesisBuilder` to reduce noise and unused dependencies.
