### PR TITLE
fix(tests): remove redundant Union operation in WalletTests

### DIFF
--- a/src/Nethermind/Nethermind.Wallet.Test/WalletTests.cs
+++ b/src/Nethermind/Nethermind.Wallet.Test/WalletTests.cs
@@ -83,7 +83,7 @@ public class WalletTests
     public void Setup()
     {
         // by pre-caching wallets we make the tests do lot less work
-        Parallel.ForEach(WalletTypes.Union(WalletTypes), walletType =>
+        Parallel.ForEach(WalletTypes, walletType =>
         {
             Context cachedWallet = new Context(walletType);
             _cachedWallets.TryAdd(walletType, cachedWallet);


### PR DESCRIPTION
Remove unnecessary `WalletTypes.Union(WalletTypes)` call in WalletTests.Setup(). Union of a collection with itself returns the same elements while adding overhead from iterator allocation and duplicate checking.