### PR TITLE
Use modern libziskos and implement canonical way to reference precompiles

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
-    <PackageVersion Include="Nethermind.ZiskBindings" Version="1.0.0-preview.7" />
+    <PackageVersion Include="Nethermind.ZiskBindings" Version="1.0.0-preview.13" />
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
     <PackageVersion Include="NJsonSchema" Version="11.3.2" />
     <PackageVersion Include="NLog" Version="5.5.1" />

--- a/tools/Stateless/Makefile
+++ b/tools/Stateless/Makefile
@@ -94,9 +94,7 @@ build-zisk: build-dotnet-zisk
 		--mount type=bind,source="$(ZISK_DIR)",target=$(SRC_DIR) \
 		nethermindeth/bflat-riscv64:latest \
 		$(BFLAT_BUILD) --libc zisk $(BFLAT_REFS) \
-		-r $(BIN_DIR)/Nethermind.ZiskBindings.dll \
-		--extra-ld $(BIN_DIR)/runtimes/linux-riscv64/native/libziskos.a \
-		--extlib $(BIN_DIR)/runtimes/linux-riscv64/native/libziskos.bflat.manifest \
+		--extlib $(BIN_DIR)/libziskos.bflat.manifest \
 		$(SRC_DIR)/Program.cs
 	mkdir -p $(ZISK_DIR)/bin && \
 		mv -f $(ZISK_DIR)/Program.patched $(ZISK_DIR)/bin/nethermind && \


### PR DESCRIPTION
The latest bflat introduces a new model in which external libraries can be referenced by --extlib <path to bflat manifest>. In our case, it means that we may reuse the bflat manifest passed with nupkg of the libziskos (aka Nethermind.ZiskBindings). In that case we also remove direct references to dll and .a

## Changes

- New version of Nethermind.ZiskBindings.
- Another way to use it.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
