### PR TITLE
fix(flashbots): wrong unit in withdrawal amount

### DIFF
--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateBuilderSubmissionHandler.cs
@@ -239,7 +239,7 @@ public class ValidateSubmissionHandler
             {
                 if (withdrawal.Address == feeRecipient)
                 {
-                    amtBeforeOrWithdrawn += withdrawal.AmountInGwei;
+                    amtBeforeOrWithdrawn += withdrawal.AmountInWei;
                 }
             }
         }


### PR DESCRIPTION
amtBeforeOrWithdrawn is in Wei but we were adding AmountInGwei directly. Off by 10^9.