### PR TITLE
Move tx block-format wrapping logic from BlockDecoder to TxDecoder

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Serialization.Rlp
             int sum = 0;
             for (int i = 0; i < encodedTxs.Length; i++)
             {
-                sum += TxDecoder.GetBlockFormatLength(txs[i].Type, encodedTxs[i].Length);
+                sum += TxDecoder.GetWrappedTxLength(txs[i].Type, encodedTxs[i].Length);
             }
             return sum;
         }
@@ -126,7 +126,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 for (int i = 0; i < encodedTxs.Length; i++)
                 {
-                    TxDecoder.WriteBlockFormat(stream, item.Transactions[i].Type, encodedTxs[i]);
+                    TxDecoder.WriteWrappedFormat(stream, item.Transactions[i].Type, encodedTxs[i]);
                 }
             }
             else

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -30,14 +30,14 @@ public sealed class TxDecoder : TxDecoder<Transaction>
     /// Legacy txs use the same format; typed txs are wrapped in an RLP byte string.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int GetBlockFormatLength(TxType type, int clEncodedLength)
+    public static int GetWrappedTxLength(TxType type, int clEncodedLength)
         => type == TxType.Legacy ? clEncodedLength : Rlp.LengthOfSequence(clEncodedLength);
 
     /// <summary>
     /// Writes a pre-encoded CL-format transaction in block format.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void WriteBlockFormat(RlpStream stream, TxType type, byte[] clEncoded)
+    public static void WriteWrappedFormat(RlpStream stream, TxType type, byte[] clEncoded)
     {
         if (type != TxType.Legacy)
             stream.StartByteArray(clEncoded.Length, false);


### PR DESCRIPTION
## Changes

- Extract the legacy-vs-typed tx wrapping knowledge into static helpers on TxDecoder (GetBlockFormatLength, WriteBlockFormat) so BlockDecoder no longer directly checks TxType.Legacy for encoding decisions.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No
