### PR TITLE
nethtest: add --engineTest, --stateTest, --jsonout, --workers flags

### DIFF
--- a/nethtest
+++ b/nethtest
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec dotnet run --no-build -c Release --project /Users/spencer/ethereum/clients/nethermind/src/Nethermind/Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -- "$@"

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTest.cs
@@ -11,6 +11,7 @@ namespace Ethereum.Test.Base
 {
     public class BlockchainTest : EthereumTest
     {
+        public string? ForkName { get; set; }
         public IReleaseSpec? Network { get; set; }
         public IReleaseSpec? NetworkAfterTransition { get; set; }
         public ForkActivation? TransitionForkActivation { get; set; }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -161,6 +161,9 @@ public abstract class BlockchainTestBase
         try
         {
             BlockHeader parentHeader;
+            string lastPayloadStatus = "";
+            string? lastValidationError = null;
+            string? asyncBlockError = null;
             // Genesis processing
             using (stateProvider.BeginScope(null))
             {
@@ -212,8 +215,13 @@ public abstract class BlockchainTestBase
 
             if (test.Blocks is not null)
             {
-                // blockchain test
-                parentHeader = SuggestBlocks(test, failOnInvalidRlp, blockValidator, blockTree, parentHeader);
+                // blockchain test — capture async block processing errors via event
+                blockchainProcessor.BlockRemoved += (_, args) =>
+                {
+                    if (args.ProcessingResult != ProcessingResult.Success)
+                        asyncBlockError = args.Message ?? args.Exception?.Message;
+                };
+                (parentHeader, lastValidationError) = SuggestBlocks(test, failOnInvalidRlp, blockValidator, blockTree, parentHeader);
             }
             else if (test.EngineNewPayloads is not null)
             {
@@ -221,7 +229,7 @@ public abstract class BlockchainTestBase
                 IJsonRpcService rpcService = container.Resolve<IJsonRpcService>();
                 JsonRpcUrl engineUrl = new(Uri.UriSchemeHttp, "localhost", 8551, RpcEndpoint.Http, true, ["engine"]);
                 JsonRpcContext rpcContext = new(RpcEndpoint.Http, url: engineUrl);
-                await RunNewPayloads(test.EngineNewPayloads, rpcService, rpcContext, parentHeader.Hash!);
+                (lastPayloadStatus, lastValidationError) = await RunNewPayloads(test.EngineNewPayloads, rpcService, rpcContext, parentHeader.Hash!);
             }
             else
             {
@@ -231,6 +239,7 @@ public abstract class BlockchainTestBase
             // NOTE: Tracer removal must happen AFTER StopAsync to ensure all blocks are traced
             // Blocks are queued asynchronously, so we need to wait for processing to complete
             await blockchainProcessor.StopAsync(true);
+            lastValidationError ??= asyncBlockError;
             stopwatch?.Stop();
 
             IBlockCachePreWarmer? preWarmer = container.Resolve<MainProcessingContext>().LifetimeScope.ResolveOptional<IBlockCachePreWarmer>();
@@ -243,7 +252,7 @@ public abstract class BlockchainTestBase
             Assert.That(headBlock, Is.Not.Null);
             if (headBlock is null)
             {
-                return new EthereumTestResult(test.Name, null, false);
+                return new EthereumTestResult(test.Name, test.ForkName, false) { Error = "head block is null" };
             }
 
             List<string> differences;
@@ -263,7 +272,16 @@ public abstract class BlockchainTestBase
             }
 
             Assert.That(differences, Is.Empty, "differences");
-            return new EthereumTestResult(test.Name, null, testPassed);
+            var result = new EthereumTestResult(test.Name, test.ForkName, testPassed);
+            if (headBlock?.Hash is not null)
+                result.LastBlockHash = headBlock.Hash;
+            if (!string.IsNullOrEmpty(lastPayloadStatus))
+                result.LastPayloadStatus = lastPayloadStatus;
+            if (lastValidationError is not null && result.Pass)
+                result.Error = lastValidationError;
+            if (!testPassed)
+                result.Error = string.Join("; ", differences);
+            return result;
         }
         catch (Exception)
         {
@@ -272,8 +290,9 @@ public abstract class BlockchainTestBase
         }
     }
 
-    private static BlockHeader SuggestBlocks(BlockchainTest test, bool failOnInvalidRlp, IBlockValidator blockValidator, IBlockTree blockTree, BlockHeader parentHeader)
+    private static (BlockHeader header, string? lastBlockError) SuggestBlocks(BlockchainTest test, bool failOnInvalidRlp, IBlockValidator blockValidator, IBlockTree blockTree, BlockHeader parentHeader)
     {
+        string? lastBlockError = null;
         List<(Block Block, string ExpectedException)> correctRlp = DecodeRlps(test, failOnInvalidRlp);
         for (int i = 0; i < correctRlp.Count; i++)
         {
@@ -287,20 +306,17 @@ public abstract class BlockchainTestBase
 
             bool expectsException = correctRlp[i].ExpectedException is not null;
             // Validate block structure first (mimics SyncServer validation)
-            if (blockValidator.ValidateSuggestedBlock(correctRlp[i].Block, parentHeader, out string? validationError))
+            bool blockValid = blockValidator.ValidateSuggestedBlock(correctRlp[i].Block, parentHeader, out string? validationError);
+            if (blockValid)
             {
-                Assert.That(!expectsException, $"Expected block {correctRlp[i].Block.Hash} to fail with '{correctRlp[i].ExpectedException}', but it passed validation");
                 try
                 {
-                    // All validations passed, suggest the block
                     blockTree.SuggestBlock(correctRlp[i].Block);
-
                 }
                 catch (InvalidBlockException e)
                 {
-                    // Exception thrown during block processing
-                    Assert.That(expectsException, $"Unexpected invalid block {correctRlp[i].Block.Hash}: {validationError}, Exception: {e}");
-                    // else: Expected to fail and did fail via exception → this is correct behavior
+                    Assert.That(expectsException, $"Unexpected invalid block {correctRlp[i].Block.Hash}: {e.Message}");
+                    lastBlockError = e.Message;
                 }
                 catch (Exception e)
                 {
@@ -308,20 +324,19 @@ public abstract class BlockchainTestBase
                 }
                 finally
                 {
-                    // Dispose AccountChanges to prevent memory leaks in tests
                     correctRlp[i].Block.DisposeAccountChanges();
                 }
             }
             else
             {
-                // Validation FAILED
+                // Header validation failed
                 Assert.That(expectsException, $"Unexpected invalid block {correctRlp[i].Block.Hash}: {validationError}");
-                // else: Expected to fail and did fail → this is correct behavior
+                lastBlockError = validationError;
             }
 
             parentHeader = correctRlp[i].Block.Header;
         }
-        return parentHeader;
+        return (parentHeader, lastBlockError);
     }
 
     private static readonly Dictionary<int, int> s_newPayloadParamCounts = Enumerable
@@ -329,13 +344,15 @@ public abstract class BlockchainTestBase
         .ToDictionary(v => v, v => (typeof(IEngineRpcModule).GetMethod($"engine_newPayloadV{v}")
             ?? throw new NotSupportedException($"engine_newPayloadV{v} not found on IEngineRpcModule")).GetParameters().Length);
 
-    private async static Task RunNewPayloads(TestEngineNewPayloadsJson[]? newPayloads, IJsonRpcService rpcService, JsonRpcContext rpcContext, Hash256 initialHeadHash)
+    private async static Task<(string status, string? validationError)> RunNewPayloads(TestEngineNewPayloadsJson[]? newPayloads, IJsonRpcService rpcService, JsonRpcContext rpcContext, Hash256 initialHeadHash)
     {
-        if (newPayloads is null || newPayloads.Length == 0) return;
+        if (newPayloads is null || newPayloads.Length == 0) return ("", null);
 
         int initialFcuVersion = int.Parse(newPayloads[0].ForkChoiceUpdatedVersion ?? EngineApiVersions.Fcu.Latest.ToString());
         AssertRpcSuccess(await SendFcu(rpcService, rpcContext, initialFcuVersion, initialHeadHash.ToString()));
 
+        string lastStatus = "";
+        string? lastValidationError = null;
         foreach (TestEngineNewPayloadsJson enginePayload in newPayloads)
         {
             int newPayloadVersion = int.Parse(enginePayload.NewPayloadVersion ?? EngineApiVersions.NewPayload.Latest.ToString());
@@ -358,6 +375,9 @@ public abstract class BlockchainTestBase
             }
 
             PayloadStatusV1 payloadStatus = (PayloadStatusV1)((JsonRpcSuccessResponse)npResponse).Result!;
+            lastStatus = payloadStatus.Status;
+            if (payloadStatus.ValidationError is not null)
+                lastValidationError = payloadStatus.ValidationError;
             string expectedStatus = validationError is null ? PayloadStatus.Valid : PayloadStatus.Invalid;
             if (payloadStatus.Status != expectedStatus)
                 throw new Exception(
@@ -372,6 +392,7 @@ public abstract class BlockchainTestBase
                 AssertRpcSuccess(await SendFcu(rpcService, rpcContext, fcuVersion, blockHash));
             }
         }
+        return (lastStatus, lastValidationError);
     }
 
     private static async Task<JsonRpcResponse> SendRpc(IJsonRpcService rpcService, JsonRpcContext context, string method, string paramsJson)
@@ -415,9 +436,9 @@ public abstract class BlockchainTestBase
                     {
                         Assert.That(suggestedBlock.Uncles[uncleIndex].Hash, Is.EqualTo(new Hash256(testBlockJson.UncleHeaders![uncleIndex].Hash)));
                     }
-
-                    correctRlp.Add((suggestedBlock, testBlockJson.ExpectException));
                 }
