### PR TITLE
fix: remove redundant SetNonce call in GeneralTestBase

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -210,8 +210,8 @@ namespace Ethereum.Test.Base
                         storageItem.Value.WithoutLeadingZeros().ToArray());
                 }
 
-            stateProvider.CreateAccount(accountState.Key, accountState.Value.Balance, accountState.Value.Nonce);
-            stateProvider.InsertCode(accountState.Key, accountState.Value.Code, specProvider.GenesisSpec);
+                stateProvider.CreateAccount(accountState.Key, accountState.Value.Balance, accountState.Value.Nonce);
+                stateProvider.InsertCode(accountState.Key, accountState.Value.Code, specProvider.GenesisSpec);
             }
 
             stateProvider.Commit(specProvider.GenesisSpec);


### PR DESCRIPTION
CreateAccount already accepts nonce as a parameter, so calling SetNonce separately right after was unnecessary. This aligns GeneralTestBase with BlockchainTestBase which uses the single-call approach.