### PR TITLE
fix: prevent FlatDB live stall and make restart recovery exact

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -180,6 +180,31 @@ public class BlockProcessorTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public async Task BranchProcessor_waits_for_prewarmer_task_before_returning()
+    {
+        BlockingPreWarmer preWarmer = new();
+        (_, BranchProcessor branchProcessor, _) = CreateProcessorAndBranch(preWarmer: preWarmer);
+
+        BlockHeader header = Build.A.BlockHeader.WithAuthor(TestItem.AddressD).TestObject;
+        Block block = Build.A.Block.WithHeader(header).WithTransactions(3, MuirGlacier.Instance).TestObject;
+
+        Task<Block[]> processingTask = Task.Run(() => branchProcessor.Process(
+            null,
+            new List<Block> { block },
+            ProcessingOptions.NoValidation,
+            NullBlockTracer.Instance));
+
+        await preWarmer.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task completedTask = await Task.WhenAny(processingTask, Task.Delay(TimeSpan.FromMilliseconds(300)));
+        completedTask.Should().NotBe(processingTask, "BranchProcessor must not continue while the prewarmer task is still running");
+
+        preWarmer.Release();
+        Block[] processedBlocks = await processingTask.WaitAsync(TimeSpan.FromSeconds(5));
+        processedBlocks.Should().HaveCount(1);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void BranchProcessor_unsubscribes_from_TransactionsExecuted_after_processing()
     {
         (BlockProcessor processor, BranchProcessor branchProcessor, IWorldState stateProvider) = CreateProcessorAndBranch();
@@ -231,6 +256,32 @@ public class BlockProcessorTests
         txExecutor.ProcessTransactions(block, ProcessingOptions.NoValidation, receiptsTracer, CancellationToken.None);
 
         stateProvider.ValidatedGasRemaining.Should().Equal([37_568L, 0L]);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BlockValidationTransactionsExecutor_stops_between_transactions_when_cancelled()
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        ITransactionProcessorAdapter transactionProcessor = Substitute.For<ITransactionProcessorAdapter>();
+        CancellationTokenSource cancellationTokenSource = new();
+        int executeCount = 0;
+
+        transactionProcessor.Execute(Arg.Any<Transaction>(), Arg.Any<ITxTracer>()).Returns(_ =>
+        {
+            executeCount++;
+            cancellationTokenSource.Cancel();
+            return TransactionResult.Ok;
+        });
+
+        BlockProcessor.BlockValidationTransactionsExecutor txExecutor = new(transactionProcessor, stateProvider);
+        Block block = Build.A.Block.WithTransactions(2, MuirGlacier.Instance).TestObject;
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(block);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            txExecutor.ProcessTransactions(block, ProcessingOptions.NoValidation, receiptsTracer, cancellationTokenSource.Token));
+
+        executeCount.Should().Be(1, "cancellation should be observed before starting the next transaction");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
@@ -300,6 +351,25 @@ public class BlockProcessorTests
             CapturedToken = cancellationToken;
             return Task.CompletedTask;
         }
+
+        public CacheType ClearCaches() => default;
+    }
+
+    private sealed class BlockingPreWarmer : IBlockCachePreWarmer
+    {
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Started => _started;
+
+        public Task PreWarmCaches(Block suggestedBlock, BlockHeader? parent, IReleaseSpec spec,
+            CancellationToken cancellationToken = default, params ReadOnlySpan<IHasAccessList> systemAccessLists)
+        {
+            _started.TrySetResult();
+            return _release.Task;
+        }
+
+        public void Release() => _release.TrySetResult();
 
         public CacheType ClearCaches() => default;
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -45,8 +45,10 @@ public class BlockProcessorTests
 {
     private static (BlockProcessor processor, BranchProcessor branchProcessor, IWorldState stateProvider) CreateProcessorAndBranch(
         IRewardCalculator? rewardCalculator = null,
-        IBlockCachePreWarmer? preWarmer = null)
+        IBlockCachePreWarmer? preWarmer = null,
+        ILogManager? logManager = null)
     {
+        logManager ??= LimboLogs.Instance;
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
         BlockProcessor processor = new(HoodiSpecProvider.Instance,
@@ -57,8 +59,8 @@ public class BlockProcessorTests
             NullReceiptStorage.Instance,
             new BeaconBlockRootHandler(transactionProcessor, stateProvider),
             Substitute.For<IBlockhashStore>(),
-            LimboLogs.Instance,
-            new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
+            logManager,
+            new WithdrawalProcessor(stateProvider, logManager),
             new ExecutionRequestsProcessor(transactionProcessor));
         BranchProcessor branchProcessor = new(
             processor,
@@ -66,7 +68,7 @@ public class BlockProcessorTests
             stateProvider,
             new BeaconBlockRootHandler(transactionProcessor, stateProvider),
             Substitute.For<IBlockhashProvider>(),
-            LimboLogs.Instance,
+            logManager,
             preWarmer);
 
         return (processor, branchProcessor, stateProvider);
@@ -282,6 +284,29 @@ public class BlockProcessorTests
             txExecutor.ProcessTransactions(block, ProcessingOptions.NoValidation, receiptsTracer, cancellationTokenSource.Token));
 
         executeCount.Should().Be(1, "cancellation should be observed before starting the next transaction");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BranchProcessor_does_not_warn_for_expected_shutdown_cancellation()
+    {
+        TestLogger testLogger = new();
+        (_, BranchProcessor branchProcessor, _) = CreateProcessorAndBranch(
+            rewardCalculator: new RewardCalculator(MainnetSpecProvider.Instance),
+            logManager: new OneLoggerLogManager(new(testLogger)));
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
+        Block block = Build.A.Block.WithTransactions(1, MuirGlacier.Instance).WithHeader(header).TestObject;
+        using CancellationTokenSource cancellationTokenSource = new();
+        cancellationTokenSource.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => branchProcessor.Process(
+            null,
+            new List<Block> { block },
+            ProcessingOptions.None,
+            NullBlockTracer.Instance,
+            cancellationTokenSource.Token));
+
+        testLogger.LogList.Should().NotContain(log => log.Contains("while processing blocks.", StringComparison.Ordinal));
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -22,6 +23,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 using Nethermind.State.Repositories;
 using Nethermind.Db.Blooms;
 using Nethermind.Int256;
@@ -2200,5 +2202,312 @@ public class BlockTreeTests
                 tree.SyncPivot.Should().Be((reorgDepthHeader.Number, reorgDepthHeader.Hash!));
             }
         }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_start_block_from_exact_persisted_boundary_hash_when_present()
+    {
+        byte[] persistedBoundaryHashKey = new byte[16];
+        persistedBoundaryHashKey[^1] = 1;
+
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        tree.BestPersistedState = 2;
+        builder.BlockInfoDb.Set(persistedBoundaryHashKey, canonicalBlock2.Hash!.Bytes.ToArray());
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .TestObject;
+
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(canonicalBlock2.Hash), "The exact persisted boundary hash should take precedence over number-only restore.");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_start_block_repairs_to_matching_flat_state_when_number_only_metadata_points_to_wrong_block()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        tree.BestPersistedState = 2;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
+            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
+
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(canonicalBlock2.Hash), "Startup repair should restore the block matching the exact persisted flat state.");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_when_no_exact_repair_target_exists_fails_with_actionable_diagnostics()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        tree.BestPersistedState = 2;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakC),
+            _ => false);
+
+        TestDelegate act = () =>
+        {
+            _ = Build.A.BlockTree()
+                .WithoutSettingHead
+                .WithDatabaseFrom(builder)
+                .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+                .TestObject;
+        };
+
+        Assert.That(act, Throws.TypeOf<InvalidDataException>()
+            .With.Message.Contains("PERSISTED-BOUNDARY-REPAIR"));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_failure_contains_persisted_boundary_and_flat_state_diagnostics()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        tree.BestPersistedState = 2;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakC),
+            _ => false);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+        {
+            _ = Build.A.BlockTree()
+                .WithoutSettingHead
+                .WithDatabaseFrom(builder)
+                .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+                .TestObject;
+        })!;
+
+        exception.Message.Should().Contain("PERSISTED-BOUNDARY-REPAIR");
+        exception.Message.Should().Contain("stored number=2");
+        exception.Message.Should().Contain("stored hash=");
+        exception.Message.Should().Contain("flat persisted state=2/");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_when_persisted_boundary_is_invalid_walks_back_to_recoverable_canonical_block()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakC).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        tree.BestPersistedState = 2;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakD),
+            header => header?.Number == block1.Number && header.StateRoot == block1.StateRoot);
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
+
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(block1.Hash), "Repair should fall back to the nearest recoverable canonical block when the stored boundary is invalid.");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_is_backward_compatible_when_only_number_metadata_exists()
+    {
+        byte[] persistedBoundaryNumberKey = new byte[16];
+        byte[] persistedBoundaryHashKey = new byte[16];
+        persistedBoundaryHashKey[^1] = 1;
+
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+
+        builder.BlockInfoDb.Remove(persistedBoundaryNumberKey);
+        builder.BlockInfoDb.Remove(persistedBoundaryHashKey);
+        tree.BestPersistedState = canonicalBlock2.Number;
+        builder.BlockInfoDb.Remove(persistedBoundaryHashKey);
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
+            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
+
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(canonicalBlock2.Hash));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_repair_rewrites_number_and_hash_metadata_together()
+    {
+        byte[] persistedBoundaryHashKey = new byte[16];
+        persistedBoundaryHashKey[^1] = 1;
+
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        tree.BestPersistedState = block1.Number;
+        builder.BlockInfoDb.Set(persistedBoundaryHashKey, block1.Hash!.Bytes.ToArray());
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
+            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
+
+        byte[] numberMetadata = builder.BlockInfoDb.Get(new byte[16])!;
+        long repairedNumber = new Rlp.ValueDecoderContext(numberMetadata).DecodeLong();
+        byte[] repairedHash = builder.BlockInfoDb.Get(persistedBoundaryHashKey)!;
+
+        Assert.That(loadedTree.BestPersistedState, Is.EqualTo(canonicalBlock2.Number));
+        Assert.That(repairedNumber, Is.EqualTo(canonicalBlock2.Number));
+        Assert.That(repairedHash, Is.EqualTo(canonicalBlock2.Hash!.Bytes.ToArray()));
+    }
+
+    private sealed class StubPersistedStateInfoProvider(PersistedStateInfo? persistedStateInfo, Func<BlockHeader?, bool>? hasRecoverableState)
+        : IPersistedStateInfoProvider
+    {
+        public bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfoValue)
+        {
+            if (persistedStateInfo is PersistedStateInfo value)
+            {
+                persistedStateInfoValue = value;
+                return true;
+            }
+
+            persistedStateInfoValue = default;
+            return false;
+        }
+
+        public bool HasRecoverableStateForBlock(BlockHeader? blockHeader) => hasRecoverableState?.Invoke(blockHeader) ?? false;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -2207,32 +2207,10 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_start_block_from_exact_persisted_boundary_hash_when_present()
     {
-        byte[] persistedBoundaryHashKey = new byte[16];
-        persistedBoundaryHashKey[^1] = 1;
-
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
-        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
-        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
-
-        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(genesis);
-        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(block1);
-        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(canonicalBlock2);
-        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2();
 
         tree.BestPersistedState = 2;
-        builder.BlockInfoDb.Set(persistedBoundaryHashKey, canonicalBlock2.Hash!.Bytes.ToArray());
+        builder.BlockInfoDb.Set(BlockTree.StateHeadBlockHashDbEntryAddress, canonicalBlock2.Hash!.Bytes.ToArray());
 
         BlockTree loadedTree = Build.A.BlockTree()
             .WithoutSettingHead
@@ -2245,30 +2223,11 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_start_block_repairs_to_matching_flat_state_when_number_only_metadata_points_to_wrong_block()
     {
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
-        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
-        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
-
-        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(genesis);
-        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(block1);
-        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(canonicalBlock2);
-        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2();
 
         tree.BestPersistedState = 2;
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
             header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
 
@@ -2284,30 +2243,11 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Load_start_block_when_no_exact_repair_target_exists_fails_with_actionable_diagnostics()
     {
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
-        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
-        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
-
-        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(genesis);
-        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(block1);
-        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(canonicalBlock2);
-        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2();
 
         tree.BestPersistedState = 2;
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakC),
             _ => false);
 
@@ -2327,30 +2267,11 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Load_start_block_failure_contains_persisted_boundary_and_flat_state_diagnostics()
     {
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
-        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
-        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
-
-        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(genesis);
-        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(block1);
-        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(canonicalBlock2);
-        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2();
 
         tree.BestPersistedState = 2;
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakC),
             _ => false);
 
@@ -2372,30 +2293,14 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Load_start_block_when_persisted_boundary_is_invalid_walks_back_to_recoverable_canonical_block()
     {
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
-        BlockTree tree = builder.TestObject;
-        Block genesis = Build.A.Block.Genesis.TestObject;
-        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).WithStateRoot(TestItem.KeccakA).TestObject;
-        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
-        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakC).TestObject;
-
-        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(genesis);
-        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(block1);
-        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
-        tree.UpdateMainChain(canonicalBlock2);
-        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        (BlockTreeBuilder builder, BlockTree tree, _, Block block1, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2(
+            block1StateRoot: TestItem.KeccakA,
+            canonicalBlock2StateRoot: TestItem.KeccakB,
+            forkBlock2StateRoot: TestItem.KeccakC);
 
         tree.BestPersistedState = 2;
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakD),
             header => header?.Number == block1.Number && header.StateRoot == block1.StateRoot);
 
