### PR TITLE
fix: resolve tx type based on target block fork in eth_call

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AccessListTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AccessListTransactionForRpc.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Int256;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
@@ -35,13 +36,17 @@ public class AccessListTransactionForRpc : LegacyTransactionForRpc, IFromTransac
         V = YParity ?? 0;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
-        tx.AccessList = AccessList?.ToAccessList() ?? Core.Eip2930.AccessList.Empty;
+
+        if (tx.SupportsAccessList)
+        {
+            tx.AccessList = AccessList?.ToAccessList() ?? Core.Eip2930.AccessList.Empty;
+        }
 
         return tx;
     }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 
@@ -34,7 +35,7 @@ public class BlobTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction<
         BlobVersionedHashes = transaction.BlobVersionedHashes ?? [];
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
         if (BlobVersionedHashes is null || BlobVersionedHashes.Length == 0)
             return RpcTransactionErrors.AtLeastOneBlobInBlobTransaction;
@@ -54,12 +55,16 @@ public class BlobTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction<
         if (validateUserInput && MaxFeePerBlobGas?.IsZero == true)
             return RpcTransactionErrors.ZeroMaxFeePerBlobGas;
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (!baseResult) return baseResult;
 
         Transaction tx = baseResult.Data;
-        tx.MaxFeePerBlobGas = MaxFeePerBlobGas;
-        tx.BlobVersionedHashes = BlobVersionedHashes;
+
+        if (tx.SupportsBlobs)
+        {
+            tx.MaxFeePerBlobGas = MaxFeePerBlobGas;
+            tx.BlobVersionedHashes = BlobVersionedHashes;
+        }
 
         return tx;
     }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/EIP1559TransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/EIP1559TransactionForRpc.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Int256;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
@@ -36,7 +37,7 @@ public class EIP1559TransactionForRpc : AccessListTransactionForRpc, IFromTransa
             : transaction.MaxFeePerGas;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
         if (validateUserInput)
         {
@@ -48,12 +49,16 @@ public class EIP1559TransactionForRpc : AccessListTransactionForRpc, IFromTransa
                 return RpcTransactionErrors.MaxFeePerGasSmallerThanMaxPriorityFeePerGas(MaxFeePerGas, MaxPriorityFeePerGas);
         }
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
-        tx.GasPrice = MaxPriorityFeePerGas ?? UInt256.Zero;
-        tx.DecodedMaxFeePerGas = MaxFeePerGas ?? UInt256.Zero;
+
+        if (tx.Supports1559)
+        {
+            tx.GasPrice = MaxPriorityFeePerGas ?? UInt256.Zero;
+            tx.DecodedMaxFeePerGas = MaxFeePerGas ?? UInt256.Zero;
+        }
 
         return tx;
     }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 // ReSharper disable VirtualMemberCallInConstructor
@@ -88,12 +89,12 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         }
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
         if (validateUserInput && To is null && Input is null or { Length: 0 })
             return RpcTransactionErrors.ContractCreationWithoutData;
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
@@ -32,7 +32,7 @@ public class SetCodeTransactionForRpc : EIP1559TransactionForRpc, IFromTransacti
 
         Transaction tx = baseResult.Data;
 
-        if (tx.Type == TxType.SetCode)
+        if (tx.SupportsAuthorizationList)
         {
             tx.AuthorizationList = AuthorizationList?.ToAuthorizationList() ?? [];
         }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
 
@@ -13,7 +14,7 @@ public class SetCodeTransactionForRpc : EIP1559TransactionForRpc, IFromTransacti
     public override TxType? Type => TxType;
 
     [JsonDiscriminator]
-    public AuthorizationListForRpc AuthorizationList { get; set; }
+    public AuthorizationListForRpc? AuthorizationList { get; set; }
 
     [JsonConstructor]
     public SetCodeTransactionForRpc() { }
@@ -24,13 +25,17 @@ public class SetCodeTransactionForRpc : EIP1559TransactionForRpc, IFromTransacti
         AuthorizationList = AuthorizationListForRpc.FromAuthorizationList(transaction.AuthorizationList);
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
-        tx.AuthorizationList = AuthorizationList?.ToAuthorizationList() ?? [];
+
+        if (tx.Type == TxType.SetCode)
+        {
+            tx.AuthorizationList = AuthorizationList?.ToAuthorizationList() ?? [];
+        }
 
         return tx;
     }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
 
@@ -48,6 +49,14 @@ public abstract class TransactionForRpc
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public long? Gas { get; set; }
 
+    /// <summary>
+    /// True when the transaction type was inferred by <see cref="TransactionJsonConverter"/> rather than
+    /// explicitly provided in the JSON request. When set, <see cref="ToTransaction"/> can resolve
+    /// the type to match the target block's fork rules.
+    /// </summary>
+    [JsonIgnore]
+    internal bool IsTypeDefaulted { get; set; }
+
     [JsonConstructor]
     protected TransactionForRpc() { }
 
