### PR TITLE
fix: add bounds check before unsafe RLP length deserialization

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -568,5 +568,16 @@ namespace Nethermind.Core.Test
             }
             return data;
         }
+
+        [TestCase(new byte[] { 0xB8 }, Description = "Long string prefix 0xB8 (1 byte of length), but no length byte")]
+        [TestCase(new byte[] { 0xB9, 0x01 }, Description = "Long string prefix 0xB9 (2 bytes of length), but only 1 length byte")]
+        [TestCase(new byte[] { 0xBB, 0x00, 0x01 }, Description = "Long string prefix 0xBB (4 bytes of length), but only 2 length bytes")]
+        public void PeekLongPrefixAndContentLength_throws_on_truncated_data(byte[] truncatedData)
+        {
+            // These prefixes declare a multi-byte length field, but the data is truncated
+            // before all length bytes are present. The bounds check should catch this.
+            Action act = () => RlpHelpers.PeekNextRlpLength(truncatedData, 0);
+            act.Should().Throw<RlpException>();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Core.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -178,6 +178,11 @@ internal static class RlpHelpers
             ThrowSequenceLengthTooLong();
         }
 
+        if (position + 1 + lengthOfLength > data.Length)
+        {
+            ThrowRlpDataTruncated();
+        }
+
         int contentLength = DeserializeLengthRef(
             ref Unsafe.Add(ref MemoryMarshal.GetReference(data), position + 1),
             lengthOfLength);
@@ -267,6 +272,10 @@ internal static class RlpHelpers
     [DoesNotReturn, StackTraceHidden]
     public static void ThrowSequenceLengthTooLong()
         => throw new RlpException("Expected length of length less than or equal to 4");
+
+    [DoesNotReturn, StackTraceHidden]
+    public static void ThrowRlpDataTruncated()
+        => throw new RlpException("RLP data is truncated: not enough bytes for the declared length prefix");
 
     [DoesNotReturn, StackTraceHidden]
     public static void ThrowUnexpectedLength(int length)


### PR DESCRIPTION
## Summary

In `PeekLongPrefixAndContentLength`, the `DeserializeLengthRef` function uses `Unsafe.ReadUnaligned<ushort>` / `Unsafe.ReadUnaligned<int>` to read 1-4 bytes from a reference pointer derived via `Unsafe.Add`.

If the RLP data is truncated (e.g., prefix byte `0xBB` declares a 4-byte length follows, but only 1-2 bytes remain in the span), the unsafe read accesses memory past the span boundary. The existing `lengthOfLength <= 4` check validates the value range but not whether enough data actually remains.

### Fix

Add `position + 1 + lengthOfLength > data.Length` check before the `Unsafe.Add` call, throwing `RlpException` for truncated data. This follows the same defensive pattern used elsewhere in the RLP decoder.

## Test plan
- [x] Build compiles
- [ ] Existing RLP tests pass
- [ ] Consider adding fuzz test with truncated RLP inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)