### PR TITLE
fix(ui): assign slice result to txsToAdd array

### DIFF
--- a/src/Nethermind/Nethermind.UI/scripts/app.ts
+++ b/src/Nethermind/Nethermind.UI/scripts/app.ts
@@ -300,7 +300,7 @@ sse.addEventListener("forkChoice", (e) => {
   txsToAdd.push(...mergedData);
   lastBlockTxs = txsToAdd.length;
 
-  if (txsToAdd.length > 250000) txsToAdd.slice(txsToAdd.length - 25000);
+  if (txsToAdd.length > 250000) txsToAdd = txsToAdd.slice(txsToAdd.length - 25000);
 
   blockTxs = mapByHash(mergedData)
 });


### PR DESCRIPTION
Array.slice() returns a new array and doesn't mutate the original. Without assignment, the memory limit check did nothing - txsToAdd could grow indefinitely.