### PR TITLE
ci: make EVM benchmark iteration counts configurable

### DIFF
--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -83,9 +83,9 @@ jobs:
       # Extra reruns for opcodes that are both flagged and noisy in the first pass.
       NOISY_RERUNS: "2"
       # BenchmarkDotNet iteration tuning (defaults in code: 3/15/15).
-      BENCHMARK_LAUNCH_COUNT: "2"
-      BENCHMARK_WARMUP_COUNT: "5"
-      BENCHMARK_ITERATION_COUNT: "10"
+      BENCHMARK_LAUNCH_COUNT: "1"
+      BENCHMARK_WARMUP_COUNT: "1"
+      BENCHMARK_ITERATION_COUNT: "1"
     steps:
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -82,6 +82,10 @@ jobs:
       DELTA_MARGIN_PERCENT: "2.0"
       # Extra reruns for opcodes that are both flagged and noisy in the first pass.
       NOISY_RERUNS: "2"
+      # BenchmarkDotNet iteration tuning (defaults in code: 3/15/15).
+      BENCHMARK_LAUNCH_COUNT: "2"
+      BENCHMARK_WARMUP_COUNT: "5"
+      BENCHMARK_ITERATION_COUNT: "10"
     steps:
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -83,9 +83,9 @@ jobs:
       # Extra reruns for opcodes that are both flagged and noisy in the first pass.
       NOISY_RERUNS: "2"
       # BenchmarkDotNet iteration tuning (defaults in code: 3/15/15).
-      BENCHMARK_LAUNCH_COUNT: "1"
-      BENCHMARK_WARMUP_COUNT: "1"
-      BENCHMARK_ITERATION_COUNT: "1"
+      BENCHMARK_LAUNCH_COUNT: "2"
+      BENCHMARK_WARMUP_COUNT: "5"
+      BENCHMARK_ITERATION_COUNT: "10"
     steps:
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -934,12 +934,16 @@ public unsafe class EvmOpcodesBenchmark
 
     public class EvmOpcodesBenchmarkConfig : ManualConfig
     {
+        private static int GetEnvInt(string name, int defaultValue) =>
+            int.TryParse(Environment.GetEnvironmentVariable(name), out int v) ? v : defaultValue;
+
         public EvmOpcodesBenchmarkConfig()
         {
             // 3 process launches x 15 measurement iterations = 45 data points.
             // GcForce ensures a GC collection between iterations to reduce allocation noise.
             // Without an explicit job, BDN falls back to Job.Default (1 launch, auto-pilot)
             // because the runner's DashboardConfig.AddJob is commented out.
+            // Override defaults via BENCHMARK_LAUNCH_COUNT, BENCHMARK_WARMUP_COUNT, BENCHMARK_ITERATION_COUNT.
             AddJob(Job.Default
                 .WithRuntime(CoreRuntime.Core10_0)
                 .WithGcForce(true)
@@ -947,9 +951,9 @@ public unsafe class EvmOpcodesBenchmark
                 .WithEnvironmentVariable("DOTNET_gcConcurrent", "0")
                 .WithInvocationCount(1)
                 .WithUnrollFactor(1)
-                .WithLaunchCount(3)
-                .WithWarmupCount(15)
-                .WithIterationCount(15));
+                .WithLaunchCount(GetEnvInt("BENCHMARK_LAUNCH_COUNT", 3))
+                .WithWarmupCount(GetEnvInt("BENCHMARK_WARMUP_COUNT", 15))
+                .WithIterationCount(GetEnvInt("BENCHMARK_ITERATION_COUNT", 15)));
             HideColumns(Column.Method);
             AddColumn(StatisticColumn.Min);
             AddColumn(StatisticColumn.Max);


### PR DESCRIPTION
## Summary
- Add env var overrides (`BENCHMARK_LAUNCH_COUNT`, `BENCHMARK_WARMUP_COUNT`, `BENCHMARK_ITERATION_COUNT`) to `EvmOpcodesBenchmarkConfig` with existing values as defaults
- Set CI defaults to 2/5/10 (from 3/15/15) to reduce benchmark runtime

## Benchmark timing results

| Config | PR side | Estimated total (once merged) |
|---|---|---|
| 3/15/15 (current master) | ~24 min | ~48 min |
| 2/5/10 (this PR) | ~17 min | ~34 min |
| 1/1/1 (floor / fixed overhead) | ~12 min | ~24 min |

~30% reduction in benchmark CI time with 2/5/10 config.

## Test plan
- [x] EVM benchmark CI runs successfully with 2/5/10 config
- [x] EVM benchmark CI runs successfully with 1/1/1 config
- [x] Verified env vars are picked up by PR side (base side uses master code until merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)