### PR TITLE
Fix incorrect NodeType in TrieNodeTests

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -522,7 +522,7 @@ public class TrieNodeTests
     public void Cannot_ask_about_validity_on_non_branch_nodes()
     {
         TrieNode leaf = new(NodeType.Leaf);
-        TrieNode extension = new(NodeType.Leaf);
+        TrieNode extension = new(NodeType.Extension);
         Assert.Throws<TrieException>(() => _ = leaf.IsValidWithOneNodeLess, "leaf");
         Assert.Throws<TrieException>(() => _ = extension.IsValidWithOneNodeLess, "extension");
     }


### PR DESCRIPTION
The test `Cannot_ask_about_validity_on_non_branch_nodes` was supposed to verify both Leaf and Extension node types throw TrieException. However, both variables were created as NodeType.Leaf due to a copy-paste error from 2020. Fixed extension variable to use NodeType.Extension.