### PR TITLE
refactor: extract trie visitor orchestration from PatriciaTree

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -355,7 +355,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
 
             for (int i = 0; i < _largerEntryCount; i++)
             {
@@ -383,7 +383,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
 
             for (int i = 0; i < _largerEntryCount; i++)
             {
@@ -417,7 +417,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
             tempTree.RootHash = Keccak.EmptyTreeHash;
 
             using ArrayPoolListRef<PatriciaTree.BulkSetEntry> bulkSet = new(_largerEntryCount);
@@ -462,7 +462,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
             Hash256 originalRootHash = Keccak.EmptyTreeHash;
             tempTree.RootHash = Keccak.EmptyTreeHash;
 
@@ -483,7 +483,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
             Hash256 originalRootHash = Keccak.EmptyTreeHash;
             tempTree.RootHash = Keccak.EmptyTreeHash;
 
@@ -510,7 +510,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = new(trieStore, NullLogManager.Instance);
+            StateTree tempTree = new(trieStore.GetTrieStore(null), NullLogManager.Instance);
             Hash256 originalRootHash = Keccak.EmptyTreeHash;
             tempTree.RootHash = Keccak.EmptyTreeHash;
 
@@ -545,7 +545,7 @@ namespace Nethermind.Benchmarks.Store
             TrieStore trieStore = _largeUncommittedFullTree = TestTrieStoreFactory.Build(new MemDb(),
                 Prune.WhenCacheReaches(1.MiB),
                 Persist.EveryNBlock(2), NullLogManager.Instance);
-            StateTree tempTree = _largeUncommittedStateTree = new StateTree(trieStore, NullLogManager.Instance);
+            StateTree tempTree = _largeUncommittedStateTree = new StateTree(trieStore.GetTrieStore(null), NullLogManager.Instance);
 
             for (int i = 0; i < _largerEntryCount; i++)
             {
@@ -610,7 +610,7 @@ namespace Nethermind.Benchmarks.Store
         [Benchmark]
         public void ReadWithMemoryTrieStore()
         {
-            StateTree tempTree = new(_memoryTrieStore, NullLogManager.Instance);
+            StateTree tempTree = new(_memoryTrieStore.GetTrieStore(null), NullLogManager.Instance);
             tempTree.RootHash = _rootHash;
             for (int i = 0; i < _entryCount; i++)
             {
@@ -621,7 +621,7 @@ namespace Nethermind.Benchmarks.Store
         [Benchmark]
         public void ReadWithMemoryTrieStoreReadOnly()
         {
-            StateTree tempTree = new(_memoryTrieStore.AsReadOnly(), NullLogManager.Instance);
+            StateTree tempTree = new(_memoryTrieStore.AsReadOnly().GetTrieStore(null), NullLogManager.Instance);
             tempTree.RootHash = _rootHash;
             for (int i = 0; i < _entryCount; i++)
             {

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -315,7 +315,7 @@ public class FullPrunerTests(int fullPrunerMemoryBudgetMb, int degreeOfParalleli
         {
             PatriciaTree trie = new(new RawScopedTrieStore(new NodeStorage(TrieDb)), LimboLogs.Instance);
             TrieCopiedNodeVisitor visitor = new(new NodeStorage(CopyDb));
-            trie.Accept(visitor, BlockTree.Head!.StateRoot!);
+            visitor.TraverseState(BlockTree.Head!.StateRoot!, trie.TrieStore);
         }
 
         public void ShouldCopyAllValues()

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Core.Test.Builders
 
                 Account account = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
 
-                StateTree stateTree = new(store, LimboLogs.Instance);
+                StateTree stateTree = new(store.GetTrieStore(null), LimboLogs.Instance);
                 stateTree.Set(AccountAddress0, account);
                 stateTree.Commit();
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
@@ -4,6 +4,7 @@
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.JsonRpc.Test.Data;
@@ -11,7 +12,7 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.State.Proofs;
 using Nethermind.Logging;
 using Nethermind.State;
-using Nethermind.Trie.Pruning;
+using Nethermind.Trie;
 using NUnit.Framework;
 
 namespace Nethermind.JsonRpc.Test.Eip1186
@@ -29,10 +30,9 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             byte[] d = Bytes.FromHexString("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
-            IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(new MemDb());
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -47,7 +47,7 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Commit();
 
             AccountProofCollector accountProofCollector = new(TestItem.AddressA, new byte[][] { a, b, c, d, e });
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.Traverse(tree.RootHash, trieStore);
             AccountProof proof = accountProofCollector.BuildResult();
 
             TestToJson(proof, "{\"accountProof\":[\"0xe215a08c9a7cdf08d4425c138ef5ba3d1f6c2ae18786fe88d9a56230a00b3e83367b25\",\"0xf8518080808080a017934c1c90ce30ca48f32b4f449dab308cfba803fd6d142cab01eb1fad1b70038080808080808080a02352504a0cd6095829b18bae394d0c882d84eead7be5b6ad0a87daaff9d2fb4a8080\",\"0xf869a020227dead52ea912e013e7641ccd6b3b174498e55066b0c174a09c8c3cc4bf5eb846f8448001a0b2375a34ff2c8037d9ff04ebc16367b51d156d9a905ca54cef50bfad1a4c0711a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"],\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"balance\":\"0x1\",\"codeHash\":\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\"nonce\":\"0x0\",\"storageHash\":\"0xb2375a34ff2c8037d9ff04ebc16367b51d156d9a905ca54cef50bfad1a4c0711\",\"storageProof\":[{\"key\":\"0xaaaaaaaaaaaaaaaaaaaaaa\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf85180a0aec9a5fc3ba2ebedf137fbcf6987b303c9d8718f75253e6e2444b81a4049e5b980808080808080808080a0397f22cb0ad24543caffaad031e3a0a538e5d8ac106d8f6858a703d442c0e4d380808080\",\"0xf84ca02046d62176084b9d1eace1c8bcc2353228d10569a500ccfd1bdbd8c093f4b4e9aaa9ab12000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf85180a0aec9a5fc3ba2ebedf137fbcf6987b303c9d8718f75253e6e2444b81a4049e5b980808080808080808080a0397f22cb0ad24543caffaad031e3a0a538e5d8ac106d8f6858a703d442c0e4d380808080\",\"0xf84ca020cc5921315fe8a051acdea77b782ecb469470d4e94248cb4ff49a1ff26fe982aaa9ab34000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x1ccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf84ca0383dacaf928fae678bb3ccca17c746816e9bcfc5628853ae37c67b2d3bbaad32aaa9ab56000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x1ddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf84ca031c208aebac39ba1b4503fa46a491619019fc1a910b3bfe3c78dc3da4abdb097aaa9ab78000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x1eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf84ca03ca9062cf1266ae3ad77045eb67b33d4c9a4f5e2be44c79cad975ace0bc6ed22aaa9ab9a000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]}");
@@ -62,10 +62,9 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             byte[] d = Bytes.FromHexString("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
             byte[] e = Bytes.FromHexString("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 
-            IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(new MemDb());
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Keccak.Compute(a).Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(b).Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             storageTree.Set(Keccak.Compute(c).Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
@@ -80,7 +79,7 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Commit();
 
             AccountProofCollector accountProofCollector = new(TestItem.AddressA, new byte[][] { a });
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.Traverse(tree.RootHash, trieStore);
             AccountProof proof = accountProofCollector.BuildResult();
 
             TestToJson(proof, "{\"accountProof\":[\"0xe215a08c9a7cdf08d4425c138ef5ba3d1f6c2ae18786fe88d9a56230a00b3e83367b25\",\"0xf8518080808080a017934c1c90ce30ca48f32b4f449dab308cfba803fd6d142cab01eb1fad1b70038080808080808080a02352504a0cd6095829b18bae394d0c882d84eead7be5b6ad0a87daaff9d2fb4a8080\",\"0xf869a020227dead52ea912e013e7641ccd6b3b174498e55066b0c174a09c8c3cc4bf5eb846f8448001a0b2375a34ff2c8037d9ff04ebc16367b51d156d9a905ca54cef50bfad1a4c0711a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"],\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"balance\":\"0x1\",\"codeHash\":\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\"nonce\":\"0x0\",\"storageHash\":\"0xb2375a34ff2c8037d9ff04ebc16367b51d156d9a905ca54cef50bfad1a4c0711\",\"storageProof\":[{\"key\":\"0xaaaaaaaaaaaaaaaaaaaaaa\",\"proof\":[\"0xf8918080a02474007b0486d5e951fe3fbcdae3e63cadf9c85cb8f178d3c7ca972e2d77705a808080808080a059c4fa21a1e4c40dc3c87e925befbb78a5b6f729865a12f6f0490d9801bcbf22a06b3576bbd6c91ca7128f69f728f3e30bf8980c6381430a5e80186d0dfec89d4e8080a098cfc3bf071c19a2e230165f4152bb98a5d1ab0fee47c952de65da85fcbdfdb2808080\",\"0xf85180a0aec9a5fc3ba2ebedf137fbcf6987b303c9d8718f75253e6e2444b81a4049e5b980808080808080808080a0397f22cb0ad24543caffaad031e3a0a538e5d8ac106d8f6858a703d442c0e4d380808080\",\"0xf84ca02046d62176084b9d1eace1c8bcc2353228d10569a500ccfd1bdbd8c093f4b4e9aaa9ab12000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]}");

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -127,7 +127,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     private StorageTree CreateStorageTree(Address address, (UInt256 slot, byte[] value)[] slots)
     {
         Hash256 addressHash = Keccak.Compute(address.Bytes);
-        IScopedTrieStore storageTrieStore = (IScopedTrieStore)_trieStore.GetStorageTrieNodeResolver(addressHash);
+        IScopedTrieStore storageTrieStore = new RawScopedTrieStore(_trieDb, addressHash);
         StorageTree storageTree = new(storageTrieStore, _logManager);
 
         foreach ((UInt256 slot, byte[] value) in slots)
@@ -145,7 +145,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(0));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(0));
@@ -168,7 +168,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(0));
@@ -198,7 +198,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(3));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(0));
@@ -224,7 +224,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(1));
@@ -243,7 +243,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.MissingInFlat, Is.EqualTo(1));
@@ -265,7 +265,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.MissingInFlat, Is.EqualTo(0));
@@ -295,7 +295,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(3));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(0));
@@ -320,7 +320,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.SlotCount, Is.EqualTo(2));
@@ -345,7 +345,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
         Assert.That(verifier.Stats.SlotCount, Is.EqualTo(1));
@@ -408,7 +408,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);
-        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None, addr => new RawScopedTrieStore(_trieDb, addr));
 
         Assert.That(verifier.Stats.AccountCount, Is.EqualTo(3));
         Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(1)); // Account C mismatched

--- a/src/Nethermind/Nethermind.State.Flat/FlatStateReader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatStateReader.cs
@@ -6,7 +6,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Int256;
-using Nethermind.Logging;
 using Nethermind.State.Flat.ScopeProvider;
 using Nethermind.Trie;
 
@@ -14,8 +13,7 @@ namespace Nethermind.State.Flat;
 
 public class FlatStateReader(
     [KeyFilter(DbNames.Code)] IDb codeDb,
-    IFlatDbManager flatDbManager,
-    ILogManager logManager
+    IFlatDbManager flatDbManager
 ) : IStateReader
 {
     public bool TryGetAccount(BlockHeader? baseBlock, Address address, out AccountStruct account)
@@ -64,8 +62,7 @@ public class FlatStateReader(
 
         ReadOnlyStateTrieStoreAdapter trieStoreAdapter = new(reader);
 
-        PatriciaTree patriciaTree = new(trieStoreAdapter, logManager);
-        patriciaTree.Accept(treeVisitor, stateId.StateRoot.ToCommitment(), visitingOptions);
+        treeVisitor.TraverseState(stateId.StateRoot.ToCommitment(), trieStoreAdapter, visitingOptions);
     }
 
     public bool HasStateForBlock(BlockHeader? baseBlock) => flatDbManager.HasStateForBlock(new StateId(baseBlock));

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -78,15 +78,16 @@ public class FlatTrieVerifier
         using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId);
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
 
-        return VerifyCore(reader, trieStore, stateId.StateRoot.ToCommitment(), cancellationToken);
+        return VerifyCore(reader, trieStore, stateId.StateRoot.ToCommitment(), cancellationToken, trieStore.GetStorageTrieStore);
     }
 
     // Internal method for testing with direct components
-    internal void Verify(IPersistence.IPersistenceReader reader, IScopedTrieStore trieStore, Hash256 stateRoot, CancellationToken cancellationToken) => VerifyCore(reader, trieStore, stateRoot, cancellationToken);
+    internal void Verify(IPersistence.IPersistenceReader reader, IScopedTrieStore trieStore, Hash256 stateRoot, CancellationToken cancellationToken, Func<Hash256, IScopedTrieStore>? storageFactory = null) =>
+        VerifyCore(reader, trieStore, stateRoot, cancellationToken, storageFactory);
 
-    private bool VerifyCore(IPersistence.IPersistenceReader reader, IScopedTrieStore trieStore, Hash256 stateRoot, CancellationToken cancellationToken)
+    private bool VerifyCore(IPersistence.IPersistenceReader reader, IScopedTrieStore trieStore, Hash256 stateRoot, CancellationToken cancellationToken, Func<Hash256, IScopedTrieStore>? storageFactory = null)
     {
-        HashVerifyingTrieStore verifyingTrieStore = new(trieStore, null, _logger);
+        HashVerifyingTrieStore verifyingTrieStore = new(trieStore, null, _logger, storageFactory);
         VisitorProgressTracker progressTracker = new("Verify flat", _logManager, printNodes: false);
 
         Channel<StorageVerificationJob> channel = Channel.CreateBounded<StorageVerificationJob>(
@@ -434,7 +435,7 @@ public class FlatTrieVerifier
     private async Task ProcessStorageQueue(
         ChannelReader<StorageVerificationJob> channelReader,
         IPersistence.IPersistenceReader reader,
-        IScopedTrieStore trieStore,
+        HashVerifyingTrieStore trieStore,
         CancellationToken cancellationToken)
     {
         await foreach (StorageVerificationJob job in channelReader.ReadAllAsync(cancellationToken))
@@ -467,7 +468,7 @@ public class FlatTrieVerifier
     private void VerifyStorageHashed(
         StorageVerificationJob job,
         IPersistence.IPersistenceReader reader,
-        IScopedTrieStore trieStore,
+        HashVerifyingTrieStore trieStore,
         CancellationToken cancellationToken)
     {
         if (job.StorageRoot == Keccak.EmptyTreeHash)
@@ -477,7 +478,7 @@ public class FlatTrieVerifier
         }
 
         using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, ValueKeccak.Zero, ValueKeccak.MaxValue);
-        IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
+        IScopedTrieStore storageTrieStore = trieStore.ForStorage(job.TrieAccountPath);
         TrieLeafIterator trieIter = new(storageTrieStore, job.StorageRoot, LogTrieNodeException);
 
         bool hasFlat = flatIter.MoveNext();
@@ -524,7 +525,7 @@ public class FlatTrieVerifier
     private void VerifyStoragePreimage(
         StorageVerificationJob job,
         IPersistence.IPersistenceReader reader,
-        IScopedTrieStore trieStore,
+        HashVerifyingTrieStore trieStore,
         CancellationToken cancellationToken)
     {
         // Empty storage root — any flat entries are orphans
@@ -534,7 +535,7 @@ public class FlatTrieVerifier
             return;
         }
 
-        IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
+        IScopedTrieStore storageTrieStore = trieStore.ForStorage(job.TrieAccountPath);
         PatriciaTree storageTree = new(storageTrieStore, _logManager);
 
         HashSet<ulong> verifiedSlots = [];
@@ -837,9 +838,12 @@ public class FlatTrieVerifier
     /// <summary>
     /// Wrapper around IScopedTrieStore that verifies hashes of loaded RLP data.
     /// </summary>
-    private sealed class HashVerifyingTrieStore(IScopedTrieStore inner, Hash256? address, ILogger logger) : IScopedTrieStore
+    private sealed class HashVerifyingTrieStore(IScopedTrieStore inner, Hash256? address, ILogger logger, Func<Hash256, IScopedTrieStore>? storageFactory = null) : IScopedTrieStore
     {
         private long _hashMismatchCount;
+
+        public HashVerifyingTrieStore ForStorage(Hash256 storageAddress) =>
+            new(storageFactory!(storageAddress), storageAddress, logger);
 
         public long HashMismatchCount => Interlocked.Read(ref _hashMismatchCount);
 
@@ -883,11 +887,6 @@ public class FlatTrieVerifier
                 }
             }
         }
