### PR TITLE
Extend `CallResult` constructor visibility

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CallResult.cs
+++ b/src/Nethermind/Nethermind.Evm/CallResult.cs
@@ -31,7 +31,7 @@ public partial class VirtualMachine<TGasPolicy>
             ExceptionType = exceptionType;
         }
 
-        internal CallResult(EvmExceptionType exceptionType)
+        public CallResult(EvmExceptionType exceptionType)
         {
             StateToExecute = null;
             Output = StatusCode.FailureBytes;


### PR DESCRIPTION
Fixes Closes Resolves #

Following #10866, any overridden VM implementation which relied on public members (e.g. `InvalidCodeException`) should instantiate `CallResult` on its own.  Propose to extend access of one of class's constructors - all other are already `public`

## Changes

- Constructor access

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No