@@ -2411,10 +2316,6 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Load_start_block_is_backward_compatible_when_only_number_metadata_exists()
     {
-        byte[] persistedBoundaryNumberKey = new byte[16];
-        byte[] persistedBoundaryHashKey = new byte[16];
-        persistedBoundaryHashKey[^1] = 1;
-
         BlockTreeBuilder builder = Build.A.BlockTree()
             .WithoutSettingHead;
 
@@ -2430,12 +2331,10 @@ public class BlockTreeTests
         tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
         tree.UpdateMainChain(canonicalBlock2);
 
-        builder.BlockInfoDb.Remove(persistedBoundaryNumberKey);
-        builder.BlockInfoDb.Remove(persistedBoundaryHashKey);
         tree.BestPersistedState = canonicalBlock2.Number;
-        builder.BlockInfoDb.Remove(persistedBoundaryHashKey);
+        builder.BlockInfoDb.Remove(BlockTree.StateHeadBlockHashDbEntryAddress);
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
             header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
 
@@ -2451,13 +2350,11 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Load_start_block_repair_rewrites_number_and_hash_metadata_together()
     {
-        byte[] persistedBoundaryHashKey = new byte[16];
-        persistedBoundaryHashKey[^1] = 1;
-
-        BlockTreeBuilder builder = Build.A.BlockTree()
-            .WithoutSettingHead;
-
+        // This test does NOT clear HasBlockOnMainChain — the repair's BestPersistedState setter
+        // needs canonical info to write the hash metadata correctly.
+        BlockTreeBuilder builder = Build.A.BlockTree().WithoutSettingHead;
         BlockTree tree = builder.TestObject;
+
         Block genesis = Build.A.Block.Genesis.TestObject;
         Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis).TestObject;
         Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
@@ -2471,10 +2368,11 @@ public class BlockTreeTests
         tree.UpdateMainChain(canonicalBlock2);
         tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
 
+        // Set stale metadata pointing to block1 while flat state is at canonicalBlock2
         tree.BestPersistedState = block1.Number;
-        builder.BlockInfoDb.Set(persistedBoundaryHashKey, block1.Hash!.Bytes.ToArray());
+        builder.BlockInfoDb.Set(BlockTree.StateHeadBlockHashDbEntryAddress, block1.Hash!.Bytes.ToArray());
 
-        IPersistedStateInfoProvider persistedStateInfoProvider = new StubPersistedStateInfoProvider(
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
             header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
 
@@ -2484,30 +2382,63 @@ public class BlockTreeTests
             .WithPersistedStateInfoProvider(persistedStateInfoProvider)
             .TestObject;
 
-        byte[] numberMetadata = builder.BlockInfoDb.Get(new byte[16])!;
+        byte[] numberMetadata = builder.BlockInfoDb.Get(BlockTree.StateHeadHashDbEntryAddress)!;
         long repairedNumber = new Rlp.ValueDecoderContext(numberMetadata).DecodeLong();
-        byte[] repairedHash = builder.BlockInfoDb.Get(persistedBoundaryHashKey)!;
+        byte[] repairedHash = builder.BlockInfoDb.Get(BlockTree.StateHeadBlockHashDbEntryAddress)!;
 
         Assert.That(loadedTree.BestPersistedState, Is.EqualTo(canonicalBlock2.Number));
         Assert.That(repairedNumber, Is.EqualTo(canonicalBlock2.Number));
         Assert.That(repairedHash, Is.EqualTo(canonicalBlock2.Hash!.Bytes.ToArray()));
     }
 
-    private sealed class StubPersistedStateInfoProvider(PersistedStateInfo? persistedStateInfo, Func<BlockHeader?, bool>? hasRecoverableState)
-        : IPersistedStateInfoProvider
+    /// <summary>
+    /// Builds a block tree with genesis → block1 → canonicalBlock2 + forkBlock2 (higher difficulty fork at block 2),
+    /// then clears the main chain flag at level 2 to simulate an ambiguous persisted boundary.
+    /// </summary>
+    private static (BlockTreeBuilder Builder, BlockTree Tree, Block Genesis, Block Block1, Block CanonicalBlock2, Block ForkBlock2) CreateTreeWithForkAtBlock2(
+        Hash256? block1StateRoot = null,
+        Hash256? canonicalBlock2StateRoot = null,
+        Hash256? forkBlock2StateRoot = null)
     {
-        public bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfoValue)
-        {
-            if (persistedStateInfo is PersistedStateInfo value)
+        BlockTreeBuilder builder = Build.A.BlockTree().WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        BlockBuilder block1Builder = Build.A.Block.WithNumber(1).WithDifficulty(1).WithTotalDifficulty(1L).WithParent(genesis);
+        if (block1StateRoot is not null) block1Builder = block1Builder.WithStateRoot(block1StateRoot);
+        Block block1 = block1Builder.TestObject;
+
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1).WithTotalDifficulty(2L).WithParent(block1)
+            .WithStateRoot(canonicalBlock2StateRoot ?? TestItem.KeccakA).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5).WithTotalDifficulty(6L).WithParent(block1)
+            .WithStateRoot(forkBlock2StateRoot ?? TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(canonicalBlock2);
+        tree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        return (builder, tree, genesis, block1, canonicalBlock2, forkBlock2);
+    }
+
+    private static IPersistedStateInfoProvider CreatePersistedStateInfoProvider(PersistedStateInfo persistedStateInfo, Func<BlockHeader?, bool> hasRecoverableState)
+    {
+        IPersistedStateInfoProvider provider = Substitute.For<IPersistedStateInfoProvider>();
+        provider.TryGetPersistedStateInfo(out Arg.Any<PersistedStateInfo>())
+            .Returns(callInfo =>
             {
-                persistedStateInfoValue = value;
+                callInfo[0] = persistedStateInfo;
                 return true;
-            }
-
-            persistedStateInfoValue = default;
-            return false;
-        }
-
-        public bool HasRecoverableStateForBlock(BlockHeader? blockHeader) => hasRecoverableState?.Invoke(blockHeader) ?? false;
+            });
+        provider.HasRecoverableStateForBlock(Arg.Any<BlockHeader?>())
+            .Returns(callInfo => hasRecoverableState((BlockHeader?)callInfo[0]));
+        return provider;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -2221,15 +2221,15 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Loads_start_block_repairs_to_matching_flat_state_when_number_only_metadata_points_to_wrong_block()
+    public void Load_start_block_when_number_only_restore_points_to_exact_persisted_state_promotes_it_to_main_chain()
     {
-        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2();
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, Block forkBlock2) = CreateTreeWithForkAtBlock2();
 
         tree.BestPersistedState = 2;
 
         IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
-            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
-            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+            new PersistedStateInfo(forkBlock2.Number, forkBlock2.StateRoot),
+            header => header?.Number == forkBlock2.Number && header.StateRoot == forkBlock2.StateRoot);
 
         BlockTree loadedTree = Build.A.BlockTree()
             .WithoutSettingHead
@@ -2237,7 +2237,8 @@ public class BlockTreeTests
             .WithPersistedStateInfoProvider(persistedStateInfoProvider)
             .TestObject;
 
-        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(canonicalBlock2.Hash), "Startup repair should restore the block matching the exact persisted flat state.");
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(forkBlock2.Hash), "Startup should promote the exact persisted-state block to main chain when main-chain markers are stale.");
+        Assert.That(loadedTree.FindCanonicalBlockInfo(forkBlock2.Number)?.BlockHash, Is.EqualTo(forkBlock2.Hash), "The promoted boundary should become the canonical block at its level.");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
@@ -2291,9 +2292,9 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Load_start_block_when_persisted_boundary_is_invalid_walks_back_to_recoverable_canonical_block()
+    public void Load_start_block_when_persisted_boundary_is_invalid_fails_without_exact_canonical_match()
     {
-        (BlockTreeBuilder builder, BlockTree tree, _, Block block1, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2(
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, _) = CreateTreeWithForkAtBlock2(
             block1StateRoot: TestItem.KeccakA,
             canonicalBlock2StateRoot: TestItem.KeccakB,
             forkBlock2StateRoot: TestItem.KeccakC);
@@ -2302,15 +2303,47 @@ public class BlockTreeTests
 
         IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, TestItem.KeccakD),
-            header => header?.Number == block1.Number && header.StateRoot == block1.StateRoot);
+            _ => false);
 
-        BlockTree loadedTree = Build.A.BlockTree()
-            .WithoutSettingHead
-            .WithDatabaseFrom(builder)
-            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
-            .TestObject;
+        TestDelegate act = () =>
+        {
+            _ = Build.A.BlockTree()
+                .WithoutSettingHead
+                .WithDatabaseFrom(builder)
+                .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+                .TestObject;
+        };
 
-        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(block1.Hash), "Repair should fall back to the nearest recoverable canonical block when the stored boundary is invalid.");
+        Assert.That(act, Throws.TypeOf<InvalidDataException>()
+            .With.Message.Contains("PERSISTED-BOUNDARY-REPAIR"));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Load_start_block_when_number_only_restore_matches_state_but_is_not_canonical_fails_loudly()
+    {
+        (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, Block forkBlock2) = CreateTreeWithForkAtBlock2(
+            canonicalBlock2StateRoot: TestItem.KeccakA,
+            forkBlock2StateRoot: TestItem.KeccakA);
+
+        tree.BestPersistedState = canonicalBlock2.Number;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
+            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+
+        Assert.That(forkBlock2.StateRoot, Is.EqualTo(canonicalBlock2.StateRoot), "sanity check");
+
+        TestDelegate act = () =>
+        {
+            _ = Build.A.BlockTree()
+                .WithoutSettingHead
+                .WithDatabaseFrom(builder)
+                .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+                .TestObject;
+        };
+
+        Assert.That(act, Throws.TypeOf<InvalidDataException>()
+            .With.Message.Contains("PERSISTED-BOUNDARY-REPAIR"));
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -2319,7 +2319,7 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Load_start_block_when_number_only_restore_matches_state_but_is_not_canonical_fails_loudly()
+    public void Load_start_block_when_number_only_restore_matches_exact_persisted_state_promotes_it_to_main_chain()
     {
         (BlockTreeBuilder builder, BlockTree tree, _, _, Block canonicalBlock2, Block forkBlock2) = CreateTreeWithForkAtBlock2(
             canonicalBlock2StateRoot: TestItem.KeccakA,
@@ -2328,22 +2328,19 @@ public class BlockTreeTests
         tree.BestPersistedState = canonicalBlock2.Number;
 
         IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
-            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
-            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+            new PersistedStateInfo(forkBlock2.Number, forkBlock2.StateRoot),
+            header => header?.Number == forkBlock2.Number && header.StateRoot == forkBlock2.StateRoot);
 
         Assert.That(forkBlock2.StateRoot, Is.EqualTo(canonicalBlock2.StateRoot), "sanity check");
 
-        TestDelegate act = () =>
-        {
-            _ = Build.A.BlockTree()
-                .WithoutSettingHead
-                .WithDatabaseFrom(builder)
-                .WithPersistedStateInfoProvider(persistedStateInfoProvider)
-                .TestObject;
-        };
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
 
-        Assert.That(act, Throws.TypeOf<InvalidDataException>()
-            .With.Message.Contains("PERSISTED-BOUNDARY-REPAIR"));
+        Assert.That(loadedTree.Head?.Hash, Is.EqualTo(forkBlock2.Hash), "Startup should promote the exact persisted-state block when number-only metadata restores the wrong main-chain marker.");
+        Assert.That(loadedTree.FindCanonicalBlockInfo(forkBlock2.Number)?.BlockHash, Is.EqualTo(forkBlock2.Hash), "The promoted persisted-state block should become canonical at its level.");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -11,7 +11,9 @@ using System.Threading.Tasks;
 using Autofac;
 using ConcurrentCollections;
 using FluentAssertions;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Tracing;
+using Nethermind.Blockchain.Visitors;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
@@ -935,7 +937,7 @@ public class BlockchainProcessorTests
                     block2.Number,
                     block2.Hash,
                     new PersistedStateInfo(block2.Number, block2.StateRoot),
-                    "validated against exact persisted state"));
+                    "validated against exact persisted state and canonical chain"));
 
         Block suggestedBlock = Build.A.Block
             .WithNumber(3)
@@ -951,11 +953,11 @@ public class BlockchainProcessorTests
         message.Should().Contain($"stored persisted boundary number={block2.Number}");
         message.Should().Contain($"stored persisted boundary hash={block2.Hash}");
         message.Should().Contain($"flat persisted state={block2.Number}/{block2.StateRoot}");
-        message.Should().Contain("startup reconciliation outcome=validated against exact persisted state");
+        message.Should().Contain("startup reconciliation outcome=validated against exact persisted state and canonical chain");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Restart_with_ambiguous_persisted_boundary_repairs_and_processes_next_canonical_block()
+    public async Task Restart_with_exact_persisted_boundary_hash_replays_only_canonical_descendants_from_loaded_head()
     {
         BlockTreeBuilder builder = Build.A.BlockTree()
             .WithoutSettingHead;
@@ -965,6 +967,20 @@ public class BlockchainProcessorTests
         Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1L).WithTotalDifficulty(1L).WithParent(genesis).WithStateRoot(TestItem.KeccakA).TestObject;
         Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1L).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
         Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5L).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakC).TestObject;
+        Block nextCanonicalBlock = Build.A.Block
+            .WithNumber(3)
+            .WithDifficulty(1L)
+            .WithTotalDifficulty(3L)
+            .WithParent(canonicalBlock2)
+            .WithStateRoot(TestItem.KeccakD)
+            .TestObject;
+        Block staleBlock3 = Build.A.Block
+            .WithNumber(3)
+            .WithDifficulty(6L)
+            .WithTotalDifficulty(12L)
+            .WithParent(forkBlock2)
+            .WithStateRoot(TestItem.KeccakE)
+            .TestObject;
 
         sourceTree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
         sourceTree.UpdateMainChain(genesis);
@@ -973,12 +989,11 @@ public class BlockchainProcessorTests
         sourceTree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
         sourceTree.UpdateMainChain(canonicalBlock2);
         sourceTree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
-
-        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
-        level2.HasBlockOnMainChain = false;
-        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+        sourceTree.SuggestBlock(nextCanonicalBlock).Should().Be(AddBlockResult.Added);
+        sourceTree.SuggestBlock(staleBlock3).Should().Be(AddBlockResult.Added);
 
         sourceTree.BestPersistedState = canonicalBlock2.Number;
+        builder.BlockInfoDb.Set(BlockTree.StateHeadBlockHashDbEntryAddress, canonicalBlock2.Hash!.Bytes.ToArray());
 
         IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
             new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
@@ -990,26 +1005,25 @@ public class BlockchainProcessorTests
             .WithPersistedStateInfoProvider(persistedStateInfoProvider)
             .TestObject;
 
-        Block nextCanonicalBlock = Build.A.Block
-            .WithNumber(3)
-            .WithDifficulty(1L)
-            .WithTotalDifficulty(3L)
-            .WithParent(canonicalBlock2)
-            .WithStateRoot(TestItem.KeccakD)
-            .TestObject;
-
-        loadedTree.SuggestBlock(nextCanonicalBlock).Should().Be(AddBlockResult.Added);
-
         IStateReader stateReader = Substitute.For<IStateReader>();
-        stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+        stateReader.HasStateForBlock(canonicalBlock2.Header).Returns(true);
 
-        BlockchainProcessor processor = CreateProcessorForDirectProcess(loadedTree, stateReader);
+        List<Hash256> suggestedBlocks = [];
+        EventHandler<BlockEventArgs> handler = (_, args) => suggestedBlocks.Add(args.Block.Hash!);
+        loadedTree.NewBestSuggestedBlock += handler;
 
-        Block? processedBlock = processor.Process(nextCanonicalBlock, ProcessingOptions.None, NullBlockTracer.Instance, CancellationToken.None);
+        try
+        {
+            StartupBlockTreeFixer fixer = new(new SyncConfig(), loadedTree, stateReader, LimboNoErrorLogger.Instance, 16, persistedStateInfoProvider);
+            await loadedTree.Accept(fixer, CancellationToken.None);
+        }
+        finally
+        {
+            loadedTree.NewBestSuggestedBlock -= handler;
+        }
 
