### PR TITLE
fix(evm.Transactionsubstate): return hex decoded custom errors

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -100,7 +100,7 @@ public readonly ref struct TransactionSubstate
             return;
 
         ReadOnlySpan<byte> span = Output.Span;
-        Error = TryGetErrorMessage(span) ?? EncodeErrorMessage(span);
+        Error = TryGetErrorMessage(span) ?? span.ToHexString(true);
     }
 
     public static string EncodeErrorMessage(ReadOnlySpan<byte> span) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/ByteCodeBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/ByteCodeBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm;
@@ -68,6 +69,26 @@ public static class ByteCodeBuilderExtensions
             // REVERT(offset=0, length=totalLength)
             .PushData(totalLength)
             .PushData(0)
+            .Op(Instruction.REVERT);
+
+        return prepare;
+    }
+
+    public static Prepare RevertWithCustomError(this Prepare prepare, byte[] selector)
+    {
+        if (selector.Length != 4)
+            throw new ArgumentException("Custom error selector must be exactly 4 bytes", nameof(selector));
+
+        // Push the 4-byte selector right-aligned into a 32-byte word, store at memory 0,
+        // then REVERT(offset=28, length=4) — returning only the 4 selector bytes.
+        prepare
+            .PushData(selector)
+            .PushData(224)              // shift left 224 bits to put selector at bytes 0-3
+            .Op(Instruction.SHL)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(4)                // length = 4
+            .PushData(0)                // offset = 0
             .Op(Instruction.REVERT);
 
         return prepare;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -229,6 +229,29 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Estimate_gas_with_custom_error_returns_hex_selector()
+    {
+        // Regression test for https://github.com/NethermindEth/nethermind/issues/11059
+        // A no-parameter custom error (e.g. ActionFailed()) produces exactly 4 revert bytes.
+        // Those bytes must be returned as hex, not decoded as UTF-8.
+        using Context ctx = await Context.CreateWithLondonEnabled();
+
+        // keccak4("ActionFailed()") = 0x080a1c27 
+        byte[] selector = [0x08, 0x0a, 0x1c, 0x27];
+
+        byte[] code = Prepare.EvmCode
+            .RevertWithCustomError(selector)
+            .Done;
+
+        string dataStr = code.ToHexString();
+        TransactionForRpc transaction = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
+            $$"""{"from": "{{SecondaryTestAddress}}", "type": "0x2", "data": "{{dataStr}}", "gas": 1000000}""");
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+        Assert.That(
+            serialized, Is.EqualTo("""{"jsonrpc":"2.0","error":{"code":3,"message":"execution reverted: 0x080a1c27","data":"0x080a1c27"},"id":67}"""));
+    }
+
+    [Test]
     public async Task Estimate_gas_with_abi_encoded_revert()
     {
         using Context ctx = await Context.CreateWithLondonEnabled();


### PR DESCRIPTION
Fixes Closes Resolves #11059 

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- In Transaction Substate.cs hex decoding of custom errors

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

This fixes the bug in which eth_estimateGas was returning garbled output due to  ``Error = TryGetErrorMessage(span) ?? EncodeErrorMessage(span);`` as it was not decoding custom error and the fallback function tried to utf decode it instead of returning as hex string 

custom errors - https://www.soliditylang.org/blog/2021/04/21/custom-errors/

_Optional. Remove if not applicable._
