### PR TITLE
fix: fix hardcoded PadDirection in SliceWithZeroPadding UInt256 overloads

### DIFF
--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -26,16 +26,16 @@ namespace Nethermind.Evm
         }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) => startIndex >= span.Length || startIndex > int.MaxValue
-                ? new ZeroPaddedSpan(default, length, PadDirection)
+                ? new ZeroPaddedSpan(default, length, padDirection: padDirection)
                 : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) => startIndex >= span.Length || startIndex > int.MaxValue
-                ? new ZeroPaddedSpan(default, length, PadDirection)
+                ? new ZeroPaddedSpan(default, length, padDirection: padDirection)
                 : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
             startIndex >= bytes.Length || startIndex > int.MaxValue
-                ? new ZeroPaddedSpan(default, length, PadDirection)
+                ? new ZeroPaddedSpan(default, length, padDirection: padDirection)
                 : SliceWithZeroPadding(bytes.Span, (int)startIndex, length, padDirection);
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>


### PR DESCRIPTION


## Changes

UInt256 overloads of SliceWithZeroPadding ignored the padDirection parameter in the out-of-bounds branch, always using PadDirection.Right instead of the caller-provided value

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_