-        processedBlock.Should().NotBeNull();
-        processedBlock!.Hash.Should().Be(nextCanonicalBlock.Hash!);
-        loadedTree.Head!.Hash.Should().Be(nextCanonicalBlock.Hash!);
+        loadedTree.Head!.Hash.Should().Be(canonicalBlock2.Hash!);
+        suggestedBlocks.Should().Equal(nextCanonicalBlock.Hash!);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -33,9 +34,28 @@ namespace Nethermind.Blockchain.Test;
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public class BlockchainProcessorTests
 {
+    private sealed class RecordingLogger : InterfaceLogger
+    {
+        private readonly ConcurrentQueue<string> _logs = new();
+
+        public IEnumerable<string> Logs => _logs;
+
+        public void Info(string text) => _logs.Enqueue(text);
+        public void Warn(string text) => _logs.Enqueue(text);
+        public void Debug(string text) => _logs.Enqueue(text);
+        public void Trace(string text) => _logs.Enqueue(text);
+        public void Error(string text, Exception? ex = null) => _logs.Enqueue(text);
+
+        public bool IsInfo { get; set; }
+        public bool IsWarn { get; set; } = true;
+        public bool IsDebug { get; set; }
+        public bool IsTrace { get; set; }
+        public bool IsError { get; set; } = true;
+    }
+
     private class ProcessingTestContext
     {
-        private readonly ILogManager _logManager = LimboLogs.Instance;
+        private readonly ILogManager _logManager;
 
         private class BranchProcessorMock : IBranchProcessor
         {
@@ -91,11 +111,13 @@ public class BlockchainProcessorTests
                 int nextBlock = 0;
                 while (true)
                 {
+                    token.ThrowIfCancellationRequested();
                     lock (_gate)
                     {
                         bool notYet = false;
                         for (int i = nextBlock; i < suggestedBlocks.Count; i++)
                         {
+                            token.ThrowIfCancellationRequested();
                             BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(suggestedBlocks));
                             Block suggestedBlock = suggestedBlocks[i];
                             BlockProcessing?.Invoke(this, new BlockEventArgs(suggestedBlock));
@@ -201,8 +223,9 @@ public class BlockchainProcessorTests
         private const int ProcessingWait = 10_000;
         private const int MockRecheckInterval = 200;
 
-        public ProcessingTestContext(bool startProcessor)
+        public ProcessingTestContext(bool startProcessor, ILogManager? logManager = null, BlockchainProcessor.Options? options = null)
         {
+            _logManager = logManager ?? LimboLogs.Instance;
             _logger = _logManager.GetClassLogger();
             _stateReader = Substitute.For<IStateReader>();
 
@@ -211,7 +234,7 @@ public class BlockchainProcessorTests
                 .TestObject;
             _branchProcessor = new BranchProcessorMock(_logManager, _stateReader);
             _recoveryStep = new RecoveryStepMock(_logManager);
-            _processor = new BlockchainProcessor(_blockTree, _branchProcessor, _recoveryStep, _stateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default, Substitute.For<IProcessingStats>());
+            _processor = new BlockchainProcessor(_blockTree, _branchProcessor, _recoveryStep, _stateReader, _logManager, options ?? BlockchainProcessor.Options.Default, Substitute.For<IProcessingStats>());
             _resetEvent = new AutoResetEvent(false);
             _queueEmptyResetEvent = new AutoResetEvent(false);
 
@@ -396,6 +419,12 @@ public class BlockchainProcessorTests
             return this;
         }
 
+        public ProcessingTestContext Allow(Block block)
+        {
+            _branchProcessor.Allow(block.Hash!);
+            return this;
+        }
+
         public ProcessingTestContext CountIs(int expectedCount)
         {
             Assert.That(() => _processor.Count, Is.EqualTo(expectedCount).After(ProcessingWait, 10));
@@ -498,6 +527,8 @@ public class BlockchainProcessorTests
             _branchProcessor.Processed.Should().BeEquivalentTo(blocks.Select(b => b.Hash));
             return this;
         }
+
+        public Task StopAsync() => _processor.StopAsync(processRemainingBlocks: false);
 
         public ProcessingTestContext StateSyncedTo(Block block4D8)
         {
@@ -849,6 +880,138 @@ public class BlockchainProcessorTests
             .QueueIsEmpty(3);
     }
 
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public async Task ProcessBlock_WhenBlockTakesLongerThanThreshold_EmitsWatchdogWarning()
+    {
+        RecordingLogger testLogger = new();
+        BlockchainProcessor.Options options = new()
+        {
+            BlockProcessingWatchdogThreshold = TimeSpan.FromMilliseconds(200),
+            BlockProcessingWatchdogRepeatInterval = TimeSpan.FromSeconds(10),
+        };
+        ProcessingTestContext context = new(true, new OneLoggerLogManager(new(testLogger)), options);
+
+        try
+        {
+            context
+                .Suggested(_block0)
+                .Recovered(_block0)
+                .Sleep(500);
+
+            testLogger.Logs.Should().Contain(log => log.Contains("Block processing watchdog: block", StringComparison.Ordinal));
+        }
+        finally
+        {
+            context.Recovered(_block0);
+            context.Allow(_block0);
+            await context.StopAsync();
+        }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BuildMaxBranchSizeReachedMessage_IncludesStartupDiagnostics()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree tree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1L).WithTotalDifficulty(1L).WithParent(genesis).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block block2 = Build.A.Block.WithNumber(2).WithDifficulty(1L).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(genesis);
+        tree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block1);
+        tree.SuggestBlock(block2).Should().Be(AddBlockResult.Added);
+        tree.UpdateMainChain(block2);
+
+        tree.BestPersistedState = block2.Number;
+        typeof(BlockTree)
+            .GetProperty(nameof(BlockTree.LastStartupBoundaryDiagnostics), BindingFlags.Instance | BindingFlags.Public)!
+            .SetValue(
+                tree,
+                new StartupBoundaryDiagnostics(
+                    block2.Number,
+                    block2.Hash,
+                    new PersistedStateInfo(block2.Number, block2.StateRoot),
+                    "validated against exact persisted state"));
+
+        Block suggestedBlock = Build.A.Block
+            .WithNumber(3)
+            .WithDifficulty(1L)
+            .WithTotalDifficulty(3L)
+            .WithParent(block2)
+            .WithStateRoot(TestItem.KeccakC)
+            .TestObject;
+
+        string message = BlockchainProcessor.BuildMaxBranchSizeReachedMessage(tree, suggestedBlock, block2, block2.Header);
+
+        message.Should().Contain("Maximum size of branch reached (8192)");
+        message.Should().Contain($"stored persisted boundary number={block2.Number}");
+        message.Should().Contain($"stored persisted boundary hash={block2.Hash}");
+        message.Should().Contain($"flat persisted state={block2.Number}/{block2.StateRoot}");
+        message.Should().Contain("startup reconciliation outcome=validated against exact persisted state");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Restart_with_ambiguous_persisted_boundary_repairs_and_processes_next_canonical_block()
+    {
+        BlockTreeBuilder builder = Build.A.BlockTree()
+            .WithoutSettingHead;
+
+        BlockTree sourceTree = builder.TestObject;
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(1L).WithTotalDifficulty(1L).WithParent(genesis).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block canonicalBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(1L).WithTotalDifficulty(2L).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+        Block forkBlock2 = Build.A.Block.WithNumber(2).WithDifficulty(5L).WithTotalDifficulty(6L).WithParent(block1).WithStateRoot(TestItem.KeccakC).TestObject;
+
+        sourceTree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+        sourceTree.UpdateMainChain(genesis);
+        sourceTree.SuggestBlock(block1).Should().Be(AddBlockResult.Added);
+        sourceTree.UpdateMainChain(block1);
+        sourceTree.SuggestBlock(canonicalBlock2).Should().Be(AddBlockResult.Added);
+        sourceTree.UpdateMainChain(canonicalBlock2);
+        sourceTree.SuggestBlock(forkBlock2).Should().Be(AddBlockResult.Added);
+
+        ChainLevelInfo level2 = builder.ChainLevelInfoRepository.LoadLevel(2)!;
+        level2.HasBlockOnMainChain = false;
+        builder.ChainLevelInfoRepository.PersistLevel(2, level2);
+
+        sourceTree.BestPersistedState = canonicalBlock2.Number;
+
+        IPersistedStateInfoProvider persistedStateInfoProvider = CreatePersistedStateInfoProvider(
+            new PersistedStateInfo(canonicalBlock2.Number, canonicalBlock2.StateRoot),
+            header => header?.Number == canonicalBlock2.Number && header.StateRoot == canonicalBlock2.StateRoot);
+
+        BlockTree loadedTree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .WithDatabaseFrom(builder)
+            .WithPersistedStateInfoProvider(persistedStateInfoProvider)
+            .TestObject;
+
+        Block nextCanonicalBlock = Build.A.Block
+            .WithNumber(3)
+            .WithDifficulty(1L)
+            .WithTotalDifficulty(3L)
+            .WithParent(canonicalBlock2)
+            .WithStateRoot(TestItem.KeccakD)
+            .TestObject;
+
+        loadedTree.SuggestBlock(nextCanonicalBlock).Should().Be(AddBlockResult.Added);
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+
+        BlockchainProcessor processor = CreateProcessorForDirectProcess(loadedTree, stateReader);
+
+        Block? processedBlock = processor.Process(nextCanonicalBlock, ProcessingOptions.None, NullBlockTracer.Instance, CancellationToken.None);
+
+        processedBlock.Should().NotBeNull();
+        processedBlock!.Hash.Should().Be(nextCanonicalBlock.Hash!);
+        loadedTree.Head!.Hash.Should().Be(nextCanonicalBlock.Hash!);
+    }
+
     [Test]
     public void ProcessingLongRangeFastSync_ProcessOnlyLastBlock()
     {
@@ -870,5 +1033,36 @@ public class BlockchainProcessorTests
                 _block1D2,
                 _block5D10
             );
+    }
+
+    private static BlockchainProcessor CreateProcessorForDirectProcess(IBlockTree blockTree, IStateReader stateReader)
+    {
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        branchProcessor
+            .Process(Arg.Any<BlockHeader?>(), Arg.Any<IReadOnlyList<Block>>(), Arg.Any<ProcessingOptions>(), Arg.Any<IBlockTracer>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => ((IReadOnlyList<Block>)callInfo[1]).ToArray());
+
+        return new BlockchainProcessor(
+            blockTree,
+            branchProcessor,
+            Substitute.For<IBlockPreprocessorStep>(),
+            stateReader,
+            LimboLogs.Instance,
+            BlockchainProcessor.Options.Default,
+            Substitute.For<IProcessingStats>());
+    }
+
+    private static IPersistedStateInfoProvider CreatePersistedStateInfoProvider(PersistedStateInfo persistedStateInfo, Func<BlockHeader?, bool> hasRecoverableState)
+    {
+        IPersistedStateInfoProvider persistedStateInfoProvider = Substitute.For<IPersistedStateInfoProvider>();
+        persistedStateInfoProvider.TryGetPersistedStateInfo(out Arg.Any<PersistedStateInfo>())
+            .Returns(callInfo =>
+            {
+                callInfo[0] = persistedStateInfo;
+                return true;
+            });
+        persistedStateInfoProvider.HasRecoverableStateForBlock(Arg.Any<BlockHeader?>())
+            .Returns(callInfo => hasRecoverableState((BlockHeader?)callInfo[0]));
+        return persistedStateInfoProvider;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Visitors;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -156,6 +158,96 @@ public class StartupTreeFixerTests
         BlockVisitOutcome result = await fixer.VisitBlock(null!, CancellationToken.None);
 
         Assert.That(result, Is.EqualTo(BlockVisitOutcome.None));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Fixer_starts_from_repaired_head()
+    {
+        BlockTree tree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .TestObject;
+
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        Block repairedHead = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).TestObject;
+        Block queuedBlock = Build.A.Block.WithNumber(3).WithDifficulty(4).WithParent(repairedHead).TestObject;
+
+        tree.SuggestBlock(block0);
+        tree.SuggestBlock(block1);
+        tree.SuggestBlock(repairedHead);
+        tree.SuggestBlock(queuedBlock);
+
+        tree.UpdateMainChain(block0);
+        tree.UpdateMainChain(block1);
+        tree.UpdateMainChain(repairedHead);
+
+        StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, Substitute.For<IStateReader>(), LimboNoErrorLogger.Instance);
+
+        Assert.That(fixer.StartLevelInclusive, Is.EqualTo(repairedHead.Number + 1));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public async Task Fixer_with_repaired_head_and_recoverable_parent_suggests_blocks_normally()
+    {
+        BlockTree tree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .TestObject;
+
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        Block repairedHead = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).TestObject;
+        Block queuedBlock = Build.A.Block.WithNumber(3).WithDifficulty(4).WithParent(repairedHead).TestObject;
+
+        tree.SuggestBlock(block0);
+        tree.SuggestBlock(block1);
+        tree.SuggestBlock(repairedHead);
+        tree.SuggestBlock(queuedBlock);
+
+        tree.UpdateMainChain(block0);
+        tree.UpdateMainChain(block1);
+        tree.UpdateMainChain(repairedHead);
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(repairedHead.Header).Returns(true);
+
+        IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, stateReader, LimboNoErrorLogger.Instance);
+        BlockVisitOutcome result = await fixer.VisitBlock(queuedBlock, CancellationToken.None);
+
+        Assert.That(result, Is.EqualTo(BlockVisitOutcome.Suggest));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Fixer_logs_error_when_head_does_not_match_persisted_state_info()
+    {
+        BlockTree tree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .TestObject;
+
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).WithStateRoot(TestItem.KeccakB).TestObject;
+
+        tree.SuggestBlock(block0);
+        tree.SuggestBlock(block1);
+        tree.UpdateMainChain(block0);
+        tree.UpdateMainChain(block1);
+
+        TestLogger testLogger = new();
+        IPersistedStateInfoProvider persistedStateInfoProvider = Substitute.For<IPersistedStateInfoProvider>();
+        persistedStateInfoProvider.TryGetPersistedStateInfo(out Arg.Any<PersistedStateInfo>())
+            .Returns(callInfo =>
+            {
+                callInfo[0] = new PersistedStateInfo(block1.Number, TestItem.KeccakC);
+                return true;
+            });
+
+        _ = new StartupBlockTreeFixer(
+            new SyncConfig(),
+            tree,
+            Substitute.For<IStateReader>(),
+            new ILogger(testLogger),
+            persistedStateInfoProvider: persistedStateInfoProvider);
+
+        testLogger.LogList.Should().Contain(log => log.Contains("Startup head does not match persisted state info.", StringComparison.Ordinal));
     }
 
     private static void SuggestNumberOfBlocks(IBlockTree blockTree, int blockAmount)

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Visitors;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -209,11 +211,70 @@ public class StartupTreeFixerTests
 
         IStateReader stateReader = Substitute.For<IStateReader>();
         stateReader.HasStateForBlock(repairedHead.Header).Returns(true);
+        List<Hash256> suggestedBlocks = [];
+        EventHandler<BlockEventArgs> handler = (_, args) => suggestedBlocks.Add(args.Block.Hash!);
+        tree.NewBestSuggestedBlock += handler;
 
-        IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, stateReader, LimboNoErrorLogger.Instance);
-        BlockVisitOutcome result = await fixer.VisitBlock(queuedBlock, CancellationToken.None);
+        try
+        {
+            StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, stateReader, LimboNoErrorLogger.Instance);
+            await tree.Accept(fixer, CancellationToken.None);
+        }
+        finally
+        {
+            tree.NewBestSuggestedBlock -= handler;
+        }
 
-        Assert.That(result, Is.EqualTo(BlockVisitOutcome.Suggest));
+        suggestedBlocks.Should().Equal(queuedBlock.Hash!);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public async Task Fixer_only_suggests_blocks_that_descend_from_repaired_head()
+    {
+        BlockTree tree = Build.A.BlockTree()
+            .WithoutSettingHead
+            .TestObject;
+
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        Block repairedHead = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).WithStateRoot(TestItem.KeccakA).TestObject;
+        Block staleForkHead = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).WithStateRoot(TestItem.KeccakB).TestObject;
+        Block canonicalBlock3 = Build.A.Block.WithNumber(3).WithDifficulty(4).WithParent(repairedHead).WithStateRoot(TestItem.KeccakB).TestObject;
+        Block staleBlock3 = Build.A.Block.WithNumber(3).WithDifficulty(4).WithParent(staleForkHead).WithStateRoot(TestItem.KeccakC).TestObject;
+        Block canonicalBlock4 = Build.A.Block.WithNumber(4).WithDifficulty(5).WithParent(canonicalBlock3).WithStateRoot(TestItem.KeccakD).TestObject;
+        Block staleBlock4 = Build.A.Block.WithNumber(4).WithDifficulty(5).WithParent(staleBlock3).WithStateRoot(TestItem.KeccakE).TestObject;
+
+        tree.SuggestBlock(block0);
+        tree.SuggestBlock(block1);
+        tree.SuggestBlock(repairedHead);
+        tree.SuggestBlock(staleForkHead);
+        tree.SuggestBlock(canonicalBlock3);
+        tree.SuggestBlock(staleBlock3);
+        tree.SuggestBlock(canonicalBlock4);
+        tree.SuggestBlock(staleBlock4);
+
+        tree.UpdateMainChain(block0);
+        tree.UpdateMainChain(block1);
+        tree.UpdateMainChain(repairedHead);
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(repairedHead.Header).Returns(true);
+
+        List<Hash256> suggestedBlocks = [];
+        EventHandler<BlockEventArgs> handler = (_, args) => suggestedBlocks.Add(args.Block.Hash!);
+        tree.NewBestSuggestedBlock += handler;
+
+        try
+        {
+            StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, stateReader, LimboNoErrorLogger.Instance, 16);
+            await tree.Accept(fixer, CancellationToken.None);
+        }
+        finally
+        {
+            tree.NewBestSuggestedBlock -= handler;
+        }
+
+        suggestedBlocks.Should().Equal(canonicalBlock3.Hash!, canonicalBlock4.Hash!);
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -381,8 +381,8 @@ public partial class BlockTree
             bool? hasRecoverableState = startBlock is null
                 ? null
                 : _persistedStateInfoProvider?.HasRecoverableStateForBlock(startBlock.Header);
-            string persistedStateDescription = _persistedStateInfoProvider?.TryGetPersistedStateInfo(out PersistedStateInfo stateInfo) == true
-                ? $"{stateInfo.BlockNumber} / {stateInfo.StateRoot}"
+            string persistedStateDescription = persistedStateInfoValue is PersistedStateInfo logStateInfo
+                ? $"{logStateInfo.BlockNumber} / {logStateInfo.StateRoot}"
                 : "<unavailable>";
 
             Logger.Info(

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -357,15 +357,17 @@ public partial class BlockTree
             persistedStateInfoValue = persistedStateInfo;
         }
 
