### PR TITLE
refactor(trie): remove dead code in TrieNode.Decoder

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -305,7 +305,7 @@ namespace Nethermind.Trie
                     }
                     else
                     {
-                        if (ReferenceEquals(data, _nullNode) || data is null)
+                        if (ReferenceEquals(data, _nullNode))
                         {
                             totalLength++;
                         }
@@ -398,7 +398,7 @@ namespace Nethermind.Trie
                     }
                     else
                     {
-                        if (ReferenceEquals(data, _nullNode) || data is null)
+                        if (ReferenceEquals(data, _nullNode))
                         {
                             destination[position++] = 128;
                         }


### PR DESCRIPTION
Remove unreachable `|| data is null` in else branches where data was already checked for null.