### PR TITLE
chore: add review-pr Claude Code skill

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: review-pr
+description: >
+  Reviews a Nethermind GitHub pull request. Use when the user runs /review-pr with a PR
+  number, or asks to "review PR #NNN" or "review this PR". Fetches the PR diff and
+  metadata via the gh CLI, then produces a structured Nethermind-specific code review
+  covering: summary, issues/nitpicks (C# style, architecture, test coverage), and a PR
+  template checklist. This skill is specific to the Nethermind Ethereum client codebase.
+---
+
+# PR Review -- Nethermind
+
+## Workflow
+
+### 1. Fetch PR data
+
+Run both commands in parallel:
+
+```bash
+gh pr view <number> --json number,title,body,author,baseRefName,headRefName,additions,deletions,changedFiles,state
+gh pr diff <number>
+```
+
+If the diff is very large (>1000 lines), also fetch the file list to prioritize:
+
+```bash
+gh pr view <number> --json files
+```
+
+### 2. Load conventions reference
+
+Read `references/nethermind-conventions.md` before writing the review -- it contains the specific rules to check for.
+
+### 3. Deep-dive on suspicious files (optional)
+
+If the diff is ambiguous or a file seems central to the change, read the full file from the repo:
+
+```bash
+gh pr checkout <number>   # only if needed for full file context
+```
+
+Or read specific files directly if the branch is already checked out.
+
+### 4. Post inline comments on the diff
+
+For every issue found, post it as an **inline comment on the exact line** in the PR using the GitHub API.
+Do NOT write a separate summary of issues -- the inline comments ARE the review.
+
+**Tone:**
+- Terse and direct. Every sentence carries information.
+- Only comment on things that need to change. No praise for correct code.
+- "This allocates on every call" not "This may potentially cause allocation issues."
+
+**Getting the head commit SHA** (needed for the API call):
+
+```bash
+gh pr view <number> --json headRefOid --jq '.headRefOid'
+```
+
+**Posting inline comments** -- batch all comments into a single API call:
+
+```bash
+gh api repos/NethermindEth/nethermind/pulls/<number>/reviews \
+  --method POST \
+  --field commit_id="<sha>" \
+  --field event="COMMENT" \
+  --field body="<optional top-level summary, 1 sentence max, or empty string>" \
+  --field "comments[][path]=src/Nethermind/Some.File.cs" \
+  --field "comments[][line]=<line number in the NEW file>" \
+  --field "comments[][side]=RIGHT" \
+  --field "comments[][body]=<comment text>" \
+  --field "comments[][path]=src/Nethermind/Another.File.cs" \
+  --field "comments[][line]=<line number>" \
+  --field "comments[][side]=RIGHT" \
+  --field "comments[][body]=<comment text>" \
+  # ... repeat for each issue
+```
+
+**Line number rules:**
+- Use the line number in the **new (right) side** of the diff, not the diff position.
+- Count from the hunk header: `@@ -old,n +new,m @@` -- `new` is the starting line in the new file. Count context lines down to the target line.
+- For new files, line numbers start at 1.
+- `side` is always `RIGHT` (the new version).
+
+**If a comment fails** (line not in diff, wrong path, etc.), fall back to posting it as a top-level review comment in the `body` field with the file:line reference.
+
+### 5. Post the verdict
+
+After posting inline comments, submit the final verdict as a separate review:
+
+```bash
+# If requesting changes:
+gh pr review <number> --request-changes --body "<1-2 sentence summary of what must change>"
+
+# If approving:
+gh pr review <number> --approve --body ""
+
+# If commenting only:
+gh pr review <number> --comment --body "<1-2 sentence summary>"
+```
+
+The top-level verdict body should only mention:
+- The overall verdict rationale (1 sentence)
+- Any issues that could NOT be posted inline (with file:line)
+- PR template problems (missing sections in the description)
+
+Skip the verdict body entirely if everything was captured in inline comments.
+
+---
+
+## Tips
+
+- Batch all inline comments into ONE API call -- do not make one call per comment
+- Count line numbers carefully from the `@@` hunk header
+- Suggest the concrete fix in every comment, not just the problem
+- Nethermind disallows LINQ -- common violation to check
+- Check test coverage for bug fixes
+- If the diff is clean, post no inline comments and approve

--- a/.claude/skills/review-pr/references/nethermind-conventions.md
+++ b/.claude/skills/review-pr/references/nethermind-conventions.md
@@ -1,0 +1,51 @@
+# Nethermind Code Review Conventions
+
+Derived from AGENTS.md and project patterns. Use this checklist during PR review.
+
+## C# Style Rules (flag violations)
+
+- **No `var`** — explicit types required, except for very long nested generic types
+- **`is null` / `is not null`** — never `== null` or `!= null`
+- **`nameof()`** — never string literals for member references
+- **`?.` null-conditional** — use where applicable instead of explicit null checks
+- **`ArgumentNullException.ThrowIfNull`** — for null checks at method boundaries (not manual `if (x == null) throw`)
+- **`ObjectDisposedException.ThrowIf`** — for disposal checks
+- **No LINQ** — flag any `.Select()`, `.Where()`, `.Any()`, `.FirstOrDefault()`, etc. where a simple `for`/`foreach` would suffice. LINQ has overhead and should only appear for complex queries where declarative syntax adds real clarity
+- **No `#region` / `#endregion`** pragmas
+- **File-scoped namespaces** — `namespace Foo.Bar;` not `namespace Foo.Bar { ... }`
+- **Pattern matching** — prefer switch expressions and pattern matching over traditional if/else chains
+- **Documentation comments** — all public APIs need `<summary>` XML doc comments
+- **Comments explain why, not what** — flag comments that just restate the code
+
+## Architecture / Design Rules
+
+- **Low allocation** — flag unnecessary allocations: new collections inside hot loops, closures capturing large objects, boxing value types, string concatenation in loops (use `StringBuilder` or interpolation)
+- **Generic base class** — methods in generic types that don't depend on the type parameter should be in a non-generic base or static helper (prevents redundant JIT instantiations)
+- **DRY** — flag duplicated blocks of 5+ lines that should be extracted. But don't flag one-liner duplications.
+- **Minimal changes** — PRs should not rename variables, reformat unrelated code, or refactor beyond what's needed. Flag scope creep.
+- **No over-engineering** — flag unnecessary abstractions, helpers for one-time operations, or design for hypothetical future requirements
+
+## Test Rules
+
+- **Regression tests required** — every bug fix must include a test that fails without the fix
+- **Add to existing test files** — don't create new test files when an existing one covers the area
+- **Parameterized tests** — multiple similar tests should use `[TestCase]` / `[Theory]` rather than copy-pasted test methods
+- **Test naming** — should describe the scenario: `MethodName_Condition_ExpectedResult`
+
+## Common Nethermind Pitfalls to Check
+
+- `Hash256` vs `Keccak` — ensure the correct type is used; don't confuse them
+- `UInt256` arithmetic — check for overflow and correct ordering (big-endian vs little-endian)
+- `RlpStream` / `Rlp.Encode` — mutations must be in the right order; length prefix is computed before encoding children
+- Thread safety in `BlockTree`, `TxPool`, `TrieStore` — any shared state changes need lock analysis
+- Disposal — `IDisposable` implementations should call `ObjectDisposedException.ThrowIf` before operations
+- Logging — avoid string interpolation in log calls; use structured logging with message templates: `_logger.Debug("Value {Value}", val)` not `_logger.Debug($"Value {val}")`
+
+## PR Template Checklist
+
+Verify the PR description includes:
+- [ ] Issue reference (Fixes/Closes/Resolves #NNN) or explicitly removed
+- [ ] ## Changes section with bullet points listing what changed
+- [ ] Type-of-change checkboxes (at least one ticked)
+- [ ] Testing section filled in (Requires testing: Yes/No; if Yes, Did you write tests: Yes/No)
+- [ ] Documentation section filled in

--- a/.claude/skills/review-pr/references/nethermind-conventions.md
+++ b/.claude/skills/review-pr/references/nethermind-conventions.md
@@ -16,7 +16,7 @@ Derived from AGENTS.md and project patterns. Use this checklist during PR review
 - **Pattern matching** — prefer switch expressions and pattern matching over traditional if/else chains
 - **Documentation comments** — all public APIs need `<summary>` XML doc comments
 - **Comments explain why, not what** — flag comments that just restate the code
-
+- **Concise code** — prefer single line methods with `=>` instead of `{ ... }`, prefer ternary operator `? ... : ...` instead of `if-else` pattern when evaluating expression.
 ## Architecture / Design Rules
 
 - **Low allocation** — flag unnecessary allocations: new collections inside hot loops, closures capturing large objects, boxing value types, string concatenation in loops (use `StringBuilder` or interpolation)

--- a/.claude/skills/review-pr/references/nethermind-conventions.md
+++ b/.claude/skills/review-pr/references/nethermind-conventions.md
@@ -21,7 +21,7 @@ Derived from AGENTS.md and project patterns. Use this checklist during PR review
 
 - **Low allocation** — flag unnecessary allocations: new collections inside hot loops, closures capturing large objects, boxing value types, string concatenation in loops (use `StringBuilder` or interpolation)
 - **Generic base class** — methods in generic types that don't depend on the type parameter should be in a non-generic base or static helper (prevents redundant JIT instantiations)
-- **DRY** — flag duplicated blocks of 5+ lines that should be extracted. But don't flag one-liner duplications.
+- **DRY** — flag duplicated blocks of 5+ lines that should be extracted. But don't flag one-liner duplications. This should include similar code that can be reusable with parametrization.
 - **Minimal changes** — PRs should not rename variables, reformat unrelated code, or refactor beyond what's needed. Flag scope creep.
 - **No over-engineering** — flag unnecessary abstractions, helpers for one-time operations, or design for hypothetical future requirements
 

--- a/.gitignore
+++ b/.gitignore
@@ -440,7 +440,9 @@ FodyWeavers.xsd
 .DS_Store
 
 # AI
-.claude/
+.claude/*
+!.claude/skills
+!.claude/skills/**
 .gemini/
 
 # Worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -442,7 +442,9 @@ FodyWeavers.xsd
 # AI
 .claude/*
 !.claude/skills
-!.claude/skills/**
+.claude/skills/*
+!.claude/skills/review-pr
+!.claude/skills/review-pr/**
 .gemini/
 
 # Worktrees


### PR DESCRIPTION
## Changes

- Adds `.claude/skills/review-pr/` — a project-local Claude Code skill that enables `/review-pr <number>` for reviewing Nethermind PRs
- Adds `.claude/skills/review-pr/references/nethermind-conventions.md` — Nethermind-specific coding rules (no LINQ, no `var`, structured logging, etc.) derived from AGENTS.md
- Updates `.gitignore`: changes `.claude/` to `.claude/*` + `!.claude/skills/**` so skill files are tracked while local Claude Code state remains ignored

## How it works

Any developer with Claude Code can run `/review-pr 10591` and the skill will:
1. Fetch PR metadata and diff via `gh` CLI
2. Check changes against Nethermind conventions
3. Post inline comments on the exact diff lines via the GitHub API

## Type of change

- [x] Refactor (no production code changed)

## Testing

- [x] Requires no testing

## Documentation

- [x] Does not require documentation update