### PR TITLE
Add command-based IRunStep execution to the runner

### DIFF
--- a/src/Nethermind/Nethermind.Api/Steps/RunnerCommandAttribute.cs
+++ b/src/Nethermind/Nethermind.Api/Steps/RunnerCommandAttribute.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Api.Steps;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class RunnerCommandAttribute(string name) : Attribute
+{
+    public string Name { get; } = name;
+    public string Description { get; init; } = "";
+    public bool IsDefault { get; init; }
+}

--- a/src/Nethermind/Nethermind.Api/Steps/StepInfo.cs
+++ b/src/Nethermind/Nethermind.Api/Steps/StepInfo.cs
@@ -27,6 +27,12 @@ namespace Nethermind.Api.Steps
                 StepType.GetCustomAttribute<RunnerStepDependenciesAttribute>();
             Dependencies = dependenciesAttribute?.Dependencies ?? [];
             Dependents = dependenciesAttribute?.Dependents ?? [];
+
+            RunnerCommandAttribute? commandAttribute =
+                StepType.GetCustomAttribute<RunnerCommandAttribute>();
+            CommandName = commandAttribute?.Name;
+            CommandDescription = commandAttribute?.Description;
+            IsDefaultCommand = commandAttribute?.IsDefault ?? false;
         }
 
         public Type StepBaseType { get; }
@@ -35,6 +41,10 @@ namespace Nethermind.Api.Steps
 
         public Type[] Dependencies { get; }
         public Type[] Dependents { get; }
+
+        public string? CommandName { get; }
+        public string? CommandDescription { get; }
+        public bool IsDefaultCommand { get; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Init/Modules/BuiltInStepsModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BuiltInStepsModule.cs
@@ -3,6 +3,7 @@
 
 using Autofac;
 using Nethermind.Api.Steps;
+using Nethermind.Init;
 using Nethermind.Init.Steps;
 
 namespace Nethermind.Runner.Ethereum.Modules;
@@ -33,7 +34,8 @@ public class BuiltInStepsModule : Module
         typeof(StartBlockProcessor),
         typeof(StartBlockProducer),
         typeof(StartMonitoring),
-        typeof(StartLogIndex)
+        typeof(StartLogIndex),
+        typeof(RunVerifyTrie)
     ];
 
     protected override void Load(ContainerBuilder builder)

--- a/src/Nethermind/Nethermind.Init/RunVerifyTrie.cs
+++ b/src/Nethermind/Nethermind.Init/RunVerifyTrie.cs
@@ -14,10 +14,8 @@ using Nethermind.State;
 
 namespace Nethermind.Init;
 
