### PR TITLE
Fix static node not marked as static when added via AddAsync

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
@@ -58,6 +58,17 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        public async Task add_should_emit_node_with_static_flag()
+        {
+            ValueTask<List<Node>> listTask = _staticNodesManager.DiscoverNodes(default).Take(1).ToListAsync();
+
+            await _staticNodesManager.AddAsync(Enode, false);
+            List<Node> nodes = await listTask;
+
+            nodes[0].IsStatic.Should().BeTrue();
+        }
+
+        [Test]
         public async Task remove_should_delete_an_existing_static_node_and_trigger_an_event()
         {
             var eventRaised = false;

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -40,7 +40,7 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
 
         if (_logger.IsInfo) _logger.Info($"Static node added: {enode}");
 
-        Node node = new(networkNode);
+        Node node = new(networkNode, isStatic: true);
         NodeAdded?.Invoke(this, new NodeEventArgs(node));
 
         if (updateFile)


### PR DESCRIPTION
## Summary
- Fixed bug where nodes added via `StaticNodesManager.AddAsync` were not marked with `IsStatic=true`
- Added unit test to verify nodes emitted via `DiscoverNodes` have the static flag set

## Test plan
- [x] `add_should_emit_node_with_static_flag` test verifies the fix
- [x] All existing `StaticNodesManagerTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)