### PR TITLE
fix: make `DbTracker.Paused` thread-safe with volatile

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
@@ -74,7 +74,13 @@ public class DbMonitoringModule : Module
             return _createdDbs;
         }
 
-        public bool Paused { get; set; } = false;
+        private volatile bool _paused;
+
+        public bool Paused
+        {
+            get => _paused;
+            set => _paused = value;
+        }
 
         private void UpdateDbMetrics()
         {


### PR DESCRIPTION
The Paused property was accessed from multiple threads (block processing events and metrics timer callback) without synchronization, causing potential stale reads due to CPU cache coherency issues.

Add volatile keyword to ensure cross-thread visibility of the flag.