### PR TITLE
Bump codecov-action from v3 to v5

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -154,7 +154,7 @@ jobs:
 
   codecov-upload:
     name: Upload Codecov reports
-    needs: [tests-summary]
+    needs: [tests, tests-summary]
     if: needs.tests.outputs.collect_coverage == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -165,8 +165,9 @@ jobs:
           pattern: '*-coverage'
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           name: codecov-nethermind
           directory: .coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- `codecov/codecov-action@v3` in `nethermind-tests.yml` is deprecated; v5 is already used in `ci-surge.yml` and `ci-taiko.yml`
- Also aligns token passing style (`env:` instead of `with:`) with the rest of the repo

## Test plan
- [x] Verified v5 input parameters are compatible (token, name, directory all supported)
- [ ] Coverage upload will be validated on next master push after merge