### PR TITLE
fix(test): replace fork type checks with spec flag checks in test harness

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -90,10 +90,9 @@ public abstract class BlockchainTestBase
         // under the target fork rules when the fork requires it (e.g. EIP-7928 sets BlockAccessListHash).
         bool genesisUsesTargetFork = test.Network.IsEip7928Enabled;
 
-        List<(ForkActivation Activation, IReleaseSpec Spec)> transitions =
-        isEngineTest || genesisUsesTargetFork ?
-        [((ForkActivation)0, test.Network)] :
-        [((ForkActivation)0, test.GenesisSpec), ((ForkActivation)1, test.Network)]; // genesis block is always initialized with Frontier
+        List<(ForkActivation Activation, IReleaseSpec Spec)> transitions = isEngineTest || genesisUsesTargetFork
+            ? [((ForkActivation)0, test.Network)]
+            : [((ForkActivation)0, test.GenesisSpec), ((ForkActivation)1, test.Network)]; // genesis block is always initialized with Frontier
 
         if (test.NetworkAfterTransition is not null)
         {
@@ -103,7 +102,7 @@ public abstract class BlockchainTestBase
         ISpecProvider specProvider = new CustomSpecProvider(test.ChainId, test.ChainId, transitions.ToArray());
 
 
-        if (test.Network is Cancun || test.NetworkAfterTransition is Cancun)
+        if (test.Network.IsEip4844Enabled || test.NetworkAfterTransition?.IsEip4844Enabled == true)
         {
             await KzgPolynomialCommitments.InitializeAsync();
         }

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -128,7 +128,7 @@ namespace Ethereum.Test.Base
                 MixHash = test.CurrentRandom,
                 WithdrawalsRoot = test.CurrentWithdrawalsRoot ?? (spec.WithdrawalsEnabled ? PatriciaTree.EmptyTreeHash : null),
                 ParentBeaconBlockRoot = test.CurrentBeaconRoot,
-                ExcessBlobGas = test.CurrentExcessBlobGas ?? (test.Fork is Cancun ? 0ul : null),
+                ExcessBlobGas = test.CurrentExcessBlobGas ?? (test.Fork.IsEip4844Enabled ? 0ul : null),
                 SlotNumber = test.CurrentSlotNumber,
                 BlobGasUsed = BlobGasCalculator.CalculateBlobGas(test.Transaction),
                 RequestsHash = test.RequestsHash ?? (spec.RequestsEnabled ? ExecutionRequestExtensions.EmptyRequestsHash : null),


### PR DESCRIPTION
## Summary

- Replace `test.Fork is Cancun` / `test.Network is Cancun` exact type checks with `IsEip4844Enabled` spec flag checks in the Ethereum test harness
- Fixes BLOBBASEFEE (0x4A) returning `BadInstruction` on post-Cancun state and blockchain tests (Prague, Osaka, …) that won't specify `CurrentExcessBlobGas` explicitly (fuzz testing in practive)
- Fixes KZG polynomial commitments not being initialized for post-Cancun blockchain tests

## Root cause

The named fork classes (`Cancun`, `Prague`, `Osaka`, …) are **sibling classes** inheriting from `NamedReleaseSpec<T>`, not a class hierarchy. The fork chain is expressed via `Parent` composition. So `test.Fork is Cancun` only matches the exact `Cancun` class — it returns `false` for Prague, Osaka, and any future fork.

This caused two issues:
1. **`GeneralTestBase.cs`**: `ExcessBlobGas` defaulted to `null` instead of `0` for post-Cancun forks. At runtime, `InstructionBlobBaseFee` checks `Header.ExcessBlobGas.HasValue` and returns `BadInstruction` when null — even though the opcode is correctly registered in the lookup table.
2. **`BlockchainTestBase.cs`**: KZG commitments were not initialized for post-Cancun forks, which would cause blob verification failures.

Introduced in #10825 which replaced the previous fork ordering comparison with the type check.

No other `is <NamedFork>` patterns exist in the codebase.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified with two Osaka state tests that previously failed with `BadInstruction` at the BLOBBASEFEE opcode — both now execute correctly past the opcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)