### PR TITLE
fix: shorten validator exit and withdrawability delays in assertoor config

### DIFF
--- a/.github/workflows/test-assertoor.yml
+++ b/.github/workflows/test-assertoor.yml
@@ -2,8 +2,6 @@ name: Assertoor tests
 
 on:
   workflow_dispatch:
-  push:
-    branches: [fix/assertoor-validator-exit-test]
   workflow_run:
     workflows: ["Publish Docker image"]
     branches: [master]

--- a/.github/workflows/test-assertoor.yml
+++ b/.github/workflows/test-assertoor.yml
@@ -2,6 +2,8 @@ name: Assertoor tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [fix/assertoor-validator-exit-test]
   workflow_run:
     workflows: ["Publish Docker image"]
     branches: [master]

--- a/scripts/config/assertoor.yml
+++ b/scripts/config/assertoor.yml
@@ -11,6 +11,8 @@ participants_matrix:
    - cl_type: nimbus
 network_params:
   preset: "minimal"
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
 additional_services:
   - assertoor
 <ASSERTOOR_PARAMS_PLACEHOLDER>


### PR DESCRIPTION
## Changes

Add `shard_committee_period: 1` and `min_validator_withdrawability_delay: 1` to the assertoor kurtosis config.

## Why

The `validator-exit-test` has never passed (0% pass rate across all master runs).

`shard_committee_period` gates voluntary exits: a validator may only exit once
`current_epoch >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD`. The `ethereum-package`
minimal defaults (`default_minimal_network_params()`) set it to **256 epochs**, which at 8 slots ×
6 s = 48 s per epoch is roughly **3.4 hours**. The test starts submitting voluntary exits at epoch 1,
so every CL client correctly rejects them and the test fails.

With `shard_committee_period: 1`, genesis validators (activation epoch 0) become eligible at epoch 1,
which is exactly when the test starts submitting. Note this is the exact boundary — if the test ever
submits before epoch 1 completes, `0` would give margin.

`min_validator_withdrawability_delay` is also 256 by default and sets
`withdrawable_epoch = exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY`. Left at the default, the exit
is accepted but the validator is not withdrawable for another ~3.4 hours, so any assertion past the
exit itself still times out. Lowering it to 1 keeps the whole exit→withdrawable path inside the run.

## Caveat

`scripts/config/assertoor.yml` is the single config for the whole dynamically-retrieved suite
(`retriveAllTests.py`, which excludes only `pectra-dev`, `verkle`, `validator-lifecycle`, `slashing`
and `mev`). Both overrides therefore change chain behaviour for **every** test in the run, not just
`validator-exit-test` — this needs one full confirming run before it comes out of draft. The "0% pass
rate" measurement also predates several months of master and is worth re-checking.

Fixes #10964