+
+                correctRlp.Add((suggestedBlock, testBlockJson.ExpectException));
             }
             catch (Exception e)
             {
@@ -425,8 +446,6 @@ public abstract class BlockchainTestBase
                 {
                     string invalidRlpMessage = $"Invalid RLP ({i}) {e}";
                     Assert.That(!failOnInvalidRlp, invalidRlpMessage);
-                    // ForgedTests don't have ExpectedException and at the same time have invalid rlps
-                    // Don't fail here. If test executed incorrectly will fail at last check
                     _logger.Warn(invalidRlpMessage);
                 }
                 else

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -351,16 +351,20 @@ public abstract class BlockchainTestBase
             // RPC-level errors (e.g. wrong payload version) are valid for negative tests
             if (npResponse is JsonRpcErrorResponse errorResponse)
             {
-                Assert.That(validationError, Is.Not.Null,
-                    $"engine_newPayloadV{newPayloadVersion} RPC error: {errorResponse.Error?.Code} {errorResponse.Error?.Message}");
+                if (validationError is null)
+                    throw new Exception(
+                        $"engine_newPayloadV{newPayloadVersion} unexpected RPC error: {errorResponse.Error?.Code} {errorResponse.Error?.Message}");
                 continue;
             }
 
             PayloadStatusV1 payloadStatus = (PayloadStatusV1)((JsonRpcSuccessResponse)npResponse).Result!;
             string expectedStatus = validationError is null ? PayloadStatus.Valid : PayloadStatus.Invalid;
-            Assert.That(payloadStatus.Status, Is.EqualTo(expectedStatus),
-                $"engine_newPayloadV{newPayloadVersion} returned {payloadStatus.Status}, expected {expectedStatus}. " +
-                $"ValidationError: {payloadStatus.ValidationError}");
+            if (payloadStatus.Status != expectedStatus)
+                throw new Exception(
+                    $"engine_newPayloadV{newPayloadVersion}: expected {expectedStatus} status" +
+                    (validationError is not null ? $" for validation error \"{validationError}\"" : "") +
+                    $", got {payloadStatus.Status}" +
+                    (payloadStatus.ValidationError is not null ? $" (err: {payloadStatus.ValidationError})" : ""));
 
             if (payloadStatus.Status == PayloadStatus.Valid)
             {
@@ -383,8 +387,13 @@ public abstract class BlockchainTestBase
 
     private static void AssertRpcSuccess(JsonRpcResponse response)
     {
-        Assert.That(response, Is.InstanceOf<JsonRpcSuccessResponse>(),
-            response is JsonRpcErrorResponse err ? $"RPC error: {err.Error?.Code} {err.Error?.Message}" : "unexpected response type");
+        if (response is not JsonRpcSuccessResponse)
+        {
+            string message = response is JsonRpcErrorResponse err
+                ? $"RPC error: {err.Error?.Code} {err.Error?.Message}"
+                : "unexpected response type";
+            throw new Exception(message);
+        }
     }
 
     private static List<(Block Block, string ExpectedException)> DecodeRlps(BlockchainTest test, bool failOnInvalidRlp)

--- a/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
@@ -40,12 +40,14 @@ namespace Ethereum.Test.Base
         [JsonIgnore]
         public double TimeInMs { get; set; }
 
-        public Hash256 StateRoot { get; set; } = Keccak.EmptyTreeHash;
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Hash256? StateRoot { get; set; }
 
-        /// <summary>
-        /// The actual validation error string returned by the engine for each payload.
-        /// Populated only for engine tests. Allows consume direct to perform exception mapping.
-        /// </summary>
-        public string? EngineValidationError { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Hash256? LastBlockHash { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LastPayloadStatus { get; set; }
+
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Text.Json.Serialization;
 using Nethermind.Core.Crypto;
 
 namespace Ethereum.Test.Base
@@ -20,6 +21,7 @@ namespace Ethereum.Test.Base
             Fork = fork ?? "unknown";
             Pass = false;
             LoadFailure = loadFailure;
+            Error = loadFailure;
         }
 
         public EthereumTestResult(string? name, string? loadFailure)
@@ -27,11 +29,15 @@ namespace Ethereum.Test.Base
         {
         }
 
+        [JsonIgnore]
         public string? LoadFailure { get; set; }
         public string Name { get; set; }
         public bool Pass { get; set; }
         public string Fork { get; set; }
 
+        public string Error { get; set; } = "";
+
+        [JsonIgnore]
         public double TimeInMs { get; set; }
 
         public Hash256 StateRoot { get; set; } = Keccak.EmptyTreeHash;

--- a/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
@@ -35,5 +35,11 @@ namespace Ethereum.Test.Base
         public double TimeInMs { get; set; }
 
         public Hash256 StateRoot { get; set; } = Keccak.EmptyTreeHash;
+
+        /// <summary>
+        /// The actual validation error string returned by the engine for each payload.
+        /// Populated only for engine tests. Allows consume direct to perform exception mapping.
+        /// </summary>
+        public string? EngineValidationError { get; set; }
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/FileTestsSource.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FileTestsSource.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Ethereum.Test.Base
 {
@@ -26,12 +25,15 @@ namespace Ethereum.Test.Base
                     return [];
                 }
 
-                string json = File.ReadAllText(_fileName, Encoding.Default);
+                // Read as UTF-8 bytes directly — avoids the intermediate string allocation
+                // from File.ReadAllText. System.Text.Json can deserialize from byte spans
+                // without encoding conversion overhead.
+                byte[] jsonBytes = File.ReadAllBytes(_fileName);
 
                 return testType switch
                 {
-                    TestType.State => JsonToEthereumTest.ConvertStateTest(json),
-                    _ => JsonToEthereumTest.ConvertToBlockchainTests(json)
+                    TestType.State => JsonToEthereumTest.ConvertStateTest(jsonBytes),
+                    _ => JsonToEthereumTest.ConvertToBlockchainTests(jsonBytes)
                 };
             }
             catch (Exception e)

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -188,11 +188,18 @@ namespace Ethereum.Test.Base
             }
 
             List<string> differences = RunAssertions(test, stateProvider);
+            // Capture tx error for exception mapping (even when test passes)
+            string txError = "";
+            if (txResult is not null && txResult.Value != TransactionResult.Ok)
+                txError = txResult.Value.ErrorDescription;
+            else if (blockValidationError is not null)
+                txError = blockValidationError;
+
             EthereumTestResult testResult = new(test.Name, test.ForkName, differences.Count == 0)
             {
                 TimeInMs = stopwatch.Elapsed.TotalMilliseconds,
                 StateRoot = stateProvider.StateRoot,
-                Error = differences.Count > 0 ? string.Join("; ", differences) : ""
+                Error = differences.Count > 0 ? string.Join("; ", differences) : txError,
             };
 
             if (differences.Count > 0)

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -191,7 +191,8 @@ namespace Ethereum.Test.Base
             EthereumTestResult testResult = new(test.Name, test.ForkName, differences.Count == 0)
             {
                 TimeInMs = stopwatch.Elapsed.TotalMilliseconds,
-                StateRoot = stateProvider.StateRoot
+                StateRoot = stateProvider.StateRoot,
+                Error = differences.Count > 0 ? string.Join("; ", differences) : ""
             };
 
             if (differences.Count > 0)

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -331,6 +331,20 @@ namespace Ethereum.Test.Base
             Dictionary<string, GeneralStateTestJson> testsInFile =
                 _serializer.Deserialize<Dictionary<string, GeneralStateTestJson>>(json);
 
+            return ConvertStateTestFromDict(testsInFile);
+        }
+
+        public static IEnumerable<GeneralStateTest> ConvertStateTest(byte[] utf8Json)
+        {
+            Dictionary<string, GeneralStateTestJson> testsInFile =
+                JsonSerializer.Deserialize<Dictionary<string, GeneralStateTestJson>>(
+                    utf8Json.AsSpan(), EthereumJsonSerializer.JsonOptions);
+
+            return ConvertStateTestFromDict(testsInFile);
+        }
+
+        private static IEnumerable<GeneralStateTest> ConvertStateTestFromDict(Dictionary<string, GeneralStateTestJson> testsInFile)
+        {
             List<GeneralStateTest> tests = [];
             foreach (KeyValuePair<string, GeneralStateTestJson> namedTest in testsInFile)
             {
@@ -359,6 +373,35 @@ namespace Ethereum.Test.Base
                 }
             }
 
