### PR TITLE
Refactor MemoryExtensions.AsArray overloads to remove duplicate logic

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/MemoryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/MemoryExtensions.cs
@@ -12,13 +12,7 @@ public static class MemoryExtensions
     /// <returns></returns>
     public static byte[] AsArray(this in Memory<byte> memory)
     {
-        if (memory.Length == 0) return Array.Empty<byte>();
-
-        if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment) &&
-            segment.Offset == 0 && segment.Count == segment.Array!.Length
-        ) return segment.Array;
-
-        return memory.Span.ToArray();
+        return AsArray((ReadOnlyMemory<byte>)memory);
     }
 
     public static byte[] AsArray(this in ReadOnlyMemory<byte> memory)
@@ -37,3 +31,4 @@ public static class MemoryExtensions
         memory.Span.Clear();
     }
 }
+


### PR DESCRIPTION


Refactor `MemoryExtensions.AsArray` overloads so that the `Memory<byte>` overload delegates to the `ReadOnlyMemory<byte>` overload instead of duplicating the same logic.
