### PR TITLE
style: enable CA2208 and fix incorrect exception argument params

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -105,4 +105,5 @@ dotnet_diagnostic.IDE0290.severity = error
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 dotnet_diagnostic.CA1507.severity = warning
 dotnet_diagnostic.CA1510.severity = warning
+dotnet_diagnostic.CA2208.severity = suggestion
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/JavaScriptConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/JavaScriptConverter.cs
@@ -23,7 +23,7 @@ public static class JavaScriptConverter
         IArrayBuffer arrayBuffer => arrayBuffer.GetBytes(),
         IArrayBufferView arrayBufferView => arrayBufferView.GetBytes(),
         IList list => list.ToEnumerable().Select(Convert.ToByte).ToArray(),
-        _ => throw new ArgumentException(nameof(input))
+        _ => throw new ArgumentException("Unsupported input type.", nameof(input))
     };
 
     public static byte[] ToWord(this object input) => input switch

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaValidatorFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaValidatorFactory.cs
@@ -115,7 +115,7 @@ namespace Nethermind.Consensus.AuRa
                         _logManager,
                         _forSealing),
 
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(validator), validator.ValidatorType, "Unknown validator type.")
             };
         }
     }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Config/AuRaChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Config/AuRaChainSpecEngineParameters.cs
@@ -111,7 +111,7 @@ public class AuRaChainSpecEngineParameters : IChainSpecEngineParameters
                     .ToImmutableSortedDictionary();
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(validatorJson), validatorType, "Unknown validator type.");
         }
 
         return validator;

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -453,7 +453,7 @@ namespace Nethermind.Core.Extensions
         {
             if (bits.Length % 8 != 0)
             {
-                throw new ArgumentException(nameof(bits));
+                throw new ArgumentException("Bit array length must be a multiple of 8.", nameof(bits));
             }
 
             byte[] bytes = new byte[bits.Length / 8];
@@ -642,7 +642,7 @@ namespace Nethermind.Core.Extensions
             }
 
             [DoesNotReturn]
-            static void ThrowArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException();
+            static void ThrowArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException(nameof(hex), "Output hex span has incorrect length.");
         }
 
         public static void OutputBytesToCharHex(ref byte input, int length, ref char charsRef, bool withZeroX, int leadingZeros)

--- a/src/Nethermind/Nethermind.Era1/EraStore.cs
+++ b/src/Nethermind/Nethermind.Era1/EraStore.cs
@@ -240,7 +240,7 @@ public class EraStore : IEraStore
     private void GuardMissingEpoch(long epoch)
     {
         if (!HasEpoch(epoch))
-            throw new ArgumentOutOfRangeException($"Epoch not available.", epoch, nameof(epoch));
+            throw new ArgumentOutOfRangeException(nameof(epoch), epoch, "Epoch not available.");
     }
 
     private readonly struct EraRenter(EraStore store, EraReader reader, long epoch) : IDisposable

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/TransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/TransactionForRpcTests.cs
@@ -83,7 +83,7 @@ public class TransactionForRpcTests
                 SetCodeTransactionForRpcTests.ValidateSchema(json);
                 break;
             default:
-                throw new ArgumentOutOfRangeException("txType", transaction.Type, "Unknown transaction type.");
+                throw new ArgumentOutOfRangeException(nameof(transaction), transaction.Type, "Unknown transaction type.");
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/TransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/TransactionForRpcTests.cs
@@ -83,7 +83,7 @@ public class TransactionForRpcTests
                 SetCodeTransactionForRpcTests.ValidateSchema(json);
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException("txType", transaction.Type, "Unknown transaction type.");
         }
     }
 

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -674,7 +674,7 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
             => throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(StateProvider)}");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException();
+        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -674,7 +674,7 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
             => throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(StateProvider)}");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException(null, "Unknown change type.");
+        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -674,7 +674,7 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
             => throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(StateProvider)}");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
