### PR TITLE
fix: lazy-initialize GasCosts in OverridableReleaseSpec and SpecProviderSubstitute

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/SpecProviderSubstitute.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SpecProviderSubstitute.cs
@@ -14,7 +14,7 @@ public static class SpecProviderSubstitute
         IReleaseSpec genesis = ReleaseSpecSubstitute.Create();
         sub.GenesisSpec.Returns(genesis);
         IReleaseSpec spec = sub.GetSpec(Arg.Any<ForkActivation>());
-        spec.GasCosts.Returns(_ => new SpecGasCosts(spec));
+        spec.GasCosts.Returns(new SpecGasCosts(spec));
         return sub;
     }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -119,7 +119,8 @@ namespace Nethermind.Specs.Test
         public bool IsEip7939Enabled { get; set; } = spec.IsEip7939Enabled;
         public bool IsEip7907Enabled { get; set; } = spec.IsEip7907Enabled;
         public bool IsRip7728Enabled { get; set; } = spec.IsRip7728Enabled;
-        public SpecGasCosts GasCosts => new(this);
+        private SpecGasCosts? _gasCosts;
+        public SpecGasCosts GasCosts => _gasCosts ??= new(this);
         FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
     }
 }


### PR DESCRIPTION
## Changes

- `OverridableReleaseSpec.GasCosts`: was allocating `new SpecGasCosts(this)` on every property access. Added a backing field with `??=` lazy init, matching `ReleaseSpec` pattern.
- `SpecProviderSubstitute.GasCosts`: was using `Returns(_ => new SpecGasCosts(spec))` — the lambda caused NSubstitute to invoke the factory on every access. Changed to `Returns(new SpecGasCosts(spec))` to return a single cached instance, matching `ReleaseSpecSubstitute`.

Both changes follow the pattern established in `ReleaseSpec.cs`:
```csharp
private SpecGasCosts? _gasCosts;
SpecGasCosts IReleaseSpec.GasCosts => _gasCosts ??= new SpecGasCosts(this);
```

Depends on #10591. Can be retargeted to `master` after that merges.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] Requires testing
- [ ] Requires no testing

## Documentation

- [ ] Requires documentation update
- [ ] Does not require documentation update