@@ -60,7 +69,16 @@ public abstract class TransactionForRpc
         BlockTimestamp = extraData.BlockTimestamp;
     }
 
-    public virtual Result<Transaction> ToTransaction(bool validateUserInput = false) => new Transaction { Type = Type ?? default };
+    public virtual Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+        => new Transaction { Type = ResolveType(spec) };
+
+    private TxType ResolveType(IReleaseSpec? spec)
+    {
+        TxType type = Type ?? default;
+        return spec is not null && !spec.IsEip2930Enabled && IsTypeDefaulted && type > TxType.Legacy
+            ? TxType.Legacy
+            : type;
+    }
 
     public abstract void EnsureDefaults(long? gasCap);
     public abstract bool ShouldSetBaseFee();
@@ -89,7 +107,7 @@ public abstract class TransactionForRpc
                 .Where(p => p.GetCustomAttribute<JsonDiscriminatorAttribute>() is not null)
                 .Select(p => p.Name).ToArray();
 
-            TxTypeInfo typeInfo = new TxTypeInfo
+            TxTypeInfo typeInfo = new()
             {
                 TxType = T.TxType,
                 Type = txType,
@@ -125,34 +143,38 @@ public abstract class TransactionForRpc
             Utf8JsonReader txTypeReader = reader;
             JsonObject untyped = JsonSerializer.Deserialize<JsonObject>(ref txTypeReader, options);
 
-            Type concreteTxType = DeriveTxType(untyped, options);
+            Type concreteTxType = DeriveTxType(untyped, options, out bool isDefaulted);
 
-            return (TransactionForRpc?)JsonSerializer.Deserialize(ref reader, concreteTxType, options);
+            TransactionForRpc? result = (TransactionForRpc?)JsonSerializer.Deserialize(ref reader, concreteTxType, options);
+            result?.IsTypeDefaulted = isDefaulted;
+            return result;
         }
 
-        private Type DeriveTxType(JsonObject untyped, JsonSerializerOptions options)
+        private Type DeriveTxType(JsonObject untyped, JsonSerializerOptions options, out bool isDefaulted)
         {
-            Type defaultTxType = typeof(EIP1559TransactionForRpc);
             const string gasPriceFieldKey = nameof(LegacyTransactionForRpc.GasPrice);
             const string typeFieldKey = nameof(TransactionForRpc.Type);
+            isDefaulted = false;
 
             if (untyped.TryGetPropertyValue(typeFieldKey, out JsonNode? node))
             {
                 TxType? setType = node.Deserialize<TxType?>(options);
                 if (setType is not null)
                 {
-                    return _txTypes.FirstOrDefault(p => p.TxType == setType)?.Type ??
-                           throw new JsonException("Unknown transaction type");
+                    return _txTypes.FirstOrDefault(p => p.TxType == setType)?.Type ?? throw new JsonException("Unknown transaction type");
                 }
             }
 
-            if (untyped.ContainsKey(gasPriceFieldKey))
-            {
-                return typeof(LegacyTransactionForRpc);
-            }
+            return untyped.ContainsKey(gasPriceFieldKey)
+                ? typeof(LegacyTransactionForRpc)
+                : _txTypes.FirstOrDefault(p => p.DiscriminatorProperties.Any(untyped.ContainsKey))?.Type
+                  ?? GetDefaultType(out isDefaulted);
 
-            return _txTypes
-                .FirstOrDefault(p => p.DiscriminatorProperties.Any(untyped.ContainsKey))?.Type ?? defaultTxType;
+            static Type GetDefaultType(out bool isDefaulted)
+            {
+                isDefaulted = true;
+                return typeof(EIP1559TransactionForRpc);
+            }
         }
 
         public override void Write(Utf8JsonWriter writer, TransactionForRpc value, JsonSerializerOptions options)

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
@@ -75,9 +75,7 @@ public abstract class TransactionForRpc
     private TxType ResolveType(IReleaseSpec? spec)
     {
         TxType type = Type ?? default;
-        return spec is not null && !spec.IsEip2930Enabled && IsTypeDefaulted && type > TxType.Legacy
-            ? TxType.Legacy
-            : type;
+        return spec is not null && !spec.IsEip2930Enabled && IsTypeDefaulted ? TxType.Legacy : type;
     }
 
     public abstract void EnsureDefaults(long? gasCap);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Serialization.Json;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 using System.Collections;
 using System.Text.Json;
@@ -78,5 +80,72 @@ public class TransactionForRpcDeserializationTests
             yield return Make(TxType.Blob, """{"type":"0x3"}""");
             yield return Make(TxType.SetCode, """{"type":"0x4"}""");
         }
