### PR TITLE
fix: update SetL1OriginSignature API to use byte[] and add validation

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/L1OriginStoreTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/L1OriginStoreTests.cs
@@ -164,7 +164,7 @@ public class L1OriginStoreTests
     public void Can_store_and_retrieve_signature()
     {
         UInt256 blockId = 123;
-        int[] signature = Enumerable.Range(0, 65).ToArray();
+        byte[] signature = Enumerable.Range(0, 65).Select(i => (byte)i).ToArray();
         L1Origin origin = new(blockId, Hash256.Zero, 456, Hash256.Zero, null) { Signature = signature };
 
         _store.WriteL1Origin(blockId, origin);
@@ -196,7 +196,7 @@ public class L1OriginStoreTests
     [TestCase(L1OriginDecoder.SignatureLength * 2)]
     public void Fails_for_invalid_length_signature(int signatureLength)
     {
-        int[] signature = Enumerable.Range(0, signatureLength).ToArray();
+        byte[] signature = Enumerable.Range(0, signatureLength).Select(i => (byte)i).ToArray();
         L1Origin origin = new(1, Hash256.Zero, 456, Hash256.Zero, null) { Signature = signature };
 
         Action act = () => _decoder.Encode(origin);
@@ -210,7 +210,7 @@ public class L1OriginStoreTests
         [Values(false, true)] bool withSignature)
     {
         int[]? buildPayloadArgsId = withBuildPayload ? Enumerable.Range(0, 8).ToArray() : null;
-        int[]? signature = withSignature ? Enumerable.Range(0, 65).ToArray() : null;
+        byte[]? signature = withSignature ? Enumerable.Range(0, 65).Select(i => (byte)i).ToArray() : null;
         L1Origin origin = new(123, Hash256.Zero, 456, Hash256.Zero, buildPayloadArgsId, withForcedInclusion, signature);
 
         Rlp encoded = _decoder.Encode(origin);

--- a/src/Nethermind/Nethermind.Taiko/L1Origin.cs
+++ b/src/Nethermind/Nethermind.Taiko/L1Origin.cs
@@ -12,7 +12,7 @@ public class L1Origin(UInt256 blockId,
     ValueHash256 l1BlockHash,
     int[]? buildPayloadArgsId,
     bool isForcedInclusion = false,
-    int[]? signature = null)
+    byte[]? signature = null)
 {
     public UInt256 BlockId { get; set; } = blockId;
     public ValueHash256? L2BlockHash { get; set; } = l2BlockHash;
@@ -22,7 +22,7 @@ public class L1Origin(UInt256 blockId,
     // Taiko uses int-like serializer (Go's default encoding for byte arrays)
     public int[]? BuildPayloadArgsId { get; set; } = buildPayloadArgsId;
     public bool IsForcedInclusion { get; set; } = isForcedInclusion;
-    public int[]? Signature { get; set; } = signature;
+    public byte[]? Signature { get; set; } = signature;
 
     /// <summary>
     /// IsPreconfBlock returns true if the L1Origin is for a preconfirmation block.

--- a/src/Nethermind/Nethermind.Taiko/L1OriginDecoder.cs
+++ b/src/Nethermind/Nethermind.Taiko/L1OriginDecoder.cs
@@ -32,7 +32,7 @@ public sealed class L1OriginDecoder : RlpStreamDecoder<L1Origin>
         }
 
         bool isForcedInclusion = itemsCount >= 6 && rlpStream.DecodeBool();
-        int[]? signature = itemsCount >= 7 ? Array.ConvertAll(rlpStream.DecodeByteArray(), Convert.ToInt32) : null;
+        byte[]? signature = itemsCount >= 7 ? rlpStream.DecodeByteArray() : null;
 
         return new(blockId, l2BlockHash, l1BlockHeight, l1BlockHash, buildPayloadArgsId, isForcedInclusion, signature);
     }
@@ -87,7 +87,7 @@ public sealed class L1OriginDecoder : RlpStreamDecoder<L1Origin>
                 throw new RlpException($"{nameof(item.Signature)} should be exactly {SignatureLength}");
             }
 
-            stream.Encode(Array.ConvertAll(item.Signature, Convert.ToByte));
+            stream.Encode(item.Signature);
         }
     }
 

--- a/src/Nethermind/Nethermind.Taiko/Rpc/ITaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/ITaikoEngineRpcModule.cs
@@ -88,7 +88,7 @@ public interface ITaikoEngineRpcModule : IEngineRpcModule
         Description = "Sets the L1 origin signature for the given block ID.",
         IsSharable = true,
         IsImplemented = true)]
-    ResultWrapper<L1Origin> taikoAuth_setL1OriginSignature(UInt256 blockId, int[] signature);
+    ResultWrapper<L1Origin> taikoAuth_setL1OriginSignature(UInt256 blockId, byte[] signature);
 
     /// <summary>
     /// Clears txpool state (hash cache, account cache, pending transactions) after a chain reorg.

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -370,8 +370,13 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
         return ResultWrapper<UInt256>.Success(batchId);
     }
 
-    public ResultWrapper<L1Origin> taikoAuth_setL1OriginSignature(UInt256 blockId, int[] signature)
+    public ResultWrapper<L1Origin> taikoAuth_setL1OriginSignature(UInt256 blockId, byte[] signature)
     {
+        if (signature.Length != L1OriginDecoder.SignatureLength)
+        {
+            return ResultWrapper<L1Origin>.Fail($"signature must be exactly {L1OriginDecoder.SignatureLength} bytes, got {signature.Length}");
+        }
+
         L1Origin? l1Origin = l1OriginStore.ReadL1Origin(blockId);
         if (l1Origin is null)
         {


### PR DESCRIPTION
Closes https://github.com/taikoxyz/taiko-geth/pull/531

## Changes

- Change L1Origin.Signature from int[] to byte[]
- Add 65-byte validation in taikoAuth_setL1OriginSignature RPC method
- Update RLP encoder/decoder to handle byte[] type
- Update tests to use byte[] fixtures

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: 

## Testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No