### PR TITLE
style: enable nullable for Logging, Config, and leaf packages

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/ConfigProviderTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProviderTests.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Config.Test
         [TestCase(typeof(long), 0L)]
         public void GetDefault_returns_correct_default_value_for_value_types(Type type, object expected)
         {
-            object result = ConfigSourceHelper.GetDefault(type);
+            object? result = ConfigSourceHelper.GetDefault(type);
             Assert.That(result, Is.EqualTo(expected));
         }
 

--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -49,7 +49,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
         configProvider.AddSource(argsSource);
 
         configProvider.Initialize();
-        (_, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
+        (_, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Is.Empty);
     }
@@ -70,7 +70,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(1));
         Assert.Multiple(() =>
@@ -96,7 +96,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(3));
         Assert.Multiple(() =>
@@ -121,7 +121,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(1));
         Assert.Multiple(() =>
@@ -145,7 +145,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
         ConfigProvider? configProvider = new();
         configProvider.AddSource(envSource);
 
-        (bool isSet, object value) = envSource.GetValue(typeof(string), "BlocksConfig", "ExtraData");
+        (bool isSet, object? value) = envSource.GetValue(typeof(string), "BlocksConfig", "ExtraData");
 
         Assert.Multiple(() =>
         {
@@ -171,7 +171,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         Assert.DoesNotThrow(configProvider.Initialize);
 
-        (bool isSet, object value) = envSource.GetValue(typeof(bool), "BloomConfig", "Index");
+        (bool isSet, object? value) = envSource.GetValue(typeof(bool), "BloomConfig", "Index");
 
         Assert.Multiple(() =>
         {

--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -49,7 +49,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
         configProvider.AddSource(argsSource);
 
         configProvider.Initialize();
-        (_, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
+        (_, IList<(IConfigSource Source, string? Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Is.Empty);
     }
@@ -70,7 +70,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(1));
         Assert.Multiple(() =>
@@ -96,7 +96,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(3));
         Assert.Multiple(() =>
@@ -121,7 +121,7 @@ public class ConfigProvider_FindIncorrectSettings_Tests
 
         configProvider.Initialize();
 
-        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
+        (string ErrorMsg, IList<(IConfigSource Source, string? Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
         Assert.That(Errors, Has.Count.EqualTo(1));
         Assert.Multiple(() =>

--- a/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
@@ -11,30 +11,30 @@ namespace Nethermind.Config
     {
         private readonly Dictionary<string, string> _args = new(args, StringComparer.OrdinalIgnoreCase);
 
-        public (bool IsSet, object Value) GetValue(Type type, string category, string name)
+        public (bool IsSet, object? Value) GetValue(Type type, string category, string name)
         {
-            (bool isSet, string value) = GetRawValue(category?.Replace("Config", string.Empty), name);
-            return (isSet, isSet ? ConfigSourceHelper.ParseValue(type, value, category, name) : ConfigSourceHelper.GetDefault(type));
+            (bool isSet, string? value) = GetRawValue(category?.Replace("Config", string.Empty)!, name);
+            return (isSet, isSet ? ConfigSourceHelper.ParseValue(type, value!, category, name) : ConfigSourceHelper.GetDefault(type));
         }
 
-        public (bool IsSet, string Value) GetRawValue(string category, string name)
+        public (bool IsSet, string? Value) GetRawValue(string category, string name)
         {
             string variableName = string.IsNullOrEmpty(category) ? name : $"{category}.{name}";
             bool isSet = _args.ContainsKey(variableName);
             return (isSet, isSet ? _args[variableName] : null);
         }
 
-        public IEnumerable<(string Category, string Name)> GetConfigKeys()
+        public IEnumerable<(string? Category, string? Name)> GetConfigKeys()
         {
-            IEnumerable<(string, string)> argsPairs = _args.Keys.Select(static k => k.Split('.')).Select(static a =>
+            IEnumerable<(string?, string?)> argsPairs = _args.Keys.Select(static k => k.Split('.')).Select(static a =>
             {
                 if (a.Length == 0)
                 {
-                    return (null, null);
+                    return ((string?)null, (string?)null);
                 }
                 if (a.Length == 1)
                 {
-                    return (null, a[0]);
+                    return ((string?)null, a[0]);
                 }
 
                 return (a[0], a[1]);

--- a/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
@@ -24,23 +24,18 @@ namespace Nethermind.Config
             return (isSet, isSet ? _args[variableName] : null);
         }
 
-        public IEnumerable<(string? Category, string? Name)> GetConfigKeys()
-        {
-            IEnumerable<(string?, string?)> argsPairs = _args.Keys.Select(static k => k.Split('.')).Select(static a =>
-            {
-                if (a.Length == 0)
+        public IEnumerable<(string? Category, string Name)> GetConfigKeys() =>
+            _args.Keys
+                .Select(static k => k.Split('.'))
+                .Where(static a => a.Length > 0)
+                .Select(static a =>
                 {
-                    return ((string?)null, (string?)null);
-                }
-                if (a.Length == 1)
-                {
-                    return ((string?)null, a[0]);
-                }
+                    if (a.Length == 1)
+                    {
+                        return ((string?)null, a[0]);
+                    }
 
-                return (a[0], a[1]);
-            });
-
-            return argsPairs;
-        }
+                    return (a[0], a[1]);
+                });
     }
 }

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Config
             set
             {
                 byte[] bytes = Encoding.UTF8.GetBytes(value);
-                if (bytes is not null && bytes.Length > 32)
+                if (bytes.Length > 32)
                 {
                     throw new InvalidConfigurationException($"Extra Data length was more than 32 bytes. You provided: {_extraDataString}",
                         ExitCodes.TooLongExtraData);

--- a/src/Nethermind/Nethermind.Config/ConfigCategoryAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigCategoryAttribute.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Config
 {
     public class ConfigCategoryAttribute : Attribute
     {
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public bool HiddenFromDocs { get; set; }
 

--- a/src/Nethermind/Nethermind.Config/ConfigCategoryAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigCategoryAttribute.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Config
 {
     public class ConfigCategoryAttribute : Attribute
     {
-        public string? Description { get; set; }
+        public string Description { get; set; } = "";
 
         public bool HiddenFromDocs { get; set; }
 

--- a/src/Nethermind/Nethermind.Config/ConfigExtensions.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigExtensions.cs
@@ -13,7 +13,7 @@ public static class ConfigExtensions
 {
     private static readonly ConcurrentDictionary<string, bool> PortOptions = new();
 
-    public static string GetCategoryName(Type type)
+    public static string? GetCategoryName(Type type)
     {
         if (type.IsAssignableTo(typeof(INoCategoryConfig)))
             return null;
@@ -35,10 +35,10 @@ public static class ConfigExtensions
     public static T GetDefaultValue<T>(this IConfig config, string propertyName)
     {
         Type type = config.GetType();
-        Type interfaceType = type.GetInterface($"I{type.Name}");
-        PropertyInfo propertyInfo = interfaceType.GetProperty(propertyName);
-        ConfigItemAttribute attribute = propertyInfo.GetCustomAttribute<ConfigItemAttribute>();
-        string defaultValue = attribute.DefaultValue;
-        return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(defaultValue);
+        Type interfaceType = type.GetInterface($"I{type.Name}")!;
+        PropertyInfo propertyInfo = interfaceType.GetProperty(propertyName)!;
+        ConfigItemAttribute attribute = propertyInfo.GetCustomAttribute<ConfigItemAttribute>()!;
+        string? defaultValue = attribute.DefaultValue;
+        return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(defaultValue!)!;
     }
 }

--- a/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
@@ -8,17 +8,17 @@ namespace Nethermind.Config;
 [AttributeUsage(AttributeTargets.Property)]
 public class ConfigItemAttribute : Attribute
 {
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
-    public string DefaultValue { get; set; }
+    public string? DefaultValue { get; set; }
 
     public bool HiddenFromDocs { get; set; }
 
     public bool DisabledForCli { get; set; }
 
-    public string EnvironmentVariable { get; set; }
+    public string? EnvironmentVariable { get; set; }
 
     public bool IsPortOption { get; set; }
 
-    public string CliOptionAlias { get; set; }
+    public string? CliOptionAlias { get; set; }
 }

--- a/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Config;
 [AttributeUsage(AttributeTargets.Property)]
 public class ConfigItemAttribute : Attribute
 {
-    public string? Description { get; set; }
+    public string Description { get; set; } = "";
 
     public string? DefaultValue { get; set; }
 
@@ -16,9 +16,9 @@ public class ConfigItemAttribute : Attribute
 
     public bool DisabledForCli { get; set; }
 
-    public string? EnvironmentVariable { get; set; }
+    public string EnvironmentVariable { get; set; } = "";
 
     public bool IsPortOption { get; set; }
 
-    public string? CliOptionAlias { get; set; }
+    public string CliOptionAlias { get; set; } = "";
 }

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -89,18 +89,18 @@ public class ConfigProvider : IConfigProvider
         return _instances[configType];
     }
 
-    public object GetRawValue(string category, string name)
+    public object? GetRawValue(string category, string name)
     {
         for (int i = 0; i < _configSource.Count; i++)
         {
-            (bool isSet, string str) = _configSource[i].GetRawValue(category, name);
+            (bool isSet, string? str) = _configSource[i].GetRawValue(category, name);
             if (isSet)
             {
                 return str;
             }
         }
 
-        return Categories.TryGetValue(category, out object value) ? value.GetType()
+        return Categories.TryGetValue(category, out object? value) ? value.GetType()
             .GetProperties(BindingFlags.Instance | BindingFlags.Public)
             .SingleOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase))
             ?.GetValue(value) : null;
@@ -117,20 +117,20 @@ public class ConfigProvider : IConfigProvider
             if (directImplementation is not null)
             {
                 Categories.Add(@interface.Name[1..],
-                    Activator.CreateInstance(directImplementation));
+                    Activator.CreateInstance(directImplementation)!);
 
                 _implementations[@interface] = directImplementation;
 
-                object config = Activator.CreateInstance(_implementations[@interface]);
-                _instances[@interface] = (IConfig)config!;
+                object config = Activator.CreateInstance(_implementations[@interface])!;
+                _instances[@interface] = (IConfig)config;
 
                 foreach (PropertyInfo propertyInfo in config.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
                     for (int i = 0; i < _configSource.Count; i++)
                     {
-                        string category = @interface.IsAssignableFrom(typeof(INoCategoryConfig)) ? null : config.GetType().Name;
+                        string? category = @interface.IsAssignableFrom(typeof(INoCategoryConfig)) ? null : config.GetType().Name;
                         string name = propertyInfo.Name;
-                        (bool isSet, object value) = _configSource[i].GetValue(propertyInfo.PropertyType, category, name);
+                        (bool isSet, object? value) = _configSource[i].GetValue(propertyInfo.PropertyType, category!, name);
                         if (isSet)
                         {
                             try
@@ -150,7 +150,7 @@ public class ConfigProvider : IConfigProvider
         }
     }
 
-    public (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) FindIncorrectSettings()
+    public (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) FindIncorrectSettings()
     {
         if (_instances.IsEmpty)
         {
@@ -163,14 +163,14 @@ public class ConfigProvider : IConfigProvider
                 .Select(p => GetKey(i.GetType().Name, p.Name)))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        List<(IConfigSource Source, string Category, string Name)> incorrectSettings = [];
+        List<(IConfigSource Source, string? Category, string? Name)> incorrectSettings = [];
 
         // Skip the validation for ArgsConfigSource items as they are already validated by the CLI parser
         foreach (IConfigSource source in _configSource.Where(s => s is not ArgsConfigSource))
         {
-            IEnumerable<(string Category, string Name)> configs = source.GetConfigKeys();
+            IEnumerable<(string? Category, string? Name)> configs = source.GetConfigKeys();
 
-            foreach ((string category, string name) in configs)
+            foreach ((string? category, string? name) in configs)
             {
                 if (!propertySet.Contains(GetKey(category, name)))
                 {
@@ -183,7 +183,7 @@ public class ConfigProvider : IConfigProvider
 
         return (msg, incorrectSettings);
 
-        static string GetConfigSourceName(IConfigSource source) => source switch
+        static string? GetConfigSourceName(IConfigSource source) => source switch
         {
             ArgsConfigSource => "RuntimeOption",
             EnvConfigSource => "EnvironmentVariable(NETHERMIND_*)",
@@ -191,7 +191,7 @@ public class ConfigProvider : IConfigProvider
             _ => source.ToString()
         };
 
-        static string GetKey(string category, string name)
+        static string GetKey(string? category, string? name)
         {
             if (string.IsNullOrEmpty(category))
             {

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -150,7 +150,7 @@ public class ConfigProvider : IConfigProvider
         }
     }
 
-    public (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) FindIncorrectSettings()
+    public (string ErrorMsg, IList<(IConfigSource Source, string? Category, string Name)> Errors) FindIncorrectSettings()
     {
         if (_instances.IsEmpty)
         {
@@ -163,14 +163,14 @@ public class ConfigProvider : IConfigProvider
                 .Select(p => GetKey(i.GetType().Name, p.Name)))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        List<(IConfigSource Source, string? Category, string? Name)> incorrectSettings = [];
+        List<(IConfigSource Source, string? Category, string Name)> incorrectSettings = [];
 
         // Skip the validation for ArgsConfigSource items as they are already validated by the CLI parser
         foreach (IConfigSource source in _configSource.Where(s => s is not ArgsConfigSource))
         {
-            IEnumerable<(string? Category, string? Name)> configs = source.GetConfigKeys();
+            IEnumerable<(string? Category, string Name)> configs = source.GetConfigKeys();
 
-            foreach ((string? category, string? name) in configs)
+            foreach ((string? category, string name) in configs)
             {
                 if (!propertySet.Contains(GetKey(category, name)))
                 {
@@ -191,7 +191,7 @@ public class ConfigProvider : IConfigProvider
             _ => source.ToString()
         };
 
-        static string GetKey(string? category, string? name)
+        static string GetKey(string? category, string name)
         {
             if (string.IsNullOrEmpty(category))
             {

--- a/src/Nethermind/Nethermind.Config/ConfigRegistrationSource.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigRegistrationSource.cs
@@ -37,7 +37,7 @@ public class ConfigRegistrationSource : IRegistrationSource
             InstanceSharing.Shared,
             InstanceOwnership.OwnedByLifetimeScope,
             new[] { service },
-            new Dictionary<string, object>());
+            new Dictionary<string, object?>());
 
         return new IComponentRegistration[] { registration };
     }

--- a/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigSourceHelper.cs
@@ -15,11 +15,11 @@ namespace Nethermind.Config
 {
     public static class ConfigSourceHelper
     {
-        public static object ParseValue(Type valueType, string valueString, string category, string name)
+        public static object? ParseValue(Type valueType, string valueString, string? category, string name)
         {
             try
             {
-                object value;
+                object? value;
                 if (valueType.IsArray || (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
                 {
                     if (IsNullString(valueString))
@@ -28,7 +28,7 @@ namespace Nethermind.Config
                     }
 
                     //supports Arrays, e.g int[] and generic IEnumerable<T>, IList<T>
-                    Type itemType = valueType.IsGenericType ? valueType.GetGenericArguments()[0] : valueType.GetElementType();
+                    Type itemType = (valueType.IsGenericType ? valueType.GetGenericArguments()[0] : valueType.GetElementType())!;
 
                     if (itemType == typeof(byte) && !valueString.AsSpan().TrimStart().StartsWith('['))
                     {
@@ -38,7 +38,7 @@ namespace Nethermind.Config
                     //In case of collection of objects (more complex config models) we parse entire collection
                     else if (itemType.IsClass && typeof(IConfigModel).IsAssignableFrom(itemType))
                     {
-                        object objCollection = JsonSerializer.Deserialize(valueString, valueType);
+                        object? objCollection = JsonSerializer.Deserialize(valueString, valueType);
                         value = objCollection;
                     }
                     else
@@ -46,8 +46,8 @@ namespace Nethermind.Config
                         valueString = valueString.Trim().RemoveStart('[').RemoveEnd(']');
                         string[] valueItems = valueString.Split(',').Select(static s => s.Trim()).ToArray();
                         IList collection = (valueType.IsGenericType
-                            ? (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType))
-                            : (IList)Activator.CreateInstance(valueType, valueItems.Length))!;
+                            ? (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType))!
+                            : (IList)Activator.CreateInstance(valueType, valueItems.Length)!)!;
 
                         int i = 0;
                         foreach (string valueItem in valueItems)
@@ -58,7 +58,7 @@ namespace Nethermind.Config
                                 item = valueItem[1..^1];
                             }
 
-                            object itemValue = GetValue(itemType, item);
+                            object? itemValue = GetValue(itemType, item);
                             if (valueType.IsGenericType)
                             {
                                 collection.Add(itemValue);
@@ -96,9 +96,9 @@ namespace Nethermind.Config
         private static bool IsNullString(string valueString) =>
             valueString?.Equals("null", StringComparison.OrdinalIgnoreCase) ?? true;
 
-        public static object GetDefault(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
+        public static object? GetDefault(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
 
-        private static bool TryFromHex(Type type, string itemValue, out object value)
+        private static bool TryFromHex(Type type, string itemValue, out object? value)
         {
             if (!itemValue.StartsWith("0x", StringComparison.Ordinal))
             {
@@ -120,7 +120,7 @@ namespace Nethermind.Config
             return false;
         }
 
-        private static object GetValue(Type valueType, string itemValue)
+        private static object? GetValue(Type valueType, string itemValue)
         {
             if (Nullable.GetUnderlyingType(valueType) is { } nullableType)
             {
@@ -139,7 +139,7 @@ namespace Nethermind.Config
 
             if (valueType == typeof(Address))
             {
-                return Address.TryParse(itemValue, out Address address)
+                return Address.TryParse(itemValue, out Address? address)
                     ? address
                     : throw new FormatException($"Could not parse {itemValue} to {typeof(Address)}");
             }
@@ -156,12 +156,12 @@ namespace Nethermind.Config
 
             if (valueType.IsEnum)
             {
-                return Enum.TryParse(valueType, itemValue, true, out object enumValue)
+                return Enum.TryParse(valueType, itemValue, true, out object? enumValue)
                     ? enumValue
                     : throw new FormatException($"Cannot parse enum value: {itemValue}, type: {valueType.Name}");
             }
 
-            return TryFromHex(valueType, itemValue, out object value) ? value : Convert.ChangeType(itemValue, valueType);
+            return TryFromHex(valueType, itemValue, out object? value) ? value : Convert.ChangeType(itemValue, valueType);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
@@ -15,58 +15,62 @@ namespace Nethermind.Config
         {
         }
 
-        public (bool IsSet, object Value) GetValue(Type type, string category, string name)
+        public (bool IsSet, object? Value) GetValue(Type type, string category, string name)
         {
-            (bool isSet, string value) = GetRawValue(category, name);
+            (bool isSet, string? value) = GetRawValue(category, name);
 
             // Unset blank values for non-string types
             if (type != typeof(string) && string.IsNullOrWhiteSpace(value))
                 isSet = false;
 
-            return (isSet, isSet ? ConfigSourceHelper.ParseValue(type, value, category, name) : ConfigSourceHelper.GetDefault(type));
+            return (isSet, isSet ? ConfigSourceHelper.ParseValue(type, value!, category, name) : ConfigSourceHelper.GetDefault(type));
         }
 
-        public (bool IsSet, string Value) GetRawValue(string category, string name)
+        public (bool IsSet, string? Value) GetRawValue(string category, string name)
         {
             string variableName = string.IsNullOrEmpty(category) ? $"NETHERMIND_{name.ToUpperInvariant()}" : $"NETHERMIND_{category.ToUpperInvariant()}_{name.ToUpperInvariant()}";
-            string variableValueString = _environmentWrapper.GetEnvironmentVariable(variableName);
+            string? variableValueString = _environmentWrapper.GetEnvironmentVariable(variableName);
             return (variableValueString is not null, variableValueString);
         }
 
-        public IEnumerable<(string Category, string Name)> GetConfigKeys() => _environmentWrapper.GetEnvironmentVariables().Keys.Cast<string>().Where(static k => k.StartsWith("NETHERMIND_")).Select(static v => v.Split('_')).Select(static a =>
-        {
-            // actually only possible value is "NETHERMIND_"
-            if (a.Length <= 1)
-            {
-                return (null, null);
-            }
+        public IEnumerable<(string? Category, string? Name)> GetConfigKeys() =>
+            _environmentWrapper.GetEnvironmentVariables().Keys.Cast<string>()
+                .Where(static k => k.StartsWith("NETHERMIND_"))
+                .Select(static v => v.Split('_'))
+                .Select(static a =>
+                {
+                    // actually only possible value is "NETHERMIND_"
+                    if (a.Length <= 1)
+                    {
+                        return ((string?)null, (string?)null);
+                    }
 
-            // variables like "NETHERMIND_CONFIG"
-            if (a.Length == 2)
-            {
-                return (null, a[1]);
-            }
+                    // variables like "NETHERMIND_CONFIG"
+                    if (a.Length == 2)
+                    {
+                        return ((string?)null, a[1]);
+                    }
 
-            // VARIABLES like "NETHERMIND_CLI_SWITCH_LOCAL"
-            if (a.Length > 2 && !a[1].EndsWith("config", StringComparison.OrdinalIgnoreCase))
-            {
-                return (null, string.Join(null, a[1..]));
-            }
+                    // VARIABLES like "NETHERMIND_CLI_SWITCH_LOCAL"
+                    if (a.Length > 2 && !a[1].EndsWith("config", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ((string?)null, string.Join(null, a[1..]));
+                    }
 
-            // Variables like "NETHERMIND_JSONRPCCONFIG_ENABLED"
-            return (a[1], a[2]);
-        });
+                    // Variables like "NETHERMIND_JSONRPCCONFIG_ENABLED"
+                    return (a[1], a[2]);
+                });
     }
 
     public interface IEnvironment
     {
-        string GetEnvironmentVariable(string variableName);
+        string? GetEnvironmentVariable(string variableName);
         System.Collections.IDictionary GetEnvironmentVariables();
     }
 
     public class EnvironmentWrapper : IEnvironment
     {
-        public string GetEnvironmentVariable(string variableName) => Environment.GetEnvironmentVariable(variableName);
+        public string? GetEnvironmentVariable(string variableName) => Environment.GetEnvironmentVariable(variableName);
 
         public System.Collections.IDictionary GetEnvironmentVariables() => Environment.GetEnvironmentVariables();
     }

--- a/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
@@ -33,18 +33,13 @@ namespace Nethermind.Config
             return (variableValueString is not null, variableValueString);
         }
 
-        public IEnumerable<(string? Category, string? Name)> GetConfigKeys() =>
+        public IEnumerable<(string? Category, string Name)> GetConfigKeys() =>
             _environmentWrapper.GetEnvironmentVariables().Keys.Cast<string>()
                 .Where(static k => k.StartsWith("NETHERMIND_"))
                 .Select(static v => v.Split('_'))
+                .Where(static a => a.Length > 1)
                 .Select(static a =>
                 {
-                    // actually only possible value is "NETHERMIND_"
-                    if (a.Length <= 1)
-                    {
-                        return ((string?)null, (string?)null);
-                    }
-
                     // variables like "NETHERMIND_CONFIG"
                     if (a.Length == 2)
                     {

--- a/src/Nethermind/Nethermind.Config/IConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/IConfigProvider.cs
@@ -22,6 +22,6 @@ namespace Nethermind.Config
         /// <param name="category">Configuration category (e.g. Init).</param>
         /// <param name="name">Name of the configuration property.</param>
         /// <returns></returns>
-        object GetRawValue(string category, string name);
+        object? GetRawValue(string category, string name);
     }
 }

--- a/src/Nethermind/Nethermind.Config/IConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/IConfigSource.cs
@@ -8,10 +8,10 @@ namespace Nethermind.Config
 {
     public interface IConfigSource
     {
-        (bool IsSet, object Value) GetValue(Type type, string category, string name);
+        (bool IsSet, object? Value) GetValue(Type type, string category, string name);
 
-        (bool IsSet, string Value) GetRawValue(string category, string name);
+        (bool IsSet, string? Value) GetRawValue(string category, string name);
 
-        IEnumerable<(string Category, string Name)> GetConfigKeys();
+        IEnumerable<(string? Category, string? Name)> GetConfigKeys();
     }
 }

--- a/src/Nethermind/Nethermind.Config/IConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/IConfigSource.cs
@@ -12,6 +12,6 @@ namespace Nethermind.Config
 
         (bool IsSet, string? Value) GetRawValue(string category, string name);
 
-        IEnumerable<(string? Category, string? Name)> GetConfigKeys();
+        IEnumerable<(string? Category, string Name)> GetConfigKeys();
     }
 }

--- a/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
@@ -7,8 +7,8 @@ namespace Nethermind.Config;
 public interface INoCategoryConfig : IConfig
 {
     [ConfigItem(Description = "Path to the configuration file.")]
-    public string Config { get; set; }
+    public string? Config { get; set; }
 
     [ConfigItem(Description = "Defines host value for CLI function \"switchLocal\".", DefaultValue = "http://localhost", EnvironmentVariable = "NETHERMIND_CLI_SWITCH_LOCAL")]
-    public string CliSwitchLocal { get; set; }
+    public string? CliSwitchLocal { get; set; }
 }

--- a/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
+++ b/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
@@ -17,7 +17,7 @@ public interface IProcessExitSource
 public class ProcessExitSource : IProcessExitSource
 {
     private static readonly CancellationToken _cancelledToken = new(canceled: true);
-    private CancellationTokenSource _cancellationTokenSource;
+    private CancellationTokenSource? _cancellationTokenSource;
     private readonly TaskCompletionSource _exitResult = new();
 
     public ProcessExitSource(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Config/JsonConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/JsonConfigProvider.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Config
 
         public IConfig GetConfig(Type configType) => _provider.GetConfig(configType);
 
-        public object GetRawValue(string category, string name) => _provider.GetRawValue(category, name);
+        public object? GetRawValue(string category, string name) => _provider.GetRawValue(category, name);
 
         public void AddSource(IConfigSource configSource) => _provider.AddSource(configSource);
 

--- a/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
@@ -39,14 +39,14 @@ public class JsonConfigSource : IConfigSource
             StringBuilder missingConfigFileMessage = new($"Config file {configFilePath} does not exist.");
             try
             {
-                string directory = Path.GetDirectoryName(configFilePath);
+                string? directory = Path.GetDirectoryName(configFilePath);
                 directory = Path.IsPathRooted(configFilePath)
                     ? directory
-                    : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directory);
+                    : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directory!);
 
                 missingConfigFileMessage.AppendLine().AppendLine($"Search directory: {directory}");
 
-                string[] configFiles = Directory.GetFiles(directory, "*.json");
+                string[] configFiles = Directory.GetFiles(directory!, "*.json");
                 if (configFiles.Length > 0)
                 {
                     missingConfigFileMessage.AppendLine("Found the following config files:");
@@ -121,10 +121,10 @@ public class JsonConfigSource : IConfigSource
     private void ParseValue(Type type, string category, string name)
     {
         string valueString = _values[category][name];
-        _parsedValues[category][name] = ConfigSourceHelper.ParseValue(type, valueString, category, name);
+        _parsedValues[category][name] = ConfigSourceHelper.ParseValue(type, valueString, category, name)!;
     }
 
-    public (bool IsSet, object Value) GetValue(Type type, string category, string name)
+    public (bool IsSet, object? Value) GetValue(Type type, string category, string name)
     {
         (bool isSet, _) = GetRawValue(category, name);
         if (isSet)
@@ -140,7 +140,7 @@ public class JsonConfigSource : IConfigSource
         return (false, ConfigSourceHelper.GetDefault(type));
     }
 
-    public (bool IsSet, string Value) GetRawValue(string category, string name)
+    public (bool IsSet, string? Value) GetRawValue(string category, string name)
     {
         if (string.IsNullOrEmpty(category) || string.IsNullOrEmpty(name))
         {
@@ -151,5 +151,5 @@ public class JsonConfigSource : IConfigSource
         return (isSet, isSet ? _values[category][name] : null);
     }
 
-    public IEnumerable<(string Category, string Name)> GetConfigKeys() => _values.SelectMany(m => m.Value.Keys.Select(n => (m.Key, n)));
+    public IEnumerable<(string? Category, string? Name)> GetConfigKeys() => _values.SelectMany(m => m.Value.Keys.Select(n => ((string?)m.Key, (string?)n)));
 }

--- a/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
@@ -151,5 +151,5 @@ public class JsonConfigSource : IConfigSource
         return (isSet, isSet ? _values[category][name] : null);
     }
 
-    public IEnumerable<(string? Category, string? Name)> GetConfigKeys() => _values.SelectMany(m => m.Value.Keys.Select(n => ((string?)m.Key, (string?)n)));
+    public IEnumerable<(string? Category, string Name)> GetConfigKeys() => _values.SelectMany(m => m.Value.Keys.Select(n => ((string?)m.Key, n)));
 }

--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="NonBlocking" />

--- a/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
@@ -5,8 +5,8 @@ namespace Nethermind.Config;
 
 public class NoCategoryConfig : INoCategoryConfig
 {
-    public string Config { get; set; } = null;
-    public string MonitoringJob { get; set; }
-    public string MonitoringGroup { get; set; }
-    public string CliSwitchLocal { get; set; }
+    public string? Config { get; set; } = null;
+    public string? MonitoringJob { get; set; }
+    public string? MonitoringGroup { get; set; }
+    public string? CliSwitchLocal { get; set; }
 }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Logging.NLog
             if (IsTrace) _logger.Trace(text);
         }
 
-        public void Error(string text, Exception ex = null)
+        public void Error(string text, Exception? ex = null)
         {
             if (IsError) _logger.Error(ex, text);
         }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Logging.NLog
             _logger.Log(evt);
         }
 
-        public void Error(string text, LogEventKind kind, Exception ex = null)
+        public void Error(string text, LogEventKind kind, Exception? ex = null)
         {
             if (!IsError) return;
             LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Error, _logger.Name, ex, null, text);

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -43,9 +43,9 @@ public class NLogManager : ILogManager, IDisposable
 
     private static void SetupLogFile(string logFileName, string logDirectory)
     {
-        if (LogManager.Configuration?.AllTargets is not null)
+        if (LogManager.Configuration?.AllTargets is { } allTargets)
         {
-            foreach (FileTarget target in LogManager.Configuration?.AllTargets.OfType<FileTarget>())
+            foreach (FileTarget target in allTargets.OfType<FileTarget>())
             {
                 string fileNameToUse = (target.Name == DefaultFileTargetName) ? logFileName : target.FileName.Render(LogEventInfo.CreateNullEvent());
                 target.FileName = !Path.IsPathFullyQualified(fileNameToUse) ? Path.GetFullPath(Path.Combine(logDirectory, fileNameToUse)) : fileNameToUse;

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -24,7 +24,7 @@ public class NLogManager : ILogManager, IDisposable
     /// </summary>
     public NLogManager() { /* Log in temp dir? */ }
 
-    public NLogManager(string logFileName, string logDirectory = null, string logRules = null)
+    public NLogManager(string logFileName, string? logDirectory = null, string? logRules = null)
     {
         Setup(logFileName, logDirectory, logRules);
         // Required since 'NLog.config' could change during runtime, we need to re-apply the configuration
@@ -33,7 +33,7 @@ public class NLogManager : ILogManager, IDisposable
         Static.LogManager = this;
     }
 
-    private static void Setup(string logFileName, string logDirectory = null, string logRules = null)
+    private static void Setup(string logFileName, string? logDirectory = null, string? logRules = null)
     {
         logDirectory = SetupLogDirectory(logDirectory);
         SetupLogFile(logFileName, logDirectory);
@@ -53,7 +53,7 @@ public class NLogManager : ILogManager, IDisposable
         }
     }
 
-    private static string SetupLogDirectory(string logDirectory)
+    private static string SetupLogDirectory(string? logDirectory)
     {
         logDirectory = (string.IsNullOrEmpty(logDirectory) ? DefaultFolder : logDirectory).GetApplicationResourcePath();
         if (!Directory.Exists(logDirectory))
@@ -66,20 +66,22 @@ public class NLogManager : ILogManager, IDisposable
 
     private static readonly ConcurrentDictionary<string, ILogger> s_namedLoggers = new();
     private static readonly Func<string, ILogger> s_namedLoggerBuilder = BuildNamedLogger;
-    private readonly EventHandler<LoggingConfigurationChangedEventArgs> _logManagerOnConfigurationChanged;
+    private readonly EventHandler<LoggingConfigurationChangedEventArgs>? _logManagerOnConfigurationChanged;
 
     private static ILogger BuildLogger(Type type)
         => new(new NLogLogger(type));
     private static ILogger BuildNamedLogger(string loggerName)
         => new(new NLogLogger(loggerName));
 
+#if !ZK_EVM
     public ILogger GetClassLogger<T>() => TypedLogger<T>.Logger;
+#endif
 
     public ILogger GetLogger(string loggerName) => s_namedLoggers.GetOrAdd(loggerName, s_namedLoggerBuilder);
 
-    public void SetGlobalVariable(string name, object value) => GlobalDiagnosticsContext.Set(name, value);
+    public void SetGlobalVariable(string name, object? value) => GlobalDiagnosticsContext.Set(name, value);
 
-    private static void SetupLogRules(string logRules)
+    private static void SetupLogRules(string? logRules)
     {
         //Add rules here for e.g. 'JsonRpc.*: Warn; Block.*: Error;',
         if (logRules is not null)

--- a/src/Nethermind/Nethermind.Logging.NLog/Nethermind.Logging.NLog.csproj
+++ b/src/Nethermind/Nethermind.Logging.NLog/Nethermind.Logging.NLog.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Logging/ConsoleAsyncLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ConsoleAsyncLogger.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Logging
     public class ConsoleAsyncLogger : InterfaceLogger
     {
         private readonly LogLevel _logLevel;
-        private readonly string _prefix;
+        private readonly string? _prefix;
         private readonly BlockingCollection<string> _queuedEntries = new(new ConcurrentQueue<string>());
 
         public void Flush()
@@ -24,7 +24,7 @@ namespace Nethermind.Logging
 
         private readonly Task _task;
 
-        public ConsoleAsyncLogger(LogLevel logLevel, string prefix = null)
+        public ConsoleAsyncLogger(LogLevel logLevel, string? prefix = null)
         {
             _logLevel = logLevel;
             _prefix = prefix;
@@ -61,7 +61,7 @@ namespace Nethermind.Logging
 
         public void Trace(string text) => Log(text);
 
-        public void Error(string text, Exception ex = null) => Log(ex is not null ? $"{text}, Exception: {ex}" : text);
+        public void Error(string text, Exception? ex = null) => Log(ex is not null ? $"{text}, Exception: {ex}" : text);
 
         public bool IsInfo => (int)_logLevel >= 2;
         public bool IsWarn => (int)_logLevel >= 1;

--- a/src/Nethermind/Nethermind.Logging/ILogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogManager.cs
@@ -11,7 +11,7 @@ public interface ILogManager
 
     ILogger GetLogger(string loggerName);
 
-    void SetGlobalVariable(string name, object value) { }
+    void SetGlobalVariable(string name, object? value) { }
 
     static string GetLoggerName(Type type) => (type.FullName ?? type.Name).Replace("Nethermind.", string.Empty);
 }

--- a/src/Nethermind/Nethermind.Logging/ILogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogger.cs
@@ -88,7 +88,7 @@ public struct ILogger : IEquatable<ILogger>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void DebugError(
         [InterpolatedStringHandlerArgument("")] ref DebugInterpolatedStringHandler handler,
-        Exception ex = null)
+        Exception? ex = null)
     {
         if (IsDebug) _logger.Error("DEBUG/ERROR: " + handler.ToStringAndClear(), LogEventKind.DebugError, ex);
     }
@@ -98,7 +98,7 @@ public struct ILogger : IEquatable<ILogger>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public readonly void DebugError(string text, Exception ex = null)
+    public readonly void DebugError(string text, Exception? ex = null)
     {
         if (IsDebug) _logger.Error("DEBUG/ERROR: " + text, LogEventKind.DebugError, ex);
     }
@@ -135,7 +135,7 @@ public struct ILogger : IEquatable<ILogger>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void TraceError(
         [InterpolatedStringHandlerArgument("")] ref TraceInterpolatedStringHandler handler,
-        Exception ex = null)
+        Exception? ex = null)
     {
         if (IsTrace) _logger.Error("TRACE/ERROR: " + handler.ToStringAndClear(), LogEventKind.TraceError, ex);
     }
@@ -145,7 +145,7 @@ public struct ILogger : IEquatable<ILogger>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public readonly void TraceError(string text, Exception ex = null)
+    public readonly void TraceError(string text, Exception? ex = null)
     {
         if (IsTrace) _logger.Error("TRACE/ERROR: " + text, LogEventKind.TraceError, ex);
     }

--- a/src/Nethermind/Nethermind.Logging/ILogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogger.cs
@@ -56,7 +56,7 @@ public struct ILogger : IEquatable<ILogger>
     public bool Equals(ILogger other) => _logger == other._logger;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public readonly void Error(string text, Exception ex = null)
+    public readonly void Error(string text, Exception? ex = null)
     {
         if (IsError) _logger.Error(text, ex);
     }

--- a/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Logging
         /// filter these events separately from plain errors. Default implementation drops the
         /// kind and falls through to <see cref="Error(string, Exception)"/>.
         /// </summary>
-        void Error(string text, LogEventKind kind, Exception ex = null) => Error(text, ex);
+        void Error(string text, LogEventKind kind, Exception? ex = null) => Error(text, ex);
 
         bool IsInfo { get; }
         bool IsWarn { get; }

--- a/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Logging
         void Warn(string text);
         void Debug(string text);
         void Trace(string text);
-        void Error(string text, Exception ex = null);
+        void Error(string text, Exception? ex = null);
 
         /// <summary>
         /// Logs a warning tagged with a <see cref="LogEventKind"/>. Sinks that support structured

--- a/src/Nethermind/Nethermind.Logging/LimboLogs.cs
+++ b/src/Nethermind/Nethermind.Logging/LimboLogs.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Logging
         {
         }
 
-        private static LimboLogs _instance;
+        private static LimboLogs? _instance;
 
         public static LimboLogs Instance => _instance ?? LazyInitializer.EnsureInitialized(ref _instance, static () => new LimboLogs());
 

--- a/src/Nethermind/Nethermind.Logging/LimboNoErrorLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/LimboNoErrorLogger.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Logging
     /// </summary>
     public class LimboNoErrorLogger : InterfaceLogger
     {
-        private static LimboNoErrorLogger _instance;
+        private static LimboNoErrorLogger? _instance;
 
         public static ILogger Instance
         {
@@ -40,7 +40,7 @@ namespace Nethermind.Logging
         {
         }
 
-        public void Error(string text, Exception ex = null)
+        public void Error(string text, Exception? ex = null)
         {
             Console.Error.WriteLine(text);
             Console.Error.WriteLine(ex);

--- a/src/Nethermind/Nethermind.Logging/LimboTraceLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/LimboTraceLogger.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Logging
     /// </summary>
     public class LimboTraceLogger : InterfaceLogger
     {
-        private static LimboTraceLogger _instance;
+        private static LimboTraceLogger? _instance;
 
         public static ILogger Instance
         {
@@ -40,7 +40,7 @@ namespace Nethermind.Logging
         {
         }
 
-        public void Error(string text, Exception ex = null)
+        public void Error(string text, Exception? ex = null)
         {
         }
 

--- a/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
+++ b/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
@@ -1,1 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Nethermind/Nethermind.Logging/NoErrorLimboLogs.cs
+++ b/src/Nethermind/Nethermind.Logging/NoErrorLimboLogs.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Logging
         {
         }
 
-        private static NoErrorLimboLogs _instance;
+        private static NoErrorLimboLogs? _instance;
 
         public static NoErrorLimboLogs Instance => _instance ?? LazyInitializer.EnsureInitialized(ref _instance, static () => new NoErrorLimboLogs());
 

--- a/src/Nethermind/Nethermind.Logging/NullLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/NullLogger.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Logging
         {
         }
 
-        public void Error(string text, Exception ex = null)
+        public void Error(string text, Exception? ex = null)
         {
         }
 

--- a/src/Nethermind/Nethermind.Logging/PathUtils.cs
+++ b/src/Nethermind/Nethermind.Logging/PathUtils.cs
@@ -11,19 +11,19 @@ public static class PathUtils
 {
     static PathUtils()
     {
-        string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath);
+        string? processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath);
 
-        ExecutingDirectory = processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase)
-            || processName.Equals("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)
+        ExecutingDirectory = (processName is not null && (processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+            || processName.Equals("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)))
             // A workaround for tests in JetBrains Rider ignoring MTP:
             // https://youtrack.jetbrains.com/projects/RIDER/issues/RIDER-131530
             ? AppContext.BaseDirectory
-            : Path.GetDirectoryName(Environment.ProcessPath);
+            : Path.GetDirectoryName(Environment.ProcessPath) ?? AppContext.BaseDirectory;
     }
 
     public static string ExecutingDirectory { get; }
 
-    public static string GetApplicationResourcePath(this string resourcePath, string overridePrefixPath = null)
+    public static string GetApplicationResourcePath(this string resourcePath, string? overridePrefixPath = null)
     {
         if (string.IsNullOrWhiteSpace(resourcePath))
         {

--- a/src/Nethermind/Nethermind.Logging/SimpleConsoleLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/SimpleConsoleLogger.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Logging
             if (IsTrace) WriteEntry(text);
         }
 
-        public void Error(string text, Exception ex = null)
+        public void Error(string text, Exception? ex = null)
         {
             if (IsError) Console.Error.WriteLine(DateTime.Now.ToString(dateFormat) + text + (ex is not null ? " " + ex : string.Empty));
         }

--- a/src/Nethermind/Nethermind.Logging/TestErrorLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/TestErrorLogManager.cs
@@ -25,7 +25,7 @@ public class TestErrorLogManager : ILogManager
         public void Warn(string text) { }
         public void Debug(string text) { }
         public void Trace(string text) { }
-        public void Error(string text, Exception ex = null) => _errors.Enqueue(new Error() { Text = text, Exception = ex });
+        public void Error(string text, Exception? ex = null) => _errors.Enqueue(new Error() { Text = text, Exception = ex });
         public bool IsInfo => false;
         public bool IsWarn => false;
         public bool IsDebug => true;
@@ -35,7 +35,7 @@ public class TestErrorLogManager : ILogManager
 
     public record Error
     {
-        public string Text { get; init; }
-        public Exception Exception { get; init; }
+        public required string Text { get; init; }
+        public Exception? Exception { get; init; }
     }
 }

--- a/src/Nethermind/Nethermind.Logging/TestLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/TestLogManager.cs
@@ -48,7 +48,7 @@ namespace Nethermind.Logging
                 }
             }
 
-            public void Error(string text, Exception ex = null)
+            public void Error(string text, Exception? ex = null)
             {
                 if (IsError)
                 {
@@ -64,7 +64,7 @@ namespace Nethermind.Logging
 
             private bool CheckLevel(LogLevel logLevel) => level >= logLevel;
 
-            private static void Log(string text, Exception ex = null)
+            private static void Log(string text, Exception? ex = null)
             {
                 Console.Error.WriteLine(text);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -80,7 +80,7 @@ public partial class EngineRpcModule : IEngineRpcModule
         ValidationResult validationResult = executionPayloadParams.ValidateParams(releaseSpec, version, out string? error);
         if (validationResult != ValidationResult.Success)
         {
-            if (_logger.IsWarn) _logger.Warn(error);
+            if (_logger.IsWarn) _logger.Warn(error!);
             return validationResult == ValidationResult.Fail
                 ? ResultWrapper<PayloadStatusV1>.Fail(error!, ErrorCodes.InvalidParams)
                 : ResultWrapper<PayloadStatusV1>.Success(PayloadStatusV1.Invalid(null, error));

--- a/src/Nethermind/Nethermind.Network.Contract/Nethermind.Network.Contract.csproj
+++ b/src/Nethermind/Nethermind.Network.Contract/Nethermind.Network.Contract.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -418,7 +418,7 @@ IConfigProvider CreateConfigProvider(ParseResult parseResult)
     configProvider.AddSource(new JsonConfigSource(configFile));
     configProvider.Initialize();
 
-    (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
+    (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
 
     if (Errors.Any())
         logger.Warn($"Invalid configuration settings:\n{ErrorMsg}");

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -418,7 +418,7 @@ IConfigProvider CreateConfigProvider(ParseResult parseResult)
     configProvider.AddSource(new JsonConfigSource(configFile));
     configProvider.Initialize();
 
-    (string ErrorMsg, IList<(IConfigSource Source, string? Category, string? Name)> Errors) = configProvider.FindIncorrectSettings();
+    (string ErrorMsg, IList<(IConfigSource Source, string? Category, string Name)> Errors) = configProvider.FindIncorrectSettings();
 
     if (Errors.Any())
         logger.Warn($"Invalid configuration settings:\n{ErrorMsg}");

--- a/src/Nethermind/Nethermind.Seq/Nethermind.Seq.csproj
+++ b/src/Nethermind/Nethermind.Seq/Nethermind.Seq.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />
   </ItemGroup>

--- a/tools/DocGen/ConfigGenerator.cs
+++ b/tools/DocGen/ConfigGenerator.cs
@@ -101,10 +101,10 @@ internal static class ConfigGenerator
             if (configAttr?.HiddenFromDocs ?? true)
                 continue;
 
-            string description = configAttr.Description.Replace("\n", "\n  ").TrimEnd(' ');
+            string description = configAttr!.Description?.Replace("\n", "\n  ").TrimEnd(' ') ?? string.Empty;
             string cliAlias = string.IsNullOrWhiteSpace(configAttr.CliOptionAlias)
                 ? $"{moduleName}-{prop.Name}"
-                : configAttr.CliOptionAlias;
+                : configAttr.CliOptionAlias!;
             (string value, string cliValue) = GetValue(prop);
 
             file.Write($$"""

--- a/tools/DocGen/ConfigGenerator.cs
+++ b/tools/DocGen/ConfigGenerator.cs
@@ -101,10 +101,10 @@ internal static class ConfigGenerator
             if (configAttr?.HiddenFromDocs ?? true)
                 continue;
 
-            string description = configAttr!.Description?.Replace("\n", "\n  ").TrimEnd(' ') ?? string.Empty;
+            string description = configAttr!.Description.Replace("\n", "\n  ").TrimEnd(' ');
             string cliAlias = string.IsNullOrWhiteSpace(configAttr.CliOptionAlias)
                 ? $"{moduleName}-{prop.Name}"
-                : configAttr.CliOptionAlias!;
+                : configAttr.CliOptionAlias;
             (string value, string cliValue) = GetValue(prop);
 
             file.Write($$"""


### PR DESCRIPTION
## Summary

- Enable `<Nullable>enable</Nullable>` for packages that previously had `none` or `annotations`
- Fix all nullable warnings to compile cleanly with `TreatWarningsAsErrors`
- Packages enabled: **Nethermind.Logging**, **Nethermind.Logging.NLog**, **Nethermind.Config**, **Nethermind.Network.Contract**, **Nethermind.Seq**
- Downstream fixes in Merge.Plugin, Runner, Config.Test to match updated interface nullability

## Nullable Status (Topological Order)

Legend:
- [x] = `<Nullable>enable</Nullable>` (full nullable warnings)
- [~] = `<Nullable>annotations</Nullable>` (metadata only, no warnings)
- [ ] = no `<Nullable>` setting (effectively disabled)

### Leaf packages (no internal deps)

- [x] Nethermind.Analyzers
- [x] Nethermind.Logging ✅ **this PR**
- [x] Nethermind.Logging.Microsoft
- [x] Nethermind.Serialization.SszGenerator
- [x] Nethermind.UI

### Core layer

- [x] Nethermind.Core  <- Logging
- [x] Nethermind.Logging.NLog  <- Logging ✅ **this PR**
- [x] Nethermind.Abi  <- Core
- [x] Nethermind.Config  <- Core ✅ **this PR**
- [ ] Nethermind.Serialization.Json  <- Core
- [~] Nethermind.Serialization.Rlp  <- Core
- [x] Nethermind.Serialization.Ssz  <- Core

### Infrastructure layer

- [ ] Nethermind.Monitoring  <- Config, Logging
- [x] Nethermind.Network.Contract  <- Config ✅ **this PR**
- [x] Nethermind.Seq  <- Config ✅ **this PR**
- [ ] Nethermind.Grpc  <- Config, Core, Serialization.Json
- [x] Nethermind.Sockets  <- Core, Logging, Serialization.Json
- [~] Nethermind.Specs  <- Config, Core, Serialization.Json
- [~] Nethermind.Crypto  <- Core, Serialization.Rlp
- [~] Nethermind.Db  <- Config, Serialization.Rlp
- [x] Nethermind.Merkleization  <- Core, Serialization.Ssz
- [ ] Nethermind.Network.Stats  <- Config, Core, Logging, Network.Contract
- [ ] Nethermind.KeyStore  <- Config, Core, Crypto, Serialization.Json

### Data layer

- [~] Nethermind.Trie  <- Core, Db, Serialization.Rlp
- [~] Nethermind.Evm  <- Core, Crypto, Serialization.Rlp, Specs, Trie
- [x] Nethermind.Evm.Precompiles  <- Core, Crypto, Evm, Serialization.Rlp, Specs
- [~] Nethermind.State  <- Core, Db, Evm, Serialization.Rlp, Trie
- [x] Nethermind.TxPool  <- Config, Core, Crypto, Db, Evm, Network.Contract, State

### Blockchain layer

- [~] Nethermind.Blockchain  <- Abi, Core, Db, Evm, Evm.Precompiles, Network.Stats, Specs, State, TxPool
- [ ] Nethermind.Wallet  <- Core, KeyStore, Serialization.Rlp, TxPool
- [~] Nethermind.Consensus  <- Blockchain, Config, Core, Crypto, Evm, TxPool
- [x] Nethermind.History  <- Consensus
- [x] Nethermind.Stateless.Executor  <- Consensus
- [~] Nethermind.Synchronization  <- Consensus, History, Logging, Network.Contract, Trie
- [x] Nethermind.Stateless.ZiskGuest  <- Stateless.Executor

### Network / Facade layer

- [~] Nethermind.Facade  <- Consensus, Core, Crypto, Synchronization
- [~] Nethermind.Network  <- Blockchain, Config, Core, Crypto, Network.Contract, Network.Stats, Synchronization
- [x] Nethermind.State.Flat  <- Blockchain, Core, Db, Evm, Serialization.Rlp, State, Synchronization, Trie
- [x] Nethermind.Network.Enr  <- Crypto, Network
- [x] Nethermind.Network.Dns  <- Network, Network.Enr

### RPC layer

- [~] Nethermind.JsonRpc  <- Abi, Blockchain, Config, Consensus, Core, Crypto, Evm, Facade, Network, Network.Dns, Sockets, Synchronization, Wallet

### API / Init layer

- [x] Nethermind.Api  <- Blockchain, Facade, Grpc, History, JsonRpc, Monitoring, Network, Sockets
- [ ] Nethermind.Db.Rpc  <- Db, JsonRpc, Serialization.Json, State
- [~] Nethermind.Consensus.Clique  <- Api, Blockchain, Consensus, JsonRpc
- [~] Nethermind.Consensus.Ethash  <- Api, Blockchain, Consensus, Core, Crypto, Serialization.Rlp, Specs
- [x] Nethermind.Db.Rocks  <- Api, Db
- [x] Nethermind.Era1  <- Api, Blockchain, Consensus, Core, JsonRpc, Merkleization, Serialization.Rlp, Serialization.Ssz, State
- [x] Nethermind.ExternalSigner.Plugin  <- Api, JsonRpc
- [x] Nethermind.Merge.Plugin  <- Api
- [x] Nethermind.Network.Discovery  <- Api, Crypto, Facade, Network, Network.Enr
- [x] Nethermind.UPnP.Plugin  <- Api

### Plugin layer

- [x] Nethermind.Flashbots  <- Merge.Plugin
- [ ] Nethermind.HealthChecks  <- Api, Merge.Plugin
- [x] Nethermind.Init  <- Api, Db.Rocks, Db.Rpc, Era1, Network.Discovery, Network.Dns, Network.Enr, Specs, State.Flat
- [~] Nethermind.Consensus.AuRa  <- Abi, Api, Blockchain, Facade, Init, Specs, Synchronization
- [x] Nethermind.EthStats  <- Api, Blockchain, Core, Init, JsonRpc, Logging, Network
- [x] Nethermind.Hive  <- Api, Init
- [x] Nethermind.Init.Snapshot  <- Api, Init
- [x] Nethermind.JsonRpc.TraceStore  <- Api, Init
- [x] Nethermind.Optimism  <- Api, Blockchain, Consensus, Core, Init, JsonRpc, Merge.Plugin
- [x] Nethermind.Shutter  <- Blockchain, Consensus, Core, Crypto, Init, Merge.Plugin, Merkleization, Network.Discovery, Serialization.Ssz, Specs
- [x] Nethermind.Taiko  <- Api, Blockchain, Consensus, Core, Evm, Evm.Precompiles, Init, JsonRpc, Logging, Merge.Plugin, Serialization.Json
- [~] Nethermind.Xdc  <- Api, Consensus, Core, Init
- [x] Nethermind.Merge.AuRa  <- Blockchain, Consensus, Consensus.AuRa, Core, Db, Evm, Merge.Plugin, Specs, State

## Changes

- [x] Breaking change
- [x] Non-breaking change
- [ ] Bug fix

## Test plan
- [x] Both `Nethermind.slnx` and `Benchmarks.slnx` build with 0 errors
- [ ] CI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)