-
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) =>
-            address is null
-                ? this
-                : new HashVerifyingTrieStore((IScopedTrieStore)inner.GetStorageTrieNodeResolver(address), address, logger);
 
         public INodeStorage.KeyScheme Scheme => inner.Scheme;
 

--- a/src/Nethermind/Nethermind.State.Flat/Importer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Importer.cs
@@ -44,10 +44,6 @@ public class Importer(
         }
 
         ITrieStore trieStore = new RawTrieStore(nodeStorage);
-        PatriciaTree tree = new(trieStore, logManager)
-        {
-            RootHash = to.StateRoot.ToHash256()
-        };
 
         Channel<Entry> channel = Channel.CreateBounded<Entry>(2_000_000);
         if (_logger.IsWarn) _logger.Warn("Starting import");
@@ -60,7 +56,7 @@ public class Importer(
             Visitor visitor = new(channel.Writer, progressTracker, cancellationToken);
             try
             {
-                tree.Accept(visitor, to.StateRoot.ToHash256(), new VisitingOptions()
+                visitor.Traverse(to.StateRoot.ToHash256(), trieStore, new VisitingOptions()
                 {
                     MaxDegreeOfParallelism = Math.Min(4, Environment.ProcessorCount), // Tend to be faster with low thread
                 });

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/AbstractMinimalTrieStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/AbstractMinimalTrieStore.cs
@@ -25,8 +25,6 @@ public abstract class AbstractMinimalTrieStore : IScopedTrieStore
         return value ?? throw new TrieNodeException($"Missing trie node. {path}:{hash}", path, hash);
     }
 
-    public virtual ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => throw new UnsupportedOperationException("Get trie node resolver not supported");
-
     public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
 
     public abstract class AbstractMinimalCommitter(ConcurrencyController quota) : ICommitter

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatReadOnlyTrieStore.cs
@@ -62,7 +62,7 @@ internal sealed class FlatReadOnlyTrieStore(IFlatDbManager flatDbManager) : IRea
     private ITrieNodeResolver Resolve(Hash256? address)
     {
         ReadOnlyStateTrieStoreAdapter adapter = _adapter ?? throw new InvalidOperationException("BeginScope has not been called");
-        return address is null ? adapter : adapter.GetStorageTrieNodeResolver(address);
+        return address is null ? adapter : adapter.GetStorageTrieStore(address);
     }
 
     private sealed class ScopeCleanup(FlatReadOnlyTrieStore store) : IDisposable

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/OverridableFlatScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/OverridableFlatScopeProvider.cs
@@ -182,8 +182,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
             ConcurrencyController concurrency = new(1);
             StateTrieStoreAdapter trieStoreAdapter = new(snapshotBundle, concurrency);
 
-            PatriciaTree patriciaTree = new(trieStoreAdapter, LimboLogs.Instance);
-            patriciaTree.Accept(treeVisitor, stateId.StateRoot.ToCommitment(), visitingOptions);
+            treeVisitor.TraverseState(stateId.StateRoot.ToCommitment(), trieStoreAdapter, visitingOptions);
         }
 
         public bool HasStateForBlock(BlockHeader? baseBlock) => overridableWorldScope.HasStateForBlock(baseBlock);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ReadOnlyStateTrieStoreAdapter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ReadOnlyStateTrieStoreAdapter.cs
@@ -17,11 +17,6 @@ internal class ReadOnlyStateTrieStoreAdapter(ReadOnlySnapshotBundle bundle) : Ab
 
     public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => throw new InvalidOperationException("Commit not supported");
 
-    public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) =>
-        address is null
-            ? this
-            : new ReadOnlyStorageTrieStoreAdapter(bundle, address); // Used in trie visitor and weird very edge case that cuts the whole thing to pieces
-
     public IScopedTrieStore GetStorageTrieStore(Hash256 address) => new ReadOnlyStorageTrieStoreAdapter(bundle, address);
 }
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/StateTrieStoreAdapter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/StateTrieStoreAdapter.cs
@@ -26,12 +26,6 @@ internal sealed class StateTrieStoreAdapter(
     public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) =>
         new Committer(bundle, concurrencyQuota);
 
-    public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address)
-    {
-        if (address is null) return this;
-        return new StorageTrieStoreAdapter(bundle, concurrencyQuota, address);
-    }
-
     private class Committer(SnapshotBundle bundle, ConcurrencyController concurrencyQuota) : AbstractMinimalCommitter(concurrencyQuota)
     {
         public override TrieNode CommitNode(ref TreePath path, TrieNode node)
@@ -55,11 +49,6 @@ internal sealed class StateTrieStoreWarmerAdapter(
     public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) =>
         bundle.TryLoadStateRlp(path, hash, flags);
 
-    public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address)
-    {
-        if (address is null) return this;
-        return new StorageTrieStoreWarmerAdapter(bundle, address);
-    }
 }
 
 internal sealed class StorageTrieStoreAdapter(

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -11,6 +11,7 @@ using Nethermind.State.Flat.ScopeProvider;
 using Nethermind.State.Snap;
 using Nethermind.State.SnapServer;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Flat.Sync.Snap;
 
@@ -267,10 +268,19 @@ public class FlatSnapServer(
         CancellationToken cancellationToken)
     {
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
-        PatriciaTree tree = new(trieStore, logManager);
         using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new();
-        tree.Accept(visitor, rootHash.ToCommitment(), opt, storageAddr: storage?.ToCommitment(), storageRoot: storageRoot?.ToCommitment());
+        Hash256 effectiveRoot = rootHash.ToCommitment();
+        if (storage is not null)
+        {
+            ITrieNodeResolver resolver = trieStore.GetStorageTrieStore(storage!.Value.ToCommitment());
+            effectiveRoot = storageRoot!.Value.ToCommitment();
+            visitor.TraverseStorage(effectiveRoot, resolver, opt);
+        }
+        else
+        {
+            visitor.TraverseState(effectiveRoot, trieStore, opt);
+        }
 
         IByteArrayList proofs = startingHash != Keccak.Zero || visitor.StoppedEarly ? new ByteArrayListAdapter(visitor.GetProofs()) : EmptyByteArrayList.Instance;
         return (visitor.GetBytesSize(), proofs, visitor.StoppedEarly);

--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeBulkSetterTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeBulkSetterTests.cs
@@ -300,7 +300,7 @@ public class PatriciaTreeBulkSetterTests
             {
                 TreeDumper td = new(expectAccounts: false);
                 pTree.Commit();
-                pTree.Accept(td, pTree.RootHash);
+                td.TraverseState(pTree.RootHash, pTree.TrieStore);
                 if (pTree.RootHash != root)
                 {
                     TestContext.Error.WriteLine($"Baseline {originalDump}");
@@ -386,7 +386,7 @@ public class PatriciaTreeBulkSetterTests
             {
                 TreeDumper td = new(expectAccounts: false);
                 pTree.Commit();
-                pTree.Accept(td, pTree.RootHash);
+                td.TraverseState(pTree.RootHash, pTree.TrieStore);
                 if (pTree.RootHash != root)
                 {
                     TestContext.Error.WriteLine($"Baseline {originalDump}");
@@ -442,7 +442,7 @@ public class PatriciaTreeBulkSetterTests
             {
                 TreeDumper td = new(expectAccounts: false);
                 pTree.Commit();
-                pTree.Accept(td, pTree.RootHash);
+                td.TraverseState(pTree.RootHash, pTree.TrieStore);
                 if (pTree.RootHash != root)
                 {
                     TestContext.Error.WriteLine($"Baseline {originalDump}");
@@ -488,7 +488,7 @@ public class PatriciaTreeBulkSetterTests
             {
                 pTree.Commit();
                 TreeDumper td = new(expectAccounts: false);
-                pTree.Accept(td, pTree.RootHash);
+                td.TraverseState(pTree.RootHash, pTree.TrieStore);
                 originalDump = td.ToString();
             }
             root = pTree.RootHash;
@@ -750,8 +750,6 @@ public class PatriciaTreeBulkSetterTests
         public byte[] LoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => baseTrieStore.LoadRlp(in path, hash, flags);
 
         public byte[] TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => baseTrieStore.TryLoadRlp(in path, hash, flags);
-
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 address) => baseTrieStore.GetStorageTrieNodeResolver(address);
 
         public INodeStorage.KeyScheme Scheme => baseTrieStore.Scheme;
 

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
@@ -25,36 +26,40 @@ namespace Nethermind.Store.Test.Proofs
     [TestFixture, Parallelizable(ParallelScope.All)]
     public class AccountProofCollectorTests
     {
-        private static AccountProof CollectProof(StateTree tree, Address address, UInt256[] storageKeys = null)
+        private static AccountProof CollectProof(StateTree tree, ITrieStore trieStore, Address address, UInt256[] storageKeys = null)
         {
             AccountProofCollector collector = storageKeys is not null
                 ? new(address, storageKeys)
                 : new(address);
-            tree.Accept(collector, tree.RootHash);
+            if (storageKeys is not null)
+                collector.Traverse(tree.RootHash, trieStore);
+            else
+                collector.TraverseState(tree.RootHash, tree.TrieStore);
             return collector.BuildResult();
         }
 
-        private static AccountProof CollectProof(StateTree tree, Address address, byte[][] storageKeys)
+        private static AccountProof CollectProof(StateTree tree, ITrieStore trieStore, Address address, byte[][] storageKeys)
         {
             AccountProofCollector collector = new(address, storageKeys);
-            tree.Accept(collector, tree.RootHash);
+            collector.Traverse(tree.RootHash, trieStore);
             return collector.BuildResult();
         }
 
-        private static AccountProof CollectProof(StateTree tree, byte[] addressBytes, ValueHash256[] storageKeys)
+        private static AccountProof CollectProof(StateTree tree, ITrieStore trieStore, byte[] addressBytes, ValueHash256[] storageKeys)
         {
             AccountProofCollector collector = new(addressBytes, storageKeys);
-            tree.Accept(collector, tree.RootHash);
+            collector.Traverse(tree.RootHash, trieStore);
             return collector.BuildResult();
         }
 
-        private static StateTree CreateTwoAccountTree(Account account1, Account account2)
+        private static (StateTree tree, TestRawTrieStore trieStore) CreateTwoAccountTree(Account account1, Account account2)
         {
-            StateTree tree = new();
+            TestRawTrieStore trieStore = new(new MemDb());
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
             tree.Commit();
-            return tree;
+            return (tree, trieStore);
         }
 
         private static readonly string[] StorageValueHexes =
@@ -69,12 +74,12 @@ namespace Nethermind.Store.Test.Proofs
         /// <summary>
         /// Creates a state tree with a storage tree containing hashed key-value pairs for AddressA.
         /// </summary>
-        private static (StateTree tree, IDb memDb) CreateTreeWithHashedStorage(byte[][] keys, int valueCount)
+        private static (StateTree tree, IDb memDb, ITrieStore trieStore) CreateTreeWithHashedStorage(byte[][] keys, int valueCount)
         {
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             for (int i = 0; i < valueCount; i++)
             {
                 storageTree.Set(Keccak.Compute(keys[i]).Bytes, Rlp.Encode(Bytes.FromHexString(StorageValueHexes[i])));
@@ -85,7 +90,7 @@ namespace Nethermind.Store.Test.Proofs
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
             tree.Commit();
-            return (tree, memDb);
+            return (tree, memDb, trieStore);
         }
 
         [Test]
@@ -93,7 +98,7 @@ namespace Nethermind.Store.Test.Proofs
         {
             StateTree tree = new();
             AccountProofCollector accountProofCollector = new(TestItem.AddressA, new UInt256[] { 1, 2, 3 });
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressA));
             Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
@@ -118,7 +123,7 @@ namespace Nethermind.Store.Test.Proofs
             tree.Commit();
 
             AccountProofCollector accountProofCollector = new(TestItem.AddressC, new UInt256[] { 1, 2, 3 });
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             proof.Proof.Should().HaveCount(1);
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressC));
@@ -140,7 +145,7 @@ namespace Nethermind.Store.Test.Proofs
             tree.Commit();
 
             AccountProofCollector accountProofCollector = new(TestItem.AddressC, new UInt256[] { 1, 2, 3 });
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             proof.Proof.Should().HaveCount(1);
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressC));
@@ -173,7 +178,7 @@ namespace Nethermind.Store.Test.Proofs
             // now wer are looking for a trying to trick the code to think that the extension of c and d is a good match
             // if everything is ok the proof length of 1 is enough since the extension from the root is not matched
             AccountProofCollector accountProofCollector = new(a);
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             proof.Proof.Should().HaveCount(1);
 
@@ -186,12 +191,12 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressA));
 
-            AccountProof proof2 = CollectProof(tree, TestItem.AddressB);
+            AccountProof proof2 = CollectProof(tree, trieStore, TestItem.AddressB);
             Assert.That(proof2.Address, Is.EqualTo(TestItem.AddressB));
         }
 
@@ -200,12 +205,12 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.Balance, Is.EqualTo(UInt256.One));
 
