### PR TITLE
fix: clean stale flat storage when contract storage becomes empty

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -353,6 +353,33 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     }
 
     [Test]
+    public void Verify_EmptyStorageRoot_DetectsOrphanedFlatStorage()
+    {
+        Address address = TestItem.AddressA;
+        // Account with EmptyTreeHash storage root (e.g. after self-destruct)
+        Account account = new(1, 0, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
+
+        _stateTree.Set(address, account);
+        _stateTree.Commit();
+        Hash256 stateRoot = _stateTree.RootHash;
+
+        StateId toState = new(1, stateRoot);
+        WriteAccountToFlat(address, account, toState);
+
+        // Inject stale storage entries that should not exist
+        WriteStorageDirectToDb(address, 0, [0x01, 0x15, 0xe8]);
+        WriteStorageDirectToDb(address, 1, [0xab, 0xcd]);
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        FlatTrieVerifier verifier = new(_logManager);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+
+        Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
+        Assert.That(verifier.Stats.MismatchedAccount, Is.EqualTo(0));
+        Assert.That(verifier.Stats.MissingInTrie, Is.EqualTo(2), "Should detect 2 orphaned flat storage entries");
+    }
+
+    [Test]
     public void Verify_MixedScenario_DetectsAllIssues()
     {
         // Account A: in both, matches

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -78,12 +78,4 @@ public class FlatTreeSyncStoreTests
         Assert.That(HasStorageEntries(address), Is.False, "Storage entries should be deleted after EnsureStorageEmpty");
     }
 
-    [Test]
-    public void EnsureStorageEmpty_on_empty_account_is_noop()
-    {
-        Address address = TestItem.AddressA;
-
-        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
-        Assert.DoesNotThrow(() => store.EnsureStorageEmpty(Keccak.Compute(address.Bytes)));
-    }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.State.Flat.Sync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Sync;
+
+[TestFixture]
+public class FlatTreeSyncStoreTests
+{
+    private SnapshotableMemColumnsDb<FlatDbColumns> _columnsDb = null!;
+    private IPersistence _persistence = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
+        _persistence = new RocksDbPersistence(_columnsDb);
+    }
+
+    [TearDown]
+    public void TearDown() => _columnsDb.Dispose();
+
+    private void WriteStorageDirectToDb(Address address, UInt256 slot, byte[] value)
+    {
+        IDb storageDb = _columnsDb.GetColumnDb(FlatDbColumns.Storage);
+        ValueHash256 addrHash = ValueKeccak.Compute(address.Bytes);
+        Span<byte> slotBytes = stackalloc byte[32];
+        slot.ToBigEndian(slotBytes);
+        ValueHash256 slotHash = ValueKeccak.Compute(slotBytes);
+
+        byte[] storageKey = new byte[52];
+        addrHash.Bytes[..4].CopyTo(storageKey.AsSpan()[..4]);
+        slotHash.Bytes.CopyTo(storageKey.AsSpan()[4..36]);
+        addrHash.Bytes[4..20].CopyTo(storageKey.AsSpan()[36..52]);
+
+        storageDb.Set(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros().ToArray());
+    }
+
+    private bool HasStorageEntries(Address address)
+    {
+        IDb storageDb = _columnsDb.GetColumnDb(FlatDbColumns.Storage);
+        ValueHash256 addrHash = ValueKeccak.Compute(address.Bytes);
+        byte[] prefix = addrHash.Bytes[..4].ToArray();
+
+        foreach (byte[] key in storageDb.GetAllKeys())
+        {
+            if (key.AsSpan()[..4].SequenceEqual(prefix))
+                return true;
+        }
+        return false;
+    }
+
+    [Test]
+    public void EnsureStorageEmpty_deletes_all_storage_entries()
+    {
+        Address address = TestItem.AddressA;
+        WriteStorageDirectToDb(address, 0, [0x01, 0x15, 0xe8]);
+        WriteStorageDirectToDb(address, 1, [0xab, 0xcd]);
+        WriteStorageDirectToDb(address, 42, [0xff]);
+
+        Assert.That(HasStorageEntries(address), Is.True, "Storage entries should exist before cleanup");
+
+        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
+        store.EnsureStorageEmpty(Keccak.Compute(address.Bytes));
+
+        Assert.That(HasStorageEntries(address), Is.False, "Storage entries should be deleted after EnsureStorageEmpty");
+    }
+
+    [Test]
+    public void EnsureStorageEmpty_does_not_affect_other_accounts()
+    {
+        Address addressA = TestItem.AddressA;
+        Address addressB = TestItem.AddressB;
+        WriteStorageDirectToDb(addressA, 0, [0x11]);
+        WriteStorageDirectToDb(addressB, 0, [0x22]);
+
+        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
+        store.EnsureStorageEmpty(Keccak.Compute(addressA.Bytes));
+
+        Assert.That(HasStorageEntries(addressA), Is.False, "AddressA storage should be deleted");
+        Assert.That(HasStorageEntries(addressB), Is.True, "AddressB storage should remain");
+    }
+
+    [Test]
+    public void EnsureStorageEmpty_on_empty_account_is_noop()
+    {
+        Address address = TestItem.AddressA;
+
+        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
+        Assert.DoesNotThrow(() => store.EnsureStorageEmpty(Keccak.Compute(address.Bytes)));
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -79,21 +79,6 @@ public class FlatTreeSyncStoreTests
     }
 
     [Test]
-    public void EnsureStorageEmpty_does_not_affect_other_accounts()
-    {
-        Address addressA = TestItem.AddressA;
-        Address addressB = TestItem.AddressB;
-        WriteStorageDirectToDb(addressA, 0, [0x11]);
-        WriteStorageDirectToDb(addressB, 0, [0x22]);
-
-        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
-        store.EnsureStorageEmpty(Keccak.Compute(addressA.Bytes));
-
-        Assert.That(HasStorageEntries(addressA), Is.False, "AddressA storage should be deleted");
-        Assert.That(HasStorageEntries(addressB), Is.True, "AddressB storage should remain");
-    }
-
-    [Test]
     public void EnsureStorageEmpty_on_empty_account_is_noop()
     {
         Address address = TestItem.AddressA;

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -473,6 +473,12 @@ public class FlatTrieVerifier
         IScopedTrieStore trieStore,
         CancellationToken cancellationToken)
     {
+        if (job.StorageRoot == Keccak.EmptyTreeHash)
+        {
+            VerifyEmptyStorage(job, reader);
+            return;
+        }
+
         using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, ValueKeccak.Zero, ValueKeccak.MaxValue);
         IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
         TrieLeafIterator trieIter = new(storageTrieStore, job.StorageRoot, LogTrieNodeException);

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -453,6 +453,20 @@ public class FlatTrieVerifier
         }
     }
 
