### PR TITLE
fix: add pruned state checks to debug_standardTrace*ToFile endpoints

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -35,11 +35,11 @@ namespace Nethermind.JsonRpc.Test.Modules;
 [Parallelizable(ParallelScope.Self)]
 public class DebugModuleTests
 {
-    private readonly IJsonRpcConfig jsonRpcConfig = new JsonRpcConfig();
-    private readonly ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-    private readonly IDebugBridge debugBridge = Substitute.For<IDebugBridge>();
-    private readonly IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-    private readonly IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
+    private readonly IJsonRpcConfig _jsonRpcConfig = new JsonRpcConfig();
+    private readonly ISpecProvider _specProvider = Substitute.For<ISpecProvider>();
+    private readonly IDebugBridge _debugBridge = Substitute.For<IDebugBridge>();
+    private readonly IBlockFinder _blockFinder = Substitute.For<IBlockFinder>();
+    private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
     private DebugRpcModule CreateDebugRpcModule(IDebugBridge customDebugBridge)
@@ -47,38 +47,35 @@ public class DebugModuleTests
         return new(
             LimboLogs.Instance,
             customDebugBridge,
-            jsonRpcConfig,
-            specProvider,
-            blockchainBridge,
+            _jsonRpcConfig,
+            _specProvider,
+            _blockchainBridge,
             new BlocksConfig(),
-            blockFinder
+            _blockFinder
         );
     }
 
     [Test]
     public async Task Get_from_db()
     {
-        byte[] key = new byte[] { 1, 2, 3 };
-        byte[] value = new byte[] { 4, 5, 6 };
-        debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns(value);
+        byte[] key = [1, 2, 3];
+        byte[] value = [4, 5, 6];
+        _debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns(value);
         _ = Substitute.For<IConfigProvider>();
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
-        using var response =
-            await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as JsonRpcSuccessResponse;
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as JsonRpcSuccessResponse;
 
-        byte[]? result = response?.Result as byte[];
+        Assert.That(response, Is.Not.Null);
     }
 
     [Test]
     public async Task Get_from_db_null_value()
     {
-        debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns((byte[])null!);
+        _debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns((byte[])null!);
         _ = Substitute.For<IConfigProvider>();
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
-        byte[] key = new byte[] { 1, 2, 3 };
-        using var response =
-            await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as
-                JsonRpcSuccessResponse;
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        byte[] key = [1, 2, 3];
+        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFromDb", "STATE", key) as JsonRpcSuccessResponse;
 
         Assert.That(response, Is.Not.Null);
     }
@@ -87,18 +84,11 @@ public class DebugModuleTests
     [TestCase(0x1)]
     public async Task Get_chain_level(object parameter)
     {
-        debugBridge.GetLevelInfo(1).Returns(
-            new ChainLevelInfo(
-                true,
-                new[]
-                {
-                    new BlockInfo(TestItem.KeccakA, 1000),
-                    new BlockInfo(TestItem.KeccakB, 1001),
-                }));
+        _debugBridge.GetLevelInfo(1).Returns(new ChainLevelInfo(true, new BlockInfo(TestItem.KeccakA, 1000), new BlockInfo(TestItem.KeccakB, 1001)));
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getChainLevel", parameter) as JsonRpcSuccessResponse;
-        var chainLevel = response?.Result as ChainLevelForRpc;
+        ChainLevelForRpc? chainLevel = response?.Result as ChainLevelForRpc;
         Assert.That(chainLevel, Is.Not.Null);
         Assert.That(chainLevel?.HasBlockOnMainChain, Is.EqualTo(true));
         Assert.That(chainLevel?.BlockInfos.Length, Is.EqualTo(2));
@@ -109,9 +99,9 @@ public class DebugModuleTests
     {
         BlockDecoder decoder = new();
         Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
-        debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).Returns(rlp.Bytes);
+        _debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).Returns(rlp.Bytes);
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcSuccessResponse;
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
@@ -122,15 +112,16 @@ public class DebugModuleTests
         HeaderDecoder decoder = new();
         Block blk = Build.A.Block.WithNumber(0).TestObject;
         Rlp rlp = decoder.Encode(blk.Header);
