### PR TITLE
feat: add maxUsedGas to eth_simulateV1 results

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/GasConsumed.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/GasConsumed.cs
@@ -10,7 +10,8 @@ namespace Nethermind.Evm.TransactionProcessing;
 /// <param name="OperationGas">Gas used for EVM operations.</param>
 /// <param name="BlockGas">EIP-7778: Regular gas for block accounting (pre-refund). When 0, use SpentGas.</param>
 /// <param name="BlockStateGas">EIP-8037: State gas for block accounting. Block gasUsed = max(sum_regular, sum_state).</param>
-public readonly record struct GasConsumed(long SpentGas, long OperationGas, long BlockGas = 0, long BlockStateGas = 0)
+/// <param name="MaxUsedGas">Maximum gas consumed before refunds; if 0, use SpentGas.</param>
+public readonly record struct GasConsumed(long SpentGas, long OperationGas, long BlockGas = 0, long BlockStateGas = 0, long MaxUsedGas = 0)
 {
     /// <summary>
     /// Gets the effective regular gas for block accounting. When EIP-7778 is enabled,
@@ -18,6 +19,11 @@ public readonly record struct GasConsumed(long SpentGas, long OperationGas, long
     /// </summary>
     public long EffectiveBlockGas => BlockGas > 0 ? BlockGas : SpentGas;
 
+    /// <summary>
+    /// Gets gas consumed before refunds (and floor adjusted), used by eth_simulate maxUsedGas.
+    /// </summary>
+    public long EffectiveMaxUsedGas => MaxUsedGas > 0 ? MaxUsedGas : SpentGas;
+
     public static implicit operator long(GasConsumed gas) => gas.SpentGas;
-    public static implicit operator GasConsumed(long spentGas) => new(spentGas, spentGas, 0);
+    public static implicit operator GasConsumed(long spentGas) => new(spentGas, spentGas, 0, 0, spentGas);
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -853,7 +853,7 @@ namespace Nethermind.Evm.TransactionProcessing
             long blockGas = spentGas - intrinsicState;
             long blockStateGas = intrinsicState;
 
-            return new GasConsumed(spentGas, spentGas, blockGas, blockStateGas);
+            return new GasConsumed(spentGas, spentGas, blockGas, blockStateGas, spentGas);
         }
 
         protected virtual bool DeployLegacyContract(IReleaseSpec spec, Address codeOwner, in TransactionSubstate substate, in StackAccessTracker accessedItems, ref TGasPolicy unspentGas)
@@ -1056,7 +1056,8 @@ namespace Nethermind.Evm.TransactionProcessing
             UInt256 refundAmount = (ulong)(tx.GasLimit - spentGas) * gasPrice;
             PayRefund(tx, refundAmount, spec);
 
-            return new GasConsumed(spentGas, operationGas, blockGas, blockStateGas);
+            long maxUsedGas = Math.Max(preRefundGas, floorGasLong);
+            return new GasConsumed(spentGas, operationGas, blockGas, blockStateGas, maxUsedGas);
         }
 
         protected virtual void PayRefund(Transaction tx, UInt256 refundAmount, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/SimulateCallResult.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/SimulateCallResult.cs
@@ -10,6 +10,7 @@ public class SimulateCallResult
     public ulong Status { get; set; }
     public byte[]? ReturnData { get; set; }
     public ulong? GasUsed { get; set; }
+    public ulong? MaxUsedGas { get; set; }
     public Error? Error { get; set; }
     public ICollection<Log> Logs { get; set; } = [];
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTxTracer.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTxTracer.cs
@@ -85,6 +85,7 @@ public sealed class SimulateTxTracer : TxTracer
         TraceResult = new SimulateCallResult
         {
             GasUsed = (ulong)gasSpent.SpentGas,
+            MaxUsedGas = (ulong)gasSpent.EffectiveMaxUsedGas,
             ReturnData = output,
             Status = StatusCode.Success,
             Logs = _logs.Select((entry, i) => new Log
@@ -107,6 +108,7 @@ public sealed class SimulateTxTracer : TxTracer
         TraceResult = new SimulateCallResult
         {
             GasUsed = (ulong)gasSpent.SpentGas,
+            MaxUsedGas = (ulong)gasSpent.EffectiveMaxUsedGas,
             Error = new Error
             {
                 Message = error is TransactionSubstate.Revert ? "execution reverted" : "execution reverted: " + error,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -190,6 +190,7 @@ public class EthSimulateTestsBlocksAndTransactions
 
         SimulateBlockResult<SimulateCallResult> blockResult = data.Last();
         blockResult.Calls.Select(static c => c.Status).Should().BeEquivalentTo(new[] { (ulong)ResultType.Success, (ulong)ResultType.Success });
+        blockResult.Calls.Should().OnlyContain(static c => c.MaxUsedGas.HasValue && c.GasUsed.HasValue && c.MaxUsedGas.Value >= c.GasUsed.Value);
 
     }
 
@@ -346,6 +347,11 @@ public class EthSimulateTestsBlocksAndTransactions
 
         SimulateCallResult callResult = result.Data.First().Calls.First();
         Assert.That(callResult.Status, Is.EqualTo((ulong)ResultType.Success));
+        Assert.That(callResult.MaxUsedGas, Is.Not.Null);
+        Assert.That(callResult.GasUsed, Is.Not.Null);
+        ulong maxUsedGas = callResult.MaxUsedGas ?? 0;
+        ulong gasUsed = callResult.GasUsed ?? 0;
+        Assert.That(maxUsedGas, Is.GreaterThanOrEqualTo(gasUsed));
 
         UInt256 gasAvailable = new(callResult.ReturnData!, isBigEndian: true);
         Assert.That(gasAvailable, Is.LessThan((UInt256)gasCap));


### PR DESCRIPTION
## Summary
- Add `maxUsedGas` to `eth_simulateV1` call results and populate it from pre-refund gas usage.
- Update simulate tests to validate `maxUsedGas` is present and `>= gasUsed`.

Related spec update: https://github.com/ethereum/execution-apis/pull/746

I build this locally, then ran a local copy of hive rpc-compat tests and as far as I can tell it's working and passing.