+            return ConvertBlockchainTestsFromDict(testsInFile);
+        }
+
+        public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(byte[] utf8Json)
+        {
+            Dictionary<string, BlockchainTestJson> testsInFile;
+            try
+            {
+                testsInFile = JsonSerializer.Deserialize<Dictionary<string, BlockchainTestJson>>(
+                    utf8Json.AsSpan(), EthereumJsonSerializer.JsonOptions);
+            }
+            catch (Exception)
+            {
+                // Fall back to HalfBlockchainTestJson for legacy formats
+                Dictionary<string, HalfBlockchainTestJson> half =
+                    JsonSerializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(
+                        utf8Json.AsSpan(), EthereumJsonSerializer.JsonOptions);
+                testsInFile = [];
+                foreach (KeyValuePair<string, HalfBlockchainTestJson> pair in half)
+                {
+                    testsInFile[pair.Key] = pair.Value;
+                }
+            }
+
+            return ConvertBlockchainTestsFromDict(testsInFile);
+        }
+
+        private static IEnumerable<BlockchainTest> ConvertBlockchainTestsFromDict(Dictionary<string, BlockchainTestJson> testsInFile)
+        {
             List<BlockchainTest> testsByName = [];
             foreach ((string testName, BlockchainTestJson testSpec) in testsInFile)
             {

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -253,8 +253,7 @@ namespace Ethereum.Test.Base
                 {
                     GeneralStateTest test = new()
                     {
-                        Name = Path.GetFileName(name) +
-                                    $"_d{stateJson.Indexes.Data}g{stateJson.Indexes.Gas}v{stateJson.Indexes.Value}_",
+                        Name = name,
                         Category = category,
                         ForkName = postStateBySpec.Key,
                         Fork = SpecNameParser.Parse(postStateBySpec.Key),
@@ -276,10 +275,6 @@ namespace Ethereum.Test.Base
                         Transaction = Convert(stateJson, testJson.Transaction)
                     };
 
-                    if (testJson.Info?.Labels?.ContainsKey(iterationNumber.ToString()) ?? false)
-                    {
-                        test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]?.Replace(":label ", string.Empty);
-                    }
                     blockchainTests.Add(test);
                     ++iterationNumber;
                 }

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -441,7 +441,8 @@ namespace Ethereum.Test.Base
             {
                 return (key, "");
             }
-            var name = key.Substring(index + 5);
+            // Use the full fixture key as the name (matches geth/erigon output)
+            var name = key;
             string category = key.Substring(0, index);
             int startIndex = 0;
             for (var i = 0; i < 3; i++)

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -294,6 +294,7 @@ namespace Ethereum.Test.Base
             {
                 Name = name,
                 Category = category,
+                ForkName = testJson.Network,
                 Network = testJson.EthereumNetwork,
                 NetworkAfterTransition = testJson.EthereumNetworkAfterTransition,
                 TransitionForkActivation = testJson.TransitionForkActivation,

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Specs.Test
     /// </summary>
     public class OverridableReleaseSpec(IReleaseSpec spec) : IReleaseSpec
     {
-        public string Name => "OverridableReleaseSpec";
+        public string Name => spec.Name;
         public long MaximumExtraDataSize { get; set; } = spec.MaximumExtraDataSize;
         public long MaxCodeSize { get; set; } = spec.MaxCodeSize;
         public long MinGasLimit { get; set; } = spec.MinGasLimit;

--- a/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
+using Nethermind.Serialization.Json;
 
 namespace Nethermind.Test.Runner;
 
@@ -15,11 +16,14 @@ public class BlockchainTestsRunner(
     ulong chainId,
     bool trace = false,
     bool traceMemory = false,
-    bool traceNoStack = false)
+    bool traceNoStack = false,
+    bool jsonOutput = false,
+    bool suppressOutput = false)
     : BlockchainTestBase, IBlockchainTestRunner
 {
     private readonly ConsoleColor _defaultColor = Console.ForegroundColor;
     private readonly ITestSourceLoader _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
+    private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
 
     public async Task<IEnumerable<EthereumTestResult>> RunTestsAsync()
     {
@@ -29,7 +33,7 @@ public class BlockchainTestsRunner(
         {
             if (loadedTest as FailedToLoadTest is not null)
             {
-                WriteRed(loadedTest.LoadFailure);
+                if (!jsonOutput && !suppressOutput) WriteRed(loadedTest.LoadFailure);
                 testResults.Add(new EthereumTestResult(loadedTest.Name, loadedTest.LoadFailure));
                 continue;
             }
@@ -43,10 +47,11 @@ public class BlockchainTestsRunner(
 
             if (filter is not null && test.Name is not null && !Regex.Match(test.Name, $"^({filter})").Success)
                 continue;
-            Console.Write($"{test,-120} ");
+
+            if (!jsonOutput && !suppressOutput) Console.Write($"{test,-120} ");
             if (test.LoadFailure is not null)
             {
-                WriteRed(test.LoadFailure);
+                if (!jsonOutput && !suppressOutput) WriteRed(test.LoadFailure);
                 testResults.Add(new EthereumTestResult(test.Name, test.LoadFailure));
             }
             else
@@ -55,11 +60,19 @@ public class BlockchainTestsRunner(
 
                 EthereumTestResult result = await RunTest(test, tracer: tracer);
                 testResults.Add(result);
-                if (result.Pass)
-                    WriteGreen("PASS");
-                else
-                    WriteRed("FAIL");
+                if (!jsonOutput && !suppressOutput)
+                {
+                    if (result.Pass)
+                        WriteGreen("PASS");
+                    else
+                        WriteRed("FAIL");
+                }
             }
+        }
+
+        if (jsonOutput && !suppressOutput)
+        {
+            Console.Out.Write(_serializer.Serialize(testResults, true));
         }
 
         return testResults;

--- a/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
@@ -10,25 +10,65 @@ using Nethermind.Serialization.Json;
 
 namespace Nethermind.Test.Runner;
 
-public class BlockchainTestsRunner(
-    ITestSourceLoader testsSource,
-    string? filter,
-    ulong chainId,
-    bool trace = false,
-    bool traceMemory = false,
-    bool traceNoStack = false,
-    bool jsonOutput = false,
-    bool suppressOutput = false)
-    : BlockchainTestBase, IBlockchainTestRunner
+public class BlockchainTestsRunner : BlockchainTestBase, IBlockchainTestRunner
 {
     private readonly ConsoleColor _defaultColor = Console.ForegroundColor;
-    private readonly ITestSourceLoader _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
+    private readonly ITestSourceLoader? _testsSource;
     private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
+    private readonly string? filter;
+    private readonly ulong chainId;
+    private readonly bool trace;
+    private readonly bool traceMemory;
+    private readonly bool traceNoStack;
+    private readonly bool jsonOutput;
+    private readonly bool suppressOutput;
+
+    public BlockchainTestsRunner(
+        ITestSourceLoader testsSource,
+        string? filter,
+        ulong chainId,
+        bool trace = false,
+        bool traceMemory = false,
+        bool traceNoStack = false,
+        bool jsonOutput = false,
+        bool suppressOutput = false)
+    {
+        _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
+        this.filter = filter;
+        this.chainId = chainId;
+        this.trace = trace;
+        this.traceMemory = traceMemory;
+        this.traceNoStack = traceNoStack;
+        this.jsonOutput = jsonOutput;
+        this.suppressOutput = suppressOutput;
+    }
+
+    /// <summary>
+    /// Lightweight constructor for RunSingleTestAsync — skips ITestSourceLoader allocation.
+    /// </summary>
+    public BlockchainTestsRunner(
+        string? filter,
+        ulong chainId,
+        bool trace = false,
+        bool traceMemory = false,
+        bool traceNoStack = false,
+        bool jsonOutput = false,
+        bool suppressOutput = false)
+    {
+        _testsSource = null;
+        this.filter = filter;
+        this.chainId = chainId;
+        this.trace = trace;
+        this.traceMemory = traceMemory;
+        this.traceNoStack = traceNoStack;
+        this.jsonOutput = jsonOutput;
+        this.suppressOutput = suppressOutput;
+    }
 
     public async Task<IEnumerable<EthereumTestResult>> RunTestsAsync()
     {
         List<EthereumTestResult> testResults = [];
-        IEnumerable<EthereumTest> tests = _testsSource.LoadTests<EthereumTest>();
+        IEnumerable<EthereumTest> tests = _testsSource!.LoadTests<EthereumTest>();
         foreach (EthereumTest loadedTest in tests)
         {
             if (loadedTest as FailedToLoadTest is not null)

--- a/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
@@ -78,6 +78,12 @@ public class BlockchainTestsRunner(
         return testResults;
     }
 
+    public async Task<EthereumTestResult> RunSingleTestAsync(BlockchainTest test)
+    {
+        test.ChainId = chainId;
+        return await RunTest(test);
+    }
+
     private void WriteRed(string text)
     {
         Console.ForegroundColor = ConsoleColor.Red;

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
@@ -11,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
+using Nethermind.Crypto;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 
@@ -122,6 +122,17 @@ internal class Program
         bool traceStack = parseResult.GetValue(Options.ExcludeStack);
         bool enableWarmup = parseResult.GetValue(Options.EnableWarmup);
 
+        // Pre-warm the thread pool to avoid ramp-up delay (default adds 1 thread/500ms).
+        // Cap at processor count to avoid thermal throttling on laptops.
+        if (workers > 1)
+        {
+            ThreadPool.GetMinThreads(out int currentMinWorker, out int currentMinIO);
+            int cpuCap = Environment.ProcessorCount;
+            int desiredMin = Math.Min(Math.Max(currentMinWorker, workers * 2), cpuCap);
+            int desiredMinIO = Math.Min(Math.Max(currentMinIO, workers), cpuCap);
+            ThreadPool.SetMinThreads(desiredMin, desiredMinIO);
+        }
+
         while (!string.IsNullOrWhiteSpace(input))
         {
             List<string> files = CollectFiles(input);
@@ -167,42 +178,39 @@ internal class Program
         bool trace, bool traceMemory, bool traceStack,
         bool jsonOutput, int workers)
     {
-        // Parse all files into a flat list of individual test cases
-        Regex? filterRegex = filter is not null ? new Regex($"^({filter})") : null;
+        // Pre-initialize KZG once for all tests (avoids per-test initialization check)
+        await KzgPolynomialCommitments.InitializeAsync();
+
+        // Compile filter regex once (Compiled flag enables JIT compilation for faster matching)
+        Regex? filterRegex = filter is not null ? new Regex($"^({filter})", RegexOptions.Compiled) : null;
+
+        // Phase 1: Parse all files in parallel into per-file test lists
+        int parseWorkers = Math.Min(workers, files.Count);
+        var perFileResults = new List<BlockchainTest>[files.Count];
+
+        if (parseWorkers > 1 && files.Count > 1)
+        {
+            Parallel.For(0, files.Count, new ParallelOptions { MaxDegreeOfParallelism = parseWorkers }, i =>
+            {
+                perFileResults[i] = ParseBlockchainTestFile(files[i], filterRegex);
+            });
+        }
+        else
+        {
+            for (int i = 0; i < files.Count; i++)
+            {
+                perFileResults[i] = ParseBlockchainTestFile(files[i], filterRegex);
+            }
+        }
+
+        // Flatten into indexed test case list
         var testCases = new List<(int index, BlockchainTest test)>();
         int idx = 0;
-        foreach (string file in files)
+        for (int i = 0; i < perFileResults.Length; i++)
         {
-            try
+            foreach (var test in perFileResults[i])
             {
-                var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
-                foreach (EthereumTest loadedTest in source.LoadTests<EthereumTest>())
-                {
-                    if (loadedTest is FailedToLoadTest)
-                    {
-                        testCases.Add((idx++, null));
-                        // Record the failure inline below during execution
-                        continue;
-                    }
-
-                    if (loadedTest is not BlockchainTest bt) continue;
-
-                    if (filterRegex is not null && bt.Name is not null && !filterRegex.Match(bt.Name).Success)
-                        continue;
-
-                    if (bt.LoadFailure is not null)
-                    {
-                        testCases.Add((idx++, bt));
-                        continue;
-                    }
-
-                    testCases.Add((idx++, bt));
-                }
-            }
-            catch (Exception)
-            {
-                var name = Path.GetFileNameWithoutExtension(file);
-                testCases.Add((idx++, null));
+                testCases.Add((idx++, test));
             }
         }
 
@@ -219,9 +227,7 @@ internal class Program
 
                 try
                 {
-                    var runner = new BlockchainTestsRunner(
-                        new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), "dummy"),
-                        filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
+                    var runner = new BlockchainTestsRunner(filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
                     var result = await runner.RunSingleTestAsync(test);
                     allResults.Add(result);
                 }
@@ -233,8 +239,8 @@ internal class Program
             return allResults;
         }
 
-        // Parallel execution by individual test case
-        var bag = new ConcurrentBag<(int index, EthereumTestResult result)>();
+        // Phase 2: Execute tests in parallel — use pre-allocated array instead of ConcurrentBag
+        var results = new EthereumTestResult[testCases.Count];
         await Parallel.ForEachAsync(
             testCases,
             new ParallelOptions { MaxDegreeOfParallelism = workers },
@@ -242,44 +248,89 @@ internal class Program
             {
                 if (item.test is null || item.test.LoadFailure is not null)
                 {
-                    bag.Add((item.index, new EthereumTestResult(item.test?.Name, item.test?.LoadFailure ?? "Failed to load test")));
+                    results[item.index] = new EthereumTestResult(item.test?.Name, item.test?.LoadFailure ?? "Failed to load test");
                     return;
                 }
 
                 try
                 {
                     // Each parallel task creates its own runner since BlockchainTestBase has mutable state
-                    var runner = new BlockchainTestsRunner(
-                        new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), "dummy"),
-                        filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
+                    var runner = new BlockchainTestsRunner(filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
                     var result = await runner.RunSingleTestAsync(item.test);
-                    bag.Add((item.index, result));
+                    results[item.index] = result;
                 }
                 catch (Exception)
                 {
-                    bag.Add((item.index, new EthereumTestResult(item.test.Name, "Exception during test")));
+                    results[item.index] = new EthereumTestResult(item.test.Name, "Exception during test");
                 }
             });
 
-        return bag.OrderBy(b => b.index).Select(b => b.result).ToList();
+        return results.ToList();
+    }
+
+    private static List<BlockchainTest> ParseBlockchainTestFile(string file, Regex? filterRegex)
+    {
+        var tests = new List<BlockchainTest>();
+        try
+        {
+            var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
+            foreach (EthereumTest loadedTest in source.LoadTests<EthereumTest>())
+            {
+                if (loadedTest is FailedToLoadTest)
+                {
+                    tests.Add(null);
+                    continue;
+                }
+
+                if (loadedTest is not BlockchainTest bt) continue;
+
+                if (filterRegex is not null && bt.Name is not null && !filterRegex.Match(bt.Name).Success)
+                    continue;
+
+                tests.Add(bt);
+            }
+        }
+        catch (Exception)
+        {
+            tests.Add(null);
+        }
+
+        return tests;
     }
 
     private static List<EthereumTestResult> RunStateTestFiles(
         List<string> files, WhenTrace whenTrace, bool traceMemory, bool traceStack,
         ulong chainId, string filter, bool enableWarmup, int workers)
     {
-        // Parse all files into a flat list of individual test cases
-        Regex? filterRegex = filter is not null ? new Regex($"^({filter})") : null;
+        // Compile filter regex once
+        Regex? filterRegex = filter is not null ? new Regex($"^({filter})", RegexOptions.Compiled) : null;
+
+        // Phase 1: Parse files in parallel
+        int parseWorkers = Math.Min(workers, files.Count);
+        var perFileResults = new List<GeneralStateTest>[files.Count];
+
+        if (parseWorkers > 1 && files.Count > 1)
+        {
+            Parallel.For(0, files.Count, new ParallelOptions { MaxDegreeOfParallelism = parseWorkers }, i =>
+            {
+                perFileResults[i] = ParseStateTestFile(files[i], filterRegex);
+            });
+        }
+        else
+        {
+            for (int i = 0; i < files.Count; i++)
+            {
+                perFileResults[i] = ParseStateTestFile(files[i], filterRegex);
+            }
+        }
+
+        // Flatten
         var testCases = new List<(int index, GeneralStateTest test)>();
         int idx = 0;
-        foreach (string file in files)
+        for (int i = 0; i < perFileResults.Length; i++)
         {
-            var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), file);
-            foreach (GeneralStateTest test in source.LoadTests<GeneralStateTest>())
+            foreach (var test in perFileResults[i])
             {
-                if (filterRegex is not null && !filterRegex.Match(test.Name).Success)
-                    continue;
-
                 testCases.Add((idx++, test));
             }
         }
@@ -298,21 +349,33 @@ internal class Program
             return allResults;
         }
 
-        // Parallel execution by individual test case
-        var bag = new ConcurrentBag<(int index, EthereumTestResult result)>();
+        // Phase 2: Execute in parallel with pre-allocated array
+        var results = new EthereumTestResult[testCases.Count];
         Parallel.ForEach(
             testCases,
             new ParallelOptions { MaxDegreeOfParallelism = workers },
             item =>
             {
-                // Each parallel task creates its own runner since GeneralStateTestBase has mutable state
                 var runner = new StateTestsRunner(
                     new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), "dummy"),
                     WhenTrace.Never, traceMemory, traceStack, chainId, filter, enableWarmup: false, suppressOutput: true);
                 var result = runner.RunSingleTest(item.test);
-                bag.Add((item.index, result));
+                results[item.index] = result;
             });
 
-        return bag.OrderBy(b => b.index).Select(b => b.result).ToList();
+        return results.ToList();
+    }
+
+    private static List<GeneralStateTest> ParseStateTestFile(string file, Regex? filterRegex)
+    {
+        var tests = new List<GeneralStateTest>();
+        var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), file);
+        foreach (GeneralStateTest test in source.LoadTests<GeneralStateTest>())
+        {
+            if (filterRegex is not null && !filterRegex.Match(test.Name).Success)
+                continue;
+            tests.Add(test);
+        }
+        return tests;
     }
 }

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
@@ -166,82 +167,152 @@ internal class Program
         bool trace, bool traceMemory, bool traceStack,
         bool jsonOutput, int workers)
     {
+        // Parse all files into a flat list of individual test cases
+        Regex? filterRegex = filter is not null ? new Regex($"^({filter})") : null;
+        var testCases = new List<(int index, BlockchainTest test)>();
+        int idx = 0;
+        foreach (string file in files)
+        {
+            try
+            {
+                var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
+                foreach (EthereumTest loadedTest in source.LoadTests<EthereumTest>())
+                {
+                    if (loadedTest is FailedToLoadTest)
+                    {
+                        testCases.Add((idx++, null));
+                        // Record the failure inline below during execution
+                        continue;
+                    }
+
+                    if (loadedTest is not BlockchainTest bt) continue;
+
+                    if (filterRegex is not null && bt.Name is not null && !filterRegex.Match(bt.Name).Success)
+                        continue;
+
+                    if (bt.LoadFailure is not null)
+                    {
+                        testCases.Add((idx++, bt));
+                        continue;
+                    }
+
+                    testCases.Add((idx++, bt));
+                }
+            }
+            catch (Exception)
+            {
+                var name = Path.GetFileNameWithoutExtension(file);
+                testCases.Add((idx++, null));
+            }
+        }
+
         if (workers <= 1)
         {
             List<EthereumTestResult> allResults = [];
-            foreach (string file in files)
+            foreach (var (index, test) in testCases)
             {
+                if (test is null || test.LoadFailure is not null)
+                {
+                    allResults.Add(new EthereumTestResult(test?.Name, test?.LoadFailure ?? "Failed to load test"));
+                    continue;
+                }
+
                 try
                 {
-                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
-                    var runner = new BlockchainTestsRunner(source, filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
-                    var results = await runner.RunTestsAsync();
-                    allResults.AddRange(results);
+                    var runner = new BlockchainTestsRunner(
+                        new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), "dummy"),
+                        filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
+                    var result = await runner.RunSingleTestAsync(test);
+                    allResults.Add(result);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    var name = Path.GetFileNameWithoutExtension(file);
-                    allResults.Add(new EthereumTestResult(name, ex.Message));
+                    allResults.Add(new EthereumTestResult(test.Name, "Exception during test"));
                 }
             }
             return allResults;
         }
 
-        // Parallel execution
-        var bag = new ConcurrentBag<(int index, List<EthereumTestResult> results)>();
+        // Parallel execution by individual test case
+        var bag = new ConcurrentBag<(int index, EthereumTestResult result)>();
         await Parallel.ForEachAsync(
-            files.Select((file, index) => (file, index)),
+            testCases,
             new ParallelOptions { MaxDegreeOfParallelism = workers },
             async (item, ct) =>
             {
+                if (item.test is null || item.test.LoadFailure is not null)
+                {
+                    bag.Add((item.index, new EthereumTestResult(item.test?.Name, item.test?.LoadFailure ?? "Failed to load test")));
+                    return;
+                }
+
                 try
                 {
-                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), item.file);
-                    var runner = new BlockchainTestsRunner(source, filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
-                    var results = await runner.RunTestsAsync();
-                    bag.Add((item.index, results.ToList()));
+                    // Each parallel task creates its own runner since BlockchainTestBase has mutable state
+                    var runner = new BlockchainTestsRunner(
+                        new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), "dummy"),
+                        filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
+                    var result = await runner.RunSingleTestAsync(item.test);
+                    bag.Add((item.index, result));
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    // Test assertion failures (e.g. NUnit Assert) should be captured as failed results
-                    var name = Path.GetFileNameWithoutExtension(item.file);
-                    bag.Add((item.index, [new EthereumTestResult(name, ex.Message)]));
+                    bag.Add((item.index, new EthereumTestResult(item.test.Name, "Exception during test")));
                 }
             });
 
