### PR TITLE
Fix flaky test: Will_Trigger_ReorgBoundaryEvent_On_Prune

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -487,7 +487,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         _commitSetQueue.Enqueue(set);
         LatestCommittedBlockNumber = Math.Max(set.BlockNumber, LatestCommittedBlockNumber);
-        AnnounceReorgBoundaries();
     }
 
     public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;


### PR DESCRIPTION

Closes #

## Changes

- Fixed race condition in `TrieStore.PushToMainCommitSetQueue` that caused the `ReorgBoundaryReached` event to fire with stale `LastPersistedBlockNumber` values before pruning had a chance to update it
- Removed premature `AnnounceReorgBoundaries()` call from `PushToMainCommitSetQueue` - the event is now only fired in `SaveSnapshot` after pruning has updated the boundary value
- This makes the test deterministic by ensuring the event always fires with the correct updated reorg boundary

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No (test already exists, fixed the underlying race condition)

#### Notes on testing

The test `Will_Trigger_ReorgBoundaryEvent_On_Prune` in `TreeStoreTests.cs` was flaky due to a race condition. The fix ensures the `ReorgBoundaryReached` event is only fired after pruning has updated `LastPersistedBlockNumber`, making the test deterministic. Verified by running the test 5+ times consecutively.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
