### PR TITLE
fix: Duplicate-signature quorum bypass in XDC vote aggregation and certificate verification

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
@@ -12,6 +12,7 @@ using Nethermind.Xdc.Errors;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -167,34 +168,28 @@ internal class QuorumCertificateManager : IQuorumCertificateManager
             return false;
         }
 
-        //Possible optimize here
-        Signature[] uniqueSignatures = qc.Signatures.Distinct().ToArray();
-
         ulong qcRound = qc.ProposedBlockInfo.Round;
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(certificateTarget, qcRound);
         double certificateThreshold = spec.CertificateThreshold;
         double required = Math.Ceiling(epochSwitchInfo.Masternodes.Length * certificateThreshold);
-        if ((qcRound > 0) && (uniqueSignatures.Length < required))
-        {
-            error = $"Number of votes ({uniqueSignatures.Length}/{epochSwitchInfo.Masternodes.Length}) does not meet threshold of {certificateThreshold}";
-            return false;
-        }
 
         ValueHash256 voteHash = VoteHash(qc.ProposedBlockInfo, qc.GapNumber);
-        bool allValid = true;
-        Parallel.ForEach(uniqueSignatures, (s, state) =>
+        var masternodeSet = new HashSet<Address>(epochSwitchInfo.Masternodes);
+        HashSet<Address> uniqueSigners = new();
+        foreach (Signature s in qc.Signatures)
         {
             Address signer = _ethereumEcdsa.RecoverAddress(s, voteHash);
-            if (!epochSwitchInfo.Masternodes.Contains(signer))
+            if (!masternodeSet.Contains(signer))
             {
-                allValid = false;
-                state.Stop();
+                error = $"Quorum certificate contains one or more invalid vote signatures";
+                return false;
             }
-        });
+            uniqueSigners.Add(signer);
+            }
 
-        if (!allValid)
+        if ((qcRound > 0) && (uniqueSigners.Count < required))
         {
-            error = $"Quorum certificate contains one or more invalid vote signatures";
+            error = $"Number of unique signers ({uniqueSigners.Count}/{epochSwitchInfo.Masternodes.Length}) does not meet threshold of {certificateThreshold}";
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -72,7 +72,8 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeout.Round);
         var CertificateThreshold = spec.CertificateThreshold;
-        if (collectedTimeouts.Count >= epochSwitchInfo.Masternodes.Length * CertificateThreshold)
+        var uniqueSignerCount = collectedTimeouts.Where(t => t.Signer is not null).Select(t => t.Signer).Distinct().Count();
+        if (uniqueSignerCount >= epochSwitchInfo.Masternodes.Length * CertificateThreshold)
         {
             OnTimeoutPoolThresholdReached(collectedTimeouts, timeout);
         }
@@ -90,9 +91,17 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
     private void OnTimeoutPoolThresholdReached(IEnumerable<Timeout> timeouts, Timeout timeout)
     {
-        Signature[] signatures = timeouts.Select(t => t.Signature).ToArray();
+        var seenSigners = new HashSet<Address>();
+        var signatures = new List<Signature>();
+        foreach (var t in timeouts)
+        {
+            if (t.Signer is not null && seenSigners.Add(t.Signer))
+    {
+                signatures.Add(t.Signature);
+            }
+        }
 
-        var timeoutCertificate = new TimeoutCertificate(timeout.Round, signatures, timeout.GapNumber);
+        var timeoutCertificate = new TimeoutCertificate(timeout.Round, signatures.ToArray(), timeout.GapNumber);
 
         ProcessTimeoutCertificate(timeoutCertificate);
     }
@@ -130,7 +139,6 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         }
         var nextEpochCandidates = new HashSet<Address>(snapshot.NextEpochCandidates);
 
-        var signatures = new HashSet<Signature>(timeoutCertificate.Signatures);
         var xdcHeader = _blockTree.Head?.Header as XdcBlockHeader;
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeoutCertificate.Round);
         EpochSwitchInfo epochInfo = _epochSwitchManager.GetTimeoutCertificateEpochInfo(timeoutCertificate);
@@ -139,27 +147,23 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
             errorMessage = $"Failed to get epoch switch info for timeout certificate with round {timeoutCertificate.Round}";
             return false;
         }