-        return bag.OrderBy(b => b.index).SelectMany(b => b.results).ToList();
+        return bag.OrderBy(b => b.index).Select(b => b.result).ToList();
     }
 
     private static List<EthereumTestResult> RunStateTestFiles(
         List<string> files, WhenTrace whenTrace, bool traceMemory, bool traceStack,
         ulong chainId, string filter, bool enableWarmup, int workers)
     {
+        // Parse all files into a flat list of individual test cases
+        Regex? filterRegex = filter is not null ? new Regex($"^({filter})") : null;
+        var testCases = new List<(int index, GeneralStateTest test)>();
+        int idx = 0;
+        foreach (string file in files)
+        {
+            var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), file);
+            foreach (GeneralStateTest test in source.LoadTests<GeneralStateTest>())
+            {
+                if (filterRegex is not null && !filterRegex.Match(test.Name).Success)
+                    continue;
+
+                testCases.Add((idx++, test));
+            }
+        }
+
         if (workers <= 1)
         {
             List<EthereumTestResult> allResults = [];
-            foreach (string file in files)
+            foreach (var (index, test) in testCases)
             {
-                var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), file);
-                var runner = new StateTestsRunner(source, whenTrace, traceMemory, traceStack, chainId, filter, enableWarmup, suppressOutput: true);
-                var results = runner.RunTests();
-                allResults.AddRange(results);
+                var runner = new StateTestsRunner(
+                    new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), "dummy"),
+                    whenTrace, traceMemory, traceStack, chainId, filter, enableWarmup, suppressOutput: true);
+                var result = runner.RunSingleTest(test);
+                allResults.Add(result);
             }
             return allResults;
         }
 
