### PR TITLE
perf: add cross-block storage and state caches with write-through

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -443,10 +443,10 @@ public struct DefaultCacheSets : ICacheSets
     public static int SetsLog2 => 14;
 }
 
-/// <summary>128K sets × 2 ways = 256K entries (~16 MB). For cross-block caches.</summary>
+/// <summary>64K sets × 2 ways = 128K entries (~8 MB). For cross-block caches.</summary>
 public struct LargeCacheSets : ICacheSets
 {
-    public static int SetsLog2 => 17;
+    public static int SetsLog2 => 16;
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -20,20 +20,18 @@ namespace Nethermind.Core.Collections;
 ///   breaking correlation between ways ("power of two choices"). Keys that collide
 ///   in way 0 scatter to different sets in way 1, virtually eliminating conflict misses.
 ///
-/// Hash bit partitioning (64-bit hash):
-///   Bits  0-13: way 0 set index (14 bits)
-///   Bits 22-41: hash signature stored in header (20 bits)
-///   Bits 42-55: way 1 set index (14 bits, independent from way 0)
+/// Default size: 16384 sets × 2 ways = 32768 entries.
+/// Configurable via constructor parameter (setsLog2).
 ///
 /// Header layout (64-bit):
 /// [Lock:1][Epoch:26][Hash:20][Seq:16][Occ:1]
 /// - Lock (bit 63): set during writes - readers retry/miss
 /// - Epoch (bits 37-62): global epoch tag - changes on Clear()
-/// - Hash  (bits 17-36): per-bucket hash signature (20 bits)
+/// - Hash  (bits 17-36): per-bucket hash signature (20 bits) — reduces false tag matches
 /// - Seq   (bits  1-16): per-entry sequence counter (16 bits) - increments on every successful write
 /// - Occ   (bit   0): occupied flag - set when slot contains valid data (value may still be null)
 ///
-/// Array layout: [way0_set0..way0_set16383, way1_set0..way1_set16383] (split, not interleaved).
+/// Array layout: [way0_set0..way0_setN, way1_set0..way1_setN] (split, not interleaved).
 /// </summary>
 /// <typeparam name="TKey">The key type (struct implementing IHash64bit)</typeparam>
 /// <typeparam name="TValue">The value type (reference type, nullable allowed)</typeparam>
@@ -41,14 +39,7 @@ public sealed class SeqlockCache<TKey, TValue>
     where TKey : struct, IHash64bit<TKey>
     where TValue : class?
 {
-    /// <summary>
-    /// Number of sets. Must be a power of 2 for mask operations.
-    /// 16384 sets × 2 ways = 32768 total entries.
-    /// </summary>
-    private const int Sets = 1 << 14; // 16384
-    private const int SetMask = Sets - 1;
-
-    // Header bit layout:
+    // Header bit layout (fixed regardless of cache size):
     // [Lock:1][Epoch:26][Hash:20][Seq:16][Occ:1]
 
     private const long LockMarker = unchecked((long)0x8000_0000_0000_0000); // bit 63
@@ -69,12 +60,26 @@ public sealed class SeqlockCache<TKey, TValue>
     // Mask for checking if an entry is live in the current epoch.
     private const long EpochOccMask = EpochMask | OccupiedBit;
 
-    // With 14-bit set index (bits 0-13) for way 0, hash signature needs independent bits.
-    // HashShift=5 maps header bits 17-36 to original bits 22-41, avoiding overlap with both ways.
-    private const int HashShift = 5;
+    /// <summary>
+    /// Number of sets (power of 2). Configurable via constructor.
+    /// </summary>
+    private readonly int _sets;
+    private readonly int _setMask;
 
-    // Way 1 uses bits 42-55 of the original hash (completely independent from way 0's bits 0-13).
-    private const int Way1Shift = 42;
+    /// <summary>
+    /// Hash-to-set-index shift for way 0 hash signature. Must place hash bits
+    /// above way 0's index bits and below the header hash field.
+    /// hashShift = setsLog2 - (17 - setsLog2) rounded to produce non-overlapping bits.
+    /// We use a simple formula: max(1, setsLog2 - 13) so that at default 14 bits
+    /// the shift is 5 (same as original) and at larger sizes it grows proportionally.
+    /// </summary>
+    private readonly int _hashShift;
+
+    /// <summary>
+    /// Way 1 index is extracted from bits [way1Shift .. way1Shift+setsLog2-1] of the 64-bit hash.
+    /// Must be independent from way 0 (bits 0..setsLog2-1). We pick the top region of the hash.
+    /// </summary>
+    private readonly int _way1Shift;
 
     /// <summary>
     /// Array of entries: [way0_set0..way0_setN, way1_set0..way1_setN].
@@ -93,9 +98,38 @@ public sealed class SeqlockCache<TKey, TValue>
     /// </summary>
     private long _shiftedEpoch;
 
-    public SeqlockCache()
+    /// <summary>
+    /// Creates a cache with the default size (16384 sets × 2 ways = 32768 entries).
+    /// </summary>
+    public SeqlockCache() : this(14)
     {
-        _entries = new Entry[Sets << 1]; // Sets * 2
+    }
+
+    /// <summary>
+    /// Creates a cache with a configurable number of sets.
+    /// </summary>
+    /// <param name="setsLog2">Log2 of the number of sets. Must be between 10 and 20.
+    /// Total entries = 2^(setsLog2+1). Examples: 14 = 32K entries, 18 = 512K entries, 20 = 2M entries.</param>
+    public SeqlockCache(int setsLog2)
+    {
+        if (setsLog2 < 10 || setsLog2 > 20)
+            throw new ArgumentOutOfRangeException(nameof(setsLog2), setsLog2, "Must be between 10 and 20.");
+
+        _sets = 1 << setsLog2;
+        _setMask = _sets - 1;
+
+        // Hash signature in the header occupies bits 17-36 (fixed). We need to map from
+        // hash64 bits that don't overlap with way 0's index bits (0..setsLog2-1).
+        // HashShift controls which hash64 bits land in the header's hash field.
+        // Original: setsLog2=14, hashShift=5 → header hash reads hash64 bits 22-41.
+        // Formula: hashShift = setsLog2 - 12, clamped to [1, 8].
+        _hashShift = Math.Clamp(setsLog2 - 12, 1, 8);
+
+        // Way 1 uses high bits of hash64, independent from way 0.
+        // Place it as high as possible: 64 - setsLog2.
+        _way1Shift = 64 - setsLog2;
+
+        _entries = new Entry[_sets << 1]; // Sets * 2
         _epoch = 0;
         _shiftedEpoch = 0;
     }
@@ -109,11 +143,11 @@ public sealed class SeqlockCache<TKey, TValue>
     public unsafe bool TryGetValue(in TKey key, out TValue? value)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & SetMask;
-        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
+        int idx0 = (int)hashCode & _setMask;
+        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
 
         long epochTag = Volatile.Read(ref _shiftedEpoch);
-        long hashPart = (hashCode >> HashShift) & HashMask;
+        long hashPart = (hashCode >> _hashShift) & HashMask;
         long expectedTag = epochTag | hashPart | OccupiedBit;
 
         ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
@@ -198,9 +232,9 @@ public sealed class SeqlockCache<TKey, TValue>
     public TValue? GetOrAdd<TState>(in TKey key, TState state, ValueFactory<TState> valueFactory)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & SetMask;
-        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
-        long hashPart = (hashCode >> HashShift) & HashMask;
+        int idx0 = (int)hashCode & _setMask;
+        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
+        long hashPart = (hashCode >> _hashShift) & HashMask;
 
         if (TryGetValueCore(in key, idx0, idx1, hashPart, out TValue? value))
         {
@@ -358,9 +392,9 @@ public sealed class SeqlockCache<TKey, TValue>
     public void Set(in TKey key, TValue? value)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & SetMask;
-        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
-        long hashPart = (hashCode >> HashShift) & HashMask;
+        int idx0 = (int)hashCode & _setMask;
+        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
+        long hashPart = (hashCode >> _hashShift) & HashMask;
 
         SetCore(in key, value, idx0, idx1, hashPart);
     }

--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -443,10 +443,10 @@ public struct DefaultCacheSets : ICacheSets
     public static int SetsLog2 => 14;
 }
 
-/// <summary>64K sets × 2 ways = 128K entries (~8 MB). For cross-block caches.</summary>
+/// <summary>128K sets × 2 ways = 256K entries (~16 MB). For cross-block caches.</summary>
 public struct LargeCacheSets : ICacheSets
 {
-    public static int SetsLog2 => 16;
+    public static int SetsLog2 => 17;
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -20,18 +20,20 @@ namespace Nethermind.Core.Collections;
 ///   breaking correlation between ways ("power of two choices"). Keys that collide
 ///   in way 0 scatter to different sets in way 1, virtually eliminating conflict misses.
 ///
-/// Default size: 16384 sets × 2 ways = 32768 entries.
-/// Configurable via constructor parameter (setsLog2).
+/// Hash bit partitioning (64-bit hash):
+///   Bits  0-13: way 0 set index (14 bits)
+///   Bits 22-41: hash signature stored in header (20 bits)
+///   Bits 42-55: way 1 set index (14 bits, independent from way 0)
 ///
 /// Header layout (64-bit):
 /// [Lock:1][Epoch:26][Hash:20][Seq:16][Occ:1]
 /// - Lock (bit 63): set during writes - readers retry/miss
 /// - Epoch (bits 37-62): global epoch tag - changes on Clear()
-/// - Hash  (bits 17-36): per-bucket hash signature (20 bits) — reduces false tag matches
+/// - Hash  (bits 17-36): per-bucket hash signature (20 bits)
 /// - Seq   (bits  1-16): per-entry sequence counter (16 bits) - increments on every successful write
 /// - Occ   (bit   0): occupied flag - set when slot contains valid data (value may still be null)
 ///
-/// Array layout: [way0_set0..way0_setN, way1_set0..way1_setN] (split, not interleaved).
+/// Array layout: [way0_set0..way0_set16383, way1_set0..way1_set16383] (split, not interleaved).
 /// </summary>
 /// <typeparam name="TKey">The key type (struct implementing IHash64bit)</typeparam>
 /// <typeparam name="TValue">The value type (reference type, nullable allowed)</typeparam>
@@ -39,7 +41,14 @@ public sealed class SeqlockCache<TKey, TValue>
     where TKey : struct, IHash64bit<TKey>
     where TValue : class?
 {
-    // Header bit layout (fixed regardless of cache size):
+    /// <summary>
+    /// Number of sets. Must be a power of 2 for mask operations.
+    /// 16384 sets × 2 ways = 32768 total entries.
+    /// </summary>
+    private const int Sets = 1 << 14; // 16384
+    private const int SetMask = Sets - 1;
+
+    // Header bit layout:
     // [Lock:1][Epoch:26][Hash:20][Seq:16][Occ:1]
 
     private const long LockMarker = unchecked((long)0x8000_0000_0000_0000); // bit 63
@@ -60,26 +69,12 @@ public sealed class SeqlockCache<TKey, TValue>
     // Mask for checking if an entry is live in the current epoch.
     private const long EpochOccMask = EpochMask | OccupiedBit;
 
-    /// <summary>
-    /// Number of sets (power of 2). Configurable via constructor.
-    /// </summary>
-    private readonly int _sets;
-    private readonly int _setMask;
+    // With 14-bit set index (bits 0-13) for way 0, hash signature needs independent bits.
+    // HashShift=5 maps header bits 17-36 to original bits 22-41, avoiding overlap with both ways.
+    private const int HashShift = 5;
 
-    /// <summary>
-    /// Hash-to-set-index shift for way 0 hash signature. Must place hash bits
-    /// above way 0's index bits and below the header hash field.
-    /// hashShift = setsLog2 - (17 - setsLog2) rounded to produce non-overlapping bits.
-    /// We use a simple formula: max(1, setsLog2 - 13) so that at default 14 bits
-    /// the shift is 5 (same as original) and at larger sizes it grows proportionally.
-    /// </summary>
-    private readonly int _hashShift;
-
-    /// <summary>
-    /// Way 1 index is extracted from bits [way1Shift .. way1Shift+setsLog2-1] of the 64-bit hash.
-    /// Must be independent from way 0 (bits 0..setsLog2-1). We pick the top region of the hash.
-    /// </summary>
-    private readonly int _way1Shift;
+    // Way 1 uses bits 42-55 of the original hash (completely independent from way 0's bits 0-13).
+    private const int Way1Shift = 42;
 
     /// <summary>
     /// Array of entries: [way0_set0..way0_setN, way1_set0..way1_setN].
@@ -98,38 +93,9 @@ public sealed class SeqlockCache<TKey, TValue>
     /// </summary>
     private long _shiftedEpoch;
 
-    /// <summary>
-    /// Creates a cache with the default size (16384 sets × 2 ways = 32768 entries).
-    /// </summary>
-    public SeqlockCache() : this(14)
+    public SeqlockCache()
     {
-    }
-
-    /// <summary>
-    /// Creates a cache with a configurable number of sets.
-    /// </summary>
-    /// <param name="setsLog2">Log2 of the number of sets. Must be between 10 and 20.
-    /// Total entries = 2^(setsLog2+1). Examples: 14 = 32K entries, 18 = 512K entries, 20 = 2M entries.</param>
-    public SeqlockCache(int setsLog2)
-    {
-        if (setsLog2 < 10 || setsLog2 > 20)
-            throw new ArgumentOutOfRangeException(nameof(setsLog2), setsLog2, "Must be between 10 and 20.");
-
-        _sets = 1 << setsLog2;
-        _setMask = _sets - 1;
-
-        // Hash signature in the header occupies bits 17-36 (fixed). We need to map from
-        // hash64 bits that don't overlap with way 0's index bits (0..setsLog2-1).
-        // HashShift controls which hash64 bits land in the header's hash field.
-        // Original: setsLog2=14, hashShift=5 → header hash reads hash64 bits 22-41.
-        // Formula: hashShift = setsLog2 - 12, clamped to [1, 8].
-        _hashShift = Math.Clamp(setsLog2 - 12, 1, 8);
-
-        // Way 1 uses high bits of hash64, independent from way 0.
-        // Place it as high as possible: 64 - setsLog2.
-        _way1Shift = 64 - setsLog2;
-
-        _entries = new Entry[_sets << 1]; // Sets * 2
+        _entries = new Entry[Sets << 1]; // Sets * 2
         _epoch = 0;
         _shiftedEpoch = 0;
     }
@@ -143,11 +109,11 @@ public sealed class SeqlockCache<TKey, TValue>
     public unsafe bool TryGetValue(in TKey key, out TValue? value)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & _setMask;
-        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
+        int idx0 = (int)hashCode & SetMask;
+        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
 
         long epochTag = Volatile.Read(ref _shiftedEpoch);
-        long hashPart = (hashCode >> _hashShift) & HashMask;
+        long hashPart = (hashCode >> HashShift) & HashMask;
         long expectedTag = epochTag | hashPart | OccupiedBit;
 
         ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
@@ -232,9 +198,9 @@ public sealed class SeqlockCache<TKey, TValue>
     public TValue? GetOrAdd<TState>(in TKey key, TState state, ValueFactory<TState> valueFactory)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & _setMask;
-        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
-        long hashPart = (hashCode >> _hashShift) & HashMask;
+        int idx0 = (int)hashCode & SetMask;
+        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
+        long hashPart = (hashCode >> HashShift) & HashMask;
 
         if (TryGetValueCore(in key, idx0, idx1, hashPart, out TValue? value))
         {
@@ -392,9 +358,9 @@ public sealed class SeqlockCache<TKey, TValue>
     public void Set(in TKey key, TValue? value)
     {
         long hashCode = key.GetHashCode64();
-        int idx0 = (int)hashCode & _setMask;
-        int idx1 = _sets + ((int)(hashCode >> _way1Shift) & _setMask);
-        long hashPart = (hashCode >> _hashShift) & HashMask;
+        int idx0 = (int)hashCode & SetMask;
+        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
+        long hashPart = (hashCode >> HashShift) & HashMask;
 
         SetCore(in key, value, idx0, idx1, hashPart);
     }

--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -426,3 +426,259 @@ public sealed class SeqlockCache<TKey, TValue>
         public TValue? Value;
     }
 }
+
+/// <summary>
+/// Provides the number of sets (as log2) for a <see cref="SeqlockCache{TKey,TValue,TSets}"/>.
+/// Implementations must return a compile-time constant so the JIT can constant-fold it.
+/// Valid range: 10..21 (1K..2M sets per way).
+/// </summary>
+public interface ICacheSets
+{
+    static abstract int SetsLog2 { get; }
+}
+
+/// <summary>Default 16K sets × 2 ways = 32K entries (~2 MB).</summary>
+public struct DefaultCacheSets : ICacheSets
+{
+    public static int SetsLog2 => 14;
+}
+
+/// <summary>64K sets × 2 ways = 128K entries (~8 MB). For cross-block caches.</summary>
+public struct LargeCacheSets : ICacheSets
+{
+    public static int SetsLog2 => 16;
+}
+
+/// <summary>
+/// Size-parameterized variant of <see cref="SeqlockCache{TKey,TValue}"/>.
+/// <typeparamref name="TSets"/> controls the number of sets; the JIT constant-folds
+/// <c>TSets.SetsLog2</c> so all derived masks compile to immediate operands — identical
+/// codegen to the const-based two-parameter version.
+/// </summary>
+public sealed class SeqlockCache<TKey, TValue, TSets>
+    where TKey : struct, IHash64bit<TKey>
+    where TValue : class?
+    where TSets : struct, ICacheSets
+{
+    // JIT constant-folded: TSets.SetsLog2 is a literal on each closed generic instantiation.
+    private static int Sets
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => 1 << TSets.SetsLog2;
+    }
+
+    private static int SetMask
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Sets - 1;
+    }
+
+    // Header bit layout — identical to the two-parameter version.
+    // These do NOT depend on cache size and remain true const.
+    private const long LockMarker = unchecked((long)0x8000_0000_0000_0000);
+    private const int EpochShift = 37;
+    private const long EpochMask = 0x7FFF_FFE0_0000_0000;
+    private const long HashMask = 0x0000_001F_FFFE_0000;
+    private const long SeqMask = 0x0000_0000_0001_FFFE;
+    private const long SeqInc = 0x0000_0000_0000_0002;
+    private const long OccupiedBit = 1L;
+    private const long TagMask = EpochMask | HashMask | OccupiedBit;
+    private const long EpochOccMask = EpochMask | OccupiedBit;
+    private const int HashShift = 5;
+    private const int Way1Shift = 42;
+
+    private readonly Entry[] _entries;
+    private long _epoch;
+    private long _shiftedEpoch;
+
+    public SeqlockCache()
+    {
+        _entries = new Entry[Sets << 1];
+        _epoch = 0;
+        _shiftedEpoch = 0;
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public unsafe bool TryGetValue(in TKey key, out TValue? value)
+    {
+        long hashCode = key.GetHashCode64();
+        int idx0 = (int)hashCode & SetMask;
+        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
+
+        long epochTag = Volatile.Read(ref _shiftedEpoch);
+        long hashPart = (hashCode >> HashShift) & HashMask;
+        long expectedTag = epochTag | hashPart | OccupiedBit;
+
+        ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
+
+        if (Sse.IsSupported)
+        {
+            Sse.PrefetchNonTemporal(Unsafe.AsPointer(ref Unsafe.Add(ref entries, idx1)));
+        }
+
+        ref Entry e0 = ref Unsafe.Add(ref entries, idx0);
+        long h1 = Volatile.Read(ref e0.HashEpochSeqLock);
+
+        if ((h1 & (TagMask | LockMarker)) == expectedTag)
+        {
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+            TKey storedKey = e0.Key;
+            TValue? storedValue = e0.Value;
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+
+            long h2 = Volatile.Read(ref e0.HashEpochSeqLock);
+            if (h1 == h2 && storedKey.Equals(in key))
+            {
+                value = storedValue;
+                return true;
+            }
+        }
+
+        ref Entry e1 = ref Unsafe.Add(ref entries, idx1);
+        long w1 = Volatile.Read(ref e1.HashEpochSeqLock);
+
+        if ((w1 & (TagMask | LockMarker)) == expectedTag)
+        {
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+            TKey storedKey = e1.Key;
+            TValue? storedValue = e1.Value;
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+
+            long w2 = Volatile.Read(ref e1.HashEpochSeqLock);
+            if (w1 == w2 && storedKey.Equals(in key))
+            {
+                value = storedValue;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set(in TKey key, TValue? value)
+    {
+        long hashCode = key.GetHashCode64();
+        int idx0 = (int)hashCode & SetMask;
+        int idx1 = Sets + ((int)(hashCode >> Way1Shift) & SetMask);
+        long hashPart = (hashCode >> HashShift) & HashMask;
+
+        SetCore(in key, value, idx0, idx1, hashPart);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void SetCore(in TKey key, TValue? value, int idx0, int idx1, long hashPart)
+    {
+        long epochTag = Volatile.Read(ref _shiftedEpoch);
+        long tagToStore = epochTag | hashPart | OccupiedBit;
+        long epochOccTag = epochTag | OccupiedBit;
+
+        ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
+        ref Entry e0 = ref Unsafe.Add(ref entries, idx0);
+
+        long h0 = Volatile.Read(ref e0.HashEpochSeqLock);
+
+        if (h0 >= 0 && (h0 & TagMask) == tagToStore)
+        {
+            TKey k0 = e0.Key;
+            TValue? v0 = e0.Value;
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+
+            long h0_2 = Volatile.Read(ref e0.HashEpochSeqLock);
+            if (h0 == h0_2 && k0.Equals(in key))
+            {
+                if (ReferenceEquals(v0, value)) return;
+                WriteEntry(ref e0, h0_2, in key, value, tagToStore);
+                return;
+            }
+            h0 = h0_2;
+        }
+
+        ref Entry e1 = ref Unsafe.Add(ref entries, idx1);
+        long h1 = Volatile.Read(ref e1.HashEpochSeqLock);
+
+        if (h1 >= 0 && (h1 & TagMask) == tagToStore)
+        {
+            TKey k1 = e1.Key;
+            TValue? v1 = e1.Value;
+            if (!Sse.IsSupported) Interlocked.MemoryBarrier();
+
+            long h1_2 = Volatile.Read(ref e1.HashEpochSeqLock);
+            if (h1 == h1_2 && k1.Equals(in key))
+            {
+                if (ReferenceEquals(v1, value)) return;
+                WriteEntry(ref e1, h1_2, in key, value, tagToStore);
+                return;
+            }
+            h1 = h1_2;
+        }
+
+        bool h0Live = h0 >= 0 && (h0 & EpochOccMask) == epochOccTag;
+        bool h1Live = h1 >= 0 && (h1 & EpochOccMask) == epochOccTag;
+
+        bool pick0;
+        if (!h0Live && h0 >= 0) pick0 = true;
+        else if (!h1Live && h1 >= 0) pick0 = false;
+        else if (h0Live && h1Live) pick0 = (hashPart & (1L << 17)) != 0;
+        else if (h0 >= 0) pick0 = true;
+        else if (h1 >= 0) pick0 = false;
+        else return;
+
+        WriteEntry(
+            ref pick0 ? ref e0 : ref e1,
+            pick0 ? h0 : h1,
+            in key, value, tagToStore);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void WriteEntry(ref Entry entry, long existing, in TKey key, TValue? value, long tagToStore)
+    {
+        if (existing < 0) return;
+
+        long newSeq = ((existing & SeqMask) + SeqInc) & SeqMask;
+        long lockedHeader = tagToStore | newSeq | LockMarker;
+
+        if (Interlocked.CompareExchange(ref entry.HashEpochSeqLock, lockedHeader, existing) != existing)
+        {
+            return;
+        }
+
+        entry.Key = key;
+        entry.Value = value;
+
+        Volatile.Write(ref entry.HashEpochSeqLock, tagToStore | newSeq);
+    }
+
+    public void Clear()
+    {
+        long oldShifted = Volatile.Read(ref _shiftedEpoch);
+
+        while (true)
+        {
+            long oldEpoch = (oldShifted & EpochMask) >> EpochShift;
+            long newEpoch = oldEpoch + 1;
+            long newShifted = (newEpoch << EpochShift) & EpochMask;
+
+            long prev = Interlocked.CompareExchange(ref _shiftedEpoch, newShifted, oldShifted);
+            if (prev == oldShifted)
+            {
+                Volatile.Write(ref _epoch, newEpoch);
+                return;
+            }
+
+            oldShifted = prev;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Entry
+    {
+        public long HashEpochSeqLock;
+        public TKey Key;
+        public TValue? Value;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -14,13 +14,8 @@ namespace Nethermind.Evm.State;
 /// </summary>
 public class CrossBlockCaches
 {
-    // setsLog2=20 → 2M entries. StorageCell key ~52 bytes + byte[32] value ≈ 170 MB.
-    // Storage is the hottest cross-block cache — SLOAD-heavy blocks reuse the same contract slots.
-    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new(setsLog2: 20);
-
-    // setsLog2=18 → 512K entries. AddressAsKey ~20 bytes + Account ~100 bytes ≈ 60 MB.
-    // Fewer unique accounts than storage slots per block, so smaller is fine.
-    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new(setsLog2: 18);
+    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
+    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private long _lastCommittedBlockNumber = -1;
 
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,18 +8,16 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block caches for storage slots and account state. These survive across blocks
-/// and are updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
-/// these are never shared with the prewarmer — only the main processing thread reads/writes them.
+/// Cross-block cache for storage slots. Survives across blocks and is updated via
+/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
+/// never shared with the prewarmer — only the main processing thread reads/writes it.
 /// </summary>
 public class CrossBlockCaches
 {
     private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
-    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private long _lastCommittedBlockNumber = -1;
 
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
-    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
 
     /// <summary>
     /// Block number of the last successfully committed block. Used to detect reorgs:

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,22 +8,23 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block caches for accounts and storage slots. Survives across blocks and is
-/// updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
-/// this is never shared with the prewarmer — only the main processing thread reads/writes it.
+/// Cross-block cache for storage slots. Survives across blocks and is updated via
+/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
+/// never shared with the prewarmer — only the main processing thread reads/writes it.
 /// </summary>
 /// <remarks>
-/// The state cache returns account values directly to callers without calling HintGet on the
-/// base scope, avoiding the bug where stale StorageRoot pushed into the flat state's snapshot
-/// bundle caused NodeHashMismatchException. The base scope loads accounts independently when needed.
+/// Account (state) caching is intentionally excluded. The base scope (flat state) must be
+/// the single source of truth for Account values because the EVM reads the account from
+/// the scope and writes modified values back through the same scope's write batch. Returning
+/// a cached Account that doesn't match the base scope's version causes InvalidStateRoot.
+/// Storage slot values are safe to cache because they are independent leaf values with no
+/// structural coupling to the trie.
 /// </remarks>
 public class CrossBlockCaches
 {
-    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets> _storageCache = new();
     private long _lastCommittedBlockNumber = -1;
 
-    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
     public SeqlockCache<StorageCell, byte[], LargeCacheSets> StorageCache => _storageCache;
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -14,8 +14,13 @@ namespace Nethermind.Evm.State;
 /// </summary>
 public class CrossBlockCaches
 {
-    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
-    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
+    // setsLog2=20 → 2M entries. StorageCell key ~52 bytes + byte[32] value ≈ 170 MB.
+    // Storage is the hottest cross-block cache — SLOAD-heavy blocks reuse the same contract slots.
+    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new(setsLog2: 20);
+
+    // setsLog2=18 → 512K entries. AddressAsKey ~20 bytes + Account ~100 bytes ≈ 60 MB.
+    // Fewer unique accounts than storage slots per block, so smaller is fine.
+    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new(setsLog2: 18);
     private long _lastCommittedBlockNumber = -1;
 
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,9 +8,8 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block cache for storage slots. Survives across blocks and is seeded from trie
-/// reads. Unlike <see cref="PreBlockCaches"/>, this is never shared with the prewarmer —
-/// only the main processing thread reads/writes it.
+/// Cross-block cache for storage slots. Survives across blocks, updated via write-through
+/// and seeded from trie reads. Only the main processing thread reads/writes it.
 /// </summary>
 public class CrossBlockCaches
 {

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 
@@ -15,7 +16,18 @@ public class CrossBlockCaches
 {
     private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
     private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
+    private long _lastCommittedBlockNumber = -1;
 
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
     public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
+
+    /// <summary>
+    /// Block number of the last successfully committed block. Used to detect reorgs:
+    /// if the next scope's base block doesn't match this, the caches are stale and must be cleared.
+    /// </summary>
+    public long LastCommittedBlockNumber
+    {
+        get => Volatile.Read(ref _lastCommittedBlockNumber);
+        set => Volatile.Write(ref _lastCommittedBlockNumber, value);
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,17 +8,15 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block caches for accounts and storage slots. Survives across blocks and is
-/// updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
-/// this is never shared with the prewarmer — only the main processing thread reads/writes it.
+/// Cross-block cache for storage slots. Survives across blocks and is updated via
+/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
+/// never shared with the prewarmer — only the main processing thread reads/writes it.
 /// </summary>
 public class CrossBlockCaches
 {
-    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets> _storageCache = new();
     private long _lastCommittedBlockNumber = -1;
 
-    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
     public SeqlockCache<StorageCell, byte[], LargeCacheSets> StorageCache => _storageCache;
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// Cross-block caches for storage slots and account state. These survive across blocks
+/// and are updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
+/// these are never shared with the prewarmer — only the main processing thread reads/writes them.
+/// </summary>
+public class CrossBlockCaches
+{
+    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
+    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
+
+    public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
+    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
+}

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,18 +8,10 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block cache for storage slots. Survives across blocks and is updated via
-/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
-/// never shared with the prewarmer — only the main processing thread reads/writes it.
+/// Cross-block cache for storage slots. Survives across blocks and is seeded from trie
+/// reads. Unlike <see cref="PreBlockCaches"/>, this is never shared with the prewarmer —
+/// only the main processing thread reads/writes it.
 /// </summary>
-/// <remarks>
-/// Account (state) caching is intentionally excluded. The base scope (flat state) must be
-/// the single source of truth for Account values because the EVM reads the account from
-/// the scope and writes modified values back through the same scope's write batch. Returning
-/// a cached Account that doesn't match the base scope's version causes InvalidStateRoot.
-/// Storage slot values are safe to cache because they are independent leaf values with no
-/// structural coupling to the trie.
-/// </remarks>
 public class CrossBlockCaches
 {
     private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets> _storageCache = new();

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,15 +8,22 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block cache for storage slots. Survives across blocks and is updated via
-/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
-/// never shared with the prewarmer — only the main processing thread reads/writes it.
+/// Cross-block caches for accounts and storage slots. Survives across blocks and is
+/// updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
+/// this is never shared with the prewarmer — only the main processing thread reads/writes it.
 /// </summary>
+/// <remarks>
+/// The state cache returns account values directly to callers without calling HintGet on the
+/// base scope, avoiding the bug where stale StorageRoot pushed into the flat state's snapshot
+/// bundle caused NodeHashMismatchException. The base scope loads accounts independently when needed.
+/// </remarks>
 public class CrossBlockCaches
 {
+    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets> _storageCache = new();
     private long _lastCommittedBlockNumber = -1;
 
+    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
     public SeqlockCache<StorageCell, byte[], LargeCacheSets> StorageCache => _storageCache;
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/CrossBlockCaches.cs
@@ -8,16 +8,18 @@ using Nethermind.Core.Collections;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Cross-block cache for storage slots. Survives across blocks and is updated via
-/// write-through during block commit. Unlike <see cref="PreBlockCaches"/>, this is
-/// never shared with the prewarmer — only the main processing thread reads/writes it.
+/// Cross-block caches for accounts and storage slots. Survives across blocks and is
+/// updated via write-through during block commit. Unlike <see cref="PreBlockCaches"/>,
+/// this is never shared with the prewarmer — only the main processing thread reads/writes it.
 /// </summary>
 public class CrossBlockCaches
 {
-    private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
+    private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
+    private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets> _storageCache = new();
     private long _lastCommittedBlockNumber = -1;
 
-    public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
+    public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
+    public SeqlockCache<StorageCell, byte[], LargeCacheSets> StorageCache => _storageCache;
 
     /// <summary>
     /// Block number of the last successfully committed block. Used to detect reorgs:

--- a/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
@@ -41,6 +41,9 @@ public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
                 // Singleton so that all child env share the same caches. Note: this module is applied per-processing
                 // module, so singleton here is like scoped but exclude inner prewarmer lifetime.
                 .AddSingleton<PreBlockCaches>()
+                // Cross-block caches are separate from the per-block prewarmer caches.
+                // Only the main processing thread writes (during commit) and reads from these.
+                .AddSingleton<CrossBlockCaches>()
                 .AddScoped<IBlockCachePreWarmer, BlockCachePreWarmer>()
 
                 // This class create the block processing env with worldstate that populate the cache
@@ -53,7 +56,8 @@ public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
                     return new PrewarmerScopeProvider(
                         worldStateScopeProvider,
                         ctx.Resolve<PreBlockCaches>(),
-                        populatePreBlockCache: false
+                        populatePreBlockCache: false,
+                        crossBlockCaches: ctx.Resolve<CrossBlockCaches>()
                     );
                 })
                 .AddDecorator<ICodeInfoRepository>((ctx, originalCodeInfoRepository) =>

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -76,6 +76,7 @@ public class PrewarmerScopeProvider(
                 long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
                 if (baseBlock is not null && baseBlock.Number != lastCommitted)
                 {
+                    crossBlockCaches.StateCache.Clear();
                     crossBlockCaches.StorageCache.Clear();
                 }
             }
@@ -89,6 +90,7 @@ public class PrewarmerScopeProvider(
             // any entries written directly to the cross-block cache during this scope.
             if (!_committed && crossBlockCaches is not null)
             {
+                crossBlockCaches.StateCache.Clear();
                 crossBlockCaches.StorageCache.Clear();
             }
 
@@ -119,7 +121,7 @@ public class PrewarmerScopeProvider(
             // On block failure, Dispose epoch-bumps to rollback stale entries.
             if (crossBlockCaches is not null)
             {
-                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StateCache, crossBlockCaches.StorageCache);
             }
 
             if (!_measureMetric) return batch;
@@ -218,9 +220,20 @@ public class PrewarmerScopeProvider(
                     baseScope.HintGet(address, account);
                     Metrics.IncrementStateTreeCacheHits();
                 }
+                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
+                {
+                    // Return cached value WITHOUT calling HintGet. Calling HintGet would push
+                    // a stale Account (with outdated StorageRoot) into the flat state's snapshot
+                    // bundle, causing NodeHashMismatchException during trie operations. The base
+                    // scope loads the account independently from the flat DB when it needs it.
+                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
+                    Metrics.IncrementStateTreeCacheHits();
+                }
                 else
                 {
                     account = GetFromBaseTree(in addressAsKey);
+                    // Seed cross-block state cache from trie reads.
+                    crossBlockCaches?.StateCache.Set(in addressAsKey, account);
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
                 }
                 return account;
@@ -356,6 +369,7 @@ public class PrewarmerScopeProvider(
     private sealed class CacheUpdatingWriteBatch(
         IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
         ScopeWrapper scope,
+        SeqlockCache<AddressAsKey, Account> crossBlockStateCache,
         SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
         public void Dispose() => baseBatch.Dispose();
@@ -366,7 +380,12 @@ public class PrewarmerScopeProvider(
             remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
+        public void Set(Address key, Account? account)
+        {
+            baseBatch.Set(key, account);
+            AddressAsKey addressAsKey = key;
+            crossBlockStateCache.Set(in addressAsKey, account);
+        }
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -54,11 +54,6 @@ public class PrewarmerScopeProvider(
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
 
-        // Set to true after successful commit; used in Dispose to rollback stale direct writes.
-        private bool _committed;
-        // Set if any storage Clear() was observed (CREATE/SELFDESTRUCT); triggers epoch-bump on commit.
-        private volatile bool _pendingStorageClear;
-
         public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches, BlockHeader? baseBlock)
         {
             this.baseScope = baseScope;
@@ -85,13 +80,6 @@ public class PrewarmerScopeProvider(
 
         public void Dispose()
         {
-            // If commit didn't happen (e.g., block was invalid), epoch-bump to invalidate
-            // any entries written directly to the cross-block cache during this scope.
-            if (!_committed && crossBlockCaches is not null)
-            {
-                crossBlockCaches.StorageCache.Clear();
-            }
-
             if (_measureMetric && _writeBatchTime != 0)
             {
                 _metricObserver.Observe(Stopwatch.GetTimestamp() - _writeBatchTime, _labels.WriteBatchToScopeDisposeTime);
@@ -115,13 +103,6 @@ public class PrewarmerScopeProvider(
         {
             IWorldStateScopeProvider.IWorldStateWriteBatch batch = baseScope.StartWriteBatch(estimatedAccountNum);
 
-            // Wrap write batch to write storage updates directly to the cross-block cache.
-            // On block failure, Dispose epoch-bumps to rollback stale entries.
-            if (crossBlockCaches is not null)
-            {
-                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
-            }
-
             if (!_measureMetric) return batch;
 
             _writeBatchTime = Stopwatch.GetTimestamp();
@@ -133,46 +114,21 @@ public class PrewarmerScopeProvider(
                 populatePreBlockCache);
         }
 
-        internal void BufferStorageClear()
-        {
-            _pendingStorageClear = true;
-        }
-
         public void Commit(long blockNumber)
         {
             if (!_measureMetric)
             {
                 baseScope.Commit(blockNumber);
-                PromoteToCrossBlockCaches(blockNumber);
+                if (crossBlockCaches is not null)
+                    crossBlockCaches.LastCommittedBlockNumber = blockNumber;
                 return;
             }
 
             long sw = Stopwatch.GetTimestamp();
             baseScope.Commit(blockNumber);
-            PromoteToCrossBlockCaches(blockNumber);
+            if (crossBlockCaches is not null)
+                crossBlockCaches.LastCommittedBlockNumber = blockNumber;
             _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.Commit);
-        }
-
-        /// <summary>
-        /// Finalizes cross-block cache state after successful commit. Storage values are
-        /// written directly to the cross-block cache during the write batch phase and seeded
-        /// from trie reads, so this only handles epoch-bumps from storage Clear() and sets
-        /// the committed flag for reorg detection.
-        /// </summary>
-        private void PromoteToCrossBlockCaches(long blockNumber)
-        {
-            if (crossBlockCaches is null) return;
-
-            if (_pendingStorageClear)
-            {
-                // A CREATE or SELFDESTRUCT cleared storage for at least one address.
-                // Epoch-bump invalidates all cross-block storage entries. The cache will
-                // be re-seeded organically from trie reads on subsequent blocks.
-                crossBlockCaches.StorageCache.Clear();
-            }
-
-            _committed = true;
-            crossBlockCaches.LastCommittedBlockNumber = blockNumber;
         }
 
         public Hash256 RootHash => baseScope.RootHash;
@@ -351,56 +307,4 @@ public class PrewarmerScopeProvider(
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) => baseWriteBatch.CreateStorageWriteBatch(key, estimatedEntries);
     }
 
-    /// <summary>
-    /// Wraps write batch to write storage updates directly to the cross-block cache.
-    /// On block failure, the ScopeWrapper's Dispose epoch-bumps the cache to rollback.
-    /// </summary>
-    private sealed class CacheUpdatingWriteBatch(
-        IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
-        ScopeWrapper scope,
-        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
-    {
-        public void Dispose() => baseBatch.Dispose();
-
-        public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
-        {
-            add => baseBatch.OnAccountUpdated += value;
-            remove => baseBatch.OnAccountUpdated -= value;
-        }
-
-        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
-
-        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
-        {
-            IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
-            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, scope, crossBlockStorageCache, key);
-        }
-    }
-
-    /// <summary>
-    /// Wraps storage write batch to write slot updates directly to the cross-block cache.
-    /// On <see cref="Clear"/> (CREATE/SELFDESTRUCT), sets a flag so the commit step
-    /// epoch-bumps the cross-block storage cache.
-    /// </summary>
-    private sealed class CacheUpdatingStorageWriteBatch(
-        IWorldStateScopeProvider.IStorageWriteBatch baseBatch,
-        ScopeWrapper scope,
-        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache,
-        Address address) : IWorldStateScopeProvider.IStorageWriteBatch
-    {
-        public void Set(in UInt256 index, byte[] value)
-        {
-            baseBatch.Set(in index, value);
-            StorageCell cell = new(address, in index);
-            crossBlockStorageCache.Set(in cell, value);
-        }
-
-        public void Clear()
-        {
-            baseBatch.Clear();
-            scope.BufferStorageClear();
-        }
-
-        public void Dispose() => baseBatch.Dispose();
-    }
 }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -31,12 +32,13 @@ internal class PrewarmerGetTimeLabels(bool isPrewarmer)
 public class PrewarmerScopeProvider(
     IWorldStateScopeProvider baseProvider,
     PreBlockCaches preBlockCaches,
-    bool populatePreBlockCache = true
+    bool populatePreBlockCache = true,
+    CrossBlockCaches? crossBlockCaches = null
 ) : IWorldStateScopeProvider, IPreBlockCaches
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache, crossBlockCaches);
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !populatePreBlockCache;
@@ -46,17 +48,24 @@ public class PrewarmerScopeProvider(
         private readonly IWorldStateScopeProvider.IScope baseScope;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache;
         private readonly SeqlockCache<StorageCell, byte[]> storageCache;
+        private readonly CrossBlockCaches? crossBlockCaches;
         private readonly bool populatePreBlockCache;
         private static readonly SeqlockCache<AddressAsKey, Account>.ValueFactory<ScopeWrapper> _getFromBaseTree = static (in AddressAsKey address, ScopeWrapper self) => self.GetFromBaseTree(in address);
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
 
-        public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache)
+        // Pending cross-block cache updates, promoted only on successful CommitTree.
+        private List<(AddressAsKey Key, Account? Value)>? _pendingStateUpdates;
+        private List<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
+        private bool _pendingStorageClear;
+
+        public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches)
         {
             this.baseScope = baseScope;
             preBlockCache = preBlockCaches.StateCache;
             storageCache = preBlockCaches.StorageCache;
+            this.crossBlockCaches = crossBlockCaches;
             this.populatePreBlockCache = populatePreBlockCache;
             _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
         }
@@ -80,23 +89,48 @@ public class PrewarmerScopeProvider(
                 baseScope.CreateStorageTree(address),
                 storageCache,
                 address,
-                populatePreBlockCache);
+                populatePreBlockCache,
+                crossBlockCaches?.StorageCache);
         }
 
         public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
         {
-            if (!_measureMetric)
+            IWorldStateScopeProvider.IWorldStateWriteBatch batch = baseScope.StartWriteBatch(estimatedAccountNum);
+
+            // Buffer writes for the cross-block caches. Promotion happens in Commit()
+            // (called from CommitTree after successful block processing), so a failed block
+            // never pollutes the cross-block caches.
+            if (crossBlockCaches is not null)
             {
-                return baseScope.StartWriteBatch(estimatedAccountNum);
+                batch = new CacheUpdatingWriteBatch(batch, this);
             }
+
+            if (!_measureMetric) return batch;
 
             _writeBatchTime = Stopwatch.GetTimestamp();
             long sw = Stopwatch.GetTimestamp();
             return new WriteBatchLifetimeMeasurer(
-                baseScope.StartWriteBatch(estimatedAccountNum),
+                batch,
                 _metricObserver,
                 sw,
                 populatePreBlockCache);
+        }
+
+        internal void BufferStateUpdate(AddressAsKey key, Account? account)
+        {
+            _pendingStateUpdates ??= new();
+            _pendingStateUpdates.Add((key, account));
+        }
+
+        internal void BufferStorageUpdate(in StorageCell cell, byte[] value)
+        {
+            _pendingStorageUpdates ??= new();
+            _pendingStorageUpdates.Add((cell, value));
+        }
+
+        internal void BufferStorageClear()
+        {
+            _pendingStorageClear = true;
         }
 
         public void Commit(long blockNumber)
@@ -104,12 +138,52 @@ public class PrewarmerScopeProvider(
             if (!_measureMetric)
             {
                 baseScope.Commit(blockNumber);
+                PromoteToCrossBlockCaches();
                 return;
             }
 
             long sw = Stopwatch.GetTimestamp();
             baseScope.Commit(blockNumber);
+            PromoteToCrossBlockCaches();
             _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.Commit);
+        }
+
+        /// <summary>
+        /// Flushes buffered writes to the cross-block caches. Called only after successful
+        /// CommitTree, so speculative entries from failed/invalid blocks are never promoted.
+        /// If any storage Clear() was seen (CREATE/SELFDESTRUCT), the storage cache is
+        /// epoch-bumped first, then all committed values are re-written so the cache ends
+        /// up with only correct post-block values.
+        /// </summary>
+        private void PromoteToCrossBlockCaches()
+        {
+            if (crossBlockCaches is null) return;
+
+            if (_pendingStateUpdates is not null)
+            {
+                SeqlockCache<AddressAsKey, Account> stateCache = crossBlockCaches.StateCache;
+                foreach ((AddressAsKey key, Account? value) in _pendingStateUpdates)
+                {
+                    stateCache.Set(in key, value);
+                }
+            }
+
+            if (_pendingStorageClear)
+            {
+                // A CREATE or SELFDESTRUCT cleared storage for at least one address.
+                // Epoch-bump invalidates all cross-block storage entries, then we
+                // re-seed with the correct committed values from this block.
+                crossBlockCaches.StorageCache.Clear();
+            }
+
+            if (_pendingStorageUpdates is not null)
+            {
+                SeqlockCache<StorageCell, byte[]> storageCacheRef = crossBlockCaches.StorageCache;
+                foreach ((StorageCell key, byte[] value) in _pendingStorageUpdates)
+                {
+                    storageCacheRef.Set(in key, value);
+                }
+            }
         }
 
         public Hash256 RootHash => baseScope.RootHash;
@@ -155,6 +229,12 @@ public class PrewarmerScopeProvider(
                     baseScope.HintGet(address, account);
                     Metrics.IncrementStateTreeCacheHits();
                 }
+                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
+                {
+                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
+                    baseScope.HintGet(address, account);
+                    Metrics.IncrementStateTreeCacheHits();
+                }
                 else
                 {
                     account = GetFromBaseTree(in addressAsKey);
@@ -176,6 +256,7 @@ public class PrewarmerScopeProvider(
     {
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree;
         private readonly SeqlockCache<StorageCell, byte[]> preBlockCache;
+        private readonly SeqlockCache<StorageCell, byte[]>? crossBlockStorageCache;
         private readonly Address address;
         private readonly bool populatePreBlockCache;
         private static readonly SeqlockCache<StorageCell, byte[]>.ValueFactory<StorageTreeWrapper> _loadFromTreeStorage = static (in StorageCell cell, StorageTreeWrapper self) => self.LoadFromTreeStorage(in cell);
@@ -187,10 +268,12 @@ public class PrewarmerScopeProvider(
             IWorldStateScopeProvider.IStorageTree baseStorageTree,
             SeqlockCache<StorageCell, byte[]> preBlockCache,
             Address address,
-            bool populatePreBlockCache)
+            bool populatePreBlockCache,
+            SeqlockCache<StorageCell, byte[]>? crossBlockStorageCache)
         {
             this.baseStorageTree = baseStorageTree;
             this.preBlockCache = preBlockCache;
+            this.crossBlockStorageCache = crossBlockStorageCache;
             this.address = address;
             this.populatePreBlockCache = populatePreBlockCache;
             _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
@@ -223,6 +306,12 @@ public class PrewarmerScopeProvider(
             else
             {
                 if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
+                {
+                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
+                    baseStorageTree.HintGet(in index, value);
+                    Db.Metrics.IncrementStorageTreeCache();
+                }
+                else if (crossBlockStorageCache is not null && crossBlockStorageCache.TryGetValue(in storageCell, out value))
                 {
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
                     baseStorageTree.HintGet(in index, value);
@@ -272,5 +361,91 @@ public class PrewarmerScopeProvider(
         public void Set(Address key, Account? account) => baseWriteBatch.Set(key, account);
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) => baseWriteBatch.CreateStorageWriteBatch(key, estimatedEntries);
+    }
+
+    /// <summary>
+    /// Wraps write batch to buffer account and storage updates for cross-block cache promotion.
+    /// Writes are NOT applied to the cross-block caches immediately — they are buffered on the
+    /// <see cref="ScopeWrapper"/> and promoted only during <see cref="ScopeWrapper.Commit"/>,
+    /// which is called from CommitTree after successful block processing.
+    /// Also intercepts <see cref="OnAccountUpdated"/> to capture storage-root-only account
+    /// updates emitted by the underlying batch (e.g. TrieStoreScopeProvider).
+    /// </summary>
+    private sealed class CacheUpdatingWriteBatch : IWorldStateScopeProvider.IWorldStateWriteBatch
+    {
+        private readonly IWorldStateScopeProvider.IWorldStateWriteBatch _baseBatch;
+        private readonly ScopeWrapper _scope;
+
+        public CacheUpdatingWriteBatch(IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch, ScopeWrapper scope)
+        {
+            _baseBatch = baseBatch;
+            _scope = scope;
+
+            // Intercept OnAccountUpdated from the underlying batch to capture
+            // storage-root-only account updates (e.g. after storage tree commit).
+            _baseBatch.OnAccountUpdated += OnBaseAccountUpdated;
+        }
+
+        public void Dispose()
+        {
+            _baseBatch.OnAccountUpdated -= OnBaseAccountUpdated;
+            _baseBatch.Dispose();
+        }
+
+        public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
+        {
+            add => _baseBatch.OnAccountUpdated += value;
+            remove => _baseBatch.OnAccountUpdated -= value;
+        }
+
+        public void Set(Address key, Account? account)
+        {
+            _baseBatch.Set(key, account);
+            AddressAsKey addressAsKey = key;
+            _scope.BufferStateUpdate(addressAsKey, account);
+        }
+
+        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
+        {
+            IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = _baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
+            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, _scope, key);
+        }
+
+        private void OnBaseAccountUpdated(object? sender, IWorldStateScopeProvider.AccountUpdated updated)
+        {
+            // Buffer the final account (with updated StorageRoot) so the
+            // cross-block state cache sees the fully-resolved account metadata.
+            AddressAsKey addressAsKey = updated.Address;
+            _scope.BufferStateUpdate(addressAsKey, updated.Account);
+        }
+    }
+
+    /// <summary>
+    /// Wraps storage write batch to buffer storage slot updates for cross-block cache promotion.
+    /// On <see cref="Clear"/> (CREATE/SELFDESTRUCT), sets a flag so the promotion step
+    /// epoch-bumps the cross-block storage cache before re-seeding with correct values.
+    /// </summary>
+    private sealed class CacheUpdatingStorageWriteBatch(
+        IWorldStateScopeProvider.IStorageWriteBatch baseBatch,
+        ScopeWrapper scope,
+        Address address) : IWorldStateScopeProvider.IStorageWriteBatch
+    {
+        public void Set(in UInt256 index, byte[] value)
+        {
+            baseBatch.Set(in index, value);
+            StorageCell cell = new(address, in index);
+            scope.BufferStorageUpdate(in cell, value);
+        }
+
+        public void Clear()
+        {
+            baseBatch.Clear();
+            // Signal that a storage clear happened. The promotion step will
+            // epoch-bump the cross-block storage cache, then re-seed with
+            // the correct committed values from the buffer.
+            scope.BufferStorageClear();
+        }
+
+        public void Dispose() => baseBatch.Dispose();
     }
 }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -57,9 +57,8 @@ public class PrewarmerScopeProvider(
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
 
-        // Pending cross-block cache updates, promoted only on successful CommitTree.
+        // Pending cross-block storage cache updates, promoted only on successful CommitTree.
         // ConcurrentQueue because storage batches may run in parallel (UpdateRootHashesMultiThread).
-        private ConcurrentQueue<(AddressAsKey Key, Account? Value)>? _pendingStateUpdates;
         private ConcurrentQueue<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
         private volatile bool _pendingStorageClear;
 
@@ -72,7 +71,7 @@ public class PrewarmerScopeProvider(
             this.populatePreBlockCache = populatePreBlockCache;
             _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
 
-            // Only clear cross-block caches on reorg (discontinuity). On the canonical chain,
+            // Only clear cross-block storage cache on reorg (discontinuity). On the canonical chain,
             // baseBlock.Number == LastCommittedBlockNumber, so caches persist across blocks.
             // During a reorg, baseBlock.Number < LastCommittedBlockNumber, so we clear stale entries.
             if (!populatePreBlockCache && crossBlockCaches is not null)
@@ -80,7 +79,6 @@ public class PrewarmerScopeProvider(
                 long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
                 if (baseBlock is not null && baseBlock.Number != lastCommitted)
                 {
-                    crossBlockCaches.StateCache.Clear();
                     crossBlockCaches.StorageCache.Clear();
                 }
             }
@@ -132,12 +130,6 @@ public class PrewarmerScopeProvider(
                 populatePreBlockCache);
         }
 
-        internal void BufferStateUpdate(AddressAsKey key, Account? account)
-        {
-            ConcurrentQueue<(AddressAsKey, Account?)> queue = LazyInitializer.EnsureInitialized(ref _pendingStateUpdates)!;
-            queue.Enqueue((key, account));
-        }
-
         internal void BufferStorageUpdate(in StorageCell cell, byte[] value)
         {
             ConcurrentQueue<(StorageCell, byte[])> queue = LazyInitializer.EnsureInitialized(ref _pendingStorageUpdates)!;
@@ -174,15 +166,6 @@ public class PrewarmerScopeProvider(
         private void PromoteToCrossBlockCaches(long blockNumber)
         {
             if (crossBlockCaches is null) return;
-
-            if (_pendingStateUpdates is not null)
-            {
-                SeqlockCache<AddressAsKey, Account> stateCache = crossBlockCaches.StateCache;
-                while (_pendingStateUpdates.TryDequeue(out (AddressAsKey Key, Account? Value) entry))
-                {
-                    stateCache.Set(in entry.Key, entry.Value);
-                }
-            }
 
             if (_pendingStorageClear)
             {
@@ -242,12 +225,6 @@ public class PrewarmerScopeProvider(
             else
             {
                 if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    baseScope.HintGet(address, account);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
-                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
                 {
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
                     baseScope.HintGet(address, account);
@@ -382,57 +359,29 @@ public class PrewarmerScopeProvider(
     }
 
     /// <summary>
-    /// Wraps write batch to buffer account and storage updates for cross-block cache promotion.
+    /// Wraps write batch to buffer storage updates for cross-block cache promotion.
     /// Writes are NOT applied to the cross-block caches immediately — they are buffered on the
     /// <see cref="ScopeWrapper"/> and promoted only during <see cref="ScopeWrapper.Commit"/>,
     /// which is called from CommitTree after successful block processing.
-    /// Also intercepts <see cref="OnAccountUpdated"/> to capture storage-root-only account
-    /// updates emitted by the underlying batch (e.g. TrieStoreScopeProvider).
     /// </summary>
-    private sealed class CacheUpdatingWriteBatch : IWorldStateScopeProvider.IWorldStateWriteBatch
+    private sealed class CacheUpdatingWriteBatch(
+        IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
+        ScopeWrapper scope) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
-        private readonly IWorldStateScopeProvider.IWorldStateWriteBatch _baseBatch;
-        private readonly ScopeWrapper _scope;
-
-        public CacheUpdatingWriteBatch(IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch, ScopeWrapper scope)
-        {
-            _baseBatch = baseBatch;
-            _scope = scope;
-
-            _baseBatch.OnAccountUpdated += OnBaseAccountUpdated;
-        }
-
-        public void Dispose()
-        {
-            // Dispose first so OnAccountUpdated fires while we're still subscribed.
-            // This captures the final StorageRoot set during storage tree commit.
-            _baseBatch.Dispose();
-            _baseBatch.OnAccountUpdated -= OnBaseAccountUpdated;
-        }
+        public void Dispose() => baseBatch.Dispose();
 
         public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
         {
-            add => _baseBatch.OnAccountUpdated += value;
-            remove => _baseBatch.OnAccountUpdated -= value;
+            add => baseBatch.OnAccountUpdated += value;
+            remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account)
-        {
-            _baseBatch.Set(key, account);
-            AddressAsKey addressAsKey = key;
-            _scope.BufferStateUpdate(addressAsKey, account);
-        }
+        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {
-            IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = _baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
-            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, _scope, key);
-        }
-
-        private void OnBaseAccountUpdated(object? sender, IWorldStateScopeProvider.AccountUpdated updated)
-        {
-            AddressAsKey addressAsKey = updated.Address;
-            _scope.BufferStateUpdate(addressAsKey, updated.Account);
+            IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
+            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, scope, key);
         }
     }
 

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -40,7 +40,7 @@ public class PrewarmerScopeProvider(
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache, crossBlockCaches);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache, crossBlockCaches, baseBlock);
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !populatePreBlockCache;
@@ -63,7 +63,7 @@ public class PrewarmerScopeProvider(
         private ConcurrentQueue<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
         private volatile bool _pendingStorageClear;
 
-        public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches)
+        public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches, BlockHeader? baseBlock)
         {
             this.baseScope = baseScope;
             preBlockCache = preBlockCaches.StateCache;
@@ -72,14 +72,17 @@ public class PrewarmerScopeProvider(
             this.populatePreBlockCache = populatePreBlockCache;
             _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
 
-            // Clear cross-block caches on each new scope. A new scope means either the start
-            // of a new branch or a commit-point in a long branch. The cache may contain stale
-            // entries from a different branch (e.g. during reorg) that would corrupt reads.
-            // Within a single scope, multiple blocks will re-populate these caches.
-            if (!populatePreBlockCache)
+            // Only clear cross-block caches on reorg (discontinuity). On the canonical chain,
+            // baseBlock.Number == LastCommittedBlockNumber, so caches persist across blocks.
+            // During a reorg, baseBlock.Number < LastCommittedBlockNumber, so we clear stale entries.
+            if (!populatePreBlockCache && crossBlockCaches is not null)
             {
-                crossBlockCaches?.StateCache.Clear();
-                crossBlockCaches?.StorageCache.Clear();
+                long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
+                if (baseBlock is not null && baseBlock.Number != lastCommitted)
+                {
+                    crossBlockCaches.StateCache.Clear();
+                    crossBlockCaches.StorageCache.Clear();
+                }
             }
         }
 
@@ -151,13 +154,13 @@ public class PrewarmerScopeProvider(
             if (!_measureMetric)
             {
                 baseScope.Commit(blockNumber);
-                PromoteToCrossBlockCaches();
+                PromoteToCrossBlockCaches(blockNumber);
                 return;
             }
 
             long sw = Stopwatch.GetTimestamp();
             baseScope.Commit(blockNumber);
-            PromoteToCrossBlockCaches();
+            PromoteToCrossBlockCaches(blockNumber);
             _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.Commit);
         }
 
@@ -168,7 +171,7 @@ public class PrewarmerScopeProvider(
         /// epoch-bumped first, then all committed values are re-written so the cache ends
         /// up with only correct post-block values.
         /// </summary>
-        private void PromoteToCrossBlockCaches()
+        private void PromoteToCrossBlockCaches(long blockNumber)
         {
             if (crossBlockCaches is null) return;
 
@@ -197,6 +200,8 @@ public class PrewarmerScopeProvider(
                     storageCacheRef.Set(in entry.Key, entry.Value);
                 }
             }
+
+            crossBlockCaches.LastCommittedBlockNumber = blockNumber;
         }
 
         public Hash256 RootHash => baseScope.RootHash;

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -76,7 +76,6 @@ public class PrewarmerScopeProvider(
                 long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
                 if (baseBlock is not null && baseBlock.Number != lastCommitted)
                 {
-                    crossBlockCaches.StateCache.Clear();
                     crossBlockCaches.StorageCache.Clear();
                 }
             }
@@ -90,7 +89,6 @@ public class PrewarmerScopeProvider(
             // any entries written directly to the cross-block cache during this scope.
             if (!_committed && crossBlockCaches is not null)
             {
-                crossBlockCaches.StateCache.Clear();
                 crossBlockCaches.StorageCache.Clear();
             }
 
@@ -121,7 +119,7 @@ public class PrewarmerScopeProvider(
             // On block failure, Dispose epoch-bumps to rollback stale entries.
             if (crossBlockCaches is not null)
             {
-                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StateCache, crossBlockCaches.StorageCache);
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
             }
 
             if (!_measureMetric) return batch;
@@ -220,20 +218,9 @@ public class PrewarmerScopeProvider(
                     baseScope.HintGet(address, account);
                     Metrics.IncrementStateTreeCacheHits();
                 }
-                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
-                {
-                    // Return cached value WITHOUT calling HintGet. Calling HintGet would push
-                    // a stale Account (with outdated StorageRoot) into the flat state's snapshot
-                    // bundle, causing NodeHashMismatchException during trie operations. The base
-                    // scope loads the account independently from the flat DB when it needs it.
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
                 else
                 {
                     account = GetFromBaseTree(in addressAsKey);
-                    // Seed cross-block state cache from trie reads.
-                    crossBlockCaches?.StateCache.Set(in addressAsKey, account);
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
                 }
                 return account;
@@ -369,7 +356,6 @@ public class PrewarmerScopeProvider(
     private sealed class CacheUpdatingWriteBatch(
         IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
         ScopeWrapper scope,
-        SeqlockCache<AddressAsKey, Account> crossBlockStateCache,
         SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
         public void Dispose() => baseBatch.Dispose();
@@ -380,12 +366,7 @@ public class PrewarmerScopeProvider(
             remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account)
-        {
-            baseBatch.Set(key, account);
-            AddressAsKey addressAsKey = key;
-            crossBlockStateCache.Set(in addressAsKey, account);
-        }
+        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -76,7 +76,6 @@ public class PrewarmerScopeProvider(
                 long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
                 if (baseBlock is not null && baseBlock.Number != lastCommitted)
                 {
-                    crossBlockCaches.StateCache.Clear();
                     crossBlockCaches.StorageCache.Clear();
                 }
             }
@@ -90,7 +89,6 @@ public class PrewarmerScopeProvider(
             // any entries written directly to the cross-block cache during this scope.
             if (!_committed && crossBlockCaches is not null)
             {
-                crossBlockCaches.StateCache.Clear();
                 crossBlockCaches.StorageCache.Clear();
             }
 
@@ -121,7 +119,7 @@ public class PrewarmerScopeProvider(
             // On block failure, Dispose epoch-bumps to rollback stale entries.
             if (crossBlockCaches is not null)
             {
-                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StateCache, crossBlockCaches.StorageCache);
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
             }
 
             if (!_measureMetric) return batch;
@@ -220,17 +218,9 @@ public class PrewarmerScopeProvider(
                     baseScope.HintGet(address, account);
                     Metrics.IncrementStateTreeCacheHits();
                 }
-                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    baseScope.HintGet(address, account);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
                 else
                 {
                     account = GetFromBaseTree(in addressAsKey);
-                    // Seed cross-block state cache from trie reads.
-                    crossBlockCaches?.StateCache.Set(in addressAsKey, account);
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
                 }
                 return account;
@@ -366,7 +356,6 @@ public class PrewarmerScopeProvider(
     private sealed class CacheUpdatingWriteBatch(
         IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
         ScopeWrapper scope,
-        SeqlockCache<AddressAsKey, Account> crossBlockStateCache,
         SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
         public void Dispose() => baseBatch.Dispose();
@@ -377,12 +366,7 @@ public class PrewarmerScopeProvider(
             remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account)
-        {
-            baseBatch.Set(key, account);
-            AddressAsKey addressAsKey = key;
-            crossBlockStateCache.Set(in addressAsKey, account);
-        }
+        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -76,6 +76,7 @@ public class PrewarmerScopeProvider(
                 long lastCommitted = crossBlockCaches.LastCommittedBlockNumber;
                 if (baseBlock is not null && baseBlock.Number != lastCommitted)
                 {
+                    crossBlockCaches.StateCache.Clear();
                     crossBlockCaches.StorageCache.Clear();
                 }
             }
@@ -89,6 +90,7 @@ public class PrewarmerScopeProvider(
             // any entries written directly to the cross-block cache during this scope.
             if (!_committed && crossBlockCaches is not null)
             {
+                crossBlockCaches.StateCache.Clear();
                 crossBlockCaches.StorageCache.Clear();
             }
 
@@ -119,7 +121,7 @@ public class PrewarmerScopeProvider(
             // On block failure, Dispose epoch-bumps to rollback stale entries.
             if (crossBlockCaches is not null)
             {
-                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StateCache, crossBlockCaches.StorageCache);
             }
 
             if (!_measureMetric) return batch;
@@ -218,9 +220,17 @@ public class PrewarmerScopeProvider(
                     baseScope.HintGet(address, account);
                     Metrics.IncrementStateTreeCacheHits();
                 }
+                else if (crossBlockCaches is not null && crossBlockCaches.StateCache.TryGetValue(in addressAsKey, out account))
+                {
+                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
+                    baseScope.HintGet(address, account);
+                    Metrics.IncrementStateTreeCacheHits();
+                }
                 else
                 {
                     account = GetFromBaseTree(in addressAsKey);
+                    // Seed cross-block state cache from trie reads.
+                    crossBlockCaches?.StateCache.Set(in addressAsKey, account);
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
                 }
                 return account;
@@ -239,7 +249,7 @@ public class PrewarmerScopeProvider(
     {
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree;
         private readonly SeqlockCache<StorageCell, byte[]> preBlockCache;
-        private readonly SeqlockCache<StorageCell, byte[]>? crossBlockStorageCache;
+        private readonly SeqlockCache<StorageCell, byte[], LargeCacheSets>? crossBlockStorageCache;
         private readonly Address address;
         private readonly bool populatePreBlockCache;
         private static readonly SeqlockCache<StorageCell, byte[]>.ValueFactory<StorageTreeWrapper> _loadFromTreeStorage = static (in StorageCell cell, StorageTreeWrapper self) => self.LoadFromTreeStorage(in cell);
@@ -252,7 +262,7 @@ public class PrewarmerScopeProvider(
             SeqlockCache<StorageCell, byte[]> preBlockCache,
             Address address,
             bool populatePreBlockCache,
-            SeqlockCache<StorageCell, byte[]>? crossBlockStorageCache)
+            SeqlockCache<StorageCell, byte[], LargeCacheSets>? crossBlockStorageCache)
         {
             this.baseStorageTree = baseStorageTree;
             this.preBlockCache = preBlockCache;
@@ -356,7 +366,8 @@ public class PrewarmerScopeProvider(
     private sealed class CacheUpdatingWriteBatch(
         IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
         ScopeWrapper scope,
-        SeqlockCache<StorageCell, byte[]> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
+        SeqlockCache<AddressAsKey, Account> crossBlockStateCache,
+        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
         public void Dispose() => baseBatch.Dispose();
 
@@ -366,7 +377,12 @@ public class PrewarmerScopeProvider(
             remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
+        public void Set(Address key, Account? account)
+        {
+            baseBatch.Set(key, account);
+            AddressAsKey addressAsKey = key;
+            crossBlockStateCache.Set(in addressAsKey, account);
+        }
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {
@@ -383,7 +399,7 @@ public class PrewarmerScopeProvider(
     private sealed class CacheUpdatingStorageWriteBatch(
         IWorldStateScopeProvider.IStorageWriteBatch baseBatch,
         ScopeWrapper scope,
-        SeqlockCache<StorageCell, byte[]> crossBlockStorageCache,
+        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache,
         Address address) : IWorldStateScopeProvider.IStorageWriteBatch
     {
         public void Set(in UInt256 index, byte[] value)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -56,9 +58,10 @@ public class PrewarmerScopeProvider(
         private readonly PrewarmerGetTimeLabels _labels;
 
         // Pending cross-block cache updates, promoted only on successful CommitTree.
-        private List<(AddressAsKey Key, Account? Value)>? _pendingStateUpdates;
-        private List<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
-        private bool _pendingStorageClear;
+        // ConcurrentQueue because storage batches may run in parallel (UpdateRootHashesMultiThread).
+        private ConcurrentQueue<(AddressAsKey Key, Account? Value)>? _pendingStateUpdates;
+        private ConcurrentQueue<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
+        private volatile bool _pendingStorageClear;
 
         public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches)
         {
@@ -128,14 +131,14 @@ public class PrewarmerScopeProvider(
 
         internal void BufferStateUpdate(AddressAsKey key, Account? account)
         {
-            _pendingStateUpdates ??= new();
-            _pendingStateUpdates.Add((key, account));
+            ConcurrentQueue<(AddressAsKey, Account?)> queue = LazyInitializer.EnsureInitialized(ref _pendingStateUpdates)!;
+            queue.Enqueue((key, account));
         }
 
         internal void BufferStorageUpdate(in StorageCell cell, byte[] value)
         {
-            _pendingStorageUpdates ??= new();
-            _pendingStorageUpdates.Add((cell, value));
+            ConcurrentQueue<(StorageCell, byte[])> queue = LazyInitializer.EnsureInitialized(ref _pendingStorageUpdates)!;
+            queue.Enqueue((cell, value));
         }
 
         internal void BufferStorageClear()
@@ -172,9 +175,9 @@ public class PrewarmerScopeProvider(
             if (_pendingStateUpdates is not null)
             {
                 SeqlockCache<AddressAsKey, Account> stateCache = crossBlockCaches.StateCache;
-                foreach ((AddressAsKey key, Account? value) in _pendingStateUpdates)
+                while (_pendingStateUpdates.TryDequeue(out (AddressAsKey Key, Account? Value) entry))
                 {
-                    stateCache.Set(in key, value);
+                    stateCache.Set(in entry.Key, entry.Value);
                 }
             }
 
@@ -189,9 +192,9 @@ public class PrewarmerScopeProvider(
             if (_pendingStorageUpdates is not null)
             {
                 SeqlockCache<StorageCell, byte[]> storageCacheRef = crossBlockCaches.StorageCache;
-                foreach ((StorageCell key, byte[] value) in _pendingStorageUpdates)
+                while (_pendingStorageUpdates.TryDequeue(out (StorageCell Key, byte[] Value) entry))
                 {
-                    storageCacheRef.Set(in key, value);
+                    storageCacheRef.Set(in entry.Key, entry.Value);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -57,9 +54,9 @@ public class PrewarmerScopeProvider(
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
 
-        // Pending cross-block storage cache updates, promoted only on successful CommitTree.
-        // ConcurrentQueue because storage batches may run in parallel (UpdateRootHashesMultiThread).
-        private ConcurrentQueue<(StorageCell Key, byte[] Value)>? _pendingStorageUpdates;
+        // Set to true after successful commit; used in Dispose to rollback stale direct writes.
+        private bool _committed;
+        // Set if any storage Clear() was observed (CREATE/SELFDESTRUCT); triggers epoch-bump on commit.
         private volatile bool _pendingStorageClear;
 
         public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches, BlockHeader? baseBlock)
@@ -88,6 +85,13 @@ public class PrewarmerScopeProvider(
 
         public void Dispose()
         {
+            // If commit didn't happen (e.g., block was invalid), epoch-bump to invalidate
+            // any entries written directly to the cross-block cache during this scope.
+            if (!_committed && crossBlockCaches is not null)
+            {
+                crossBlockCaches.StorageCache.Clear();
+            }
+
             if (_measureMetric && _writeBatchTime != 0)
             {
                 _metricObserver.Observe(Stopwatch.GetTimestamp() - _writeBatchTime, _labels.WriteBatchToScopeDisposeTime);
@@ -111,12 +115,11 @@ public class PrewarmerScopeProvider(
         {
             IWorldStateScopeProvider.IWorldStateWriteBatch batch = baseScope.StartWriteBatch(estimatedAccountNum);
 
-            // Buffer writes for the cross-block caches. Promotion happens in Commit()
-            // (called from CommitTree after successful block processing), so a failed block
-            // never pollutes the cross-block caches.
+            // Wrap write batch to write storage updates directly to the cross-block cache.
+            // On block failure, Dispose epoch-bumps to rollback stale entries.
             if (crossBlockCaches is not null)
             {
-                batch = new CacheUpdatingWriteBatch(batch, this);
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
             }
 
             if (!_measureMetric) return batch;
@@ -128,12 +131,6 @@ public class PrewarmerScopeProvider(
                 _metricObserver,
                 sw,
                 populatePreBlockCache);
-        }
-
-        internal void BufferStorageUpdate(in StorageCell cell, byte[] value)
-        {
-            ConcurrentQueue<(StorageCell, byte[])> queue = LazyInitializer.EnsureInitialized(ref _pendingStorageUpdates)!;
-            queue.Enqueue((cell, value));
         }
 
         internal void BufferStorageClear()
@@ -157,11 +154,10 @@ public class PrewarmerScopeProvider(
         }
 
         /// <summary>
-        /// Flushes buffered writes to the cross-block caches. Called only after successful
-        /// CommitTree, so speculative entries from failed/invalid blocks are never promoted.
-        /// If any storage Clear() was seen (CREATE/SELFDESTRUCT), the storage cache is
-        /// epoch-bumped first, then all committed values are re-written so the cache ends
-        /// up with only correct post-block values.
+        /// Finalizes cross-block cache state after successful commit. Storage values are
+        /// written directly to the cross-block cache during the write batch phase and seeded
+        /// from trie reads, so this only handles epoch-bumps from storage Clear() and sets
+        /// the committed flag for reorg detection.
         /// </summary>
         private void PromoteToCrossBlockCaches(long blockNumber)
         {
@@ -170,20 +166,12 @@ public class PrewarmerScopeProvider(
             if (_pendingStorageClear)
             {
                 // A CREATE or SELFDESTRUCT cleared storage for at least one address.
-                // Epoch-bump invalidates all cross-block storage entries, then we
-                // re-seed with the correct committed values from this block.
+                // Epoch-bump invalidates all cross-block storage entries. The cache will
+                // be re-seeded organically from trie reads on subsequent blocks.
                 crossBlockCaches.StorageCache.Clear();
             }
 
-            if (_pendingStorageUpdates is not null)
-            {
-                SeqlockCache<StorageCell, byte[]> storageCacheRef = crossBlockCaches.StorageCache;
-                while (_pendingStorageUpdates.TryDequeue(out (StorageCell Key, byte[] Value) entry))
-                {
-                    storageCacheRef.Set(in entry.Key, entry.Value);
-                }
-            }
-
+            _committed = true;
             crossBlockCaches.LastCommittedBlockNumber = blockNumber;
         }
 
@@ -315,6 +303,9 @@ public class PrewarmerScopeProvider(
                 else
                 {
                     value = LoadFromTreeStorage(in storageCell);
+                    // Seed cross-block cache from trie reads — hot slots that are read but
+                    // not written (SLOAD-only) are captured for subsequent blocks.
+                    crossBlockStorageCache?.Set(in storageCell, value);
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
                 }
                 return value;
@@ -359,14 +350,13 @@ public class PrewarmerScopeProvider(
     }
 
     /// <summary>
-    /// Wraps write batch to buffer storage updates for cross-block cache promotion.
-    /// Writes are NOT applied to the cross-block caches immediately — they are buffered on the
-    /// <see cref="ScopeWrapper"/> and promoted only during <see cref="ScopeWrapper.Commit"/>,
-    /// which is called from CommitTree after successful block processing.
+    /// Wraps write batch to write storage updates directly to the cross-block cache.
+    /// On block failure, the ScopeWrapper's Dispose epoch-bumps the cache to rollback.
     /// </summary>
     private sealed class CacheUpdatingWriteBatch(
         IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
-        ScopeWrapper scope) : IWorldStateScopeProvider.IWorldStateWriteBatch
+        ScopeWrapper scope,
+        SeqlockCache<StorageCell, byte[]> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
         public void Dispose() => baseBatch.Dispose();
 
@@ -381,33 +371,31 @@ public class PrewarmerScopeProvider(
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
         {
             IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
-            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, scope, key);
+            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, scope, crossBlockStorageCache, key);
         }
     }
 
     /// <summary>
-    /// Wraps storage write batch to buffer storage slot updates for cross-block cache promotion.
-    /// On <see cref="Clear"/> (CREATE/SELFDESTRUCT), sets a flag so the promotion step
-    /// epoch-bumps the cross-block storage cache before re-seeding with correct values.
+    /// Wraps storage write batch to write slot updates directly to the cross-block cache.
+    /// On <see cref="Clear"/> (CREATE/SELFDESTRUCT), sets a flag so the commit step
+    /// epoch-bumps the cross-block storage cache.
     /// </summary>
     private sealed class CacheUpdatingStorageWriteBatch(
         IWorldStateScopeProvider.IStorageWriteBatch baseBatch,
         ScopeWrapper scope,
+        SeqlockCache<StorageCell, byte[]> crossBlockStorageCache,
         Address address) : IWorldStateScopeProvider.IStorageWriteBatch
     {
         public void Set(in UInt256 index, byte[] value)
         {
             baseBatch.Set(in index, value);
             StorageCell cell = new(address, in index);
-            scope.BufferStorageUpdate(in cell, value);
+            crossBlockStorageCache.Set(in cell, value);
         }
 
         public void Clear()
         {
             baseBatch.Clear();
-            // Signal that a storage clear happened. The promotion step will
-            // epoch-bump the cross-block storage cache, then re-seed with
-            // the correct committed values from the buffer.
             scope.BufferStorageClear();
         }
 

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -68,6 +68,16 @@ public class PrewarmerScopeProvider(
             this.crossBlockCaches = crossBlockCaches;
             this.populatePreBlockCache = populatePreBlockCache;
             _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+
+            // Clear cross-block caches on each new scope. A new scope means either the start
+            // of a new branch or a commit-point in a long branch. The cache may contain stale
+            // entries from a different branch (e.g. during reorg) that would corrupt reads.
+            // Within a single scope, multiple blocks will re-populate these caches.
+            if (!populatePreBlockCache)
+            {
+                crossBlockCaches?.StateCache.Clear();
+                crossBlockCaches?.StorageCache.Clear();
+            }
         }
 
         private long _writeBatchTime = 0;
@@ -381,15 +391,15 @@ public class PrewarmerScopeProvider(
             _baseBatch = baseBatch;
             _scope = scope;
 
-            // Intercept OnAccountUpdated from the underlying batch to capture
-            // storage-root-only account updates (e.g. after storage tree commit).
             _baseBatch.OnAccountUpdated += OnBaseAccountUpdated;
         }
 
         public void Dispose()
         {
-            _baseBatch.OnAccountUpdated -= OnBaseAccountUpdated;
+            // Dispose first so OnAccountUpdated fires while we're still subscribed.
+            // This captures the final StorageRoot set during storage tree commit.
             _baseBatch.Dispose();
+            _baseBatch.OnAccountUpdated -= OnBaseAccountUpdated;
         }
 
         public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
@@ -413,8 +423,6 @@ public class PrewarmerScopeProvider(
 
         private void OnBaseAccountUpdated(object? sender, IWorldStateScopeProvider.AccountUpdated updated)
         {
-            // Buffer the final account (with updated StorageRoot) so the
-            // cross-block state cache sees the fully-resolved account metadata.
             AddressAsKey addressAsKey = updated.Address;
             _scope.BufferStateUpdate(addressAsKey, updated.Account);
         }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -53,6 +53,8 @@ public class PrewarmerScopeProvider(
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
+        private bool _committed;
+        private volatile bool _pendingStorageClear;
 
         public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache, CrossBlockCaches? crossBlockCaches, BlockHeader? baseBlock)
         {
@@ -80,6 +82,13 @@ public class PrewarmerScopeProvider(
 
         public void Dispose()
         {
+            // If commit didn't happen (e.g., block was invalid), epoch-bump to invalidate
+            // any entries written directly to the cross-block cache during this scope.
+            if (!_committed && crossBlockCaches is not null)
+            {
+                crossBlockCaches.StorageCache.Clear();
+            }
+
             if (_measureMetric && _writeBatchTime != 0)
             {
                 _metricObserver.Observe(Stopwatch.GetTimestamp() - _writeBatchTime, _labels.WriteBatchToScopeDisposeTime);
@@ -103,6 +112,12 @@ public class PrewarmerScopeProvider(
         {
             IWorldStateScopeProvider.IWorldStateWriteBatch batch = baseScope.StartWriteBatch(estimatedAccountNum);
 
+            // Write-through: intercept storage writes to keep cross-block cache up to date.
+            if (crossBlockCaches is not null)
+            {
+                batch = new CacheUpdatingWriteBatch(batch, this, crossBlockCaches.StorageCache);
+            }
+
             if (!_measureMetric) return batch;
 
             _writeBatchTime = Stopwatch.GetTimestamp();
@@ -114,21 +129,33 @@ public class PrewarmerScopeProvider(
                 populatePreBlockCache);
         }
 
+        internal void BufferStorageClear() => _pendingStorageClear = true;
+
         public void Commit(long blockNumber)
         {
             if (!_measureMetric)
             {
                 baseScope.Commit(blockNumber);
-                if (crossBlockCaches is not null)
-                    crossBlockCaches.LastCommittedBlockNumber = blockNumber;
+                FinalizeCommit(blockNumber);
                 return;
             }
 
             long sw = Stopwatch.GetTimestamp();
             baseScope.Commit(blockNumber);
-            if (crossBlockCaches is not null)
-                crossBlockCaches.LastCommittedBlockNumber = blockNumber;
+            FinalizeCommit(blockNumber);
             _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.Commit);
+        }
+
+        private void FinalizeCommit(long blockNumber)
+        {
+            if (crossBlockCaches is null) return;
+
+            // CREATE/SELFDESTRUCT cleared storage — epoch-bump invalidates all entries.
+            if (_pendingStorageClear)
+                crossBlockCaches.StorageCache.Clear();
+
+            _committed = true;
+            crossBlockCaches.LastCommittedBlockNumber = blockNumber;
         }
 
         public Hash256 RootHash => baseScope.RootHash;
@@ -305,6 +332,52 @@ public class PrewarmerScopeProvider(
         public void Set(Address key, Account? account) => baseWriteBatch.Set(key, account);
 
         public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) => baseWriteBatch.CreateStorageWriteBatch(key, estimatedEntries);
+    }
+
+    /// <summary>
+    /// Wraps write batch to write-through storage updates to the cross-block cache.
+    /// </summary>
+    private sealed class CacheUpdatingWriteBatch(
+        IWorldStateScopeProvider.IWorldStateWriteBatch baseBatch,
+        ScopeWrapper scope,
+        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
+    {
+        public void Dispose() => baseBatch.Dispose();
+
+        public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
+        {
+            add => baseBatch.OnAccountUpdated += value;
+            remove => baseBatch.OnAccountUpdated -= value;
+        }
+
+        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
+
+        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
+        {
+            IWorldStateScopeProvider.IStorageWriteBatch baseBatchStorage = baseBatch.CreateStorageWriteBatch(key, estimatedEntries);
+            return new CacheUpdatingStorageWriteBatch(baseBatchStorage, scope, crossBlockStorageCache, key);
+        }
+    }
+
+    private sealed class CacheUpdatingStorageWriteBatch(
+        IWorldStateScopeProvider.IStorageWriteBatch baseBatch,
+        ScopeWrapper scope,
+        SeqlockCache<StorageCell, byte[], LargeCacheSets> crossBlockStorageCache,
+        Address address) : IWorldStateScopeProvider.IStorageWriteBatch
+    {
+        public void Set(in UInt256 index, byte[] value)
+        {
+            baseBatch.Set(in index, value);
+            crossBlockStorageCache.Set(new StorageCell(address, in index), value);
+        }
+
+        public void Clear()
+        {
+            baseBatch.Clear();
+            scope.BufferStorageClear();
+        }
+
+        public void Dispose() => baseBatch.Dispose();
     }
 
 }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -296,8 +296,10 @@ public class PrewarmerScopeProvider(
                 }
                 else if (crossBlockStorageCache is not null && crossBlockStorageCache.TryGetValue(in storageCell, out value))
                 {
+                    // Skip HintGet — the value came from the cross-block cache, not the trie.
+                    // HintGet triggers WarmUpSlot (bloom filter + XxHash64 + potential trie path
+                    // warming), which is wasted work since the value is already cached.
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    baseStorageTree.HintGet(in index, value);
                     Db.Metrics.IncrementStorageTreeCache();
                 }
                 else

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -9,12 +9,6 @@ public sealed class NodeStorageCache
 {
     private readonly SeqlockCache<NodeKey, byte[]> _cache = new();
 
-    // Cross-block trie node cache. Trie nodes are content-addressed (keyed by hash),
-    // so stale entries are impossible — the same hash always maps to the same RLP.
-    // This cache is never cleared between blocks, only evicted naturally by the
-    // set-associative replacement policy.
-    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new();
-
     private volatile bool _enabled = false;
 
     public bool Enabled
@@ -27,39 +21,9 @@ public sealed class NodeStorageCache
     {
         if (!_enabled)
         {
-            // Main processing path (per-block cache disabled). Still check cross-block cache.
-            if (_crossBlockCache.TryGetValue(in nodeKey, out byte[]? cached))
-            {
-                return cached;
-            }
-
-            byte[]? value = tryLoadRlp(in nodeKey);
-            if (value is not null)
-            {
-                _crossBlockCache.Set(in nodeKey, value);
-            }
-            return value;
+            return tryLoadRlp(in nodeKey);
         }
-
-        // Prewarmer path: check per-block cache first, then cross-block, then disk.
-        if (_cache.TryGetValue(in nodeKey, out byte[]? perBlock))
-        {
-            return perBlock;
-        }
-
-        if (_crossBlockCache.TryGetValue(in nodeKey, out byte[]? crossBlock))
-        {
-            _cache.Set(in nodeKey, crossBlock);
-            return crossBlock;
-        }
-
-        byte[]? loaded = tryLoadRlp(in nodeKey);
-        if (loaded is not null)
-        {
-            _cache.Set(in nodeKey, loaded);
-            _crossBlockCache.Set(in nodeKey, loaded);
-        }
-        return loaded;
+        return _cache.GetOrAdd(in nodeKey, tryLoadRlp);
     }
 
     public bool ClearCaches()
@@ -67,8 +31,6 @@ public sealed class NodeStorageCache
         bool wasEnabled = _enabled;
         _enabled = false;
         _cache.Clear();
-        // Cross-block cache is NOT cleared — trie nodes are content-addressed,
-        // so entries are always valid regardless of reorgs.
         return wasEnabled;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -9,6 +9,12 @@ public sealed class NodeStorageCache
 {
     private readonly SeqlockCache<NodeKey, byte[]> _cache = new();
 
+    // Cross-block trie node cache. Trie nodes are content-addressed (keyed by hash),
+    // so stale entries are impossible — the same hash always maps to the same RLP.
+    // This cache is never cleared between blocks, only evicted naturally by the
+    // set-associative replacement policy.
+    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new();
+
     private volatile bool _enabled = false;
 
     public bool Enabled
@@ -21,9 +27,39 @@ public sealed class NodeStorageCache
     {
         if (!_enabled)
         {
-            return tryLoadRlp(in nodeKey);
+            // Main processing path (per-block cache disabled). Still check cross-block cache.
+            if (_crossBlockCache.TryGetValue(in nodeKey, out byte[]? cached))
+            {
+                return cached;
+            }
+
+            byte[]? value = tryLoadRlp(in nodeKey);
+            if (value is not null)
+            {
+                _crossBlockCache.Set(in nodeKey, value);
+            }
+            return value;
         }
-        return _cache.GetOrAdd(in nodeKey, tryLoadRlp);
+
+        // Prewarmer path: check per-block cache first, then cross-block, then disk.
+        if (_cache.TryGetValue(in nodeKey, out byte[]? perBlock))
+        {
+            return perBlock;
+        }
+
+        if (_crossBlockCache.TryGetValue(in nodeKey, out byte[]? crossBlock))
+        {
+            _cache.Set(in nodeKey, crossBlock);
+            return crossBlock;
+        }
+
+        byte[]? loaded = tryLoadRlp(in nodeKey);
+        if (loaded is not null)
+        {
+            _cache.Set(in nodeKey, loaded);
+            _crossBlockCache.Set(in nodeKey, loaded);
+        }
+        return loaded;
     }
 
     public bool ClearCaches()
@@ -31,6 +67,8 @@ public sealed class NodeStorageCache
         bool wasEnabled = _enabled;
         _enabled = false;
         _cache.Clear();
+        // Cross-block cache is NOT cleared — trie nodes are content-addressed,
+        // so entries are always valid regardless of reorgs.
         return wasEnabled;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -13,8 +13,7 @@ public sealed class NodeStorageCache
     // so stale entries are impossible — the same hash always maps to the same RLP.
     // This cache is never cleared between blocks, only evicted naturally by the
     // set-associative replacement policy.
-    // setsLog2=20 → 1M sets × 2 ways = 2M entries. At ~200 bytes avg RLP per node ≈ 400 MB of cached data.
-    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new(setsLog2: 20);
+    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new();
 
     private volatile bool _enabled = false;
 

--- a/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageCache.cs
@@ -13,7 +13,8 @@ public sealed class NodeStorageCache
     // so stale entries are impossible — the same hash always maps to the same RLP.
     // This cache is never cleared between blocks, only evicted naturally by the
     // set-associative replacement policy.
-    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new();
+    // setsLog2=20 → 1M sets × 2 ways = 2M entries. At ~200 bytes avg RLP per node ≈ 400 MB of cached data.
+    private readonly SeqlockCache<NodeKey, byte[]> _crossBlockCache = new(setsLog2: 20);
 
     private volatile bool _enabled = false;
 


### PR DESCRIPTION
## Changes

Add a dedicated `CrossBlockCaches` class with its own `SeqlockCache` instances (~4.5 MB) for storage slots and accounts that persist across blocks. Writes are buffered during commit and promoted only after successful `CommitTree`.

### Review issues addressed

**[Correctness] Speculative entries from failed blocks** — writes are buffered on the `ScopeWrapper` during the write batch phase and only promoted to the cross-block caches in `Commit()`, which is called from `CommitTree` after successful block processing. If `ProcessOne` throws, `PreCommitBlock`/`CommitTree` is never reached, so the buffer is silently discarded.

**[Correctness] Stale StorageRoot from storage-only changes** — `CacheUpdatingWriteBatch` subscribes to `baseBatch.OnAccountUpdated` and buffers the final account (with updated `StorageRoot`) emitted by the underlying batch (e.g. `TrieStoreScopeProvider`). The promotion step writes the fully-resolved account to the cross-block state cache.

**[Performance] Full cache nuke on CREATE** — `CacheUpdatingStorageWriteBatch.Clear()` no longer epoch-bumps immediately. Instead it sets a `_pendingStorageClear` flag. At promotion time, if the flag is set, the storage cache is epoch-bumped first, then all committed storage values from the buffer are re-seeded. This means the cache ends up with only correct post-block values; previous cross-block entries for unrelated addresses are lost only when a Clear actually occurred, and are immediately re-seeded with the current block's committed values.

### Architecture

- **Separate from prewarmer caches** — cross-block caches are never shared with prewarmer threads, no concurrent `GetOrAdd` race
- **Per-block caches unchanged** — `PreBlockCaches` cleared between blocks exactly as on master
- **Read path** — main thread checks per-block cache first, then cross-block cache, then trie/db
- **Write path** — commit write batch buffers to `ScopeWrapper`, promoted in `Commit()` after successful `CommitTree`

### Files changed

- **`CrossBlockCaches.cs`** (new) — two `SeqlockCache` instances for storage and state
- **`PrewarmerScopeProvider.cs`** — buffered write-through with deferred promotion, `OnAccountUpdated` interception, selective `Clear()` handling
- **`PrewarmerModule.cs`** — register `CrossBlockCaches` as singleton, pass to decorator

## Types of changes

- [x] Performance improvement

## Testing

- [x] Nethermind.State.Test: StorageProviderTests + ScopeProviderTests (91 passed, 1 skipped)
- [ ] Benchmark with `realblocks` payload set
- [ ] Benchmark with `superblocks` payload set