+        bool isCanonicalStartBlock = startBlock is not null && IsCanonical(startBlock);
+
         if (persistedStateInfoValue is PersistedStateInfo exactPersistedState &&
             startBlock is not null &&
-            !MatchesPersistedState(startBlock, exactPersistedState))
+            (!MatchesPersistedState(startBlock, exactPersistedState) || !isCanonicalStartBlock))
         {
             startBlock = RepairPersistedBoundary(startBlock, persistedNumber, persistedHash, exactPersistedState, out reconciliationOutcome);
         }
         else if (persistedStateInfoValue is PersistedStateInfo)
         {
-            reconciliationOutcome = "validated against exact persisted state";
+            reconciliationOutcome = "validated against exact persisted state and canonical chain";
         }
         else if (startBlock is not null)
         {
@@ -452,10 +454,27 @@ public partial class BlockTree
         block.Number == persistedStateInfo.BlockNumber &&
         block.StateRoot == persistedStateInfo.StateRoot;
 
+    private bool IsCanonical(Block block) =>
+        block.Hash is not null &&
+        FindCanonicalBlockInfo(block.Number)?.BlockHash == block.Hash;
+
     private Block RepairPersistedBoundary(Block restoredBlock, long? persistedNumber, Hash256? persistedHash, PersistedStateInfo persistedStateInfo, out string reconciliationOutcome)
     {
-        Block? repairedBlock = FindBlockByStateRoot(persistedStateInfo.BlockNumber, persistedStateInfo.StateRoot) ??
-            FindRecoverableCanonicalBoundary(Math.Min(restoredBlock.Number, persistedStateInfo.BlockNumber));
+        bool promotedRestoredBlockToMainChain = false;
+        Block? repairedBlock = null;
+        if (MatchesPersistedState(restoredBlock, persistedStateInfo))
+        {
+            repairedBlock = restoredBlock;
+            if (!IsCanonical(repairedBlock))
+            {
+                PromoteStartupBoundaryToMainChain(repairedBlock);
+                promotedRestoredBlockToMainChain = true;
+            }
+        }
+        else
+        {
+            repairedBlock = FindCanonicalBlockByStateRoot(persistedStateInfo.BlockNumber, persistedStateInfo.StateRoot);
+        }
 
         if (repairedBlock is null)
         {
@@ -464,59 +483,51 @@ public partial class BlockTree
                 $"{PersistedBoundaryRepairLogMarker}: failed to repair persisted boundary. " +
                 $"stored number={persistedNumber?.ToString() ?? "<none>"}, stored hash={persistedHash?.ToString() ?? "<none>"}, " +
                 $"restored block={restoredBlock.ToString(Block.Format.Short)}, " +
-                $"flat persisted state={persistedStateInfo.BlockNumber}/{persistedStateInfo.StateRoot}.");
+                $"flat persisted state={persistedStateInfo.BlockNumber}/{persistedStateInfo.StateRoot}, " +
+                "no canonical block matched the exact persisted flat-state identity.");
         }
 
         if (Logger.IsWarn)
         {
-            Logger.Warn(
-                $"{PersistedBoundaryRepairLogMarker}: persisted boundary repaired from {restoredBlock.ToString(Block.Format.Short)} " +
-                $"to {repairedBlock.ToString(Block.Format.Short)}.");
+            string repairAction = promotedRestoredBlockToMainChain
+                ? $"persisted boundary promoted to main chain at {repairedBlock.ToString(Block.Format.Short)}"
+                : $"persisted boundary repaired from {restoredBlock.ToString(Block.Format.Short)} to {repairedBlock.ToString(Block.Format.Short)}";
+            Logger.Warn($"{PersistedBoundaryRepairLogMarker}: {repairAction}.");
         }
 
-        reconciliationOutcome = $"repaired to {repairedBlock.ToString(Block.Format.Short)}";
+        reconciliationOutcome = promotedRestoredBlockToMainChain
+            ? $"promoted exact persisted-state block to main chain at {repairedBlock.ToString(Block.Format.Short)}"
+            : $"repaired to {repairedBlock.ToString(Block.Format.Short)}";
         BestPersistedState = repairedBlock.Number;
         return repairedBlock;
     }
 
-    private Block? FindBlockByStateRoot(long blockNumber, ValueHash256 stateRoot)
+    private Block? FindCanonicalBlockByStateRoot(long blockNumber, ValueHash256 stateRoot)
     {
-        ChainLevelInfo? level = LoadLevel(blockNumber);
-        if (level is null)
+        BlockInfo? canonicalInfo = FindCanonicalBlockInfo(blockNumber);
+        if (canonicalInfo?.BlockHash is not Hash256 blockHash)
         {
             return null;
         }
 
-        foreach (BlockInfo blockInfo in level.BlockInfos)
-        {
-            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber);
-            if (block?.StateRoot == stateRoot)
-            {
-                return block;
-            }
-        }
-
-        return null;
+        Block? canonicalBlock = FindBlock(blockHash, BlockTreeLookupOptions.None, blockNumber);
+        return canonicalBlock?.StateRoot == stateRoot ? canonicalBlock : null;
     }
 
-    private Block? FindRecoverableCanonicalBoundary(long startNumber)
+    private void PromoteStartupBoundaryToMainChain(Block block)
     {
-        for (long number = startNumber; number >= _genesisBlockNumber; number--)
-        {
-            BlockInfo? canonicalInfo = FindCanonicalBlockInfo(number);
-            if (canonicalInfo?.BlockHash is not Hash256 blockHash)
-            {
-                continue;
-            }
+        ChainLevelInfo? level = LoadLevel(block.Number) ?? throw new InvalidDataException(
+            $"Missing chain level at number {block.Number} while promoting startup boundary.");
+        int? index = level.FindIndex(block.Hash) ?? throw new InvalidDataException(
+            $"Unable to find startup boundary block {block.ToString(Block.Format.Short)} on its chain level.");
 
-            Block? canonicalBlock = FindBlock(blockHash, BlockTreeLookupOptions.None, number);
-            if (canonicalBlock is not null && _persistedStateInfoProvider?.HasRecoverableStateForBlock(canonicalBlock.Header) == true)
-            {
-                return canonicalBlock;
-            }
+        if (index.Value != 0)
+        {
+            level.SwapToMain(index.Value);
         }
 
-        return null;
+        level.HasBlockOnMainChain = true;
+        _chainLevelInfoRepository.PersistLevel(block.Number, level);
     }
 
     private void SetHeadBlock(Hash256 headHash)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -8,11 +8,13 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 
 namespace Nethermind.Blockchain;
 
 public partial class BlockTree
 {
+    private const string PersistedBoundaryRepairLogMarker = "PERSISTED-BOUNDARY-REPAIR";
     private bool _tryToRecoverFromHeaderBelowBodyCorruption = false;
 
     public void RecalculateTreeLevels()
@@ -322,14 +324,21 @@ public partial class BlockTree
     private void LoadStartBlock()
     {
         Block? startBlock = null;
+        string reconciliationOutcome = "startup boundary unavailable";
         byte[] persistedNumberData = _blockInfoDb.Get(StateHeadHashDbEntryAddress);
+        byte[]? persistedHashData = _blockInfoDb.Get(StateHeadBlockHashDbEntryAddress);
         BestPersistedState = persistedNumberData is null ? null : new Rlp.ValueDecoderContext(persistedNumberData).DecodeLong();
         long? persistedNumber = BestPersistedState;
+        Hash256? persistedHash = persistedHashData is null ? null : new Hash256(persistedHashData);
         if (persistedNumber is not null)
         {
-            startBlock = FindBlock(persistedNumber.Value, BlockTreeLookupOptions.None);
+            startBlock = TryLoadStartBlockFromExactBoundary(persistedNumber.Value, persistedHash)
+                ?? FindBlock(persistedNumber.Value, BlockTreeLookupOptions.None);
             if (Logger.IsInfo) Logger.Info(
                 $"Start block loaded from reorg boundary - {persistedNumber} - {startBlock?.ToString(Block.Format.Short)}");
+            reconciliationOutcome = persistedHash is null
+                ? "loaded from number-only persisted boundary metadata"
+                : "loaded from exact persisted-boundary hash metadata";
         }
         else
         {
@@ -338,7 +347,52 @@ public partial class BlockTree
             {
                 startBlock = FindBlock(new Hash256(data), BlockTreeLookupOptions.None);
                 if (Logger.IsInfo) Logger.Info($"Start block loaded from HEAD - {startBlock?.ToString(Block.Format.Short)}");
+                reconciliationOutcome = "loaded from legacy HEAD metadata";
             }
+        }
+
+        PersistedStateInfo? persistedStateInfoValue = null;
+        if (_persistedStateInfoProvider?.TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo) == true)
+        {
+            persistedStateInfoValue = persistedStateInfo;
+        }
+
+        if (persistedStateInfoValue is PersistedStateInfo exactPersistedState &&
+            startBlock is not null &&
+            !MatchesPersistedState(startBlock, exactPersistedState))
+        {
+            startBlock = RepairPersistedBoundary(startBlock, persistedNumber, persistedHash, exactPersistedState, out reconciliationOutcome);
+        }
+        else if (persistedStateInfoValue is PersistedStateInfo)
+        {
+            reconciliationOutcome = "validated against exact persisted state";
+        }
+        else if (startBlock is not null)
+        {
+            reconciliationOutcome = "persisted state info unavailable";
+        }
+
+        if (Logger.IsInfo)
+        {
+            BlockInfo? canonicalInfo = startBlock is null ? null : FindCanonicalBlockInfo(startBlock.Number);
+            bool? isCanonical = startBlock is null || startBlock.Hash is null
+                ? null
+                : canonicalInfo?.BlockHash == startBlock.Hash;
+            bool? hasRecoverableState = startBlock is null
+                ? null
+                : _persistedStateInfoProvider?.HasRecoverableStateForBlock(startBlock.Header);
+            string persistedStateDescription = _persistedStateInfoProvider?.TryGetPersistedStateInfo(out PersistedStateInfo stateInfo) == true
+                ? $"{stateInfo.BlockNumber} / {stateInfo.StateRoot}"
+                : "<unavailable>";
+
+            Logger.Info(
+                "Startup state diagnostics: " +
+                $"stored persisted boundary number={persistedNumber?.ToString() ?? "<none>"}, " +
+                $"stored persisted boundary hash={persistedHash?.ToString() ?? "<none>"}, " +
+                $"flat persisted state={persistedStateDescription}, " +
+                $"restored block={(startBlock?.ToString(Block.Format.Short) ?? "<none>")}, " +
+                $"restored canonical={isCanonical?.ToString() ?? "<n/a>"}, " +
+                $"restored recoverable={hasRecoverableState?.ToString() ?? "<n/a>"}.");
         }
 
         if (startBlock is not null)
@@ -349,7 +403,120 @@ public partial class BlockTree
             }
 
             SetHeadBlock(startBlock.Hash);
+            if (Logger.IsInfo)
+            {
+                Logger.Info($"Startup head set to {Head?.ToString(Block.Format.Short)}, state root: {Head?.StateRoot}.");
+            }
         }
