### PR TITLE
fix: TransientResource disposal leaks and missing pruning in PersistenceManager

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -321,6 +321,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (endBlock.BlockNumber <= persistedStateId.BlockNumber)
         {
             if (_logger.IsWarn) _logger.Warn($"Cannot register snapshot earlier than bigcache. Snapshot number {endBlock.BlockNumber}, bigcache number: {persistedStateId}");
+            _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+            snapshot.Dispose();
             return;
         }
 
@@ -340,8 +342,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         {
             if (!_populateTrieNodeCacheJobs.Writer.TryWrite(transientResource))
             {
-                // Ignore it, just dispose
-                transientResource.Dispose();
+                // Queue full, return to pool instead of leaking
+                _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
             }
 
             if (!_compactorJobs.Writer.TryWrite(endBlock))

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -289,6 +289,7 @@ public class PersistenceManager(
                 batch.SetStateTrieNode(path, node);
 
                 node.IsPersisted = true;
+                node.PrunePersistedRecursively(1);
             }
 
             _trieNodesSortBuffer.Clear();
@@ -317,6 +318,7 @@ public class PersistenceManager(
                 batch.SetStorageTrieNode(address, path, node);
 
                 node.IsPersisted = true;
+                node.PrunePersistedRecursively(1);
             }
 
             Metrics.FlatPersistenceSnapshotSize.Observe(stateNodesSize, labels: new StringLabel("state_nodes"));


### PR DESCRIPTION
## Summary
- Does not seems to do anything. But make design that dependes on fully pooled transient resource work.
- Return `TransientResource` to pool instead of leaking on early-return and queue-full paths in `FlatDbManager.AddSnapshot`
- Call `PrunePersistedRecursively(1)` after marking nodes persisted in `PersistenceManager` to release in-memory references to persisted children

## Test plan
- [x] `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/ -c release` — 285 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)