### PR TITLE
fix(test): add missing isLeaf assertion in HexPrefixTests

### DIFF
--- a/src/Nethermind/Ethereum.HexPrefix.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Ethereum.HexPrefix.Test/HexPrefixTests.cs
@@ -30,6 +30,7 @@ namespace Ethereum.HexPrefix.Test
             Assert.That(resultHex, Is.EqualTo(test.Output));
 
             (byte[] key, bool isLeaf) = Nethermind.Trie.HexPrefix.FromBytes(bytes);
+            Assert.That(isLeaf, Is.EqualTo(test.IsTerm));
             byte[] checkBytes = Nethermind.Trie.HexPrefix.ToBytes(key, isLeaf);
             string checkHex = checkBytes.ToHexString(false);
             Assert.That(checkHex, Is.EqualTo(test.Output));


### PR DESCRIPTION
The test was checking round-trip encoding but never verified that FromBytes returns the correct isLeaf flag. Added explicit assertion to compare decoded isLeaf against expected test.IsTerm.