+    }
+
+    [TestCaseSource(nameof(SpecAwareResolutionCases))]
+    public TxType Test_DefaultedType_IsResolvedBySpec(string txJson, IReleaseSpec? spec)
+    {
+        TransactionForRpc transactionForRpc = _serializer.Deserialize<TransactionForRpc>(txJson);
+        Result<Transaction> result = transactionForRpc.ToTransaction(spec: spec);
+        return result.Data?.Type ?? transactionForRpc.Type ?? TxType.Legacy;
+    }
+
+    public static IEnumerable SpecAwareResolutionCases
+    {
+        get
+        {
+            static TestCaseData Make(TxType expected, string json, IReleaseSpec? spec) =>
+                new(json, spec) { TestName = $"Resolves to {expected} from {json} on {spec?.Name ?? "null"}", ExpectedResult = expected };
+
+            // Defaulted type on pre-Berlin (no EIP-2930) → Legacy
+            yield return Make(TxType.Legacy, """{}""", Istanbul.Instance);
+            yield return Make(TxType.Legacy, """{"nonce":"0x0","input":null}""", Istanbul.Instance);
+            yield return Make(TxType.Legacy, """{"type":null}""", Istanbul.Instance);
+
+            // Defaulted type on post-Berlin → keeps EIP1559
+            yield return Make(TxType.EIP1559, """{}""", Berlin.Instance);
+            yield return Make(TxType.EIP1559, """{}""", London.Instance);
+
+            // Explicit type is preserved regardless of spec
+            yield return Make(TxType.EIP1559, """{"type":"0x2"}""", Istanbul.Instance);
+            yield return Make(TxType.AccessList, """{"type":"0x1"}""", Istanbul.Instance);
+
+            // Discriminator-matched type is not defaulted → preserved
+            yield return Make(TxType.AccessList, """{"accessList":[]}""", Istanbul.Instance);
+            yield return Make(TxType.EIP1559, """{"maxFeePerGas":"0x0"}""", Istanbul.Instance);
+
+            // gasPrice → Legacy, not defaulted
+            yield return Make(TxType.Legacy, """{"gasPrice":"0x1"}""", London.Instance);
+
+            // No spec (null) → keeps defaulted EIP1559
+            yield return Make(TxType.EIP1559, """{}""", null);
+        }
+    }
+
+    [Test]
+    public void Test_DefaultedType_ProducesLegacyTransaction_OnPreBerlinSpec()
+    {
+        // Minimal eth_call payload — no type, no gasPrice, no EIP-1559 fields
+        TransactionForRpc rpc = _serializer.Deserialize<TransactionForRpc>(
+            """{"to":"0x0000000000000000000000000000000000000001","data":"0x01"}""");
+
+        Result<Transaction> result = rpc.ToTransaction(spec: Istanbul.Instance);
+
+        Transaction tx = result.Data!;
+        Assert.That(tx.Type, Is.EqualTo(TxType.Legacy));
+        Assert.That(tx.AccessList, Is.Null);
+    }
+
+    [Test]
+    public void Test_DefaultedType_ProducesEip1559Transaction_OnPostLondonSpec()
+    {
+        TransactionForRpc rpc = _serializer.Deserialize<TransactionForRpc>(
+            """{"to":"0x0000000000000000000000000000000000000001","data":"0x01"}""");
+
+        Result<Transaction> result = rpc.ToTransaction(spec: London.Instance);
+
+        Transaction tx = result.Data!;
+        Assert.That(tx.Type, Is.EqualTo(TxType.EIP1559));
+        Assert.That(tx.AccessList, Is.Not.Null);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
@@ -122,30 +122,27 @@ public class TransactionForRpcDeserializationTests
         }
     }
 
-    [Test]
-    public void Test_DefaultedType_ProducesLegacyTransaction_OnPreBerlinSpec()
+    [TestCaseSource(nameof(DefaultedTypeResolutionCases))]
+    public TxType Test_DefaultedType_ResolvesCorrectly(IReleaseSpec spec, bool hasAccessList)
     {
-        // Minimal eth_call payload — no type, no gasPrice, no EIP-1559 fields
         TransactionForRpc rpc = _serializer.Deserialize<TransactionForRpc>(
             """{"to":"0x0000000000000000000000000000000000000001","data":"0x01"}""");
 
-        Result<Transaction> result = rpc.ToTransaction(spec: Istanbul.Instance);
-
-        Transaction tx = result.Data!;
-        Assert.That(tx.Type, Is.EqualTo(TxType.Legacy));
-        Assert.That(tx.AccessList, Is.Null);
+        Transaction tx = rpc.ToTransaction(spec: spec).Data!;
+        Assert.That(tx.AccessList is not null, Is.EqualTo(hasAccessList));
+        return tx.Type;
     }
 