-[RunnerStepDependencies(
-    dependencies: [typeof(InitializeBlockTree)],
-    dependents: [typeof(InitializeBlockchain)]
-)]
+[RunnerCommand("verify-trie", Description = "Verifies the state trie integrity and exits")]
+[RunnerStepDependencies(typeof(InitializeBlockTree))]
 public class RunVerifyTrie(
     IWorldStateManager worldStateManager,
     IBlockTree blockTree,

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -42,20 +42,19 @@ namespace Nethermind.Init.Steps
 
         public async Task InitializeAll(CancellationToken cancellationToken)
         {
-            List<Task> allRequiredSteps = CreateAndExecuteSteps(cancellationToken);
-            if (allRequiredSteps.Count == 0)
-                return;
-            do
-            {
-                Task current = await Task.WhenAny(allRequiredSteps);
-                ReviewFailedAndThrow(current);
-                if (current.IsCanceled && _logger.IsDebug) _logger.Debug("A required step was cancelled!");
-                allRequiredSteps.Remove(current);
-            } while (allRequiredSteps.Any(s => !s.IsCompleted));
+            Dictionary<Type, StepWrapper> graph = BuildStepGraph(cancellationToken);
+            Type defaultRoot = FindDefaultCommandStep(graph);
+            await ExecuteFromRoot(defaultRoot, graph, cancellationToken);
         }
 
+        public async Task InitializeCommand(string commandName, CancellationToken cancellationToken)
+        {
+            Dictionary<Type, StepWrapper> graph = BuildStepGraph(cancellationToken);
+            Type commandRoot = FindCommandStep(commandName, graph);
+            await ExecuteFromRoot(commandRoot, graph, cancellationToken);
+        }
 
-        private List<Task> CreateAndExecuteSteps(CancellationToken cancellationToken)
+        private Dictionary<Type, StepWrapper> BuildStepGraph(CancellationToken cancellationToken)
         {
             Dictionary<Type, StepWrapper> stepInfoMap = [];
 
@@ -71,6 +70,11 @@ namespace Nethermind.Init.Steps
 
             foreach ((Type key, StepWrapper stepWrapper) in stepInfoMap)
             {
+                // Command steps don't push their dependents into other steps.
+                // They are inert in normal mode and only activate when invoked as a command root.
+                if (stepWrapper.StepInfo.CommandName is not null)
+                    continue;
+
                 foreach (Type type in stepWrapper.StepInfo.Dependents)
                 {
                     if (stepInfoMap.TryGetValue(type, out StepWrapper? dependent))
@@ -82,9 +86,12 @@ namespace Nethermind.Init.Steps
                         throw new StepDependencyException($"The dependent step {type.Name} for {stepWrapper.StepInfo.StepBaseType.Name} is missing.");
                     }
                 }
+            }
 
+            foreach ((Type key, StepWrapper stepWrapper) in stepInfoMap)
+            {
                 // Remove absent optional dependencies
-                for (var i = 0; i < stepWrapper.Dependencies.Count; i++)
+                for (int i = 0; i < stepWrapper.Dependencies.Count; i++)
                 {
                     Type dep = stepWrapper.Dependencies[i];
                     if (!stepInfoMap.ContainsKey(dep))
@@ -103,16 +110,98 @@ namespace Nethermind.Init.Steps
                 }
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Ethereum steps dependency tree:\n{BuildStepDependencyTree(stepInfoMap)}");
-            List<Task> allRequiredSteps = new();
-            foreach (StepWrapper stepWrapper in stepInfoMap.Values)
+            return stepInfoMap;
+        }
+
+        private static HashSet<Type> ComputeTransitiveClosure(Type rootType, Dictionary<Type, StepWrapper> graph)
+        {
+            HashSet<Type> closure = [];
+            Queue<Type> queue = new();
+            queue.Enqueue(rootType);
+
+            while (queue.Count > 0)
+            {
+                Type current = queue.Dequeue();
+                if (!closure.Add(current))
+                    continue;
+
+                if (graph.TryGetValue(current, out StepWrapper? wrapper))
+                {
+                    foreach (Type dep in wrapper.Dependencies)
+                    {
+                        queue.Enqueue(dep);
+                    }
+                }
+            }
+
+            return closure;
+        }
+
+        private async Task ExecuteFromRoot(Type rootType, Dictionary<Type, StepWrapper> fullGraph, CancellationToken cancellationToken)
+        {
+            HashSet<Type> closure = ComputeTransitiveClosure(rootType, fullGraph);
+
+            // Filter graph to only steps in the closure
+            Dictionary<Type, StepWrapper> graph = [];
+            foreach ((Type key, StepWrapper wrapper) in fullGraph)
+            {
+                if (closure.Contains(key))
+                {
+                    graph.Add(key, wrapper);
+                }
+            }
+
+            if (_logger.IsDebug) _logger.Debug($"Ethereum steps dependency tree:\n{BuildStepDependencyTree(graph)}");
+
+            List<Task> allRequiredSteps = [];
+            foreach (StepWrapper stepWrapper in graph.Values)
             {
                 StepInfo stepInfo = stepWrapper.StepInfo;
-                Task task = ExecuteStep(stepWrapper, stepInfoMap, cancellationToken);
+                Task task = ExecuteStep(stepWrapper, graph, cancellationToken);
                 if (_logger.IsDebug) _logger.Debug($"Executing step: {stepInfo}");
                 allRequiredSteps.Add(task);
             }
-            return allRequiredSteps;
+
+            if (allRequiredSteps.Count == 0)
+                return;
+
+            do
+            {
+                Task current = await Task.WhenAny(allRequiredSteps);
+                ReviewFailedAndThrow(current);
+                if (current.IsCanceled && _logger.IsDebug) _logger.Debug("A required step was cancelled!");
+                allRequiredSteps.Remove(current);
+            } while (allRequiredSteps.Any(s => !s.IsCompleted));
+        }
+
+        private static Type FindDefaultCommandStep(Dictionary<Type, StepWrapper> graph)
+        {
+            foreach ((Type key, StepWrapper wrapper) in graph)
+            {
+                if (wrapper.StepInfo.IsDefaultCommand)
+                    return key;
+            }
+
+            throw new StepDependencyException("No default command step found. Ensure a step is annotated with [RunnerCommand(IsDefault = true)].");
+        }
+
+        private static Type FindCommandStep(string commandName, Dictionary<Type, StepWrapper> graph)
+        {
+            foreach ((Type key, StepWrapper wrapper) in graph)
+            {
+                if (wrapper.StepInfo.CommandName == commandName)
+                    return key;
+            }
+
+            List<string> availableCommands = [];
+            foreach (StepWrapper wrapper in graph.Values)
+            {
+                if (wrapper.StepInfo.CommandName is not null && !wrapper.StepInfo.IsDefaultCommand)
+                    availableCommands.Add(wrapper.StepInfo.CommandName);
+            }
+
+            throw new StepDependencyException(
+                $"Command '{commandName}' not found. Available commands: {string.Join(", ", availableCommands)}");
         }
 
         private async Task ExecuteStep(StepWrapper stepWrapper, Dictionary<Type, StepWrapper> stepBaseTypeMap, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
@@ -11,7 +11,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(StartBlockProcessor), typeof(InitializeBlockchain), typeof(InitializePlugins))]
+    [RunnerStepDependencies(typeof(StartBlockProcessor), typeof(InitializeBlockchain), typeof(InitializePlugins), typeof(EvmWarmer))]
     public class LoadGenesisBlock(IMainProcessingContext mainProcessingContext, IBlockTree blockTree, IInitConfig initConfig, ILogManager logManager) : IStep
     {
         private readonly ILogger _logger = logManager.GetClassLogger();

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsLoaderTests.cs
@@ -40,7 +40,7 @@ public class EthereumStepsLoaderTests
         steps.AddRange(LoadStepInfoFromAssembly(typeof(InitializeBlockTree).Assembly));
         steps.AddRange(LoadStepInfoFromAssembly(typeof(EthereumRunner).Assembly));
 
-        HashSet<Type> optionalSteps = [typeof(RunVerifyTrie), typeof(ExitOnInvalidBlock), typeof(ImportFlatDb)];
+        HashSet<Type> optionalSteps = [typeof(ExitOnInvalidBlock), typeof(ImportFlatDb)];
         steps = steps.Where((s) => !optionalSteps.Contains(s.StepBaseType)).ToHashSet();
 
         using IContainer container = new ContainerBuilder()

--- a/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
@@ -29,6 +29,13 @@ public class EthereumRunner(INethermindApi api, EthereumStepsManager stepsManage
         if (_logger.IsInfo) _logger.Info(infoScreen);
     }
 
+    public async Task StartCommand(string commandName, CancellationToken cancellationToken)
+    {
+        if (_logger.IsDebug) _logger.Debug($"Starting command: {commandName}");
+
+        await stepsManager.InitializeCommand(commandName, cancellationToken);
+    }
+
     public async Task StopAsync()
     {
         await serviceStopper.StopAllServices();

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Modules/StartRpcStepsModule.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Modules/StartRpcStepsModule.cs
@@ -17,7 +17,8 @@ public class StartRpcStepsModule(IGrpcConfig grpcConfig) : Module
     protected override void Load(ContainerBuilder builder)
     {
         builder
-            .AddStep(typeof(StartRpc));
+            .AddStep(typeof(StartRpc))
+            .AddStep(typeof(NethermindClientStep));
 
         if (grpcConfig.Enabled)
         {

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/NethermindClientStep.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/NethermindClientStep.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api.Steps;
+using Nethermind.Init.Steps;
+
+namespace Nethermind.Runner.Ethereum.Steps;
+
+[RunnerCommand("run", IsDefault = true, Description = "Run the Nethermind client")]
+[RunnerStepDependencies(
+    typeof(LogHardwareInfo),
+    typeof(StartMonitoring),
+    typeof(StartBlockProducer),
+    typeof(EvmWarmer),
+    typeof(DatabaseMigrations),
+    typeof(StartLogIndex),
+    typeof(StartRpc)
+)]
+public class NethermindClientStep : IStep
+{
+    public Task Execute(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/NethermindClientStep.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/NethermindClientStep.cs
@@ -10,11 +10,10 @@ namespace Nethermind.Runner.Ethereum.Steps;
 
 [RunnerCommand("run", IsDefault = true, Description = "Run the Nethermind client")]
 [RunnerStepDependencies(
-    typeof(LogHardwareInfo),
-    typeof(StartMonitoring),
+    typeof(LogHardwareInfo),     // Standalone: logs CPU info, MustInitialize=false
+    typeof(StartMonitoring),     // Standalone: starts Prometheus/Grafana metrics, MustInitialize=false
     typeof(StartBlockProducer),
-    typeof(EvmWarmer),
-    typeof(DatabaseMigrations),
+    typeof(DatabaseMigrations),  // Background runtime migrations that wait for NotSyncing mode; needs full init
     typeof(StartLogIndex),
     typeof(StartRpc)
 )]

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartGrpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartGrpc.cs
@@ -8,7 +8,12 @@ using Nethermind.Logging;
 
 namespace Nethermind.Runner.Ethereum.Steps
 {
-    [RunnerStepDependencies]
+    // Uses dependents instead of being listed in NethermindClientStep's dependencies
+    // because StartGrpc is only registered when gRPC is enabled (see StartRpcStepsModule).
+    [RunnerStepDependencies(
+        dependencies: [],
+        dependents: [typeof(NethermindClientStep)]
+    )]
     public class StartGrpc(GrpcRunner grpcRunner, ILogManager logManager) : IStep
     {
         public async Task Execute(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
+using Nethermind.Api.Steps;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
@@ -131,9 +132,29 @@ async Task<int> ConfigureAsync(string[] args)
 
     TypeDiscovery.Initialize(typeof(INethermindPlugin));
 
+    List<(string Name, string Description)> stepCommands = DiscoverStepCommands();
+    Argument<string> commandArgument = new("command")
+    {
+        Description = "Optional command to run instead of the full client",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+    commandArgument.Validators.Add(result =>
+    {
+        string? value = result.GetValueOrDefault<string>();
+        if (value is not null && !stepCommands.Any(c => c.Name == value))
+            result.AddError($"Unknown command '{value}'. Available commands: {string.Join(", ", stepCommands.Select(c => c.Name))}");
+    });
+    rootCommand.Add(commandArgument);
+
     AddConfigurationOptions(rootCommand);
 
-    rootCommand.SetAction((result, token) => RunAsync(result, pluginLoader, token));
+    rootCommand.SetAction((result, token) =>
+    {
+        string? command = result.GetValue(commandArgument);
+        if (command is not null)
+            return RunCommandAsync(result, pluginLoader, command, token);
+        return RunAsync(result, pluginLoader, token);
+    });
 
     parseResult = rootCommand.Parse(args);
     parseResult.InvocationConfiguration.EnableDefaultExceptionHandler = false;
@@ -227,6 +248,91 @@ async Task<int> RunAsync(ParseResult parseResult, PluginLoader pluginLoader, Can
     exit.Set();
 
     return processExitSource.ExitCode;
+}
+
+async Task<int> RunCommandAsync(ParseResult parseResult, PluginLoader pluginLoader, string commandName, CancellationToken cancellationToken)
+{
+    IConfigProvider configProvider = CreateConfigProvider(parseResult);
+    IInitConfig initConfig = configProvider.GetConfig<IInitConfig>();
+    IKeyStoreConfig keyStoreConfig = configProvider.GetConfig<IKeyStoreConfig>();
+    ISnapshotConfig snapshotConfig = configProvider.GetConfig<ISnapshotConfig>();
+    IPluginConfig pluginConfig = configProvider.GetConfig<IPluginConfig>();
+
+    pluginLoader.OrderPlugins(pluginConfig);
+
+    ResolveDataDirectory(parseResult.GetValue(BasicOptions.DataDirectory),
+        initConfig, keyStoreConfig, snapshotConfig);
+
+    NLogManager logManager = new(initConfig.LogFileName, initConfig.LogDirectory, initConfig.LogRules);
+    DotNettyLoggerFactory.DefaultFactory = new NethermindLoggerFactory(logManager, lowerLogLevel: true);
+#if !DEBUG
+    DotNettyLeakDetector.Level = DotNettyLeakDetector.DetectionLevel.Disabled;
+#endif
+
+    logger = logManager.GetClassLogger();
+
+    ConfigureSeqLogger(configProvider);
+    ResolveDatabaseDirectory(parseResult.GetValue(BasicOptions.DatabasePath), initConfig);
+
+    if (parseResult.GetValue(BasicOptions.PurgeDb))
+    {
+        PurgeDatabaseDirectory(initConfig.BaseDbPath);
+    }
+    else if (parseResult.GetValue(BasicOptions.ForceResync))
+    {
+        PurgeDatabaseDirectory(initConfig.BaseDbPath, preserveNetwork: true);
+    }
+
+    logger.Info($"Running command: {commandName}");
+
+    if (logger.IsInfo) logger.Info($"RocksDB: v{DbOnTheRocks.GetRocksDbVersion()}");
+
+    processExitSource = new(cancellationToken);
+    ApiBuilder apiBuilder = new(processExitSource!, configProvider, logManager);
+    IList<INethermindPlugin> plugins = await pluginLoader.LoadPlugins(configProvider, apiBuilder.ChainSpec);
+    EthereumRunner ethereumRunner = apiBuilder.CreateEthereumRunner(plugins);
+
+    try
+    {
+        await ethereumRunner.StartCommand(commandName, processExitSource.Token);
+    }
+    catch (OperationCanceledException)
+    {
+        if (logger.IsTrace) logger.Trace("Nethermind operation was canceled.");
+    }
+    catch (Exception ex)
+    {
+        if (logger.IsError) logger.Error(unhandledError, ex);
+
+        processExitSource.Exit(ex is IExceptionWithExitCode withExit ? withExit.ExitCode : ExitCodes.GeneralError);
+    }
+
+    logger.Info("Command completed. Shutting down...");
+
+    await ethereumRunner.StopAsync();
+
+    logger.Info("Nethermind is shut down");
+
+    exit.Set();
+
+    return processExitSource.ExitCode;
+}
+
+static List<(string Name, string Description)> DiscoverStepCommands()
+{
+    List<(string Name, string Description)> commands = [];
+
+    foreach (Type type in TypeDiscovery.FindNethermindBasedTypes(typeof(IStep)))
+    {
+        if (type.IsAbstract || type.IsInterface)
+            continue;
+
+        RunnerCommandAttribute? attr = type.GetCustomAttribute<RunnerCommandAttribute>();
+        if (attr is not null && !attr.IsDefault && !commands.Any(c => c.Name == attr.Name))
+            commands.Add((attr.Name, attr.Description));
+    }
+
+    return commands;
 }
 
 void AddConfigurationOptions(Command command)


### PR DESCRIPTION
## Summary

Currently, the only way to create an alternative CLI tool that reuses Nethermind's initialization infrastructure is to create a completely separate project. This leads to duplicated setup code (database, state, block tree, processors) and missed initialization because the proper init relies heavily on the `IStep` pipeline. For example, `Nethermind.PerfTest` manually reconstructs ~350 lines of blockchain infrastructure that the step pipeline already provides.

This PR fills that gap by allowing any `IStep` to be annotated with `[RunnerCommand("name")]`, making it invocable as a CLI subcommand. The runner resolves only the step's transitive dependencies, executes them, runs the command, and exits. This means new tools like trie verification, database inspection, or performance testing can be built as single-file steps that automatically get correct initialization through the dependency graph.

**Key benefits:**
- **No more duplicated init code** — command steps declare their dependencies and get proper initialization for free
- **Correct by construction** — the same DI container and step pipeline used by the full client is reused, so commands can't miss initialization
- **Minimal execution** — only the required subset of steps runs (e.g., `verify-trie` runs 7 steps instead of ~25), so commands start fast and exit cleanly
- **Easy to extend** — adding a new command is a single `IStep` class with two attributes, usable from plugins too

## Changes

- **`RunnerCommandAttribute`** — new attribute with `Name`, `Description`, `IsDefault` properties
- **`StepInfo`** — exposes `CommandName`, `CommandDescription`, `IsDefaultCommand` from the attribute
- **`EthereumStepsManager`** — refactored into `BuildStepGraph`, `ComputeTransitiveClosure`, `ExecuteFromRoot`. `InitializeAll` finds the default command; `InitializeCommand(name)` finds by name. Command steps' `dependents` are inert (not pushed into other steps).
- **`NethermindClientStep`** — default command depending on all leaf steps (`LogHardwareInfo`, `StartMonitoring`, `StartBlockProducer`, `DatabaseMigrations`, `StartLogIndex`, `StartRpc`). `StartGrpc` pushes in via `dependents` since it's conditionally registered.
- **`RunVerifyTrie`** — annotated with `[RunnerCommand("verify-trie")]`, always registered in `BuiltInStepsModule`. `DiagnosticMode.VerifyTrie` check preserved for backwards compatibility.
- **`EthereumRunner`** — added `StartCommand(commandName, token)`
- **`Program.cs`** — discovers commands via `TypeDiscovery`, registers optional `Argument<string>` on `RootCommand`, branches to `RunCommandAsync` (exits after command) vs `RunAsync` (waits for exit signal)
- **`EvmWarmer`** — moved from leaf to `LoadGenesisBlock` dependency (EVM should be warm before first block processing)

## Future migration candidates

The following standalone binaries manually reconstruct parts of the init pipeline and could adopt `[RunnerCommand]`:

| Project | What it does | Migration benefit |
|---------|-------------|-------------------|
| **`Nethermind.PerfTest`** | Replays blocks measuring throughput/GC. Manually builds ~350 lines of DB, state, block tree, processors, validators, genesis. | **Strong** — ~65-75% code elimination. Only perf metrics and block loading logic would remain. |
| `tools/Evm` (t8n) | EVM transaction execution for testing | Weak — intentionally lightweight, no DB/network |
| `tools/SendBlobs` | EIP-4844 blob sender | Weak — client-side, doesn't need node init |
| `tools/StatelessExecution` | Stateless block execution | Weak — specialized, manual EVM setup |

`Nethermind.PerfTest` is the strongest candidate — it duplicates `InitDatabase`, `InitializeBlockTree`, `InitializeBlockchain`, and `LoadGenesisBlock` entirely.

## Test plan

- [x] `dotnet build src/Nethermind/Nethermind.slnx` compiles
- [x] `dotnet test --project src/Nethermind/Nethermind.Runner.Test/` — step loader tests pass, smoke tests pass (96/96)
- [ ] `nethermind verify-trie --config mainnet` runs 7 steps, verifies trie, exits
- [ ] `nethermind` starts node normally with all steps (unchanged behavior)
- [ ] `nethermind --help` shows the optional `[command]` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)