### PR TITLE
fix: add bounds on filter address and topic array sizes

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
@@ -84,6 +84,9 @@ public class Filter : IJsonRpcParam
         }
     }
 
+    private const int MaxAddressCount = 1000;
+    private const int MaxTopicValuesPerSlot = 1000;
+
     private static HashSet<AddressAsKey>? GetAddress(JsonElement token, JsonSerializerOptions options)
     {
         switch (token.ValueKind)
@@ -93,7 +96,13 @@ public class Filter : IJsonRpcParam
             case JsonValueKind.String:
                 return [new AddressAsKey(new Address(token.ToString()))];
             case JsonValueKind.Array:
-                HashSet<AddressAsKey> result = new(token.GetArrayLength());
+                int addressCount = token.GetArrayLength();
+                if (addressCount > MaxAddressCount)
+                {
+                    throw new JsonException($"Too many addresses ({addressCount}). Max is {MaxAddressCount}.");
+                }
+
+                HashSet<AddressAsKey> result = new(addressCount);
                 foreach (JsonElement element in token.EnumerateArray())
                 {
                     result.Add(new(new Address(element.ToString())));
@@ -123,7 +132,13 @@ public class Filter : IJsonRpcParam
                     yield return [new Hash256(token.GetString()!)];
                     break;
                 case JsonValueKind.Array:
-                    Hash256[] result = new Hash256[token.GetArrayLength()];
+                    int topicCount = token.GetArrayLength();
+                    if (topicCount > MaxTopicValuesPerSlot)
+                    {
+                        throw new JsonException($"Too many topic values ({topicCount}). Max is {MaxTopicValuesPerSlot}.");
+                    }
+
+                    Hash256[] result = new Hash256[topicCount];
                     int i = 0;
                     foreach (JsonElement element in token.EnumerateArray())
                     {


### PR DESCRIPTION
## Summary
- Add max count validation (1000) for address and topic arrays in `eth_getLogs` filter deserialization
- Prevents excessive memory allocation from oversized filter parameters
- Throws `JsonException` on limit violation

## Test plan
- [x] Build compiles
- [ ] Existing filter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)