### PR TITLE
fix(taiko): correct RLP buffer size in GetCompressedTxsLength

### DIFF
--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -295,7 +295,7 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
         public readonly ulong GetCompressedTxsLength()
         {
             int contentLength = Transactions.Sum(GetTxLength);
-            byte[] data = ArrayPool<byte>.Shared.Rent(contentLength);
+            byte[] data = ArrayPool<byte>.Shared.Rent(Rlp.LengthOfSequence(contentLength));
 
             try
             {


### PR DESCRIPTION
Fixed buffer underallocation in GetCompressedTxsLength(). The method was allocating only contentLength bytes but then calling StartSequence() which writes an RLP header (1-9 bytes) before the actual content. This could cause out-of-bounds writes.

The fix aligns with EstimateTxLength() in the same file which already uses Rlp.LengthOfSequence(contentLength) correctly.