### PR TITLE
Remove max reorg check in XDC

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/QuorumCertificateManager.cs
@@ -148,7 +148,7 @@ internal class QuorumCertificateManager : IQuorumCertificateManager
         }
 
         _context.HighestCommitBlock = new BlockRoundInfo(grandParentHeader.Hash, grandParentHeader.ExtraConsensusData.BlockRound, grandParentHeader.Number);
-        _logger.Info($"Committed block {grandParentHeader.ToString(BlockHeader.Format.Full)} round={grandParentHeader.ExtraConsensusData.BlockRound}");
+        _logger.Info($"Committed block {grandParentHeader.ToString(BlockHeader.Format.Short)} round={grandParentHeader.ExtraConsensusData.BlockRound}");
         //Mark grand parent as finalized
         _blockTree.ForkChoiceUpdated(grandParentHeader.Hash, grandParentHeader.Hash);
         error = null;

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
@@ -18,7 +18,6 @@ namespace Nethermind.Xdc;
 
 internal class XdcBlockTree : BlockTree
 {
-    private const int MaxSearchDepth = 1024;
     private readonly IXdcConsensusContext _xdcConsensus;
 
     public XdcBlockTree(
@@ -51,13 +50,6 @@ internal class XdcBlockTree : BlockTree
         }
         if (finalizedBlockInfo.BlockNumber >= header.Number)
         {
-            return AddBlockResult.InvalidBlock;
-        }
-        if (header.Number - finalizedBlockInfo.BlockNumber > MaxSearchDepth)
-        {
-            //Theoretically very deep reorgs could happen, if the chain doesn't finalize for a long time
-            //TODO Maybe this needs to be revisited later
-            Logger.Warn($"Deep reorg past {MaxSearchDepth} blocks detected! Rejecting block {header.ToString(BlockHeader.Format.Full)}");
             return AddBlockResult.InvalidBlock;
         }
         BlockHeader current = header;


### PR DESCRIPTION
If node is behind head, blocks can arrive faster than they can be committed. 
This removes a check that can fail because of this.