### PR TITLE
fix(precompiles): add missing metrics increment for L1SloadPrecompile

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/L1SloadPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/L1SloadPrecompile.cs
@@ -43,6 +43,7 @@ public class L1SloadPrecompile : IPrecompile<L1SloadPrecompile>
 
     public Result<byte[]> Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
     {
+        Metrics.L1SloadPrecompile++;
         if (Logger.IsDebug) Logger.Debug($"L1SLOAD: precompile called, input_len={inputData.Length}");
 
         if (inputData.Length != L1PrecompileConstants.ExpectedInputLength)


### PR DESCRIPTION
L1SloadPrecompile.Run() was missing the Metrics.L1SloadPrecompile++ call that all other precompiles have. The metric was defined in Metrics.cs but never incremented, so L1SLOAD calls weren't being tracked.