### PR TITLE
fix: replace LINQ FirstOrDefault with direct array access

### DIFF
--- a/src/Nethermind/Nethermind.Sockets/Extensions.cs
+++ b/src/Nethermind/Nethermind.Sockets/Extensions.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Linq;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,8 +32,9 @@ public static class Extensions
                 string moduleName = string.Empty;
                 if (context.Request.Path.HasValue)
                 {
-                    var path = context.Request.Path.Value;
-                    moduleName = path.Split("/", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault() ?? string.Empty;
+                    string path = context.Request.Path.Value;
+                    string[] pathParts = path.Split("/", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    moduleName = pathParts.Length > 0 ? pathParts[0] : string.Empty;
                 }
 
                 module = webSocketsManager?.GetModule(moduleName);
@@ -45,7 +45,7 @@ public static class Extensions
                 }
 
                 clientName = context.Request.Query.TryGetValue("client", out StringValues clientValues)
-                    ? clientValues.FirstOrDefault() ?? string.Empty
+                    ? clientValues.Count > 0 ? clientValues[0] ?? string.Empty : string.Empty
                     : string.Empty;
 
                 if (logger.IsDebug) logger.Info($"Initializing WebSockets for client: '{clientName}'.");


### PR DESCRIPTION
Replace LINQ FirstOrDefault() calls with direct array indexing to avoid unnecessary allocations in WebSocket middleware. This aligns with project guidelines that prefer simple loops over LINQ for performance-critical paths.

Changes:
- Replace path.Split().FirstOrDefault() with direct pathParts[0] access
- Replace clientValues.FirstOrDefault() with direct clientValues[0] access
- Remove unused System.Linq import
- Use explicit string type instead of var for path variable