-    [Test]
-    public void Test_DefaultedType_ProducesEip1559Transaction_OnPostLondonSpec()
+    public static IEnumerable DefaultedTypeResolutionCases
     {
-        TransactionForRpc rpc = _serializer.Deserialize<TransactionForRpc>(
-            """{"to":"0x0000000000000000000000000000000000000001","data":"0x01"}""");
-
-        Result<Transaction> result = rpc.ToTransaction(spec: London.Instance);
-
-        Transaction tx = result.Data!;
-        Assert.That(tx.Type, Is.EqualTo(TxType.EIP1559));
-        Assert.That(tx.AccessList, Is.Not.Null);
+        get
+        {
+            yield return new TestCaseData(Istanbul.Instance, false)
+                .SetName("Pre-Berlin spec resolves to Legacy without AccessList")
+                .Returns(TxType.Legacy);
+            yield return new TestCaseData(London.Instance, true)
+                .SetName("Post-London spec resolves to EIP1559 with AccessList")
+                .Returns(TxType.EIP1559);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/TransactionForRpcDeserializationTests.cs
@@ -87,7 +87,8 @@ public class TransactionForRpcDeserializationTests
     {
         TransactionForRpc transactionForRpc = _serializer.Deserialize<TransactionForRpc>(txJson);
         Result<Transaction> result = transactionForRpc.ToTransaction(spec: spec);
-        return result.Data?.Type ?? transactionForRpc.Type ?? TxType.Legacy;
+        Assert.That(result.IsError, Is.False, result.Error);
+        return result.Data!.Type;
     }
 
     public static IEnumerable SpecAwareResolutionCases

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugSimulateTestsBlocksAndTransactions.cs
@@ -131,7 +131,7 @@ public class DebugSimulateTestsBlocksAndTransactions : TracedSimulateTestsBase<G
         IBlockchainBridge mockBridge = Substitute.For<IBlockchainBridge>();
         mockBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(false);
 
-        SimulateTxExecutor<GethLikeTxTrace> executor = new(mockBridge, chain.BlockFinder, new JsonRpcConfig(), new GethStyleSimulateBlockTracerFactory(GethTraceOptions.Default));
+        SimulateTxExecutor<GethLikeTxTrace> executor = new(mockBridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new GethStyleSimulateBlockTracerFactory(GethTraceOptions.Default));
 
         // Execute and verify the error message includes block number
         ResultWrapper<IReadOnlyList<SimulateBlockResult<GethLikeTxTrace>>> result = executor.Execute(payload, BlockParameter.Latest);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
@@ -61,7 +61,7 @@ public class EthSimulateTestsPrecompilesWithRedirection
         };
 
         //will mock our GetCachedCodeInfo function - it shall be called 3 times if redirect is working, 2 times if not
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
 
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result = executor.Execute(payload, BlockParameter.Latest);
 
@@ -175,7 +175,7 @@ public class EthSimulateTestsPrecompilesWithRedirection
         };
 
         //will mock our GetCachedCodeInfo function - it shall be called 3 times if redirect is working, 2 times if not
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
 
         Debug.Assert(contractAddress is not null, nameof(contractAddress) + " is not null");
         Assert.That(chain.ReadOnlyState.AccountExists(contractAddress), Is.True);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -182,7 +182,7 @@ public class EthSimulateTestsBlocksAndTransactions
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
         //will mock our GetCachedCodeInfo function - it shall be called 3 times if redirect is working, 2 times if not
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result = executor.Execute(payload, BlockParameter.Latest);
         IReadOnlyList<SimulateBlockResult<SimulateCallResult>> data = result.Data;
         Assert.That((bool)result.Result, Is.EqualTo(true), result.Result.ToString());
@@ -223,7 +223,7 @@ public class EthSimulateTestsBlocksAndTransactions
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
         //will mock our GetCachedCodeInfo function - it shall be called 3 times if redirect is working, 2 times if not
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
             executor.Execute(payload, BlockParameter.Latest);
         IReadOnlyList<SimulateBlockResult<SimulateCallResult>> data = result.Data;
@@ -264,7 +264,7 @@ public class EthSimulateTestsBlocksAndTransactions
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
         //will mock our GetCachedCodeInfo function - it shall be called 3 times if redirect is working, 2 times if not
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
 
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
             executor.Execute(payload, BlockParameter.Latest);
@@ -426,7 +426,7 @@ public class EthSimulateTestsBlocksAndTransactions
             ]
         };
 
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), new SimulateBlockMutatorTracerFactory());
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result = executor.Execute(payload, BlockParameter.Latest);
 
         Assert.That((bool)result.Result, Is.True, result.Result.ToString());

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Simulate/TracedSimulateTestsBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Simulate/TracedSimulateTestsBase.cs
@@ -40,7 +40,7 @@ public abstract class TracedSimulateTestsBase<TTrace>
         chain.BlockTree.UpdateMainChain(new List<Block> { chain.BlockFinder.Head! }, true, true);
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
-        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), CreateTracerFactory());
+        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, CreateTracerFactory());
         ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>> result = executor.Execute(payload, BlockParameter.Latest);
         IReadOnlyList<SimulateBlockResult<TTrace>> data = result.Data;
         Assert.That(data, Has.Count.EqualTo(7));
