### PR TITLE
feat(jsonrpc): add response header injection infrastructure

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcContextResponseHeadersTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcContextResponseHeadersTests.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.JsonRpc.Modules;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test;
+
+[TestFixture]
+public class JsonRpcContextResponseHeadersTests
+{
+    [TearDown]
+    public void TearDown()
+    {
+        JsonRpcContext.Current.Value?.Dispose();
+        JsonRpcContext.Current.Value = null;
+    }
+
+    [Test]
+    public void SetResponseHeader_WhenContextExists_AddsHeader()
+    {
+        using JsonRpcContext context = new(RpcEndpoint.Http);
+
+        JsonRpcContext.SetResponseHeader("X-Arb-Gas-Used", "12345");
+
+        Assert.That(context.ResponseHeaders, Is.Not.Null);
+        Assert.That(context.ResponseHeaders!["X-Arb-Gas-Used"], Is.EqualTo("12345"));
+    }
+
+    [Test]
+    public void SetResponseHeader_WhenContextIsNull_DoesNotThrow()
+    {
+        JsonRpcContext.Current.Value = null;
+
+        Assert.DoesNotThrow(() => JsonRpcContext.SetResponseHeader("X-Arb-Gas-Used", "12345"));
+    }
+
+    [Test]
+    public void SetResponseHeader_WhenCalledMultipleTimes_OverwritesPreviousValue()
+    {
+        using JsonRpcContext context = new(RpcEndpoint.Http);
+
+        JsonRpcContext.SetResponseHeader("X-Arb-Gas-Used", "12345");
+        JsonRpcContext.SetResponseHeader("X-Arb-Gas-Used", "67890");
+
+        Assert.That(context.ResponseHeaders!["X-Arb-Gas-Used"], Is.EqualTo("67890"));
+    }
+
+    [Test]
+    public void SetResponseHeader_WhenCalledWithMultipleHeaders_AddsAllHeaders()
+    {
+        using JsonRpcContext context = new(RpcEndpoint.Http);
+
+        JsonRpcContext.SetResponseHeader("X-Arb-Gas-Used", "12345");
+        JsonRpcContext.SetResponseHeader("X-Arb-Block-Time", "1234567890");
+        JsonRpcContext.SetResponseHeader("X-Arb-L1-Block", "100");
+
+        Assert.That(context.ResponseHeaders!.Count, Is.EqualTo(3));
+        Assert.That(context.ResponseHeaders["X-Arb-Gas-Used"], Is.EqualTo("12345"));
+        Assert.That(context.ResponseHeaders["X-Arb-Block-Time"], Is.EqualTo("1234567890"));
+        Assert.That(context.ResponseHeaders["X-Arb-L1-Block"], Is.EqualTo("100"));
+    }
+
+    [Test]
+    public void ResponseHeaders_ByDefault_IsNull()
+    {
+        using JsonRpcContext context = new(RpcEndpoint.Http);
+
+        Assert.That(context.ResponseHeaders, Is.Null);
+    }
+
+    [Test]
+    public void SetResponseHeader_LazilyCreatesResponseHeaders()
+    {
+        using JsonRpcContext context = new(RpcEndpoint.Http);
+        Assert.That(context.ResponseHeaders, Is.Null);
+
+        JsonRpcContext.SetResponseHeader("X-Test", "value");
+
+        Assert.That(context.ResponseHeaders, Is.Not.Null);
+    }
+
+    [Test]
+    public void SetResponseHeader_WithHttpEndpoint_WorksCorrectly()
+    {
+        using JsonRpcContext httpContext = new(RpcEndpoint.Http);
+        JsonRpcContext.SetResponseHeader("X-Http-Header", "http-value");
+        Assert.That(httpContext.ResponseHeaders!["X-Http-Header"], Is.EqualTo("http-value"));
+    }
+
+    [Test]
+    public void SetResponseHeader_WithWsEndpoint_WorksCorrectly()
+    {
+        using JsonRpcContext wsContext = new(RpcEndpoint.Ws);
+        JsonRpcContext.SetResponseHeader("X-Ws-Header", "ws-value");
+        Assert.That(wsContext.ResponseHeaders!["X-Ws-Header"], Is.EqualTo("ws-value"));
+    }
+
+    [Test]
+    public void ContextDispose_ClearsCurrentContext()
+    {
+        JsonRpcContext context = new(RpcEndpoint.Http);
+        JsonRpcContext.SetResponseHeader("X-Test", "value");
+
+        context.Dispose();
+
+        JsonRpcContext.SetResponseHeader("X-Test-After", "value");
+        Assert.That(context.ResponseHeaders!.TryGetValue("X-Test", out _), Is.True);
+        Assert.That(context.ResponseHeaders!.TryGetValue("X-Test-After", out _), Is.False);
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Nethermind.JsonRpc.Modules;
 
@@ -27,6 +28,20 @@ namespace Nethermind.JsonRpc
         public IJsonRpcDuplexClient? DuplexClient { get; }
         public JsonRpcUrl? Url { get; }
         public bool IsAuthenticated { get; }
+
+        public IDictionary<string, string>? ResponseHeaders { get; private set; }
+
+        public static void SetResponseHeader(string key, string value)
+        {
+            JsonRpcContext? context = Current.Value;
+            if (context is null)
+            {
+                return;
+            }
+
+            context.ResponseHeaders ??= new Dictionary<string, string>();
+            context.ResponseHeaders[key] = value;
+        }
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/HttpJsonRpcResponseSink.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/HttpJsonRpcResponseSink.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
@@ -200,6 +201,14 @@ internal sealed class HttpJsonRpcResponseSink(
         context.Response.StatusCode = isCollection
             ? StatusCodes.Status200OK
             : GetStatusCode(response);
+
+        if (JsonRpcContext.Current.Value?.ResponseHeaders is { } responseHeaders)
+        {
+            foreach (KeyValuePair<string, string> header in responseHeaders)
+            {
+                context.Response.Headers[header.Key] = header.Value;
+            }
+        }
     }
 
     private static int GetStatusCode(JsonRpcResponse? response) =>


### PR DESCRIPTION
## Changes

  - Add `ResponseHeaders` dictionary property to `JsonRpcContext` for storing custom HTTP response headers
  - Add static `SetResponseHeader(string key, string value)` method for thread-safe header injection from any RPC handler
  - Apply response headers from `JsonRpcContext` to HTTP response before writing body in `Startup.cs`

  ## Types of changes

  #### What types of changes does your code introduce?

  - [ ] Bugfix (a non-breaking change that fixes an issue)
  - [x] New feature (a non-breaking change that adds functionality)
  - [ ] Breaking change (a change that causes existing functionality not to work as expected)
  - [ ] Optimization
  - [ ] Refactoring
  - [ ] Documentation update
  - [ ] Build-related changes
  - [ ] Other: _Description_

  ## Testing

  #### Requires testing

  - [x] Yes
  - [ ] No

  #### If yes, did you write tests?

  - [x] Yes
  - [ ] No

  #### Notes on testing

  - Unit tests in `JsonRpcContextResponseHeadersTests.cs` covering:
    - Setting single header
    - Setting multiple headers
    - Overwriting existing header
    - No-op when context is null (thread safety)

  ## Documentation

  #### Requires documentation update

  - [ ] Yes
  - [x] No

  #### Requires explanation in Release Notes

  - [ ] Yes
  - [x] No

  ## Remarks

  This provides infrastructure for RPC handlers to inject custom HTTP response headers. The feature is used by Arbitrum plugin to expose block metadata (`X-Arb-Gas-Used`) for benchmarking.