### PR TITLE
fix: ExecutionPayloadV4.Create() calls V1 base instead of V3

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV4.cs
@@ -19,7 +19,7 @@ public class ExecutionPayloadV4 : ExecutionPayloadV3, IExecutionPayloadFactory<E
 {
     protected new static TExecutionPayload Create<TExecutionPayload>(Block block) where TExecutionPayload : ExecutionPayloadV4, new()
     {
-        TExecutionPayload executionPayload = ExecutionPayload.Create<TExecutionPayload>(block);
+        TExecutionPayload executionPayload = ExecutionPayloadV3.Create<TExecutionPayload>(block);
         executionPayload.BlockAccessList = block.EncodedBlockAccessList ?? (block.BlockAccessList is null ? null : Rlp.Encode(block.BlockAccessList!.Value).Bytes);
         executionPayload.SlotNumber = block.SlotNumber;
         return executionPayload;


### PR DESCRIPTION
## Summary

- `ExecutionPayloadV4.Create()` called `ExecutionPayload.Create()` (V1 base) instead of `ExecutionPayloadV3.Create()`, skipping `BlobGasUsed`, `ExcessBlobGas`, and `ParentBeaconBlockRoot` fields
- This caused `engine_getPayloadV6` responses to omit these required fields, preventing Nethermind from proposing blocks after the Gloas fork

## Changes

One-line fix in `ExecutionPayloadV4.cs:22`:
```diff
- TExecutionPayload executionPayload = ExecutionPayload.Create<TExecutionPayload>(block);
+ TExecutionPayload executionPayload = ExecutionPayloadV3.Create<TExecutionPayload>(block);
```

## Test plan

- [x] Built Nethermind Docker image with fix
- [x] Tested with Kurtosis: Lighthouse + Geth (supernode) + 2x Lodestar + Nethermind
- [x] Nethermind nodes successfully proposed blocks post-Gloas (slots 3, 5, 7, 8, 18) — previously failed with `missing field blobGasUsed`
- [x] All 3 nodes in consensus through 5+ epochs, epoch 3 finalized, same head root

🤖 Generated with [Claude Code](https://claude.com/claude-code)