### PR TITLE
Remove unused StoreReceipts and ReceiptsMigration from InitConfig

### DIFF
--- a/src/Nethermind/Nethermind.Api/InitConfig.cs
+++ b/src/Nethermind/Nethermind.Api/InitConfig.cs
@@ -24,8 +24,6 @@ namespace Nethermind.Api
         public string? KzgSetupPath { get; set; } = null;
         public string LogDirectory { get; set; } = "logs";
         public string? LogRules { get; set; } = null;
-        public bool StoreReceipts { get; set; } = true;
-        public bool ReceiptsMigration { get; set; } = false;
         public DiagnosticMode DiagnosticMode { get; set; } = DiagnosticMode.None;
         public DumpOptions AutoDump { get; set; } = DumpOptions.Default;
 


### PR DESCRIPTION
## Changes

Remove unused `StoreReceipts` and `ReceiptsMigration` properties from `InitConfig`. These properties are already defined in `IReceiptConfig`/`ReceiptConfig` and used from there.

## Types of changes

- [x] Refactoring

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No