### PR TITLE
Fix Eth62ProtocolHandler to handle NewBlockMessage in background

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -306,7 +306,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         }
 
         [Test]
-        public void Throws_if_adding_new_block_fails()
+        public void Disconnects_peer_if_adding_new_block_fails()
         {
             using NewBlockMessage newBlockMessage = new();
             newBlockMessage.Block = Build.A.Block.WithParent(_genesisBlock).TestObject;
@@ -317,10 +317,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             IByteBuffer getBlockHeadersPacket = _svc.ZeroSerialize(newBlockMessage);
             getBlockHeadersPacket.ReadByte();
 
-            _syncManager.WhenForAnyArgs(w => w.AddNewBlock(null, _handler)).Do(ci => throw new Exception());
-            Assert.Throws<Exception>(
-                () => _handler.HandleMessage(
-                    new ZeroPacket(getBlockHeadersPacket) { PacketType = Eth62MessageCode.NewBlock }));
+            _syncManager.WhenForAnyArgs(w => w.AddNewBlock(null!, _handler)).Do(_ => throw new Exception());
+            _handler.HandleMessage(new ZeroPacket(getBlockHeadersPacket) { PacketType = Eth62MessageCode.NewBlock });
+
+            _session.Received().InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, Arg.Any<string>());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -183,9 +183,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 case Eth62MessageCode.NewBlock:
                     if (CanAcceptBlockGossip())
                     {
-                        using NewBlockMessage newBlockMsg = Deserialize<NewBlockMessage>(message.Content);
-                        ReportIn(newBlockMsg, size);
-                        Handle(newBlockMsg);
+                        HandleInBackground<NewBlockMessage>(message, Handle);
                     }
                     break;
             }
@@ -309,7 +307,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             }
         }
 
-        private void Handle(NewBlockMessage msg)
+        private ValueTask Handle(NewBlockMessage msg, CancellationToken cancellationToken)
         {
             try
             {
@@ -321,6 +319,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 if (Logger.IsDebug) Logger.Debug($"Handling {msg} from {Node:c} failed: " + e.Message);
                 throw;
             }
+
+            return ValueTask.CompletedTask;
         }
 
         protected virtual void NotifyOfStatus(BlockHeader head)

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -135,6 +135,7 @@ public class TrieStoreScopeProvider : IWorldStateScopeProvider
                 }
             }
 
+            // STUCK HERE (comment will be removed)
             Task.WaitAll(commitTask.AsSpan());
             _backingStateTree.Commit();
             _storages.Clear();


### PR DESCRIPTION
When a **new block** is received over P2P (gossiped `NewBlockMessage`), the node can hang.

**Cause:** Block processing eventually calls `TrieStoreScopeProvider.Commit()`. It schedules tasks onto the same event loop thread and then blocks with `Task.WaitAll`, causing a self-deadlock.

Blocks with no transactions don’t trigger trie commits, so they process fine.
To reproduce on a private chain, create a transaction that modifies storage and process it from `NewBlockMessage` gossip.
The hang was observed on XDC and JOC 

Flow when a new block is received (stuck at Task.WaitAll):

```
ZeroNettyP2PHandler.ChannelRead0()
  → XdcProtocolHandler.HandleMessage()
  → Eth62ProtocolHandler.Handle()
  → SyncServer.AddNewBlock()
  → SyncServer.SyncBlock()
  → BlockTree.SuggestBlock()
  → … process block …
  → WorldState.CommitTree()
  → TrieStoreScopeProvider.Commit()
  → Task.WaitAll()   ← stuck here
```