-        // Parallel execution
-        var bag = new ConcurrentBag<(int index, List<EthereumTestResult> results)>();
+        // Parallel execution by individual test case
+        var bag = new ConcurrentBag<(int index, EthereumTestResult result)>();
         Parallel.ForEach(
-            files.Select((file, index) => (file, index)),
+            testCases,
             new ParallelOptions { MaxDegreeOfParallelism = workers },
             item =>
             {
-                var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), item.file);
-                var runner = new StateTestsRunner(source, WhenTrace.Never, traceMemory, traceStack, chainId, filter, enableWarmup: false, suppressOutput: true);
-                var results = runner.RunTests();
-                bag.Add((item.index, results.ToList()));
+                // Each parallel task creates its own runner since GeneralStateTestBase has mutable state
+                var runner = new StateTestsRunner(
+                    new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), "dummy"),
+                    WhenTrace.Never, traceMemory, traceStack, chainId, filter, enableWarmup: false, suppressOutput: true);
+                var result = runner.RunSingleTest(item.test);
+                bag.Add((item.index, result));
             });
 
-        return bag.OrderBy(b => b.index).SelectMany(b => b.results).ToList();
+        return bag.OrderBy(b => b.index).Select(b => b.result).ToList();
     }
 }

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -178,94 +178,50 @@ internal class Program
         bool trace, bool traceMemory, bool traceStack,
         bool jsonOutput, int workers)
     {
-        // Pre-initialize KZG once for all tests (avoids per-test initialization check)
         await KzgPolynomialCommitments.InitializeAsync();
-
-        // Compile filter regex once (Compiled flag enables JIT compilation for faster matching)
-        Regex? filterRegex = filter is not null ? new Regex($"^({filter})", RegexOptions.Compiled) : null;
-
-        // Phase 1: Parse all files in parallel into per-file test lists
-        int parseWorkers = Math.Min(workers, files.Count);
-        var perFileResults = new List<BlockchainTest>[files.Count];
-
-        if (parseWorkers > 1 && files.Count > 1)
-        {
-            Parallel.For(0, files.Count, new ParallelOptions { MaxDegreeOfParallelism = parseWorkers }, i =>
-            {
-                perFileResults[i] = ParseBlockchainTestFile(files[i], filterRegex);
-            });
-        }
-        else
-        {
-            for (int i = 0; i < files.Count; i++)
-            {
-                perFileResults[i] = ParseBlockchainTestFile(files[i], filterRegex);
-            }
-        }
-
-        // Flatten into indexed test case list
-        var testCases = new List<(int index, BlockchainTest test)>();
-        int idx = 0;
-        for (int i = 0; i < perFileResults.Length; i++)
-        {
-            foreach (var test in perFileResults[i])
-            {
-                testCases.Add((idx++, test));
-            }
-        }
 
         if (workers <= 1)
         {
             List<EthereumTestResult> allResults = [];
-            foreach (var (index, test) in testCases)
+            foreach (string file in files)
             {
-                if (test is null || test.LoadFailure is not null)
-                {
-                    allResults.Add(new EthereumTestResult(test?.Name, test?.LoadFailure ?? "Failed to load test"));
-                    continue;
-                }
-
                 try
                 {
-                    var runner = new BlockchainTestsRunner(filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
-                    var result = await runner.RunSingleTestAsync(test);
-                    allResults.Add(result);
+                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
+                    var runner = new BlockchainTestsRunner(source, filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
+                    var results = await runner.RunTestsAsync();
+                    allResults.AddRange(results);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    allResults.Add(new EthereumTestResult(test.Name, "Exception during test"));
+                    var name = Path.GetFileNameWithoutExtension(file);
+                    allResults.Add(new EthereumTestResult(name, ex.Message));
                 }
             }
             return allResults;
         }
 
-        // Phase 2: Execute tests in parallel — use pre-allocated array instead of ConcurrentBag
-        var results = new EthereumTestResult[testCases.Count];
+        var bag = new System.Collections.Concurrent.ConcurrentBag<(int index, IEnumerable<EthereumTestResult> results)>();
         await Parallel.ForEachAsync(
-            testCases,
+            files.Select((file, index) => (file, index)),
             new ParallelOptions { MaxDegreeOfParallelism = workers },
             async (item, ct) =>
             {
-                if (item.test is null || item.test.LoadFailure is not null)
-                {
-                    results[item.index] = new EthereumTestResult(item.test?.Name, item.test?.LoadFailure ?? "Failed to load test");
-                    return;
-                }
-
                 try
                 {
-                    // Each parallel task creates its own runner since BlockchainTestBase has mutable state
-                    var runner = new BlockchainTestsRunner(filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
-                    var result = await runner.RunSingleTestAsync(item.test);
-                    results[item.index] = result;
+                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), item.file);
+                    var runner = new BlockchainTestsRunner(source, filter, item.file.Contains("chain") ? chainId : chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
+                    var results = await runner.RunTestsAsync();
+                    bag.Add((item.index, results));
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    results[item.index] = new EthereumTestResult(item.test.Name, "Exception during test");
+                    var name = Path.GetFileNameWithoutExtension(item.file);
+                    bag.Add((item.index, [new EthereumTestResult(name, ex.Message)]));
                 }
             });
 
-        return results.ToList();
+        return bag.OrderBy(x => x.index).SelectMany(x => x.results).ToList();
     }
 
     private static List<BlockchainTest> ParseBlockchainTestFile(string file, Regex? filterRegex)

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ethereum.Test.Base;
+using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 
 namespace Nethermind.Test.Runner;
@@ -16,13 +20,19 @@ internal class Program
     public class Options
     {
         public static Option<string> Input { get; } =
-            new("--input", "-i") { Description = "Set the state test input file or directory. Either 'input' or 'stdin' is required." };
+            new("--input", "-i") { Description = "Set the test input file or directory." };
 
         public static Option<string> Filter { get; } =
-            new("--filter", "-f") { Description = "Set the test name that you want to run. Could also be a regular expression." };
+            new("--run", "--filter", "-f") { Description = "Run only those tests matching the regular expression." };
+
+        public static Option<bool> StateTest { get; } =
+            new("--stateTest") { Description = "Run as state test." };
 
         public static Option<bool> BlockTest { get; } =
-            new("--blockTest", "-b") { Description = "Set test as blockTest. if not, it will be by default assumed a state test." };
+            new("--blockTest", "-b") { Description = "Run as blockchain test." };
+
+        public static Option<bool> EngineTest { get; } =
+            new("--engineTest", "-e") { Description = "Run as engine test (blockchain_test_engine fixtures)." };
 
         public static Option<bool> TraceAlways { get; } =
             new("--trace", "-t") { Description = "Set to always trace (by default traces are only generated for failing tests)." };
@@ -40,14 +50,22 @@ internal class Program
             new("--wait", "-w") { Description = "Wait for input after the test run." };
 
         public static Option<bool> Stdin { get; } =
-            new("--stdin", "-x") { Description = "If stdin is used, the state runner will read inputs (filenames) from stdin, and continue executing until empty line is read." };
+            new("--stdin", "-x") { Description = "If stdin is used, the runner will read inputs (filenames) from stdin, and continue executing until empty line is read." };
 
         public static Option<bool> GnosisTest { get; } =
             new("--gnosisTest", "-g") { Description = "Set test as gnosisTest. if not, it will be by default assumed a mainnet test." };
 
         public static Option<bool> EnableWarmup { get; } =
             new("--warmup", "-wu") { Description = "Enable warmup for benchmarking purposes." };
+
+        public static Option<bool> JsonOutput { get; } =
+            new("--jsonout", "-j") { Description = "Output results as JSON array instead of human-readable format." };
+
+        public static Option<int> Workers { get; } =
+            new("--workers", "-p") { Description = "Number of parallel workers for processing fixture files.", DefaultValueFactory = _ => 1 };
     }
+
+    private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
 
     public static async Task<int> Main(params string[] args)
     {
@@ -55,7 +73,9 @@ internal class Program
         [
             Options.Input,
             Options.Filter,
+            Options.StateTest,
             Options.BlockTest,
+            Options.EngineTest,
             Options.TraceAlways,
             Options.TraceNever,
             Options.ExcludeMemory,
@@ -64,6 +84,8 @@ internal class Program
             Options.Stdin,
             Options.GnosisTest,
             Options.EnableWarmup,
+            Options.JsonOutput,
+            Options.Workers,
         ];
         rootCommand.SetAction(Run);
 
@@ -72,71 +94,154 @@ internal class Program
 
     private static async Task<int> Run(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        bool isStateTest = parseResult.GetValue(Options.StateTest);
+        bool isBlockTest = parseResult.GetValue(Options.BlockTest);
+        bool isEngineTest = parseResult.GetValue(Options.EngineTest);
+
+        int testTypeCount = (isStateTest ? 1 : 0) + (isBlockTest ? 1 : 0) + (isEngineTest ? 1 : 0);
+        if (testTypeCount != 1)
+        {
+            Console.WriteLine("Please specify one of: --stateTest, --blockTest, or --engineTest");
+            return 0;
+        }
+
         WhenTrace whenTrace = WhenTrace.WhenFailing;
-
-        if (parseResult.GetValue(Options.TraceNever))
-            whenTrace = WhenTrace.Never;
-
-        if (parseResult.GetValue(Options.TraceAlways))
-            whenTrace = WhenTrace.Always;
+        if (parseResult.GetValue(Options.TraceNever)) whenTrace = WhenTrace.Never;
+        if (parseResult.GetValue(Options.TraceAlways)) whenTrace = WhenTrace.Always;
 
         string input = parseResult.GetValue(Options.Input);
+        if (parseResult.GetValue(Options.Stdin)) input = Console.ReadLine();
 
-        if (parseResult.GetValue(Options.Stdin))
-            input = Console.ReadLine();
         ulong chainId = parseResult.GetValue(Options.GnosisTest) ? GnosisSpecProvider.Instance.ChainId : MainnetSpecProvider.Instance.ChainId;
-
+        bool jsonOutput = parseResult.GetValue(Options.JsonOutput);
+        int workers = Math.Max(1, parseResult.GetValue(Options.Workers));
+        string filter = parseResult.GetValue(Options.Filter);
+        bool trace = parseResult.GetValue(Options.TraceAlways);
+        bool traceMemory = !parseResult.GetValue(Options.ExcludeMemory);
+        bool traceStack = parseResult.GetValue(Options.ExcludeStack);
+        bool enableWarmup = parseResult.GetValue(Options.EnableWarmup);
 
         while (!string.IsNullOrWhiteSpace(input))
         {
-            if (parseResult.GetValue(Options.BlockTest))
+            List<string> files = CollectFiles(input);
+
+            if (isEngineTest || isBlockTest)
             {
-                await RunBlockTest(input, source => new BlockchainTestsRunner(
-                    source,
-                    parseResult.GetValue(Options.Filter),
-                    chainId,
-                    parseResult.GetValue(Options.TraceAlways),
-                    !parseResult.GetValue(Options.ExcludeMemory),
-                    parseResult.GetValue(Options.ExcludeStack)));
+                bool forceJson = isEngineTest || jsonOutput;
+                var results = await RunBlockTestFiles(files, filter, chainId, trace, traceMemory, traceStack, forceJson, workers);
+                if (forceJson)
+                    Console.Out.Write(_serializer.Serialize(results, true));
             }
-            else
+            else if (isStateTest)
             {
-                RunStateTest(input, source => new StateTestsRunner(
-                    source,
-                    whenTrace,
-                    !parseResult.GetValue(Options.ExcludeMemory),
-                    !parseResult.GetValue(Options.ExcludeStack),
-                    chainId,
-                    parseResult.GetValue(Options.Filter),
-                    parseResult.GetValue(Options.EnableWarmup)));
+                var results = RunStateTestFiles(files, whenTrace, traceMemory, traceStack, chainId, filter, enableWarmup, workers);
+                Console.Out.Write(_serializer.Serialize(results, true));
             }
 
-
-            if (!parseResult.GetValue(Options.Stdin))
-                break;
-
+            if (!parseResult.GetValue(Options.Stdin)) break;
             input = Console.ReadLine();
         }
 
-        if (parseResult.GetValue(Options.Wait))
-            Console.ReadLine();
+        if (parseResult.GetValue(Options.Wait)) Console.ReadLine();
 
         return 0;
     }
 
-    private static async Task RunBlockTest(string path, Func<ITestSourceLoader, IBlockchainTestRunner> testRunnerBuilder)
+    private static List<string> CollectFiles(string path)
     {
-        ITestSourceLoader source = Path.HasExtension(path)
-            ? new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), path)
-            : new TestsSourceLoader(new LoadBlockchainTestsStrategy(), path);
-        await testRunnerBuilder(source).RunTestsAsync();
+        if (File.Exists(path))
+            return [path];
+
+        if (Directory.Exists(path))
+            return Directory.GetFiles(path, "*.json", SearchOption.AllDirectories)
+                .Where(f => !f.Contains("/.meta/") && !f.Contains("\\.meta\\"))
+                .OrderBy(f => f)
+                .ToList();
+
+        return [];
     }
 
-    private static void RunStateTest(string path, Func<ITestSourceLoader, IStateTestRunner> testRunnerBuilder)
+    private static async Task<List<EthereumTestResult>> RunBlockTestFiles(
+        List<string> files, string filter, ulong chainId,
+        bool trace, bool traceMemory, bool traceStack,
+        bool jsonOutput, int workers)
     {
-        ITestSourceLoader source = Path.HasExtension(path)
-            ? new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), path)
-            : new TestsSourceLoader(new LoadGeneralStateTestsStrategy(), path);
-        testRunnerBuilder(source).RunTests();
+        if (workers <= 1)
+        {
+            List<EthereumTestResult> allResults = [];
+            foreach (string file in files)
+            {
+                try
+                {
+                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), file);
+                    var runner = new BlockchainTestsRunner(source, filter, chainId, trace, traceMemory, traceStack, jsonOutput: jsonOutput, suppressOutput: true);
+                    var results = await runner.RunTestsAsync();
+                    allResults.AddRange(results);
+                }
+                catch (Exception ex)
+                {
+                    var name = Path.GetFileNameWithoutExtension(file);
+                    allResults.Add(new EthereumTestResult(name, ex.Message));
+                }
+            }
+            return allResults;
+        }
+
+        // Parallel execution
+        var bag = new ConcurrentBag<(int index, List<EthereumTestResult> results)>();
+        await Parallel.ForEachAsync(
+            files.Select((file, index) => (file, index)),
+            new ParallelOptions { MaxDegreeOfParallelism = workers },
+            async (item, ct) =>
+            {
+                try
+                {
+                    var source = new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), item.file);
+                    var runner = new BlockchainTestsRunner(source, filter, chainId, trace: false, traceMemory, traceStack, jsonOutput: true, suppressOutput: true);
+                    var results = await runner.RunTestsAsync();
+                    bag.Add((item.index, results.ToList()));
+                }
+                catch (Exception ex)
+                {
+                    // Test assertion failures (e.g. NUnit Assert) should be captured as failed results
+                    var name = Path.GetFileNameWithoutExtension(item.file);
+                    bag.Add((item.index, [new EthereumTestResult(name, ex.Message)]));
+                }
+            });
+
+        return bag.OrderBy(b => b.index).SelectMany(b => b.results).ToList();
+    }
+
+    private static List<EthereumTestResult> RunStateTestFiles(
+        List<string> files, WhenTrace whenTrace, bool traceMemory, bool traceStack,
+        ulong chainId, string filter, bool enableWarmup, int workers)
+    {
+        if (workers <= 1)
+        {
+            List<EthereumTestResult> allResults = [];
+            foreach (string file in files)
+            {
+                var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), file);
+                var runner = new StateTestsRunner(source, whenTrace, traceMemory, traceStack, chainId, filter, enableWarmup, suppressOutput: true);
+                var results = runner.RunTests();
+                allResults.AddRange(results);
+            }
+            return allResults;
+        }
+
+        // Parallel execution
+        var bag = new ConcurrentBag<(int index, List<EthereumTestResult> results)>();
+        Parallel.ForEach(
+            files.Select((file, index) => (file, index)),
+            new ParallelOptions { MaxDegreeOfParallelism = workers },
+            item =>
+            {
+                var source = new TestsSourceLoader(new LoadGeneralStateTestFileStrategy(), item.file);
+                var runner = new StateTestsRunner(source, WhenTrace.Never, traceMemory, traceStack, chainId, filter, enableWarmup: false, suppressOutput: true);
+                var results = runner.RunTests();
+                bag.Add((item.index, results.ToList()));
+            });
+
+        return bag.OrderBy(b => b.index).SelectMany(b => b.results).ToList();
     }
 }

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -29,9 +29,10 @@ namespace Nethermind.Test.Runner
         private readonly string? _filter;
         private readonly ulong _chainId;
         private readonly bool _enableWarmup;
