### PR TITLE
ci: add testing_buildBlockV1 hive tests to known failures

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -1,5 +1,10 @@
 # rpc-compat
 
+testing_buildBlockV1/build-block-empty-transactions (nethermind)
+testing_buildBlockV1/build-block-from-mempool (nethermind)
+testing_buildBlockV1/build-block-invalid-transaction (nethermind)
+testing_buildBlockV1/build-block-with-transactions (nethermind)
+
 # graphql
 
 01_eth_blockNumber (nethermind)


### PR DESCRIPTION
## Changes

- Add 4 `testing_buildBlockV1` rpc-compat hive tests to known failures list

The tests are failing because the `testing_buildBlockV1` endpoint is not yet implemented on master (#9901) and there are upstream test fixture issues. These will be removed once #9901 is merged and the fixtures are fixed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No