### PR TITLE
fix: fix encryptor leak in AesCtr method

### DIFF
--- a/src/Nethermind/Nethermind.KeyStore/AesEncrypter.cs
+++ b/src/Nethermind/Nethermind.KeyStore/AesEncrypter.cs
@@ -38,7 +38,7 @@ namespace Nethermind.KeyStore
                             aes.Key = key;
                             aes.IV = iv;
 
-                            var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+                            using var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
                             return Execute(encryptor, content);
                         }
                     case "aes-128-ctr":
@@ -74,7 +74,7 @@ namespace Nethermind.KeyStore
                             aes.Padding = PaddingMode.PKCS7;
                             aes.Key = key;
                             aes.IV = iv;
-                            var decryptor = aes.CreateDecryptor(key, aes.IV);
+                            using var decryptor = aes.CreateDecryptor(key, aes.IV);
                             return Execute(decryptor, cipher);
                         }
                     case "aes-128-ctr":


### PR DESCRIPTION


## Changes

Add `using` for `encryptor` created by `Aes.CreateEncryptor()` in `AesCtr` method

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
