### PR TITLE
fix: Flaky Nethermind.Blockchain.Test

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -324,7 +324,7 @@ public class BlockchainProcessorTests
                 _processor.BlockAdded += OnBlockAdded;
                 try
                 {
-                    Task.Run(() =>
+                    Task suggestTask = Task.Run(() =>
                     {
                         try
                         {
@@ -344,6 +344,20 @@ public class BlockchainProcessorTests
                         suggestCompleted.Task.Wait(ProcessingWait),
                         Is.True,
                         $"Timed out waiting for {block.ToString(Block.Format.Short)} to complete suggestion");
+                    // Give the Task.Run time to finish the queue write inside
+                    // Enqueue(). BlockAdded fires before the recovery queue write,
+                    // so suggestCompleted resolving does not mean the block is in
+                    // the queue yet. Without this, consecutive Suggested() calls
+                    // can race their Task.Run threads to TryWrite, reordering
+                    // blocks in the recovery queue.
+                    //
+                    // Bounded to 100ms to avoid deadlock: when _queueCount == 1,
+                    // AllowSynchronousContinuations can inline ProcessBlocks() on
+                    // the Task.Run thread, which blocks until the test calls
+                    // Allow(). An infinite wait would deadlock. The timeout
+                    // expiring is harmless — single-block enqueues have no
+                    // ordering concern.
+                    suggestTask.Wait(100);
                 }
                 finally
                 {


### PR DESCRIPTION
## Changes

- Add `suggestTask.Wait(100)` in `Suggested()` to give the `Task.Run` time to finish the queue write before the next `Suggested()` call

### Background

`Suggested()` originally called `SuggestBlock` directly without `Task.Run`. The queue write inside `Enqueue()` happened to complete before `Suggested()` returned, so consecutive calls preserved ordering in practice.

In #10453, `AllowSynchronousContinuations` was added to `_blockQueue`, which could inline `ProcessBlocks()` on the caller's thread and deadlock the test. #10513 worked around this by wrapping `SuggestBlock` in `Task.Run` and waiting on a `BlockAdded` event. This broke ordering — `BlockAdded` fires inside `Enqueue()` before the recovery queue write, so consecutive `Suggested()` calls could race their `Task.Run` threads to `TryWrite`, breaking recovery queue FIFO order.

This PR adds a bounded `suggestTask.Wait(100)` after `BlockAdded` resolves. The queue write takes microseconds, so 100ms is sufficient in practice, though not a hard guarantee.

### Root cause

`Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue_and_recovery_queue_max_has_been_reached` assumes blocks enter the recovery queue in the same order they are suggested. It calls `Recovered(block3)` only after `ProcessedFail(block2)` — so if block 3 enters the recovery queue before block 2, the recovery loop dequeues block 3 first, blocks waiting for its Allow token, and block 2 is stuck behind it. `ProcessedFail(block2)` times out after 10s.

`Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue` has the same consecutive `Suggested()` calls but pre-allows all blocks for recovery upfront, so it's resilient to reordering in practice.

The 100ms timeout avoids deadlock: when the block goes direct to `_blockQueue` (`_queueCount == 1`), `AllowSynchronousContinuations` can inline `ProcessBlocks()` on the `Task.Run` thread which blocks until `Allow()` is called. An infinite wait would deadlock since the test thread could never call `Allow()`. Single-block enqueues have no ordering concern, so the timeout expiring is harmless in that case.

### Stress test results

Without fix (24 isolated CI runners, full `Nethermind.Blockchain.Test [no-intrinsics]`):
- https://github.com/NethermindEth/nethermind/actions/runs/23627888263 — 2/24 failed (`Can_change_branch_on_invalid_block_when_invalid_branch_is_in_the_queue_and_recovery_queue_max_has_been_reached`)

With fix (30 isolated CI runners):
- https://github.com/NethermindEth/nethermind/actions/runs/23646894251 — 0/30 failed

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Stress tested with 30 isolated CI runners running full `Nethermind.Blockchain.Test [no-intrinsics]`. Reproduced locally at ~25% failure rate without fix, 0% with fix (48 runs).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

#10966