### PR TITLE
fix(tests): cover ValueDecoderContext branch in VoteDecoderTests

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/VoteDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/VoteDecoderTests.cs
@@ -41,7 +41,7 @@ public class VoteDecoderTests
                     0,
                     new Signature(new byte[64], 0)
                 ),
-                true
+                false
             );
         }
     }


### PR DESCRIPTION
The test EncodeDecode_RoundTrip_Matches_AllFields has two code paths based on useRlpStream parameter, but all three test cases were passing true. This meant the ValueDecoderContext decoding path was never actually tested. Changed one test case to use false so both branches get covered.