### PR TITLE
Add noninteractive to cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -519,6 +519,7 @@
     "nofile",
     "nonposdao",
     "nongcstatic",
+    "noninteractive",
     "nonstring",
     "nops",
     "nostack",


### PR DESCRIPTION
## Changes

Add `noninteractive` to the cspell word list to fix a spelling check failure

Related to #10572

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_
