### PR TITLE
fix(crypto): implement IHash64bit for Hash256AsKey

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Collections/SeqlockCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/SeqlockCacheTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using NUnit.Framework;
 
@@ -407,6 +408,21 @@ public class SeqlockCacheTests
 
         found.Should().BeTrue();
         result.Should().BeSameAs(account);
+    }
+
+    [Test]
+    public void Hash256AsKey_works_with_cache()
+    {
+        SeqlockCache<Hash256AsKey, byte[]> cache = new();
+        Hash256 hash = new Hash256("0x1234567890123456789012345678901234567890123456789012345678901234");
+        Hash256AsKey key = hash;
+        byte[] value = CreateValue(3);
+
+        cache.Set(in key, value);
+        bool found = cache.TryGetValue(in key, out byte[]? result);
+
+        found.Should().BeTrue();
+        result.Should().BeSameAs(value);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Core.Crypto
         private bool IsZero => _bytes == default;
     }
 
-    public readonly struct Hash256AsKey(Hash256 key) : IEquatable<Hash256AsKey>, IComparable<Hash256AsKey>
+    public readonly struct Hash256AsKey(Hash256 key) : IEquatable<Hash256AsKey>, IComparable<Hash256AsKey>, IHash64bit<Hash256AsKey>
     {
         private readonly Hash256 _key = key;
         public Hash256 Value => _key;
@@ -112,6 +112,8 @@ namespace Nethermind.Core.Crypto
 
         public bool Equals(Hash256AsKey other) => Equals(_key, other._key);
         public override int GetHashCode() => _key?.GetHashCode() ?? 0;
+        public long GetHashCode64() => _key is not null ? _key.GetHashCode64() : 0;
+        public bool Equals(in Hash256AsKey other) => Equals(_key, other._key);
 
         public int CompareTo(Hash256AsKey other) => _key.CompareTo(other._key);
     }
@@ -192,6 +194,7 @@ namespace Nethermind.Core.Crypto
         public override bool Equals(object? obj) => obj?.GetType() == typeof(Hash256) && Equals((Hash256)obj);
 
         public override int GetHashCode() => _hash256.GetHashCode();
+        internal long GetHashCode64() => SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<ValueHash256, byte>(ref Unsafe.AsRef(in _hash256)));
 
         public static bool operator ==(Hash256? a, Hash256? b) => a is null ? b is null : b is not null && a._hash256 == b._hash256;
 


### PR DESCRIPTION
## Changes

- Implement `IHash64bit<Hash256AsKey>` for `Hash256AsKey`
- Add `Hash256.GetHashCode64()` backed by `FastHash64For32Bytes`
- Add a regression test covering `SeqlockCache<Hash256AsKey, byte[]>`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet restore src/Nethermind/Nethermind.Core.Test/Nethermind.Core.Test.csproj --configfile /tmp/nethermind-nuget.config --verbosity minimal`
- `dotnet test --project src/Nethermind/Nethermind.Core.Test/Nethermind.Core.Test.csproj -c release --no-restore -- --filter FullyQualifiedName~Hash256AsKey_works_with_cache`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- Aligns `Hash256AsKey` with the existing `IHash64bit` pattern already used by `AddressAsKey` for `SeqlockCache`.