### PR TITLE
✨ feat(EIP-7708): Rename log topic from Selfedestruct to Burn

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -459,7 +459,7 @@ namespace Nethermind.Core.Specs
         bool BlockLevelAccessListsEnabled => IsEip7928Enabled;
 
         /// <summary>
-        /// EIP-7708: ETH transfers emit a log
+        /// EIP-7708: ETH transfers and burns emit a log
         /// </summary>
         public bool IsEip7708Enabled { get; }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7708Tests.cs
@@ -32,8 +32,8 @@ public class Eip7708Tests(bool eip7708Enabled)
     private static LogEntry ExpectedTransferLog(Address from, Address to, UInt256 value) =>
         new(TransferLog.Sender, value.ToBigEndian(), [TransferLog.TransferSignature, from.ToHash().ToHash256(), to.ToHash().ToHash256()]);
 
-    private static LogEntry ExpectedSelfDestructLog(Address account, UInt256 value) =>
-        new(TransferLog.Sender, value.ToBigEndian(), [TransferLog.SelfDestructSignature, account.ToHash().ToHash256()]);
+    private static LogEntry ExpectedBurnLog(Address account, UInt256 value) =>
+        new(TransferLog.Sender, value.ToBigEndian(), [TransferLog.BurnSignature, account.ToHash().ToHash256()]);
 
     private void AssertLogs(TxReceipt[] receipts, LogEntry[] expectedLogs, bool logCondition = true)
     {
@@ -196,7 +196,7 @@ public class Eip7708Tests(bool eip7708Enabled)
 
         Block block = await chain.AddBlock(callTx);
 
-        AssertLogs(chain.ReceiptStorage.Get(block), [ExpectedSelfDestructLog(contractAddress, contractBalance)], contractBalance != 0);
+        AssertLogs(chain.ReceiptStorage.Get(block), [ExpectedBurnLog(contractAddress, contractBalance)], contractBalance != 0);
     }
 
     [Test]
@@ -275,7 +275,7 @@ public class Eip7708Tests(bool eip7708Enabled)
             ExpectedTransferLog(contractBAddress, contractAAddress, contractABalance),
             ExpectedTransferLog(contractAAddress, inheritorA, contractABalance),
             ExpectedTransferLog(contractBAddress, contractAAddress, ethToSend),
-            ExpectedSelfDestructLog(contractAAddress, ethToSend)
+            ExpectedBurnLog(contractAAddress, ethToSend)
         ]);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -244,7 +244,7 @@ internal static partial class EvmInstructions
 
         if (executingAccount == inheritor)
         {
-            vm.AddSelfDestructLog(executingAccount, result);
+            vm.AddBurnLog(executingAccount, result);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -775,7 +775,7 @@ namespace Nethermind.Evm.TransactionProcessing
                             UInt256 balance = WorldState.GetBalance(toBeDestroyed);
                             if (!balance.IsZero)
                             {
-                                substate.Logs.Add(TransferLog.CreateSelfDestruct(toBeDestroyed, balance));
+                                substate.Logs.Add(TransferLog.CreateBurn(toBeDestroyed, balance));
                             }
                         }
 

--- a/src/Nethermind/Nethermind.Evm/TransferLog.cs
+++ b/src/Nethermind/Nethermind.Evm/TransferLog.cs
@@ -11,16 +11,16 @@ public static class TransferLog
 {
     // keccak256('Transfer(address,address,uint256)')
     public static readonly Hash256 TransferSignature = new("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
-    // keccak256('Selfdestruct(address,uint256)')
-    public static readonly Hash256 SelfDestructSignature = new("0x4bfaba3443c1a1836cd362418edc679fc96cae8449cbefccb6457cdf2c943083");
+    // keccak256('Burn(address,uint256)')
+    public static readonly Hash256 BurnSignature = new("0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5");
     public static readonly Address Sender = Address.SystemUser;
     public static readonly Address Erc20Sender = new("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
     public static LogEntry CreateTransfer(Address from, Address to, in UInt256 amount) =>
         CreateTransferInternal(Sender, from, to, amount);
 
-    public static LogEntry CreateSelfDestruct(Address contract, in UInt256 amount) =>
-        new(Sender, amount.ToBigEndian(), [SelfDestructSignature, contract.ToHash().ToHash256()]);
+    public static LogEntry CreateBurn(Address account, in UInt256 amount) =>
+        new(Sender, amount.ToBigEndian(), [BurnSignature, account.ToHash().ToHash256()]);
 
     public static LogEntry CreateSimulateTransfer(Address from, Address to, in UInt256 amount) =>
         CreateTransferInternal(Erc20Sender, from, to, amount);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1500,11 +1500,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         }
     }
 
-    internal void AddSelfDestructLog(Address contract, in UInt256 value)
+    internal void AddBurnLog(Address account, in UInt256 value)
     {
         if (Spec.IsEip7708Enabled && !value.IsZero)
         {
-            AddLog(TransferLog.CreateSelfDestruct(contract, value));
+            AddLog(TransferLog.CreateBurn(account, value));
         }
     }
 }


### PR DESCRIPTION
https://github.com/ethereum/EIPs/pull/11311 renamed the "Selfdestruct" log topic to "Burn" in the EIP-7708 specification.


## Rationale

"Burn" better describes what happens (ETH is destroyed) rather than how it happens (via the SELFDESTRUCT opcode). This creates a more consistent API, which reflects the outcome, not the mechanism.