-        debugBridge.GetBlock(new BlockParameter((long)0)).Returns(blk);
+        _debugBridge.GetBlock(new BlockParameter((long)0)).Returns(blk);
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawHeader", "0x") as JsonRpcSuccessResponse;
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
-    [Test]
-    public async Task Get_block_rlp()
+    [TestCase("debug_getBlockRlp", 1)]
+    [TestCase("debug_getRawBlock", "0x1")]
+    public async Task Get_block_rlp(string method, object parameter)
     {
         BlockDecoder decoder = new();
         IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
@@ -138,21 +129,7 @@ public class DebugModuleTests
         localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(localDebugBridge);
-        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", 1) as JsonRpcSuccessResponse;
-
-        Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
-    }
-
-    [Test]
-    public async Task Get_rawblock()
-    {
-        BlockDecoder decoder = new();
-        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
-        Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
-        localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
-
-        DebugRpcModule rpcModule = CreateDebugRpcModule(localDebugBridge);
-        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", "0x1") as JsonRpcSuccessResponse;
+        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, method, parameter) as JsonRpcSuccessResponse;
 
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
@@ -171,24 +148,14 @@ public class DebugModuleTests
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
-    [Test]
-    public async Task Get_block_rlp_when_missing()
+    [TestCase("debug_getBlockRlp", 1)]
+    [TestCase("debug_getRawBlock", "0x1")]
+    public async Task Get_block_rlp_when_missing(string method, object parameter)
     {
-        debugBridge.GetBlockRlp(new BlockParameter(1)).ReturnsNull();
+        _debugBridge.GetBlockRlp(new BlockParameter(1)).ReturnsNull();
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
-        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", 1) as JsonRpcErrorResponse;
-
-        Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.ResourceNotFound));
-    }
-
-    [Test]
-    public async Task Get_rawblock_when_missing()
-    {
-        debugBridge.GetBlockRlp(new BlockParameter(1)).ReturnsNull();
-
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
-        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", "0x1") as JsonRpcErrorResponse;
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, method, parameter) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.ResourceNotFound));
     }
@@ -196,11 +163,9 @@ public class DebugModuleTests
     [Test]
     public async Task Get_block_rlp_by_hash_when_missing()
     {
-        BlockDecoder decoder = new();
-        _ = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
-        debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).ReturnsNull();
+        _debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).ReturnsNull();
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         using var response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.ResourceNotFound));
@@ -234,12 +199,12 @@ public class DebugModuleTests
         BlockDecoder decoder = new();
         _blocksDb.Set(block1.Hash ?? new Hash256("0x0"), decoder.Encode(block1).Bytes);
 
-        debugBridge.GetBadBlocks().Returns(badBlocksStore.GetAll());
+        _debugBridge.GetBadBlocks().Returns(badBlocksStore.GetAll());
 
         AddBlockResult result = blockTree.SuggestBlock(block1);
         Assert.That(result, Is.EqualTo(AddBlockResult.InvalidBlock));
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         ResultWrapper<IEnumerable<BadBlock>> blocks = rpcModule.debug_getBadBlocks();
         Assert.That(blocks.Data.Count, Is.EqualTo(1));
         Assert.That(blocks.Data.ElementAt(0).Hash, Is.EqualTo(block1.Hash));
