### PR TITLE
ci: chunk Legacy VM test on ubuntu-latest for coverage

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -136,9 +136,9 @@ jobs:
           retention-days: 1
 
   tests-spec:
-    name: Run ${{ matrix.project }} (${{ matrix.runner }})
+    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -160,6 +160,20 @@ jobs:
           - Ethereum.Rlp.Test
           - Ethereum.Transaction.Test
           - Ethereum.Trie.Test
+        chunk: ['']
+        exclude: # Legacy VM unchunked on ubuntu-latest is replaced by 8 chunks below (coverage makes it too slow)
+          - runner: ubuntu-latest
+            project: Ethereum.Legacy.VM.Test
+            chunk: ''
+        include:
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 1of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 2of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 3of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 4of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 5of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 6of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 7of8 }
+          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 8of8 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -176,9 +190,11 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - name: ${{ matrix.project }}
+      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
         working-directory: src/Nethermind/${{ matrix.project }}
+        env:
+          TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings $GITHUB_WORKSPACE/src/Nethermind/codecoverage.config' || '' }}"
           set +e
@@ -198,7 +214,7 @@ jobs:
         if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.project }}-coverage
+          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage
           path: src/Nethermind/artifacts/bin/${{ matrix.project }}/release/TestResults/*.cobertura.xml
           retention-days: 1
 


### PR DESCRIPTION
## Changes

- Split `Ethereum.Legacy.VM.Test` into 8 chunks on `ubuntu-latest` where coverage instrumentation makes it too slow.
- ARM runner keeps the unchunked single job (~3m without coverage)
- Reverts the timeout bump from #11109 back to 15m since chunking lowers the worst case time to ~8m

### Problem

`Ethereum.Legacy.VM.Test` consistently timed out on `ubuntu-latest` with coverage enabled even with 20m timeout. With coverage: **~46m** ([run](https://github.com/NethermindEth/nethermind/actions/runs/24315935121))

### Solution

Chunk the test into 8 parts on `ubuntu-latest` only. With coverage, each chunk takes ~3-7m, well within the 15m timeout:
- Validated run with coverage: https://github.com/NethermindEth/nethermind/actions/runs/24318213884

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Validated with push-triggered runs with forced coverage on the test branch.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No