### PR TITLE
Cross-block cache carry-forward with reorg invalidation

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
@@ -250,6 +251,83 @@ public class BlockProcessorTests
         processedBlocks.Should().HaveCount(1, "block should process successfully without a prewarmer");
     }
 
+    private static (TrackingPreWarmer preWarmer, BranchProcessor branchProcessor) CreateTrackingBranch(
+        IRewardCalculator? rewardCalculator = null)
+    {
+        TrackingPreWarmer preWarmer = new();
+        (_, BranchProcessor branchProcessor, _) = CreateProcessorAndBranch(
+            rewardCalculator: rewardCalculator, preWarmer: preWarmer);
+        return (preWarmer, branchProcessor);
+    }
+
+    private static BlockHeader BuildBaseBlock(string label) =>
+        Build.A.BlockHeader
+            .WithNumber(0)
+            .WithHash(Keccak.Compute(label))
+            .WithStateRoot(Keccak.EmptyTreeHash)
+            .TestObject;
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BranchProcessor_sequential_blocks_validate_once_and_finalize_each_block()
+    {
+        (TrackingPreWarmer preWarmer, BranchProcessor branchProcessor) = CreateTrackingBranch();
+        BlockHeader baseBlock = BuildBaseBlock("base-a");
+        Block block1 = Build.A.Block.WithParent(baseBlock).WithTransactions(3, MuirGlacier.Instance).TestObject;
+        Block block2 = Build.A.Block.WithParent(block1).WithTransactions(3, MuirGlacier.Instance).TestObject;
+
+        branchProcessor.Process(baseBlock, new List<Block> { block1, block2 },
+            ProcessingOptions.NoValidation, NullBlockTracer.Instance);
+
+        preWarmer.FinalizedBlocks.Should().Equal(block1.Header, block2.Header);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BranchProcessor_non_sequential_block_invalidates_caches()
+    {
+        (TrackingPreWarmer preWarmer, BranchProcessor branchProcessor) = CreateTrackingBranch();
+        BlockHeader baseBlock = BuildBaseBlock("base-b");
+        Block blockA = Build.A.Block.WithParent(baseBlock).WithTransactions(3, MuirGlacier.Instance).TestObject;
+
+        branchProcessor.Process(baseBlock, new List<Block> { blockA },
+            ProcessingOptions.NoValidation, NullBlockTracer.Instance);
+
+        BlockHeader mismatchedBase = Build.A.BlockHeader
+            .WithNumber(1).WithHash(Keccak.Compute("base-c")).WithStateRoot(Keccak.EmptyTreeHash).TestObject;
+        Block blockB = Build.A.Block.WithParent(mismatchedBase).WithTransactions(3, MuirGlacier.Instance).TestObject;
+
+        branchProcessor.Process(mismatchedBase, new List<Block> { blockB },
+            ProcessingOptions.NoValidation, NullBlockTracer.Instance);
+
+        preWarmer.InvalidateCount.Should().Be(0, "cache validity is now checked in BeginScope, not on the prewarmer");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BranchProcessor_error_path_invalidates_caches_and_skips_finalize()
+    {
+        (TrackingPreWarmer preWarmer, BranchProcessor branchProcessor) =
+            CreateTrackingBranch(rewardCalculator: new RewardCalculator(MainnetSpecProvider.Instance));
+        BlockHeader baseBlock = BuildBaseBlock("base-d");
+        Block block = Build.A.Block.WithParent(baseBlock).WithTransactions(1, MuirGlacier.Instance).TestObject;
+
+        Assert.Throws<OperationCanceledException>(() => branchProcessor.Process(
+            baseBlock, new List<Block> { block }, ProcessingOptions.None, AlwaysCancelBlockTracer.Instance));
+
+        preWarmer.InvalidateCount.Should().BeGreaterThanOrEqualTo(1);
+        preWarmer.FinalizedBlocks.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BranchProcessor_null_base_block_invalidates_caches()
+    {
+        (TrackingPreWarmer preWarmer, BranchProcessor branchProcessor) = CreateTrackingBranch();
+        Block block = Build.A.Block.WithTransactions(3, MuirGlacier.Instance).TestObject;
+
+        branchProcessor.Process(null, new List<Block> { block },
+            ProcessingOptions.NoValidation, NullBlockTracer.Instance);
+
+        preWarmer.InvalidateCount.Should().Be(0, "cache validity is now checked in BeginScope, not on the prewarmer");
+    }
+
     [Test]
     public void NullBlockProcessor_TransactionsExecuted_subscribe_unsubscribe_is_safe()
     {
@@ -301,7 +379,40 @@ public class BlockProcessorTests
             return Task.CompletedTask;
         }
 
-        public CacheType ClearCaches() => default;
+        public void ClearCaches() { }
+        public void InvalidateCaches() { }
+        public void FinalizeProcessedBlock(BlockHeader block, IReleaseSpec spec) { }
+        public void FlushCarryForwardWrites() { }
+    }
+
+    private sealed class TrackingPreWarmer : IBlockCachePreWarmer
+    {
+        private readonly PreBlockCaches _preBlockCaches = new();
+
+        public List<BlockHeader> FinalizedBlocks { get; } = [];
+        public int InvalidateCount { get; private set; }
+
+        public Task PreWarmCaches(Block suggestedBlock, BlockHeader? parent, IReleaseSpec spec, CancellationToken cancellationToken = default, params ReadOnlySpan<IHasAccessList> systemAccessLists)
+            => Task.CompletedTask;
+
+        public void ClearCaches() { }
+
+        public void InvalidateCaches()
+        {
+            InvalidateCount++;
+            _preBlockCaches.InvalidateCaches();
+        }
+
+        public void FinalizeProcessedBlock(BlockHeader block, IReleaseSpec spec)
+        {
+            FinalizedBlocks.Add(block);
+            _preBlockCaches.RecordCommittedBlock(block.Number, block.Hash);
+        }
+
+        public void FlushCarryForwardWrites()
+        {
+            _preBlockCaches.FlushCarryForwardWrites();
+        }
     }
 
     private sealed class TrackingBlockAccessListWorldState(IWorldState innerWorldState)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -9,18 +9,17 @@ using Microsoft.Extensions.ObjectPool;
 using Nethermind.Blockchain;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Eip2930;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Threading;
 using Nethermind.Evm;
+using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Evm.State;
-using Nethermind.Core.Eip2930;
-using Nethermind.Core.Collections;
-using Nethermind.Core.Extensions;
-using Nethermind.State;
 using Nethermind.Trie;
 
 namespace Nethermind.Consensus.Processing;
@@ -56,13 +55,9 @@ public sealed class BlockCachePreWarmer(
     {
         if (preBlockCaches is not null)
         {
-            CacheType result = preBlockCaches.ClearCaches();
+            preBlockCaches.ClearCaches();
             nodeStorageCache.ClearCaches();
             nodeStorageCache.Enabled = true;
-            if (result != default)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Caches {result} are not empty. Clearing them.");
-            }
 
             if (parent is not null && _concurrencyLevel > 1 && !cancellationToken.IsCancellationRequested)
             {
@@ -80,13 +75,40 @@ public sealed class BlockCachePreWarmer(
         return Task.CompletedTask;
     }
 
-    public CacheType ClearCaches()
+    public void InvalidateCaches()
+    {
+        if (_logger.IsDebug) _logger.Debug("Invalidating caches");
+        preBlockCaches?.InvalidateCaches();
+        if (_logger.IsDebug) _logger.Debug("Invalidated caches");
+    }
+
+    public void FinalizeProcessedBlock(BlockHeader block, IReleaseSpec spec)
+    {
+        if (!spec.IsEip6780Enabled && preBlockCaches.HasLegacyStorageClear)
+        {
+            if (_logger.IsDebug)
+            {
+                _logger.Debug($"Legacy storage clear detected at block {block.Number}, invalidating carry-forward caches");
+            }
+
+            InvalidateCaches();
+            return;
+        }
+
+        preBlockCaches.RecordCommittedBlock(block.Number, block.Hash);
+    }
+
+    public void FlushCarryForwardWrites()
+    {
+        preBlockCaches?.FlushCarryForwardWrites();
+    }
+
+    public void ClearCaches()
     {
         if (_logger.IsDebug) _logger.Debug("Clearing caches");
-        CacheType cachesCleared = preBlockCaches?.ClearCaches() ?? default;
-        cachesCleared |= nodeStorageCache.ClearCaches() ? CacheType.Rlp : CacheType.None;
-        if (_logger.IsDebug) _logger.Debug($"Cleared caches: {cachesCleared}");
-        return cachesCleared;
+        preBlockCaches?.ClearCaches();
+        nodeStorageCache.ClearCaches();
+        if (_logger.IsDebug) _logger.Debug("Cleared caches");
     }
 
     private void PreWarmCachesParallel(BlockState blockState, Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -126,11 +126,7 @@ public class BranchProcessor(
                 if (preWarmTask is null)
                 {
                     // Even though we skip prewarming we still need to ensure the caches are cleared
-                    CacheType result = preWarmer?.ClearCaches() ?? default;
-                    if (result != default)
-                    {
-                        if (_logger.IsWarn) _logger.Warn($"Low txs, caches {result} are not empty. Clearing them.");
-                    }
+                    preWarmer?.ClearCaches();
                 }
 
                 (Block processedBlock, TxReceipt[] receipts) = blockProcessor.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
@@ -142,6 +138,7 @@ public class BranchProcessor(
 
                 // be cautious here as AuRa depends on processing
                 PreCommitBlock(suggestedBlock.Header);
+                preWarmer?.FinalizeProcessedBlock(suggestedBlock.Header, spec);
                 QueueClearCaches(preWarmTask);
 
                 if (notReadOnly)
@@ -170,6 +167,7 @@ public class BranchProcessor(
                 prefetchBlockhash = null;
 
                 _stateProvider.Reset();
+                preWarmer?.FlushCarryForwardWrites();
 
                 // Calculate the transaction hashes in the background and release tx sequence memory
                 // Hashes will be required for PersistentReceiptStorage in ForkchoiceUpdatedHandler
@@ -183,6 +181,7 @@ public class BranchProcessor(
         {
             if (_logger.IsWarn) _logger.Warn($"Encountered exception {ex} while processing blocks.");
             CancellationTokenExtensions.CancelDisposeAndClear(ref backgroundCancellation);
+            preWarmer?.InvalidateCaches();
             QueueClearCaches(preWarmTask);
             WaitAndClear(ref preWarmTask);
             throw;

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
@@ -14,5 +14,8 @@ namespace Nethermind.Consensus.Processing;
 public interface IBlockCachePreWarmer
 {
     Task PreWarmCaches(Block suggestedBlock, BlockHeader? parent, IReleaseSpec spec, CancellationToken cancellationToken = default, params ReadOnlySpan<IHasAccessList> systemAccessLists);
-    CacheType ClearCaches();
+    void ClearCaches();
+    void InvalidateCaches();
+    void FinalizeProcessedBlock(BlockHeader block, IReleaseSpec spec);
+    void FlushCarryForwardWrites();
 }

--- a/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
 using Nethermind.Trie;
 
 using CollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
@@ -17,37 +20,94 @@ public class PreBlockCaches
     private const int InitialCapacity = 4096 * 8;
     private static int LockPartitions => CollectionExtensions.LockPartitions;
 
-    private readonly Func<CacheType>[] _clearCaches;
+    private long _committedBlockNumber = -1;
+    private volatile Hash256? _committedBlockHash;
+    private volatile bool _hasLegacyStorageClear;
+
+    // Pending carry-forward writes buffered during FlushToTree, flushed after prewarm completion.
+    // State: single-threaded producer (StateProvider.FlushToTree).
+    // Storage: multi-threaded producers (PersistentStorageProvider.FlushToTree parallelizes across contracts).
+    private readonly List<(AddressAsKey Key, Account? Account)> _pendingStateWrites = new();
+    private readonly ConcurrentQueue<(StorageCell Cell, byte[] Value)> _pendingStorageWrites = new();
 
     private readonly SeqlockCache<StorageCell, byte[]> _storageCache = new();
     private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private readonly SeqlockCache<NodeKey, byte[]?> _rlpCache = new();
     private readonly ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> _precompileCache = new(LockPartitions, InitialCapacity);
 
-    public PreBlockCaches()
-    {
-        _clearCaches =
-        [
-            () => { _storageCache.Clear(); return CacheType.None; },
-            () => { _stateCache.Clear(); return CacheType.None; },
-            () => { _precompileCache.NoResizeClear(); return CacheType.None; }
-        ];
-    }
-
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
     public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
     public SeqlockCache<NodeKey, byte[]?> RlpCache => _rlpCache;
     public ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> PrecompileCache => _precompileCache;
 
-    public CacheType ClearCaches()
+    public void ClearCaches()
     {
-        CacheType isDirty = CacheType.None;
-        foreach (Func<CacheType> clearCache in _clearCaches)
-        {
-            isDirty |= clearCache();
-        }
+        _precompileCache.NoResizeClear();
+    }
 
-        return isDirty;
+    public void InvalidateCaches()
+    {
+        _storageCache.Clear();
+        _stateCache.Clear();
+        _committedBlockHash = null;
+        Volatile.Write(ref _committedBlockNumber, -1);
+        ResetBlockFlags();
+        DiscardPendingCarryForward();
+    }
+
+    public void RecordCommittedBlock(long blockNumber, Hash256? blockHash)
+    {
+        _committedBlockHash = blockHash;
+        Volatile.Write(ref _committedBlockNumber, blockNumber);
+    }
+
+    public bool IsValidForParent(long parentNumber, Hash256? parentHash)
+        => Volatile.Read(ref _committedBlockNumber) == parentNumber
+            && _committedBlockHash == parentHash;
+
+    public void NoteStorageClear() => _hasLegacyStorageClear = true;
+
+    public bool HasLegacyStorageClear => _hasLegacyStorageClear;
+
+    public void ResetBlockFlags()
+    {
+        _hasLegacyStorageClear = false;
+    }
+
+    /// <summary>
+    /// Buffer a state write for deferred carry-forward. Applied after prewarm completion.
+    /// </summary>
+    public void EnqueueStateWrite(AddressAsKey key, Account? account)
+        => _pendingStateWrites.Add((key, account));
+
+    /// <summary>
+    /// Buffer a storage write for deferred carry-forward. Thread-safe (called from parallel FlushToTree).
+    /// </summary>
+    public void EnqueueStorageWrite(in StorageCell cell, byte[] value)
+        => _pendingStorageWrites.Enqueue((cell, value));
+
+    /// <summary>
+    /// Flush all buffered carry-forward writes into the SeqlockCaches.
+    /// Called from BranchProcessor after the prewarm task is complete and state is reset.
+    /// </summary>
+    public void FlushCarryForwardWrites()
+    {
+        foreach ((AddressAsKey key, Account? account) in _pendingStateWrites)
+        {
+            _stateCache.Set(key, account);
+        }
+        _pendingStateWrites.Clear();
+
+        while (_pendingStorageWrites.TryDequeue(out (StorageCell Cell, byte[] Value) entry))
+        {
+            _storageCache.Set(entry.Cell, entry.Value);
+        }
+    }
+
+    private void DiscardPendingCarryForward()
+    {
+        _pendingStateWrites.Clear();
+        while (_pendingStorageWrites.TryDequeue(out _)) { }
     }
 
     public readonly struct PrecompileCacheKey(Address address, ReadOnlyMemory<byte> data) : IEquatable<PrecompileCacheKey>
@@ -58,14 +118,4 @@ public class PreBlockCaches
         public override bool Equals(object? obj) => obj is PrecompileCacheKey other && Equals(other);
         public override int GetHashCode() => Data.Span.FastHash() ^ Address.GetHashCode();
     }
-}
-
-[Flags]
-public enum CacheType
-{
-    None = 0,
-    Storage = 0b1,
-    State = 0b10,
-    Rlp = 0b100,
-    Precompile = 0b1000
 }

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Logging;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.State;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test;
@@ -57,6 +58,137 @@ public class StorageProviderTests(bool useFlat)
     private WorldState BuildStorageProvider(Context ctx)
     {
         return ctx.StateProvider;
+    }
+
+    [Test]
+    public void PreBlockCaches_recorded_block_matches_parent()
+    {
+        PreBlockCaches caches = new();
+        Hash256 hashA = Keccak.Compute("a");
+        Hash256 hashB = Keccak.Compute("b");
+
+        caches.IsValidForParent(0, hashA).Should().BeFalse();
+
+        caches.RecordCommittedBlock(5, hashA);
+
+        caches.IsValidForParent(5, hashA).Should().BeTrue();
+        caches.IsValidForParent(5, hashB).Should().BeFalse();
+        caches.IsValidForParent(6, hashA).Should().BeFalse();
+    }
+
+    [Test]
+    public void PreBlockCaches_invalidate_resets_metadata_and_entries()
+    {
+        PreBlockCaches caches = new();
+        AddressAsKey address = TestItem.AddressA;
+        StorageCell storageCell = new(TestItem.AddressA, 1);
+        Account account = new(1, 2);
+        Hash256 hash = Keccak.Compute("a");
+
+        caches.StateCache.Set(address, account);
+        caches.StorageCache.Set(storageCell, [1, 2, 3]);
+        caches.RecordCommittedBlock(5, hash);
+
+        caches.InvalidateCaches();
+
+        caches.IsValidForParent(5, hash).Should().BeFalse();
+        caches.StateCache.TryGetValue(in address, out _).Should().BeFalse();
+        caches.StorageCache.TryGetValue(in storageCell, out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void PreBlockCaches_clear_preserves_reusable_entries_and_metadata()
+    {
+        PreBlockCaches caches = new();
+        AddressAsKey address = TestItem.AddressA;
+        StorageCell storageCell = new(TestItem.AddressA, 1);
+        Account account = new(1, 2);
+        Hash256 hash = Keccak.Compute("a");
+
+        caches.StateCache.Set(address, account);
+        caches.StorageCache.Set(storageCell, [1, 2, 3]);
+        caches.RecordCommittedBlock(5, hash);
+
+        caches.ClearCaches();
+
+        caches.IsValidForParent(5, hash).Should().BeTrue();
+        caches.StateCache.TryGetValue(in address, out Account cachedAccount).Should().BeTrue();
+        caches.StorageCache.TryGetValue(in storageCell, out byte[] cachedValue).Should().BeTrue();
+        cachedAccount.Should().Be(account);
+        cachedValue.Should().BeEquivalentTo([1, 2, 3]);
+    }
+
+    [Test]
+    public void PrewarmerScopeProvider_BeginScope_invalidates_caches_when_parent_does_not_match()
+    {
+        PreBlockCaches caches = new();
+        Hash256 hashA = Keccak.Compute("a");
+        Hash256 hashB = Keccak.Compute("b");
+
+        caches.RecordCommittedBlock(5, hashA);
+        caches.StateCache.Set(TestItem.AddressA, new Account(1, 2));
+        caches.IsValidForParent(5, hashA).Should().BeTrue();
+
+        IWorldStateScopeProvider baseProvider = Substitute.For<IWorldStateScopeProvider>();
+        baseProvider.BeginScope(Arg.Any<BlockHeader>())
+            .Returns(Substitute.For<IWorldStateScopeProvider.IScope>());
+
+        PrewarmerScopeProvider provider = new(baseProvider, caches);
+
+        // Mismatched parent should invalidate
+        BlockHeader mismatchedParent = Build.A.BlockHeader.WithNumber(5).WithHash(hashB).TestObject;
+        provider.BeginScope(mismatchedParent);
+
+        caches.IsValidForParent(5, hashA).Should().BeFalse("BeginScope should invalidate caches when parent does not match");
+        caches.StateCache.TryGetValue(TestItem.AddressA, out _).Should().BeFalse("cache entries should be cleared on invalidation");
+    }
+
+    [Test]
+    public void PrewarmerScopeProvider_BeginScope_preserves_caches_when_parent_matches()
+    {
+        PreBlockCaches caches = new();
+        Hash256 hashA = Keccak.Compute("a");
+
+        caches.RecordCommittedBlock(5, hashA);
+        caches.StateCache.Set(TestItem.AddressA, new Account(1, 2));
+
+        IWorldStateScopeProvider baseProvider = Substitute.For<IWorldStateScopeProvider>();
+        baseProvider.BeginScope(Arg.Any<BlockHeader>())
+            .Returns(Substitute.For<IWorldStateScopeProvider.IScope>());
+
+        PrewarmerScopeProvider provider = new(baseProvider, caches);
+
+        BlockHeader matchingParent = Build.A.BlockHeader.WithNumber(5).WithHash(hashA).TestObject;
+        provider.BeginScope(matchingParent);
+
+        caches.IsValidForParent(5, hashA).Should().BeTrue("BeginScope should preserve caches when parent matches");
+        caches.StateCache.TryGetValue(TestItem.AddressA, out _).Should().BeTrue("cache entries should survive when valid");
+    }
+
+    [Test]
+    public void PreBlockCaches_storage_clear_flag_lifecycle_is_correct()
+    {
+        PreBlockCaches caches = new();
+
+        caches.HasLegacyStorageClear.Should().BeFalse();
+
+        caches.NoteStorageClear();
+        caches.HasLegacyStorageClear.Should().BeTrue();
+
+        caches.ResetBlockFlags();
+        caches.HasLegacyStorageClear.Should().BeFalse();
+    }
+
+    [Test]
+    public void PreBlockCaches_can_store_null_account_values()
+    {
+        PreBlockCaches caches = new();
+        AddressAsKey address = TestItem.AddressA;
+
+        caches.StateCache.Set(address, null);
+
+        caches.StateCache.TryGetValue(in address, out Account cachedAccount).Should().BeTrue();
+        cachedAccount.Should().BeNull();
     }
 
     [TestCase(-1)]
@@ -425,6 +557,86 @@ public class StorageProviderTests(bool useFlat)
         _values[snapshot + 1].Should().BeEquivalentTo(provider.Get(new StorageCell(ctx.Address1, 1)).ToArray());
     }
 
+    private (PreBlockCaches caches, WorldState provider, IDisposable scope, Context ctx) CreateCarryForwardTestScope()
+    {
+        PreBlockCaches caches = new();
+        Context ctx = new(useFlat, preBlockCaches: caches, setInitialState: false, populatePreBlockCache: false);
+        WorldState provider = BuildStorageProvider(ctx);
+        IDisposable scope = provider.BeginScope(IWorldState.PreGenesis);
+        return (caches, provider, scope, ctx);
+    }
+
+    [Test]
+    public void Commit_mirrors_account_writes_into_state_cache()
+    {
+        (PreBlockCaches caches, WorldState provider, IDisposable scope, Context ctx) = CreateCarryForwardTestScope();
+        using (scope) using (ctx)
+        {
+            provider.CreateAccount(TestItem.AddressA, 3, 4);
+            provider.Commit(Frontier.Instance);
+            caches.FlushCarryForwardWrites();
+
+            caches.StateCache.TryGetValue((AddressAsKey)TestItem.AddressA, out Account account).Should().BeTrue();
+            account.Should().NotBeNull();
+            account.Balance.Should().Be((UInt256)3);
+            account.Nonce.Should().Be((UInt256)4);
+        }
+    }
+
+    [Test]
+    public void Commit_mirrors_storage_writes_into_storage_cache()
+    {
+        (PreBlockCaches caches, WorldState provider, IDisposable scope, Context ctx) = CreateCarryForwardTestScope();
+        using (scope) using (ctx)
+        {
+            StorageCell storageCell = new(TestItem.AddressA, 1);
+
+            provider.CreateAccount(TestItem.AddressA, 1);
+            provider.Set(storageCell, [1, 2, 3]);
+            provider.Commit(Frontier.Instance);
+            caches.FlushCarryForwardWrites();
+
+            caches.StorageCache.TryGetValue(in storageCell, out byte[] value).Should().BeTrue();
+            value.Should().BeEquivalentTo([1, 2, 3]);
+        }
+    }
+
+    [Test]
+    public void Commit_mirrors_account_deletion_as_null_into_state_cache()
+    {
+        (PreBlockCaches caches, WorldState provider, IDisposable scope, Context ctx) = CreateCarryForwardTestScope();
+        using (scope) using (ctx)
+        {
+            provider.CreateAccount(TestItem.AddressA, 1);
+            provider.Commit(Frontier.Instance);
+            provider.DeleteAccount(TestItem.AddressA);
+            provider.Commit(Frontier.Instance);
+            caches.FlushCarryForwardWrites();
+
+            caches.StateCache.TryGetValue((AddressAsKey)TestItem.AddressA, out Account account).Should().BeTrue();
+            account.Should().BeNull();
+        }
+    }
+
+    [Test]
+    public void Commit_storage_clear_marks_legacy_storage_clear_flag()
+    {
+        (PreBlockCaches caches, WorldState provider, IDisposable scope, Context ctx) = CreateCarryForwardTestScope();
+        using (scope) using (ctx)
+        {
+            provider.CreateAccount(TestItem.AddressA, 1);
+            provider.Set(new StorageCell(TestItem.AddressA, 1), [1, 2, 3]);
+            provider.Commit(Frontier.Instance);
+
+            caches.ResetBlockFlags();
+
+            provider.ClearStorage(TestItem.AddressA);
+            provider.Commit(Frontier.Instance);
+
+            caches.HasLegacyStorageClear.Should().BeTrue();
+        }
+    }
+
     /// <summary>
     /// Reset will reset transient state
     /// </summary>
@@ -745,7 +957,7 @@ public class StorageProviderTests(bool useFlat)
         public readonly Address Address1 = new(Keccak.Compute("1"));
         public readonly Address Address2 = new(Keccak.Compute("2"));
 
-        public Context(bool useFlat, PreBlockCaches preBlockCaches = null, bool setInitialState = true, bool trackWrittenData = false)
+        public Context(bool useFlat, PreBlockCaches preBlockCaches = null, bool setInitialState = true, bool trackWrittenData = false, bool populatePreBlockCache = true)
         {
             IWorldStateScopeProvider scopeProvider;
             if (useFlat)
@@ -761,7 +973,7 @@ public class StorageProviderTests(bool useFlat)
 
             if (preBlockCaches is not null)
             {
-                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, populatePreBlockCache: true);
+                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, populatePreBlockCache);
             }
 
             if (trackWrittenData)

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -86,6 +86,7 @@ public class WorldStateManagerTests
             .Returns(new Hash256("0xec6063a04d48f4b2258f36efaef76a23ba61875f5303fcf8ede2f5d160def35d"));
 
         {
+            configProvider.GetConfig<IBlocksConfig>().PreWarmStateOnBlockProcessing = false;
             using IContainer ctx = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
                 .AddSingleton<IFinalizedStateProvider>(manualFinalizedStateProvider)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -36,7 +36,17 @@ public class PrewarmerScopeProvider(
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    {
+        if (baseBlock is null || !preBlockCaches.IsValidForParent(baseBlock.Number, baseBlock.Hash))
+        {
+            preBlockCaches.InvalidateCaches();
+        }
+
+        preBlockCaches.ResetBlockFlags();
+
+        return new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache);
+    }
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !populatePreBlockCache;
@@ -44,10 +54,10 @@ public class PrewarmerScopeProvider(
     private sealed class ScopeWrapper : IWorldStateScopeProvider.IScope
     {
         private readonly IWorldStateScopeProvider.IScope baseScope;
+        private readonly PreBlockCaches preBlockCaches;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache;
         private readonly SeqlockCache<StorageCell, byte[]> storageCache;
         private readonly bool populatePreBlockCache;
-        private static readonly SeqlockCache<AddressAsKey, Account>.ValueFactory<ScopeWrapper> _getFromBaseTree = static (in AddressAsKey address, ScopeWrapper self) => self.GetFromBaseTree(in address);
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels;
@@ -55,6 +65,7 @@ public class PrewarmerScopeProvider(
         public ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache)
         {
             this.baseScope = baseScope;
+            this.preBlockCaches = preBlockCaches;
             preBlockCache = preBlockCaches.StateCache;
             storageCache = preBlockCaches.StorageCache;
             this.populatePreBlockCache = populatePreBlockCache;
@@ -80,22 +91,39 @@ public class PrewarmerScopeProvider(
                 baseScope.CreateStorageTree(address),
                 storageCache,
                 address,
-                populatePreBlockCache);
+                _labels);
         }
 
         public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
         {
-            if (!_measureMetric)
+            IWorldStateScopeProvider.IWorldStateWriteBatch baseWriteBatch = baseScope.StartWriteBatch(estimatedAccountNum);
+
+            if (!_measureMetric && populatePreBlockCache)
             {
-                return baseScope.StartWriteBatch(estimatedAccountNum);
+                return baseWriteBatch;
             }
 
-            _writeBatchTime = Stopwatch.GetTimestamp();
-            long sw = Stopwatch.GetTimestamp();
+            long startTime = 0;
+            if (_measureMetric)
+            {
+                startTime = Stopwatch.GetTimestamp();
+                _writeBatchTime = startTime;
+            }
+
+            if (!populatePreBlockCache)
+            {
+                return new CachePopulatingWriteBatch(
+                    baseWriteBatch,
+                    preBlockCaches,
+                    _measureMetric ? _metricObserver : null,
+                    startTime,
+                    _labels);
+            }
+
             return new WriteBatchLifetimeMeasurer(
-                baseScope.StartWriteBatch(estimatedAccountNum),
+                baseWriteBatch,
                 _metricObserver,
-                sw,
+                startTime,
                 populatePreBlockCache);
         }
 
@@ -131,37 +159,20 @@ public class PrewarmerScopeProvider(
         {
             AddressAsKey addressAsKey = address;
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (populatePreBlockCache)
-            {
-                long priorReads = Metrics.ThreadLocalStateTreeReads;
-                Account? account = preBlockCache.GetOrAdd(in addressAsKey, this, _getFromBaseTree);
 
-                if (Metrics.ThreadLocalStateTreeReads == priorReads)
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
-                else
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
-                }
-                return account;
+            if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
+            {
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
+                baseScope.HintGet(address, account);
+                Metrics.IncrementStateTreeCacheHits();
             }
             else
             {
-                if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    baseScope.HintGet(address, account);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
-                else
-                {
-                    account = GetFromBaseTree(in addressAsKey);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
-                }
-                return account;
+                account = GetFromBaseTree(in addressAsKey);
+                preBlockCache.Set(in addressAsKey, account);
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
             }
+            return account;
         }
 
         public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
@@ -177,7 +188,6 @@ public class PrewarmerScopeProvider(
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree;
         private readonly SeqlockCache<StorageCell, byte[]> preBlockCache;
         private readonly Address address;
-        private readonly bool populatePreBlockCache;
         private static readonly SeqlockCache<StorageCell, byte[]>.ValueFactory<StorageTreeWrapper> _loadFromTreeStorage = static (in StorageCell cell, StorageTreeWrapper self) => self.LoadFromTreeStorage(in cell);
         private readonly IMetricObserver _metricObserver = Db.Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Db.Metrics.DetailedMetricsEnabled;
@@ -187,13 +197,12 @@ public class PrewarmerScopeProvider(
             IWorldStateScopeProvider.IStorageTree baseStorageTree,
             SeqlockCache<StorageCell, byte[]> preBlockCache,
             Address address,
-            bool populatePreBlockCache)
+            PrewarmerGetTimeLabels labels)
         {
             this.baseStorageTree = baseStorageTree;
             this.preBlockCache = preBlockCache;
             this.address = address;
-            this.populatePreBlockCache = populatePreBlockCache;
-            _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+            _labels = labels;
         }
 
         public Hash256 RootHash => baseStorageTree.RootHash;
@@ -202,39 +211,21 @@ public class PrewarmerScopeProvider(
         {
             StorageCell storageCell = new StorageCell(address, in index); // TODO: Make the dictionary use UInt256 directly
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (populatePreBlockCache)
+
+            long priorReads = Db.Metrics.ThreadLocalStorageTreeReads;
+            byte[] value = preBlockCache.GetOrAdd(in storageCell, this, _loadFromTreeStorage);
+
+            if (Db.Metrics.ThreadLocalStorageTreeReads == priorReads)
             {
-                long priorReads = Db.Metrics.ThreadLocalStorageTreeReads;
-
-                byte[] value = preBlockCache.GetOrAdd(in storageCell, this, _loadFromTreeStorage);
-
-                if (Db.Metrics.ThreadLocalStorageTreeReads == priorReads)
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    // Read from Concurrent Cache
-                    Db.Metrics.IncrementStorageTreeCache();
-                }
-                else
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
-                }
-                return value;
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
+                baseStorageTree.HintGet(in index, value);
+                Db.Metrics.IncrementStorageTreeCache();
             }
             else
             {
-                if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    baseStorageTree.HintGet(in index, value);
-                    Db.Metrics.IncrementStorageTreeCache();
-                }
-                else
-                {
-                    value = LoadFromTreeStorage(in storageCell);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
-                }
-                return value;
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
             }
+            return value;
         }
 
         public void HintGet(in UInt256 index, byte[]? value) => baseStorageTree.HintGet(in index, value);
@@ -251,6 +242,84 @@ public class PrewarmerScopeProvider(
         public byte[] Get(in ValueHash256 hash) =>
             // Not a critical path. so we just forward for simplicity
             baseStorageTree.Get(in hash);
+    }
+
+    private sealed class CachePopulatingWriteBatch : IWorldStateScopeProvider.IWorldStateWriteBatch
+    {
+        private readonly IWorldStateScopeProvider.IWorldStateWriteBatch _baseWriteBatch;
+        private readonly PreBlockCaches _preBlockCaches;
+        private readonly IMetricObserver? _metricObserver;
+        private readonly long _startTime;
+        private readonly PrewarmerGetTimeLabels _labels;
+
+        public CachePopulatingWriteBatch(
+            IWorldStateScopeProvider.IWorldStateWriteBatch baseWriteBatch,
+            PreBlockCaches preBlockCaches,
+            IMetricObserver? metricObserver,
+            long startTime,
+            PrewarmerGetTimeLabels labels)
+        {
+            _baseWriteBatch = baseWriteBatch;
+            _preBlockCaches = preBlockCaches;
+            _metricObserver = metricObserver;
+            _startTime = startTime;
+            _labels = labels;
+
+            // Subscribe to capture accounts with final storage roots (set during base Dispose)
+            baseWriteBatch.OnAccountUpdated += OnBaseAccountUpdated;
+        }
+
+        private void OnBaseAccountUpdated(object? sender, IWorldStateScopeProvider.AccountUpdated e)
+        {
+            // This fires with the correct storage root, overriding any stale entry from Set()
+            _preBlockCaches.EnqueueStateWrite(e.Address, e.Account);
+        }
+
+        public void Dispose()
+        {
+            // Base Dispose fires OnAccountUpdated with corrected storage roots, then writes to trie
+            _baseWriteBatch.Dispose();
+            _baseWriteBatch.OnAccountUpdated -= OnBaseAccountUpdated;
+            _metricObserver?.Observe(Stopwatch.GetTimestamp() - _startTime, _labels.WriteBatchLifetime);
+        }
+
+        public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
+        {
+            add => _baseWriteBatch.OnAccountUpdated += value;
+            remove => _baseWriteBatch.OnAccountUpdated -= value;
+        }
+
+        public void Set(Address key, Account? account)
+        {
+            _baseWriteBatch.Set(key, account);
+            _preBlockCaches.EnqueueStateWrite(key, account);
+        }
+
+        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries)
+            => new CachePopulatingStorageWriteBatch(
+                _baseWriteBatch.CreateStorageWriteBatch(key, estimatedEntries),
+                _preBlockCaches,
+                key);
+    }
+
+    private sealed class CachePopulatingStorageWriteBatch(
+        IWorldStateScopeProvider.IStorageWriteBatch baseStorageWriteBatch,
+        PreBlockCaches preBlockCaches,
+        Address address) : IWorldStateScopeProvider.IStorageWriteBatch
+    {
+        public void Dispose() => baseStorageWriteBatch.Dispose();
+
+        public void Set(in UInt256 index, byte[] value)
+        {
+            baseStorageWriteBatch.Set(in index, value);
+            preBlockCaches.EnqueueStorageWrite(new StorageCell(address, in index), value);
+        }
+
+        public void Clear()
+        {
+            baseStorageWriteBatch.Clear();
+            preBlockCaches.NoteStorageClear();
+        }
     }
 
     private class WriteBatchLifetimeMeasurer(IWorldStateScopeProvider.IWorldStateWriteBatch baseWriteBatch, IMetricObserver metricObserver, long startTime, bool populatePreBlockCache) : IWorldStateScopeProvider.IWorldStateWriteBatch


### PR DESCRIPTION
## Changes

- Add cache-populating write-batch wrappers in PrewarmerScopeProvider that mirror account and storage writes into PreBlockCaches during FlushToTree. This allows the SeqlockCaches to carry forward block N's post-state as block N+1's pre-state, reducing trie reads on sequential processing.

- PreBlockCaches tracks committed block number/hash metadata and a legacy storage-clear flag for pre-EIP-6780 SELFDESTRUCT handling. BranchProcessor validates cache continuity before the first prewarm and invalidates on parent mismatch, errors, or legacy storage clears.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
