### PR TITLE
fix(tests): use enableEip1559 parameter in nonce validation test

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
@@ -490,7 +490,7 @@ internal class SpecialTransactionsTests
         var blockChain = await XdcTestBlockchain.Create(5, false);
         blockChain.ChangeReleaseSpec((spec) =>
         {
-            spec.IsEip1559Enabled = false;
+            spec.IsEip1559Enabled = enableEip1559;
             spec.IsTipTrc21FeeEnabled = false;
         });
 


### PR DESCRIPTION
The test `Malformed_SenderNonceEqualLesserThanTxNonce_SignTx_Fails_Validation` accepts `enableEip1559` parameter via TestCase attributes but hardcodes `false` instead of using the parameter. This makes the `[TestCase(true)]` run identical to `[TestCase(false)]`.

Same type of bug was fixed in c102e1d473.