### PR TITLE
Handle IP addresses better in discv5

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
@@ -40,26 +40,30 @@ namespace Nethermind.Network.Discovery.Test
             await _channel.CloseAsync();
         }
 
-        [Test]
-        public async Task ForwardsSentMessageToChannel()
+        [TestCase("127.0.0.1", "127.0.0.1")]
+        [TestCase("::ffff:127.0.0.1", "127.0.0.1")]
+        public async Task ForwardsSentMessageToChannel(string destinationAddress, string expectedDestinationAddress)
         {
             byte[] data = [1, 2, 3];
-            var to = IPEndPoint.Parse("127.0.0.1:10001");
+            IPEndPoint to = new(IPAddress.Parse(destinationAddress), 10001);
+            IPEndPoint expectedTo = new(IPAddress.Parse(expectedDestinationAddress), 10001);
 
             await _handler.SendAsync(data, to);
 
             DatagramPacket packet = _channel.ReadOutbound<DatagramPacket>();
             packet.Should().NotBeNull();
             packet.Content.ReadAllBytesAsArray().Should().BeEquivalentTo(data);
-            packet.Recipient.Should().Be(to);
+            packet.Recipient.Should().Be(expectedTo);
         }
 
-        [Test]
-        public async Task ForwardsReceivedMessageToReader()
+        [TestCase("127.0.0.1", "127.0.0.1")]
+        [TestCase("::ffff:127.0.0.1", "127.0.0.1")]
+        public async Task ForwardsReceivedMessageToReader(string senderAddress, string expectedSenderAddress)
         {
             byte[] data = [1, 2, 3];
-            var from = IPEndPoint.Parse("127.0.0.1:10000");
-            var to = IPEndPoint.Parse("127.0.0.1:10001");
+            IPEndPoint from = new(IPAddress.Parse(senderAddress), 10000);
+            IPEndPoint expectedFrom = new(IPAddress.Parse(expectedSenderAddress), 10000);
+            IPEndPoint to = IPEndPoint.Parse("127.0.0.1:10001");
 
             using var cancellationSource = new CancellationTokenSource(10_000);
             IAsyncEnumerator<UdpReceiveResult> enumerator = _handler
@@ -75,7 +79,7 @@ namespace Nethermind.Network.Discovery.Test
 
             forwardedPacket.Should().NotBeNull();
             forwardedPacket.Buffer.Should().BeEquivalentTo(data);
-            forwardedPacket.RemoteEndPoint.Should().Be(from);
+            forwardedPacket.RemoteEndPoint.Should().Be(expectedFrom);
         }
 
         [TestCase(0)]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
@@ -40,29 +40,25 @@ namespace Nethermind.Network.Discovery.Test
             await _channel.CloseAsync();
         }
 
-        [TestCase("127.0.0.1", "127.0.0.1")]
-        [TestCase("::ffff:127.0.0.1", "127.0.0.1")]
-        public async Task ForwardsSentMessageToChannel(string destinationAddress, string expectedDestinationAddress)
+        [Test]
+        public async Task ForwardsSentMessageToChannel()
         {
             byte[] data = [1, 2, 3];
-            IPEndPoint to = new(IPAddress.Parse(destinationAddress), 10001);
-            IPEndPoint expectedTo = new(IPAddress.Parse(expectedDestinationAddress), 10001);
+            IPEndPoint to = new(IPAddress.Loopback, 10001);
 
             await _handler.SendAsync(data, to);
 
             DatagramPacket packet = _channel.ReadOutbound<DatagramPacket>();
             packet.Should().NotBeNull();
             packet.Content.ReadAllBytesAsArray().Should().BeEquivalentTo(data);
-            packet.Recipient.Should().Be(expectedTo);
+            packet.Recipient.Should().Be(to);
         }
 
