### PR TITLE
fix: gracefully handle MaxBranchSize exceeded in PrepareProcessingBranch

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -800,4 +800,77 @@ public class BlockchainProcessorTests
                 _block5D10
             );
     }
+
+    /// <summary>
+    /// Regression test for issue #10494: when blocks are on the main chain but state is missing
+    /// (e.g. DB corruption on an archive node) or blocks are not on the main chain (e.g. after
+    /// restart with reorg boundary), PrepareProcessingBranch used to throw InvalidOperationException
+    /// after walking back 8192 ancestors, crashing block processing entirely.
+    /// After the fix, the walk stops at MaxBranchSize and the block is gracefully rejected as
+    /// orphaned (InvalidBlockException) instead of crashing the processor.
+    /// </summary>
+    [TestCase(true, Description = "Blocks on main chain but no state (DB corruption on archive node)")]
+    [TestCase(false, Description = "Blocks not on main chain (restart with reorg boundary)")]
+    [MaxTime(Timeout.MaxTestTime)]
+    public void PrepareProcessingBranch_does_not_crash_when_branch_exceeds_max_size(bool onMainChain)
+    {
+        const int chainLength = 8200;
+
+        BlockTree blockTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .TestObject;
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(false);
+
+        BlockchainProcessor processor = new(
+            blockTree,
+            Substitute.For<IBranchProcessor>(),
+            Substitute.For<IBlockPreprocessorStep>(),
+            stateReader,
+            LimboLogs.Instance,
+            BlockchainProcessor.Options.Default,
+            Substitute.For<IProcessingStats>());
+
+        Block genesis = Build.A.Block.WithNumber(0).WithNonce(0).WithDifficulty(0).TestObject;
+        blockTree.SuggestBlock(genesis);
+        blockTree.UpdateMainChain(new[] { genesis }, true);
+
+        Block previous = genesis;
+        Block[] chainBlocks = new Block[chainLength];
+        for (int i = 0; i < chainLength; i++)
+        {
+            Block block = Build.A.Block
+                .WithNumber(i + 1)
+                .WithNonce((ulong)(i + 1))
+                .WithParent(previous)
+                .WithDifficulty(2)
+                .TestObject;
+            chainBlocks[i] = block;
+            blockTree.SuggestBlock(block, BlockTreeSuggestOptions.None);
+            previous = block;
+        }
+
+        if (onMainChain)
+        {
+            blockTree.UpdateMainChain(chainBlocks, false);
+        }
+
+        Block tipBlock = Build.A.Block
+            .WithNumber(chainLength + 1)
+            .WithNonce((ulong)(chainLength + 1))
+            .WithParent(previous)
+            .WithDifficulty(2)
+            .TestObject;
+        blockTree.SuggestBlock(tipBlock, BlockTreeSuggestOptions.None);
+
+        // Before the fix, this threw InvalidOperationException("Maximum size of branch reached").
+        // After the fix, the walk stops gracefully and the block is rejected as orphaned.
+        Action act = () => processor.Process(
+            tipBlock,
+            ProcessingOptions.None,
+            NullBlockTracer.Instance);
+
+        act.Should().NotThrow<InvalidOperationException>();
+        act.Should().Throw<InvalidBlockException>();
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -690,7 +690,8 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             iterations++;
             if (iterations > MaxBranchSize)
             {
-                ThrowMaxBranchSizeReached();
+                if (_logger.IsWarn) WarnMaxBranchSizeReached(suggestedBlock, toBeProcessed);
+                break;
             }
 
             if (!options.ContainsFlag(ProcessingOptions.Trace))
@@ -810,9 +811,9 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         void TraceStateRootLookup(Hash256? stateRoot)
             => _logger.Trace($"State root lookup: {stateRoot}");
 
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowMaxBranchSizeReached()
-            => throw new InvalidOperationException($"Maximum size of branch reached ({MaxBranchSize}). This is unexpected.");
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void WarnMaxBranchSizeReached(Block suggestedBlock, Block toBeProcessed)
+            => _logger.Warn($"Maximum branch size ({MaxBranchSize}) reached while preparing branch for {suggestedBlock.ToString(Block.Format.Short)}. Stopped at {toBeProcessed.ToString(Block.Format.Short)}. This may indicate missing state or corrupted chain metadata.");
     }
 
     [Todo(Improve.Refactor, "This probably can be made conditional (in DEBUG only)")]


### PR DESCRIPTION
Fixes #10494

## Changes

- Replace `throw InvalidOperationException` with `break` + warning log when `PrepareProcessingBranch` exceeds `MaxBranchSize` (8192)
- The existing validation in `PrepareBlocksToProcess` rejects the block as orphaned (`InvalidBlockException`), which the processing pipeline handles gracefully instead of crashing in a tight loop
- Add parameterized regression test covering both scenarios: main-chain blocks with missing state (DB corruption) and non-main-chain ancestors (restart with reorg boundary)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Parameterized test `PrepareProcessingBranch_does_not_crash_when_branch_exceeds_max_size` builds a chain of 8200 blocks and verifies that processing no longer throws `InvalidOperationException` (the old crash) but instead throws `InvalidBlockException` (graceful rejection).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

When `PrepareProcessingBranch` walks back more than 8192 ancestors (due to missing state or non-canonical blocks), the node no longer crashes with `InvalidOperationException`. Instead it logs a warning and gracefully rejects the block, allowing the processor to continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)