### PR TITLE
Remove unused System.Threading.Tasks import from PatriciaTree.BulkSet

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Threading;


### PR DESCRIPTION
Removes unused `using System.Threading.Tasks;` directive from `PatriciaTree.BulkSet.cs`.