@@ -249,25 +214,24 @@ public class DebugModuleTests
     [Test]
     public void Debug_traceCall_test()
     {
-        GethTxTraceEntry entry = new();
-
-        entry.Storage = new Dictionary<string, string>
+        GethTxTraceEntry entry = new()
         {
-            {"1".PadLeft(64, '0'), "2".PadLeft(64, '0')},
-            {"3".PadLeft(64, '0'), "4".PadLeft(64, '0')},
+            Storage = new Dictionary<string, string>
+            {
+                {"1".PadLeft(64, '0'), "2".PadLeft(64, '0')},
+                {"3".PadLeft(64, '0'), "4".PadLeft(64, '0')},
+            },
+            Memory =
+            [
+                "5".PadLeft(64, '0'),
+                "6".PadLeft(64, '0')
+            ],
+            Stack = [],
+            Opcode = "STOP",
+            Gas = 22000,
+            GasCost = 1,
+            Depth = 1
         };
-
-        entry.Memory = new string[]
-        {
-            "5".PadLeft(64, '0'),
-            "6".PadLeft(64, '0')
-        };
-
-        entry.Stack = [];
-        entry.Opcode = "STOP";
-        entry.Gas = 22000;
-        entry.GasCost = 1;
-        entry.Depth = 1;
 
         var trace = new GethLikeTxTrace();
         trace.ReturnValue = Bytes.FromHexString("a2");
@@ -276,36 +240,35 @@ public class DebugModuleTests
         GethTraceOptions gtOptions = new();
 
         Transaction transaction = Build.A.Transaction.WithTo(TestItem.AddressA).WithHash(TestItem.KeccakA).TestObject;
-        TransactionForRpc txForRpc = TransactionForRpc.FromTransaction(transaction);
 
-        debugBridge.GetTransactionTrace(Arg.Any<Transaction>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
-        blockFinder.Head.Returns(Build.A.Block.WithNumber(1).TestObject);
-        blockFinder.FindHeader(Arg.Any<Hash256>(), Arg.Any<BlockTreeLookupOptions>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
-        blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
-        blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+        _debugBridge.GetTransactionTrace(Arg.Any<Transaction>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>()).Returns(trace);
+        _blockFinder.Head.Returns(Build.A.Block.WithNumber(1).TestObject);
+        _blockFinder.FindHeader(Arg.Any<Hash256>(), Arg.Any<BlockTreeLookupOptions>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
+        _blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(Build.A.BlockHeader.WithNumber(1).TestObject);
+        _blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
-        ResultWrapper<GethLikeTxTrace> debugTraceCall = rpcModule.debug_traceCall(txForRpc, null, gtOptions);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<GethLikeTxTrace> debugTraceCall = rpcModule.debug_traceCall(TransactionForRpc.FromTransaction(transaction), null, gtOptions);
         var expected = ResultWrapper<GethLikeTxTrace>.Success(
-            new GethLikeTxTrace()
+            new GethLikeTxTrace
             {
                 Failed = false,
-                Entries = new List<GethTxTraceEntry>()
-                {
-                    new GethTxTraceEntry()
+                Entries =
+                [
+                    new GethTxTraceEntry
                     {
                         Gas = 22000,
                         GasCost = 1,
                         Depth = 1,
-                        Memory = new string[]
-                        {
+                        Memory =
+                        [
                             "0000000000000000000000000000000000000000000000000000000000000005",
                             "0000000000000000000000000000000000000000000000000000000000000006"
-                        },
+                        ],
                         Opcode = "STOP",
                         ProgramCounter = 0,
                         Stack = [],
-                        Storage = new Dictionary<string, string>()
+                        Storage = new Dictionary<string, string>
                         {
                             {
                                 "0000000000000000000000000000000000000000000000000000000000000001",
@@ -317,9 +280,9 @@ public class DebugModuleTests
                             },
                         }
                     }
-                },
+                ],
                 Gas = 0,
-                ReturnValue = new byte[] { 162 }
+                ReturnValue = [162]
             }
         );
 
@@ -329,8 +292,8 @@ public class DebugModuleTests
     [Test]
     public async Task Migrate_receipts()
     {
-        debugBridge.MigrateReceipts(Arg.Any<long>(), Arg.Any<long>()).Returns(true);
-        IDebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        _debugBridge.MigrateReceipts(Arg.Any<long>(), Arg.Any<long>()).Returns(true);
+        IDebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         string response = await RpcTest.TestSerializedRequest(rpcModule, "debug_migrateReceipts", 100);
         Assert.That(response, Is.Not.Null);
     }
@@ -338,116 +301,78 @@ public class DebugModuleTests
     [Test]
     public async Task Update_head_block()
     {
-        debugBridge.UpdateHeadBlock(Arg.Any<Hash256>());
-        IDebugRpcModule rpcModule = CreateDebugRpcModule(debugBridge);
+        _debugBridge.UpdateHeadBlock(Arg.Any<Hash256>());
+        IDebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         await RpcTest.TestSerializedRequest(rpcModule, "debug_resetHead", TestItem.KeccakA);
-        debugBridge.Received().UpdateHeadBlock(TestItem.KeccakA);
+        _debugBridge.Received().UpdateHeadBlock(TestItem.KeccakA);
     }
 
-    [Test]
-    public void StandardTraceBlockToFile()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void StandardTraceBlockToFile(bool isBadBlock)
     {
-        var blockHash = Keccak.EmptyTreeHash;
+        Hash256 blockHash = Keccak.EmptyTreeHash;
 
         static IEnumerable<string> GetFileNames(Hash256 hash) =>
             new[] { $"block_{hash.ToShortString()}-0", $"block_{hash.ToShortString()}-1" };
 
-        var header = Build.A.BlockHeader.WithHash(blockHash).TestObject;
-        blockFinder.FindHeader(blockHash).Returns(header);
-        blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+        BlockHeader header = Build.A.BlockHeader.WithHash(blockHash).TestObject;
+        _blockFinder.FindHeader(blockHash).Returns(header);
+        _blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
 
-        debugBridge
-            .TraceBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
-            .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
+        if (isBadBlock)
+        {
+            _debugBridge
+                .TraceBadBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
+        }
+        else
+        {
+            _debugBridge
+                .TraceBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
+        }
 
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBlockToFile(blockHash);
-        var expected = ResultWrapper<IEnumerable<string>>.Success(GetFileNames(blockHash));
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IEnumerable<string>> actual = isBadBlock
+            ? rpcModule.debug_standardTraceBadBlockToFile(blockHash)
+            : rpcModule.debug_standardTraceBlockToFile(blockHash);
 
-        actual.Should().BeEquivalentTo(expected);
+        actual.Should().BeEquivalentTo(ResultWrapper<IEnumerable<string>>.Success(GetFileNames(blockHash)));
     }
 
-    [Test]
-    public void StandardTraceBadBlockToFile()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void StandardTraceBlockToFile_returns_error_when_missing_block(bool isBadBlock)
     {
-        var blockHash = Keccak.EmptyTreeHash;
+        Hash256 blockHash = TestItem.KeccakA;
 
-        static IEnumerable<string> GetFileNames(Hash256 hash) =>
-            new[] { $"block_{hash.ToShortString()}-0", $"block_{hash.ToShortString()}-1" };
+        _blockFinder.FindHeader(blockHash).ReturnsNull();
 
-        var header = Build.A.BlockHeader.WithHash(blockHash).TestObject;
-        blockFinder.FindHeader(blockHash).Returns(header);
-        blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
-
-        debugBridge
-            .TraceBadBlockToFile(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
-            .Returns(static c => GetFileNames(c.ArgAt<Hash256>(0)));
-
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBadBlockToFile(blockHash);
-        var expected = ResultWrapper<IEnumerable<string>>.Success(GetFileNames(blockHash));
-
-        actual.Should().BeEquivalentTo(expected);
-    }
-
-    [Test]
-    public void StandardTraceBlockToFile_returns_error_when_missing_block()
-    {
-        var blockHash = TestItem.KeccakA;
-
-        blockFinder.FindHeader(blockHash).ReturnsNull();
-
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBlockToFile(blockHash);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IEnumerable<string>> actual = isBadBlock
+            ? rpcModule.debug_standardTraceBadBlockToFile(blockHash)
+            : rpcModule.debug_standardTraceBlockToFile(blockHash);
 
         actual.Result.ResultType.Should().Be(ResultType.Failure);
         actual.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
         actual.Result.Error.Should().Contain("Cannot find header");
     }
 
-    [Test]
-    public void StandardTraceBlockToFile_returns_error_when_state_unavailable()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void StandardTraceBlockToFile_returns_error_when_state_unavailable(bool isBadBlock)
     {
-        var blockHash = TestItem.KeccakA;
-        var header = Build.A.BlockHeader.WithHash(blockHash).WithNumber(100).TestObject;
+        Hash256 blockHash = TestItem.KeccakA;
+        BlockHeader header = Build.A.BlockHeader.WithHash(blockHash).WithNumber(100).TestObject;
 
-        blockFinder.FindHeader(blockHash).Returns(header);
-        blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(false);
+        _blockFinder.FindHeader(blockHash).Returns(header);
+        _blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(false);
 
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBlockToFile(blockHash);
-
-        actual.Result.ResultType.Should().Be(ResultType.Failure);
-        actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);
-        actual.Result.Error.Should().Contain("No state available");
-    }
-
-    [Test]
-    public void StandardTraceBadBlockToFile_returns_error_when_missing_block()
-    {
-        var blockHash = TestItem.KeccakA;
-
-        blockFinder.FindHeader(blockHash).ReturnsNull();
-
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBadBlockToFile(blockHash);
-
-        actual.Result.ResultType.Should().Be(ResultType.Failure);
-        actual.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
-        actual.Result.Error.Should().Contain("Cannot find header");
-    }
-
-    [Test]
-    public void StandardTraceBadBlockToFile_returns_error_when_state_unavailable()
-    {
-        var blockHash = TestItem.KeccakA;
-        var header = Build.A.BlockHeader.WithHash(blockHash).WithNumber(100).TestObject;
-
-        blockFinder.FindHeader(blockHash).Returns(header);
-        blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(false);
-
-        var rpcModule = CreateDebugRpcModule(debugBridge);
-        var actual = rpcModule.debug_standardTraceBadBlockToFile(blockHash);
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IEnumerable<string>> actual = isBadBlock
+            ? rpcModule.debug_standardTraceBadBlockToFile(blockHash)
+            : rpcModule.debug_standardTraceBlockToFile(blockHash);
 
         actual.Result.ResultType.Should().Be(ResultType.Failure);
         actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -41,10 +41,9 @@ public class DebugRpcModule(
     private readonly BlockDecoder _blockDecoder = new();
     private readonly ulong _secondsPerSlot = blocksConfig.SecondsPerSlot;
 
-
     public ResultWrapper<ChainLevelForRpc> debug_getChainLevel(in long number)
     {
-        ChainLevelInfo levelInfo = debugBridge.GetLevelInfo(number);
+        ChainLevelInfo? levelInfo = debugBridge.GetLevelInfo(number);
         return levelInfo is null
             ? ResultWrapper<ChainLevelForRpc>.Fail($"Chain level {number} does not exist", ErrorCodes.ResourceNotFound)
             : ResultWrapper<ChainLevelForRpc>.Success(new ChainLevelForRpc(levelInfo));
@@ -63,7 +62,7 @@ public class DebugRpcModule(
             return ResultWrapper<GethLikeTxTrace>.Fail($"Cannot find block hash for transaction {transactionHash}", ErrorCodes.ResourceNotFound);
         }
 
-        var header = TryGetHeaderAndCheckState<GethLikeTxTrace>(blockHash!, out var headerError);
+        TryGetHeaderAndCheckState(blockHash!, out ResultWrapper<GethLikeTxTrace>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -85,14 +84,14 @@ public class DebugRpcModule(
     {
         blockParameter ??= BlockParameter.Latest;
 
-        var header = TryGetHeaderAndCheckState<GethLikeTxTrace>(blockParameter, out var headerError);
+        BlockHeader? header = TryGetHeaderAndCheckState(blockParameter, out ResultWrapper<GethLikeTxTrace>? headerError);
         if (headerError is not null)
         {
             return headerError;
         }
 
         // default to previous block gas if unspecified
-        call.Gas ??= header.GasLimit;
+        call.Gas ??= header!.GasLimit;
 
         // enforces gas cap
         call.EnsureDefaults(jsonRpcConfig.GasCap);
@@ -118,7 +117,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<GethLikeTxTrace> debug_traceTransactionByBlockhashAndIndex(Hash256 blockhash, int index, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<GethLikeTxTrace>(blockhash, out var headerError);
+        TryGetHeaderAndCheckState(blockhash, out ResultWrapper<GethLikeTxTrace>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -126,7 +125,7 @@ public class DebugRpcModule(
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
-        var transactionTrace = debugBridge.GetTransactionTrace(blockhash, index, cancellationToken, options);
+        GethLikeTxTrace? transactionTrace = debugBridge.GetTransactionTrace(blockhash, index, cancellationToken, options);
         if (transactionTrace is null)
         {
             return ResultWrapper<GethLikeTxTrace>.Fail($"Cannot find transactionTrace {blockhash}", ErrorCodes.ResourceNotFound);
@@ -138,7 +137,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<GethLikeTxTrace> debug_traceTransactionByBlockAndIndex(BlockParameter blockParameter, int index, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<GethLikeTxTrace>(blockParameter, out var headerError);
+        TryGetHeaderAndCheckState(blockParameter, out ResultWrapper<GethLikeTxTrace>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -152,7 +151,7 @@ public class DebugRpcModule(
             throw new InvalidDataException("Block number value incorrect");
         }
 
-        var transactionTrace = debugBridge.GetTransactionTrace(blockNo.Value, index, cancellationToken, options);
+        GethLikeTxTrace? transactionTrace = debugBridge.GetTransactionTrace(blockNo.Value, index, cancellationToken, options);
         if (transactionTrace is null)
         {
             return ResultWrapper<GethLikeTxTrace>.Fail($"Cannot find transactionTrace {blockNo}", ErrorCodes.ResourceNotFound);
@@ -164,7 +163,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<GethLikeTxTrace> debug_traceTransactionInBlockByHash(byte[] blockRlp, Hash256 transactionHash, GethTraceOptions options = null)
     {
-        var block = TryGetBlockAndCheckState<GethLikeTxTrace>(new Rlp(blockRlp), out var blockError);
+        Block? block = TryGetBlockAndCheckState(new Rlp(blockRlp), out ResultWrapper<GethLikeTxTrace>? blockError);
         if (blockError is not null)
         {
             return blockError;
@@ -172,7 +171,7 @@ public class DebugRpcModule(
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
-        var transactionTrace = debugBridge.GetTransactionTrace(block, transactionHash, cancellationToken, options);
+        GethLikeTxTrace? transactionTrace = debugBridge.GetTransactionTrace(block, transactionHash, cancellationToken, options);
         if (transactionTrace is null)
         {
             return ResultWrapper<GethLikeTxTrace>.Fail($"Trace is null for RLP {blockRlp.ToHexString()} and transactionTrace hash {transactionHash}", ErrorCodes.ResourceNotFound);
@@ -183,7 +182,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<GethLikeTxTrace> debug_traceTransactionInBlockByIndex(byte[] blockRlp, int txIndex, GethTraceOptions options = null)
     {
-        var block = TryGetBlockAndCheckState<GethLikeTxTrace>(new Rlp(blockRlp), out var blockError);
+        Block? block = TryGetBlockAndCheckState(new Rlp(blockRlp), out ResultWrapper<GethLikeTxTrace>? blockError);
         if (blockError is not null)
         {
             return blockError;
@@ -191,8 +190,8 @@ public class DebugRpcModule(
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
-        var blockTrace = debugBridge.GetBlockTrace(block, cancellationToken, options);
-        var transactionTrace = blockTrace?.ElementAtOrDefault(txIndex);
+        IReadOnlyCollection<GethLikeTxTrace>? blockTrace = debugBridge.GetBlockTrace(block, cancellationToken, options);
+        GethLikeTxTrace? transactionTrace = blockTrace?.ElementAtOrDefault(txIndex);
         if (transactionTrace is null)
         {
             return ResultWrapper<GethLikeTxTrace>.Fail($"Trace is null for RLP {blockRlp.ToHexString()} and transaction index {txIndex}", ErrorCodes.ResourceNotFound);
@@ -212,7 +211,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null)
     {
-        var block = TryGetBlockAndCheckState<IReadOnlyCollection<GethLikeTxTrace>>(new Rlp(blockRlp), out var blockError);
+        Block? block = TryGetBlockAndCheckState(new Rlp(blockRlp), out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? blockError);
         if (blockError is not null)
         {
             return blockError;
@@ -222,7 +221,7 @@ public class DebugRpcModule(
         CancellationToken cancellationToken = timeout.Token;
         try
         {
-            var blockTrace = debugBridge.GetBlockTrace(block, cancellationToken, options);
+            IReadOnlyCollection<GethLikeTxTrace>? blockTrace = debugBridge.GetBlockTrace(block, cancellationToken, options);
 
             if (blockTrace is null)
                 return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail($"Trace is null for RLP {blockRlp.ToHexString()}", ErrorCodes.ResourceNotFound);
@@ -243,7 +242,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByNumber(BlockParameter blockNumber, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<IReadOnlyCollection<GethLikeTxTrace>>(blockNumber, out var headerError);
+        TryGetHeaderAndCheckState(blockNumber, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -271,7 +270,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByHash(Hash256 blockHash, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<IReadOnlyCollection<GethLikeTxTrace>>(blockHash, out var headerError);
+        TryGetHeaderAndCheckState<IReadOnlyCollection<GethLikeTxTrace>>(blockHash, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -311,27 +310,11 @@ public class DebugRpcModule(
         throw new NotImplementedException();
     }
 
-    public ResultWrapper<byte[]> debug_getBlockRlp(long blockNumber)
-    {
-        byte[] rlp = debugBridge.GetBlockRlp(new BlockParameter(blockNumber));
-        if (rlp is null)
-        {
-            return ResultWrapper<byte[]>.Fail($"Block {blockNumber} was not found", ErrorCodes.ResourceNotFound);
-        }
+    public ResultWrapper<byte[]> debug_getBlockRlp(long blockNumber) =>
+        GetBlockRlpOrFail(new BlockParameter(blockNumber));
 
-        return ResultWrapper<byte[]>.Success(rlp);
-    }
-
-    public ResultWrapper<byte[]> debug_getBlockRlpByHash(Hash256 hash)
-    {
-        byte[] rlp = debugBridge.GetBlockRlp(new BlockParameter(hash));
-        if (rlp is null)
-        {
-            return ResultWrapper<byte[]>.Fail($"Block {hash} was not found", ErrorCodes.ResourceNotFound);
-        }
-
-        return ResultWrapper<byte[]>.Success(rlp);
-    }
+    public ResultWrapper<byte[]> debug_getBlockRlpByHash(Hash256 hash) =>
+        GetBlockRlpOrFail(new BlockParameter(hash));
 
     public ResultWrapper<MemStats> debug_memStats(BlockParameter blockParameter)
     {
@@ -395,28 +378,21 @@ public class DebugRpcModule(
         RlpBehaviors behavior =
             (specProvider.GetReceiptSpec(receipts[0].BlockNumber).IsEip658Enabled ?
                 RlpBehaviors.Eip658Receipts : RlpBehaviors.None) | RlpBehaviors.SkipTypedWrapping;
-        var rlp = receipts.Select(tx => Rlp.Encode(tx, behavior).Bytes);
+        IEnumerable<byte[]>? rlp = receipts.Select(tx => Rlp.Encode(tx, behavior).Bytes);
         return ResultWrapper<byte[][]>.Success(rlp.ToArray());
     }
 
-    public ResultWrapper<byte[]> debug_getRawBlock(BlockParameter blockParameter)
-    {
-        var blockRLP = debugBridge.GetBlockRlp(blockParameter);
-        if (blockRLP is null)
-        {
-            return ResultWrapper<byte[]>.Fail($"Block {blockParameter} was not found", ErrorCodes.ResourceNotFound);
-        }
-        return ResultWrapper<byte[]>.Success(blockRLP);
-    }
+    public ResultWrapper<byte[]> debug_getRawBlock(BlockParameter blockParameter) =>
+        GetBlockRlpOrFail(blockParameter);
 
     public ResultWrapper<byte[]> debug_getRawHeader(BlockParameter blockParameter)
     {
-        var block = debugBridge.GetBlock(blockParameter);
+        Block? block = debugBridge.GetBlock(blockParameter);
         if (block is null)
         {
             return ResultWrapper<byte[]>.Fail($"Block {blockParameter} was not found", ErrorCodes.ResourceNotFound);
         }
-        Rlp rlp = Rlp.Encode<BlockHeader>(block.Header);
+        Rlp rlp = Rlp.Encode(block.Header);
         return ResultWrapper<byte[]>.Success(rlp.Bytes);
     }
 
@@ -427,7 +403,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<IEnumerable<string>> debug_standardTraceBlockToFile(Hash256 blockHash, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<IEnumerable<string>>(blockHash, out var headerError);
+        TryGetHeaderAndCheckState(blockHash, out ResultWrapper<IEnumerable<string>>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -445,7 +421,7 @@ public class DebugRpcModule(
 
     public ResultWrapper<IEnumerable<string>> debug_standardTraceBadBlockToFile(Hash256 blockHash, GethTraceOptions options = null)
     {
-        var header = TryGetHeaderAndCheckState<IEnumerable<string>>(blockHash, out var headerError);
+        TryGetHeaderAndCheckState(blockHash, out ResultWrapper<IEnumerable<string>>? headerError);
         if (headerError is not null)
         {
             return headerError;
@@ -573,6 +549,14 @@ public class DebugRpcModule(
         }
     }
 
+    private ResultWrapper<byte[]> GetBlockRlpOrFail(BlockParameter blockParameter)
+    {
+        byte[]? rlp = debugBridge.GetBlockRlp(blockParameter);
+        return rlp is null
+            ? ResultWrapper<byte[]>.Fail($"Block {blockParameter} was not found", ErrorCodes.ResourceNotFound)
+            : ResultWrapper<byte[]>.Success(rlp);
+    }
+
     private static ResultWrapper<TResult> GetFailureResult<TResult, TSearch>(SearchResult<TSearch> searchResult, bool isTemporary)
         where TSearch : class =>
         ResultWrapper<TResult>.Fail(searchResult, isTemporary && searchResult.ErrorCode == ErrorCodes.ResourceNotFound);
@@ -599,7 +583,7 @@ public class DebugRpcModule(
             return null;
         }
 
-        error = default!;
+        error = null;
         return header;
     }
 
@@ -620,7 +604,7 @@ public class DebugRpcModule(
             return null;
         }
 
-        error = default!;
+        error = null;
         return header;
     }
 
@@ -654,7 +638,7 @@ public class DebugRpcModule(
             return null;
         }
 
-        error = default!;
+        error = null;
         return block;
     }
 }


### PR DESCRIPTION
Closes #8174

## Changes

- Added `HasStateForBlock` checks to `debug_standardTraceBlockToFile` and `debug_standardTraceBadBlockToFile` using existing `TryGetHeader` helper
- Before: pruned state → `MissingTrieNodeException` internal error
- After: clean `ResourceUnavailable` / `ResourceNotFound` errors
- Consistent with all other debug trace endpoints

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

4 unit tests added, verified fail-without-fix / pass-with-fix

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No