+    private void VerifyEmptyStorage(StorageVerificationJob job, IPersistence.IPersistenceReader reader)
+    {
+        using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, ValueKeccak.Zero, ValueKeccak.MaxValue);
+        while (flatIter.MoveNext())
+        {
+            if (!IsZeroValue(flatIter.CurrentValue))
+            {
+                Interlocked.Increment(ref _slotCount);
+                Interlocked.Increment(ref _missingInTrie);
+                if (_logger.IsWarn) _logger.Warn($"Orphaned flat storage for empty-root account. Account: {job.FlatAccountKey}, Slot: {flatIter.CurrentKey}");
+            }
+        }
+    }
+
     private void VerifyStorageHashed(
         StorageVerificationJob job,
         IPersistence.IPersistenceReader reader,
@@ -510,6 +524,13 @@ public class FlatTrieVerifier
         IScopedTrieStore trieStore,
         CancellationToken cancellationToken)
     {
+        // Empty storage root — any flat entries are orphans
+        if (job.StorageRoot == Keccak.EmptyTreeHash)
+        {
+            VerifyEmptyStorage(job, reader);
+            return;
+        }
+
         IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
         PatriciaTree storageTree = new(storageTrieStore, _logManager);
 

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -398,7 +398,7 @@ public class FlatTrieVerifier
             if (_logger.IsWarn) _logger.Warn($"Mismatched account. Path: {triePath}. Flat: {flatAccount}, Trie: {trieAccount}");
         }
 