+
+        LastStartupBoundaryDiagnostics = new StartupBoundaryDiagnostics(
+            persistedNumber,
+            persistedHash,
+            persistedStateInfoValue,
+            reconciliationOutcome);
+    }
+
+    private Block? TryLoadStartBlockFromExactBoundary(long persistedNumber, Hash256? persistedHash)
+    {
+        if (persistedHash is null)
+        {
+            return null;
+        }
+
+        Block? exactBlock = FindBlock(persistedHash, BlockTreeLookupOptions.None);
+        if (exactBlock is null)
+        {
+            if (Logger.IsWarn)
+            {
+                Logger.Warn($"Stored persisted boundary hash {persistedHash} could not be resolved at startup.");
+            }
+
+            return null;
+        }
+
+        if (exactBlock.Number != persistedNumber)
+        {
+            if (Logger.IsWarn)
+            {
+                Logger.Warn(
+                    $"Stored persisted boundary hash {persistedHash} resolved to block number {exactBlock.Number}, expected {persistedNumber}. Falling back to repair.");
+            }
+
+            return null;
+        }
+
+        return exactBlock;
+    }
+
+    private static bool MatchesPersistedState(Block block, PersistedStateInfo persistedStateInfo) =>
+        block.Number == persistedStateInfo.BlockNumber &&
+        block.StateRoot == persistedStateInfo.StateRoot;
+
+    private Block RepairPersistedBoundary(Block restoredBlock, long? persistedNumber, Hash256? persistedHash, PersistedStateInfo persistedStateInfo, out string reconciliationOutcome)
+    {
+        Block? repairedBlock = FindBlockByStateRoot(persistedStateInfo.BlockNumber, persistedStateInfo.StateRoot) ??
+            FindRecoverableCanonicalBoundary(Math.Min(restoredBlock.Number, persistedStateInfo.BlockNumber));
+
+        if (repairedBlock is null)
+        {
+            reconciliationOutcome = "repair failed";
+            throw new InvalidDataException(
+                $"{PersistedBoundaryRepairLogMarker}: failed to repair persisted boundary. " +
+                $"stored number={persistedNumber?.ToString() ?? "<none>"}, stored hash={persistedHash?.ToString() ?? "<none>"}, " +
+                $"restored block={restoredBlock.ToString(Block.Format.Short)}, " +
+                $"flat persisted state={persistedStateInfo.BlockNumber}/{persistedStateInfo.StateRoot}.");
+        }
+
+        if (Logger.IsWarn)
+        {
+            Logger.Warn(
+                $"{PersistedBoundaryRepairLogMarker}: persisted boundary repaired from {restoredBlock.ToString(Block.Format.Short)} " +
+                $"to {repairedBlock.ToString(Block.Format.Short)}.");
+        }
+
+        reconciliationOutcome = $"repaired to {repairedBlock.ToString(Block.Format.Short)}";
+        BestPersistedState = repairedBlock.Number;
+        return repairedBlock;
+    }
+
+    private Block? FindBlockByStateRoot(long blockNumber, ValueHash256 stateRoot)
+    {
+        ChainLevelInfo? level = LoadLevel(blockNumber);
+        if (level is null)
+        {
+            return null;
+        }
+
+        foreach (BlockInfo blockInfo in level.BlockInfos)
+        {
+            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber);
+            if (block?.StateRoot == stateRoot)
+            {
+                return block;
+            }
+        }
+
+        return null;
+    }
+
+    private Block? FindRecoverableCanonicalBoundary(long startNumber)
+    {
+        for (long number = startNumber; number >= _genesisBlockNumber; number--)
+        {
+            BlockInfo? canonicalInfo = FindCanonicalBlockInfo(number);
+            if (canonicalInfo?.BlockHash is not Hash256 blockHash)
+            {
+                continue;
+            }
+
+            Block? canonicalBlock = FindBlock(blockHash, BlockTreeLookupOptions.None, number);
+            if (canonicalBlock is not null && _persistedStateInfoProvider?.HasRecoverableStateForBlock(canonicalBlock.Header) == true)
+            {
+                return canonicalBlock;
+            }
+        }
+
+        return null;
     }
 
     private void SetHeadBlock(Hash256 headHash)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -25,15 +25,23 @@ using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 using Nethermind.State.Repositories;
 using Nethermind.Db.Blooms;
 
 namespace Nethermind.Blockchain
 {
+    public readonly record struct StartupBoundaryDiagnostics(
+        long? StoredPersistedBoundaryNumber,
+        Hash256? StoredPersistedBoundaryHash,
+        PersistedStateInfo? PersistedStateInfo,
+        string ReconciliationOutcome);
+
     public partial class BlockTree : IBlockTree
     {
         // there is not much logic in the addressing here
         private static readonly byte[] StateHeadHashDbEntryAddress = new byte[16];
+        private static readonly byte[] StateHeadBlockHashDbEntryAddress = CreateMetadataAddress(1);
         internal static Hash256 DeletePointerAddressInDb = new(new BitArray(32 * 8, true).ToBytes());
         internal static Hash256 HeadAddressInDb = Keccak.Zero;
 
@@ -45,6 +53,7 @@ namespace Nethermind.Blockchain
         private readonly IDb _metadataDb;
         private readonly IBadBlockStore _badBlockStore;
         private readonly IBlockAccessListStore _balStore;
+        private readonly IPersistedStateInfoProvider? _persistedStateInfoProvider;
 
         private readonly LruCache<ValueHash256, Block> _invalidBlocks =
             new(128, 128, "invalid blocks");
@@ -54,6 +63,7 @@ namespace Nethermind.Blockchain
         private readonly IBloomStorage _bloomStorage;
         private readonly ISyncConfig _syncConfig;
         private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
+        public StartupBoundaryDiagnostics? LastStartupBoundaryDiagnostics { get; private set; }
 
         public BlockHeader? Genesis { get; protected set; }
         public Block? Head { get; private set; }
@@ -120,6 +130,7 @@ namespace Nethermind.Blockchain
             IBloomStorage? bloomStorage,
             ISyncConfig? syncConfig,
             ILogManager? logManager,
+            IPersistedStateInfoProvider? persistedStateInfoProvider = null,
             long genesisBlockNumber = 0)
         {
             Logger = logManager?.GetClassLogger<BlockTree>() ?? throw new ArgumentNullException(nameof(logManager));
@@ -129,6 +140,7 @@ namespace Nethermind.Blockchain
             _metadataDb = metadataDb ?? throw new ArgumentNullException(nameof(metadataDb));
             _badBlockStore = badBlockStore ?? throw new ArgumentNullException(nameof(badBlockStore));
             _balStore = balStore ?? throw new ArgumentNullException(nameof(balStore));
+            _persistedStateInfoProvider = persistedStateInfoProvider;
             SpecProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _bloomStorage = bloomStorage ?? throw new ArgumentNullException(nameof(bloomStorage));
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
@@ -191,6 +203,13 @@ namespace Nethermind.Blockchain
             {
                 ThisNodeInfo.AddInfo("Network ID   :", $"{NetworkId}");
             }
+        }
+
+        private static byte[] CreateMetadataAddress(byte marker)
+        {
+            byte[] address = new byte[16];
+            address[^1] = marker;
+            return address;
         }
 
         public AddBlockResult Insert(BlockHeader header, BlockTreeInsertHeaderOptions headerOptions = BlockTreeInsertHeaderOptions.None)
@@ -1726,9 +1745,22 @@ namespace Nethermind.Blockchain
             set
             {
                 _highestPersistedState = value;
-                if (value.HasValue)
+                using (_blockInfoDb.StartWriteBatch())
                 {
-                    _blockInfoDb.Set(StateHeadHashDbEntryAddress, Rlp.Encode(value.Value).Bytes);
+                    if (value.HasValue)
+                    {
+                        _blockInfoDb.Set(StateHeadHashDbEntryAddress, Rlp.Encode(value.Value).Bytes);
+
+                        BlockInfo? canonicalInfo = FindCanonicalBlockInfo(value.Value);
+                        if (canonicalInfo?.BlockHash is Hash256 blockHash)
+                        {
+                            _blockInfoDb.PutSpan(StateHeadBlockHashDbEntryAddress, blockHash.Bytes);
+                        }
+                        else
+                        {
+                            _blockInfoDb.Remove(StateHeadBlockHashDbEntryAddress);
+                        }
+                    }
                 }
 
                 TryUpdateSyncPivot();

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -40,8 +40,8 @@ namespace Nethermind.Blockchain
     public partial class BlockTree : IBlockTree
     {
         // there is not much logic in the addressing here
-        private static readonly byte[] StateHeadHashDbEntryAddress = new byte[16];
-        private static readonly byte[] StateHeadBlockHashDbEntryAddress = CreateMetadataAddress(1);
+        internal static readonly byte[] StateHeadHashDbEntryAddress = new byte[16];
+        internal static readonly byte[] StateHeadBlockHashDbEntryAddress = CreateMetadataAddress(1);
         internal static Hash256 DeletePointerAddressInDb = new(new BitArray(32 * 8, true).ToBytes());
         internal static Hash256 HeadAddressInDb = Keccak.Zero;
 
@@ -1745,9 +1745,9 @@ namespace Nethermind.Blockchain
             set
             {
                 _highestPersistedState = value;
-                using (_blockInfoDb.StartWriteBatch())
+                if (value.HasValue)
                 {
-                    if (value.HasValue)
+                    using (_blockInfoDb.StartWriteBatch())
                     {
                         _blockInfoDb.Set(StateHeadHashDbEntryAddress, Rlp.Encode(value.Value).Bytes);
 

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -33,8 +34,9 @@ namespace Nethermind.Blockchain.Visitors
         private long? _lastProcessedLevel;
         private long? _processingGapStart;
 
-        private bool _firstBlockVisited = true;
         private bool _suggestBlocks = true;
+        private HashSet<Hash256> _eligibleParentHashes = [];
+        private HashSet<Hash256> _suggestedBlockHashesInCurrentLevel = [];
         private readonly BlockTreeSuggestPacer _blockTreeSuggestPacer;
         private readonly IPersistedStateInfoProvider? _persistedStateInfoProvider;
 
@@ -77,9 +79,15 @@ namespace Nethermind.Blockchain.Visitors
 
             _blocksCheckedInCurrentLevel = 0;
             _bodiesInCurrentLevel = 0;
+            _suggestedBlockHashesInCurrentLevel = [];
 
             _currentLevelNumber++;
             _currentLevel = chainLevelInfo;
+            _eligibleParentHashes = GetEligibleParentHashesForLevel();
+            if (_currentLevelNumber == StartLevelInclusive)
+            {
+                _suggestBlocks = CanSuggestBlocksFromHead();
+            }
 
             if ((_currentLevelNumber - StartLevelInclusive) % 1000 == 0)
             {
@@ -145,12 +153,10 @@ namespace Nethermind.Blockchain.Visitors
             _blocksCheckedInCurrentLevel++;
             _bodiesInCurrentLevel++;
 
-            if (_firstBlockVisited)
+            if (!_suggestBlocks || !ShouldSuggestBlock(block))
             {
-                _suggestBlocks = CanSuggestBlocks(block);
+                return BlockVisitOutcome.None;
             }
-
-            if (!_suggestBlocks) return BlockVisitOutcome.None;
 
             Task waitSuggestQueue = _blockTreeSuggestPacer.WaitForQueue(block.Number, cancellationToken);
 
@@ -164,6 +170,11 @@ namespace Nethermind.Blockchain.Visitors
                 }
 
                 await waitSuggestQueue;
+            }
+
+            if (block.Hash is not null)
+            {
+                _suggestedBlockHashesInCurrentLevel.Add(block.Hash);
             }
 
             return BlockVisitOutcome.Suggest;
@@ -203,6 +214,7 @@ namespace Nethermind.Blockchain.Visitors
                 return Task.FromResult(LevelVisitOutcome.DeleteLevel);
             }
 
+            _eligibleParentHashes = _suggestedBlockHashesInCurrentLevel;
             return Task.FromResult(LevelVisitOutcome.None);
         }
 
@@ -215,22 +227,42 @@ namespace Nethermind.Blockchain.Visitors
             }
         }
 
-        private bool CanSuggestBlocks(Block block)
+        private bool CanSuggestBlocksFromHead()
         {
-            _firstBlockVisited = false;
-            if (block?.ParentHash is not null)
+            Block? head = _blockTree.Head;
+            return head is not null &&
+                head.StateRoot is not null &&
+                _stateReader.HasStateForBlock(head.Header);
+        }
+
+        private HashSet<Hash256> GetEligibleParentHashesForLevel()
+        {
+            if (_currentLevelNumber == StartLevelInclusive)
             {
-                BlockHeader? parentHeader = _blockTree.FindParentHeader(block.Header, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                if (parentHeader is null || parentHeader.StateRoot is null ||
-                    !_stateReader.HasStateForBlock(parentHeader))
-                    return false;
+                return _blockTree.Head?.Hash is Hash256 headHash ? [headHash] : [];
             }
-            else
+
+            return _eligibleParentHashes.Count == 0 ? [] : [.. _eligibleParentHashes];
+        }
+
+        private bool ShouldSuggestBlock(Block block)
+        {
+            if (block.ParentHash is null || !_eligibleParentHashes.Contains(block.ParentHash))
             {
                 return false;
             }
 
-            return true;
+            if (_currentLevelNumber != StartLevelInclusive)
+            {
+                return true;
+            }
+
+            BlockHeader? parentHeader = _blockTree.Head?.Hash == block.ParentHash
+                ? _blockTree.Head?.Header
+                : _blockTree.FindParentHeader(block.Header, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            return parentHeader is not null &&
+                parentHeader.StateRoot is not null &&
+                _stateReader.HasStateForBlock(parentHeader);
         }
 
         private void LogPlannedOperation()

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -36,24 +36,28 @@ namespace Nethermind.Blockchain.Visitors
         private bool _firstBlockVisited = true;
         private bool _suggestBlocks = true;
         private readonly BlockTreeSuggestPacer _blockTreeSuggestPacer;
+        private readonly IPersistedStateInfoProvider? _persistedStateInfoProvider;
 
         public StartupBlockTreeFixer(
             ISyncConfig syncConfig,
             IBlockTree blockTree,
             IStateReader stateReader,
             ILogger logger,
-            long batchSize = DefaultBatchSize)
+            long batchSize = DefaultBatchSize,
+            IPersistedStateInfoProvider? persistedStateInfoProvider = null)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _blockTreeSuggestPacer = new BlockTreeSuggestPacer(_blockTree, batchSize, batchSize / 2);
             _stateReader = stateReader;
             _logger = logger;
+            _persistedStateInfoProvider = persistedStateInfoProvider;
 
             long assumedHead = _blockTree.Head?.Number ?? 0;
             _startNumber = Math.Max(_blockTree.SyncPivot.BlockNumber, assumedHead + 1);
             _blocksToLoad = (assumedHead + 1) >= _startNumber ? (_blockTree.BestKnownNumber - _startNumber + 1) : 0;
 
             _currentLevelNumber = _startNumber - 1; // because we always increment on entering
+            LogPersistedStateMismatch();
             LogPlannedOperation();
         }
 
@@ -240,6 +244,31 @@ namespace Nethermind.Blockchain.Visitors
                 if (_logger.IsInfo)
                     _logger.Info(
                         $"Found {_blocksToLoad} block tree levels to review for fixes starting from {StartLevelInclusive}");
+            }
+        }
+
+        private void LogPersistedStateMismatch()
+        {
+            if (_blockTree.Head is not { } head)
+            {
+                return;
+            }
+
+            if (_persistedStateInfoProvider?.TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo) != true)
+            {
+                return;
+            }
+
+            if (head.Number == persistedStateInfo.BlockNumber && head.StateRoot == persistedStateInfo.StateRoot)
+            {
+                return;
+            }
+
+            if (_logger.IsError)
+            {
+                _logger.Error(
+                    $"Startup head does not match persisted state info. Head={head.ToString(Block.Format.Short)} root={head.StateRoot}, " +
+                    $"persisted state={persistedStateInfo.BlockNumber}/{persistedStateInfo.StateRoot}.");
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -149,6 +149,11 @@ namespace Nethermind.Blockchain.Visitors
 
         async Task<BlockVisitOutcome> IBlockTreeVisitor.VisitBlock(Block block, CancellationToken cancellationToken)
         {
+            if (block is null)
+            {
+                return BlockVisitOutcome.None;
+            }
+
             AssertNotVisitingAfterGap();
             _blocksCheckedInCurrentLevel++;
             _bodiesInCurrentLevel++;

--- a/src/Nethermind/Nethermind.Consensus.Test/ReadOnlyTxProcessingScopeTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ReadOnlyTxProcessingScopeTests.cs
@@ -43,9 +43,11 @@ public class ReadOnlyTxProcessingScopeTests
 
         Task waitTask = Task.Run(() => BlockCachePreWarmer.WaitForAddressWarmer(doneEvent, TimeSpan.FromMilliseconds(100), block, new ILogger(logger)));
 
-        await Task.Delay(250);
-
-        logger.LogList.Should().Contain(log => log.Contains("Waiting for address warmer to finish", StringComparison.Ordinal));
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+        while (!logger.LogList.Exists(log => log.Contains("Waiting for address warmer to finish", StringComparison.Ordinal)))
+        {
+            await Task.Delay(10, cts.Token);
+        }
         waitTask.IsCompleted.Should().BeFalse("the prewarmer must not report completion while the address warmer is still running");
 
         doneEvent.Set();

--- a/src/Nethermind/Nethermind.Consensus.Test/ReadOnlyTxProcessingScopeTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ReadOnlyTxProcessingScopeTests.cs
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Evm.State;
+using Nethermind.Logging;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -27,5 +32,23 @@ public class ReadOnlyTxProcessingScopeTests
         env.Dispose();
 
         closed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task AddressWarmerWait_WhenWarmupDoesNotFinish_WarnsWithoutReportingCompletion()
+    {
+        using ManualResetEventSlim doneEvent = new(initialState: false);
+        TestLogger logger = new();
+        Block block = Build.A.Block.WithNumber(123).TestObject;
+
+        Task waitTask = Task.Run(() => BlockCachePreWarmer.WaitForAddressWarmer(doneEvent, TimeSpan.FromMilliseconds(100), block, new ILogger(logger)));
+
+        await Task.Delay(250);
+
+        logger.LogList.Should().Contain(log => log.Contains("Waiting for address warmer to finish", StringComparison.Ordinal));
+        waitTask.IsCompleted.Should().BeFalse("the prewarmer must not report completion while the address warmer is still running");
+
+        doneEvent.Set();
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -33,6 +33,8 @@ public sealed class BlockCachePreWarmer(
     ILogManager logManager
 ) : IBlockCachePreWarmer
 {
+    internal static readonly TimeSpan AddressWarmerWaitWarningInterval = TimeSpan.FromSeconds(30);
+
     private readonly int _concurrencyLevel = concurrency == 0 ? Math.Min(Environment.ProcessorCount - 1, 16) : concurrency;
     private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory, preBlockCaches), Environment.ProcessorCount * 2);
     private readonly ILogger _logger = logManager.GetClassLogger<BlockCachePreWarmer>();
@@ -87,6 +89,17 @@ public sealed class BlockCachePreWarmer(
         cachesCleared |= nodeStorageCache.ClearCaches() ? CacheType.Rlp : CacheType.None;
         if (_logger.IsDebug) _logger.Debug($"Cleared caches: {cachesCleared}");
         return cachesCleared;
+    }
+
+    internal static void WaitForAddressWarmer(ManualResetEventSlim doneEvent, TimeSpan warningInterval, Block block, ILogger logger)
+    {
+        while (!doneEvent.Wait(warningInterval))
+        {
+            if (logger.IsWarn)
+            {
+                logger.Warn($"Waiting for address warmer to finish for block {block.ToString(Block.Format.Short)}.");
+            }
+        }
     }
 
     private void PreWarmCachesParallel(BlockState blockState, Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
@@ -283,7 +296,7 @@ public sealed class BlockCachePreWarmer(
         private readonly ArrayPoolList<AccessList>? SystemTxAccessLists = GetAccessLists(block, spec, systemAccessLists);
         private readonly ManualResetEventSlim _doneEvent = new(initialState: false);
 
-        public void Wait() => _doneEvent.Wait();
+        public void Wait() => WaitForAddressWarmer(_doneEvent, AddressWarmerWaitWarningInterval, Block, PreWarmer._logger);
 
         private static ArrayPoolList<AccessList>? GetAccessLists(Block block, IReleaseSpec spec, ReadOnlySpan<IHasAccessList> systemAccessLists)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -41,6 +41,7 @@ namespace Nethermind.Consensus.Processing
 
                 for (int i = 0; i < block.Transactions.Length; i++)
                 {
+                    token.ThrowIfCancellationRequested();
                     _balBuilder?.GeneratedBlockAccessList.IncrementBlockAccessIndex();
                     Transaction currentTx = block.Transactions[i];
                     ProcessTransaction(block, currentTx, i, receiptsTracer, processingOptions);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -71,6 +71,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private CancellationTokenSource? _loopCancellationSource;
     private Task? _recoveryTask;
     private Task? _processorTask;
+    private Task? _watchdogTask;
     private DateTime _lastProcessedBlock;
 
     private int _currentRecoveryQueueSize;
@@ -78,6 +79,9 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private const int MaxBranchSize = 8192;
     private readonly CompositeBlockTracer _compositeBlockTracer = new();
     private readonly Stopwatch _stopwatch = new();
+    private Block? _currentProcessingWatchdogBlock;
+    private long _currentProcessingWatchdogStartTimestamp;
+    private int _watchdogWarningCount;
 
     public event EventHandler<IBlockchainProcessor.InvalidBlockEventArgs>? InvalidBlock;
     public event EventHandler<BlockStatistics>? NewProcessingStatistics;
@@ -198,6 +202,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         _loopCancellationSource ??= new CancellationTokenSource();
         _recoveryTask = RunRecovery();
         _processorTask = RunProcessing();
+        _watchdogTask = RunProcessingWatchdog();
 
         if (_logger.IsInfo) _logger.Info($"{nameof(BlockchainProcessor)} started.");
 
@@ -218,6 +223,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
 
         _recoveryComplete = true;
+        CancellationTokenSource? loopCancellationSource = _loopCancellationSource;
         if (processRemainingBlocks)
         {
             _recoveryQueue.Writer.TryComplete();
@@ -226,12 +232,16 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
         else
         {
-            CancellationTokenExtensions.CancelDisposeAndClear(ref _loopCancellationSource);
+            loopCancellationSource?.Cancel();
             _recoveryQueue.Writer.TryComplete();
             _blockQueue.Writer.TryComplete();
         }
 
         await Task.WhenAll(_recoveryTask ?? Task.CompletedTask, _processorTask ?? Task.CompletedTask);
+        loopCancellationSource?.Cancel();
+        await (_watchdogTask ?? Task.CompletedTask);
+        loopCancellationSource?.Dispose();
+        _loopCancellationSource = null;
         if (isStarted && _logger.IsInfo) _logger.Info($"{nameof(BlockchainProcessor)} shutdown complete.");
     }
 
@@ -318,6 +328,75 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
     }
 
+    private async Task RunProcessingWatchdog()
+    {
+        TimeSpan threshold = _options.BlockProcessingWatchdogThreshold;
+        if (threshold <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        TimeSpan repeatInterval = _options.BlockProcessingWatchdogRepeatInterval <= TimeSpan.Zero
+            ? threshold
+            : _options.BlockProcessingWatchdogRepeatInterval;
+        TimeSpan pollInterval = threshold < TimeSpan.FromSeconds(1)
+            ? threshold
+            : TimeSpan.FromSeconds(1);
+        if (repeatInterval < pollInterval)
+        {
+            pollInterval = repeatInterval;
+        }
+
+        if (pollInterval <= TimeSpan.Zero)
+        {
+            pollInterval = TimeSpan.FromMilliseconds(100);
+        }
+
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(pollInterval, CancellationToken);
+
+                Block? currentBlock = Volatile.Read(ref _currentProcessingWatchdogBlock);
+                long currentStartTimestamp = Volatile.Read(ref _currentProcessingWatchdogStartTimestamp);
+                if (currentBlock is null || currentStartTimestamp == 0)
+                {
+                    continue;
+                }
+
+                TimeSpan elapsed = Stopwatch.GetElapsedTime(currentStartTimestamp);
+                int warningCount = Volatile.Read(ref _watchdogWarningCount);
+                TimeSpan nextWarningAt = threshold + TimeSpan.FromTicks(repeatInterval.Ticks * warningCount);
+                if (elapsed < nextWarningAt)
+                {
+                    continue;
+                }
+
+                if (!ReferenceEquals(currentBlock, Volatile.Read(ref _currentProcessingWatchdogBlock)) ||
+                    currentStartTimestamp != Volatile.Read(ref _currentProcessingWatchdogStartTimestamp))
+                {
+                    continue;
+                }
+
+                if (Interlocked.CompareExchange(ref _watchdogWarningCount, warningCount + 1, warningCount) != warningCount)
+                {
+                    continue;
+                }
+
+                if (_logger.IsWarn)
+                {
+                    _logger.Warn(
+                        $"Block processing watchdog: block {currentBlock.ToString(Block.Format.Short)} has been processing for {elapsed}. " +
+                        $"IsProcessingBlock={IsProcessingBlock}.");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
     private bool IsProcessingBlock { get => _isProcessingBlock; set { _isProcessingBlock = value; _blockTree.IsProcessingBlock = value; } }
 
     private async Task RunProcessingLoop()
@@ -354,6 +433,20 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         void Trace() => _logger.Trace($"Now {_blockQueue.Reader.Count} blocks waiting in the queue.");
     }
 
+    private void StartProcessingWatchdog(Block block)
+    {
+        Volatile.Write(ref _currentProcessingWatchdogBlock, block);
+        Volatile.Write(ref _currentProcessingWatchdogStartTimestamp, Stopwatch.GetTimestamp());
+        Volatile.Write(ref _watchdogWarningCount, 0);
+    }
+
+    private void ClearProcessingWatchdog()
+    {
+        Volatile.Write(ref _currentProcessingWatchdogBlock, null);
+        Volatile.Write(ref _currentProcessingWatchdogStartTimestamp, 0);
+        Volatile.Write(ref _watchdogWarningCount, 0);
+    }
+
     private void ProcessBlocks()
     {
         bool isTrace = _logger.IsTrace;
@@ -369,6 +462,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
                 Block block = blockRef.Block;
                 if (isTrace) TraceProcessing(block);
 
+                StartProcessingWatchdog(block);
                 _stats.Start();
                 Block processedBlock = Process(block, blockRef.ProcessingOptions, _compositeBlockTracer.GetTracer(), CancellationToken, out string? error);
 
@@ -388,6 +482,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             }
             finally
             {
+                ClearProcessingWatchdog();
                 Interlocked.Decrement(ref _queueCount);
             }
         }
@@ -811,8 +906,25 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             => _logger.Trace($"State root lookup: {stateRoot}");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowMaxBranchSizeReached()
-            => throw new InvalidOperationException($"Maximum size of branch reached ({MaxBranchSize}). This is unexpected.");
+        void ThrowMaxBranchSizeReached() => throw new InvalidOperationException(
+            BuildMaxBranchSizeReachedMessage(_blockTree, suggestedBlock, toBeProcessed, branchingPoint));
+    }
+
+    internal static string BuildMaxBranchSizeReachedMessage(IBlockTree blockTree, Block suggestedBlock, Block? currentBlock, BlockHeader? branchingPoint)
+    {
+        StartupBoundaryDiagnostics? startupDiagnostics = (blockTree as BlockTree)?.LastStartupBoundaryDiagnostics;
+        PersistedStateInfo? persistedStateInfo = startupDiagnostics?.PersistedStateInfo;
+        return
+            $"Maximum size of branch reached ({MaxBranchSize}). This is unexpected. " +
+            $"Suggested block={suggestedBlock.ToString(Block.Format.Short)}, " +
+            $"current block={currentBlock?.ToString(Block.Format.Short) ?? "<null>"}, " +
+            $"branching point={branchingPoint?.ToString(BlockHeader.Format.Short) ?? "<null>"}, " +
+            $"head={blockTree.Head?.ToString(Block.Format.Short) ?? "<null>"} root={blockTree.Head?.StateRoot?.ToString() ?? "<null>"}, " +
+            $"best persisted state={blockTree.BestPersistedState?.ToString() ?? "<none>"}, " +
+            $"stored persisted boundary number={startupDiagnostics?.StoredPersistedBoundaryNumber?.ToString() ?? "<unavailable>"}, " +
+            $"stored persisted boundary hash={startupDiagnostics?.StoredPersistedBoundaryHash?.ToString() ?? "<unavailable>"}, " +
+            $"flat persisted state={(persistedStateInfo is PersistedStateInfo stateInfo ? $"{stateInfo.BlockNumber}/{stateInfo.StateRoot}" : "<unavailable>")}, " +
+            $"startup reconciliation outcome={startupDiagnostics?.ReconciliationOutcome ?? "<unavailable>"}";
     }
 
     [Todo(Improve.Refactor, "This probably can be made conditional (in DEBUG only)")]
@@ -903,6 +1015,8 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         public static Options Default = new();
 
         public bool StoreReceiptsByDefault { get; set; } = true;
+        public TimeSpan BlockProcessingWatchdogThreshold { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan BlockProcessingWatchdogRepeatInterval { get; set; } = TimeSpan.FromSeconds(30);
 
         public DumpOptions DumpOptions { get; set; } = DumpOptions.None;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -182,7 +182,11 @@ public class BranchProcessor(
         }
         catch (Exception ex) // try to restore at all cost
         {
-            if (_logger.IsWarn) _logger.Warn($"Encountered exception {ex} while processing blocks.");
+            bool expectedCancellation = ex is OperationCanceledException && token.IsCancellationRequested;
+            if (!expectedCancellation && _logger.IsWarn)
+            {
+                _logger.Warn($"Encountered exception {ex} while processing blocks.");
+            }
             CancellationTokenExtensions.CancelDisposeAndClear(ref backgroundCancellation);
             QueueClearCaches(preWarmTask);
             WaitAndClear(ref preWarmTask);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -33,6 +33,7 @@ public class BranchProcessor(
     private Task _clearTask = Task.CompletedTask;
 
     private const int MaxUncommittedBlocks = 64;
+    private static readonly TimeSpan PreWarmWaitWarningInterval = TimeSpan.FromSeconds(30);
     private readonly Action<Task> _clearCaches = _ => preWarmer?.ClearCaches();
 
     public event EventHandler<BlockProcessedEventArgs>? BlockProcessed;
@@ -193,9 +194,19 @@ public class BranchProcessor(
             worldStateCloser?.Dispose();
         }
 
-        static void WaitAndClear(ref Task? task)
+        void WaitAndClear(ref Task? task)
         {
-            task?.GetAwaiter().GetResult();
+            if (task is not null)
+            {
+                while (!task.Wait(PreWarmWaitWarningInterval))
+                {
+                    if (_logger.IsWarn)
+                    {
+                        _logger.Warn("Waiting for prewarmer task to finish before continuing block processing.");
+                    }
+                }
+            }
+
             task = null;
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -16,6 +16,7 @@ using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.State.Repositories;
 using Nethermind.Db.Blooms;
@@ -34,6 +35,7 @@ namespace Nethermind.Core.Test.Builders
         private Hash256? _stateRoot;
         private Func<Block, Hash256>? _stateRootGen;
         private Func<Block, Transaction, IEnumerable<LogEntry>>? _logCreationFunction;
+        private IPersistedStateInfoProvider? _persistedStateInfoProvider;
 
         private bool _onlyHeaders;
         private bool _noHead = false;
@@ -76,7 +78,8 @@ namespace Nethermind.Core.Test.Builders
                         _specProvider,
                         BloomStorage,
                         SyncConfig,
-                        LimboLogs.Instance);
+                        LimboLogs.Instance,
+                        _persistedStateInfoProvider);
                 }
 
                 return _blockTree;
@@ -523,6 +526,12 @@ namespace Nethermind.Core.Test.Builders
         public BlockTreeBuilder WithSyncConfig(ISyncConfig syncConfig)
         {
             SyncConfig = syncConfig;
+            return this;
+        }
+
+        public BlockTreeBuilder WithPersistedStateInfoProvider(IPersistedStateInfoProvider persistedStateInfoProvider)
+        {
+            _persistedStateInfoProvider = persistedStateInfoProvider;
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Threading;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.State;
 using Nethermind.State.Flat;
 using Nethermind.Trie.Pruning;
 using NUnit.Framework;
@@ -34,6 +36,11 @@ internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbMa
         IgnoreOnInvalidState(stateId);
         return flatDbManager.HasStateForBlock(stateId);
     }
+
+    public bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo) =>
+        flatDbManager.TryGetPersistedStateInfo(out persistedStateInfo);
+
+    public bool HasRecoverableStateForBlock(BlockHeader? blockHeader) => flatDbManager.HasRecoverableStateForBlock(blockHeader);
 
     private void IgnoreOnInvalidState(StateId stateId)
     {

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -60,6 +60,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 ctx.Resolve<IFlatDbConfig>(),
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IMetricsConfig>().EnableDetailedMetric))
+            .Bind<IPersistedStateInfoProvider, IFlatDbManager>()
             .AddSingleton<IResourcePool, ResourcePool>()
             .AddSingleton<ITrieNodeCache, TrieNodeCache>()
             .AddSingleton<ISnapshotCompactor, SnapshotCompactor>()

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -60,7 +60,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 ctx.Resolve<IFlatDbConfig>(),
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IMetricsConfig>().EnableDetailedMetric))
-            .Bind<IPersistedStateInfoProvider, IFlatDbManager>()
+            .AddSingleton<IPersistedStateInfoProvider, FlatPersistedStateInfoProvider>()
             .AddSingleton<IResourcePool, ResourcePool>()
             .AddSingleton<ITrieNodeCache, TrieNodeCache>()
             .AddSingleton<ISnapshotCompactor, SnapshotCompactor>()

--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -22,7 +22,8 @@ namespace Nethermind.Init.Steps
         ISyncConfig syncConfig,
         IBlockProcessingQueue blockProcessingQueue,
         IBlockTree blockTree,
-        ILogManager logManager
+        ILogManager logManager,
+        IPersistedStateInfoProvider? persistedStateInfoProvider = null
     ) : IStep
     {
         private readonly ILogger _logger = logManager.GetClassLogger();
@@ -58,7 +59,7 @@ namespace Nethermind.Init.Steps
             }
             else
             {
-                using StartupBlockTreeFixer fixer = new(syncConfig, blockTree, worldStateManager!.GlobalStateReader, _logger!);
+                using StartupBlockTreeFixer fixer = new(syncConfig, blockTree, worldStateManager!.GlobalStateReader, _logger!, persistedStateInfoProvider: persistedStateInfoProvider);
                 await blockTree.Accept(fixer, cancellationToken).ContinueWith(t =>
                 {
                     if (t.IsFaulted)

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
@@ -51,7 +52,7 @@ public class FlatDbManagerTests
         _cts.Dispose();
     }
 
-    private FlatDbManager CreateManager() => new(
+    private FlatDbManager CreateManager(ILogManager? logManager = null, TimeSpan? compactorEnqueueWarningDelay = null) => new(
         _resourcePool,
         _processExitSource,
         _trieNodeCache,
@@ -59,8 +60,9 @@ public class FlatDbManagerTests
         _snapshotRepository,
         _persistenceManager,
         _config,
-        LimboLogs.Instance,
-        enableDetailedMetrics: false);
+        logManager ?? LimboLogs.Instance,
+        enableDetailedMetrics: false,
+        compactorEnqueueWarningDelay: compactorEnqueueWarningDelay);
 
     private static StateId CreateStateId(long blockNumber, byte rootByte = 0)
     {
@@ -256,7 +258,7 @@ public class FlatDbManagerTests
     [Test]
     public async Task AddSnapshot_WhenCompactorQueueIsFull_CompletesWithinBoundedTime()
     {
-        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3) =
+        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3, _) =
             await SetupSaturatedCompactorQueue();
         await using (manager)
         {
@@ -267,7 +269,7 @@ public class FlatDbManagerTests
                 Task completedTask = await Task.WhenAny(thirdAddSnapshot, Task.Delay(TimeSpan.FromMilliseconds(500)));
                 bool completed = completedTask == thirdAddSnapshot;
 
-                Assert.That(completed, Is.True, "AddSnapshot should not remain blocked when the compactor queue is saturated.");
+                Assert.That(completed, Is.False, "AddSnapshot should wait for the background compactor pipeline instead of executing compaction inline.");
             }
             finally
             {
@@ -280,16 +282,22 @@ public class FlatDbManagerTests
     [Test]
     public async Task AddSnapshot_WhenQueueSaturated_EmitsBackpressureSignal()
     {
-        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3) =
+        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3, TestLogger testLogger) =
             await SetupSaturatedCompactorQueue();
         await using (manager)
         {
-            manager.AddSnapshot(snapshot3, resource3);
+            Task blockedAddSnapshot = Task.Run(() => manager.AddSnapshot(snapshot3, resource3));
 
+            Assert.That(
+                SpinWait.SpinUntil(
+                    () => testLogger.LogList.Exists(log => log.Contains("Compactor job stall!", StringComparison.Ordinal)),
+                    TimeSpan.FromSeconds(2)),
+                Is.True,
+                "Expected a warning while waiting to enqueue a compactor job.");
             Assert.That(Metrics.CompactorQueueFullCount, Is.EqualTo(1));
-            Assert.That(Metrics.InlineDrainActivationCount, Is.EqualTo(1));
 
             releaseCompaction.TrySetResult();
+            await blockedAddSnapshot.WaitAsync(TimeSpan.FromSeconds(5));
         }
     }
 
@@ -297,7 +305,7 @@ public class FlatDbManagerTests
     /// Creates a FlatDbManager with MaxInFlightCompactJob=1, fills the queue with two snapshots (first blocks compaction),
     /// and returns the manager, a release handle, and a third snapshot ready to trigger backpressure.
     /// </summary>
-    private async Task<(FlatDbManager Manager, TaskCompletionSource ReleaseCompaction, Snapshot Snapshot3, TransientResource Resource3)> SetupSaturatedCompactorQueue()
+    private async Task<(FlatDbManager Manager, TaskCompletionSource ReleaseCompaction, Snapshot Snapshot3, TransientResource Resource3, TestLogger Logger)> SetupSaturatedCompactorQueue()
     {
         _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 1, InlineCompaction = false };
         _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(0));
