### PR TITLE
chore: Remove `debug_getBlockRlp` method

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Blockchain.Tracing.GethStyle;
@@ -36,7 +37,7 @@ namespace Nethermind.JsonRpc.Test.Modules;
 public class DebugModuleTests
 {
     private readonly IJsonRpcConfig _jsonRpcConfig = new JsonRpcConfig();
-    private readonly ISpecProvider _specProvider = Substitute.For<ISpecProvider>();
+    private readonly ISpecProvider _specProvider = SpecProviderSubstitute.Create();
     private readonly IDebugBridge _debugBridge = Substitute.For<IDebugBridge>();
     private readonly IBlockFinder _blockFinder = Substitute.For<IBlockFinder>();
     private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
@@ -90,8 +91,38 @@ public class DebugModuleTests
         using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getChainLevel", parameter) as JsonRpcSuccessResponse;
         ChainLevelForRpc? chainLevel = response?.Result as ChainLevelForRpc;
         Assert.That(chainLevel, Is.Not.Null);
-        Assert.That(chainLevel?.HasBlockOnMainChain, Is.EqualTo(true));
-        Assert.That(chainLevel?.BlockInfos.Length, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(chainLevel?.HasBlockOnMainChain, Is.EqualTo(true));
+            Assert.That(chainLevel?.BlockInfos.Length, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task Get_raw_header()
+    {
+        HeaderDecoder decoder = new();
+        Block blk = Build.A.Block.WithNumber(0).TestObject;
+        Rlp rlp = decoder.Encode(blk.Header);
+        _debugBridge.GetBlock(new BlockParameter((long)0)).Returns(blk);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawHeader", "0x") as JsonRpcSuccessResponse;
+        Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
+    }
+
+    [Test]
+    public async Task Get_raw_block_by_number()
+    {
+        BlockDecoder decoder = new();
+        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
+        Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
+        localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(localDebugBridge);
+        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", "0x1") as JsonRpcSuccessResponse;
+
+        Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
     [Test]
@@ -107,34 +138,7 @@ public class DebugModuleTests
     }
 
     [Test]
-    public async Task Get_raw_Header()
-    {
-        HeaderDecoder decoder = new();
-        Block blk = Build.A.Block.WithNumber(0).TestObject;
-        Rlp rlp = decoder.Encode(blk.Header);
-        _debugBridge.GetBlock(new BlockParameter((long)0)).Returns(blk);
-
-        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
-        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawHeader", "0x") as JsonRpcSuccessResponse;
-        Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
-    }
-
-    [TestCase("debug_getRawBlock", "0x1")]
-    public async Task Get_block_rlp(string method, object parameter)
-    {
-        BlockDecoder decoder = new();
-        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
-        Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
-        localDebugBridge.GetBlockRlp(new BlockParameter(1)).Returns(rlp.Bytes);
-
-        DebugRpcModule rpcModule = CreateDebugRpcModule(localDebugBridge);
-        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, method, parameter) as JsonRpcSuccessResponse;
-
-        Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
-    }
-
-    [Test]
-    public async Task Get_rawblock_named()
+    public async Task Get_raw_block_by_name()
     {
         BlockDecoder decoder = new();
         IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
@@ -205,8 +209,11 @@ public class DebugModuleTests
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         ResultWrapper<IEnumerable<BadBlock>> blocks = rpcModule.debug_getBadBlocks();
         Assert.That(blocks.Data.Count, Is.EqualTo(1));
-        Assert.That(blocks.Data.ElementAt(0).Hash, Is.EqualTo(block1.Hash));
-        Assert.That(blocks.Data.ElementAt(0).Block.Difficulty, Is.EqualTo(new UInt256(2)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blocks.Data.ElementAt(0).Hash, Is.EqualTo(block1.Hash));
+            Assert.That(blocks.Data.ElementAt(0).Block.Difficulty, Is.EqualTo(new UInt256(2)));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -93,7 +93,7 @@ public class DebugModuleTests
         Assert.That(chainLevel, Is.Not.Null);
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(chainLevel?.HasBlockOnMainChain, Is.EqualTo(true));
+            Assert.That(chainLevel?.HasBlockOnMainChain, Is.True);
             Assert.That(chainLevel?.BlockInfos.Length, Is.EqualTo(2));
         }
     }
@@ -183,7 +183,7 @@ public class DebugModuleTests
     [Test]
     public void Debug_getBadBlocks_test()
     {
-        IBadBlockStore badBlocksStore = null!;
+        BadBlockStore badBlocksStore = null!;
         BlockTree blockTree = BuildBlockTree(b => b.WithBadBlockStore(badBlocksStore = new BadBlockStore(b.BadBlocksDb, 100)));
 
         Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -208,7 +208,7 @@ public class DebugModuleTests
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         ResultWrapper<IEnumerable<BadBlock>> blocks = rpcModule.debug_getBadBlocks();
-        Assert.That(blocks.Data.Count, Is.EqualTo(1));
+        Assert.That(blocks.Data.Count(), Is.EqualTo(1));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(blocks.Data.ElementAt(0).Hash, Is.EqualTo(block1.Hash));
@@ -238,8 +238,10 @@ public class DebugModuleTests
             Depth = 1
         };
 
-        GethLikeTxTrace trace = new();
-        trace.ReturnValue = Bytes.FromHexString("a2");
+        GethLikeTxTrace trace = new()
+        {
+            ReturnValue = Bytes.FromHexString("a2")
+        };
         trace.Entries.Add(entry);
 
         GethTraceOptions gtOptions = new();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -95,14 +95,14 @@ public class DebugModuleTests
     }
 
     [Test]
-    public async Task Get_block_rlp_by_hash()
+    public async Task Get_raw_block_by_hash()
     {
         BlockDecoder decoder = new();
         Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
         _debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).Returns(rlp.Bytes);
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
-        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcSuccessResponse;
+        using JsonRpcSuccessResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", Keccak.Zero) as JsonRpcSuccessResponse;
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
@@ -119,7 +119,6 @@ public class DebugModuleTests
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
-    [TestCase("debug_getBlockRlp", 1)]
     [TestCase("debug_getRawBlock", "0x1")]
     public async Task Get_block_rlp(string method, object parameter)
     {
@@ -148,7 +147,6 @@ public class DebugModuleTests
         Assert.That((byte[]?)response?.Result, Is.EqualTo(rlp.Bytes));
     }
 
-    [TestCase("debug_getBlockRlp", 1)]
     [TestCase("debug_getRawBlock", "0x1")]
     public async Task Get_block_rlp_when_missing(string method, object parameter)
     {
@@ -161,12 +159,12 @@ public class DebugModuleTests
     }
 
     [Test]
-    public async Task Get_block_rlp_by_hash_when_missing()
+    public async Task Get_raw_block_by_hash_when_missing()
     {
         _debugBridge.GetBlockRlp(new BlockParameter(Keccak.Zero)).ReturnsNull();
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
-        using JsonRpcErrorResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", Keccak.Zero) as JsonRpcErrorResponse;
+        using JsonRpcErrorResponse? response = await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getRawBlock", Keccak.Zero) as JsonRpcErrorResponse;
 
         Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.ResourceNotFound));
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -311,12 +311,6 @@ public class DebugRpcModule(
         throw new NotImplementedException();
     }
 
