### PR TITLE
fix: EIP-8024 EXCHANGE off-by-one in TryDecodePair

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -183,10 +183,10 @@ public class Eip8024Tests : VirtualMachineTestsBase
     [Test]
     public void Exchange_HighRangeImmediate_Succeeds()
     {
-        // Test 0xd0: k=160, q=10, r=0, q>=r -> n=r+2=2, m=(29-q)+2=21
-        // Exchange(2, 21) needs 21 items on stack
+        // Test 0xd0: k=160, q=10, r=0, q>=r -> n=r+2=2, m=(29-q)+1=20
+        // Exchange(2, 20) needs 20 items on stack
         Prepare prepare = Prepare.EvmCode;
-        for (int i = 1; i <= 21; i++) prepare.PushData(i);
+        for (int i = 1; i <= 20; i++) prepare.PushData(i);
         byte[] code = prepare
             .Op(Instruction.EXCHANGE).Data(0xd0)
             .MSTORE(0).Return(32, 0)
@@ -194,8 +194,8 @@ public class Eip8024Tests : VirtualMachineTestsBase
 
         TestAllTracerWithOutput result = Execute(code);
         result.StatusCode.Should().Be(StatusCode.Success);
-        // Stack top is 21, which is stored
-        new UInt256(result.ReturnValue, true).Should().Be(21);
+        // Stack top is 20, which is stored
+        new UInt256(result.ReturnValue, true).Should().Be(20);
     }
 
     [Test]
@@ -217,10 +217,10 @@ public class Eip8024Tests : VirtualMachineTestsBase
     [Test]
     public void Exchange_EdgeCase_0x80_Succeeds()
     {
-        // 0x80: k=80 (128-48), q=5, r=0, q>=r -> n=r+2=2, m=(29-5)+2=26
-        // Exchange(2, 26) needs 26 items on stack
+        // 0x80: k=80 (128-48), q=5, r=0, q>=r -> n=r+2=2, m=(29-5)+1=25
+        // Exchange(2, 25) needs 25 items on stack
         Prepare prepare = Prepare.EvmCode;
-        for (int i = 1; i <= 26; i++) prepare.PushData(i);
+        for (int i = 1; i <= 25; i++) prepare.PushData(i);
         byte[] code = prepare
             .Op(Instruction.EXCHANGE).Data(0x80)
             .MSTORE(0).Return(32, 0)
@@ -315,13 +315,13 @@ public class Eip8024Tests : VirtualMachineTestsBase
     public void Exchange_MaxDepth_StackUnderflow()
     {
         Prepare prepare = Prepare.EvmCode;
-        for (int i = 0; i < 30; i++)
+        for (int i = 0; i < 29; i++)
         {
             prepare.PushData(0);
         }
 
         byte[] code = prepare
-            .Op(Instruction.EXCHANGE).Data(0x00) // n=2, m=31 -> needs depth 31
+            .Op(Instruction.EXCHANGE).Data(0x00) // n=2, m=30 -> needs depth 30, only 29 items
             .Done;
 
         TestAllTracerWithOutput result = Execute(code);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -688,9 +688,9 @@ internal static partial class EvmInstructions
         int mask = (q - r) >> 31;
 
         // EIP-8024 base mapping (0-based stack): if (q < r) n=q+1, m=r+1 else n=r+1, m=29-q
-        // Add +1 for 1-indexed stack positions used by Exchange: if (q < r) final_n=q+2, final_m=r+2; else final_n=r+2, final_m=31-q
+        // Add +1 for 1-indexed stack positions used by Exchange: if (q < r) final_n=q+2, final_m=r+2; else final_n=r+2, final_m=30-q
         n = ((q & mask) | (r & ~mask)) + 2;
-        m = ((r & mask) | ((29 - q) & ~mask)) + 2;
+        m = (((r + 1) & mask) | ((29 - q) & ~mask)) + 1;
 
         if ((uint)(imm - 0x50) <= 0x2F)
             return false;


### PR DESCRIPTION
## Summary

- Fix off-by-one bug in `TryDecodePair` that causes EXCHANGE opcode to request one extra stack depth for 91 of 208 valid immediates (all `q >= r` cases)
- This causes spurious `StackUnderflow` errors on fuzz-generated code, leading to `HeaderGasUsedMismatch` and blocking sync on bal-devnet-2

## Root Cause

The branchless `TryDecodePair` in `EvmInstructions.Stack.cs` applies a uniform `+2` offset to both `n` and `m`:

```csharp
n = ((q & mask) | (r & ~mask)) + 2;
m = ((r & mask) | ((29 - q) & ~mask)) + 2;  // BUG: +2 is wrong for q >= r case
```

Per the [EIP-8024 spec](https://eips.ethereum.org/EIPS/eip-8024), `decode_pair` returns:
- `q < r`: `(q+1, r+1)` — both get +1, so Nethermind's 1-indexed +2 is correct ✓
- `q >= r`: `(r+1, 29-q)` — first gets +1, second gets +0. Nethermind's 1-indexed mapping needs `(r+2, 30-q)`, not `(r+2, 31-q)` ✗

This matches [geth's implementation](https://github.com/ethereum/go-ethereum/blob/bal-devnet-2/core/vm/instructions.go#L962-L974) which uses the same asymmetric offsets.

## Fix

```csharp
n = ((q & mask) | (r & ~mask)) + 2;           // unchanged
m = (((r + 1) & mask) | ((29 - q) & ~mask)) + 1;  // fixed
```

When `q < r` (mask=-1): `m = (r+1) + 1 = r+2` ✓  
When `q >= r` (mask=0): `m = (29-q) + 1 = 30-q` ✓

## Impact

Block 10131 on bal-devnet-2 contains a contract creation tx (index 623, hash `0x13e44f26...`) with init code using `EXCHANGE 0xd5`. The buggy decode produces `Exchange(7, 21)` requiring 21 stack items, but only 20 exist → StackUnderflow → all 1,000,000 gas consumed instead of 987,956. The 12,044 gas difference propagates as `HeaderGasUsedMismatch`, blocking Nethermind sync.

## Verification

- All 208 valid EXCHANGE immediates verified against geth's `decodePair` — zero mismatches
- Built local image, joined bal-devnet-2 with checkpoint sync — syncs past block 10131 (previously stuck) to chain head with **zero gas mismatches**

🤖 Generated with [Claude Code](https://claude.com/claude-code)