### PR TITLE
fix(xdc): remove unused imports in XdcSort.cs

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/XdcSort.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcSort.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Nethermind.Xdc;
 


### PR DESCRIPTION
Remove dead imports System.Text and System.Runtime.InteropServices.JavaScript.JSType. Neither is used anywhere in the file. The JSType import is for browser JS interop which makes no sense in blockchain sorting code.