@@ -324,12 +332,14 @@ public class FlatDbManagerTests
         (Snapshot snapshot2, TransientResource resource2) = CreateSnapshot(realResourcePool, 2, 3);
         (Snapshot snapshot3, TransientResource resource3) = CreateSnapshot(realResourcePool, 3, 4);
 
-        FlatDbManager manager = CreateManager();
+        TestLogger testLogger = new();
+        OneLoggerLogManager logManager = new(new ILogger(testLogger));
+        FlatDbManager manager = CreateManager(logManager, TimeSpan.FromMilliseconds(50));
         manager.AddSnapshot(snapshot1, resource1);
         await firstCompactionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         manager.AddSnapshot(snapshot2, resource2);
 
-        return (manager, releaseCompaction, snapshot3, resource3);
+        return (manager, releaseCompaction, snapshot3, resource3, testLogger);
     }
 
     private static (Snapshot Snapshot, TransientResource Resource) CreateSnapshot(ResourcePool resourcePool, long fromBlock, long toBlock)

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -209,54 +209,48 @@ public class FlatDbManagerTests
     [Test]
     public async Task AddSnapshot_WhenCompactorQueueIsFull_CompletesWithinBoundedTime()
     {
-        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 1, InlineCompaction = false };
-        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(0));
-        _snapshotRepository.TryAddSnapshot(Arg.Any<Snapshot>()).Returns(true);
+        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3) =
+            await SetupSaturatedCompactorQueue();
+        await using (manager)
+        {
+            Task thirdAddSnapshot = Task.Run(() => manager.AddSnapshot(snapshot3, resource3));
 
-        TaskCompletionSource firstCompactionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        TaskCompletionSource releaseCompaction = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        int compactionCallCount = 0;
-        _snapshotCompactor.DoCompactSnapshot(Arg.Any<StateId>())
-            .Returns(_ =>
+            try
             {
-                int callCount = Interlocked.Increment(ref compactionCallCount);
-                if (callCount == 1)
-                {
-                    firstCompactionStarted.TrySetResult();
-                    releaseCompaction.Task.GetAwaiter().GetResult();
-                }
+                Task completedTask = await Task.WhenAny(thirdAddSnapshot, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                bool completed = completedTask == thirdAddSnapshot;
 
-                return false;
-            });
-
-        ResourcePool realResourcePool = new(_config);
-        (Snapshot snapshot1, TransientResource resource1) = CreateSnapshot(realResourcePool, 1, 2);
-        (Snapshot snapshot2, TransientResource resource2) = CreateSnapshot(realResourcePool, 2, 3);
-        (Snapshot snapshot3, TransientResource resource3) = CreateSnapshot(realResourcePool, 3, 4);
-
-        await using FlatDbManager manager = CreateManager();
-        manager.AddSnapshot(snapshot1, resource1);
-        await firstCompactionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        manager.AddSnapshot(snapshot2, resource2);
-
-        Task thirdAddSnapshot = Task.Run(() => manager.AddSnapshot(snapshot3, resource3));
-
-        try
-        {
-            Task completedTask = await Task.WhenAny(thirdAddSnapshot, Task.Delay(TimeSpan.FromMilliseconds(500)));
-            bool completed = completedTask == thirdAddSnapshot;
-
-            Assert.That(completed, Is.True, "AddSnapshot should not remain blocked when the compactor queue is saturated.");
-        }
-        finally
-        {
-            releaseCompaction.TrySetResult();
-            await thirdAddSnapshot.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(completed, Is.True, "AddSnapshot should not remain blocked when the compactor queue is saturated.");
+            }
+            finally
+            {
+                releaseCompaction.TrySetResult();
+                await thirdAddSnapshot.WaitAsync(TimeSpan.FromSeconds(5));
+            }
         }
     }
 
     [Test]
     public async Task AddSnapshot_WhenQueueSaturated_EmitsBackpressureSignal()
