### PR TITLE
fix: dispose SnappyStream in PayloadByNumberProtocol

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadByNumberProtocol.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadByNumberProtocol.cs
@@ -104,6 +104,7 @@ public class PayloadByNumberProtocol(
         }
         finally
         {
+            decompressor?.Dispose();
             ArrayPool<byte>.Shared.Return(buffer);
         }
     }

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadByNumberProtocol.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadByNumberProtocol.cs
@@ -72,7 +72,7 @@ public class PayloadByNumberProtocol(
             return null;
         }
 
-        Stream? decompressor = await ReadPayloadData(downChannel);
+        using Stream? decompressor = await ReadPayloadData(downChannel);
 
         if (decompressor is null)
         {
@@ -104,7 +104,6 @@ public class PayloadByNumberProtocol(
         }
         finally
         {
-            decompressor?.Dispose();
             ArrayPool<byte>.Shared.Return(buffer);
         }
     }


### PR DESCRIPTION
## Changes

- Dispose the `SnappyStream` returned by `ReadPayloadData` in `PayloadByNumberProtocol.DialAsync`
- Keep the decompressor cleanup in the existing `finally` block next to the pooled buffer return
- Prevent repeated payload requests from leaving decompression streams undisposed on the happy path or on exceptions

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No