### PR TITLE
Fix ChannelDecoder returning garbage bytes from buffer

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/CL/Decoding/ChannelDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Decoding/ChannelDecoder.cs
@@ -31,7 +31,7 @@ public class ChannelDecoder
         {
             throw new Exception($"Unsupported compression algorithm {data[0]}");
         }
-        return memoryStream.GetBuffer();
+        return memoryStream.GetBuffer().AsMemory(0, (int)memoryStream.Length);
     }
 
     private static void CopyDataWithLimit(Stream input, Stream output)


### PR DESCRIPTION
MemoryStream.GetBuffer() returns the internal buffer which may be larger than actual data written.
This caused RLP decoder to receive trailing zero bytes after decompressed channel data, potentially corrupting batch parsing. Fixed by slicing buffer to actual length.