### PR TITLE
fix(dns): correct Base64 padding calculation in EnrRecordParser

### DIFF
--- a/src/Nethermind/Nethermind.Network.Dns/EnrRecordParser.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrRecordParser.cs
@@ -44,8 +44,9 @@ public class EnrRecordParser : IEnrRecordParser
         {
             if (base64[^1] != '=')
             {
-                int mod3 = base64.Count % 4;
-                for (int i = 0; i < mod3; i++)
+                int mod4 = base64.Count % 4;
+                int paddingNeeded = (4 - mod4) % 4;
+                for (int i = 0; i < paddingNeeded; i++)
                 {
                     byteBuffer.WriteString("=", Encoding.UTF8);
                 }


### PR DESCRIPTION
Fixed incorrect padding logic in AddPadding method. The old code added `mod4` padding characters instead of `(4 - mod4) % 4`. This caused 3 padding chars to be added when length % 4 == 3, but Base64 only allows max 2. The variable was also misleadingly named `mod3` while computing % 4.