### PR TITLE
fix: remove unused InvalidChainTracker field from MergePlugin

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -53,7 +53,6 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
     protected ITxPoolConfig _txPoolConfig = null!;
     protected IPoSSwitcher _poSSwitcher = NoPoS.Instance;
     private IBlockCacheService _blockCacheService = null!;
-    private InvalidChainTracker.InvalidChainTracker _invalidChainTracker = null!;
 
     private IMergeBlockProductionPolicy? _mergeBlockProductionPolicy;
 
@@ -88,7 +87,6 @@ public partial class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) 
 
             _blockCacheService = _api.Context.Resolve<IBlockCacheService>();
             _poSSwitcher = _api.Context.Resolve<IPoSSwitcher>();
-            _invalidChainTracker = _api.Context.Resolve<InvalidChainTracker.InvalidChainTracker>();
             if (_txPoolConfig.BlobsSupport.SupportsReorgs())
             {
                 ProcessedTransactionsDbCleaner processedTransactionsDbCleaner = new(_api.Context.Resolve<IManualBlockFinalizationManager>(), _api.DbProvider.BlobTransactionsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs), _api.LogManager);


### PR DESCRIPTION
MergePlugin was resolving `InvalidChainTracker` into a private field that was never used afterwards. All real wiring of `InvalidChainTracker` to the blockchain processor happens via `BaseMergePluginModule` and `OnActivate<IMainProcessingContext>`, so this extra resolve was pure dead code and unnecessary DI work.

Removed the unused `_invalidChainTracker` field from MergePlugin and the corresponding `Resolve<InvalidChainTracker.InvalidChainTracker>()` call in Init, leaving the existing DI wiring in `BaseMergePluginModule` as the single source of integration.