-            AccountProof proof2 = CollectProof(tree, TestItem.AddressB);
+            AccountProof proof2 = CollectProof(tree, trieStore, TestItem.AddressB);
             Assert.That(proof2.Balance, Is.EqualTo(UInt256.One + 1));
         }
 
@@ -215,12 +220,12 @@ namespace Nethermind.Store.Test.Proofs
             byte[] code = new byte[] { 1, 2, 3 };
             Account account1 = Build.An.Account.WithBalance(1).WithCode(code).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.CodeHash, Is.EqualTo(account1.CodeHash));
 
-            AccountProof proof2 = CollectProof(tree, TestItem.AddressB);
+            AccountProof proof2 = CollectProof(tree, trieStore, TestItem.AddressB);
             Assert.That(proof2.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
         }
 
@@ -229,12 +234,12 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).WithNonce(UInt256.One).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.Nonce, Is.EqualTo(account1.Nonce));
 
-            AccountProof proof2 = CollectProof(tree, TestItem.AddressB);
+            AccountProof proof2 = CollectProof(tree, trieStore, TestItem.AddressB);
             Assert.That(proof2.Nonce, Is.EqualTo(UInt256.Zero));
         }
 
@@ -243,12 +248,12 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.StorageRoot, Is.EqualTo(TestItem.KeccakA));
 
-            AccountProof proof2 = CollectProof(tree, TestItem.AddressB);
+            AccountProof proof2 = CollectProof(tree, trieStore, TestItem.AddressB);
             Assert.That(proof2.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
         }
 
@@ -257,9 +262,9 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA);
             Assert.That(proof.Proof.Length, Is.EqualTo(3));
         }
 
@@ -268,19 +273,19 @@ namespace Nethermind.Store.Test.Proofs
         {
             Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
-            StateTree tree = CreateTwoAccountTree(account1, account2);
+            (StateTree tree, TestRawTrieStore trieStore) = CreateTwoAccountTree(account1, account2);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA,
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA,
                 new[] { Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000001") });
             Assert.That(proof.StorageProofs.Length, Is.EqualTo(2));
         }
 
-        private static (StateTree tree, IDb memDb) CreateTreeWithUInt256Storage()
+        private static (StateTree tree, IDb memDb, ITrieStore trieStore) CreateTreeWithUInt256Storage()
         {
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(UInt256.Zero, Bytes.FromHexString(StorageValueHexes[0]));
             storageTree.Set(UInt256.One, Bytes.FromHexString(StorageValueHexes[1]));
             storageTree.Commit();
@@ -289,7 +294,7 @@ namespace Nethermind.Store.Test.Proofs
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
             tree.Commit();
-            return (tree, memDb);
+            return (tree, memDb, trieStore);
         }
 
         private static readonly byte[][] StorageKeyZeroAndOne =
@@ -301,8 +306,8 @@ namespace Nethermind.Store.Test.Proofs
         [Test]
         public void Storage_proofs_have_values_set()
         {
-            (StateTree tree, _) = CreateTreeWithUInt256Storage();
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, StorageKeyZeroAndOne);
+            (StateTree tree, _, ITrieStore trieStore) = CreateTreeWithUInt256Storage();
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, StorageKeyZeroAndOne);
             Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
             Assert.That(proof.StorageProofs[1].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[1]));
         }
@@ -310,8 +315,8 @@ namespace Nethermind.Store.Test.Proofs
         [Test]
         public void Storage_proofs_have_keys_set()
         {
-            (StateTree tree, _) = CreateTreeWithUInt256Storage();
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, StorageKeyZeroAndOne);
+            (StateTree tree, _, ITrieStore trieStore) = CreateTreeWithUInt256Storage();
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, StorageKeyZeroAndOne);
             Assert.That(proof.StorageProofs![0].Key!, Is.EqualTo("0x0"));
             Assert.That(proof.StorageProofs![1].Key!, Is.EqualTo("0x1"));
         }
@@ -324,9 +329,9 @@ namespace Nethermind.Store.Test.Proofs
         {
             byte[] c = Bytes.FromHexString("0x0000000000cccccccccccccccccccccccccccccccccccccccccccccccccccccc");
             byte[][] keys = [StorageKeyA, StorageKeyB, c];
-            (StateTree tree, _) = CreateTreeWithHashedStorage(keys, 3);
+            (StateTree tree, _, ITrieStore trieStore) = CreateTreeWithHashedStorage(keys, 3);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, keys);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, keys);
             for (int i = 0; i < 3; i++)
                 Assert.That(proof.StorageProofs?[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
         }
@@ -334,9 +339,9 @@ namespace Nethermind.Store.Test.Proofs
         private void Storage_proofs_have_values_set_complex_5_keys(byte[] c, byte[] d, byte[] e)
         {
             byte[][] keys = [StorageKeyA, StorageKeyB, c, d, e];
-            (StateTree tree, _) = CreateTreeWithHashedStorage(keys, 5);
+            (StateTree tree, _, ITrieStore trieStore) = CreateTreeWithHashedStorage(keys, 5);
 
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, keys);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, keys);
             for (int i = 0; i < 5; i++)
                 Assert.That(proof.StorageProofs?[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
         }
@@ -365,9 +370,9 @@ namespace Nethermind.Store.Test.Proofs
             int[] storedValueIndices = [0, 2, 4];
 
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             for (int i = 0; i < storedKeys.Length; i++)
                 storageTree.Set(Keccak.Compute(storedKeys[i]).Bytes, Rlp.Encode(Bytes.FromHexString(StorageValueHexes[storedValueIndices[i]])));
             storageTree.Commit();
@@ -378,7 +383,7 @@ namespace Nethermind.Store.Test.Proofs
             tree.Commit();
 
             byte[][] queryKeys = [StorageKeyA, StorageKeyB, c, d, e];
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, queryKeys);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, queryKeys);
             Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[0]));
             Assert.That(proof.StorageProofs?[1].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo("0x00"));
             Assert.That(proof.StorageProofs?[2].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[2]));
@@ -400,11 +405,11 @@ namespace Nethermind.Store.Test.Proofs
             tree.Commit();
 
             TreeDumper dumper = new();
-            tree.Accept(dumper, tree.RootHash);
+            dumper.TraverseState(tree.RootHash, tree.TrieStore);
             Console.WriteLine(dumper.ToString());
 
             AccountProofCollector accountProofCollector = new(TestItem.AddressA);
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Balance, Is.EqualTo((UInt256)0));
             Assert.That(proof.Nonce, Is.EqualTo(UInt256.Zero));
@@ -421,10 +426,10 @@ namespace Nethermind.Store.Test.Proofs
 
             // Store all 5 keys but only query a, c, e
             byte[][] allKeys = [StorageKeyA, StorageKeyB, c, d, e];
-            (StateTree tree, _) = CreateTreeWithHashedStorage(allKeys, 5);
+            (StateTree tree, _, ITrieStore trieStore) = CreateTreeWithHashedStorage(allKeys, 5);
 
             byte[][] queryKeys = [StorageKeyA, c, e];
-            AccountProof proof = CollectProof(tree, TestItem.AddressA, queryKeys);
+            AccountProof proof = CollectProof(tree, trieStore, TestItem.AddressA, queryKeys);
             Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
             Assert.That(proof.StorageProofs?[1].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[2]));
             Assert.That(proof.StorageProofs?[2].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[4]));
@@ -435,14 +440,14 @@ namespace Nethermind.Store.Test.Proofs
         public void Storage_proofs_have_values_set_complex_with_inline_nodes()
         {
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             storageTree.Set(Bytes.FromHexString("1000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("aa"));
             storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("ab"));
             storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000010"), Bytes.FromHexString("1111111111111111111111111111111111111111111111111111111111111111"));
             storageTree.Commit();
-            storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), storageTree.RootHash, LimboLogs.Instance);
+            storageTree = new(trieStore.GetTrieStore(TestItem.AddressA.ToAccountPath.ToCommitment()), storageTree.RootHash, LimboLogs.Instance);
             Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
@@ -450,14 +455,14 @@ namespace Nethermind.Store.Test.Proofs
             tree.Commit();
 
             TreeDumper dumper = new();