+    {
+        (FlatDbManager manager, TaskCompletionSource releaseCompaction, Snapshot snapshot3, TransientResource resource3) =
+            await SetupSaturatedCompactorQueue();
+        await using (manager)
+        {
+            manager.AddSnapshot(snapshot3, resource3);
+
+            Assert.That(Metrics.CompactorQueueFullCount, Is.EqualTo(1));
+            Assert.That(Metrics.InlineDrainActivationCount, Is.EqualTo(1));
+
+            releaseCompaction.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Creates a FlatDbManager with MaxInFlightCompactJob=1, fills the queue with two snapshots (first blocks compaction),
+    /// and returns the manager, a release handle, and a third snapshot ready to trigger backpressure.
+    /// </summary>
+    private async Task<(FlatDbManager Manager, TaskCompletionSource ReleaseCompaction, Snapshot Snapshot3, TransientResource Resource3)> SetupSaturatedCompactorQueue()
     {
         _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 1, InlineCompaction = false };
         _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(0));
@@ -283,16 +277,12 @@ public class FlatDbManagerTests
         (Snapshot snapshot2, TransientResource resource2) = CreateSnapshot(realResourcePool, 2, 3);
         (Snapshot snapshot3, TransientResource resource3) = CreateSnapshot(realResourcePool, 3, 4);
 
-        await using FlatDbManager manager = CreateManager();
+        FlatDbManager manager = CreateManager();
         manager.AddSnapshot(snapshot1, resource1);
         await firstCompactionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         manager.AddSnapshot(snapshot2, resource2);
-        manager.AddSnapshot(snapshot3, resource3);
 
-        Assert.That(Metrics.CompactorQueueFullCount, Is.EqualTo(1));
-        Assert.That(Metrics.InlineDrainActivationCount, Is.EqualTo(1));
-
-        releaseCompaction.TrySetResult();
+        return (manager, releaseCompaction, snapshot3, resource3);
     }
 
     private static (Snapshot Snapshot, TransientResource Resource) CreateSnapshot(ResourcePool resourcePool, long fromBlock, long toBlock)

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -38,6 +38,8 @@ public class FlatDbManagerTests
         _snapshotRepository = Substitute.For<ISnapshotRepository>();
         _persistenceManager = Substitute.For<IPersistenceManager>();
         _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = true };
+        Metrics.CompactorQueueFullCount = 0;
+        Metrics.InlineDrainActivationCount = 0;
     }
 
     [TearDown]
@@ -97,6 +99,19 @@ public class FlatDbManagerTests
         StateId stateId = CreateStateId(10);
         _snapshotRepository.HasState(stateId).Returns(false);
         _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(5));
+
+        await using FlatDbManager manager = CreateManager();
+        bool result = manager.HasStateForBlock(stateId);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public async Task HasStateForBlock_EarlierBlockNumberWithoutExactStateId_ReturnsFalse()
+    {
+        StateId stateId = CreateStateId(9, rootByte: 9);
+        _snapshotRepository.HasState(stateId).Returns(false);
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(10, rootByte: 10));
 
         await using FlatDbManager manager = CreateManager();
         bool result = manager.HasStateForBlock(stateId);
@@ -189,5 +204,103 @@ public class FlatDbManagerTests
         manager.AddSnapshot(snapshot, transientResource);
 
         _resourcePool.Received(1).ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+    }
+
+    [Test]
+    public async Task AddSnapshot_WhenCompactorQueueIsFull_CompletesWithinBoundedTime()
+    {
+        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 1, InlineCompaction = false };
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(0));
+        _snapshotRepository.TryAddSnapshot(Arg.Any<Snapshot>()).Returns(true);
+
+        TaskCompletionSource firstCompactionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseCompaction = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int compactionCallCount = 0;
+        _snapshotCompactor.DoCompactSnapshot(Arg.Any<StateId>())
+            .Returns(_ =>
+            {
+                int callCount = Interlocked.Increment(ref compactionCallCount);
+                if (callCount == 1)
+                {
+                    firstCompactionStarted.TrySetResult();
+                    releaseCompaction.Task.GetAwaiter().GetResult();
+                }
+
+                return false;
+            });
+
+        ResourcePool realResourcePool = new(_config);
+        (Snapshot snapshot1, TransientResource resource1) = CreateSnapshot(realResourcePool, 1, 2);
+        (Snapshot snapshot2, TransientResource resource2) = CreateSnapshot(realResourcePool, 2, 3);
+        (Snapshot snapshot3, TransientResource resource3) = CreateSnapshot(realResourcePool, 3, 4);
+
+        await using FlatDbManager manager = CreateManager();
+        manager.AddSnapshot(snapshot1, resource1);
+        await firstCompactionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        manager.AddSnapshot(snapshot2, resource2);
+
+        Task thirdAddSnapshot = Task.Run(() => manager.AddSnapshot(snapshot3, resource3));
+
+        try
+        {
+            Task completedTask = await Task.WhenAny(thirdAddSnapshot, Task.Delay(TimeSpan.FromMilliseconds(500)));
+            bool completed = completedTask == thirdAddSnapshot;
+
+            Assert.That(completed, Is.True, "AddSnapshot should not remain blocked when the compactor queue is saturated.");
+        }
+        finally
+        {
+            releaseCompaction.TrySetResult();
+            await thirdAddSnapshot.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task AddSnapshot_WhenQueueSaturated_EmitsBackpressureSignal()
+    {
+        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 1, InlineCompaction = false };
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(0));
+        _snapshotRepository.TryAddSnapshot(Arg.Any<Snapshot>()).Returns(true);
+
+        TaskCompletionSource firstCompactionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseCompaction = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int compactionCallCount = 0;
+        _snapshotCompactor.DoCompactSnapshot(Arg.Any<StateId>())
+            .Returns(_ =>
+            {
+                int callCount = Interlocked.Increment(ref compactionCallCount);
+                if (callCount == 1)
+                {
+                    firstCompactionStarted.TrySetResult();
+                    releaseCompaction.Task.GetAwaiter().GetResult();
+                }
+
+                return false;
+            });
+
+        ResourcePool realResourcePool = new(_config);
+        (Snapshot snapshot1, TransientResource resource1) = CreateSnapshot(realResourcePool, 1, 2);
+        (Snapshot snapshot2, TransientResource resource2) = CreateSnapshot(realResourcePool, 2, 3);
+        (Snapshot snapshot3, TransientResource resource3) = CreateSnapshot(realResourcePool, 3, 4);
+
+        await using FlatDbManager manager = CreateManager();
+        manager.AddSnapshot(snapshot1, resource1);
+        await firstCompactionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        manager.AddSnapshot(snapshot2, resource2);
+        manager.AddSnapshot(snapshot3, resource3);
+
+        Assert.That(Metrics.CompactorQueueFullCount, Is.EqualTo(1));
+        Assert.That(Metrics.InlineDrainActivationCount, Is.EqualTo(1));
+
+        releaseCompaction.TrySetResult();
+    }
+
+    private static (Snapshot Snapshot, TransientResource Resource) CreateSnapshot(ResourcePool resourcePool, long fromBlock, long toBlock)
+    {
+        StateId snapshotFrom = CreateStateId(fromBlock);
+        StateId snapshotTo = CreateStateId(toBlock);
+        Snapshot snapshot = resourcePool.CreateSnapshot(snapshotFrom, snapshotTo, ResourcePool.Usage.MainBlockProcessing);
+        TransientResource transientResource = resourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
+        return (snapshot, transientResource);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -117,6 +119,51 @@ public class FlatDbManagerTests
         bool result = manager.HasStateForBlock(stateId);
 
         Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void FlatPersistedStateInfoProvider_TryGetPersistedStateInfo_ReadsCurrentStateFromPersistence()
+    {
+        IPersistence persistence = Substitute.For<IPersistence>();
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        StateId currentState = CreateStateId(12, rootByte: 4);
+        reader.CurrentState.Returns(currentState);
+        persistence.CreateReader().Returns(reader);
+
+        FlatPersistedStateInfoProvider provider = new(persistence, _snapshotRepository);
+
+        bool result = provider.TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo);
+
+        Assert.That(result, Is.True);
+        Assert.That(persistedStateInfo.BlockNumber, Is.EqualTo(currentState.BlockNumber));
+        Assert.That(persistedStateInfo.StateRoot, Is.EqualTo(currentState.StateRoot));
+    }
+
+    [Test]
+    public void FlatPersistedStateInfoProvider_HasRecoverableStateForBlock_UsesSnapshotsAndExactPersistedState()
+    {
+        IPersistence persistence = Substitute.For<IPersistence>();
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        StateId currentState = CreateStateId(12, rootByte: 4);
+        reader.CurrentState.Returns(currentState);
+        persistence.CreateReader().Returns(reader);
+
+        BlockHeader snapshotHeader = Build.A.BlockHeader.WithNumber(9).WithStateRoot(TestItem.KeccakA).TestObject;
+        BlockHeader persistedHeader = Build.A.BlockHeader.WithNumber(currentState.BlockNumber).WithStateRoot(TestItem.KeccakB).TestObject;
+        BlockHeader missingHeader = Build.A.BlockHeader.WithNumber(10).WithStateRoot(TestItem.KeccakC).TestObject;
+
+        currentState = new StateId(persistedHeader);
+        reader.CurrentState.Returns(currentState);
+
+        _snapshotRepository.HasState(new StateId(snapshotHeader)).Returns(true);
+        _snapshotRepository.HasState(new StateId(persistedHeader)).Returns(false);
+        _snapshotRepository.HasState(new StateId(missingHeader)).Returns(false);
+
+        FlatPersistedStateInfoProvider provider = new(persistence, _snapshotRepository);
+
+        Assert.That(provider.HasRecoverableStateForBlock(snapshotHeader), Is.True);
+        Assert.That(provider.HasRecoverableStateForBlock(persistedHeader), Is.True);
+        Assert.That(provider.HasRecoverableStateForBlock(missingHeader), Is.False);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -183,6 +183,24 @@ public class PersistenceManagerTests
         result.Dispose();
     }
 
+    [Test]
+    public void DetermineSnapshotToPersist_WhenFinalizationIsStale_ChoosesForcePersistCandidate()
+    {
+        StateId latest = CreateStateId(300);
+        StateId target = CreateStateId(16);
+        _finalizedStateProvider.SetFinalizedBlockNumber(10);
+
+        using Snapshot expectedSnapshot = CreateSnapshot(Block0, target, compacted: true);
+
+        Snapshot? result = _persistenceManager.DetermineSnapshotToPersist(latest);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.From, Is.EqualTo(Block0));
+        Assert.That(result.To, Is.EqualTo(target));
+
+        result.Dispose();
+    }
+
     #endregion
 
     #region Edge Cases
@@ -385,6 +403,31 @@ public class PersistenceManagerTests
 
         // Verify current persisted state was updated
         Assert.That(_persistenceManager.GetCurrentPersistedStateId(), Is.EqualTo(to));
