### PR TITLE
ci: bump tests-spec timeout to 20m

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
   push:
-    branches: [master, test/legacy-vm-timeout-bump]
+    branches: [master]
   workflow_dispatch:
     inputs:
       coverage:

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, test/legacy-vm-timeout-bump]
   workflow_dispatch:
     inputs:
       coverage:
@@ -138,7 +138,7 @@ jobs:
   tests-spec:
     name: Run ${{ matrix.project }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Changes

- Bump `tests-spec` job timeout from 15m to 20m to match `tests-chunked`
- `Ethereum.Legacy.VM.Test` consistently times out on `ubuntu-latest` x64 runners at the 15m limit (passes fine on ARM), causing the entire workflow to report as cancelled/failed on master

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Validated with a push-triggered run on this branch: https://github.com/NethermindEth/nethermind/actions/runs/24295576265

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No