### PR TITLE
fix(sync): correct log level mismatch in SyncDispatcher

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Synchronization.ParallelSync
             }
             catch (OperationCanceledException)
             {
-                if (Logger.IsTrace) Logger.Debug($"{request} - Operation was canceled");
+                if (Logger.IsTrace) Logger.Trace($"{request} - Operation was canceled");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Logger.Debug was called under an IsTrace guard in the OperationCanceledException handler. This caused cancellation messages to be logged at Debug level instead of Trace, adding unnecessary noise. Aligned it with the consistent pattern used in surrounding catch blocks.