### PR TITLE
test: Slight cleanup of TestBlockchain FromContainer structure

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -125,7 +125,7 @@ public class TestBlockchain : IDisposable
 
     // Resolving all these component at once is faster.
     protected FromContainer _fromContainer = null!;
-    public class FromContainer(
+    public sealed class FromContainer(
         Lazy<IStateReader> stateReader,
         Lazy<IEthereumEcdsa> ethereumEcdsa,
         Lazy<INonceManager> nonceManager,

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -54,9 +54,9 @@ public class XdcTestBlockchain : TestBlockchain
         XdcTestBlockchain chain = new(useHotStuffModule, withPenalty);
         await chain.Build(configurer);
 
-        var fromXdcContainer = (FromContainer)chain.Container.Resolve<FromXdcContainer>();
+        var fromXdcContainer = chain.Container.Resolve<FromXdcContainer>();
 
-        Configuration testConfiguration = fromXdcContainer.Configuration;
+        Configuration testConfiguration = chain.Container.Resolve<FromContainer>().Configuration;
 
         if (testConfiguration.SuggestGenesisOnStart)
         {
@@ -96,35 +96,7 @@ public class XdcTestBlockchain : TestBlockchain
     public Signer Signer => (Signer)_fromXdcContainer.Signer;
 
     private FromXdcContainer _fromXdcContainer = null!;
-    public class FromXdcContainer(
-        Lazy<IStateReader> stateReader,
-        Lazy<IEthereumEcdsa> ethereumEcdsa,
-        Lazy<INonceManager> nonceManager,
-        Lazy<IReceiptStorage> receiptStorage,
-        Lazy<ITxPool> txPool,
-        Lazy<IWorldStateManager> worldStateManager,
-        Lazy<IBlockPreprocessorStep> blockPreprocessorStep,
-        Lazy<IBlockTree> blockTree,
-        Lazy<IBlockFinder> blockFinder,
-        Lazy<ILogFinder> logFinder,
-        Lazy<IChainHeadInfoProvider> chainHeadInfoProvider,
-        Lazy<IDbProvider> dbProvider,
-        Lazy<ISpecProvider> specProvider,
-        Lazy<ISealEngine> sealEngine,
-        Lazy<ITransactionComparerProvider> transactionComparerProvider,
-        Lazy<IPoSSwitcher> poSSwitcher,
-        Lazy<IChainLevelInfoRepository> chainLevelInfoRepository,
-        Lazy<IMainProcessingContext> mainProcessingContext,
-        Lazy<IReadOnlyTxProcessingEnvFactory> readOnlyTxProcessingEnvFactory,
-        Lazy<IBlockProducerEnvFactory> blockProducerEnvFactory,
-        Lazy<Configuration> configuration,
-        Lazy<TestBlockchainUtil> testBlockchainUtil,
-        Lazy<PoWTestBlockchainUtil> poWTestBlockchainUtil,
-        Lazy<ManualTimestamper> manualTimestamper,
-        Lazy<IManualBlockProductionTrigger> blockProductionTrigger,
-        Lazy<IShareableTxProcessorSource> shareableTxProcessorSource,
-        Lazy<ISealer> sealer,
-        Lazy<IForkInfo> forkInfo,
+    public sealed class FromXdcContainer(
         Lazy<IEpochSwitchManager> epochSwitchManager,
         Lazy<IQuorumCertificateManager> quorumCertificateManager,
         Lazy<ITimeoutCertificateManager> timeoutCertificateManager,
@@ -132,7 +104,7 @@ public class XdcTestBlockchain : TestBlockchain
         Lazy<IMasternodesCalculator> masternodesCalculator,
         Lazy<IVotesManager> votesManager,
         Lazy<ISigner> signer
-    ) : FromContainer(stateReader, ethereumEcdsa, nonceManager, receiptStorage, txPool, worldStateManager, blockPreprocessorStep, blockTree, blockFinder, logFinder, chainHeadInfoProvider, dbProvider, specProvider, sealEngine, transactionComparerProvider, poSSwitcher, chainLevelInfoRepository, mainProcessingContext, readOnlyTxProcessingEnvFactory, blockProducerEnvFactory, configuration, testBlockchainUtil, poWTestBlockchainUtil, manualTimestamper, blockProductionTrigger, shareableTxProcessorSource, sealer, forkInfo)
+    )
     {
         public IEpochSwitchManager EpochSwitchManager => epochSwitchManager.Value;
         public IQuorumCertificateManager QuorumCertificateManager => quorumCertificateManager.Value;
@@ -159,7 +131,7 @@ public class XdcTestBlockchain : TestBlockchain
         RandomSigner = new TestRandomSigner(MasterNodeCandidates, Container.Resolve<IBlockTree>(), Container.Resolve<IEpochSwitchManager>());
 
         _fromXdcContainer = Container.Resolve<FromXdcContainer>();
-        _fromContainer = (FromContainer)_fromXdcContainer;
+        _fromContainer = Container.Resolve<FromContainer>();
 
         BlockchainProcessor.Start();
 


### PR DESCRIPTION
## Summary

Slight cleanup of test infrastructure:
- Sealed `TestBlockchain.FromContainer` to prevent inheritance
- Separated XDC-specific dependencies into standalone `FromXdcContainer`
- Both containers now resolved independently from DI

## Test plan

- [x] Solution builds successfully
- [x] All 321 XDC tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)