### PR TITLE
fix: return NoopSnapServer instead of null for HashDB (#11116) [1.37.0-rc2]

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNetworkModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNetworkModule.cs
@@ -36,7 +36,7 @@ public class PseudoNetworkModule() : Module
                         ISyncConfig syncConfig = m.Context.Resolve<ISyncConfig>();
                         IWorldStateManager worldStateManager = m.Context.Resolve<IWorldStateManager>();
 
-                        if (syncConfig.SnapServingEnabled == true)
+                        if (syncConfig.SnapServingEnabled == true || syncConfig.SnapSync)
                         {
                             protocolManager.AddSupportedCapability(new Capability(Protocol.Snap, 1));
                         }

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -19,6 +19,7 @@ using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
 using Nethermind.Monitoring.Config;
 using Nethermind.State;
+using Nethermind.State.SnapServer;
 using Nethermind.State.Flat;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.ScopeProvider;
@@ -43,6 +44,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 new TrieStoreBoundaryWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
             })
             .AddSingleton<IStateReader, FlatStateReader>()
+            .AddSingleton<ISnapServer, IWorldStateManager>(wsm => wsm.SnapServer)
 
             // Disable some pruning trie store specific  components
             .AddSingleton<IPruningTrieStateAdminRpcModule, PruningTrieStateAdminRpcModuleStub>()

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -133,7 +133,7 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .Map<PublicKey, IRlpxHost>(rlpx => rlpx.LocalNodeId)
             .AddProtocolHandler<P2PProtocolHandler>(Protocol.P2P)
 
-            .AddSingleton<State.SnapServer.ISnapServer, State.IWorldStateManager>(wsm => wsm.SnapServer!)
+            .AddSingleton<State.SnapServer.ISnapServer, State.IWorldStateManager>(wsm => wsm.SnapServer)
 
             // Protocol handler factories (using clean DSL with Autofac Func auto-generation)
             .AddProtocolHandler<Subprotocols.Snap.SnapProtocolHandler>()

--- a/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Network.P2P.Subprotocols.Snap;
 using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.State.Snap;