@@ -73,7 +73,7 @@ public abstract class TracedSimulateTestsBase<TTrace>
         chain.BlockTree.UpdateMainChain(new List<Block> { chain.BlockFinder.Head! }, true, true);
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
-        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), CreateTracerFactory());
+        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, CreateTracerFactory());
         ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>> result =
             executor.Execute(payload, BlockParameter.Latest);
         IReadOnlyList<SimulateBlockResult<TTrace>> data = result.Data;
@@ -108,7 +108,7 @@ public abstract class TracedSimulateTestsBase<TTrace>
         chain.BlockTree.UpdateMainChain(new List<Block> { chain.BlockFinder.Head! }, true, true);
         chain.BlockTree.UpdateHeadBlock(chain.BlockFinder.Head!.Hash!);
 
-        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), CreateTracerFactory());
+        SimulateTxExecutor<TTrace> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, CreateTracerFactory());
 
         ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>> result =
             executor.Execute(payload, BlockParameter.Latest);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1156,6 +1156,7 @@ public class TraceRpcModuleTests
             blockFinder,
             new JsonRpcConfig(),
             Substitute.For<IBlockchainBridge>(),
+            Substitute.For<ISpecProvider>(),
             Substitute.For<IBlocksConfig>());
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -97,7 +97,7 @@ public class DebugRpcModule(
         // enforces gas cap
         call.EnsureDefaults(jsonRpcConfig.GasCap);
 
-        Result<Transaction> txResult = call.ToTransaction(validateUserInput: true);
+        Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(header!));
         if (!txResult.Success(out Transaction? tx, out string? error))
         {
             return ResultWrapper<GethLikeTxTrace>.Fail(error, ErrorCodes.InvalidInput);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -450,7 +450,7 @@ public class DebugRpcModule(
     public ResultWrapper<IReadOnlyList<SimulateBlockResult<GethLikeTxTrace>>> debug_simulateV1(
         SimulatePayload<TransactionForRpc> payload, BlockParameter? blockParameter = null, GethTraceOptions? options = null)
     {
-        return new SimulateTxExecutor<GethLikeTxTrace>(blockchainBridge, blockFinder, jsonRpcConfig, new GethStyleSimulateBlockTracerFactory(options: options ?? GethTraceOptions.Default), _secondsPerSlot)
+        return new SimulateTxExecutor<GethLikeTxTrace>(blockchainBridge, blockFinder, jsonRpcConfig, specProvider, new GethStyleSimulateBlockTracerFactory(options: options ?? GethTraceOptions.Default), _secondsPerSlot)
             .Execute(payload, blockParameter);
     }
 
@@ -522,6 +522,7 @@ public class DebugRpcModule(
                 blockchainBridge,
                 blockFinder,
                 jsonRpcConfig,
+                specProvider,
                 new GethStyleSimulateBlockTracerFactory(options: options ?? GethTraceOptions.Default),
                 _secondsPerSlot
             ).Execute(simulatePayload, concreteBlockParameter);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -89,7 +89,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                             return ResultWrapper<TResult, string>.Fail("execution reverted: " + errorMessage, ErrorCodes.ExecutionReverted, executionRevertedReason.ToHexString(true));
                         }
 
-                        string errorData = errorMessage is not null ? Encoding.UTF8.GetBytes(errorMessage).ToHexString(true) : null;
+                        string? errorData = errorMessage is not null ? Encoding.UTF8.GetBytes(errorMessage).ToHexString(true) : null;
                         return ResultWrapper<TResult, string?>.Fail("execution reverted: " + errorMessage, ErrorCodes.ExecutionReverted, errorData);
                     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Facade;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -20,14 +21,15 @@ namespace Nethermind.JsonRpc.Modules.Eth
     public partial class EthRpcModule
     {
         // Single call executor
-        private abstract class TxExecutor<TResult>(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig)
+        private abstract class TxExecutor<TResult>(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider)
             : ExecutorBase<TResult, TransactionForRpc, Transaction>(blockchainBridge, blockFinder, rpcConfig)
         {
             private bool NoBaseFee { get; set; }
 
-            protected override Result<Transaction> Prepare(TransactionForRpc call)
+            protected override Result<Transaction> Prepare(TransactionForRpc call, BlockHeader header)
             {
-                Result<Transaction> result = call.ToTransaction(validateUserInput: true);
+                IReleaseSpec spec = specProvider.GetSpec(header);
+                Result<Transaction> result = call.ToTransaction(validateUserInput: true, spec: spec);
                 if (result.IsError) return result;
 
                 Transaction tx = result.Data;
@@ -62,9 +64,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 {
                     searchResult ??= _blockFinder.SearchForHeader(blockParameter);
                     if (!searchResult.Value.IsError)
-                    {
-                        transactionCall.Gas = searchResult.Value.Object.GasLimit;
-                    }
+                        transactionCall.Gas = searchResult.Value.Object!.GasLimit;
                 }
 
                 // enforces gas cap
@@ -89,30 +89,29 @@ namespace Nethermind.JsonRpc.Modules.Eth
                             return ResultWrapper<TResult, string>.Fail("execution reverted: " + errorMessage, ErrorCodes.ExecutionReverted, executionRevertedReason.ToHexString(true));
                         }
 
-                        var errorData = errorMessage is not null ? Encoding.UTF8.GetBytes(errorMessage).ToHexString(true) : null;
+                        string errorData = errorMessage is not null ? Encoding.UTF8.GetBytes(errorMessage).ToHexString(true) : null;
                         return ResultWrapper<TResult, string?>.Fail("execution reverted: " + errorMessage, ErrorCodes.ExecutionReverted, errorData);
                     }
 
-                    return ResultWrapper<TResult>.Fail(errorMessage, ErrorCodes.InvalidInput, bodyData);
+                    return ResultWrapper<TResult>.Fail(errorMessage ?? "", ErrorCodes.InvalidInput, bodyData);
                 }
 
                 return ResultWrapper<TResult>.Success(bodyData);
             }
         }
 
