### PR TITLE
fix AuRaBlockFinalizationManager unclean shutdown

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.AuRa.Test
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(3, 1, 1);
             FinalizeToLevel(1, blockTreeBuilder.ChainLevelInfoRepository);
 
-            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
             finalizationManager.LastFinalizedBlockLevel.Should().Be(1);
         }
@@ -86,7 +86,7 @@ namespace Nethermind.AuRa.Test
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree();
             HashSet<BlockHeader> finalizedBlocks = new();
 
-            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager, twoThirdsMajorityTransition);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager, twoThirdsMajorityTransition);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
             finalizationManager.BlocksFinalized += (sender, args) =>
             {
@@ -117,7 +117,7 @@ namespace Nethermind.AuRa.Test
         {
             int count = 2;
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(count, blockBeneficiaries: [TestItem.AddressA, TestItem.AddressB]);
-            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             IEnumerable<bool> result = Enumerable.Range(0, count).Select(i => blockTreeBuilder.ChainLevelInfoRepository.LoadLevel(i).MainChainBlock.IsFinalized);
@@ -141,7 +141,7 @@ namespace Nethermind.AuRa.Test
             Block genesis = Build.A.Block.Genesis.TestObject;
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree(genesis);
 
-            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             blockTreeBuilder
@@ -185,7 +185,7 @@ namespace Nethermind.AuRa.Test
             SetupValidators(minForFinalization, beneficiaries);
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(chainLength, blockBeneficiaries: beneficiaries);
             BlockTree blockTree = blockTreeBuilder.TestObject;
-            AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             long result = finalizationManager.GetLastLevelFinalizedBy(blockTree.Head.Hash);
@@ -216,7 +216,7 @@ namespace Nethermind.AuRa.Test
             SetupValidators(minForFinalization, beneficiaries);
             BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(chainLength, blockBeneficiaries: beneficiaries);
             BlockTree blockTree = blockTreeBuilder.TestObject;
-            AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            AuRaBlockFinalizationManager finalizationManager = new(blockTree, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _logManager);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
 
             long? result = finalizationManager.GetFinalizationLevel(level);
@@ -235,7 +235,6 @@ namespace Nethermind.AuRa.Test
                 blockTree,
                 Substitute.For<IChainLevelInfoRepository>(),
                 _validatorStore,
-                _validSealerStrategy,
                 _logManager);
 
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
@@ -255,7 +254,6 @@ namespace Nethermind.AuRa.Test
                 blockTreeBuilder.TestObject,
                 blockTreeBuilder.ChainLevelInfoRepository,
                 _validatorStore,
-                _validSealerStrategy,
                 _logManager,
                 twoThirdsMajorityTransition ? 0 : long.MaxValue);
             finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
@@ -25,7 +25,6 @@ namespace Nethermind.AuRa.Test
         private IBranchProcessor _blockProcessor;
         private IValidatorStore _validatorStore;
         private ILogManager _logManager;
-        private IValidSealerStrategy _validSealerStrategy;
 
         [SetUp]
         public void Initialize()
@@ -34,7 +33,6 @@ namespace Nethermind.AuRa.Test
             _blockProcessor = Substitute.For<IBranchProcessor>();
             _validatorStore = Substitute.For<IValidatorStore>();
             _logManager = LimboLogs.Instance;
-            _validSealerStrategy = Substitute.For<IValidSealerStrategy>();
 
             _validatorStore.GetValidators(Arg.Any<long?>()).Returns([TestItem.AddressA, TestItem.AddressB, TestItem.AddressC]);
         }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
