### PR TITLE
fix: unsubscribe from BlocksProcessing in Dispose

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
@@ -345,6 +345,7 @@ namespace Nethermind.Consensus.AuRa
         public void Dispose()
         {
             _branchProcessor.BlockProcessed -= OnBlockProcessed;
+            _branchProcessor.BlocksProcessing -= OnBlocksProcessing;
         }
 
         [DebuggerDisplay("Count = {Count}")]


### PR DESCRIPTION
AuRaBlockFinalizationManager subscribes to both BlockProcessed and BlocksProcessing
events but previously unsubscribed only from BlockProcessed. Ensure all handlers are unsubscribed in Dispose().
