### PR TITLE
fix: use DbNames constants for discovery store paths

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
@@ -53,7 +53,7 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
             .Bind<INodeSource, IStaticNodesManager>()
 
             // Used by NodesLoader, and ProtocolsManager which add entry on sync peer connected
-            .AddNetworkStorage(DbNames.PeersDb, "peers")
+            .AddNetworkStorage(DbNames.PeersDb, DbNames.PeersDb)
             .Bind<INodeSource, NodesLoader>()
             .AddComposite<INodeSource, CompositeNodeSource>()
 
@@ -104,8 +104,8 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
                 .AddSingleton<IDiscoveryApp, CompositeDiscoveryApp>()
                 .AddSingleton<INodeRecordProvider, NodeRecordProvider>()
 
-                .AddNetworkStorage(DbNames.DiscoveryNodes, "discoveryNodes")
-                .AddNetworkStorage(DbNames.DiscoveryV5Nodes, "discoveryV5Nodes")
+                .AddNetworkStorage(DbNames.DiscoveryNodes, DbNames.DiscoveryNodes)
+                .AddNetworkStorage(DbNames.DiscoveryV5Nodes, DbNames.DiscoveryV5Nodes)
 
                 .AddSingleton<INodeDistanceCalculator, NodeDistanceCalculator>()
                 .AddSingleton<INodeTable, NodeTable>()


### PR DESCRIPTION
## Changes

- Replace hardcoded network storage `storePath` values in `DiscoveryModule` with the matching `DbNames` constants
- Keep `DiscoveryModule` and `DatabasePurger` on the same source of truth for peer and discovery directory names
- Prevent future `DbNames` renames from making `--force-resync` delete directories that should be preserved

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No