+    }
+
+    [Test]
+    public void AddToPersistence_WhenForcePersisting_AdvancesCurrentPersistedStateMonotonically()
+    {
+        StateId state16 = CreateStateId(16, rootByte: 1);
+        StateId state32 = CreateStateId(32, rootByte: 2);
+        StateId latest = CreateStateId(300, rootByte: 3);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(10);
+
+        using Snapshot snapshot16 = CreateSnapshot(Block0, state16, compacted: true);
+        using Snapshot snapshot32 = CreateSnapshot(state16, state32, compacted: true);
+
+        IPersistence.IWriteBatch writeBatch = Substitute.For<IPersistence.IWriteBatch>();
+        _persistence.CreateWriteBatch(Arg.Any<StateId>(), Arg.Any<StateId>()).Returns(writeBatch);
+
+        _persistenceManager.AddToPersistence(latest);
+
+        Assert.That(_persistenceManager.GetCurrentPersistedStateId(), Is.EqualTo(state32));
+        Received.InOrder(() =>
+        {
+            _persistence.CreateWriteBatch(Block0, state16);
+            _persistence.CreateWriteBatch(state16, state32);
+        });
     }
 
     #endregion

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -20,6 +20,7 @@ namespace Nethermind.State.Flat;
 public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 {
     private static readonly TimeSpan GatherGiveUpDeadline = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultCompactorEnqueueWarningDelay = TimeSpan.FromSeconds(10);
 
     private readonly ILogger _logger;
     private readonly IPersistenceManager _persistenceManager;
@@ -55,6 +56,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private readonly CancellationTokenSource _cancelTokenSource;
     private int _isDisposed = 0;
     private readonly bool _enableDetailedMetrics;
+    private readonly TimeSpan _compactorEnqueueWarningDelay;
 
     public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
@@ -67,7 +69,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         IPersistenceManager persistenceManager,
         IFlatDbConfig config,
         ILogManager logManager,
-        bool enableDetailedMetrics)
+        bool enableDetailedMetrics,
+        TimeSpan? compactorEnqueueWarningDelay = null)
     {
         _trieNodeCache = trieNodeCache;
         _snapshotCompactor = snapshotCompactor;
@@ -76,6 +79,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         _persistenceManager = persistenceManager;
         _logger = logManager.GetClassLogger<FlatDbManager>();
         _enableDetailedMetrics = enableDetailedMetrics;
+        _compactorEnqueueWarningDelay = compactorEnqueueWarningDelay ?? DefaultCompactorEnqueueWarningDelay;
 
         _compactSize = config.CompactSize;
         _inlineCompaction = config.InlineCompaction;
@@ -133,13 +137,6 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     private ValueTask QueuePersistenceJob(StateId stateId, CancellationToken cancellationToken)
         => _persistenceJobs.Writer.WriteAsync(stateId, cancellationToken);
-
-    private void ExecuteCompactAndPersistInline(StateId stateId, TransientResource transientResource)
-    {
-        PopulateTrieNodeCache(transientResource);
-        CompactSnapshot(stateId);
-        PersistIfNeeded(stateId);
-    }
 
     private async Task RunPersistence(CancellationToken cancellationToken)
     {
@@ -366,16 +363,44 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             }
             else
             {
-                if (_cancelTokenSource.Token.IsCancellationRequested) return; // When cancelled the queue stop
-
                 Metrics.CompactorQueueFullCount++;
-                if (_logger.IsWarn)
+                EnqueueCompactorJobWithWarnings(endBlock, persistedStateId);
+            }
+        }
+    }
+
+    private void EnqueueCompactorJobWithWarnings(StateId endBlock, StateId persistedStateId)
+    {
+        if (_cancelTokenSource.Token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        long stallStart = Stopwatch.GetTimestamp();
+        while (true)
+        {
+            Task<bool> waitToWriteTask = _compactorJobs.Writer.WaitToWriteAsync(_cancelTokenSource.Token).AsTask();
+            if (waitToWriteTask.Wait(_compactorEnqueueWarningDelay))
+            {
+                if (!waitToWriteTask.Result || _cancelTokenSource.Token.IsCancellationRequested)
                 {
-                    _logger.Warn($"Compactor job stall! Insufficient reorg depth or too slow persistence! Persisted state: {persistedStateId}, snapshot target: {endBlock}. Executing inline drain.");
+                    return;
                 }
 
-                Metrics.InlineDrainActivationCount++;
-                ExecuteCompactAndPersistInline(endBlock, transientResource);
+                if (_compactorJobs.Writer.TryWrite(endBlock))
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            if (_logger.IsWarn)
+            {
+                _logger.Warn(
+                    $"Compactor job stall! Insufficient reorg depth or too slow persistence! " +
+                    $"Persisted state: {persistedStateId}, snapshot target: {endBlock}, " +
+                    $"waiting for enqueue for {Stopwatch.GetElapsedTime(stallStart)}.");
             }
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Nethermind.Config;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -116,16 +117,28 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     private async Task RunCompactJob(StateId stateId, CancellationToken cancellationToken)
     {
-        // We do this async because of the lock
+        CompactSnapshot(stateId);
+        await QueuePersistenceJob(stateId, cancellationToken);
+    }
+
+    private void CompactSnapshot(StateId stateId)
+    {
         _snapshotRepository.AddStateId(stateId);
 
         if (_snapshotCompactor.DoCompactSnapshot(stateId))
         {
             ClearReadOnlyBundleCache();
         }
+    }
 
-        // Trigger persistence job.
-        await _persistenceJobs.Writer.WriteAsync(stateId, cancellationToken);
+    private ValueTask QueuePersistenceJob(StateId stateId, CancellationToken cancellationToken)
+        => _persistenceJobs.Writer.WriteAsync(stateId, cancellationToken);
+
+    private void ExecuteCompactAndPersistInline(StateId stateId, TransientResource transientResource)
+    {
+        PopulateTrieNodeCache(transientResource);
+        CompactSnapshot(stateId);
+        PersistIfNeeded(stateId);
     }
 
     private async Task RunPersistence(CancellationToken cancellationToken)
@@ -343,18 +356,26 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         }
         else
         {
-            if (!_populateTrieNodeCacheJobs.Writer.TryWrite(transientResource))
+            if (_compactorJobs.Writer.TryWrite(endBlock))
             {
-                // Ignore it, just dispose
-                transientResource.Dispose();
+                if (!_populateTrieNodeCacheJobs.Writer.TryWrite(transientResource))
+                {
+                    // Ignore it, just dispose
+                    transientResource.Dispose();
+                }
             }
-
-            if (!_compactorJobs.Writer.TryWrite(endBlock))
+            else
             {
                 if (_cancelTokenSource.Token.IsCancellationRequested) return; // When cancelled the queue stop
 
-                if (_logger.IsWarn) _logger.Warn("Compactor job stall! Insufficient reorg depth or too slow persistence!");
-                _compactorJobs.Writer.WriteAsync(endBlock).AsTask().Wait();
+                Metrics.CompactorQueueFullCount++;
+                if (_logger.IsWarn)
+                {
+                    _logger.Warn($"Compactor job stall! Insufficient reorg depth or too slow persistence! Persisted state: {persistedStateId}, snapshot target: {endBlock}. Executing inline drain.");
+                }
+
+                Metrics.InlineDrainActivationCount++;
+                ExecuteCompactAndPersistInline(endBlock, transientResource);
             }
         }
     }
@@ -404,10 +425,27 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     public bool HasStateForBlock(in StateId stateId)
     {
+        // FlatDB recoverability is exact by StateId. Do not weaken this to block-number-only checks,
+        // otherwise startup can accept the wrong branch/root after persisted-boundary drift.
         if (_snapshotRepository.HasState(stateId)) return true;
         if (_persistenceManager.GetCurrentPersistedStateId() == stateId) return true;
         return false;
     }
+
+    public bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo)
+    {
+        StateId currentPersistedStateId = _persistenceManager.GetCurrentPersistedStateId();
+        if (currentPersistedStateId == StateId.PreGenesis)
+        {
+            persistedStateInfo = default;
+            return false;
+        }
+
+        persistedStateInfo = new PersistedStateInfo(currentPersistedStateId.BlockNumber, currentPersistedStateId.StateRoot);
+        return true;
+    }
+
+    public bool HasRecoverableStateForBlock(BlockHeader? blockHeader) => HasStateForBlock(new StateId(blockHeader));
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Nethermind/Nethermind.State.Flat/FlatPersistedStateInfoProvider.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatPersistedStateInfoProvider.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.State;
+using Nethermind.State.Flat.Persistence;
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Lightweight startup/recovery seam for exact persisted flat-state identity.
+/// This intentionally avoids the full <see cref="IFlatDbManager"/> graph so startup
+/// diagnostics do not create a dependency cycle through persistence finalization.
+/// </summary>
+public class FlatPersistedStateInfoProvider(
+    IPersistence persistence,
+    ISnapshotRepository snapshotRepository) : IPersistedStateInfoProvider
+{
+    public bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo)
+    {
+        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
+        StateId currentState = reader.CurrentState;
+        if (currentState == StateId.PreGenesis)
+        {
+            persistedStateInfo = default;
+            return false;
+        }
+
+        persistedStateInfo = new PersistedStateInfo(currentState.BlockNumber, currentState.StateRoot);
+        return true;
+    }
+
+    public bool HasRecoverableStateForBlock(BlockHeader? blockHeader)
+    {
+        StateId stateId = new(blockHeader);
+        if (snapshotRepository.HasState(stateId))
+        {
+            return true;
+        }
+
+        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
+        return reader.CurrentState == stateId;
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -6,7 +6,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Flat;
 
-public interface IFlatDbManager : IFlatCommitTarget
+public interface IFlatDbManager : IFlatCommitTarget, IPersistedStateInfoProvider
 {
     event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
     SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);

--- a/src/Nethermind/Nethermind.State.Flat/Metrics.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Metrics.cs
@@ -85,4 +85,14 @@ public static class Metrics
     [ExponentialPowerHistogramMetric(Start = 1, Factor = 1.5, Count = 1, LabelNames = [])]
     public static IMetricObserver CompactTime { get; set; } = new NoopMetricObserver();
 
+    [DetailedMetric]
+    [CounterMetric]
+    [Description("Number of times the compactor queue was full when adding a snapshot")]
+    public static long CompactorQueueFullCount { get; set; }
+
+    [DetailedMetric]
+    [CounterMetric]
+    [Description("Number of times AddSnapshot had to execute compaction and persistence inline")]
+    public static long InlineDrainActivationCount { get; set; }
+
 }

--- a/src/Nethermind/Nethermind.State/IPersistedStateInfoProvider.cs
+++ b/src/Nethermind/Nethermind.State/IPersistedStateInfoProvider.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.State
+{
+    public interface IPersistedStateInfoProvider
+    {
+        bool TryGetPersistedStateInfo(out PersistedStateInfo persistedStateInfo);
+        bool HasRecoverableStateForBlock(BlockHeader? blockHeader);
+    }
+
+    public readonly record struct PersistedStateInfo(long BlockNumber, in ValueHash256 StateRoot);
+}

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
@@ -34,7 +34,7 @@ internal class XdcBlockTree : BlockTree
         IBloomStorage? bloomStorage,
         ISyncConfig? syncConfig,
         ILogManager? logManager,
-        long genesisBlockNumber = 0) : base(blockStore, headerDb, blockInfoDb, metadataDb, badBlockStore, balStore, chainLevelInfoRepository, specProvider, bloomStorage, syncConfig, logManager, genesisBlockNumber)
+        long genesisBlockNumber = 0) : base(blockStore, headerDb, blockInfoDb, metadataDb, badBlockStore, balStore, chainLevelInfoRepository, specProvider, bloomStorage, syncConfig, logManager, genesisBlockNumber: genesisBlockNumber)
     {
         _xdcConsensus = xdcConsensus;
     }


### PR DESCRIPTION
## Changes

### Track A: Prevent Live Processing Stall

- **Replace unbounded producer-side wait in `FlatDbManager.AddSnapshot`** with an inline drain fallback when the compactor queue is saturated — the processing thread now helps drain compaction/persistence instead of blocking forever on channel capacity
- **Add processing watchdog** in `BlockchainProcessor` — a single long-lived background task that emits periodic warnings when a block has been processing longer than a configurable threshold (default 30s)
- **Harden `AddressWarmer.Wait()` and `BranchProcessor.WaitAndClear`** with periodic warning logs while blocked, preserving the invariant that processing does not continue while the prewarmer can still publish into shared caches
- **Add per-transaction `CancellationToken` check** in `BlockValidationTransactionsExecutor.ProcessTransactions` — the token was accepted but never observed between transactions
- **Add backpressure metrics** (`CompactorQueueFullCount`, `InlineDrainActivationCount`) to the FlatDB metrics class
- **Add startup diagnostic logs** printing stored persisted-boundary metadata, FlatDB persisted `StateId`, canonical status, and recoverability on every startup

### Track B: Make Restart Recovery Exact

- **Persist exact boundary hash metadata** alongside the block number when `BestPersistedState` is updated — both are written atomically in a single DB batch
- **Add startup reconciliation** in `BlockTree.Initializer.LoadStartBlock()` that validates the restored block against the exact FlatDB persisted `StateId` and canonical chain status
- **Add startup repair** that promotes a non-canonical persisted-state block to the main chain, or finds the canonical block matching the exact persisted state root — fails loudly with full diagnostics if no match exists instead of drifting into the later `Maximum size of branch reached (8192)` failure
- **Harden `StartupBlockTreeFixer`** to only suggest blocks descending from the repaired head using per-level eligible parent hash tracking, and to log an error if the head still doesn't match persisted state info
- **Enrich the max-branch-size exception** with persisted-boundary number/hash, flat persisted state, and reconciliation outcome
- **Introduce `IPersistedStateInfoProvider`** seam in `Nethermind.State` (implemented by `FlatPersistedStateInfoProvider`) to expose persisted state info to `Nethermind.Blockchain` without creating a project cycle

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

**FlatDB backpressure (Nethermind.State.Flat.Test):**
- `AddSnapshot_WhenCompactorQueueIsFull_CompletesWithinBoundedTime` — proves the producer does not block indefinitely under queue saturation
- `AddSnapshot_WhenQueueSaturated_EmitsBackpressureSignal` — verifies metric counters increment on inline drain
- `HasStateForBlock_EarlierBlockNumberWithoutExactStateId_ReturnsFalse` — locks in exact `StateId` semantics
- `FlatPersistedStateInfoProvider` tests for `TryGetPersistedStateInfo` and `HasRecoverableStateForBlock`

**Force-persist path (Nethermind.State.Flat.Test):**
- `DetermineSnapshotToPersist_WhenFinalizationIsStale_ChoosesForcePersistCandidate`
- `AddToPersistence_WhenForcePersisting_AdvancesCurrentPersistedStateMonotonically`

**Exact startup restore (Nethermind.Blockchain.Test):**
- `Loads_start_block_from_exact_persisted_boundary_hash_when_present`
- `Load_start_block_when_number_only_restore_points_to_exact_persisted_state_promotes_it_to_main_chain`
- `Load_start_block_when_no_exact_repair_target_exists_fails_with_actionable_diagnostics`
- `Load_start_block_failure_contains_persisted_boundary_and_flat_state_diagnostics`
- `Load_start_block_when_persisted_boundary_is_invalid_fails_without_exact_canonical_match`
- `Load_start_block_when_number_only_restore_matches_state_but_is_not_canonical_fails_loudly`
- `Load_start_block_is_backward_compatible_when_only_number_metadata_exists`
- `Load_start_block_repair_rewrites_number_and_hash_metadata_together`

**Startup fixer (Nethermind.Blockchain.Test):**
- `Fixer_starts_from_repaired_head`
- `Fixer_with_repaired_head_and_recoverable_parent_suggests_blocks_normally`
- `Fixer_only_suggests_blocks_that_descend_from_repaired_head`
- `Fixer_logs_error_when_head_does_not_match_persisted_state_info`

**End-to-end restart:**
- `Restart_with_exact_persisted_boundary_hash_replays_only_canonical_descendants_from_loaded_head`

**Observability:**
- `ProcessBlock_WhenBlockTakesLongerThanThreshold_EmitsWatchdogWarning`
- `BuildMaxBranchSizeReachedMessage_IncludesStartupDiagnostics`
- `AddressWarmerWait_WhenWarmupDoesNotFinish_WarnsWithoutReportingCompletion`
- `BranchProcessor_waits_for_prewarmer_task_before_returning`
- `BlockValidationTransactionsExecutor_stops_between_transactions_when_cancelled`
