### PR TITLE
fix: fix inverted dispose logic in BackgroundTaskScheduler

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -202,7 +202,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
 
     public async ValueTask DisposeAsync()
     {
-        if (!Interlocked.CompareExchange(ref _disposed, true, false)) return;
+        if (Interlocked.CompareExchange(ref _disposed, true, false)) return;
 
         _branchProcessor.BlocksProcessing -= BranchProcessorOnBranchesProcessing;
         _branchProcessor.BlockProcessed -= BranchProcessorOnBranchProcessed;


### PR DESCRIPTION

## Changes

Fix inverted `Interlocked.CompareExchange` condition in `DisposeAsync()` that prevented cleanup from executing

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_