### PR TITLE
fix Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue()

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -82,10 +82,11 @@ public class BlockchainProcessorTests
                 Processed.AddRange(suggestedBlocks.Select(x => x.Hash!));
 
                 _logger.Info($"Processing {suggestedBlocks.Last().ToString(Block.Format.Short)}");
+                int nextBlock = 0;
                 while (true)
                 {
                     bool notYet = false;
-                    for (int i = 0; i < suggestedBlocks.Count; i++)
+                    for (int i = nextBlock; i < suggestedBlocks.Count; i++)
                     {
                         BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(suggestedBlocks));
                         Block suggestedBlock = suggestedBlocks[i];
@@ -102,6 +103,9 @@ public class BlockchainProcessorTests
                             notYet = true;
                             break;
                         }
+
+                        BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(suggestedBlock, []));
+                        nextBlock = i + 1;
                     }
 
                     if (notYet)
@@ -111,7 +115,6 @@ public class BlockchainProcessorTests
                     else
                     {
                         _rootProcessed.Add(suggestedBlocks.Last().StateRoot!);
-                        BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(suggestedBlocks.Last(), []));
                         return suggestedBlocks.ToArray();
                     }
                 }


### PR DESCRIPTION
Fixes 

 failed Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue (10s    
  126ms)                                                                                
      Block was never processed 2 (0xfa3741...3a20ba)                                   
  Assert.That(wasProcessed, Is.True)                                                    
    Expected: True                                                                      
    But was:  False                                                                     
                                                                                        
    from /home/runner/work/nethermind/nethermind/src/Nethermind/artifacts/bin/Nethermind.Blockchain.Test/release/Nethermind.Blockchain.Test.dll (net10.0|x64)                
      Block was never processed 2 (0xfa3741...3a20ba)                                   
    Assert.That(wasProcessed, Is.True)                                                  
      Expected: True                                                                    
      But was:  False                                                                   
                                                                                        
      at Nethermind.Blockchain.Test.BlockchainProcessorTests.ProcessingTestContext.ProcessedFail(Block block) in  /_/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs:286          
      at Nethermind.Blockchain.Test.BlockchainProcessorTests.Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue() in  /_/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs:692          
                                                                                       
## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test fix