@@ -19,23 +19,20 @@ namespace Nethermind.Consensus.AuRa
 {
     public class AuRaBlockFinalizationManager : IAuRaBlockFinalizationManager
     {
-        private static readonly List<BlockHeader> Empty = new List<BlockHeader>();
+        private static readonly List<BlockHeader> Empty = new();
         private readonly IBlockTree _blockTree;
         private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
         private readonly ILogger _logger;
-        private IBranchProcessor _branchProcessor;
+        private IBranchProcessor? _branchProcessor;
         private readonly IValidatorStore _validatorStore;
-        private readonly IValidSealerStrategy _validSealerStrategy;
         private readonly long _twoThirdsMajorityTransition;
-        private long _lastFinalizedBlockLevel;
         private Hash256 _lastProcessedBlockHash = Keccak.EmptyTreeHash;
-        private readonly ValidationStampCollection _consecutiveValidatorsForNotYetFinalizedBlocks = new ValidationStampCollection();
+        private readonly ValidationStampCollection _consecutiveValidatorsForNotYetFinalizedBlocks = new();
 
         public AuRaBlockFinalizationManager(
             IBlockTree blockTree,
             IChainLevelInfoRepository chainLevelInfoRepository,
             IValidatorStore validatorStore,
-            IValidSealerStrategy validSealerStrategy,
             ILogManager logManager,
             long twoThirdsMajorityTransition = long.MaxValue)
         {
@@ -43,7 +40,6 @@ namespace Nethermind.Consensus.AuRa
             _chainLevelInfoRepository = chainLevelInfoRepository ?? throw new ArgumentNullException(nameof(chainLevelInfoRepository));
             _logger = logManager?.GetClassLogger<AuRaBlockFinalizationManager>() ?? throw new ArgumentNullException(nameof(logManager));
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
-            _validSealerStrategy = validSealerStrategy ?? throw new ArgumentNullException(nameof(validSealerStrategy));
             _twoThirdsMajorityTransition = twoThirdsMajorityTransition;
             Initialize();
         }
@@ -58,8 +54,8 @@ namespace Nethermind.Consensus.AuRa
 
         private void Initialize()
         {
-            var hasHead = _blockTree.Head is not null;
-            var level = hasHead ? _blockTree.Head.Number + 1 : 0;
+            bool hasHead = _blockTree.Head is not null;
+            long level = hasHead ? _blockTree.Head.Number + 1 : 0;
             ChainLevelInfo chainLevel;
             do
             {
@@ -81,21 +77,25 @@ namespace Nethermind.Consensus.AuRa
         {
             void UnFinalizeBlock(BlockHeader blockHeader, BatchWrite batch)
             {
-                var (chainLevel, blockInfo) = GetBlockInfo(blockHeader);
-                blockInfo.IsFinalized = false;
-                _chainLevelInfoRepository.PersistLevel(blockHeader.Number, chainLevel, batch);
+                var info = GetBlockInfo(blockHeader);
+                if (info is not null)
+                {
+                    (ChainLevelInfo chainLevel, BlockInfo blockInfo) = info.Value;
+                    blockInfo.IsFinalized = false;
+                    _chainLevelInfoRepository.PersistLevel(blockHeader.Number, chainLevel, batch);
+                }
             }
 
             // rerunning block
             BlockHeader header = e.Blocks[0].Header;
-            if (_blockTree.WasProcessed(header.Number, header.Hash))
+            if (_blockTree.WasProcessed(header.Number, header.Hash!))
             {
                 using var batch = _chainLevelInfoRepository.StartBatch();
                 // need to un-finalize blocks
-                var minSealersForFinalization = GetMinSealersForFinalization(header.Number);
+                int minSealersForFinalization = GetMinSealersForFinalization(header.Number);
                 for (int i = 1; i < minSealersForFinalization; i++)
                 {
-                    header = _blockTree.FindParentHeader(header, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                    header = _blockTree.FindParentHeader(header!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                     if (header is not null)
                     {
                         UnFinalizeBlock(header, batch);
@@ -116,13 +116,13 @@ namespace Nethermind.Consensus.AuRa
 
         private void FinalizeBlocks(BlockHeader finalizingBlock)
         {
-            var finalizedBlocks = GetFinalizedBlocks(finalizingBlock);
+            IReadOnlyList<BlockHeader> finalizedBlocks = GetFinalizedBlocks(finalizingBlock);
 
-            if (finalizedBlocks.Any())
+            if (finalizedBlocks.Count > 0)
             {
                 if (_logger.IsTrace) _logger.Trace(finalizedBlocks.Count == 1
                         ? $"Blocks finalized by {finalizingBlock.ToString(BlockHeader.Format.FullHashAndNumber)}: {finalizedBlocks[0].ToString(BlockHeader.Format.FullHashAndNumber)}."
-                        : $"Blocks finalized by {finalizingBlock.ToString(BlockHeader.Format.FullHashAndNumber)}: {finalizedBlocks[0].Number}-{finalizedBlocks[finalizedBlocks.Count - 1].Number} [{string.Join(",", finalizedBlocks.Select(static b => b.Hash))}].");
+                        : $"Blocks finalized by {finalizingBlock.ToString(BlockHeader.Format.FullHashAndNumber)}: {finalizedBlocks[0].Number}-{finalizedBlocks[^1].Number} [{string.Join(",", finalizedBlocks.Select(static b => b.Hash))}].");
 
                 LastFinalizedBlockLevel = finalizedBlocks[^1].Number;
                 BlocksFinalized?.Invoke(this, new FinalizeEventArgs(finalizingBlock, finalizedBlocks));
@@ -136,14 +136,14 @@ namespace Nethermind.Consensus.AuRa
                 if (_logger.IsInfo) _logger.Info($"Block {_twoThirdsMajorityTransition}: Transitioning to 2/3 quorum.");
             }
 
-            var minSealersForFinalization = GetMinSealersForFinalization(block.Number);
-            var originalBlock = block;
+            int minSealersForFinalization = GetMinSealersForFinalization(block.Number);
+            BlockHeader originalBlock = block;
 
             bool IsConsecutiveBlock() => originalBlock.ParentHash == _lastProcessedBlockHash;
             bool ConsecutiveBlockWillFinalizeBlocks() => _consecutiveValidatorsForNotYetFinalizedBlocks.Count >= minSealersForFinalization;
 
             List<BlockHeader> finalizedBlocks;
-            var isConsecutiveBlock = IsConsecutiveBlock();
+            bool isConsecutiveBlock = IsConsecutiveBlock();
             HashSet<Address> validators = null;
             bool iterateThroughBlocks = true;
             // For consecutive blocks we can do a lot of optimizations.
@@ -170,43 +170,54 @@ namespace Nethermind.Consensus.AuRa
             if (iterateThroughBlocks)
             {
                 finalizedBlocks = new List<BlockHeader>();
-                var originalBlockSealer = originalBlock.Beneficiary;
+                Address originalBlockSealer = originalBlock.Beneficiary;
                 bool ancestorsNotYetRemoved = true;
 
-                using (var batch = _chainLevelInfoRepository.StartBatch())
+                using (BatchWrite batch = _chainLevelInfoRepository.StartBatch())
                 {
-                    var (chainLevel, blockInfo) = GetBlockInfo(block);
-
-                    // if this block sealer seals for 2nd time than this seal can not finalize any blocks
-                    // as the 1st seal or some seal between 1st seal and current one would already finalize some of them
-                    bool OriginalBlockSealerSignedOnlyOnce() => !validators.Contains(originalBlockSealer) || block.Beneficiary != originalBlockSealer;
-
-                    while (!blockInfo.IsFinalized && (isConsecutiveBlock || OriginalBlockSealerSignedOnlyOnce()))
+                    var info = GetBlockInfo(block);
+                    if (info is not null)
                     {
-                        validators.Add(block.Beneficiary);
-                        if (validators.Count >= minSealersForFinalization)
-                        {
-                            blockInfo.IsFinalized = true;
-                            _chainLevelInfoRepository.PersistLevel(block.Number, chainLevel, batch);
+                        (ChainLevelInfo? chainLevel, BlockInfo? blockInfo) = info.Value;
 
-                            finalizedBlocks.Add(block);
-                            if (ancestorsNotYetRemoved)
+                        // if this block sealer seals for 2nd time than this seal can not finalize any blocks
+                        // as the 1st seal or some seal between 1st seal and current one would already finalize some of them
+                        bool OriginalBlockSealerSignedOnlyOnce() => !validators.Contains(originalBlockSealer) || block.Beneficiary != originalBlockSealer;
+
+                        while (!blockInfo.IsFinalized && (isConsecutiveBlock || OriginalBlockSealerSignedOnlyOnce()))
+                        {
+                            validators.Add(block.Beneficiary);
+                            if (validators.Count >= minSealersForFinalization)
                             {
-                                _consecutiveValidatorsForNotYetFinalizedBlocks.RemoveAncestors(block.Number);
-                                ancestorsNotYetRemoved = false;
+                                blockInfo.IsFinalized = true;
+                                _chainLevelInfoRepository.PersistLevel(block.Number, chainLevel, batch);
+
+                                finalizedBlocks.Add(block);
+                                if (ancestorsNotYetRemoved)
+                                {
+                                    _consecutiveValidatorsForNotYetFinalizedBlocks.RemoveAncestors(block.Number);
+                                    ancestorsNotYetRemoved = false;
+                                }
+                            }
+                            else
+                            {
+                                _consecutiveValidatorsForNotYetFinalizedBlocks.Add(block);
+                            }
+
+                            if (!block.IsGenesis)
+                            {
+                                block = _blockTree.FindParentHeader(block, BlockTreeLookupOptions.None);
+                                if (block is null)
+                                    break;
+                                var parentInfo = GetBlockInfo(block);
+                                if (parentInfo is null)
+                                    break;
+                                (chainLevel, blockInfo) = parentInfo.Value;
                             }
                         }
-                        else
-                        {
-                            _consecutiveValidatorsForNotYetFinalizedBlocks.Add(block);
-                        }
-
-                        if (!block.IsGenesis)
-                        {
-                            block = _blockTree.FindParentHeader(block, BlockTreeLookupOptions.None);
-                            (chainLevel, blockInfo) = GetBlockInfo(block);
-                        }
                     }
+                    else
+                        return Empty;
                 }
 
                 finalizedBlocks.Reverse(); // we were adding from the last to earliest, going through parents
@@ -216,16 +227,16 @@ namespace Nethermind.Consensus.AuRa
                 finalizedBlocks = Empty;
             }
 
-            _lastProcessedBlockHash = originalBlock.Hash;
+            _lastProcessedBlockHash = originalBlock.Hash!;
 
             return finalizedBlocks;
         }
 
-        private (ChainLevelInfo parentLevel, BlockInfo parentBlockInfo) GetBlockInfo(BlockHeader blockHeader)
+        private (ChainLevelInfo parentLevel, BlockInfo parentBlockInfo)? GetBlockInfo(BlockHeader blockHeader)
         {
-            var chainLevelInfo = _chainLevelInfoRepository.LoadLevel(blockHeader.Number);
-            var blockInfo = chainLevelInfo.BlockInfos.First(i => i.BlockHash == blockHeader.Hash);
-            return (chainLevelInfo, blockInfo);
+            ChainLevelInfo? chainLevelInfo = _chainLevelInfoRepository.LoadLevel(blockHeader.Number);
+            BlockInfo? blockInfo = chainLevelInfo?.BlockInfos.FirstOrDefault(i => i.BlockHash == blockHeader.Hash);
+            return blockInfo != null ? (chainLevelInfo, blockInfo) : null;
         }
 
         /* Simple, unoptimized method implementation for reference:
@@ -271,14 +282,14 @@ namespace Nethermind.Consensus.AuRa
         }
         */
 
-        public event EventHandler<FinalizeEventArgs> BlocksFinalized;
+        public event EventHandler<FinalizeEventArgs>? BlocksFinalized;
 
         public long GetLastLevelFinalizedBy(Hash256 blockHash)
         {
-            var block = _blockTree.FindHeader(blockHash, BlockTreeLookupOptions.None);
-            var validators = new HashSet<Address>();
-            var minSealersForFinalization = GetMinSealersForFinalization(block.Number);
-            while (block.Number > 0)
+            BlockHeader block = _blockTree.FindHeader(blockHash, BlockTreeLookupOptions.None)!;
+            HashSet<Address> validators = new();
+            int minSealersForFinalization = GetMinSealersForFinalization(block.Number);
+            while (block!.Number > 0)
             {
                 validators.Add(block.Beneficiary);
                 if (validators.Count >= minSealersForFinalization)
@@ -295,8 +306,8 @@ namespace Nethermind.Consensus.AuRa
         public long? GetFinalizationLevel(long level)
         {
             BlockHeader? block = _blockTree.FindHeader(level, BlockTreeLookupOptions.None);
-            var validators = new HashSet<Address>();
-            var minSealersForFinalization = GetMinSealersForFinalization(level);
+            HashSet<Address> validators = new();
+            int minSealersForFinalization = GetMinSealersForFinalization(level);
 
             // this can only happen when we are fast syncing headers before pivot
             if (block is null)
@@ -331,12 +342,12 @@ namespace Nethermind.Consensus.AuRa
 
         public long LastFinalizedBlockLevel
         {
-            get => _lastFinalizedBlockLevel;
+            get;
             private set
             {
-                if (_lastFinalizedBlockLevel < value)
+                if (field < value)
                 {
-                    _lastFinalizedBlockLevel = value;
+                    field = value;
                     if (_logger.IsTrace) _logger.Trace($"Setting {nameof(LastFinalizedBlockLevel)} to {value}.");
                 }
             }
@@ -344,15 +355,18 @@ namespace Nethermind.Consensus.AuRa
 
         public void Dispose()
         {
-            _branchProcessor.BlockProcessed -= OnBlockProcessed;
-            _branchProcessor.BlocksProcessing -= OnBlocksProcessing;
+            if (_branchProcessor is not null)
+            {
+                _branchProcessor.BlockProcessed -= OnBlockProcessed;
+                _branchProcessor.BlocksProcessing -= OnBlocksProcessing;
+            }
         }
 
         [DebuggerDisplay("Count = {Count}")]
         private class ValidationStampCollection
         {
             private readonly IDictionary<Address, int> _validatorCount = new Dictionary<Address, int>();
-            private readonly Deque<BlockHeader> _blocks = new Deque<BlockHeader>();
+            private readonly Deque<BlockHeader> _blocks = new();
 
             public int Count => _validatorCount.Count;
 
@@ -370,7 +384,7 @@ namespace Nethermind.Consensus.AuRa
                     {
                         _blocks.AddToBack(blockHeader);
                     }
-                    int count = _validatorCount.TryGetValue(blockHeader.Beneficiary, out count) ? count + 1 : 1;
+                    int count = _validatorCount.TryGetValue(blockHeader.Beneficiary!, out count) ? count + 1 : 1;
                     _validatorCount[blockHeader.Beneficiary] = count;
                 }
             }
@@ -379,11 +393,11 @@ namespace Nethermind.Consensus.AuRa
             {
                 for (int i = _blocks.Count - 1; i >= 0; i--)
                 {
-                    var item = _blocks[i];
+                    BlockHeader item = _blocks[i];
                     if (item.Number <= blockNumber)
                     {
                         _blocks.RemoveFromBack();
-                        var setCount = _validatorCount[item.Beneficiary];
+                        int setCount = _validatorCount[item.Beneficiary!];
                         if (setCount == 1)
                         {
                             _validatorCount.Remove(item.Beneficiary);
@@ -406,12 +420,12 @@ namespace Nethermind.Consensus.AuRa
                 _blocks.Clear();
             }
 
-            public BlockHeader GetBlockThatWillBeFinalized(out HashSet<Address> validators, int minSealersForFinalization)
+            public BlockHeader? GetBlockThatWillBeFinalized(out HashSet<Address> validators, int minSealersForFinalization)
             {
                 validators = new HashSet<Address>();
                 for (int i = 0; i < _blocks.Count; i++)
                 {
-                    var block = _blocks[i];
+                    BlockHeader? block = _blocks[i];
                     validators.Add(block.Beneficiary);
                     if (validators.Count >= minSealersForFinalization)
                     {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -9,7 +9,6 @@ using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Consensus.AuRa.Transactions;
-using Nethermind.Consensus.AuRa.Validators;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
@@ -32,7 +31,6 @@ public class InitializeBlockchainAuRa(AuRaNethermindApi api, IChainHeadInfoProvi
             api.BlockTree!,
             api.ChainLevelInfoRepository!,
             api.ValidatorStore!,
-            new ValidSealerStrategy(),
             api.LogManager,
             chainSpecAuRa.TwoThirdsMajorityTransition);
 

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
-using Nethermind.Consensus.Processing;
-using Nethermind.Core;
 using Nethermind.Merge.Plugin;
 using NSubstitute;
 using NUnit.Framework;
@@ -19,7 +16,6 @@ public class AuRaMergeFinalizationManagerTests
     private IManualBlockFinalizationManager _manualFinalizationManager;
     private IAuRaBlockFinalizationManager _auRaFinalizationManager;
     private IPoSSwitcher _poSSwitcher;
-    private IBranchProcessor _branchProcessor;
 
     [SetUp]
     public void Setup()
@@ -27,7 +23,6 @@ public class AuRaMergeFinalizationManagerTests
         _manualFinalizationManager = Substitute.For<IManualBlockFinalizationManager>();
         _auRaFinalizationManager = Substitute.For<IAuRaBlockFinalizationManager>();
         _poSSwitcher = Substitute.For<IPoSSwitcher>();
-        _branchProcessor = Substitute.For<IBranchProcessor>();
     }
 
     [TearDown]
@@ -52,29 +47,6 @@ public class AuRaMergeFinalizationManagerTests
         }
 
         _auRaFinalizationManager.Received(1).Dispose();
-    }
-
-    [Test]
-    public void Post_merge_blocks_do_not_trigger_aura_finalization()
-    {
-        _poSSwitcher.HasEverReachedTerminalBlock().Returns(false);
-
-        AuRaMergeFinalizationManager manager = new(_manualFinalizationManager, _auRaFinalizationManager, _poSSwitcher);
-        manager.SetMainBlockBranchProcessor(_branchProcessor);
-
-        // Trigger merge transition
-        _poSSwitcher.TerminalBlockReached += Raise.Event();
-        _auRaFinalizationManager.ClearReceivedCalls();
-
-        // Fire a block processed event — should NOT reach AuRa finalization
-        int blocksFinalized = 0;
-        manager.BlocksFinalized += (_, _) => blocksFinalized++;
-
-        _branchProcessor.BlockProcessed += Raise.EventWith(
-            new BlockProcessedEventArgs(Nethermind.Core.Test.Builders.Build.A.Block.TestObject, Array.Empty<TxReceipt>()));
-
-        Assert.That(blocksFinalized, Is.Zero,
-            "Post-merge BlockProcessed should not trigger AuRa finalization");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Consensus.AuRa;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Merge.Plugin;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.AuRa.Test;
+
+[Parallelizable(ParallelScope.Self)]
+public class AuRaMergeFinalizationManagerTests
+{
+    private IManualBlockFinalizationManager _manualFinalizationManager;
+    private IAuRaBlockFinalizationManager _auRaFinalizationManager;
+    private IPoSSwitcher _poSSwitcher;
+    private IBranchProcessor _branchProcessor;
+
+    [SetUp]
+    public void Setup()
+    {
+        _manualFinalizationManager = Substitute.For<IManualBlockFinalizationManager>();
+        _auRaFinalizationManager = Substitute.For<IAuRaBlockFinalizationManager>();
+        _poSSwitcher = Substitute.For<IPoSSwitcher>();
+        _branchProcessor = Substitute.For<IBranchProcessor>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _manualFinalizationManager?.Dispose();
+        _auRaFinalizationManager?.Dispose();
+    }
+
+    [TestCase(true, Description = "Already post-merge at startup")]
+    [TestCase(false, Description = "Merge transition at runtime")]
+    public void Disposes_aura_manager_on_merge(bool alreadyPostMerge)
+    {
+        _poSSwitcher.HasEverReachedTerminalBlock().Returns(alreadyPostMerge);
+
+        AuRaMergeFinalizationManager _ = new(_manualFinalizationManager, _auRaFinalizationManager, _poSSwitcher);
+
+        if (!alreadyPostMerge)
+        {
+            _auRaFinalizationManager.DidNotReceive().Dispose();
+            _poSSwitcher.TerminalBlockReached += Raise.Event();
+        }
+
+        _auRaFinalizationManager.Received(1).Dispose();
+    }
+
+    [Test]
+    public void Post_merge_blocks_do_not_trigger_aura_finalization()
+    {
+        _poSSwitcher.HasEverReachedTerminalBlock().Returns(false);
+
+        AuRaMergeFinalizationManager manager = new(_manualFinalizationManager, _auRaFinalizationManager, _poSSwitcher);
+        manager.SetMainBlockBranchProcessor(_branchProcessor);
+
+        // Trigger merge transition
+        _poSSwitcher.TerminalBlockReached += Raise.Event();
+        _auRaFinalizationManager.ClearReceivedCalls();
+
+        // Fire a block processed event — should NOT reach AuRa finalization
+        int blocksFinalized = 0;
+        manager.BlocksFinalized += (_, _) => blocksFinalized++;
+
+        _branchProcessor.BlockProcessed += Raise.EventWith(
+            new BlockProcessedEventArgs(Nethermind.Core.Test.Builders.Build.A.Block.TestObject, Array.Empty<TxReceipt>()));
+
+        Assert.That(blocksFinalized, Is.Zero,
+            "Post-merge BlockProcessed should not trigger AuRa finalization");
+    }
+
+    [Test]
+    public void Terminal_block_handler_unsubscribes_itself()
+    {
+        _poSSwitcher.HasEverReachedTerminalBlock().Returns(false);
+
+        AuRaMergeFinalizationManager _ = new(_manualFinalizationManager, _auRaFinalizationManager, _poSSwitcher);
+
+        // First raise disposes and unsubscribes
+        _poSSwitcher.TerminalBlockReached += Raise.Event();
+        _auRaFinalizationManager.Received(1).Dispose();
+
+        _auRaFinalizationManager.ClearReceivedCalls();
+
+        // Second raise should be a no-op — handler was unsubscribed
+        _poSSwitcher.TerminalBlockReached += Raise.Event();
+        _auRaFinalizationManager.DidNotReceive().Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
@@ -18,40 +19,39 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
     {
         _auRaBlockFinalizationManager = blockFinalizationManager;
         _auRaBlockFinalizationManager.BlocksFinalized += OnBlockFinalized;
-    }
 
-    public long GetLastLevelFinalizedBy(Hash256 blockHash)
-    {
-        return _auRaBlockFinalizationManager.GetLastLevelFinalizedBy(blockHash);
-    }
-
-    public long? GetFinalizationLevel(long level)
-    {
-        return _auRaBlockFinalizationManager.GetFinalizationLevel(level);
-    }
-
-    public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
-    {
-        _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
-    }
-
-    public override long LastFinalizedBlockLevel
-    {
-        get
+        if (poSSwitcher.HasEverReachedTerminalBlock())
         {
-            return IsPostMerge
-                ? _manualBlockFinalizationManager.LastFinalizedBlockLevel
-                : _auRaBlockFinalizationManager.LastFinalizedBlockLevel;
+            _auRaBlockFinalizationManager.Dispose();
+        }
+        else
+        {
+            poSSwitcher.TerminalBlockReached += OnTerminalBlock;
         }
     }
+
+    private void OnTerminalBlock(object? sender, EventArgs e)
+    {
+        // Unsubscribe AuRa finalization from block processing events — post-merge
+        // finalization is handled by the beacon chain via ManualBlockFinalizationManager.
+        _auRaBlockFinalizationManager.Dispose();
+    }
+
+    public long GetLastLevelFinalizedBy(Hash256 blockHash) => _auRaBlockFinalizationManager.GetLastLevelFinalizedBy(blockHash);
+
+    public long? GetFinalizationLevel(long level) => _auRaBlockFinalizationManager.GetFinalizationLevel(level);
+
+    public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor) =>
+        _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
+
+    public override long LastFinalizedBlockLevel => IsPostMerge
+        ? _manualBlockFinalizationManager.LastFinalizedBlockLevel
+        : _auRaBlockFinalizationManager.LastFinalizedBlockLevel;
 
     public override void Dispose()
     {
         _auRaBlockFinalizationManager.BlocksFinalized -= OnBlockFinalized;
-        if (IsPostMerge)
-        {
-            _auRaBlockFinalizationManager.Dispose();
-        }
+        _auRaBlockFinalizationManager.Dispose();
         base.Dispose();
     }
 

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -32,6 +32,9 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 
     private void OnTerminalBlock(object? sender, EventArgs e)
     {
+        if (sender is IPoSSwitcher switcher)
+            switcher.TerminalBlockReached -= OnTerminalBlock;
+
         // Unsubscribe AuRa finalization from block processing events — post-merge
         // finalization is handled by the beacon chain via ManualBlockFinalizationManager.
         _auRaBlockFinalizationManager.Dispose();

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -13,11 +13,13 @@ namespace Nethermind.Merge.Plugin;
 public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlockFinalizationManager
 {
     private readonly IAuRaBlockFinalizationManager _auRaBlockFinalizationManager;
+    private readonly IPoSSwitcher _poSSwitcher;
 
     public AuRaMergeFinalizationManager(IManualBlockFinalizationManager manualBlockFinalizationManager, IAuRaBlockFinalizationManager blockFinalizationManager, IPoSSwitcher poSSwitcher)
         : base(manualBlockFinalizationManager, blockFinalizationManager, poSSwitcher)
     {
         _auRaBlockFinalizationManager = blockFinalizationManager;
+        _poSSwitcher = poSSwitcher;
         _auRaBlockFinalizationManager.BlocksFinalized += OnBlockFinalized;
 
         if (poSSwitcher.HasEverReachedTerminalBlock())
@@ -26,14 +28,13 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
         }
         else
         {
-            poSSwitcher.TerminalBlockReached += OnTerminalBlock;
+            _poSSwitcher.TerminalBlockReached += OnTerminalBlock;
         }
     }
 
     private void OnTerminalBlock(object? sender, EventArgs e)
     {
-        if (sender is IPoSSwitcher switcher)
-            switcher.TerminalBlockReached -= OnTerminalBlock;
+        _poSSwitcher.TerminalBlockReached -= OnTerminalBlock;
 
         // Unsubscribe AuRa finalization from block processing events — post-merge
         // finalization is handled by the beacon chain via ManualBlockFinalizationManager.
@@ -53,6 +54,7 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 
     public override void Dispose()
     {
+        _poSSwitcher.TerminalBlockReached -= OnTerminalBlock;
         _auRaBlockFinalizationManager.BlocksFinalized -= OnBlockFinalized;
         _auRaBlockFinalizationManager.Dispose();
         base.Dispose();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Serialization.Rlp
         int GetLength(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 
-    public interface IRlpStreamEncoder<T> : IRlpDecoder<T>
+    public interface IRlpStreamEncoder<in T> : IRlpDecoder<T>
     {
         void Encode(RlpStream stream, T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }


### PR DESCRIPTION
## Changes

- Unsubscribe `AuRaBlockFinalizationManager` from block processing events at merge transition, not just at shutdown
- `AuRaMergeFinalizationManager` now hooks `IPoSSwitcher.TerminalBlockReached` and disposes the AuRa finalization manager when the merge happens, preventing post-merge blocks from triggering pre-merge finalization logic
- The event handler self-unsubscribes to avoid event/memory leaks
- Defense-in-depth: `GetBlockInfo` returns nullable and callers handle null gracefully, preventing NRE if `LoadLevel` returns null during shutdown races
- Removed unused `IValidSealerStrategy` dependency from `AuRaBlockFinalizationManager`

### Root cause

`AuRaBlockFinalizationManager` had zero merge awareness — it stayed subscribed to `BlockProcessed`/`BlocksProcessing` unconditionally and ran AuRa finalization logic on post-merge blocks. On Gnosis post-merge (block 20544072), this caused a `NullReferenceException` in `GetBlockInfo` when `LoadLevel` returned null during shutdown.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `AuRaMergeFinalizationManagerTests` with 3 tests:
- `Disposes_aura_manager_on_merge` (parameterized: startup vs runtime transition)
- `Terminal_block_handler_unsubscribes_itself` (verifies no event leak)

Existing 28 AuRa finalization tests continue to pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No