### PR TITLE
fix(network): use TrySetResult in MessageQueue.Handle to prevent race condition

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
@@ -58,7 +58,7 @@ public class MessageQueueTests
         Request<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> request1 = CreateRequest();
         Request<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> request2 = CreateRequest();
 
-        using IOwnedReadOnlyList<BlockHeader> response = new[] { Build.A.BlockHeader.TestObject }.ToPooledList();
+        IOwnedReadOnlyList<BlockHeader> response = new[] { Build.A.BlockHeader.TestObject }.ToPooledList();
 
         _queue.Send(request1);
         _queue.Send(request2);
@@ -149,7 +149,7 @@ public class MessageQueueTests
     }
 
     [Test]
-    public void Send_disposes_message_when_closed()
+    public void Send_does_not_send_when_closed()
     {
         _queue.CompleteAdding();
 

--- a/src/Nethermind/Nethermind.Network/P2P/MessageQueue.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/MessageQueue.cs
@@ -47,21 +47,14 @@ namespace Nethermind.Network.P2P
             {
                 if (_currentRequest is null)
                 {
-                    if (data is IDisposable d)
-                    {
-                        d.Dispose();
-                    }
-
+                    data.TryDispose();
                     throw new SubprotocolException($"Received a response to {nameof(TMsg)} that has not been requested");
                 }
 
                 _currentRequest.ResponseSize = size;
                 if (!_currentRequest.CompletionSource.TrySetResult(data))
                 {
-                    if (data is IDisposable d)
-                    {
-                        d.Dispose();
-                    }
+                    data.TryDispose();
                 }
                 if (_requestQueue.TryDequeue(out _currentRequest))
                 {


### PR DESCRIPTION
`MessageQueue.Handle()`https://github.com/NethermindEth/nethermind/blob/825bff45ad4e811c08f3f2d00c9d343080e85640/src/Nethermind/Nethermind.Network/P2P/MessageQueue.cs#L44-L73 used `SetResult` on the request's `TaskCompletionSource`.
If a response arrived after the 10s timeout in `HandleResponseInner`https://github.com/NethermindEth/nethermind/blob/825bff45ad4e811c08f3f2d00c9d343080e85640/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs#L62-L105 had already called `TrySetCanceled`, `SetResult` threw `InvalidOperationException` because the TCS was already in a terminal state. This permanently broke the queue: `_currentRequest` was never advanced, all subsequent requests piled up unsent, and the peer got disconnected by the DotNetty exception handler.

The analogous` [MessageDictionary`https://github.com/NethermindEth/nethermind/blob/825bff45ad4e811c08f3f2d00c9d343080e85640/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs#L17-L106 (Eth66) already uses `TrySetResult` correctly.

Replaced `SetResult` with `TrySetResult`. When it returns false (TCS already cancelled by timeout), dispose the response data to avoid pooled memory leaks. Added `MessageQueueTests` covering the race scenario and basic queue behavior.