-        [TestCase("127.0.0.1", "127.0.0.1")]
-        [TestCase("::ffff:127.0.0.1", "127.0.0.1")]
-        public async Task ForwardsReceivedMessageToReader(string senderAddress, string expectedSenderAddress)
+        [Test]
+        public async Task ForwardsReceivedMessageToReader()
         {
             byte[] data = [1, 2, 3];
-            IPEndPoint from = new(IPAddress.Parse(senderAddress), 10000);
-            IPEndPoint expectedFrom = new(IPAddress.Parse(expectedSenderAddress), 10000);
+            IPEndPoint from = new(IPAddress.Loopback, 10000);
             IPEndPoint to = IPEndPoint.Parse("127.0.0.1:10001");
 
             using var cancellationSource = new CancellationTokenSource(10_000);
@@ -79,7 +75,7 @@ namespace Nethermind.Network.Discovery.Test
 
             forwardedPacket.Should().NotBeNull();
             forwardedPacket.Buffer.Should().BeEquivalentTo(data);
-            forwardedPacket.RemoteEndPoint.Should().Be(expectedFrom);
+            forwardedPacket.RemoteEndPoint.Should().Be(from);
         }
 
         [TestCase(0)]

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
@@ -36,7 +36,8 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
 
     protected override void ChannelRead0(IChannelHandlerContext ctx, DatagramPacket msg)
     {
-        UdpReceiveResult udpPacket = new(msg.Content.ReadAllBytesAsArray(), (IPEndPoint)msg.Sender);
+        IPEndPoint sender = NormalizeEndpoint((IPEndPoint)msg.Sender);
+        UdpReceiveResult udpPacket = new(msg.Content.ReadAllBytesAsArray(), sender);
 
         if (!_inboundQueue.Writer.TryWrite(udpPacket) && _logger.IsDebug)
         {
@@ -48,7 +49,8 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
     {
         if (_nettyChannel == null) throw new("Channel for discovery v5 is not initialized");
 
-        var packet = new DatagramPacket(Unpooled.WrappedBuffer(data), destination);
+        IPEndPoint normalizedDestination = NormalizeEndpoint(destination);
+        DatagramPacket packet = new(Unpooled.WrappedBuffer(data), normalizedDestination);
 
         try
         {
@@ -60,6 +62,11 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
             throw;
         }
     }
+
+    private static IPEndPoint NormalizeEndpoint(IPEndPoint endpoint) =>
+        endpoint.Address.IsIPv4MappedToIPv6
+            ? new IPEndPoint(endpoint.Address.MapToIPv4(), endpoint.Port)
+            : endpoint;
 
     public IAsyncEnumerable<UdpReceiveResult> ReadMessagesAsync(CancellationToken token = default) =>
         _inboundQueue.Reader.ReadAllAsync(token);

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
@@ -36,8 +36,7 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
 
     protected override void ChannelRead0(IChannelHandlerContext ctx, DatagramPacket msg)
     {
-        IPEndPoint sender = NormalizeEndpoint((IPEndPoint)msg.Sender);
-        UdpReceiveResult udpPacket = new(msg.Content.ReadAllBytesAsArray(), sender);
+        UdpReceiveResult udpPacket = new(msg.Content.ReadAllBytesAsArray(), (IPEndPoint)msg.Sender);
 
         if (!_inboundQueue.Writer.TryWrite(udpPacket) && _logger.IsDebug)
         {
@@ -49,8 +48,7 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
     {
         if (_nettyChannel == null) throw new("Channel for discovery v5 is not initialized");
 
-        IPEndPoint normalizedDestination = NormalizeEndpoint(destination);
-        DatagramPacket packet = new(Unpooled.WrappedBuffer(data), normalizedDestination);
+        DatagramPacket packet = new(Unpooled.WrappedBuffer(data), destination);
 
         try
         {
@@ -58,15 +56,10 @@ public class NettyDiscoveryV5Handler : NettyDiscoveryBaseHandler, IUdpConnection
         }
         catch (SocketException exception)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Error sending data", exception);
+            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Error sending discovery v5 payload ({data.Length} bytes) to {destination}", exception);
             throw;
         }
     }
-
-    private static IPEndPoint NormalizeEndpoint(IPEndPoint endpoint) =>
-        endpoint.Address.IsIPv4MappedToIPv6
-            ? new IPEndPoint(endpoint.Address.MapToIPv4(), endpoint.Port)
-            : endpoint;
 
     public IAsyncEnumerable<UdpReceiveResult> ReadMessagesAsync(CancellationToken token = default) =>
         _inboundQueue.Reader.ReadAllAsync(token);


### PR DESCRIPTION
## Changes

- Fix
```log
Exception
System.Net.Sockets.SocketException (22): Invalid argument
   at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
   at DotNetty.Transport.Channels.Sockets.AbstractSocketMessageChannel.DoWrite(ChannelOutboundBuffer input)
--- End of stack trace from previous location ---
   at Nethermind.Network.Discovery.NettyDiscoveryV5Handler.SendAsync(Byte[] data, IPEndPoint destination) in /nethermind/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs:line 55
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

