### PR TITLE
Remove unused private constants in KeccakHash

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -21,8 +21,6 @@ namespace Nethermind.Core.Crypto
         private const int STATE_SIZE = 200;
         private const int HASH_DATA_AREA = 136;
         private const int ROUNDS = 24;
-        private const int LANE_BITS = 8 * 8;
-        private const int TEMP_BUFF_SIZE = 144;
         private static readonly ulong[] RoundConstants =
         {
             0x0000000000000001UL, 0x0000000000008082UL, 0x800000000000808aUL,


### PR DESCRIPTION
Removes two unused private constants from `KeccakHash` class that were declared but never referenced in production code.
