### PR TITLE
Remove redundant Regex in NewPayloadJsonRpcValidator

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/Eth/NewPayloadJsonRpcValidator.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/Eth/NewPayloadJsonRpcValidator.cs
@@ -1,14 +1,10 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Text.RegularExpressions;
-
 namespace Nethermind.Tools.Kute.JsonRpcValidator.Eth;
 
 public sealed class NewPayloadJsonRpcValidator : IJsonRpcValidator
 {
-    private readonly Regex _pattern = new Regex("engine_newPayload", RegexOptions.Compiled);
-
     public bool IsValid(JsonRpc.Request request, JsonRpc.Response response)
     {
         // If preconditions are not met, then mark it as Valid.
@@ -29,7 +25,7 @@ public sealed class NewPayloadJsonRpcValidator : IJsonRpcValidator
     {
         if (request is JsonRpc.Request.Single { MethodName: not null } single)
         {
-            if (_pattern.IsMatch(single.MethodName))
+            if (single.MethodName.Contains("engine_newPayload", StringComparison.Ordinal))
             {
                 return true;
             }


### PR DESCRIPTION
Removes unnecessary `Regex` usage for simple substring matching in `NewPayloadJsonRpcValidator`.
