### PR TITLE
fix: remove duplicate NewHeadBlock unsubscription in PoSSwitcher

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -153,11 +153,6 @@ namespace Nethermind.Merge.Plugin
 
         public void ForkchoiceUpdated(BlockHeader newHeadHash, Hash256 finalizedHash)
         {
-            if (finalizedHash != Keccak.Zero && _finalizedBlockHash == Keccak.Zero)
-            {
-                _blockTree.NewHeadBlock -= CheckIfTerminalBlockReached;
-            }
-
             if (finalizedHash != Keccak.Zero)
             {
                 if (_finalizedBlockHash == Keccak.Zero)


### PR DESCRIPTION
ForkchoiceUpdated method had redundant code - unsubscribing from NewHeadBlock event twice under the same condition. First if-block and nested if inside second block both checked `finalizedHash != Keccak.Zero && _finalizedBlockHash == Keccak.Zero` and did the same `-=` operation. Removed the first redundant block.