### PR TITLE
perf: Refactor `WitnessExtensions.DecodeHeaders` method

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -31,7 +31,8 @@ public class Witness : IDisposable
 
 public static class WitnessExtensions
 {
-    private static readonly IRlpValueDecoder<BlockHeader> _decoder = Rlp.GetValueDecoder<BlockHeader>();
+    private static readonly IRlpValueDecoder<BlockHeader> _decoder =
+        Rlp.GetValueDecoder<BlockHeader>() ?? new HeaderDecoder();
 
     extension(Witness witness)
     {


### PR DESCRIPTION
## Changes

- Set pre-sized `ArrayPoolList` to work around `GuardIndex`
- Used `Rlp.GetValueDecoder<BlockHeader>()` instead of creating a new `HeaderDecoder` instance
- Improved error handling (I'm not sure we should throw there, though)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No