### PR TITLE
feat: Add ClearCache() to store interfaces for testing support

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -118,5 +119,29 @@ public class BlockStoreTests
             block.Transactions[i].Data = Array.Empty<byte>();
             retrieved.GetNextTransaction().Should().BeEquivalentTo(block.Transactions[i]);
         }
+    }
+
+    [Test]
+    public void Test_ClearCache_removes_cached_blocks()
+    {
+        TestMemDb db = new();
+        BlockStore store = new(db);
+
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+        store.Insert(block);
+
+        // Populate cache
+        Block? retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, shouldCache: true);
+        retrieved.Should().BeEquivalentTo(block, _ignoreEncodedSize);
+
+        // Clear the DB but block should still be in cache
+        db.Clear();
+        retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, shouldCache: true);
+        retrieved.Should().NotBeNull();
+
+        // Clear the cache - now block should not be retrievable
+        (store as IClearableCache)?.ClearCache();
+        retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, shouldCache: true);
+        retrieved.Should().BeNull();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Nethermind.Blockchain.Headers;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
@@ -79,6 +80,22 @@ public class HeaderStoreTests
 
         store.Delete(header.Hash!);
         store.Get(header.Hash!)!.Should().BeNull();
+    }
+
+    [Test]
+    public void TestClearCache_removes_cached_headers()
+    {
+        HeaderStore store = new(new MemDb(), new MemDb());
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+
+        // Cache the header (not inserted to DB)
+        store.Cache(header);
+        store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+
+        // Clear the cache - header should no longer be retrievable
+        (store as IClearableCache)?.ClearCache();
+        store.Get(header.Hash!).Should().BeNull();
     }
 
 }

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -54,7 +54,7 @@ namespace Nethermind.Blockchain
         private readonly ISyncConfig _syncConfig;
         private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
 
-        public BlockHeader? Genesis { get; private set; }
+        public BlockHeader? Genesis { get; protected set; }
         public Block? Head { get; private set; }
 
         public BlockHeader? BestSuggestedHeader { get; private set; }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -12,7 +12,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Blockchain.Blocks;
 
-public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb, IHeaderDecoder headerDecoder = null) : IBlockStore
+public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb, IHeaderDecoder headerDecoder = null) : IBlockStore, IClearableCache
 {
     private readonly BlockDecoder _blockDecoder = new(headerDecoder ?? new HeaderDecoder());
     public const int CacheSize = 128 + 32;
@@ -88,5 +88,10 @@ public class BlockStore([KeyFilter(DbNames.Blocks)] IDb blockDb, IHeaderDecoder 
     public void Cache(Block block)
     {
         _blockCache.Set(block.Hash, block);
+    }
+
+    void IClearableCache.ClearCache()
+    {
+        _blockCache.Clear();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -19,7 +19,7 @@ public class HeaderStore(
     [KeyFilter(DbNames.Headers)] IDb headerDb,
     [KeyFilter(DbNames.BlockNumbers)] IDb blockNumberDb,
     IHeaderDecoder? decoder = null)
-    : IHeaderStore
+    : IHeaderStore, IClearableCache
 {
     // SyncProgressResolver MaxLookupBack is 256, add 16 wiggle room
     public const int CacheSize = 256 + 16;
@@ -112,4 +112,9 @@ public class HeaderStore(
     }
 
     BlockHeader? IHeaderFinder.Get(Hash256 blockHash, long? blockNumber) => Get(blockHash, true, blockNumber);
+
+    void IClearableCache.ClearCache()
+    {
+        _headerCache.Clear();
+    }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/IClearableCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/IClearableCache.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Caching;
+
+/// <summary>
+/// Interface for components that maintain an in-memory cache that can be cleared.
+/// Implement this interface explicitly on classes that have caches.
+/// Usage: <code>(store as IClearableCache)?.ClearCache()</code>
+/// </summary>
+public interface IClearableCache
+{
+    /// <summary>
+    /// Clears the in-memory cache. Does not affect underlying persistent storage.
+    /// </summary>
+    void ClearCache();
+}

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -14,7 +14,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.State.Repositories
 {
-    public class ChainLevelInfoRepository([KeyFilter(DbNames.BlockInfos)] IDb blockInfoDb) : IChainLevelInfoRepository
+    public class ChainLevelInfoRepository([KeyFilter(DbNames.BlockInfos)] IDb blockInfoDb) : IChainLevelInfoRepository, IClearableCache
     {
         private const int CacheSize = 64;
 
@@ -91,6 +91,11 @@ namespace Nethermind.State.Repositories
                     return _decoder.Decode(ref rlpValueContext, RlpBehaviors.AllowExtraBytes);
                 })
                 .ToPooledList(data.Length);
+        }
+
+        void IClearableCache.ClearCache()
+        {
+            _blockInfoCache.Clear();
         }
     }
 }


### PR DESCRIPTION
Resolves NethermindEth/nethermind-arbitrum#646

  ## Changes

  - Add `ClearCache()` method to `IBlockStore` interface with default empty implementation
  - Add `ClearCache()` method to `IHeaderStore` interface with default empty implementation
  - Add `ClearCache()` method to `IChainLevelInfoRepository` interface with default empty implementation
  - Implement `ClearCache()` in `BlockStore` to clear `_blockCache`
  - Implement `ClearCache()` in `HeaderStore` to clear `_headerCache`
  - Implement `ClearCache()` in `ChainLevelInfoRepository` to clear `_blockInfoCache`
  - Change `BlockTree.Genesis` setter from `private` to `protected` to allow derived classes to reset genesis state

  ## Types of changes

  #### What types of changes does your code introduce?

  - [ ] Bugfix (a non-breaking change that fixes an issue)
  - [x] New feature (a non-breaking change that adds functionality)
  - [ ] Breaking change (a change that causes existing functionality not to work as expected)
  - [ ] Optimization
  - [ ] Refactoring
  - [ ] Documentation update
  - [ ] Build-related changes
  - [ ] Other: _Description_

  ## Testing

  #### Requires testing

  - [ ] Yes
  - [x] No

  #### If yes, did you write tests?

  - [ ] Yes
  - [x] No

  ## Documentation

  #### Requires documentation update

  - [ ] Yes
  - [x] No

  #### Requires explanation in Release Notes

  - [ ] Yes
  - [x] No

  ## Remarks

  This PR provides the upstream interface changes required by [NethermindEth/nethermind-arbitrum#646](https://github.com/NethermindEth/nethermind-arbitrum/pull/646) to enable state reset during testing.