### PR TITLE
fix: remove unreachable code in ModExpPrecompile

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ModExpPrecompile.cs
@@ -355,13 +355,7 @@ public class ModExpPrecompile : IPrecompile<ModExpPrecompile>
             iterationCount = multiplicationResult + bitLength;
             if (iterationCount < multiplicationResult)
             {
-                // Overflowed
                 overflow = 1;
-            }
-            else if (iterationCount < 1)
-            {
-                // Min 1 iteration
-                iterationCount = 1;
             }
         }
 


### PR DESCRIPTION
Remove dead else-if branch in CalculateIterationCount. When exponentLength > 32, multiplicationResult is always >= 8, so iterationCount can never be < 1. This branch was accidentally introduced during optimization refactor in #9008.