### PR TITLE
Fix AccountDecoder.Instance allocating a new instance per call

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -12,8 +12,8 @@ namespace Nethermind.Serialization.Rlp
     {
         private readonly bool _slimFormat;
 
-        public static AccountDecoder Instance => new();
-        public static AccountDecoder Slim => new(slimFormat: true);
+        public static AccountDecoder Instance { get; } = new();
+        public static AccountDecoder Slim { get; } = new(slimFormat: true);
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AccountDecoder))]
         public AccountDecoder() { }


### PR DESCRIPTION
## Changes

- Change Instance and Slim properties from expression-bodied (`=> new()`) to auto-properties with initializers (`{ get; } = new()`) so they return a cached singleton instead of allocating on every access.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] No