### PR TITLE
Fix memory leak in `TriggerWithCondition` by implementing IDisposable

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/TriggerWithCondition.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TriggerWithCondition.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Consensus.Producers
 {
-    public class TriggerWithCondition : IBlockProductionTrigger
+    public class TriggerWithCondition : IBlockProductionTrigger, IDisposable
     {
+        private readonly IBlockProductionTrigger _trigger;
         private readonly Func<BlockProductionEventArgs, bool> _checkCondition;
 
         public TriggerWithCondition(IBlockProductionTrigger trigger, Func<bool> checkCondition) : this(trigger, _ => checkCondition())
@@ -15,6 +17,7 @@ namespace Nethermind.Consensus.Producers
 
         public TriggerWithCondition(IBlockProductionTrigger trigger, Func<BlockProductionEventArgs, bool> checkCondition)
         {
+            _trigger = trigger;
             _checkCondition = checkCondition;
             trigger.TriggerBlockProduction += TriggerOnTriggerBlockProduction;
         }
@@ -22,12 +25,18 @@ namespace Nethermind.Consensus.Producers
 
         private void TriggerOnTriggerBlockProduction(object? sender, BlockProductionEventArgs e)
         {
-            if (_checkCondition.Invoke(e))
+            if (_checkCondition(e))
             {
                 TriggerBlockProduction?.Invoke(this, e);
             }
         }
 
         public event EventHandler<BlockProductionEventArgs>? TriggerBlockProduction;
+
+        public void Dispose()
+        {
+            _trigger.TriggerBlockProduction -= TriggerOnTriggerBlockProduction;
+            _trigger.TryDispose();
+        }
     }
 }


### PR DESCRIPTION
`TriggerWithCondition` was subscribing to the inner trigger's `TriggerBlockProduction` event but never unsubscribing or disposing the inner trigger, causing a memory leak. Added `IDisposable` implementation to properly unsubscribe from the event and dispose the inner trigger when `TriggerWithCondition` is disposed.