-        if (trieAccount is not null && trieAccount.StorageRoot != Keccak.EmptyTreeHash)
+        if (trieAccount is not null)
         {
             Hash256 fullPath = triePath.Path.ToCommitment();
             StorageVerificationJob job = new(flatKey, fullPath, trieAccount.StorageRoot, isPreimageMode);
@@ -426,7 +426,7 @@ public class FlatTrieVerifier
             if (_logger.IsWarn) _logger.Warn($"Mismatched account. Hash: {trieHash}. Flat: {flatAccount}, Trie: {trieAccount}");
         }
 
-        if (trieAccount is not null && trieAccount.StorageRoot != Keccak.EmptyTreeHash)
+        if (trieAccount is not null)
         {
             Hash256 fullPath = trieHash.ToCommitment();
             StorageVerificationJob job = new(flatKey, fullPath, trieAccount.StorageRoot, true);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -117,6 +117,7 @@ public sealed class SnapshotBundle : IDisposable
             return slotValue?.ToEvmBytes();
         }
 
+        // Self-destructed at the point of the latest change
         if (selfDestructStateIdx == _snapshots.Count + _readOnlySnapshotBundle.SnapshotCount)
         {
             return null;
@@ -132,6 +133,7 @@ public sealed class SnapshotBundle : IDisposable
 
             if (i <= currentBundleSelfDestructIdx)
             {
+                // This is the snapshot with selfdestruct
                 return null;
             }
         }