-        private class CallTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig)
-            : TxExecutor<string>(blockchainBridge, blockFinder, rpcConfig)
+        private class CallTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider)
+            : TxExecutor<string>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
             protected override ResultWrapper<string> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, token);
-
                 return CreateResultWrapper(result.InputError, result.Error, result.OutputData?.ToHexString(true), result.ExecutionReverted, result.OutputData);
             }
         }
 
-        private class EstimateGasTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig)
-            : TxExecutor<UInt256?>(blockchainBridge, blockFinder, rpcConfig)
+        private class EstimateGasTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider)
+            : TxExecutor<UInt256?>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
             private readonly int _errorMargin = rpcConfig.EstimateErrorMargin;
 
@@ -124,24 +123,21 @@ namespace Nethermind.JsonRpc.Modules.Eth
             }
         }
 
-        private class CreateAccessListTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, bool optimize)
-            : TxExecutor<AccessListResultForRpc?>(blockchainBridge, blockFinder, rpcConfig)
+        private class CreateAccessListTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider, bool optimize)
+            : TxExecutor<AccessListResultForRpc?>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
             protected override ResultWrapper<AccessListResultForRpc?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.CreateAccessList(header, tx, stateOverride, token, optimize);
 
-                var rpcAccessListResult = new AccessListResultForRpc(
+                AccessListResultForRpc rpcAccessListResult = new(
                     accessList: AccessListForRpc.FromAccessList(result.AccessList ?? tx.AccessList),
                     gasUsed: GetResultGas(tx, result),
                     result.Error);
 
-                if (result.InputError)
-                {
-                    return ResultWrapper<AccessListResultForRpc?>.Fail(result.Error!, ErrorCodes.InvalidInput);
-                }
-
-                return ResultWrapper<AccessListResultForRpc?>.Success(rpcAccessListResult);
+                return result.InputError
+                    ? ResultWrapper<AccessListResultForRpc?>.Fail(result.Error!, ErrorCodes.InvalidInput)
+                    : ResultWrapper<AccessListResultForRpc?>.Success(rpcAccessListResult);
             }
 
             private static UInt256 GetResultGas(Transaction transaction, CallOutput result)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -398,7 +398,7 @@ public partial class EthRpcModule(
             .ExecuteTx(transactionCall, blockParameter, stateOverride);
 
     public ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> eth_simulateV1(SimulatePayload<TransactionForRpc> payload, BlockParameter? blockParameter = null) =>
-        new SimulateTxExecutor<SimulateCallResult>(_blockchainBridge, _blockFinder, _rpcConfig, new SimulateBlockMutatorTracerFactory(), secondsPerSlot: _secondsPerSlot)
+        new SimulateTxExecutor<SimulateCallResult>(_blockchainBridge, _blockFinder, _rpcConfig, _specProvider, new SimulateBlockMutatorTracerFactory(), secondsPerSlot: _secondsPerSlot)
             .Execute(payload, blockParameter);
 
     public virtual ResultWrapper<UInt256?> eth_estimateGas(TransactionForRpc transactionCall, BlockParameter? blockParameter, Dictionary<Address, AccountOverride>? stateOverride = null) =>

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -394,7 +394,7 @@ public partial class EthRpcModule(
     }
 
     public virtual ResultWrapper<string> eth_call(TransactionForRpc transactionCall, BlockParameter? blockParameter = null, Dictionary<Address, AccountOverride>? stateOverride = null) =>
-        new CallTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig)
+        new CallTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig, _specProvider)
             .ExecuteTx(transactionCall, blockParameter, stateOverride);
 
     public ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> eth_simulateV1(SimulatePayload<TransactionForRpc> payload, BlockParameter? blockParameter = null) =>