+using Nethermind.State.SnapServer;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using NSubstitute;
@@ -73,7 +74,8 @@ public class SnapProtocolHandlerTests
                 NodeStatsManager,
                 MessageSerializationService,
                 RunImmediatelyScheduler.Instance,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                NoopSnapServer.Instance);
             set
             {
                 _snapProtocolHandler = value;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -26,10 +26,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 {
     public class SnapProtocolHandler : ZeroProtocolHandlerBase, ISnapSyncPeer, IStaticProtocolInfo
     {
-        private static readonly TrieNodesMessage EmptyTrieNodesMessage = new(EmptyByteArrayList.Instance);
-
-        private ISnapServer? SyncServer { get; }
-        private bool ServingEnabled { get; }
+        private ISnapServer SyncServer { get; }
+        private bool CanServe { get; }
 
         public override string Name => "snap1";
         protected override TimeSpan InitTimeout => Timeouts.Eth;
@@ -40,7 +38,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
         public override string ProtocolCode => Code;
         public override int MessageIdSpaceSize => 8;
 
-        private const string DisconnectMessage = "Serving snap data in not implemented in this node.";
+        private const string DisconnectMessage = "Serving snap data is not implemented in this node.";
 
         private readonly MessageDictionary<GetAccountRangeMessage, AccountRangeMessage> _getAccountRangeRequests;
         private readonly MessageDictionary<GetStorageRangeMessage, StorageRangeMessage> _getStorageRangeRequests;
@@ -53,7 +51,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             IMessageSerializationService serializer,
             IBackgroundTaskScheduler backgroundTaskScheduler,
             ILogManager logManager,
-            ISnapServer? snapServer = null)
+            ISnapServer snapServer)
             : base(session, nodeStats, serializer, backgroundTaskScheduler, logManager)
         {
             _getAccountRangeRequests = new(Send);
@@ -61,7 +59,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             _getByteCodesRequests = new(Send);
             _getTrieNodesRequests = new(Send);
             SyncServer = snapServer;
-            ServingEnabled = SyncServer is not null;
+            CanServe = snapServer.CanServe;
         }
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
@@ -89,11 +87,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             switch (message.PacketType)
             {
                 case SnapMessageCode.GetAccountRange:
-                    if (ShouldServeSnap(nameof(GetAccountRangeMessage)))
-                    {
+                    if (ShouldServeSnap())
                         HandleInBackground<GetAccountRangeMessage, AccountRangeMessage>(message, Handle);
-                    }
-
                     break;
                 case SnapMessageCode.AccountRange:
                     AccountRangeMessage accountRangeMessage = Deserialize<AccountRangeMessage>(message.Content);
@@ -101,11 +96,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
                     Handle(accountRangeMessage, size);
                     break;
                 case SnapMessageCode.GetStorageRanges:
-                    if (ShouldServeSnap(nameof(GetStorageRangeMessage)))
-                    {
+                    if (ShouldServeSnap())
                         HandleInBackground<GetStorageRangeMessage, StorageRangeMessage>(message, Handle);
-                    }
-
                     break;
                 case SnapMessageCode.StorageRanges:
                     StorageRangeMessage storageRangesMessage = Deserialize<StorageRangeMessage>(message.Content);
@@ -113,11 +105,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
                     Handle(storageRangesMessage, size);
                     break;
                 case SnapMessageCode.GetByteCodes:
-                    if (ShouldServeSnap(nameof(GetByteCodesMessage)))
-                    {
+                    if (ShouldServeSnap())
                         HandleInBackground<GetByteCodesMessage, ByteCodesMessage>(message, Handle);
-                    }
-
                     break;
                 case SnapMessageCode.ByteCodes:
                     ByteCodesMessage byteCodesMessage = Deserialize<ByteCodesMessage>(message.Content);
@@ -125,11 +114,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
                     Handle(byteCodesMessage, size);
                     break;
                 case SnapMessageCode.GetTrieNodes:
-                    if (ShouldServeSnap(nameof(GetTrieNodes)))
-                    {
+                    if (ShouldServeSnap())
                         HandleInBackground<GetTrieNodesMessage, TrieNodesMessage>(message, Handle);
-                    }
-
                     break;
                 case SnapMessageCode.TrieNodes:
                     TrieNodesMessage trieNodesMessage = Deserialize<TrieNodesMessage>(message.Content);
@@ -139,13 +125,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             }
         }
 
