### PR TITLE
fix: dispose IncrementalHash in E2StoreWriter

### DIFF
--- a/src/Nethermind/Nethermind.Era1/E2StoreWriter.cs
+++ b/src/Nethermind/Nethermind.Era1/E2StoreWriter.cs
@@ -69,7 +69,11 @@ public class E2StoreWriter : IDisposable
         return _stream.FlushAsync(cancellation);
     }
 
-    public void Dispose() => _stream.Dispose();
+    public void Dispose()
+    {
+        _checksumCalculator.Dispose();
+        _stream.Dispose();
+    }
 
     public ValueHash256 FinalizeChecksum()
     {


### PR DESCRIPTION


## Changes

Fix `IncrementalHash` not being disposed in `E2StoreWriter.Dispose()`, causing native cryptographic resource leak

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_