### PR TITLE
fix(era1): correct verifyConcurrency assignment order in EraStore

### DIFF
--- a/src/Nethermind/Nethermind.Era1/EraStore.cs
+++ b/src/Nethermind/Nethermind.Era1/EraStore.cs
@@ -89,8 +89,8 @@ public class EraStore : IEraStore
         _trustedAccumulators = trustedAccumulators;
         _maxEraFile = maxEraSize;
         _maxOpenFile = Environment.ProcessorCount * 2;
-        if (_verifyConcurrency == 0) _verifyConcurrency = Environment.ProcessorCount;
         _verifyConcurrency = verifyConcurrency;
+        if (_verifyConcurrency == 0) _verifyConcurrency = Environment.ProcessorCount;
 
         // Geth behaviour seems to be to always read the checksum and fail when its missing.
         _checksums = fileSystem.File.ReadAllLines(Path.Join(directory, EraExporter.ChecksumsFileName))


### PR DESCRIPTION
The assignment order was wrong - checked field before assigning parameter value, then immediately overwrote with parameter. This caused the "default to ProcessorCount when 0" logic to never work.