### PR TITLE
Remove redundant wellFormed check in ShutterTxFilter

### DIFF
--- a/src/Nethermind/Nethermind.Shutter/ShutterTxFilter.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxFilter.cs
@@ -40,6 +40,6 @@ public class ShutterTxFilter(
             return AcceptTxResult.Invalid;
         }
 
-        return wellFormed ? AcceptTxResult.Accepted : AcceptTxResult.Invalid;
+        return AcceptTxResult.Accepted;
     }
 }


### PR DESCRIPTION
The ternary operator on return was unnecessary - wellFormed is always true at that point since we already return early if it's false.