@@ -321,6 +323,9 @@ public sealed class SnapshotBundle : IDisposable
 
     public void SetChangedSlot(Address address, in UInt256 index, byte[] value)
     {
+        // So right now, if the value is zero, then it is a deletion. This is not the case with verkle where you
+        // can set a value to be zero. Because of this distinction, the zerobytes logic is handled here instead of
+        // lower down.
         HashedKey<(Address, UInt256)> key = new((address, index));
         if (value is null || Bytes.AreEqual(value, StorageTree.ZeroBytes))
         {
@@ -338,6 +343,8 @@ public sealed class SnapshotBundle : IDisposable
         GuardDispose();
 
         Account? account = DoGetAccount(address, excludeChanged: true);
+        // So... a clear is always sent even on a new account. This makes is a minor optimization as
+        // it skips persistence, but probably need to make sure it does not send it at all in the first place.
         bool isNewAccount = account == null || account.StorageRoot == Keccak.EmptyTreeHash;
 
         _selfDestructedAccountAddresses.TryAdd(address, isNewAccount);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -117,7 +117,6 @@ public sealed class SnapshotBundle : IDisposable
             return slotValue?.ToEvmBytes();
         }
 
-        // Self-destructed at the point of the latest change
         if (selfDestructStateIdx == _snapshots.Count + _readOnlySnapshotBundle.SnapshotCount)
         {
             return null;
@@ -133,7 +132,6 @@ public sealed class SnapshotBundle : IDisposable
 
             if (i <= currentBundleSelfDestructIdx)
             {
-                // This is the snapshot with selfdestruct
                 return null;
             }
         }
@@ -323,9 +321,6 @@ public sealed class SnapshotBundle : IDisposable
 
     public void SetChangedSlot(Address address, in UInt256 index, byte[] value)
     {
-        // So right now, if the value is zero, then it is a deletion. This is not the case with verkle where you
-        // can set a value to be zero. Because of this distinction, the zerobytes logic is handled here instead of
-        // lower down.
         HashedKey<(Address, UInt256)> key = new((address, index));
         if (value is null || Bytes.AreEqual(value, StorageTree.ZeroBytes))
         {
@@ -343,8 +338,6 @@ public sealed class SnapshotBundle : IDisposable
         GuardDispose();
 
         Account? account = DoGetAccount(address, excludeChanged: true);
-        // So... a clear is always sent even on a new account. This makes is a minor optimization as
-        // it skips persistence, but probably need to make sure it does not send it at all in the first place.
         bool isNewAccount = account == null || account.StorageRoot == Keccak.EmptyTreeHash;
 
         _selfDestructedAccountAddresses.TryAdd(address, isNewAccount);

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -222,6 +222,14 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
     private static DeletionRange ComputeSubtreeRangeForNibble(TreePath path, int from, int to) =>
         new(path.Append(from).ToLowerBoundPath(), path.Append(to).ToUpperBoundPath());
 
+    public void EnsureStorageEmpty(Hash256 address)
+    {
+        using IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
+        ValueHash256 addressHash = address.ValueHash256;
+        writeBatch.DeleteStorageRange(addressHash, ValueKeccak.Zero, ValueKeccak.MaxValue);
+        writeBatch.DeleteStorageTrieNodeRange(addressHash, new TreePath(ValueKeccak.Zero, 64), new TreePath(ValueKeccak.MaxValue, 64));
+    }
+
     public void FinalizeSync(BlockHeader pivotHeader)
     {
         if (Interlocked.CompareExchange(ref _wasFinalized, true, false)) throw new InvalidOperationException("Db was finalized");

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -224,10 +224,12 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
 
     public void EnsureStorageEmpty(Hash256 address)
     {
+        // Only need to clean flat storage entries. Orphaned storage trie nodes are not a problem
+        // because the trie is always traversed from the account's storage root hash — if the root
+        // is EmptyTreeHash, no storage trie nodes will ever be reached.
         using IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
         ValueHash256 addressHash = address.ValueHash256;
         writeBatch.DeleteStorageRange(addressHash, ValueKeccak.Zero, ValueKeccak.MaxValue);
-        writeBatch.DeleteStorageTrieNodeRange(addressHash, new TreePath(ValueKeccak.Zero, 64), new TreePath(ValueKeccak.MaxValue, 64));
     }
 
     public void FinalizeSync(BlockHeader pivotHeader)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ using Nethermind.State;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
+using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
@@ -451,7 +453,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
         [Test]
         [Repeat(TestRepeatCount)]
-        public async Task RepairEmptyStorageRoot_does_not_hang()
+        public async Task RepairEmptyStorageRoot_calls_EnsureStorageEmpty()
         {
             RemoteDbContext remote = new(_logManager);
 
@@ -461,7 +463,13 @@ namespace Nethermind.Synchronization.Test.FastSync
             state.Set(TestItem.KeccakB, Build.An.Account.WithNonce(2).TestObject);
             state.Commit();
 
-            await using IContainer container = PrepareDownloader(remote);
+            List<Hash256> clearedAddresses = new();
+
+            await using IContainer container = PrepareDownloader(remote, configureBuilder: builder =>
+            {
+                builder.AddDecorator<ITreeSyncStore>((ctx, inner) =>
+                    new TrackingTreeSyncStore(inner, clearedAddresses));
+            });
             IStateSyncTestOperation local = container.Resolve<IStateSyncTestOperation>();
 
             local.SetAccountsAndCommit(
@@ -478,6 +486,16 @@ namespace Nethermind.Synchronization.Test.FastSync
             await ActivateAndWait(ctx);
 
             local.CompareTrees(remote, _logger, "END");
+            clearedAddresses.Should().Contain(TestItem.KeccakA, "EnsureStorageEmpty should be called for account with empty storage root in UpdatedStorages");
+        }
+
+        private class TrackingTreeSyncStore(ITreeSyncStore inner, List<Hash256> clearedAddresses) : ITreeSyncStore
+        {
+            public bool NodeExists(Hash256? address, in TreePath path, in ValueHash256 hash) => inner.NodeExists(address, path, hash);
+            public void SaveNode(Hash256? address, in TreePath path, in ValueHash256 hash, ReadOnlySpan<byte> data) => inner.SaveNode(address, path, hash, data);
+            public void EnsureStorageEmpty(Hash256 address) { clearedAddresses.Add(address); inner.EnsureStorageEmpty(address); }
+            public void FinalizeSync(BlockHeader pivotHeader) => inner.FinalizeSync(pivotHeader);
+            public ITreeSyncVerificationContext CreateVerificationContext(byte[] rootNodeData) => inner.CreateVerificationContext(rootNodeData);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -451,6 +451,37 @@ namespace Nethermind.Synchronization.Test.FastSync
 
         [Test]
         [Repeat(TestRepeatCount)]
+        public async Task RepairEmptyStorageRoot_does_not_hang()
+        {
+            RemoteDbContext remote = new(_logManager);
+
+            // Account with EmptyTreeHash storage root (storage was cleared on-chain)
+            StateTree state = remote.StateTree;
+            state.Set(TestItem.KeccakA, Build.An.Account.WithNonce(1).TestObject); // No storage
+            state.Set(TestItem.KeccakB, Build.An.Account.WithNonce(2).TestObject);
+            state.Commit();
+
+            await using IContainer container = PrepareDownloader(remote);
+            IStateSyncTestOperation local = container.Resolve<IStateSyncTestOperation>();
+
+            local.SetAccountsAndCommit(
+                (TestItem.KeccakA, Build.An.Account.WithNonce(1).TestObject),
+                (TestItem.KeccakB, Build.An.Account.WithNonce(2).TestObject));
+
+            local.DeleteStateRoot();
+
+            // Simulate snap sync detecting that this account's storage changed
+            // Even though final state has empty storage, VerifyStorageUpdated must handle it
+            container.Resolve<StateSyncPivot>().UpdatedStorages.Add(TestItem.KeccakA);
+
+            SafeContext ctx = container.Resolve<SafeContext>();
+            await ActivateAndWait(ctx);
+
+            local.CompareTrees(remote, _logger, "END");
+        }
+
+        [Test]
+        [Repeat(TestRepeatCount)]
         [CancelAfter(10000)]
         public async Task Pending_items_cache_mechanism_works_across_root_changes(CancellationToken cancellation)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -75,7 +75,7 @@ public abstract class StateSyncFeedTestsBase(
         return remoteStorageTree;
     }
 
-    protected IContainer PrepareDownloader(RemoteDbContext remote, Action<SyncPeerMock>? mockMutator = null, int syncDispatcherAllocateTimeoutMs = 10)
+    protected IContainer PrepareDownloader(RemoteDbContext remote, Action<SyncPeerMock>? mockMutator = null, int syncDispatcherAllocateTimeoutMs = 10, Action<ContainerBuilder>? configureBuilder = null)
     {
         SyncPeerMock[] syncPeers = new SyncPeerMock[defaultPeerCount];
         for (int i = 0; i < defaultPeerCount; i++)
@@ -91,6 +91,8 @@ public abstract class StateSyncFeedTestsBase(
 
         ContainerBuilder builder = BuildTestContainerBuilder(remote, syncDispatcherAllocateTimeoutMs)
             .AddSingleton<SyncPeerMock[]>(syncPeers);
+
+        configureBuilder?.Invoke(builder);
 
         builder.RegisterBuildCallback((ctx) =>
         {

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/ITreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/ITreeSyncStore.cs
@@ -30,6 +30,12 @@ public interface ITreeSyncStore
     void SaveNode(Hash256? address, in TreePath path, in ValueHash256 hash, ReadOnlySpan<byte> data);
 
     /// <summary>
+    /// Ensure all storage entries for the given address are deleted.
+    /// Called when an account's storage root is EmptyTreeHash (e.g. after self-destruct).
+    /// </summary>
+    void EnsureStorageEmpty(Hash256 address);
+
+    /// <summary>
     /// Called when sync is complete and state should be finalized and flushed.
     /// </summary>
     /// <param name="pivotHeader">The block header containing the synced state root.</param>

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/PatriciaTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/PatriciaTreeSyncStore.cs
@@ -19,6 +19,8 @@ public class PatriciaTreeSyncStore(INodeStorage nodeStorage, ILogManager logMana
     public void SaveNode(Hash256? address, in TreePath path, in ValueHash256 hash, ReadOnlySpan<byte> data) =>
         nodeStorage.Set(address, path, hash, data);
 
+    public void EnsureStorageEmpty(Hash256 address) { }
+
     public void FinalizeSync(BlockHeader pivotHeader) =>
         // Patricia trie doesn't need block header info, just flush
         nodeStorage.Flush(onlyWal: false);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -752,10 +752,16 @@ namespace Nethermind.Synchronization.FastSync
             {
                 Account? account = verificationContext.GetAccount(updatedAddress);
 
-                if (account?.StorageRoot is not null
+                if (account?.StorageRoot is not null && account.StorageRoot != Keccak.EmptyTreeHash
                     && AddNodeToPending(new StateSyncItem(account.StorageRoot, updatedAddress, TreePath.Empty, NodeDataType.Storage), dependentItem, "incomplete storage") == AddNodeResult.Added)
                 {
                     if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} missing correct storage root {account.StorageRoot}");
+                }
+                else if (account?.StorageRoot == Keccak.EmptyTreeHash)
+                {
+                    if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} is empty, ensuring flat storage cleared");
+                    _store.EnsureStorageEmpty(updatedAddress);
+                    dependentItem.Counter--;
                 }
                 else
                 {
@@ -979,6 +985,9 @@ namespace Nethermind.Synchronization.FastSync
                         }
                         else
                         {
+                            TreePath finalPath = currentStateSyncItem.Path.Append(trieNode.Key);
+                            Hash256 address = finalPath.Path.ToCommitment();
+                            _store.EnsureStorageEmpty(address);
                             dependentItem.Counter--;
                         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -752,16 +752,16 @@ namespace Nethermind.Synchronization.FastSync
             {
                 Account? account = verificationContext.GetAccount(updatedAddress);
 
-                if (account?.StorageRoot is not null && account.StorageRoot != Keccak.EmptyTreeHash
-                    && AddNodeToPending(new StateSyncItem(account.StorageRoot, updatedAddress, TreePath.Empty, NodeDataType.Storage), dependentItem, "incomplete storage") == AddNodeResult.Added)
-                {
-                    if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} missing correct storage root {account.StorageRoot}");
-                }
-                else if (account?.StorageRoot == Keccak.EmptyTreeHash)
+                if (account?.StorageRoot == Keccak.EmptyTreeHash)
                 {
                     if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} is empty, ensuring flat storage cleared");
                     _store.EnsureStorageEmpty(updatedAddress);
                     dependentItem.Counter--;
+                }
+                else if (account?.StorageRoot is not null
+                    && AddNodeToPending(new StateSyncItem(account.StorageRoot, updatedAddress, TreePath.Empty, NodeDataType.Storage), dependentItem, "incomplete storage") == AddNodeResult.Added)
+                {
+                    if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} missing correct storage root {account.StorageRoot}");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Fixes edge case where a contract's storage becomes empty during sync (e.g. all slots deleted between snap sync and healing phase). The stale flat storage entries from the initial download are not cleaned up, causing invalid blocks when block processing reads stale data while the trie says storage is empty. The flat trie verifier also fails to detect this, giving a false pass.

## Root cause

During snap sync, a contract's storage is downloaded. Between snap sync and the healing phase, the contract's storage root changes to `EmptyTreeHash` (all slots were deleted on-chain). During healing:
- TreeSync sees the account leaf with `EmptyTreeHash` storage root and skips storage sync (no nodes to download)
- FlatTreeSyncStore never gets a chance to delete the stale flat storage entries from the initial snap download
- The flat trie verifier skips verification for empty-root accounts entirely, so the corruption is not detected even when running verify trie

## Changes

- **ITreeSyncStore.EnsureStorageEmpty**: New method to delete all flat storage + trie nodes for an address (no-op for Patricia)
- **TreeSync.HandleTrieNode**: Call `EnsureStorageEmpty` when account leaf has empty storage root
- **TreeSync.VerifyStorageUpdated**: Filter `EmptyTreeHash` and call `EnsureStorageEmpty` for empty-root accounts detected during snap sync refresh
- **FlatTrieVerifier**: Verify storage for all accounts including empty-root ones, detecting orphaned flat entries. Add `VerifyEmptyStorage` for preimage mode compatibility

## Test plan

- [x] Unit test: `FlatTreeSyncStore.EnsureStorageEmpty` deletes storage entries correctly
- [x] Unit test: `FlatTrieVerifier` detects orphaned storage on empty-root accounts
- [x] E2E sync tests pass (32 tests, 0 failures)
- [x] Mainned Snap Synced with Flat