### PR TITLE
fix(upnp): correct port mapping lifetime calculation

### DIFF
--- a/src/Nethermind/Nethermind.UPnP.Plugin/UPnPStep.cs
+++ b/src/Nethermind/Nethermind.UPnP.Plugin/UPnPStep.cs
@@ -73,13 +73,13 @@ public class UPnPStep(
             Protocol.Tcp,
             networkConfig.P2PPort,
             networkConfig.P2PPort,
-            ExpirationRate.Milliseconds + 10000,
+            (int)ExpirationRate.TotalMilliseconds + 10000,
             "Nethermind P2P"));
         await device.CreatePortMapAsync(new Mapping(
             Protocol.Udp,
             networkConfig.DiscoveryPort,
             networkConfig.DiscoveryPort,
-            ExpirationRate.Milliseconds + 10000,
+            (int)ExpirationRate.TotalMilliseconds + 10000,
             "Nethermind Discovery"));
 
         if (_logger.IsDebug) _logger.Debug("UPnP mapping added");


### PR DESCRIPTION
TimeSpan.Milliseconds returns only the milliseconds component (0-999), not the total value. For TimeSpan.FromMinutes(10), .Milliseconds is 0, so mappings expired after 10 seconds instead of 10 minutes. This caused port forwarding to fail most of the time.