### PR TITLE
refactor: remove Personal module from default RPC modules

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -77,7 +77,7 @@ public interface IJsonRpcConfig : IConfig
 
 
             """,
-        DefaultValue = "[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc]")]
+        DefaultValue = "[Eth,Subscribe,Trace,TxPool,Web3,Proof,Net,Parity,Health,Rpc]")]
     string[] EnabledModules { get; set; }
 
     [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
@@ -38,7 +38,6 @@ namespace Nethermind.JsonRpc.Modules
             Trace,
             TxPool,
             Web3,
-            Personal,
             Proof,
             Net,
             Parity,


### PR DESCRIPTION
## Summary
- Remove `Personal` module from the default enabled JSON-RPC modules
- The Personal module exposes account management operations (import key, unlock, sign) that most node operators don't need enabled by default
- Users who need it can explicitly enable it via `JsonRpc.EnabledModules` configuration

## Test plan
- [x] Build compiles
- [ ] Verify Personal module is no longer auto-enabled
- [ ] Verify it can still be enabled explicitly via config

🤖 Generated with [Claude Code](https://claude.com/claude-code)