### PR TITLE
fix: restore StrictHexFormat in BlockParameterConverterTests

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
@@ -16,8 +16,6 @@ namespace Nethermind.JsonRpc.Test.Data
     [TestFixture]
     public class BlockParameterConverterTests : SerializationTestBase
     {
-        [TearDown]
-        public void TearDown() => EthereumJsonSerializer.StrictHexFormat = false;
         [TestCase("0", 0)]
         [TestCase("100", 100)]
         [TestCase("\"0x0\"", 0)]
@@ -47,15 +45,23 @@ namespace Nethermind.JsonRpc.Test.Data
         [TestCase("{ \"blockNumber\": \"100\" }", true)]
         public void Cant_read_block_number_when_strict_hex_format_is_enabled(string input, bool throws)
         {
-            EthereumJsonSerializer.StrictHexFormat = true;
-            IJsonSerializer serializer = new EthereumJsonSerializer();
+            bool original = EthereumJsonSerializer.StrictHexFormat;
+            try
+            {
+                EthereumJsonSerializer.StrictHexFormat = true;
+                IJsonSerializer serializer = new EthereumJsonSerializer();
 
-            Func<BlockParameter> action = () => serializer.Deserialize<BlockParameter>(input);
+                Func<BlockParameter> action = () => serializer.Deserialize<BlockParameter>(input);
 
-            if (throws)
-                action.Should().Throw<FormatException>();
-            else
-                action.Should().NotThrow();
+                if (throws)
+                    action.Should().Throw<FormatException>();
+                else
+                    action.Should().NotThrow();
+            }
+            finally
+            {
+                EthereumJsonSerializer.StrictHexFormat = original;
+            }
         }
 
         [TestCase("null", BlockParameterType.Latest)]


### PR DESCRIPTION
- `Cant_read_block_number_when_strict_hex_format_is_enabled` sets the static `EthereumJsonSerializer.StrictHexFormat = true` but never restored it, polluting other tests running afterward.
- Replaced with a try/finally block that saves and restores the original value. Otherwise tests fail in Linux ubuntu-24, Dotnet v10.0.103