### PR TITLE
Fix EIP-158 system account test to use IWorldState interface

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -81,19 +81,18 @@ public class StateProviderTests(bool useFlat)
     public void Eip_158_touch_zero_value_system_account_is_not_deleted()
     {
         using Context ctx = new(useFlat);
-        ParallelWorldState? parallelWorldState = ctx.WorldState as ParallelWorldState;
-        IWorldState provider = parallelWorldState is null ? ctx.WorldState : parallelWorldState.Inner;
+        IWorldState provider = ctx.WorldState;
         using var _ = provider.BeginScope(IWorldState.PreGenesis);
         var systemUser = Address.SystemUser;
 
         provider.CreateAccount(systemUser, 0);
         provider.Commit(Homestead.Instance);
 
-        var releaseSpec = new ReleaseSpec() { IsEip158Enabled = true };
+        var releaseSpec = new ReleaseSpec() { IsEip158Enabled = true, Eip158IgnoredAccount = systemUser };
         provider.InsertCode(systemUser, System.Text.Encoding.UTF8.GetBytes(""), releaseSpec);
         provider.Commit(releaseSpec);
 
-        ((WorldState)provider).GetAccount(systemUser).Should().NotBeNull();
+        provider.AccountExists(systemUser).Should().BeTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Remove `ParallelWorldState` unwrap hack from `Eip_158_touch_zero_value_system_account_is_not_deleted` test
- Fix the assertion to use `AccountExists()` via `IWorldState` instead of casting to `WorldState` and calling `GetAccount()`, which never returns null (returns `Account.TotallyEmpty`), making the original assertion vacuous
- Add `Eip158IgnoredAccount = systemUser` to the release spec so the test actually verifies system accounts survive EIP-158 cleanup

## Test plan
- [x] `Eip_158_touch_zero_value_system_account_is_not_deleted` passes for both `useFlat=true` and `useFlat=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)