+        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException(null, "Unknown change type.");
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -162,7 +162,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
-            _logger = logManager?.GetClassLogger<HeadersSyncFeed>() ?? throw new ArgumentNullException(nameof(HeadersSyncFeed));
+            _logger = logManager?.GetClassLogger<HeadersSyncFeed>() ?? throw new ArgumentNullException(nameof(logManager));
             _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
             _totalDifficultyStrategy = totalDifficultyStrategy ?? new CumulativeTotalDifficultyStrategy();
             _fastHeadersMemoryBudget = syncConfig.FastHeadersMemoryBudget;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.FastSync
                             builder.Append('□');
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new ArgumentOutOfRangeException("progressState", _syncProgress[i], "Unknown progress state.");
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.FastSync
                             builder.Append('□');
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException("progressState", _syncProgress[i], "Unknown progress state.");
+                            throw new ArgumentOutOfRangeException(nameof(_syncProgress), _syncProgress[i], "Unknown progress state.");
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.FastSync
                             builder.Append('□');
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException(nameof(_syncProgress), _syncProgress[i], "Unknown progress state.");
+                            throw new ArgumentOutOfRangeException(nameof(NodeProgressState), _syncProgress[i], "Unknown progress state.");
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BranchProgress.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.FastSync
                             builder.Append('□');
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException(nameof(NodeProgressState), _syncProgress[i], "Unknown progress state.");
+                            throw new ArgumentOutOfRangeException(nameof(_syncProgress), _syncProgress[i], "Unknown progress state.");
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/PendingSyncItems.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/PendingSyncItems.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Synchronization.FastSync
                 NodeDataType.Storage when priority <= 0.5f => StorageItemsPriority0,
                 NodeDataType.Storage when priority <= 1.5f => StorageItemsPriority1,
                 NodeDataType.Storage => StorageItemsPriority2,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(stateSyncItem), stateSyncItem.NodeDataType, "Unknown node data type.")
             };
 
             selectedCollection.Push(stateSyncItem);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(TotalDiffSelectionType), _selectionType, "Unknown selection type.");
+                    throw new ArgumentOutOfRangeException(nameof(_selectionType), _selectionType, "Unknown selection type.");
             }
 
             return _strategy.Allocate(currentPeer, peers.Where(p => p.TotalDifficulty >= currentDiff), nodeStatsManager, blockTree);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("selectionType", _selectionType, "Unknown selection type.");
+                    throw new ArgumentOutOfRangeException(nameof(_selectionType), _selectionType, "Unknown selection type.");
             }
 
             return _strategy.Allocate(currentPeer, peers.Where(p => p.TotalDifficulty >= currentDiff), nodeStatsManager, blockTree);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(_selectionType), _selectionType, "Unknown selection type.");
+                    throw new ArgumentOutOfRangeException(nameof(TotalDiffSelectionType), _selectionType, "Unknown selection type.");
             }
 
             return _strategy.Allocate(currentPeer, peers.Where(p => p.TotalDifficulty >= currentDiff), nodeStatsManager, blockTree);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/TotalDiffStrategy.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException("selectionType", _selectionType, "Unknown selection type.");
             }
 
             return _strategy.Allocate(currentPeer, peers.Where(p => p.TotalDifficulty >= currentDiff), nodeStatsManager, blockTree);

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -420,7 +420,7 @@ namespace Nethermind.TxPool.Collections
         {
             if (value is null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(value));
             }
 
             return !_cacheMap.ContainsKey(key);


### PR DESCRIPTION
## Changes

- Enable CA2208 (Instantiate argument exceptions correctly) as suggestion in `.editorconfig`
- Fix parameter names passed as message arguments (`ArgumentException(nameof(param))` → `ArgumentException("message", nameof(param))`)
- Fix swapped constructor arguments (`ArgumentOutOfRangeException(message, value, paramName)` → `ArgumentOutOfRangeException(paramName, value, message)`)
- Fix parameterless exception constructors with missing context
- Fix type name used as paramName (`nameof(HeadersSyncFeed)` → `nameof(logManager)`)
- Use `nameof` instead of raw strings where a symbol is available

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] No

#### Notes on testing

All changes are to exception constructor arguments only — no behavioral changes. Exception messages and types remain the same.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No