### PR TITLE
Optimize Kestrel socket transport for lower-latency JSON-RPC dispatch

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -71,6 +72,12 @@ public class Startup : IStartup
                 listenOptions.Protocols = HttpProtocols.Http1;
                 listenOptions.DisableAltSvcHeader = true;
             });
+        });
+        services.Configure<SocketTransportOptions>(options =>
+        {
+            options.IOQueueCount = 0;
+            options.WaitForDataBeforeAllocatingBuffer = false;
+            options.UnsafePreferInlineScheduling = true;
         });
         Bootstrap.Instance.RegisterJsonRpcServices(services);
 

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -42,6 +42,10 @@ using DotNettyLoggerFactory = DotNetty.Common.Internal.Logging.InternalLoggerFac
 using DotNettyLeakDetector = DotNetty.Common.ResourceLeakDetector;
 #endif
 
+// Inline socket I/O completions to reduce thread-pool hops on the networking hot path.
+// Must be set before any socket usage so SocketAsyncEngine picks it up during static init.
+Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS", "1");
+
 DataFeed.StartTime = Environment.TickCount64;
 Console.Title = ProductInfo.Name;
 // Increase regex cache size as more added in log coloring matches


### PR DESCRIPTION
## Changes

- Configure `SocketTransportOptions` on the JSON-RPC Kestrel server to reduce thread hops and allocation overhead:
- `IOQueueCount = 0` — schedule I/O directly on the ThreadPool instead of dedicated queues
- `WaitForDataBeforeAllocatingBuffer = false` — pre-allocate read buffers for lower first-byte latency
- `UnsafePreferInlineScheduling = true` — run application continuations on the I/O thread
- Set `DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS=1` at process startup so the runtime inlines socket completions on
the epoll/IOCP thread instead of queuing to the ThreadPool

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Needs profiling under realistic JSON-RPC load (Engine API + public RPC) to measure latency/throughput improvement and
verify no regressions. `UnsafePreferInlineScheduling` can degrade performance if any handler does expensive synchronous
work — the Engine API fast lane and standard RPC paths are async I/O–bound so should benefit, but this should be
validated under load.

`DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS` is process-wide and also affects p2p networking (DotNetty). Verify no
adverse effects on devp2p sync performance.