@@ -402,11 +402,11 @@ public partial class EthRpcModule(
             .Execute(payload, blockParameter);
 
     public virtual ResultWrapper<UInt256?> eth_estimateGas(TransactionForRpc transactionCall, BlockParameter? blockParameter, Dictionary<Address, AccountOverride>? stateOverride = null) =>
-        new EstimateGasTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig)
+        new EstimateGasTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig, _specProvider)
             .ExecuteTx(transactionCall, blockParameter, stateOverride);
 
     public virtual ResultWrapper<AccessListResultForRpc?> eth_createAccessList(TransactionForRpc transactionCall, BlockParameter? blockParameter = null, Dictionary<Address, AccountOverride>? stateOverride = null, bool optimize = true) =>
-        new CreateAccessListTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig, optimize)
+        new CreateAccessListTxExecutor(_blockchainBridge, _blockFinder, _rpcConfig, _specProvider, optimize)
             .ExecuteTx(transactionCall, blockParameter, stateOverride);
 
     public ResultWrapper<BlockForRpc> eth_getBlockByHash(Hash256 blockHash, bool returnFullTransactionObjects)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
@@ -35,13 +35,13 @@ public abstract class ExecutorBase<TResult, TRequest, TProcessing>(
         }
 
         using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
-        Result<TProcessing> prepareResult = Prepare(call);
+        Result<TProcessing> prepareResult = Prepare(call, header);
         return !prepareResult.Success(out TProcessing? data, out string? error)
             ? ResultWrapper<TResult>.Fail(error, ErrorCodes.InvalidInput)
             : Execute(header.Clone(), data, stateOverride, timeout.Token);
     }
 
