### PR TITLE
fix: prevent infinite loop in RLP CountItems on malformed data

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -568,5 +568,31 @@ namespace Nethermind.Core.Test
             }
             return data;
         }
+
+        [Test]
+        public void CountItems_counts_single_byte_items()
+        {
+            byte[] data = [0x01, 0x02, 0x03];
+            int count = RlpHelpers.CountItems(data, 0, data.Length, 10);
+            count.Should().Be(3);
+        }
+
+        [Test]
+        public void CountItems_respects_maxSearch()
+        {
+            byte[] data = [0x01, 0x02, 0x03, 0x04, 0x05];
+            int count = RlpHelpers.CountItems(data, 0, data.Length, 2);
+            count.Should().Be(2);
+        }
+
+        [Test]
+        public void CountItems_throws_on_truncated_long_form_prefix()
+        {
+            // 0xB8 = long string prefix (expects 1 byte of length to follow)
+            // But only the prefix byte is provided — data is truncated.
+            byte[] truncatedData = [0xB8];
+            Action act = () => RlpHelpers.CountItems(truncatedData, 0, truncatedData.Length, 10);
+            act.Should().Throw<RlpException>();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Core.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -163,7 +163,13 @@ internal static class RlpHelpers
         int numberOfItems = 0;
         while (position < end && numberOfItems < maxSearch)
         {
-            position += PeekNextRlpLength(data, position);
+            int length = PeekNextRlpLength(data, position);
+            if (length < 1)
+            {
+                ThrowRlpException("RLP item length is zero — malformed data would cause infinite loop");
+            }
+
+            position += length;
             numberOfItems++;
         }
         return numberOfItems;
@@ -283,4 +289,8 @@ internal static class RlpHelpers
     [DoesNotReturn, StackTraceHidden]
     public static long ThrowNotPositiveLong()
         => throw new RlpException("Long value is not a non-negative value");
+
+    [DoesNotReturn, StackTraceHidden]
+    public static void ThrowRlpException(string message)
+        => throw new RlpException(message);
 }


### PR DESCRIPTION
## Summary
- Add zero-length guard in `CountItems` to throw `RlpException` when `PeekNextRlpLength` returns 0
- Without this guard, a zero-length return would cause `position` to never advance, making the loop spin indefinitely
- Add `InternalsVisibleTo` for `Nethermind.Core.Test` to enable direct testing of internal RLP helpers

## Test plan
- [x] Build compiles
- [x] `CountItems_counts_single_byte_items` - verifies normal counting
- [x] `CountItems_respects_maxSearch` - verifies early termination
- [x] `CountItems_throws_on_truncated_long_form_prefix` - verifies truncated data throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)