### PR TITLE
Fix flaky tests: timing and race condition

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -78,7 +78,7 @@ namespace Nethermind.Network.Test
             ctx.SetupPersistedPeers(1);
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
-            Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1).After(_travisDelay, 10));
+            Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1).After(_delay, 10));
         }
 
         [Test, Retry(3)]
@@ -88,14 +88,14 @@ namespace Nethermind.Network.Test
             ctx.SetupPersistedPeers(50);
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
-            await Task.Delay(_travisDelayLong);
+            await Task.Delay(_delayLong);
 
             int expectedConnectCount = 25;
             Assert.That(
                 () => ctx.RlpxPeer.ConnectAsyncCallsCount,
                 Is
                     .InRange(expectedConnectCount, expectedConnectCount + 1)
-                    .After(_travisDelay * 10, 10));
+                    .After(_delay * 10, 10));
         }
 
         [Test]
@@ -256,11 +256,11 @@ namespace Nethermind.Network.Test
             ctx.SetupPersistedPeers(50);
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
-            await Task.Delay(_travisDelayLong);
+            await Task.Delay(_delayLong);
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.AtLeast(25));
             ctx.DisconnectAllSessions();
 
-            await Task.Delay(_travisDelayLong);
+            await Task.Delay(_delayLong);
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.AtLeast(50));
         }
 
@@ -273,7 +273,7 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
 
-            Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(0).After(_travisDelay, 10));
+            Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(0).After(_delay, 10));
         }
 
         [Test, Retry(3)]
@@ -296,7 +296,7 @@ namespace Nethermind.Network.Test
                 {
                     Assert.That(
                         () => ctx.PeerPool.ActivePeers.Count,
-                        Is.AtLeast(25).After(_travisDelayLonger * 2, 10));
+                        Is.AtLeast(25).After(_delayLonger * 2, 10));
                     ctx.DisconnectAllSessions();
                 }
             }
@@ -318,7 +318,7 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 ctx.DiscoverNew(25);
-                Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(25).After(_travisDelay, 10));
+                Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(25).After(_delay, 10));
             }
         }
 
@@ -334,8 +334,8 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 ctx.DiscoverNew(25);
-                await Task.Delay(_travisDelay);
-                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(25 * (i + 1)).After(1000, 10));
+                await Task.Delay(_delay);
+                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(25 * (i + 1)).After(_delayLonger, 10));
             }
         }
 
@@ -377,13 +377,13 @@ namespace Nethermind.Network.Test
 
             ctx.PeerPool.GetOrAdd(networkNode);
 
-            Assert.That(() => ctx.PeerPool.ActivePeers.Count, Is.EqualTo(0).After(_travisDelay, 10));
+            Assert.That(() => ctx.PeerPool.ActivePeers.Count, Is.EqualTo(0).After(_delay, 10));
         }
 
-        private readonly int _travisDelay = 500;
+        private readonly int _delay = 500;
 
-        private readonly int _travisDelayLong = 1000;
-        private readonly int _travisDelayLonger = 3000;
+        private readonly int _delayLong = 1000;
+        private readonly int _delayLonger = 3000;
 
         [Test]
         [Ignore("Behaviour changed that allows peers to go over max if awaiting response")]
@@ -397,7 +397,7 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 ctx.CreateNewIncomingSessions(25);
-                Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(25).After(_travisDelay, 10));
+                Assert.That(() => ctx.PeerManager.ActivePeers.Count, Is.EqualTo(25).After(_delay, 10));
             }
         }
 
@@ -416,10 +416,10 @@ namespace Nethermind.Network.Test
             {
                 currentCount += 25;
                 maxCount += 50;
-                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(currentCount, maxCount).After(_travisDelayLonger * 2, 10));
+                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(currentCount, maxCount).After(_delayLonger * 2, 10));
                 ctx.RlpxPeer.ConnectAsyncCallsCount.Should().BeInRange(currentCount, maxCount);
                 ctx.HandshakeAllSessions();
-                await Task.Delay(_travisDelay);
+                await Task.Delay(_delay);
                 ctx.DisconnectAllSessions();
             }
 
@@ -448,10 +448,10 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 currentCount += count;
-                await Task.Delay(_travisDelayLong);
+                await Task.Delay(_delayLong);
                 ctx.RlpxPeer.ConnectAsyncCallsCount.Should().BeInRange(currentCount, currentCount + count);
                 ctx.HandshakeAllSessions();
-                await Task.Delay(_travisDelay);
+                await Task.Delay(_delay);
                 ctx.DisconnectAllSessions();
             }
         }