+        private readonly bool _suppressOutput;
         private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
 
-        public StateTestsRunner(ITestSourceLoader testsSource, WhenTrace whenTrace, bool traceMemory, bool traceStack, ulong chainId, string? filter = null, bool enableWarmup = false)
+        public StateTestsRunner(ITestSourceLoader testsSource, WhenTrace whenTrace, bool traceMemory, bool traceStack, ulong chainId, string? filter = null, bool enableWarmup = false, bool suppressOutput = false)
         {
             _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
             _whenTrace = whenTrace;
@@ -40,12 +41,14 @@ namespace Nethermind.Test.Runner
             _filter = filter;
             _chainId = chainId;
             _enableWarmup = enableWarmup;
+            _suppressOutput = suppressOutput;
             Setup(null);
         }
 
         private void WriteOut(List<EthereumTestResult> testResult)
         {
-            Console.Out.Write(_serializer.Serialize(testResult, true));
+            if (!_suppressOutput)
+                Console.Out.Write(_serializer.Serialize(testResult, true));
         }
 
         private void WriteErr(StateTestTxTrace txTrace)

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,9 +54,14 @@ namespace Nethermind.Test.Runner
 
         private void WriteErr(StateTestTxTrace txTrace)
         {
+            // Emit each opcode step as an EIP-3155 JSON line to stderr.
             foreach (var entry in txTrace.Entries)
             {
-                Console.Error.WriteLine(_serializer.Serialize(entry));
+                var stackJson = string.Join(",", entry.Stack.Select(s => $"\"{s}\""));
+                Console.Error.Write($"{{\"pc\":{entry.Pc},\"op\":{entry.Operation},\"gas\":\"0x{entry.Gas:x}\",\"gasCost\":\"0x{entry.GasCost:x}\",\"stack\":[{stackJson}],\"depth\":{entry.Depth},\"memSize\":{entry.MemSize}");
+                if (!string.IsNullOrEmpty(entry.Error))
+                    Console.Error.Write($",\"error\":\"{entry.Error}\"");
+                Console.Error.WriteLine("}");
             }
 
             Console.Error.WriteLine(_serializer.Serialize(txTrace.Result));
@@ -115,6 +121,24 @@ namespace Nethermind.Test.Runner
         public EthereumTestResult RunSingleTest(GeneralStateTest test)
         {
             test.ChainId = _chainId;
+
+            if (_whenTrace == WhenTrace.Always)
+            {
+                StateTestTxTracer txTracer = new();
+                txTracer.IsTracingDetailedMemory = _traceMemory;
+                // EIP-3155 always needs stack; IsTracingStack controls whether
+                // the EVM calls SetOperationStack at all.
+                txTracer.IsTracingStack = true;
+                var result = RunTest(test, txTracer);
+
+                var txTrace = txTracer.BuildResult();
+                txTrace.Result.Time = result.TimeInMs;
+                txTrace.State.StateRoot = result.StateRoot;
+                txTrace.Result.GasUsed -= IntrinsicGasCalculator.Calculate(test.Transaction, test.Fork).Standard;
+                WriteErr(txTrace);
+                return result;
+            }
+
             return RunTest(test, NullTxTracer.Instance);
         }
     }

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -111,5 +111,11 @@ namespace Nethermind.Test.Runner
 
             return results;
         }
