### PR TITLE
fix: remove unreachable code in ClefSigner

### DIFF
--- a/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSigner.cs
+++ b/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSigner.cs
@@ -58,7 +58,6 @@ public class ClefSigner : IHeaderSigner, ISignerStore
     private static Address GetSignerAddress(ClefWallet clefWallet, Address? blockAuthorAccount)
     {
         Address[] accounts = clefWallet.GetAccounts();
-        if (accounts.Length == 0) throw new InvalidOperationException("Remote signer has not been configured with any signers.");
         return blockAuthorAccount is not null
             ? accounts.Any(a => a == blockAuthorAccount)
                 ? blockAuthorAccount


### PR DESCRIPTION
GetAccounts() already throws if accounts array is empty. The check in GetSignerAddress() could never execute.