### PR TITLE
Fix Kute Windows performance: disable proxy detection, fix file check

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/Program.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Program.cs
@@ -59,7 +59,7 @@ public static class Program
         collection.AddSingleton<ISystemClock, RealSystemClock>();
         collection.AddSingleton<HttpClient>(_ =>
         {
-            // Disable proxy auto-detection to avoid WPAD timeout (~2s) on Windows.
+            // Disable proxy auto-detection to avoid timeout (~2s) on Windows.
             // Each Kute invocation is a separate process, so the proxy lookup
             // would otherwise be paid on every single measured request.
             var handler = new SocketsHttpHandler


### PR DESCRIPTION
- Disable WPAD proxy auto-detection in HttpClient by using SocketsHttpHandler with UseProxy=false. On Windows, the default HttpClient triggers a WPAD lookup (~2s timeout) on every fresh process, inflating measured NP times by ~2000ms.
- Fix FileMessageProvider to use pathInfo.Exists instead of HasFlag(FileAttributes.Normal). On Windows, files have Archive attribute, not Normal, causing all file reads to fail.

<img width="433" height="122" alt="image" src="https://github.com/user-attachments/assets/0303257f-9318-4c1f-bcc9-d6903b3a3394" />


Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
