### PR TITLE
fix(wallet): use byte length in Ethereum Signed Message format

### DIFF
--- a/src/Nethermind/Nethermind.Wallet/IWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/IWallet.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Wallet
@@ -34,9 +35,10 @@ namespace Nethermind.Wallet
         }
         Signature SignMessage(byte[] message, Address address)
         {
-            string m = Encoding.UTF8.GetString(message);
-            string signatureText = $"\u0019Ethereum Signed Message:\n{m.Length}{m}";
-            return Sign(Keccak.Compute(signatureText), address);
+            byte[] prefix = Encoding.ASCII.GetBytes("\x19Ethereum Signed Message:\n");
+            byte[] lengthBytes = Encoding.ASCII.GetBytes(message.Length.ToString());
+            byte[] prefixedMessage = Bytes.Concat(prefix, lengthBytes, message);
+            return Sign(Keccak.Compute(prefixedMessage), address);
         }
         event EventHandler<AccountLockedEventArgs> AccountLocked;
         event EventHandler<AccountUnlockedEventArgs> AccountUnlocked;


### PR DESCRIPTION
## Fix

SignMessage method incorrectly used string character length instead of byte length when creating Ethereum Signed Message format. This caused invalid signatures for non-ASCII and binary messages, breaking compatibility with other Ethereum clients.

## Changes

- Replaced UTF-8 string conversion with direct byte array handling
- Use `message.Length` (byte count) instead of string character count
- Build prefix using ASCII encoding for proper Ethereum standard compliance
- Concatenate bytes directly using `Bytes.Concat` instead of string interpolation