### PR TITLE
fix: dead loop in CreateCommonPortStrings

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Stats.Model
         private static string[] CreateCommonPortStrings()
         {
             var ports = new string[100];
-            for (int i = 0; ports.Length < 100; i++)
+            for (int i = 0; i < 100; i++)
             {
                 ports[i] = (i + 30300).ToString().PadLeft(5, ' ');
             }


### PR DESCRIPTION
## Changes

Fix loop condition in `Node.CreateCommonPortStrings()` — `ports.Length < 100` is always `false` since the array is created with length 100, so the loop never executes

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_