### PR TITLE
fix: prevent false SYNCING by checking committed boundary in HasRoot

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -1428,9 +1428,14 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         if (!HasRoot(stateRoot)) return false;
 
-        // Reject blocks whose state may have been partially pruned (root exists but child nodes don't)
+        // Reject blocks whose state may have been partially pruned (root exists but child nodes don't).
+        // Both conditions must hold: block must be older than the persisted boundary AND older than
+        // the committed boundary. State within _maxDepth of LatestCommittedBlockNumber is still
+        // held in the dirty nodes cache.
         long lastPersisted = LastPersistedBlockNumber;
-        if (lastPersisted > 0 && blockNumber < lastPersisted - _maxDepth)
+        if (lastPersisted > 0
+            && blockNumber < lastPersisted - _maxDepth
+            && blockNumber < LatestCommittedBlockNumber - _maxDepth)
         {
             return false;
         }


### PR DESCRIPTION
## Changes

- Add `LatestCommittedBlockNumber` boundary check to `TrieStore.HasRoot(stateRoot, blockNumber)`, mirroring the existing `IsNoLongerNeeded` logic
- State is now only rejected when the block is beyond **both** the persisted and committed boundaries
- Add regression test `HasRoot_with_block_number_accepts_state_within_committed_boundary` that fails without the fix
- Add complementary test `HasRoot_with_block_number_rejects_state_beyond_both_boundaries` confirming the original protection still works

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two new tests added to `TreeStoreTests.cs`:

1. **`HasRoot_with_block_number_accepts_state_within_committed_boundary`** — Regression test reproducing the edge case where `LastPersistedBlockNumber > LatestCommittedBlockNumber` (e.g., node restart with a persistence checkpoint from a prior session). Verifies blocks beyond the persisted boundary but within the committed boundary are accepted. This test fails without the fix.

2. **`HasRoot_with_block_number_rejects_state_beyond_both_boundaries`** — Complementary test confirming that blocks beyond both boundaries are still correctly rejected (preserving the original PR #10534 protection against `TrieException`).

All existing `TreeStoreTests` (86 tests), `BlockchainBridgeTests.HasStateForBlock` tests pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

PR #10534 added a block number check to `HasRoot` to prevent `TrieException` on pruned blocks (issue #9408). However, the check only compared against `LastPersistedBlockNumber`, which is too aggressive when it exceeds `LatestCommittedBlockNumber`. This can happen in edge cases like node restarts where the persistence checkpoint is from a prior session. The fix adds the `LatestCommittedBlockNumber` check to mirror the established `IsNoLongerNeeded` pattern — state is only truly unavailable when the block is beyond **both** boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)