### PR TITLE
fix(eip8024): SWAPN off-by-one in stack swap depth

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -94,9 +94,9 @@ public class Eip8024Tests : VirtualMachineTestsBase
         result.StatusCode.Should().Be(StatusCode.Success);
 
         // Stack: [1, 2, 3, 4, 5, ..., 20] with 20 on top (20 items)
-        // SWAPN 17: swap top (20) with position 17 from top (index 3 = value 4)
-        // After swap: top = 4
-        new UInt256(result.ReturnValue, true).Should().Be(4);
+        // SWAPN decode(0x00)=17: swap top (20) with (n+1)th=18th item from top (value 3)
+        // After swap: top = 3
+        new UInt256(result.ReturnValue, true).Should().Be(3);
     }
 
     [Test]
@@ -417,8 +417,8 @@ public class Eip8024Tests : VirtualMachineTestsBase
         // EIP test: 600160008080808080808080808080808080806002e700
         // PUSH1 01, PUSH1 00, DUP1 x15, PUSH1 02, SWAPN 0x00
         // After setup: stack = [1, 0, 0, ..., 0, 2] (18 items with 2 on top, 1 at bottom)
-        // SWAPN 17: swap top (2) with position 17 from top (value 0)
-        // Result: top = 0
+        // SWAPN decode(0x00)=17: swap top (2) with (n+1)th=18th item from top (value 1)
+        // Result: top = 1
         byte[] code = Prepare.EvmCode
             .PushData(1)
             .PushData(0)
@@ -434,8 +434,8 @@ public class Eip8024Tests : VirtualMachineTestsBase
 
         TestAllTracerWithOutput result = Execute(code);
         result.StatusCode.Should().Be(StatusCode.Success);
-        // After SWAPN 17: swap top (2) with position 17 from top = 0
-        new UInt256(result.ReturnValue, true).Should().Be(0);
+        // After SWAPN decode(0)=17: swap top (2) with (n+1)th=18th from top = 1
+        new UInt256(result.ReturnValue, true).Should().Be(1);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -604,7 +604,7 @@ internal static partial class EvmInstructions
         if (!TryDecodeSingle(vm, ref programCounter, out int depth))
             goto BadInstruction;
 
-        return stack.Swap<TTracingInst>(depth);
+        return stack.Swap<TTracingInst>(depth + 1);
     BadInstruction:
         return EvmExceptionType.BadInstruction;
     }


### PR DESCRIPTION
## Summary

- **Fix off-by-one in `InstructionSwapN`**: `SWAPN` with immediate `n` should swap the top stack item with the `(n+1)`th item per [EIP-8024 spec](https://eips.ethereum.org/EIPS/eip-8024). The existing code called `stack.Swap(depth)` instead of `stack.Swap(depth + 1)`, swapping with the `n`th item instead.
- The regular `InstructionSwap` (SWAP1–SWAP16) correctly uses `stack.Swap(Count + 1)` — the new `InstructionSwapN` was missing the `+ 1`.
- Updated unit tests that were written against the buggy behavior.

## Root Cause

For immediate `0x00`, `TryDecodeSingle` correctly decodes to `depth = 17`. The spec requires swapping with the **(n+1)th = 18th** item from the top, but the code was swapping with the **17th**. This caused value misplacement on the stack, leading to incorrect `CALLCODE` arguments and a ~6,700 gas difference per affected transaction — enough to cause a chain split on bal-devnet-2 (Besu ↔ Nethermind disagreement on `block.gasUsed` and BAL hash).

## Reproduction

Reproduced locally with Kurtosis (Besu reference + Nethermind under test) using spamoor `evm-fuzz` with deterministic seed. Network forked at block 134; after applying the fix, nodes stayed in consensus past block 156+.

## Test plan

- [x] Updated `Eip8024Tests.SwapN_ValidImmediate_SwapsStackElements` — corrected expected stack value
- [x] Updated `Eip8024Tests.EipTestVector_SwapN_18Items_TopIs0` — corrected expected post-swap value
- [x] Verified fix in local Kurtosis network (Besu + Nethermind, 5 epochs, no fork)