-            tree.Accept(dumper, tree.RootHash);
+            dumper.TraverseState(tree.RootHash, tree.TrieStore);
             Console.WriteLine(dumper.ToString());
 
             AccountProofCollector accountProofCollector = new(
                 TestItem.AddressA.ToAccountPath.ToCommitment().Bytes,
                 new ValueHash256[] { new(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000000")) }
             );
-            tree.Accept(accountProofCollector, tree.RootHash);
+            accountProofCollector.Traverse(tree.RootHash, trieStore);
             AccountProof proof = accountProofCollector.BuildResult();
             proof.StorageProofs[0].Value?.ToHexString().Should().Be("ab");
         }
@@ -525,8 +530,8 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             int storageCount = lines.Length - 2;
 
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             Address address = new(Bytes.FromHexString(lines[0]));
             int accountIndex = int.Parse(lines[1]);
@@ -540,7 +545,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             addressWithStorage.StorageCells = new StorageCell[storageCount];
             addressWithStorage.Address = address;
 
-            StorageTree storageTree = new(new RawScopedTrieStore(memDb, address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+            StorageTree storageTree = new(trieStore.GetTrieStore(address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
             for (int j = 0; j < storageCount; j++)
             {
                 UInt256 index = UInt256.Parse(lines[j + 2].Replace("storage: ", string.Empty));
@@ -561,11 +566,11 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             tree.Commit();
 
             TreeDumper treeDumper = new();
-            tree.Accept(treeDumper, tree.RootHash);
+            treeDumper.TraverseState(tree.RootHash, tree.TrieStore);
             TestContext.Out.WriteLine(treeDumper.ToString());
 
             AccountProofCollector collector = new(address, indexes);
-            tree.Accept(collector, tree.RootHash);
+            collector.Traverse(tree.RootHash, trieStore);
 
             AccountProof accountProof = collector.BuildResult();
             accountProof.Address.Should().Be(address);
@@ -614,13 +619,13 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             }
 
             IDb memDb = new MemDb();
-            IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
-            StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
+            TestRawTrieStore trieStore = new(memDb);
+            StateTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             for (int i = 0; i < accountsCount; i++)
             {
                 Account account = Build.An.Account.WithBalance((UInt256)i).TestObject;
-                StorageTree storageTree = new(new RawScopedTrieStore(memDb, addressesWithStorage[i].Address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
+                StorageTree storageTree = new(trieStore.GetTrieStore(addressesWithStorage[i].Address.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
                 for (int j = 0; j < i; j++)
                 {
                     storageTree.Set(addressesWithStorage[i].StorageCells[j].Index, new byte[1] { 1 });
@@ -639,7 +644,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
             for (int i = 0; i < accountsCount; i++)
             {
                 AccountProofCollector collector = new(addressesWithStorage[i].Address, addressesWithStorage[i].StorageCells.Select(static sc => sc.Index).ToArray());
-                tree.Accept(collector, tree.RootHash);
+                collector.Traverse(tree.RootHash, trieStore);
 
                 AccountProof accountProof = collector.BuildResult();
                 accountProof.Address.Should().Be(addressesWithStorage[i].Address);

--- a/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
@@ -50,7 +50,14 @@ public abstract class PatriciaTrie<T> : PatriciaTree
 
         ProofCollector proofCollector = new(Rlp.Encode(index).Bytes);
 
-        Accept(proofCollector, RootHash, new());
+        if (RootRef is not null)
+        {
+            using TrieVisitContext ctx = new();
+            proofCollector.VisitTree(default, RootHash);
+            TreePath emptyPath = TreePath.Empty;
+            new RecursiveTrieVisitor<EmptyContext>(proofCollector, ctx)
+                .Start(RootRef, default, TrieStore, ref emptyPath);
+        }
 
         return proofCollector.BuildResult();
     }

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -77,7 +77,7 @@ public class SnapServer : ISnapServer
         int pathLength = pathSet.Count;
         using DeferredRlpItemList.Builder builder = new(pathLength);
         DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
-        StateTree tree = new(_store, _logManager);
+        StateTree tree = new(_store.GetTrieStore(null), _logManager);
         bool abort = false;
         long responseSize = 0;
 
@@ -280,10 +280,20 @@ public class SnapServer : ISnapServer
         RangeQueryVisitor.ILeafValueCollector valueCollector,
         CancellationToken cancellationToken)
     {
-        PatriciaTree tree = new(_store, _logManager);
         using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new();
-        tree.Accept(visitor, rootHash.ToCommitment(), opt, storageAddr: storage?.ToCommitment(), storageRoot: storageRoot?.ToCommitment());
+        Hash256? storageAddress = storage?.ToCommitment();
+        ITrieNodeResolver resolver = _store.GetTrieStore(storageAddress);
+        Hash256 effectiveRoot = rootHash.ToCommitment();
+        if (storageAddress is not null)
+        {
+            effectiveRoot = storageRoot!.Value.ToCommitment();
+            visitor.TraverseStorage(effectiveRoot, resolver, opt);
+        }
+        else
+        {
+            visitor.TraverseState(effectiveRoot, resolver, opt);
+        }
 
         ArrayPoolList<byte[]> proofs = startingHash != Keccak.Zero || visitor.StoppedEarly ? visitor.GetProofs() : ArrayPoolList<byte[]>.Empty();
         return (visitor.GetBytesSize(), proofs, visitor.StoppedEarly);

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -40,7 +40,8 @@ namespace Nethermind.State
 
         public byte[]? GetCode(Hash256 codeHash) => codeHash == Keccak.OfAnEmptyString ? [] : _codeDb[codeHash.Bytes];
 
-        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? header, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx> => _state.Accept(treeVisitor, header?.StateRoot ?? Keccak.EmptyTreeHash, visitingOptions);
+        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? header, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx> =>
+            treeVisitor.Traverse(header?.StateRoot ?? Keccak.EmptyTreeHash, _trieStore, visitingOptions);
 
         public bool HasStateForBlock(BlockHeader? baseBlock) => trieStore.HasRoot(baseBlock?.StateRoot ?? Keccak.EmptyTreeHash, baseBlock?.Number ?? 0);
 

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -29,10 +29,6 @@ namespace Nethermind.State
         public StateTree(IScopedTrieStore? store, ILogManager? logManager)
             : base(store, Keccak.EmptyTreeHash, true, logManager) => TrieType = TrieType.State;
 
-        public StateTree(ITrieStore? store, ILogManager? logManager)
-            : base(store.GetTrieStore(null), logManager)
-        {
-        }
 
         [DebuggerStepThrough]
         public Account? Get(Address address, Hash256? rootHash = null)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
@@ -65,12 +65,12 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
 
         if (!skipLogs) logger.Info("-------------------- REMOTE --------------------");
         TreeDumper dumper = new();
-        remote.StateTree.Accept(dumper, remote.StateTree.RootHash);
+        dumper.TraverseState(remote.StateTree.RootHash, remote.StateTree.TrieStore);
         string remoteStr = dumper.ToString();
         if (!skipLogs) logger.Info(remoteStr);
         if (!skipLogs) logger.Info("-------------------- LOCAL --------------------");
         dumper.Reset();
-        localTree.Accept(dumper, localTree.RootHash);
+        dumper.TraverseState(localTree.RootHash, localTree.TrieStore);
         string localStr = dumper.ToString();
         if (!skipLogs) logger.Info(localStr);
 
@@ -98,8 +98,6 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
         public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) =>
             reader.TryLoadStateRlp(path, flags);
 
-        public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) =>
-            address is null ? this : new ReadOnlyStorageTrieStore(reader, address);
     }
 
     /// <summary>
@@ -130,8 +128,6 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
         public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) =>
             new StateCommitter(writeBatch);
 
-        public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) =>
-            address is null ? this : new WritableStorageTrieStore(reader, writeBatch, address);
 
         private sealed class StateCommitter(IPersistence.IWriteBatch writeBatch) : ICommitter
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/LocalDbContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/LocalDbContext.cs
@@ -11,21 +11,31 @@ using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.FastSync;
 
-public class LocalDbContext(
-    [KeyFilter(DbNames.Code)] IDb codeDb,
-    [KeyFilter(DbNames.State)] IDb stateDb,
-    INodeStorage nodeStorage,
-    ILogManager logManager)
-    : IStateSyncTestOperation
+public class LocalDbContext : IStateSyncTestOperation
 {
-    private TestMemDb CodeDb { get; } = (TestMemDb)codeDb;
-    private TestMemDb Db { get; } = (TestMemDb)stateDb;
-    private INodeStorage NodeStorage { get; } = nodeStorage;
-    private StateTree StateTree { get; } = new(TestTrieStoreFactory.Build(nodeStorage, logManager), logManager);
+    private TestMemDb CodeDb { get; }
+    private TestMemDb Db { get; }
+    private INodeStorage NodeStorage { get; }
+    private ITrieStore TrieStore { get; }
+    private StateTree StateTree { get; }
+
+    public LocalDbContext(
+        [KeyFilter(DbNames.Code)] IDb codeDb,
+        [KeyFilter(DbNames.State)] IDb stateDb,
+        INodeStorage nodeStorage,
+        ILogManager logManager)
+    {
+        CodeDb = (TestMemDb)codeDb;
+        Db = (TestMemDb)stateDb;
+        NodeStorage = nodeStorage;
+        TrieStore = TestTrieStoreFactory.Build(nodeStorage, logManager);
+        StateTree = new(TrieStore.GetTrieStore(null), logManager);
+    }
 
     public Hash256 RootHash => StateTree.RootHash;
 
@@ -51,12 +61,12 @@ public class LocalDbContext(
 
         if (!skipLogs) logger.Info("-------------------- REMOTE --------------------");
         TreeDumper dumper = new();
-        remote.StateTree.Accept(dumper, remote.StateTree.RootHash);
+        dumper.Traverse(remote.StateTree.RootHash, remote.TrieStore);
         string remoteStr = dumper.ToString();
         if (!skipLogs) logger.Info(remoteStr);
         if (!skipLogs) logger.Info("-------------------- LOCAL --------------------");
         dumper.Reset();
-        StateTree.Accept(dumper, StateTree.RootHash);
+        dumper.Traverse(StateTree.RootHash, TrieStore);
         string localStr = dumper.ToString();
         if (!skipLogs) logger.Info(localStr);
 
@@ -64,7 +74,7 @@ public class LocalDbContext(
         {
             Assert.That(localStr, Is.EqualTo(remoteStr), $"{stage}{Environment.NewLine}{remoteStr}{Environment.NewLine}{localStr}");
             TrieStatsCollector collector = new(CodeDb, LimboLogs.Instance);
-            StateTree.Accept(collector, StateTree.RootHash);
+            collector.Traverse(StateTree.RootHash, TrieStore);
             Assert.That(collector.Stats.MissingNodes, Is.EqualTo(0));
             Assert.That(collector.Stats.MissingCode, Is.EqualTo(0));
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
@@ -15,6 +15,8 @@ using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.FastSync;
@@ -36,7 +38,7 @@ public class StateSyncFeedHealingTests : StateSyncFeedTestsBase
         IStateSyncTestOperation local = container.Resolve<IStateSyncTestOperation>();
         ISnapTrieFactory snapTrieFactory = container.Resolve<ISnapTrieFactory>();
 
-        ProcessAccountRange(remote.StateTree, snapTrieFactory, 1, rootHash, TestItem.Tree.AccountsWithPaths);
+        ProcessAccountRange(remote.StateTree, remote.TrieStore, snapTrieFactory, 1, rootHash, TestItem.Tree.AccountsWithPaths);
 
         SafeContext ctx = container.Resolve<SafeContext>();
         await ActivateAndWait(ctx);
@@ -145,7 +147,7 @@ public class StateSyncFeedHealingTests : StateSyncFeedTestsBase
             {
                 endHashIndex = startingHashIndex + 1000;
 
-                ProcessAccountRange(remote.StateTree, snapTrieFactory, blockNumber, rootHashAtBlock[blockNumber],
+                ProcessAccountRange(remote.StateTree, remote.TrieStore, snapTrieFactory, blockNumber, rootHashAtBlock[blockNumber],
                    blockAccounts.Where(a => a.Key >= pathPool[startingHashIndex] && a.Key <= pathPool[endHashIndex]).Select(a => new PathWithAccount(a.Key, a.Value)).ToArray());
 
                 startingHashIndex = endHashIndex + 1;
@@ -164,7 +166,7 @@ public class StateSyncFeedHealingTests : StateSyncFeedTestsBase
                 endHashIndex = pathPool.Length - 1;
             }
 
-            ProcessAccountRange(remote.StateTree, snapTrieFactory, blockJumps, finalRootHash,
+            ProcessAccountRange(remote.StateTree, remote.TrieStore, snapTrieFactory, blockJumps, finalRootHash,
                 accounts.Where(a => a.Key >= pathPool[startingHashIndex] && a.Key <= pathPool[endHashIndex]).Select(a => new PathWithAccount(a.Key, a.Value)).ToArray());
 
             startingHashIndex += 1000;
@@ -181,17 +183,17 @@ public class StateSyncFeedHealingTests : StateSyncFeedTestsBase
         Assert.That(data.RequestedNodesCount, Is.LessThan(accounts.Count / 2));
     }
 
-    private static void ProcessAccountRange(StateTree remoteStateTree, ISnapTrieFactory snapTrieFactory, int blockNumber, Hash256 rootHash, PathWithAccount[] accounts)
+    private static void ProcessAccountRange(StateTree remoteStateTree, ITrieStore trieStore, ISnapTrieFactory snapTrieFactory, int blockNumber, Hash256 rootHash, PathWithAccount[] accounts)
     {
         ValueHash256 startingHash = accounts.First().Path;
         ValueHash256 endHash = accounts.Last().Path;
         Hash256 limitHash = Keccak.MaxValue;
 
         AccountProofCollector accountProofCollector = new(startingHash.Bytes);
-        remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
+        accountProofCollector.TraverseState(remoteStateTree.RootHash, remoteStateTree.TrieStore);
         byte[][] firstProof = accountProofCollector.BuildResult().Proof!;
         accountProofCollector = new(endHash.Bytes);
-        remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
+        accountProofCollector.TraverseState(remoteStateTree.RootHash, remoteStateTree.TrieStore);
         byte[][] lastProof = accountProofCollector.BuildResult().Proof!;
 
         _ = SnapProviderHelper.AddAccountRange(snapTrieFactory, blockNumber, rootHash, startingHash, limitHash, accounts, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(firstProof.Length + lastProof.Length, firstProof.Concat(lastProof))));

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -328,7 +328,7 @@ public class RemoteDbContext
         CodeDb = new MemDb();
         Db = new MemDb();
         TrieStore = TestTrieStoreFactory.Build(Db, logManager);
-        StateTree = new StateTree(TrieStore, logManager);
+        StateTree = new StateTree(TrieStore.GetTrieStore(null), logManager);
     }
 
     public MemDb CodeDb { get; }

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -28,6 +28,7 @@ using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 using Bytes = Nethermind.Core.Extensions.Bytes;
 
@@ -49,7 +50,7 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
-        _inputTree.Accept(visitor, _inputTree.RootHash, CreateVisitingOptions());
+        visitor.TraverseState(_inputTree.RootHash, _inputTree.TrieStore, CreateVisitingOptions());
 
         leafCollector.Leafs.Count.Should().Be(4);
 
@@ -76,7 +77,7 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
-        tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
+        visitor.TraverseState(tree.RootHash, tree.TrieStore, CreateVisitingOptions());
 
         Dictionary<ValueHash256, byte[]?> nodes = leafCollector.Leafs.ToDictionary(static (it) => it.Item1, static (it) => it.Item2);
         nodes.Count.Should().Be(3);
@@ -100,7 +101,7 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
-        tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
+        visitor.TraverseState(tree.RootHash, tree.TrieStore, CreateVisitingOptions());
 
         leafCollector.Leafs.Count.Should().Be(0);
         Action act = () => visitor.GetProofs();
@@ -129,7 +130,7 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
-        stateTree.Accept(visitor, stateTree.RootHash, CreateVisitingOptions());
+        visitor.TraverseState(stateTree.RootHash, stateTree.TrieStore, CreateVisitingOptions());
         leafCollector.Leafs.Count.Should().Be(3);
     }
 
@@ -165,7 +166,7 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
-        stateTree.Accept(visitor, stateTree.RootHash, CreateVisitingOptions());
+        visitor.TraverseState(stateTree.RootHash, stateTree.TrieStore, CreateVisitingOptions());
 
         leafCollector.Leafs.Count.Should().Be(4);
 
@@ -203,7 +204,8 @@ public class RangeQueryVisitorTests
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(Keccak.Zero, Keccak.MaxValue, leafCollector);
-        inputStateTree.Accept(visitor, inputStateTree.RootHash, CreateVisitingOptions(), storageAddr: account);
+        ITrieNodeResolver resolver = store.GetTrieStore(account);
+        visitor.TraverseStorage(storageTree.RootHash, resolver, CreateVisitingOptions());
         Dictionary<ValueHash256, byte[]?> nodes = leafCollector.Leafs.ToDictionary((it) => it.Item1, (it) => it.Item2);
         nodes.Count.Should().Be(6);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -200,7 +200,7 @@ public class RangeQueryVisitorTests
     public void StorageRangeFetchVisitor()
     {
         TestRawTrieStore store = new(new MemDb());
-        (StateTree inputStateTree, StorageTree _, Hash256 account) = TestItem.Tree.GetTrees(store);
+        (StateTree inputStateTree, StorageTree storageTree, Hash256 account) = TestItem.Tree.GetTrees(store);
 
         RlpCollector leafCollector = new();
         using RangeQueryVisitor visitor = new(Keccak.Zero, Keccak.MaxValue, leafCollector);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -30,11 +30,18 @@ namespace Nethermind.Synchronization.Test.SnapSync;
 [TestFixture]
 public class RecreateStateFromAccountRangesTests
 {
+    private TestRawTrieStore _store;
     private StateTree _inputTree;
 
     [OneTimeSetUp]
-    public void Setup() =>
-        _inputTree = TestItem.Tree.GetStateTree();
+    public void Setup()
+    {
+        _store = new TestRawTrieStore(new MemDb());
+        _inputTree = TestItem.Tree.GetStateTree(_store);
+    }
+
+    [OneTimeTearDown]
+    public void TearDown() => ((IDisposable)_store)?.Dispose();
 
     private ContainerBuilder CreateContainerBuilder() =>
         new ContainerBuilder()
@@ -49,7 +56,7 @@ public class RecreateStateFromAccountRangesTests
     {
         AccountProofCollector accountProofCollector = new(path);
         tree ??= _inputTree;
-        tree.Accept(accountProofCollector, tree.RootHash);
+        accountProofCollector.TraverseState(tree.RootHash, tree.TrieStore);
         return accountProofCollector.BuildResult().Proof;
     }
 
@@ -353,7 +360,7 @@ public class RecreateStateFromAccountRangesTests
     [Test]
     public void CorrectlyDetermineMaxKeccakExist()
     {
-        StateTree tree = new(new TestRawTrieStore(new MemDb()), LimboLogs.Instance);
+        StateTree tree = new(new TestRawTrieStore(new MemDb()).GetTrieStore(null), LimboLogs.Instance);
 
         PathWithAccount ac1 = new(Keccak.Zero, Build.An.Account.WithBalance(1).TestObject);
         PathWithAccount ac2 = new(Keccak.Compute("anything"), Build.An.Account.WithBalance(2).TestObject);
@@ -402,7 +409,7 @@ public class RecreateStateFromAccountRangesTests
         // leaf proof nodes at range boundaries. With the keccak-only leaf change, these leaves
         // are referenced by hash rather than fully added to the boundary list.
         // The root hash verification inside AddAccountRange validates correctness.
-        StateTree inputTree = new(new TestRawTrieStore(new MemDb()), LimboLogs.Instance);
+        StateTree inputTree = new(new TestRawTrieStore(new MemDb()).GetTrieStore(null), LimboLogs.Instance);
         TestItem.Tree.FillStateTreeMultipleAccount(inputTree, 100);
         Hash256 rootHash = inputTree.RootHash;
 
@@ -446,7 +453,7 @@ public class RecreateStateFromAccountRangesTests
     {
         // Build tree with accounts in different nibble-prefix subtrees
         // Accounts with hashed paths give good distribution
-        StateTree inputTree = new(new TestRawTrieStore(new MemDb()), LimboLogs.Instance);
+        StateTree inputTree = new(new TestRawTrieStore(new MemDb()).GetTrieStore(null), LimboLogs.Instance);
         TestItem.Tree.FillStateTreeMultipleAccount(inputTree, 50);
         Hash256 rootHash = inputTree.RootHash;
 
@@ -481,7 +488,7 @@ public class RecreateStateFromAccountRangesTests
     public void MultiRangeWithLeafBoundaryProofsReconstructsCorrectRoot()
     {
         // Use a richer tree to exercise leaf boundary proof handling across multiple ranges
-        StateTree inputTree = new(new TestRawTrieStore(new MemDb()), LimboLogs.Instance);
+        StateTree inputTree = new(new TestRawTrieStore(new MemDb()).GetTrieStore(null), LimboLogs.Instance);
         TestItem.Tree.FillStateTreeMultipleAccount(inputTree, 80);
         Hash256 rootHash = inputTree.RootHash;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -19,6 +19,7 @@ using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.SnapSync
@@ -57,7 +58,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Hash256 rootHash = _inputStorageTree!.RootHash;   // "..."
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[5].Path });
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             AccountProof proof = accountProofCollector.BuildResult();
 
             using IContainer container = CreateContainer();
@@ -75,7 +76,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Hash256 rootHash = _inputStorageTree!.RootHash;   // "..."
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { TestItem.Tree.SlotsWithPaths[0].Path, TestItem.Tree.SlotsWithPaths[5].Path });
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             AccountProof proof = accountProofCollector.BuildResult();
 
             using IContainer container = CreateContainer();
@@ -111,21 +112,21 @@ namespace Nethermind.Synchronization.Test.SnapSync
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             AccountProof proof = accountProofCollector.BuildResult();
 
             StorageRange storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
             AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
             AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[2..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);
@@ -146,21 +147,21 @@ namespace Nethermind.Synchronization.Test.SnapSync
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             AccountProof proof = accountProofCollector.BuildResult();
 
             StorageRange storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
             AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
             AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[3..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
-            _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
+            accountProofCollector.Traverse(_inputStateTree.RootHash, _store);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -154,7 +154,7 @@ public class SnapProviderTests
         // Collect proofs
         AccountProofCollector proofCollector = new(accountHash.Bytes,
             new ValueHash256[] { Keccak.Zero, slots[^1].Path });
-        stateTree.Accept(proofCollector, stateTree.RootHash);
+        proofCollector.Traverse(stateTree.RootHash, store);
         AccountProof proof = proofCollector.BuildResult();
 
         using IContainer container = CreateContainer();
@@ -305,7 +305,7 @@ public class SnapProviderTests
     {
         TestMemDb stateDb = new();
         TestRawTrieStore trieStore = new(stateDb);
-        StateTree st = new(trieStore, LimboLogs.Instance);
+        StateTree st = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
         {
             using IBlockCommitter _ = trieStore.BeginBlockCommit(0);
             foreach ((Hash256, Account) entry in entries)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -60,7 +60,7 @@ public class SnapServerTest
             MemDb stateDbServer = new();
             MemDb codeDbServer = new();
             _store = new TestRawTrieStore(stateDbServer);
-            _tree = new StateTree(_store, LimboLogs.Instance);
+            _tree = new StateTree(_store.GetTrieStore(null), LimboLogs.Instance);
             Server = new SnapServer(_store.AsReadOnly(), codeDbServer, LimboLogs.Instance, lastNStateRootTracker);
 
             _clientStateDb = new MemDb();

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapUpperBoundAdapter.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapUpperBoundAdapter.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
@@ -23,8 +22,6 @@ public class SnapUpperBoundAdapter(IScopedTrieStore baseTrieStore) : IScopedTrie
     public byte[]? LoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => baseTrieStore.LoadRlp(in path, hash, flags);
 
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => baseTrieStore.TryLoadRlp(in path, hash, flags);
-
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => throw new NotSupportedException("Get storage trie node resolver not supported");
 
     public INodeStorage.KeyScheme Scheme => baseTrieStore.Scheme;
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/UnknownNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/UnknownNodeResolver.cs
@@ -27,7 +27,5 @@ internal sealed class UnknownNodeResolver : ITrieNodeResolver
 
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags) => null;
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => this;
-
     public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.Hash;
 }

--- a/src/Nethermind/Nethermind.Trie.Test/OverlayTrieStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/OverlayTrieStoreTests.cs
@@ -24,7 +24,7 @@ public class OverlayTrieStoreTests
         IDbProvider dbProvider = TestMemDbProvider.Init();
         TestRawTrieStore existingStore = new(dbProvider.StateDb);
 
-        PatriciaTree patriciaTree = new(existingStore, LimboLogs.Instance);
+        PatriciaTree patriciaTree = new(existingStore.GetTrieStore(null), LimboLogs.Instance);
         {
             using IBlockCommitter _ = existingStore.BeginBlockCommit(0);
             patriciaTree.Set(TestItem.Keccaks[0].Bytes, TestItem.Keccaks[0].BytesToArray());
@@ -38,7 +38,7 @@ public class OverlayTrieStoreTests
         ITrieStore overlayStore = new OverlayTrieStore(readOnlyDbProvider.GetDb<IDb>(DbNames.State), existingStore.AsReadOnly());
 
         // Modify the overlay tree
-        PatriciaTree overlaidTree = new(overlayStore, LimboLogs.Instance);
+        PatriciaTree overlaidTree = new(overlayStore.GetTrieStore(null), LimboLogs.Instance);
         overlaidTree.RootHash = originalRoot;
         overlaidTree.Get(TestItem.Keccaks[0].Bytes).ToArray().Should().BeEquivalentTo(TestItem.Keccaks[0].BytesToArray());
         overlaidTree.Get(TestItem.Keccaks[1].Bytes).ToArray().Should().BeEquivalentTo(TestItem.Keccaks[1].BytesToArray());
@@ -51,7 +51,7 @@ public class OverlayTrieStoreTests
         readOnlyDbProvider.GetDb<IDb>(DbNames.State).GetAllKeys().Count().Should().NotBe(originalKeyCount);
 
         // It can read the modified db
-        overlaidTree = new PatriciaTree(overlayStore, LimboLogs.Instance);
+        overlaidTree = new PatriciaTree(overlayStore.GetTrieStore(null), LimboLogs.Instance);
         overlaidTree.RootHash = newRoot;
         overlaidTree.Get(TestItem.Keccaks[0].Bytes).ToArray().Should().BeEquivalentTo(TestItem.Keccaks[0].BytesToArray());
         overlaidTree.Get(TestItem.Keccaks[1].Bytes).ToArray().Should().BeEquivalentTo(TestItem.Keccaks[1].BytesToArray());
@@ -63,7 +63,7 @@ public class OverlayTrieStoreTests
 
         // It should throw because the overlaid keys are now missing.
         readOnlyDbProvider.GetDb<IDb>(DbNames.State).GetAllKeys().Count().Should().Be(originalKeyCount);
-        overlaidTree = new PatriciaTree(overlayStore, LimboLogs.Instance);
+        overlaidTree = new PatriciaTree(overlayStore.GetTrieStore(null), LimboLogs.Instance);
         Action act = () =>
         {
             overlaidTree.RootHash = newRoot;

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -631,7 +631,7 @@ namespace Nethermind.Trie.Test.Pruning
         public void Will_persist_storage_nodes_via_state_tree()
         {
             MemDb memDb = new();
-            NodeStorage nodeStorage = new NodeStorage(memDb, scheme, requirePath: scheme == INodeStorage.KeyScheme.HalfPath);
+            NodeStorage nodeStorage = new(memDb, scheme, requirePath: scheme == INodeStorage.KeyScheme.HalfPath);
 
             using TrieStore fullTrieStore = CreateTrieStore(
                 kvStore: memDb,

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -628,6 +628,40 @@ namespace Nethermind.Trie.Test.Pruning
         }
 
         [Test]
+        public void Will_persist_storage_nodes_via_state_tree()
+        {
+            MemDb memDb = new();
+            NodeStorage nodeStorage = new NodeStorage(memDb, scheme, requirePath: scheme == INodeStorage.KeyScheme.HalfPath);
+
+            using TrieStore fullTrieStore = CreateTrieStore(
+                kvStore: memDb,
+                pruningStrategy: new TestPruningStrategy(shouldPrune: true),
+                persistenceStrategy: Archive.Instance,
+                pruningConfig: new PruningConfig() { PruningBoundary = 0 });
+
+            Hash256 address = TestItem.KeccakA;
+            StateTree stateTree = new(fullTrieStore.GetTrieStore(null), LimboLogs.Instance);
+            StorageTree storageTree = new(fullTrieStore.GetTrieStore(address), LimboLogs.Instance);
+
+            using (fullTrieStore.BeginBlockCommit(1))
+            {
+                storageTree.Set(Keccak.Compute(1.ToBigEndianByteArray()).Bytes, Keccak.Compute(2.ToBigEndianByteArray()).BytesToArray());
+                storageTree.Commit();
+
+                stateTree.Set(address, new Account(0, 1, storageTree.RootHash, Keccak.OfAnEmptyString));
+                stateTree.Commit();
+            }
+
+            fullTrieStore.WaitForPruning();
+
+            // Verify state nodes persisted
+            nodeStorage.Get(null, TreePath.Empty, stateTree.RootHash).Should().NotBeNull("state root should be persisted");
+
+            // Verify storage nodes persisted — this exercises CallRecursively's storage traversal
+            nodeStorage.Get(address, TreePath.Empty, storageTree.RootHash).Should().NotBeNull("storage root should be persisted");
+        }
+
+        [Test]
         public void Will_drop_transient_storage()
         {
             TrieNode storage1 = new(NodeType.Leaf, new byte[2]);
@@ -874,7 +908,7 @@ namespace Nethermind.Trie.Test.Pruning
             MemDb db = new();
             TrieStore trieStore = CreateTrieStore(kvStore: db);
             trieStore.HasRoot(Keccak.EmptyTreeHash).Should().BeTrue();
-            StateTree stateTree = new(trieStore, LimboLogs.Instance);
+            StateTree stateTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             Account account = new(1);
             {
@@ -910,7 +944,7 @@ namespace Nethermind.Trie.Test.Pruning
                     TrackPastKeys = false
                 });
 
-            StateTree stateTree = new(trieStore, LimboLogs.Instance);
+            StateTree stateTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             // Commit blocks 0..9
             Hash256[] rootHashes = new Hash256[10];
@@ -963,7 +997,7 @@ namespace Nethermind.Trie.Test.Pruning
                     TrackPastKeys = trackPastKeys
                 });
 
-            StateTree stateTree = new(trieStore, LimboLogs.Instance);
+            StateTree stateTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             // Start from block 1 (not genesis) to avoid special-casing block 0
             int startBlock = 1;
@@ -1402,17 +1436,16 @@ namespace Nethermind.Trie.Test.Pruning
             HashSet<Hash256> rootsToTests = new();
             void VerifyAllTrie()
             {
-                PatriciaTree readOnlyPTree = new(fullTrieStore.AsReadOnly().GetTrieStore(null), LimboLogs.Instance);
                 MemDb stubCodeDb = new();
                 foreach (Hash256 rootsToTest in rootsToTests)
                 {
                     if (!fullTrieStore.HasRoot(rootsToTest)) continue;
                     TrieStatsCollector collector = new(stubCodeDb, LimboLogs.Instance, expectAccounts: false);
-                    ptree.Accept(collector, rootHash: rootsToTest);
+                    collector.TraverseState(rootsToTest, fullTrieStore.GetTrieStore(null));
                     collector.Stats.MissingNodes.Should().Be(0);
 
                     collector = new TrieStatsCollector(stubCodeDb, LimboLogs.Instance, expectAccounts: false);
-                    readOnlyPTree.Accept(collector, rootHash: rootsToTest);
+                    collector.TraverseState(rootsToTest, fullTrieStore.AsReadOnly().GetTrieStore(null));
                     collector.Stats.MissingNodes.Should().Be(0);
                 }
             }
@@ -1578,7 +1611,7 @@ namespace Nethermind.Trie.Test.Pruning
             fullTrieStore.PrunePersistedNodes();
 
             TrieStatsCollector collector = new(new MemDb(), SimpleConsoleLogManager.Instance, expectAccounts: false);
-            ptree.Accept(collector, rootHash: persistedRootHash);
+            collector.TraverseState(persistedRootHash, fullTrieStore.GetTrieStore(null));
             collector.Stats.MissingNodes.Should().Be(0);
         }
 
@@ -1624,18 +1657,17 @@ namespace Nethermind.Trie.Test.Pruning
             List<Hash256> rootsToTests = new();
             void VerifyAllTrieExceptGenesis()
             {
-                PatriciaTree readOnlyPTree = new(fullTrieStore.AsReadOnly().GetTrieStore(null), LimboLogs.Instance);
                 MemDb stubCodeDb = new();
                 for (int i = 1; i < rootsToTests.Count; i++)
                 {
                     Console.Error.WriteLine($"Verify {i}");
                     Hash256 rootsToTest = rootsToTests[i];
                     TrieStatsCollector collector = new(stubCodeDb, LimboLogs.Instance, expectAccounts: false);
-                    ptree.Accept(collector, rootHash: rootsToTest);
+                    collector.TraverseState(rootsToTest, fullTrieStore.GetTrieStore(null));
                     collector.Stats.MissingNodes.Should().Be(0);
 
                     collector = new TrieStatsCollector(stubCodeDb, LimboLogs.Instance, expectAccounts: false);
-                    readOnlyPTree.Accept(collector, rootHash: rootsToTest);
+                    collector.TraverseState(rootsToTest, fullTrieStore.AsReadOnly().GetTrieStore(null));
                     collector.Stats.MissingNodes.Should().Be(0);
                 }
             }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
@@ -50,8 +50,7 @@ public class TrieNodeResolverWithReadFlagsTests
         ReadFlags theFlags = ReadFlags.HintCacheMiss;
         TestMemDb memDb = new();
         ITrieStore trieStore = TestTrieStoreFactory.Build(memDb, LimboLogs.Instance);
-        ITrieNodeResolver resolver = new TrieNodeResolverWithReadFlags(trieStore.GetTrieStore(null), theFlags);
-        resolver = resolver.GetStorageTrieNodeResolver(TestItem.KeccakA);
+        ITrieNodeResolver resolver = new TrieNodeResolverWithReadFlags(trieStore.GetTrieStore(TestItem.KeccakA), theFlags);
 
         Hash256 theKeccak = TestItem.KeccakA;
         memDb[NodeStorage.GetHalfPathNodeStoragePath(TestItem.KeccakA, TreePath.Empty, theKeccak)] = TestItem.KeccakA.BytesToArray();

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -336,7 +336,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ignore);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<EmptyContext>(visitor, context).Start(node, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.Received().VisitExtension(new EmptyContext(), node);
     }
@@ -349,7 +349,7 @@ public class TrieNodeTests
         TrieNode node = new(NodeType.Unknown);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<EmptyContext>(visitor, context).Start(node, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.Received().VisitMissingNode(new EmptyContext(), node.Keccak);
     }
@@ -364,7 +364,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -379,7 +379,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -394,7 +394,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -409,7 +409,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitLeafReceived[(TreePath.Empty, node, node.Value.ToArray())].Should().Be(1);
     }
@@ -423,7 +423,7 @@ public class TrieNodeTests
         TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ctx.AccountLeaf);
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitExtensionReceived[(TreePath.Empty, node)].Should().Be(1);
         visitor.VisitLeafReceived[(new(new(Bytes.FromHexString("0xa000000000000000000000000000000000000000000000000000000000000000")), 1), ctx.AccountLeaf, ctx.AccountLeaf.Value.ToArray())].Should().Be(1);
@@ -443,7 +443,7 @@ public class TrieNodeTests
 
         TreePath emptyPath = TreePath.Empty;
         node.ResolveKey(NullTrieStore.Instance, ref emptyPath);
-        node.Accept(visitor, default, NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<TreePathContext>(visitor, context).Start(node, default, NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.VisitBranchReceived[(TreePath.Empty, node)].Should().Be(1);
         for (byte i = 0; i < 16; i++)
@@ -465,7 +465,7 @@ public class TrieNodeTests
         }
 
         TreePath emptyPath = TreePath.Empty;
-        node.Accept(visitor, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath, context);
+        new RecursiveTrieVisitor<EmptyContext>(visitor, context).Start(node, new EmptyContext(), NullTrieNodeResolver.Instance, ref emptyPath);
 
         visitor.Received().VisitBranch(new EmptyContext(), node);
     }
@@ -809,7 +809,7 @@ public class TrieNodeTests
         trieNode.PrunePersistedRecursively(1);
         int count = 0;
         TreePath emptyPath = TreePath.Empty;
-        trieNode.CallRecursively((n, s, p) => count++, null, ref emptyPath, NullTrieStore.Instance, skipPersisted, LimboTraceLogger.Instance);
+        trieNode.CallRecursively((n, p) => count++, ref emptyPath, skipPersisted, LimboTraceLogger.Instance);
         count.Should().Be(1);
     }
 
@@ -1023,8 +1023,6 @@ public class TrieNodeTests
         public byte[]? LoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
 
         public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
-
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => throw new InvalidOperationException($"{nameof(GetStorageTrieNodeResolver)} not supported");
 
         public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
         public ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => new Committer(this);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
 
@@ -82,7 +82,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyA, _longLeaf2);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
@@ -101,7 +101,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
             patriciaTree.Set(_keyA, _longLeaf2);
@@ -122,7 +122,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyA, []);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
@@ -140,7 +140,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
             patriciaTree.Set(_keyA, []);
@@ -160,7 +160,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
             trieStore.CommitPatriciaTrie(1, patriciaTree);
             trieStore.CommitPatriciaTrie(2, patriciaTree);
@@ -195,7 +195,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -230,7 +230,7 @@ namespace Nethermind.Trie.Test
 
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keysA, _longLeaf1);
             patriciaTree.Set(_keysB, _longLeaf1);
             patriciaTree.Set(_keysC, _longLeaf1);
@@ -264,7 +264,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -355,7 +355,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -387,7 +387,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -424,7 +424,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -456,7 +456,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -506,7 +506,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -528,7 +528,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -558,7 +558,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf2);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
@@ -574,7 +574,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             trieStore.CommitPatriciaTrie(0, patriciaTree);
@@ -590,7 +590,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf2);
             patriciaTree.UpdateRootHash();
@@ -612,7 +612,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.UpdateRootHash();
@@ -646,7 +646,7 @@ namespace Nethermind.Trie.Test
 
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(key1, _longLeaf1);
             patriciaTree.Set(key2, _longLeaf1);
             patriciaTree.Set(key3, _longLeaf1);
@@ -695,7 +695,7 @@ namespace Nethermind.Trie.Test
 
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(key1, _longLeaf1);
             patriciaTree.Set(key2, _longLeaf1);
             patriciaTree.Set(key3, _longLeaf1);
@@ -718,7 +718,7 @@ namespace Nethermind.Trie.Test
         {
             MemDb memDb = new();
             using IPruningTrieStore trieStore = CreateTrieStore(memDb);
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -824,7 +824,7 @@ namespace Nethermind.Trie.Test
             Queue<Hash256> rootQueue = new();
 
             using TrieStore trieStore = trieStoreConfig.CreateTrieStore();
-            StateTree patriciaTree = new(trieStore, _logManager);
+            StateTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             byte[][] accounts = new byte[accountsCount][];
             byte[][] randomValues = new byte[uniqueValuesCount][];
@@ -945,7 +945,7 @@ namespace Nethermind.Trie.Test
             Stack<Hash256> rootStack = new();
 
             using TrieStore trieStore = trieStoreConfig.CreateTrieStore();
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
 
             byte[][] accounts = new byte[accountsCount][];
             byte[][] randomValues = new byte[uniqueValuesCount][];
@@ -1245,7 +1245,7 @@ namespace Nethermind.Trie.Test
             );
             finalizedStateProvider.TrieStore = trieStore;
 
-            PatriciaTree tree = new(trieStore, LimboLogs.Instance);
+            PatriciaTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
             using ArrayPoolList<(Hash256, Hash256)> kv = new(itemCount);
 
@@ -1284,7 +1284,7 @@ namespace Nethermind.Trie.Test
         {
             // Build a tree with extension, branch, and leaf nodes: _keyA, _keyB, _keyC, _keyD
             using IPruningTrieStore trieStore = CreateTrieStore();
-            PatriciaTree patriciaTree = new(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf2);
             patriciaTree.Set(_keyC, _longLeaf1);

--- a/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/VisitingTests.cs
@@ -29,7 +29,7 @@ public class VisitingTests
         MemDb memDb = new();
 
         using ITrieStore trieStore = TestTrieStoreFactory.Build(new NodeStorage(memDb, scheme), LimboLogs.Instance);
-        PatriciaTree patriciaTree = new(trieStore, LimboLogs.Instance);
+        PatriciaTree patriciaTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
         Span<byte> raw = stackalloc byte[32];
 
@@ -45,7 +45,7 @@ public class VisitingTests
 
         AppendingVisitor visitor = new(false);
 
-        patriciaTree.Accept(visitor, patriciaTree.RootHash, options);
+        visitor.TraverseState(patriciaTree.RootHash, trieStore.GetTrieStore(null), options);
 
         HashSet<int> setNibbles = new(Enumerable.Range(0, 64));
 
@@ -92,7 +92,7 @@ public class VisitingTests
         }
 
 
-        StateTree stateTree = new(trieStore, LimboLogs.Instance);
+        StateTree stateTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
 
         for (int i = 0; i < 64; i++)
         {
@@ -108,7 +108,7 @@ public class VisitingTests
 
         AppendingVisitor visitor = new(true);
 
-        stateTree.Accept(visitor, stateTree.RootHash, options);
+        visitor.Traverse(stateTree.RootHash, trieStore, options);
 
         int totalPath = 0;
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -463,9 +463,17 @@ public class BatchedTrieVisitor<TNodeContext>
                             TNodeContext storageContext = childContext.AddStorage(account.StorageRoot);
                             trieVisitContext.Level++;
 
-                            if (node.TryResolveStorageRoot(nodeResolver, ref emptyPath, out TrieNode? storageRoot))
+                            TrieNode? storageRoot = node.StorageRoot;
+                            if (storageRoot is null && account.StorageRoot != Keccak.EmptyTreeHash)
                             {
-                                nextToVisit.Add((storageRoot!, storageContext, trieVisitContext));
+                                // BatchedTrieVisitor is hash-scheme only, so storage address is not needed for resolution
+                                node.StorageRoot = storageRoot = nodeResolver
+                                    .FindCachedOrUnknown(in emptyPath, account.StorageRoot.ToCommitment());
+                            }
+
+                            if (storageRoot is not null)
+                            {
+                                nextToVisit.Add((storageRoot, storageContext, trieVisitContext));
                             }
                             else
                             {

--- a/src/Nethermind/Nethermind.Trie/CachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachedTrieStore.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie.Pruning;
@@ -27,9 +26,6 @@ public class CachedTrieStore(IScopedTrieStore @base) : IScopedTrieStore
 
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) =>
         @base.TryLoadRlp(in path, hash, flags);
-
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) =>
-        throw new InvalidOperationException("unsupported");
 
     public INodeStorage.KeyScheme Scheme => @base.Scheme;
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -79,11 +79,6 @@ namespace Nethermind.Trie
         {
         }
 
-        public PatriciaTree(ITrieStore trieStore, ILogManager logManager, ICappedArrayPool? bufferPool = null)
-            : this(trieStore.GetTrieStore(null), EmptyTreeHash, true, logManager, bufferPool: bufferPool)
-        {
-        }
-
         public PatriciaTree(IScopedTrieStore trieStore, ILogManager logManager, ICappedArrayPool? bufferPool = null)
             : this(trieStore, EmptyTreeHash, true, logManager, bufferPool: bufferPool)
         {
@@ -96,7 +91,7 @@ namespace Nethermind.Trie
             ILogManager logManager,
             ICappedArrayPool? bufferPool = null)
             : this(
-                new RawScopedTrieStore(new NodeStorage(keyValueStore), null),
+                new RawScopedTrieStore(keyValueStore),
                 rootHash,
                 allowCommits,
                 logManager,
@@ -982,110 +977,6 @@ namespace Nethermind.Trie
             finally
             {
                 path.TruncateMut(originalPathLength);
-            }
-        }
-
-        /// <summary>
-        /// Run tree visitor
-        /// </summary>
-        /// <param name="visitor">The visitor</param>
-        /// <param name="rootHash">State root hash (not storage root)</param>
-        /// <param name="visitingOptions">Options</param>
-        /// <param name="storageAddr">Address of storage, if it should visit storage. </param>
-        /// <param name="storageRoot">Root of storage if it should visit storage. Optional for performance.</param>
-        /// <typeparam name="TNodeContext"></typeparam>
-        public void Accept<TNodeContext>(
-            ITreeVisitor<TNodeContext> visitor,
-            Hash256 rootHash,
-            VisitingOptions? visitingOptions = null,
-            Hash256? storageAddr = null,
-            Hash256? storageRoot = null
-        ) where TNodeContext : struct, INodeContext<TNodeContext>
-        {
-            ArgumentNullException.ThrowIfNull(visitor);
-            ArgumentNullException.ThrowIfNull(rootHash);
-            visitingOptions ??= VisitingOptions.Default;
-
-            using TrieVisitContext trieVisitContext = new()
-            {
-                MaxDegreeOfParallelism = visitingOptions.MaxDegreeOfParallelism,
-                IsStorage = storageAddr is not null
-            };
-
-            if (storageAddr is not null)
-            {
-                Hash256 DecodeStorageRoot(Hash256 root, Hash256 address)
-                {
-                    ReadOnlySpan<byte> bytes = Get(address.Bytes, root);
-                    Rlp.ValueDecoderContext valueContext = bytes.AsRlpValueContext();
-                    return AccountDecoder.Instance.DecodeStorageRootOnly(ref valueContext);
-                }
-
-                rootHash = storageRoot ?? DecodeStorageRoot(rootHash, storageAddr);
-            }
-
-            ReadFlags flags = visitor.ExtraReadFlag;
-            if (visitor.IsFullDbScan)
-            {
-                if (TrieStore.Scheme == INodeStorage.KeyScheme.HalfPath)
-                {
-                    // With halfpath or flat, the nodes are ordered so readahead will make things faster.
-                    flags |= ReadFlags.HintReadAhead;
-                }
-                else
-                {
-                    // With hash, we don't wanna add cache as that will take some CPU time away.
-                    flags |= ReadFlags.HintCacheMiss;
-                }
-            }
-
-            ITrieNodeResolver resolver = flags != ReadFlags.None
-                ? new TrieNodeResolverWithReadFlags(TrieStore, flags)
-                : TrieStore;
-
-            if (storageAddr is not null)
-            {
-                resolver = resolver.GetStorageTrieNodeResolver(storageAddr);
-            }
-
-            bool TryGetRootRef(out TrieNode? rootRef)
-            {
-                rootRef = null;
-                if (rootHash != Keccak.EmptyTreeHash)
-                {
-                    TreePath emptyPath = TreePath.Empty;
-                    rootRef = RootHash == rootHash ? RootRef : resolver.FindCachedOrUnknown(emptyPath, rootHash);
-                    if (!rootRef!.TryResolveNode(resolver, ref emptyPath))
-                    {
-                        visitor.VisitMissingNode(default, rootHash);
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if (!visitor.IsFullDbScan)
-            {
-                visitor.VisitTree(default, rootHash);
-                if (TryGetRootRef(out TrieNode rootRef))
-                {
-                    TreePath emptyPath = TreePath.Empty;
-                    rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
-                }
-            }
-            // Full db scan
-            else if (TrieStore.Scheme == INodeStorage.KeyScheme.Hash && visitingOptions.FullScanMemoryBudget != 0)
-            {
-                visitor.VisitTree(default, rootHash);
-                BatchedTrieVisitor<TNodeContext> batchedTrieVisitor = new(visitor, resolver, visitingOptions);
-                batchedTrieVisitor.Start(rootHash, trieVisitContext);
-            }
-            else if (TryGetRootRef(out TrieNode rootRef))
-            {
-                TreePath emptyPath = TreePath.Empty;
-                visitor.VisitTree(default, rootHash);
-                rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/EmptyTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/EmptyTrieNodeResolver.cs
@@ -20,7 +20,5 @@ public class EmptyTrieNodeResolver : ITrieNodeResolver
 
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => throw new InvalidOperationException("Empty node resolver should not be called");
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => throw new InvalidOperationException("Empty node resolver should not be called");
-
     public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.Hash;
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie.Pruning
@@ -31,15 +30,6 @@ namespace Nethermind.Trie.Pruning
         /// <param name="hash"></param>
         /// <returns></returns>
         byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None);
-
-        /// <summary>
-        /// Got another node resolver for another trie. Used for tree traversal. For simplicity, if address is null,
-        /// return state trie.
-        /// </summary>
-        /// <param name="address"></param>
-        /// <returns></returns>
-        [Todo("Find a way to not have this. PatriciaTrie on its own does not need the concept of storage.")]
-        ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address);
 
         INodeStorage.KeyScheme Scheme { get; }
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -9,9 +9,17 @@ using Nethermind.Core.Crypto;
 namespace Nethermind.Trie.Pruning
 {
     /// <summary>
+    /// Provides scoped trie node resolvers for state and storage tries.
+    /// </summary>
+    public interface ITrieNodeResolverProvider
+    {
+        IScopedTrieStore GetTrieStore(Hash256? address);
+    }
+
+    /// <summary>
     /// Full traditional trie store.
     /// </summary>
-    public interface ITrieStore : IDisposable, IScopableTrieStore
+    public interface ITrieStore : IDisposable, IScopableTrieStore, ITrieNodeResolverProvider
     {
         bool HasRoot(Hash256 stateRoot);
 
@@ -23,8 +31,6 @@ namespace Nethermind.Trie.Pruning
         bool HasRoot(Hash256 stateRoot, long blockNumber) => HasRoot(stateRoot);
 
         IDisposable BeginScope(BlockHeader? baseBlock);
-
-        IScopedTrieStore GetTrieStore(Hash256? address);
 
         /// <summary>
         /// Begin a block commit for this block number. This call may be blocked if a memory pruning is currently happening.

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -15,8 +15,6 @@ namespace Nethermind.Trie.Pruning
         public TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) => new(NodeType.Unknown, hash);
         public byte[]? LoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
         public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 storage) => this;
-
         public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -22,8 +22,6 @@ namespace Nethermind.Trie.Pruning
 
         public void Set(in TreePath path, in ValueHash256 keccak, byte[] rlp) { }
 
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 storageRoot) => this;
-
         public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/RawScopedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/RawScopedTrieStore.cs
@@ -25,8 +25,6 @@ public class RawScopedTrieStore(INodeStorage nodeStorage, Hash256? address = nul
 
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => nodeStorage.Get(address, path, hash, flags);
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => new RawScopedTrieStore(nodeStorage, address);
-
     public INodeStorage.KeyScheme Scheme => nodeStorage.Scheme;
 
     public ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => new Committer(nodeStorage, address, writeFlags);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -47,9 +47,6 @@ namespace Nethermind.Trie.Pruning
 
             public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => fullTrieStore.TryLoadRlp(address, path, hash, flags);
 
-            public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address1) =>
-                address1 == address ? this : new ScopedReadOnlyTrieStore(fullTrieStore, address1);
-
             public INodeStorage.KeyScheme Scheme => fullTrieStore.Scheme;
 
             public ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => NullCommitter.Instance;

--- a/src/Nethermind/Nethermind.Trie/Pruning/ScopedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ScopedTrieStore.cs
@@ -17,9 +17,6 @@ public sealed class ScopedTrieStore(IScopableTrieStore fullTrieStore, Hash256? a
     public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) =>
         fullTrieStore.TryLoadRlp(address, path, hash, flags);
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address1) =>
-        address1 == address ? this : new ScopedTrieStore(fullTrieStore, address1);
-
     public INodeStorage.KeyScheme Scheme => fullTrieStore.Scheme;
 
     public ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) =>

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -18,6 +18,7 @@ using Nethermind.Core.Threading;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Trie.Pruning;
 
@@ -1077,16 +1078,35 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         using ArrayPoolList<(TrieNode trieNode, Hash256? address2, TreePath path)> parallelStartNodes = new(_shardedDirtyNodeCount);
 
-        void TopLevelPersist(TrieNode tn, Hash256? address2, TreePath path)
+        Hash256? currentAddress = null;
+
+        void TopLevelPersist(TrieNode tn, TreePath path)
         {
+            // Handle storage first (children before parent)
+            if (currentAddress is null && tn.IsLeaf && ResolveStorageRoot(tn, ref path) is { } storageRoot)
+            {
+                Hash256 storageAddr;
+                using (path.ScopedAppend(tn.Key))
+                {
+                    storageAddr = path.Path.ToCommitment();
+                }
+
+                TreePath emptyPath = TreePath.Empty;
+                currentAddress = storageAddr;
+                storageRoot.CallRecursively(
+                    TopLevelPersist, ref emptyPath, true, _logger,
+                    maxPathLength: parallelBoundaryPathLength);
+                currentAddress = null;
+            }
+
             if (path.Length < parallelBoundaryPathLength)
             {
-                persistedNodeRecorder.Invoke(path, address2, tn);
-                PersistNode(address2, path, tn, commitSet.BlockNumber, topLevelWriteBatch, writeFlags);
+                persistedNodeRecorder.Invoke(path, currentAddress, tn);
+                PersistNode(currentAddress, path, tn, commitSet.BlockNumber, topLevelWriteBatch, writeFlags);
             }
             else
             {
-                parallelStartNodes.Add((tn, address2, path));
+                parallelStartNodes.Add((tn, currentAddress, path));
             }
         }
 
@@ -1096,7 +1116,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         // The first CallRecursive stop at two level, yielding 256 node in parallelStartNodes, which is run concurrently
         TreePath path = TreePath.Empty;
-        commitSet.Root?.CallRecursively(TopLevelPersist, null, ref path, GetTrieStoreForPruning(null), true, _logger, maxPathLength: parallelBoundaryPathLength);
+        commitSet.Root?.CallRecursively(TopLevelPersist, ref path, true, _logger, maxPathLength: parallelBoundaryPathLength);
 
         // The amount of change in the subtrees are not balanced at all. So their writes areas buffered here
         // which get disposed in parallel instead of being disposed in `PersistNodeStartingFrom`.
@@ -1151,11 +1171,28 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         long persistedNodeCount = 0;
         INodeStorage.IWriteBatch writeBatch = _nodeStorage.StartWriteBatch();
+        Hash256? currentAddress = address2;
 
-        async ValueTask DoPersist(TrieNode node, Hash256? address3, TreePath path2)
+        async ValueTask DoPersist(TrieNode node, TreePath path2)
         {
-            persistedNodeRecorder.Invoke(path2, address3, node);
-            PersistNode(address3, path2, node, blockNumber, writeBatch, writeFlags);
+            // Handle storage first (children before parent)
+            if (currentAddress is null && node.IsLeaf && ResolveStorageRoot(node, ref path2) is { } storageRoot)
+            {
+                Hash256 storageAddr;
+                using (path2.ScopedAppend(node.Key))
+                {
+                    storageAddr = path2.Path.ToCommitment();
+                }
+
+                TreePath emptyPath = TreePath.Empty;
+                currentAddress = storageAddr;
+                await storageRoot.CallRecursivelyAsync(
+                    DoPersist, ref emptyPath, _logger);
+                currentAddress = null;
+            }
+
+            persistedNodeRecorder.Invoke(path2, currentAddress, node);
+            PersistNode(currentAddress, path2, node, blockNumber, writeBatch, writeFlags);
 
             persistedNodeCount++;
             if (persistedNodeCount % 512 == 0)
@@ -1165,8 +1202,31 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             }
         }
 
-        await tn.CallRecursivelyAsync(DoPersist, address2, ref path, GetTrieStoreForPruning(address2), _logger);
+        await tn.CallRecursivelyAsync(DoPersist, ref path, _logger);
         await disposeQueue.Writer.WriteAsync(writeBatch);
+    }
+
+    private TrieNode? ResolveStorageRoot(TrieNode node, ref TreePath path)
+    {
+        TrieNode? storageRoot = node.StorageRoot;
+        if (storageRoot is not null) return storageRoot;
+
+        if (node.Value.Length <= 64) return null; // storage leaf, not an account
+
+        Rlp.ValueDecoderContext valueContext = node.Value.AsSpan().AsRlpValueContext();
+        Hash256 storageRootKey = AccountDecoder.Instance.DecodeStorageRootOnly(ref valueContext);
+        if (storageRootKey == Keccak.EmptyTreeHash) return null;
+
+        Hash256 storagePath;
+        using (path.ScopedAppend(node.Key))
+        {
+            storagePath = path.Path.ToCommitment();
+        }
+
+        TreePath emptyPath = TreePath.Empty;
+        node.StorageRoot = storageRoot = GetTrieStoreForPruning(storagePath)
+            .FindCachedOrUnknown(in emptyPath, storageRootKey);
+        return storageRoot;
     }
 
     private void PersistNode(Hash256? address, in TreePath path, TrieNode currentNode, long blockNumber, INodeStorage.IWriteBatch writeBatch, WriteFlags writeFlags = WriteFlags.None)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -405,14 +405,16 @@ internal class TrieStoreDirtyNodesCache
         ConcurrentDictionary<Key, bool> wasPersisted = new();
         int persistedCount = 0;
 
-        void PersistNode(TrieNode n, Hash256? address, TreePath path)
+        Hash256? currentAddress = null;
+
+        void PersistNode(TrieNode n, TreePath path)
         {
             if (n.Keccak is null) return;
             if (n.NodeType == NodeType.Unknown) return;
-            Key key = new(address, path, n.Keccak);
+            Key key = new(currentAddress, path, n.Keccak);
             if (wasPersisted.TryAdd(key, true))
             {
-                nodeStorage.Set(address, path, n.Keccak, n.FullRlp.AsSpan());
+                nodeStorage.Set(currentAddress, path, n.Keccak, n.FullRlp.AsSpan());
                 n.IsPersisted = true;
                 persistedCount++;
             }
@@ -423,8 +425,8 @@ internal class TrieStoreDirtyNodesCache
             if (cancellationToken.IsCancellationRequested) return persistedCount;
             Key key = kv.Key;
             TreePath path = key.Path;
-            Hash256? address = key.Address;
-            kv.Value.Node.CallRecursively(PersistNode, address, ref path, _trieStore.GetTrieStore(address), false, _logger, resolveStorageRoot: false);
+            currentAddress = key.Address;
+            kv.Value.Node.CallRecursively(PersistNode, ref path, false, _logger);
         }
 
         return persistedCount;

--- a/src/Nethermind/Nethermind.Trie/RecursiveTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RecursiveTrieVisitor.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
@@ -13,20 +10,9 @@ using Nethermind.Core.Threading;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie.Pruning;
 
-[assembly: InternalsVisibleTo("Ethereum.Trie.Test")]
-[assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
-[assembly: InternalsVisibleTo("Nethermind.Trie.Test")]
-
 namespace Nethermind.Trie
 {
-    partial class TrieNode
-    {
-        internal void Accept<TNodeContext>(ITreeVisitor<TNodeContext> visitor, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver,
-            ref TreePath path, TrieVisitContext trieVisitContext) where TNodeContext : struct, INodeContext<TNodeContext> => new TrieNodeTraverser<TNodeContext>(visitor, trieVisitContext)
-                .Start(this, nodeContext, nodeResolver, ref path);
-    }
-
-    public class TrieNodeTraverser<TNodeContext>(ITreeVisitor<TNodeContext> visitor, TrieVisitContext options) where TNodeContext : struct, INodeContext<TNodeContext>
+    public class RecursiveTrieVisitor<TNodeContext>(ITreeVisitor<TNodeContext> visitor, TrieVisitContext options, ITrieStore? trieStore = null) where TNodeContext : struct, INodeContext<TNodeContext>
     {
         private static readonly AccountDecoder _accountDecoder = new();
         private int _maxDegreeOfParallelism = options.MaxDegreeOfParallelism;
@@ -35,7 +21,8 @@ namespace Nethermind.Trie
 
         private int _visitedNodes;
 
-        internal void Start(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path) => _ = Accept(node, nodeContext, nodeResolver, ref path, options.IsStorage, long.MaxValue);
+        public void Start(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path) =>
+            _ = Accept(node, nodeContext, nodeResolver, ref path, options.IsStorage, long.MaxValue);
 
         internal long Accept(TrieNode node, in TNodeContext nodeContext, ITrieNodeResolver nodeResolver, ref TreePath path, bool isStorage, long subtreeSizeHint)
         {
@@ -90,7 +77,7 @@ namespace Nethermind.Trie
                     {
                         visitor.VisitExtension(nodeContext, node);
                         AddVisited();
-                        TrieNode child = node.GetChild(nodeResolver, ref path, 0) ?? throw new InvalidDataException($"Child of an extension {node.Key} should not be null.");
+                        TrieNode child = node.GetChild(nodeResolver, ref path, 0) ?? throw new System.IO.InvalidDataException($"Child of an extension {node.Key} should not be null.");
                         int previousPathLength = node.AppendChildPath(ref path, 0);
                         child.ResolveKey(nodeResolver, ref path);
                         TNodeContext childContext = nodeContext.Add(node.Key!);
@@ -116,23 +103,31 @@ namespace Nethermind.Trie
                             Rlp.ValueDecoderContext decoderContext = new(node.Value.AsSpan());
                             if (!_accountDecoder.TryDecodeStruct(ref decoderContext, out AccountStruct account))
                             {
-                                throw new InvalidDataException("Non storage leaf should be an account");
+                                throw new System.IO.InvalidDataException("Non storage leaf should be an account");
                             }
                             visitor.VisitAccount(leafContext, node, account);
 
-                            if (account.HasStorage && visitor.ShouldVisit(leafContext, account.StorageRoot))
+                            if (account.HasStorage && trieStore is not null && visitor.ShouldVisit(leafContext, account.StorageRoot))
                             {
-                                if (node.TryResolveStorageRoot(nodeResolver, ref path, out TrieNode? storageRoot))
+                                Hash256 storageAccount;
+                                using (path.ScopedAppend(node.Key))
                                 {
-                                    Hash256 storageAccount;
-                                    using (path.ScopedAppend(node.Key))
-                                    {
-                                        storageAccount = path.Path.ToCommitment();
-                                    }
+                                    storageAccount = path.Path.ToCommitment();
+                                }
 
+                                TrieNode? storageRoot = node.StorageRoot;
+                                if (storageRoot is null && account.StorageRoot != Keccak.EmptyTreeHash)
+                                {
+                                    TreePath emptyPath2 = TreePath.Empty;
+                                    node.StorageRoot = storageRoot = trieStore.GetTrieStore(storageAccount)
+                                        .FindCachedOrUnknown(in emptyPath2, account.StorageRoot.ToCommitment());
+                                }
+
+                                if (storageRoot is not null)
+                                {
                                     TNodeContext storageContext = leafContext.AddStorage(storageAccount);
                                     TreePath emptyPath = TreePath.Empty;
-                                    actualSubtreeSize += Accept(storageRoot!, storageContext, nodeResolver.GetStorageTrieNodeResolver(storageAccount), ref emptyPath, true, subtreeSizeHint);
+                                    actualSubtreeSize += Accept(storageRoot, storageContext, trieStore.GetTrieStore(storageAccount), ref emptyPath, true, subtreeSizeHint);
                                 }
                                 else
                                 {
@@ -272,7 +267,7 @@ namespace Nethermind.Trie
             // TODO: Fine tune interval? Use TrieNode.GetMemorySize(false) to calculate memory usage?
             if (visitedNodes % 20_000_000 == 0)
             {
-                GC.Collect();
+                System.GC.Collect();
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -201,6 +201,16 @@ namespace Nethermind.Trie
 
         public bool IsExtension => NodeType == NodeType.Extension;
 
+        internal TrieNode? StorageRoot
+        {
+            get => (_nodeData as LeafData)?.StorageRoot;
+            set
+            {
+                if (_nodeData is LeafData leafData)
+                    leafData.StorageRoot = value;
+            }
+        }
+
         public byte[]? Key
         {
             get { return _nodeData is INodeWithKey node ? node?.Key : null; }
@@ -948,14 +958,11 @@ namespace Nethermind.Trie
         /// Note that nodes referenced by hash are not called.
         /// </summary>
         public void CallRecursively(
-            Action<TrieNode, Hash256?, TreePath> action,
-            Hash256? storageAddress,
+            Action<TrieNode, TreePath> action,
             ref TreePath currentPath,
-            ITrieNodeResolver resolver,
             bool skipPersisted,
             in ILogger logger,
-            int maxPathLength = Int32.MaxValue,
-            bool resolveStorageRoot = true)
+            int maxPathLength = Int32.MaxValue)
         {
             if (skipPersisted && IsPersisted)
             {
@@ -965,7 +972,7 @@ namespace Nethermind.Trie
 
             if (currentPath.Length >= maxPathLength)
             {
-                action(this, storageAddress, currentPath);
+                action(this, currentPath);
                 return;
             }
 
@@ -979,8 +986,8 @@ namespace Nethermind.Trie
                     {
                         if (logger.IsTrace) logger.Trace($"Persist recursively on child {i} {child} of {this}");
                         currentPath.SetLast(i);
-                        child.CallRecursively(action, storageAddress, ref currentPath, resolver, skipPersisted, logger,
-                            maxPathLength, resolveStorageRoot);
+                        child.CallRecursively(action, ref currentPath, skipPersisted, logger,
+                            maxPathLength);
                     }
                 }
 
@@ -992,47 +999,18 @@ namespace Nethermind.Trie
                 {
                     if (logger.IsTrace) logger.Trace($"Persist recursively on child 0 {child} of {this}");
                     int previousLength = AppendChildPath(ref currentPath, 0);
-                    child.CallRecursively(action, storageAddress, ref currentPath, resolver, skipPersisted, logger,
-                        maxPathLength, resolveStorageRoot);
+                    child.CallRecursively(action, ref currentPath, skipPersisted, logger,
+                        maxPathLength);
                     currentPath.TruncateMut(previousLength);
                 }
             }
-            else if (_nodeData is LeafData leafData)
-            {
-                TrieNode? storageRoot = leafData.StorageRoot;
-                if (resolveStorageRoot && (storageRoot is not null ||
-                                           TryResolveStorageRoot(resolver, ref currentPath, out storageRoot)))
-                {
-                    if (logger.IsTrace)
-                        logger.Trace($"Persist recursively on storage root {leafData.StorageRoot} of {this}");
-                    Hash256 storagePathAddr;
-                    using (currentPath.ScopedAppend(Key))
-                    {
-                        if (currentPath.Length != 64)
-                            throw new TrieException(
-                                $"unexpected storage path length. Total nibble count should add up to 64. Got {currentPath.Length}.");
-                        storagePathAddr = currentPath.Path.ToCommitment();
-                    }
 
-                    TreePath emptyPath = TreePath.Empty;
-                    storageRoot!.CallRecursively(
-                        action,
-                        storagePathAddr,
-                        ref emptyPath,
-                        resolver.GetStorageTrieNodeResolver(storagePathAddr),
-                        skipPersisted,
-                        logger);
-                }
-            }
-
-            action(this, storageAddress, currentPath);
+            action(this, currentPath);
         }
 
         public ValueTask CallRecursivelyAsync(
-            Func<TrieNode, Hash256?, TreePath, ValueTask> action,
-            Hash256? storageAddress,
+            Func<TrieNode, TreePath, ValueTask> action,
             ref TreePath currentPath,
-            ITrieNodeResolver resolver,
             ILogger logger)
         {
             if (IsPersisted)
@@ -1041,42 +1019,20 @@ namespace Nethermind.Trie
                 return default;
             }
 
-            if (currentPath.Length >= Int32.MaxValue)
+            if (_nodeData is null or LeafData)
             {
-                return action(this, storageAddress, currentPath);
+                return action(this, currentPath);
             }
 
-            if (_nodeData is not LeafData leafData)
-            {
-                if (_nodeData is null)
-                {
-                    return action(this, storageAddress, currentPath);
-                }
-
-                return CallRecursivelyNotLeafAsync(
-                    action,
-                    storageAddress,
-                    currentPath,
-                    resolver,
-                    logger);
-            }
-            else
-            {
-                return CallRecursivelyLeafAsync(
-                    action,
-                    storageAddress,
-                    currentPath,
-                    resolver,
-                    leafData,
-                    logger);
-            }
+            return CallRecursivelyNonLeafAsync(
+                action,
+                currentPath,
+                logger);
         }
 
-        private async ValueTask CallRecursivelyNotLeafAsync(
-            Func<TrieNode, Hash256?, TreePath, ValueTask> action,
-            Hash256? storageAddress,
+        private async ValueTask CallRecursivelyNonLeafAsync(
+            Func<TrieNode, TreePath, ValueTask> action,
             TreePath currentPath,
-            ITrieNodeResolver resolver,
             ILogger logger)
         {
             if (_nodeData is BranchData branchData)
@@ -1087,7 +1043,7 @@ namespace Nethermind.Trie
                     {
                         if (logger.IsTrace) logger.Trace($"Persist recursively on child {i} {child} of {this}");
                         int previousLength = AppendChildPath(ref currentPath, i);
-                        await child.CallRecursivelyAsync(action, storageAddress, ref currentPath, resolver, logger);
+                        await child.CallRecursivelyAsync(action, ref currentPath, logger);
                         currentPath.TruncateMut(previousLength);
                     }
                 }
@@ -1098,44 +1054,12 @@ namespace Nethermind.Trie
                 {
                     if (logger.IsTrace) logger.Trace($"Persist recursively on child 0 {child} of {this}");
                     int previousLength = AppendChildPath(ref currentPath, 0);
-                    await child.CallRecursivelyAsync(action, storageAddress, ref currentPath, resolver, logger);
+                    await child.CallRecursivelyAsync(action, ref currentPath, logger);
                     currentPath.TruncateMut(previousLength);
                 }
             }
 
-            await action(this, storageAddress, currentPath);
-        }
-
-        private async ValueTask CallRecursivelyLeafAsync(
-            Func<TrieNode, Hash256?, TreePath, ValueTask> action,
-            Hash256? storageAddress,
-            TreePath currentPath,
-            ITrieNodeResolver resolver,
-            LeafData leafData,
-            ILogger logger)
-        {
-            TrieNode? storageRoot = leafData.StorageRoot;
-            if (storageRoot is not null || TryResolveStorageRoot(resolver, ref currentPath, out storageRoot))
-            {
-                if (logger.IsTrace) logger.Trace($"Persist recursively on storage root {storageRoot} of {this}");
-                Hash256 storagePathAddr;
-                using (currentPath.ScopedAppend(Key))
-                {
-                    if (currentPath.Length != 64)
-                        throw new TrieException("unexpected storage path length. Total nibble count should add up to 64.");
-                    storagePathAddr = currentPath.Path.ToCommitment();
-                }
-
-                TreePath emptyPath = TreePath.Empty;
-                await storageRoot!.CallRecursivelyAsync(
-                    action,
-                    storagePathAddr,
-                    ref emptyPath,
-                    resolver.GetStorageTrieNodeResolver(storagePathAddr),
-                    logger);
-            }
-
-            await action(this, storageAddress, currentPath);
+            await action(this, currentPath);
         }
 
         /// <summary>
@@ -1207,44 +1131,6 @@ namespace Nethermind.Trie
             // }
         }
 
-        internal bool TryResolveStorageRoot(ITrieNodeResolver resolver, ref TreePath currentPath,
-            out TrieNode? storageRoot)
-        {
-            bool hasStorage = false;
-
-            if (_nodeData is LeafData data)
-            {
-                storageRoot = data.StorageRoot;
-                if (storageRoot is not null)
-                {
-                    hasStorage = true;
-                }
-                else if (Value.Length > 64) // if not a storage leaf
-                {
-                    Rlp.ValueDecoderContext valueContext = Value.AsSpan().AsRlpValueContext();
-                    Hash256 storageRootKey = _accountDecoder.DecodeStorageRootOnly(ref valueContext);
-                    if (storageRootKey != Nethermind.Core.Crypto.Keccak.EmptyTreeHash)
-                    {
-                        Hash256 storagePath;
-                        using (currentPath.ScopedAppend(Key))
-                        {
-                            storagePath = currentPath.Path.ToCommitment();
-                        }
-
-                        hasStorage = true;
-                        TreePath emptyPath = TreePath.Empty;
-                        data.StorageRoot = storageRoot = resolver.GetStorageTrieNodeResolver(storagePath)
-                            .FindCachedOrUnknown(in emptyPath, storageRootKey);
-                    }
-                }
-            }
-            else
-            {
-                storageRoot = null;
-            }
-
-            return hasStorage;
-        }
 
         private void SeekChild(ref ValueRlpStream rlpStream, int index)
         {

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -34,7 +34,5 @@ public class TrieNodeResolverWithReadFlags(ITrieNodeResolver baseResolver, ReadF
         return _baseResolver.LoadRlp(treePath, hash, _defaultFlags);
     }
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 address) => new TrieNodeResolverWithReadFlags(_baseResolver.GetStorageTrieNodeResolver(address), _defaultFlags);
-
     public INodeStorage.KeyScheme Scheme => _baseResolver.Scheme;
 }

--- a/src/Nethermind/Nethermind.Trie/TrieVisitorExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieVisitorExtensions.cs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Trie;
+
+public static class TrieVisitorExtensions
+{
+    public static void Traverse<TNodeContext>(
+        this ITreeVisitor<TNodeContext> visitor,
+        Hash256 rootHash,
+        ITrieStore trieStore,
+        VisitingOptions? visitingOptions = null
+    ) where TNodeContext : struct, INodeContext<TNodeContext> =>
+        TraverseCore(visitor, rootHash, trieStore.GetTrieStore(null), visitingOptions, isStorage: false, trieStore);
+
+    public static void TraverseState<TNodeContext>(
+        this ITreeVisitor<TNodeContext> visitor,
+        Hash256 rootHash,
+        ITrieNodeResolver resolver,
+        VisitingOptions? visitingOptions = null
+    ) where TNodeContext : struct, INodeContext<TNodeContext> =>
+        TraverseCore(visitor, rootHash, resolver, visitingOptions, isStorage: false, trieStore: null);
+
+    public static void TraverseStorage<TNodeContext>(
+        this ITreeVisitor<TNodeContext> visitor,
+        Hash256 rootHash,
+        ITrieNodeResolver resolver,
+        VisitingOptions? visitingOptions = null
+    ) where TNodeContext : struct, INodeContext<TNodeContext> =>
+        TraverseCore(visitor, rootHash, resolver, visitingOptions, isStorage: true, trieStore: null);
+
+    private static void TraverseCore<TNodeContext>(
+        ITreeVisitor<TNodeContext> visitor,
+        Hash256 rootHash,
+        ITrieNodeResolver resolver,
+        VisitingOptions? visitingOptions,
+        bool isStorage,
+        ITrieStore? trieStore
+    ) where TNodeContext : struct, INodeContext<TNodeContext>
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        ArgumentNullException.ThrowIfNull(rootHash);
+        visitingOptions ??= VisitingOptions.Default;
+
+        using TrieVisitContext trieVisitContext = new()
+        {
+            MaxDegreeOfParallelism = visitingOptions.MaxDegreeOfParallelism,
+            IsStorage = isStorage
+        };
+
+        ReadFlags flags = visitor.ExtraReadFlag;
+        if (visitor.IsFullDbScan)
+        {
+            if (resolver.Scheme == INodeStorage.KeyScheme.HalfPath)
+            {
+                // With halfpath or flat, the nodes are ordered so readahead will make things faster.
+                flags |= ReadFlags.HintReadAhead;
+            }
+            else
+            {
+                // With hash, we don't wanna add cache as that will take some CPU time away.
+                flags |= ReadFlags.HintCacheMiss;
+            }
+        }
+
+        ITrieNodeResolver effectiveResolver = flags != ReadFlags.None
+            ? new TrieNodeResolverWithReadFlags(resolver, flags)
+            : resolver;
+
+        bool TryGetRootRef(out TrieNode? rootRef)
+        {
+            rootRef = null;
+            if (rootHash != Keccak.EmptyTreeHash)
+            {
+                TreePath emptyPath = TreePath.Empty;
+                rootRef = effectiveResolver.FindCachedOrUnknown(emptyPath, rootHash);
+                if (!rootRef!.TryResolveNode(effectiveResolver, ref emptyPath))
+                {
+                    visitor.VisitMissingNode(default, rootHash);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (!visitor.IsFullDbScan)
+        {
+            visitor.VisitTree(default, rootHash);
+            if (TryGetRootRef(out TrieNode? rootRef) && rootRef is not null)
+            {
+                TreePath emptyPath = TreePath.Empty;
+                RecursiveTrieVisitor<TNodeContext> traverser = new(visitor, trieVisitContext, trieStore);
+                traverser.Start(rootRef, default, effectiveResolver, ref emptyPath);
+            }
+        }
+        // Full db scan
+        else if (resolver.Scheme == INodeStorage.KeyScheme.Hash && visitingOptions.FullScanMemoryBudget != 0)
+        {
+            visitor.VisitTree(default, rootHash);
+            BatchedTrieVisitor<TNodeContext> batchedTrieVisitor = new(visitor, effectiveResolver, visitingOptions);
+            batchedTrieVisitor.Start(rootHash, trieVisitContext);
+        }
+        else if (TryGetRootRef(out TrieNode? rootRef) && rootRef is not null)
+        {
+            TreePath emptyPath = TreePath.Empty;
+            visitor.VisitTree(default, rootHash);
+            RecursiveTrieVisitor<TNodeContext> traverser = new(visitor, trieVisitContext, trieStore);
+            traverser.Start(rootRef, default, effectiveResolver, ref emptyPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract trie visitor orchestration from `PatriciaTree.Accept` into standalone `TrieVisitorOrchestrator` with `Visit`, `VisitState`, and `VisitStorage` methods
- Remove `GetStorageTrieNodeResolver` from `ITrieNodeResolver` interface and all implementations (resolves long-standing `[Todo]`)
- Move storage root traversal from `TrieNode.CallRecursively` into `TrieStore`, simplifying `TrieNode` significantly
- Rename `TrieNode.Visitor.cs` → `RecursiveTrieVisitor.cs` to align naming with `BatchedTrieVisitor`

## Motivation
`PatriciaTree` mixed trie data operations (get/set/commit) with visitor orchestration. `ITrieNodeResolver` carried a `GetStorageTrieNodeResolver` method that leaked storage awareness into an interface that should only know about individual tries. This refactor separates concerns:
- `PatriciaTree` — trie data operations only
- `TrieVisitorOrchestrator` — visitor dispatch, read flag setup, batched vs recursive selection
- `TrieStore` — storage root resolution during persist
- `RecursiveTrieVisitor` — recursive node walking with optional storage traversal via `ITrieStore`

## Test plan
- [ ] Existing trie tests pass (`Nethermind.Trie.Test`)
- [ ] State proof tests pass (`Nethermind.State.Test`)
- [ ] Sync tests pass (`Nethermind.Synchronization.Test`)
- [ ] Flat state tests pass (`Nethermind.State.Flat.Test`)
- [ ] Full pruning tests pass (`Nethermind.Blockchain.Test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)