-        private bool ShouldServeSnap(string messageName)
+        private bool ShouldServeSnap()
         {
-            if (!ServingEnabled)
+            if (!CanServe)
             {
                 Session.InitiateDisconnect(DisconnectReason.SnapServerNotImplemented, DisconnectMessage);
                 if (Logger.IsDebug)
-                    Logger.Debug($"Peer disconnected because of requesting Snap data ({messageName}). Peer: {Session.Node.ClientId}");
+                    Logger.Debug($"Peer disconnected because of requesting Snap data. Peer: {Session.Node.ClientId}");
                 return false;
             }
 
@@ -211,42 +197,28 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         private TrieNodesMessage FulfillTrieNodesMessage(GetTrieNodesMessage getTrieNodesMessage, CancellationToken cancellationToken)
         {
-            if (SyncServer is null) return EmptyTrieNodesMessage;
             IByteArrayList? trieNodes = SyncServer.GetTrieNodes(getTrieNodesMessage.Paths, getTrieNodesMessage.RootHash, cancellationToken);
             return new TrieNodesMessage(trieNodes);
         }
 
         private AccountRangeMessage FulfillAccountRangeMessage(GetAccountRangeMessage getAccountRangeMessage, CancellationToken cancellationToken)
         {
-            if (SyncServer is null) return new AccountRangeMessage
-            {
-                Proofs = EmptyByteArrayList.Instance,
-                PathsWithAccounts = ArrayPoolList<PathWithAccount>.Empty(),
-            };
             AccountRange? accountRange = getAccountRangeMessage.AccountRange;
             (IOwnedReadOnlyList<PathWithAccount>? ranges, IByteArrayList? proofs) = SyncServer.GetAccountRanges(accountRange.RootHash, accountRange.StartingHash,
                 accountRange.LimitHash, getAccountRangeMessage.ResponseBytes, cancellationToken);
-            AccountRangeMessage? response = new() { Proofs = proofs, PathsWithAccounts = ranges };
-            return response;
+            return new AccountRangeMessage { Proofs = proofs, PathsWithAccounts = ranges };
         }
 
         private StorageRangeMessage FulfillStorageRangeMessage(GetStorageRangeMessage getStorageRangeMessage, CancellationToken cancellationToken)
         {
-            if (SyncServer is null) return new StorageRangeMessage()
-            {
-                Proofs = EmptyByteArrayList.Instance,
-                Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
-            };
             StorageRange? storageRange = getStorageRangeMessage.StorageRange;
             (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IByteArrayList? proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
                 storageRange.StartingHash, storageRange.LimitHash, getStorageRangeMessage.ResponseBytes, cancellationToken);
-            StorageRangeMessage? response = new() { Proofs = proofs, Slots = ranges };
-            return response;
+            return new StorageRangeMessage { Proofs = proofs, Slots = ranges };
         }
 
         private ByteCodesMessage FulfillByteCodesMessage(GetByteCodesMessage getByteCodesMessage, CancellationToken cancellationToken)
         {
-            if (SyncServer is null) return new ByteCodesMessage(EmptyByteArrayList.Instance);
             IByteArrayList byteCodes = SyncServer.GetByteCodes(getByteCodesMessage.Hashes, getByteCodesMessage.Bytes, cancellationToken);
             return new ByteCodesMessage(byteCodes);
         }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateManager.cs
@@ -41,7 +41,7 @@ public class FlatWorldStateManager(
 
     public IWorldStateScopeProvider GlobalWorldState => _mainWorldState;
     public IStateReader GlobalStateReader => flatStateReader;
-    public ISnapServer? SnapServer => _snapServer ??= new FlatSnapServer(
+    public ISnapServer SnapServer => _snapServer ??= new FlatSnapServer(
         flatDbManager,
         codeDb,
         flatStateRootIndex,

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -20,7 +20,9 @@ public class FlatSnapServer(
     IFlatStateRootIndex stateRootIndex,
     ILogManager logManager) : ISnapServer
 {
-    private readonly ILogger _logger = logManager.GetClassLogger();
+    public bool CanServe => true;
+
+    private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapServer>();
 
     private const long HardResponseByteLimit = 2000000;
     private const int HardResponseNodeLimit = 100000;

--- a/src/Nethermind/Nethermind.State/IWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateManager.cs
@@ -14,7 +14,7 @@ public interface IWorldStateManager
 {
     IWorldStateScopeProvider GlobalWorldState { get; }
     IStateReader GlobalStateReader { get; }
-    ISnapServer? SnapServer { get; }
+    ISnapServer SnapServer { get; }
     IReadOnlyKeyValueStore? HashServer { get; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
@@ -25,6 +25,7 @@ namespace Nethermind.State.SnapServer;
 
 public interface ISnapServer
 {
+    bool CanServe { get; }
     IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken);
     IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken);
 

--- a/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.State.Snap;
+
+namespace Nethermind.State.SnapServer;
+
+public class NoopSnapServer : ISnapServer
+{
+    public static readonly NoopSnapServer Instance = new();
+
+    public bool CanServe => false;
+
+    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
+        EmptyByteArrayList.Instance;
+
+    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken) =>
+        EmptyByteArrayList.Instance;
+
+    public (IOwnedReadOnlyList<PathWithAccount>, IByteArrayList) GetAccountRanges(Hash256 rootHash,
+        in ValueHash256 startingHash, in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken) =>
+        (ArrayPoolList<PathWithAccount>.Empty(), EmptyByteArrayList.Instance);
+
+    public (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IByteArrayList?) GetStorageRanges(
+        Hash256 rootHash, IReadOnlyList<PathWithAccount> accounts, in ValueHash256? startingHash,
+        in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken) =>
+        (ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(), EmptyByteArrayList.Instance);
+}

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -32,6 +32,8 @@ namespace Nethermind.State.SnapServer;
 
 public class SnapServer : ISnapServer
 {
+    public bool CanServe => true;
+
     private readonly IReadOnlyTrieStore _store;
     private readonly TrieStoreWithReadFlags _storeWithReadFlag;
     private readonly IReadOnlyKeyValueStore _codeDb;

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -42,6 +42,9 @@ public class WorldStateManager : IWorldStateManager
         GlobalStateReader = new StateReader(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager);
         _blockingVerifyTrie = new BlockingVerifyTrie(trieStore, GlobalStateReader, _readaOnlyCodeCb!, logManager);
         _lastNStateRootTracker = lastNStateRootTracker;
+        SnapServer = trieStore.Scheme == INodeStorage.KeyScheme.Hash
+            ? NoopSnapServer.Instance
+            : new SnapServer.SnapServer(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager, _lastNStateRootTracker);
     }
 
     public IWorldStateScopeProvider GlobalWorldState => _worldState;
@@ -56,7 +59,7 @@ public class WorldStateManager : IWorldStateManager
 
     public IStateReader GlobalStateReader { get; }
 
-    public ISnapServer? SnapServer => _trieStore.Scheme == INodeStorage.KeyScheme.Hash ? null : new SnapServer.SnapServer(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager, _lastNStateRootTracker);
+    public ISnapServer SnapServer { get; }
 
     public IWorldStateScopeProvider CreateResettableWorldState()
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -100,7 +100,10 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     /// <summary>
     /// Common code for all node
     /// </summary>
-    private async Task<IContainer> CreateNode(PrivateKey nodeKey, Func<IConfigProvider, ChainSpec, Task> configurer)
+    private Task<IContainer> CreateNode(PrivateKey nodeKey, Func<IConfigProvider, ChainSpec, Task> configurer) =>
+        CreateNode(nodeKey, configurer, dbMode);
+
+    private async Task<IContainer> CreateNode(PrivateKey nodeKey, Func<IConfigProvider, ChainSpec, Task> configurer, DbMode dbModeOverride)
     {
         IConfigProvider configProvider = new ConfigProvider();
         var loader = new ChainSpecFileLoader(new EthereumJsonSerializer(), LimboLogs.Instance);
@@ -144,7 +147,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
 
         await configurer(configProvider, spec);
 
-        switch (dbMode)
+        switch (dbModeOverride)
         {
             case DbMode.Default:
                 // Um... nothing?
@@ -318,6 +321,32 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             networkConfig.FilterPeersByRecentIp = false;
             networkConfig.FilterDiscoveryNodesByRecentIp = false;
         });
+
+        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+    }
+
+    [Test]
+    [Retry(5)]
+    public async Task SnapSync_HalfPathServer_HashClient()
+    {
+        if (dbMode != DbMode.Default) Assert.Ignore("This test only runs on the Default (HalfPath) server fixture");
+
+        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
+
+        PrivateKey clientKey = TestItem.PrivateKeyD;
+        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+        {
+            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+            syncConfig.FastSync = true;
+            syncConfig.SnapSync = true;
+
+            await SetPivot(syncConfig, cancellationTokenSource.Token);
+
+            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
+            networkConfig.P2PPort = AllocatePort();
+            networkConfig.FilterPeersByRecentIp = false;
+            networkConfig.FilterDiscoveryNodesByRecentIp = false;
+        }, DbMode.Hash);
 
         await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
     }


### PR DESCRIPTION
## Summary

Cherry-pick of #11116 (`68259f6`) onto `release/1.37.0-rc2` with conflict resolution.

- **`FlatWorldStateModule.cs`** — added `ISnapServer → IWorldStateManager` registration and `Nethermind.State.SnapServer` import.
- **`SnapProtocolHandler.cs`** — took PR's non-nullable `ISnapServer` param and `CanServe` property. Dropped the unrelated `ISyncConfig syncConfig` parameter and `SnapMessageLimits.GetTrieNodesPathsPerGroupRlpLimit` assignment — this base lacks `ISyncConfig.SnapServingMaxPathsPerGroup` and the target field is `readonly`.
- **`SnapProtocolHandlerTests.cs`** — pass `NoopSnapServer.Instance`, no `SyncConfig` arg.
- **`FlatSnapServer.cs`** — added `CanServe => true`, kept typed `GetClassLogger<FlatSnapServer>()`.

## Test plan

- [ ] CI green on `release/1.37.0-rc2`
- [ ] `Nethermind.Network` and `Nethermind.State` build clean (verified locally)
- [ ] E2E sync test `HalfPath server ↔ HashDB client` passes