### PR TITLE
fix: validate signature length in personal_ecRecover

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PersonalRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/PersonalRpcModuleTests.cs
@@ -81,5 +81,15 @@ namespace Nethermind.JsonRpc.Test.Modules
             string serialized = await RpcTest.TestSerializedRequest(rpcModule, "personal_ecRecover", "0xdeadbeaf", "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b");
             Assert.That(serialized, Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83\"}}"));
         }
+
+        [TestCase("0x00", Description = "Too short (1 byte)")]
+        [TestCase("0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001b00", Description = "Too long (66 bytes)")]
+        public async Task Personal_ecRecover_rejects_invalid_signature_length(string signature)
+        {
+            IPersonalRpcModule rpcModule = new PersonalRpcModule(_ecdsa, _wallet, _keyStore);
+            string serialized = await RpcTest.TestSerializedRequest(rpcModule, "personal_ecRecover", "0xdeadbeaf", signature);
+            Assert.That(serialized, Does.Contain("\"error\""));
+            Assert.That(serialized, Does.Contain("Invalid signature length"));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
@@ -58,6 +58,11 @@ namespace Nethermind.JsonRpc.Modules.Personal
 
         public ResultWrapper<Address> personal_ecRecover(byte[] message, byte[] signature)
         {
+            if (signature.Length != Signature.Size)
+            {
+                return ResultWrapper<Address>.Fail($"Invalid signature length: {signature.Length}. Expected {Signature.Size} bytes.");
+            }
+
             message = ToEthSignedMessage(message);
             Hash256 msgHash = Keccak.Compute(message);
             PublicKey publicKey = ecdsa.RecoverPublicKey(new Signature(signature), msgHash);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalRpcModule.cs
@@ -60,7 +60,7 @@ namespace Nethermind.JsonRpc.Modules.Personal
         {
             if (signature.Length != Signature.Size)
             {
-                return ResultWrapper<Address>.Fail($"Invalid signature length: {signature.Length}. Expected {Signature.Size} bytes.");
+                return ResultWrapper<Address>.Fail($"Invalid signature length: {signature.Length}. Expected {Signature.Size} bytes.", ErrorCodes.InvalidParams);
             }
 
             message = ToEthSignedMessage(message);


### PR DESCRIPTION
## Summary
- Add explicit signature length validation in `personal_ecRecover` before constructing the `Signature` object
- Returns a descriptive error message instead of throwing `ArgumentOutOfRangeException` for malformed signatures

## Test plan
- [x] Build compiles
- [x] `Personal_ecRecover_rejects_invalid_signature_length` - 2 parameterized test cases (too short, too long)
- [ ] Existing personal module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)