### PR TITLE
engine: return -38003 for FCUv2 payloadAttributes mismatch

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -147,6 +147,11 @@ public class PayloadAttributes
             }
 
             error = $"{methodName}{apiVersion} expected";
+            if (apiVersion == EngineApiVersions.Shanghai)
+            {
+                return PayloadAttributesValidationResult.InvalidPayloadAttributes;
+            }
+
             return actualVersion <= EngineApiVersions.Paris ? PayloadAttributesValidationResult.InvalidParams : PayloadAttributesValidationResult.InvalidPayloadAttributes;
         }
 
@@ -154,6 +159,11 @@ public class PayloadAttributes
         if (timestampVersion != apiVersion)
         {
             error = $"{methodName}{timestampVersion} expected";
+            if (apiVersion == EngineApiVersions.Shanghai)
+            {
+                return PayloadAttributesValidationResult.InvalidPayloadAttributes;
+            }
+
             return timestampVersion <= EngineApiVersions.Paris ? PayloadAttributesValidationResult.InvalidParams : PayloadAttributesValidationResult.UnsupportedFork;
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -635,13 +635,13 @@ public partial class EngineModuleTests
             "{0}V2 expected",
             null,
             "0x6817d4b48be0bc14f144cc242cdc47a5ccc40de34b9c3934acad45057369f576",
-            ErrorCodes.InvalidParams);
+            MergeErrorCodes.InvalidPayloadAttributes);
         yield return (
             London.Instance,
             "{0}V1 expected",
             Array.Empty<Withdrawal>(),
             "0xaa4aa15951a28e6adab430a795e36a84649bbafb1257eda23e38b9131cbd3b98",
-            ErrorCodes.InvalidParams);
+            MergeErrorCodes.InvalidPayloadAttributes);
     }
 
     [TestCaseSource(nameof(ZeroWithdrawalsTestCases))]


### PR DESCRIPTION
This PR updates `engine_forkchoiceUpdatedV2` to return `-38003: Invalid payload attributes` when the wrong `payloadAttributes` version is used.

  In particular, FCUv2 payload-attribute version mismatches such as:
  - missing `withdrawals` at or after Shanghai
  - unexpected `withdrawals` before Shanghai

  should be treated as `Invalid payload attributes`, not `Invalid params`.

  ## Why

  This change aligns the client with the latest Engine API spec update in:
  - ethereum/execution-apis#761

  It also follows the implementation discussion and prior client-side change in:
  - ethereum/go-ethereum#33918

  The spec was clarified so that FCUv2 now behaves consistently with newer forkchoiceUpdated versions for payloadAttributes structure/version
  mismatches.

  ## What changed

  - Updated FCUv2 payload attributes validation to return `-38003` for payloadAttributes version mismatches.
  - Added/updated regression coverage for the affected FCUv2 cases.

  ## Hive impact

  This fixes the Hive `engine-withdrawals` failure caused by returning the wrong error code for FCUv2 payloadAttributes mismatches.

  Relevant Hive failure:
  - https://hive.ethpandaops.io/#/test/generic/1773130719-e0853d5fae804ded99a295a416e78bad

  After this change, the client returns the expected error code for the affected FCUv2 cases.

  If my understanding or interpretation of the spec change is incorrect, please let me know and I can adjust the implementation accordingly.