-    public ResultWrapper<byte[]> debug_getBlockRlp(long blockNumber) =>
-        GetBlockRlpOrFail(new BlockParameter(blockNumber));
-
-    public ResultWrapper<byte[]> debug_getBlockRlpByHash(Hash256 hash) =>
-        GetBlockRlpOrFail(new BlockParameter(hash));
-
     public ResultWrapper<MemStats> debug_memStats(BlockParameter blockParameter)
     {
         throw new NotImplementedException();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -59,12 +59,6 @@ public interface IDebugRpcModule : IRpcModule
     [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = true)]
     ResultWrapper<GcStats> debug_gcStats();
 
-    [JsonRpcMethod(Description = "Retrieves a block in the RLP-serialized form.", IsImplemented = true, IsSharable = true)]
-    ResultWrapper<byte[]> debug_getBlockRlp(long number);
-
-    [JsonRpcMethod(Description = "Retrieves a block in the RLP-serialized form.", IsImplemented = true, IsSharable = true)]
-    ResultWrapper<byte[]> debug_getBlockRlpByHash(Hash256 hash);
-
     [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = true)]
     ResultWrapper<MemStats> debug_memStats(BlockParameter blockParameter);
 


### PR DESCRIPTION
## Changes

Removed the `debug_getBlockRlp` and `debug_getBlockRlpByHash` JSON-RPC methods as duplicates of `debug_getRawBlock`. Also, Geth supports the latter only.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No