### PR TITLE
Rename EnsRegistrar to Registrar in ChainSpecParamsJson

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainParametersTests.cs
@@ -16,11 +16,9 @@ public class ChainParametersTests
     [Test]
     public void ChainParameters_should_have_same_properties_as_chainSpecParamsJson()
     {
-        string[] chainParametersExceptions = {
-            "Registrar"
-        };
+        string[] chainParametersExceptions = [];
         string[] chainSpecParamsJsonExceptions = {
-            "ChainId", "EnsRegistrar", "NetworkId"
+            "ChainId", "NetworkId"
         };
         IEnumerable<string> chainParametersProperties = typeof(ChainParameters).GetProperties()
             .Where(x => !chainParametersExceptions.Contains(x.Name))

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -101,7 +101,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             MaxCodeSize = chainSpecJson.Params.MaxCodeSize,
             MaxCodeSizeTransition = chainSpecJson.Params.MaxCodeSizeTransition,
             MaxCodeSizeTransitionTimestamp = chainSpecJson.Params.MaxCodeSizeTransitionTimestamp,
-            Registrar = chainSpecJson.Params.EnsRegistrar,
+            Registrar = chainSpecJson.Params.Registrar,
             ForkBlock = chainSpecJson.Params.ForkBlock,
             ForkCanonHash = chainSpecJson.Params.ForkCanonHash,
             Eip7Transition = chainSpecJson.Params.Eip7Transition,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -17,8 +16,7 @@ public class ChainSpecParamsJson
     public ulong? ChainId { get; set; }
     public ulong? NetworkId { get; set; }
 
-    [JsonPropertyName("registrar")]
-    public Address EnsRegistrar { get; set; }
+    public Address Registrar { get; set; }
 
     public long? GasLimitBoundDivisor { get; set; }
 


### PR DESCRIPTION
## Summary

Aligns the property name with `ChainParameters.Registrar`, removing the unnecessary naming exception. The `CamelCase` JSON naming policy already maps `Registrar` to `"registrar"` in JSON, so the explicit `[JsonPropertyName]` attribute was redundant.

## Changes

- Rename `ChainSpecParamsJson.EnsRegistrar` to `Registrar`
- Remove `[JsonPropertyName("registrar")]` attribute and unused `System.Text.Json.Serialization` using
- Update mapping in `ChainSpecLoader.LoadParameters`
- Remove `Registrar`/`EnsRegistrar` from exception lists in `ChainParametersTests`

## Types of changes

- [x] Refactoring

## Testing

- [x] No testing required