### PR TITLE
Remove unused using directive in FundsDistributor.cs

### DIFF
--- a/tools/SendBlobs/FundsDistributor.cs
+++ b/tools/SendBlobs/FundsDistributor.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Crypto;


### PR DESCRIPTION
Removed unused `using Nethermind.Consensus;` directive from `FundsDistributor.cs`.