-        if (signatures.Count < epochInfo.Masternodes.Length * spec.CertificateThreshold)
-        {
-            errorMessage = $"Number of unique signatures {signatures.Count} does not meet threshold of {epochInfo.Masternodes.Length * spec.CertificateThreshold}";
-            return false;
-        }
 
         ValueHash256 timeoutMsgHash = ComputeTimeoutMsgHash(timeoutCertificate.Round, timeoutCertificate.GapNumber);
-        bool allValid = true;
-        Parallel.ForEach(signatures,
-            (signature, state) =>
+        HashSet<Address> uniqueSigners = new();
+        foreach (Signature signature in timeoutCertificate.Signatures)
             {
                 Address signer = _ethereumEcdsa.RecoverAddress(signature, in timeoutMsgHash);
                 if (!nextEpochCandidates.Contains(signer))
                 {
-                    allValid = false;
-                    state.Stop();
+                errorMessage = "One or more invalid signatures";
+                return false;
+            }
+            uniqueSigners.Add(signer);
                 }
-            });
-        if (!allValid)
+
+        if (uniqueSigners.Count < epochInfo.Masternodes.Length * spec.CertificateThreshold)
         {
-            errorMessage = "One or more invalid signatures";
+            errorMessage = $"Number of unique signers {uniqueSigners.Count} does not meet threshold of {epochInfo.Masternodes.Length * spec.CertificateThreshold}";
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Xdc/VotesManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/VotesManager.cs
@@ -235,6 +235,7 @@ internal class VotesManager(
     private Signature[] GetValidSignatures(IEnumerable<Vote> votes, Address[] masternodes)
     {
         var masternodeSet = new HashSet<Address>(masternodes);
+        var seenSigners = new HashSet<Address>();
         var signatures = new List<Signature>();
         foreach (var vote in votes)
         {
@@ -243,7 +244,7 @@ internal class VotesManager(
                 vote.Signer = _ethereumEcdsa.RecoverVoteSigner(vote);
             }
 
-            if (masternodeSet.Contains(vote.Signer))
+            if (masternodeSet.Contains(vote.Signer) && seenSigners.Add(vote.Signer))
             {
                 signatures.Add(vote.Signature);
             }


### PR DESCRIPTION
Closes #11026

## Summary

Automated security fix for **Duplicate-signature quorum bypass in XDC vote aggregation and certificate verification** (Critical).

**CWE**: CWE-CWE-347
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
The vulnerability allows a single validator to forge quorum by submitting multiple distinct ECDSA signatures for the same vote/timeout message. Three files are patched:

1. **VotesManager.cs** - `GetValidSignatures()`: Added a `seenSigners` HashSet to track unique signer addresses. Only the first signature from each unique valid masternode signer is included. This ensures the QC built from collected votes contains at most one signature per validator.

2. **QuorumCertificateManager.cs** - `VerifyCertificate()`: Replaced the `Signatures.Distinct()` (which deduplicates by signature bytes) and `Parallel.ForEach` pattern with a sequential loop that recovers each signer, validates masternode membership, and collects unique signers in a `HashSet<Address>`. The threshold is now checked against `uniqueSigners.Count` instead of signature count. Added `using System.Collections.Generic` import.

3. **TimeoutCertificateManager.cs** - Three changes:
   - `HandleTimeoutVote()`: Threshold check now counts unique signers (`collectedTimeouts.Where(t => t.Signer is not null).Select(t => t.Signer).Distinct().Count()`) instead of raw `collectedTimeouts.Count`.
   - `OnTimeoutPoolThresholdReached()`: Deduplicates signatures by signer address before building the TimeoutCertificate.
   - `VerifyTimeoutCertificate()`: Replaced `HashSet<Signature>` with signer recovery loop and `HashSet<Address>` for unique signer counting, checking threshold against unique signer count.

## Caveats
- The QC verification was changed from Parallel.ForEach to sequential iteration. This trades some parallelism for correctness (no need for concurrent HashSet). The masternode count is bounded, so performance impact should be negligible.
- The initial threshold check in VotesManager.HandleVote still uses raw roundVotes.Count as a fast-path, which could let an attacker trigger the more expensive GetValidSignatures call. However, the security-critical second check (validSignatures.Length < requiredVotes) now correctly counts unique signers, so no bypass is possible.
- Timeout.Signer is expected to be set before reaching HandleTimeoutVote (either by FilterTimeout for external timeouts or explicitly for local ones). The null check in the deduplication handles edge cases defensively.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