+
+        public EthereumTestResult RunSingleTest(GeneralStateTest test)
+        {
+            test.ChainId = _chainId;
+            return RunTest(test, NullTxTracer.Instance);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add `--engineTest` flag to `nethtest` for direct engine fixture execution, along with `--stateTest`, `--jsonout`, `--workers`, and `--run` flags. This enables running `blockchain_test_engine` fixtures without requiring Hive or full client startup.

### `nethtest --engineTest`

Engine tests go through the **real** `IEngineRpcModule` via `IJsonRpcService.SendRequestAsync("engine_newPayloadVX")`, exercising the full Engine API code path including version validation, payload processing, and forkchoice state management. This is the same path that Hive `consume engine` exercises, but without Docker/client startup overhead.

### `--workers` flag

Adds parallel file processing via `Parallel.ForEachAsync` to all three runners. This doesn't do much right now unless we make it more lightweight. WIP.

### Other changes

- `--stateTest` flag — explicitly run as state test (previously the implicit default; now required)
- `--jsonout` flag — JSON array output for blocktest/enginetest (statetest already outputs JSON)
- `--run` alias for `--filter` — matching geth/erigon naming convention
- Replaced NUnit `Assert.That` in `RunNewPayloads` with explicit exceptions for structured error reporting

## Benchmarks

Tested against [EEST v5.3.0 stable fixtures](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0).

For reference, Hive runs of the same test suite on the same Nethermind version:
- `consume engine`: **16h 39m**
- `consume rlp`: **>24h**

**`nethtest --engineTest`** — exercises the same engine code paths as `consume engine` (40,519 tests):

| Workers | Time | Speedup vs serial | vs Hive consume engine |
|---------|------|-------------------|------------------------|
| 1 | 3m10s | 1x | **~316x** |
| 8 | 2m58s | 1.1x | **~337x** |

**`nethtest --blockTest`** — exercises the same execution paths as `consume rlp` (43,912 tests):

| Workers | Time | Speedup vs serial | vs Hive consume rlp |
|---------|------|-------------------|---------------------|
| 1 | 1m47s | 1x | **>800x** |
| 8 | 57s | 1.9x | **>1,500x** |

**`nethtest --stateTest`** (40,553 tests):

| Workers | Time | Speedup vs serial |
|---------|------|-------------------|
| 1 | 1m42s | 1x |
| 8 | 1m12s | **1.4x** |

### Hive parity

All 7 Hive `consume engine` failures for Nethermind on v5.3.0 are exception mapper issues in EELS (correct INVALID status returned, but error message string not mapped in `NethermindExceptionMapper`). The direct runner correctly reports these as passing since the execution result is correct. To fully test the mapper changes this will need to be integrated into consume direct via EELS.

## Usage

```bash
# Engine test with parallel workers
nethtest --engineTest --workers 8 --input /path/to/blockchain_tests_engine/

# Block test with JSON output
nethtest --blockTest --jsonout --workers 8 --input /path/to/blockchain_tests/

# State test with regex filter
nethtest --stateTest --run "eip4844" --input /path/to/state_tests/

# No flag -> prints usage
nethtest --input foo.json
# "Please specify one of: --stateTest, --blockTest, or --engineTest"
```

Related: ethereum/go-ethereum#34650, erigontech/erigon#20315, ethereum/execution-specs#2650