@@ -473,12 +473,12 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 currentCount += count;
-                await Task.Delay(_travisDelayLong);
+                await Task.Delay(_delayLong);
                 ctx.RlpxPeer.ConnectAsyncCallsCount.Should().BeInRange(currentCount, currentCount + count);
                 ctx.HandshakeAllSessions();
-                await Task.Delay(_travisDelay);
+                await Task.Delay(_delay);
                 ctx.CreateIncomingSessions();
-                await Task.Delay(_travisDelay);
+                await Task.Delay(_delay);
                 ctx.DisconnectAllSessions();
             }
         }
@@ -514,7 +514,7 @@ namespace Nethermind.Network.Test
                 ctx.TestNodeSource.AddNode(new Node(TestItem.PublicKeyA, node.Host, node.Port));
             }
 
-            Assert.That(() => ctx.PeerManager.ActivePeers.Count(static p => p.Node.IsStatic), Is.EqualTo(nodesCount).After(_travisDelay, 10));
+            Assert.That(() => ctx.PeerManager.ActivePeers.Count(static p => p.Node.IsStatic), Is.EqualTo(nodesCount).After(_delay, 10));
         }
 
         [Test, Retry(5)]
@@ -527,7 +527,7 @@ namespace Nethermind.Network.Test
             ctx.StaticNodesManager.DiscoverNodes(Arg.Any<CancellationToken>()).Returns(staticNodes.Select(n => new Node(n, true)).ToAsyncEnumerable());
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
-            await Task.Delay(_travisDelay);
+            await Task.Delay(_delay);
 
             void DisconnectHandler(object o, DisconnectEventArgs e) => disconnections++;
             ctx.Sessions.ForEach(s => s.Disconnected += DisconnectHandler);
@@ -548,7 +548,7 @@ namespace Nethermind.Network.Test
             ctx.PeerManager.Start();
             var node = new NetworkNode(ctx.GenerateEnode());
             ctx.PeerPool.GetOrAdd(node);
-            await Task.Delay(_travisDelayLong);
+            await Task.Delay(_delayLong);
 
             void DisconnectHandler(object o, DisconnectEventArgs e) => disconnections++;
             ctx.PeerManager.ActivePeers.Select(p => p.Node.Id).Should().BeEquivalentTo(new[] { node.NodeId });
@@ -570,7 +570,7 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.GetOrAdd(node);
             ctx.PeerPool.GetOrAdd(node);
             ctx.PeerPool.GetOrAdd(node);
-            await Task.Delay(_travisDelayLong);
+            await Task.Delay(_delayLong);
             ctx.PeerManager.ActivePeers.Should().HaveCount(1);
         }
 
@@ -581,7 +581,7 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
             var node = new NetworkNode(ctx.GenerateEnode());
-            Assert.That(() => ctx.PeerPool.TryRemove(node.NodeId, out _), Is.False.After(_travisDelay, 10));
+            Assert.That(() => ctx.PeerPool.TryRemove(node.NodeId, out _), Is.False.After(_delay, 10));
         }
 
         private class Context : IAsyncDisposable

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -666,7 +666,7 @@ public class SyncServerTests
         int count = 0;
         remoteServer
             .When(r => r.AddNewBlock(Arg.Is<Block>(b => b.Hash == remoteBlockTree.Head!.Hash), Arg.Any<ISyncPeer>()))
-            .Do(_ => count++);
+            .Do(_ => Interlocked.Increment(ref count));
         PeerInfo[] peers = Enumerable.Range(0, peerCount).Take(peerCount)
             .Select(_ => new PeerInfo(new SyncPeerMock(remoteBlockTree, remoteSyncServer: remoteServer)))
             .ToArray();


### PR DESCRIPTION
## Changes

- **PeerManagerTests.Will_not_stop_trying_on_rlpx_connection_failure**: Increased `After` timeout from 1000ms to `_travisDelayLonger` (3000ms). On loaded CI runners, 25 connection attempts per batch may not all complete within 1500ms, causing the assertion to see 97/100 instead of 100/100.
- **SyncServerTests.Broadcast_NewBlock_on_arrival_to_sqrt_of_peers**: Replaced `count++` with `Interlocked.Increment(ref count)`. Each `SyncPeerMock` has its own background thread processing a send queue, so when multiple mocks concurrently call `remoteServer.AddNewBlock()`, the non-atomic `count++` can lose increments (observed: 4 instead of expected 5).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

These changes fix existing flaky tests. The tests themselves serve as validation.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)