### PR TITLE
fix: use block number comparison in HasStateForBlock to prevent SYNCI…

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -91,11 +91,39 @@ public class FlatDbManagerTests
     }
 
     [Test]
-    public async Task HasStateForBlock_NotFound_ReturnsFalse()
+    public async Task HasStateForBlock_AbovePersistedAndNotInRepository_ReturnsFalse()
     {
         StateId stateId = CreateStateId(10);
         _snapshotRepository.HasState(stateId).Returns(false);
         _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(5));
+
+        await using FlatDbManager manager = CreateManager();
+        bool result = manager.HasStateForBlock(stateId);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public async Task HasStateForBlock_BelowPersistedBlockNumber_ReturnsTrue()
+    {
+        // During catch-up without FCU, force-persistence removes in-memory snapshots.
+        // Any state at or below the persisted block number is available via persistence.
+        StateId stateId = CreateStateId(5, rootByte: 0xAA);
+        _snapshotRepository.HasState(stateId).Returns(false);
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(10, rootByte: 0xBB));
+
+        await using FlatDbManager manager = CreateManager();
+        bool result = manager.HasStateForBlock(stateId);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task HasStateForBlock_PreGenesisPersisted_ReturnsFalse()
+    {
+        StateId stateId = CreateStateId(5);
+        _snapshotRepository.HasState(stateId).Returns(false);
+        _persistenceManager.GetCurrentPersistedStateId().Returns(StateId.PreGenesis);
 
         await using FlatDbManager manager = CreateManager();
         bool result = manager.HasStateForBlock(stateId);

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -384,7 +384,14 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     public bool HasStateForBlock(in StateId stateId)
     {
         if (_snapshotRepository.HasState(stateId)) return true;
-        if (_persistenceManager.GetCurrentPersistedStateId() == stateId) return true;
+
+        // Any state at or below the persisted block number is fully available via persistence.
+        // The previous exact-match check caused NewPayload to return SYNCING during catch-up
+        // without FCU: force-persistence removes in-memory snapshots, and the exact persisted
+        // StateId advances past the parent block, making HasStateForBlock return false.
+        StateId persistedStateId = _persistenceManager.GetCurrentPersistedStateId();
+        if (persistedStateId != StateId.PreGenesis && stateId.BlockNumber <= persistedStateId.BlockNumber) return true;
+
         return false;
     }
 


### PR DESCRIPTION
…NG during catch-up

HasStateForBlock previously required an exact StateId match with the persisted state. During catch-up without FCU (finalization stalled), force-persistence removes in-memory snapshots and advances the persisted StateId past the parent block. This caused NewPayload to return SYNCING instead of processing the block, stalling head advancement.

Any state at or below the persisted block number is fully available via the persistence layer, so a <= comparison is correct.

Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