-    protected abstract Result<TProcessing> Prepare(TRequest call);
+    protected abstract Result<TProcessing> Prepare(TRequest call, BlockHeader header);
 
     protected abstract ResultWrapper<TResult> Execute(BlockHeader header, TProcessing tx, Dictionary<Address, AccountOverride>? stateOverride, CancellationToken token);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -28,7 +28,7 @@ public class SimulateTxExecutor<TTrace>(
     private readonly long _blocksLimit = rpcConfig.MaxSimulateBlocksCap ?? 256;
     private readonly ulong _secondsPerSlot = secondsPerSlot ?? new BlocksConfig().SecondsPerSlot;
 
-    protected override Result<SimulatePayload<TransactionWithSourceDetails>> Prepare(SimulatePayload<TransactionForRpc> call)
+    protected override Result<SimulatePayload<TransactionWithSourceDetails>> Prepare(SimulatePayload<TransactionForRpc> call, BlockHeader header)
     {
         List<BlockStateCall<TransactionWithSourceDetails>>? blockStateCalls = null;
 
@@ -173,7 +173,7 @@ public class SimulateTxExecutor<TTrace>(
 
         using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
 
-        Result<SimulatePayload<TransactionWithSourceDetails>> prepareResult = Prepare(call);
+        Result<SimulatePayload<TransactionWithSourceDetails>> prepareResult = Prepare(call, header);
         return !prepareResult.Success(out SimulatePayload<TransactionWithSourceDetails>? data, out string? error)
             ? ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail(error, ErrorCodes.InvalidInput)
             : Execute(header.Clone(), data, stateOverride, timeout.Token);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -7,6 +7,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Facade;
@@ -20,6 +21,7 @@ public class SimulateTxExecutor<TTrace>(
     IBlockchainBridge blockchainBridge,
     IBlockFinder blockFinder,
     IJsonRpcConfig rpcConfig,
+    ISpecProvider specProvider,
     ISimulateBlockTracerFactory<TTrace> simulateBlockTracerFactory,
     ulong? secondsPerSlot = null)
     : ExecutorBase<IReadOnlyList<SimulateBlockResult<TTrace>>, SimulatePayload<TransactionForRpc>,
@@ -51,7 +53,8 @@ public class SimulateTxExecutor<TTrace>(
                         bool hadGasLimitInRequest = asLegacy?.Gas is not null;
                         bool hadNonceInRequest = asLegacy?.Nonce is not null;
 
-                        Result<Transaction> txResult = callTransactionModel.ToTransaction(validateUserInput: call.Validation);
+                        IReleaseSpec spec = specProvider.GetSpec(header);
+                        Result<Transaction> txResult = callTransactionModel.ToTransaction(validateUserInput: call.Validation, spec: spec);
                         if (!txResult.Success(out Transaction? tx, out string? error))
                         {
                             return error;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -60,7 +60,11 @@ namespace Nethermind.JsonRpc.Modules.Trace
             blockParameter ??= BlockParameter.Latest;
             call.EnsureDefaults(jsonRpcConfig.GasCap);
 
-            Result<Transaction> txResult = call.ToTransaction(validateUserInput: true);
+            SearchResult<BlockHeader> headerSearch = blockFinder.SearchForHeader(blockParameter);
+            if (headerSearch.IsError)
+                return ResultWrapper<ParityTxTraceFromReplay>.Fail(headerSearch);
+
+            Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(headerSearch.Object!));
             return !txResult.Success(out Transaction? transaction, out string? error)
                 ? ResultWrapper<ParityTxTraceFromReplay>.Fail(error, ErrorCodes.InvalidInput)
                 : TraceTx(transaction, traceTypes, blockParameter, stateOverride);
@@ -90,7 +94,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
             for (int i = 0; i < calls.Length; i++)
             {
                 calls[i].Transaction.EnsureDefaults(jsonRpcConfig.GasCap);
-                Result<Transaction> txResult = calls[i].Transaction.ToTransaction(validateUserInput: true);
+                Result<Transaction> txResult = calls[i].Transaction.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(header));
                 if (!txResult.Success(out Transaction? tx, out string? error))
                 {
                     return ResultWrapper<IEnumerable<ParityTxTraceFromReplay>>.Fail(error, ErrorCodes.InvalidInput);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -12,6 +12,7 @@ using Nethermind.Consensus.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.Tracing;
@@ -41,6 +42,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         IBlockFinder blockFinder,
         IJsonRpcConfig jsonRpcConfig,
         IBlockchainBridge blockchainBridge,
+        ISpecProvider specProvider,
         IBlocksConfig blocksConfig)
         : ITraceRpcModule
     {
@@ -371,7 +373,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         public ResultWrapper<IReadOnlyList<SimulateBlockResult<ParityLikeTxTrace>>> trace_simulateV1(
             SimulatePayload<TransactionForRpc> payload, BlockParameter? blockParameter = null, string[]? traceTypes = null)
         {
-            return new SimulateTxExecutor<ParityLikeTxTrace>(blockchainBridge, blockFinder, jsonRpcConfig, new ParityStyleSimulateBlockTracerFactory(types: GetParityTypes(traceTypes ?? ["Trace"])), _secondsPerSlot)
+            return new SimulateTxExecutor<ParityLikeTxTrace>(blockchainBridge, blockFinder, jsonRpcConfig, specProvider, new ParityStyleSimulateBlockTracerFactory(types: GetParityTypes(traceTypes ?? ["Trace"])), _secondsPerSlot)
                 .Execute(payload, blockParameter);
         }
     }

--- a/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
@@ -7,6 +7,7 @@ using Nethermind.Int256;
 using System.Text.Json.Serialization;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Facade.Eth;
+using Nethermind.Core.Specs;
 using System;
 
 namespace Nethermind.Optimism.Rpc;
@@ -64,9 +65,9 @@ public class DepositTransactionForRpc : TransactionForRpc, IFromTransaction<Depo
         DepositReceiptVersion = receipt?.DepositReceiptVersion;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;


### PR DESCRIPTION
Fixes https://github.com/NethermindEth/nethermind/issues/11069
Supersedes https://github.com/NethermindEth/nethermind/pull/11073

## Changes

Since #9529, `DeriveTxType` defaults to `EIP1559TransactionForRpc` when no type-specific fields are present. This causes `eth_call`, `eth_estimateGas`, and `eth_createAccessList` to fail on pre-Berlin blocks with "EIP-2930 is not enabled" because `AccessListTransactionForRpc.ToTransaction()` unconditionally sets `AccessList = AccessList.Empty`.

This PR makes the type resolution fork-aware:
- `DeriveTxType` now tracks whether the type was **inferred** (defaulted) vs explicitly set via an `IsTypeDefaulted` flag
- `ToTransaction()` accepts an optional `IReleaseSpec` — when the type was inferred and the target block doesn't support EIP-2930, it resolves to Legacy instead of EIP-1559
- Each subclass (`AccessListTransactionForRpc`, `EIP1559TransactionForRpc`, `BlobTransactionForRpc`, `SetCodeTransactionForRpc`) skips its type-specific fields when the resolved type is below its level
- `TxExecutor` threads `ISpecProvider` and passes the target block's spec to `ToTransaction()` via `Prepare(call, header)`
- Refactored `ExecutorBase.Prepare` to accept `BlockHeader`, eliminating a duplicate `SearchForHeader` call

Explicitly typed transactions (`"type": "0x2"`) and discriminator-matched types (`{"accessList":[]}`) are **not affected** — only the fallback default is fork-dependent.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

- [x] Yes

13 new tests covering spec-aware type resolution: defaulted types on pre/post-Berlin specs, explicit types preserved regardless of spec, discriminator-matched types unaffected, gasPrice-matched Legacy unaffected, null spec backwards compatibility, and full Transaction property assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)