### PR TITLE
Fix flaky DiscoveryPersistenceManager test on macOS CI

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Network.Discovery.Test
             _ = _persistenceManager.RunDiscoveryPersistenceCommit(cts.Token);
 
             // Poll for the expected state instead of relying on a fixed delay
-            while (_discoveryDb.Count < 2)
+            while (_discoveryDb.Count < nodes.Length)
             {
                 cts.Token.ThrowIfCancellationRequested();
                 await Task.Delay(10, cts.Token);
@@ -84,7 +84,7 @@ namespace Nethermind.Network.Discovery.Test
 
             await cts.CancelAsync();
 
-            _discoveryDb.Count.Should().Be(2);
+            _discoveryDb.Count.Should().Be(nodes.Length);
         }
     }
 }


### PR DESCRIPTION
Fixes #10911

## Changes

- Replace timing-based `Task.Delay(interval * 2)` with a polling loop that waits for the expected DB state in `RunDiscoveryPersistenceCommit_Should_Update_Nodes_In_Storage`
- Add `using` on `CancellationTokenSource` to avoid resource leak
- Replace `var` with explicit types per coding style
- Remove unused `Nethermind.Core.Extensions` import (was only needed for `ThatCancelAfter`)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

This PR fixes an existing flaky test. The fix was verified by running the test 5 times locally with 5/5 passes. The root cause was a race condition where `Task.Delay(200ms)` was insufficient for the `PeriodicTimer`-based persistence cycle to complete on slow CI runners (macOS ARM64). The polling approach is deterministic — it waits until the DB actually contains the expected nodes, with a 10s timeout as a safety net.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No