### PR TITLE
Add logIndex_compact RPC endpoint

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/LogIndex/ILogIndexRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/LogIndex/ILogIndexRpcModule.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.JsonRpc.Modules.Eth;
 
 namespace Nethermind.JsonRpc.Modules.LogIndex;
@@ -15,5 +16,6 @@ public interface ILogIndexRpcModule : IRpcModule
     [JsonRpcMethod(Description = "Retrieves log index status.", IsImplemented = true, IsSharable = true)]
     ResultWrapper<LogIndexStatus> logIndex_status();
 
-    // TODO: add compaction RPC
+    [JsonRpcMethod(Description = "Forces log index compaction.", IsImplemented = true, IsSharable = false)]
+    Task<ResultWrapper<LogIndexCompactionResult>> logIndex_compact();
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/LogIndex/LogIndexCompactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/LogIndex/LogIndexCompactionResult.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.JsonRpc.Modules.LogIndex;
+
+public class LogIndexCompactionResult
+{
+    public required string DbSizeBefore { get; init; }
+    public required string DbSizeAfter { get; init; }
+    public required string Elapsed { get; init; }
+    public required string CompactingTime { get; init; }
+}


### PR DESCRIPTION
Based on #8464

## Changes

- Add `logIndex_compact` RPC endpoint that triggers on-demand log index compaction
- Add `LogIndexCompactionResult` DTO returning DB size before/after, elapsed time, and compacting time
- Guard against disabled log index storage with a failure result
- Remove TODO comment from `ILogIndexRpcModule`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

No existing RPC-level tests for this module. The underlying `CompactAsync` is covered by integration tests in `LogIndexStorageIntegrationTests`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

New `logIndex_compact` RPC method allows operators to trigger log index compaction on demand, returning before/after DB sizes and timing statistics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)