### PR TITLE
fix: fix incorrect error messages in EraImporter

### DIFF
--- a/src/Nethermind/Nethermind.Era1/EraImporter.cs
+++ b/src/Nethermind/Nethermind.Era1/EraImporter.cs
@@ -53,7 +53,7 @@ public class EraImporter(
         if (to == 0) to = long.MaxValue;
         if (to != long.MaxValue && lastBlockInStore < to)
         {
-            throw new EraImportException($"The directory given for import '{src}' have highest block number {lastBlockInStore} which is lower then last requested block {to}.");
+            throw new EraImportException($"The directory given for import '{src}' have highest block number {lastBlockInStore} which is lower than last requested block {to}.");
         }
         if (to == long.MaxValue)
         {
@@ -67,7 +67,7 @@ public class EraImporter(
         }
         else if (from < firstBlockInStore)
         {
-            throw new EraImportException($"The directory given for import '{src}' have lowest block number {firstBlockInStore} which is lower then first requested block {from}.");
+            throw new EraImportException($"The directory given for import '{src}' have lowest block number {firstBlockInStore} which is higher than first requested block {from}.");
         }
         if (from > to && to != 0)
             throw new ArgumentException($"Start block ({from}) must not be after end block ({to})");


### PR DESCRIPTION

## Changes

- Fix typo "then" → "than" in error message for upper bound check
- Fix wrong word "lower" → "higher" in error message for lower bound check — the condition `from < firstBlockInStore` means the store's lowest block is *higher* than requested, not lower

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_