### PR TITLE
fix: false positive 'caches Rlp are not empty' warning on low-tx blocks

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -84,8 +84,6 @@ public sealed class BlockCachePreWarmer(
     {
         if (_logger.IsDebug) _logger.Debug("Clearing caches");
         CacheType cachesCleared = preBlockCaches?.ClearCaches() ?? default;
-
-        nodeStorageCache.Enabled = false;
         cachesCleared |= nodeStorageCache.ClearCaches() ? CacheType.Rlp : CacheType.None;
         if (_logger.IsDebug) _logger.Debug($"Cleared caches: {cachesCleared}");
         return cachesCleared;

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -28,7 +28,9 @@ public sealed class NodeStorageCache
 
     public bool ClearCaches()
     {
+        bool wasEnabled = _enabled;
+        _enabled = false;
         _cache.Clear();
-        return true;
+        return wasEnabled;
     }
 }


### PR DESCRIPTION
## Changes

  - `NodeStorageCache.ClearCaches()` unconditionally returned `true`, causing the "Low txs, caches Rlp are not empty.  Clearing them." warning to fire on every block with fewer than 3 transactions, regardless of whether the cache was actually dirty
  - `ClearCaches()` now captures `_enabled` before resetting it, returning `wasEnabled` as a proxy for whether the cache was in use
  - `ClearCaches()` takes ownership of setting `Enabled = false`, removing the redundant assignment in
  `BlockCachePreWarmer.ClearCaches()`
  
## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No