### PR TITLE
feat: append DB layout to public client ID version

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/ProductInfoTest.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ProductInfoTest.cs
@@ -8,7 +8,11 @@ namespace Nethermind.Core.Test;
 public class ProductInfoTest
 {
     [TearDown]
-    public void TearDown() => ProductInfo.InitializePublicClientId(ProductInfo.DefaultPublicClientIdFormat);
+    public void TearDown()
+    {
+        ProductInfo.VersionPostfix = "";
+        ProductInfo.InitializePublicClientId(ProductInfo.DefaultPublicClientIdFormat);
+    }
 
     [Test]
     public void Public_client_id_template_properly_initialized()
@@ -38,4 +42,17 @@ public class ProductInfoTest
 
     [Test]
     public void Public_client_id_not_initialized_returns_the_default_client_id() => Assert.That(ProductInfo.PublicClientId, Is.EqualTo(ProductInfo.ClientId));
+
+    [TestCase("-halfpath", "Nethermind/v{0}-halfpath/{1}/dotnet{2}")]
+    [TestCase("-hash", "Nethermind/v{0}-hash/{1}/dotnet{2}")]
+    [TestCase("", "Nethermind/v{0}/{1}/dotnet{2}")]
+    public void Version_postfix_appended_after_version(string postfix, string expectedTemplate)
+    {
+        ProductInfo.VersionPostfix = postfix;
+        ProductInfo.InitializePublicClientId(ProductInfo.DefaultPublicClientIdFormat);
+
+        string os = $"{ProductInfo.OS.ToLowerInvariant()}-{ProductInfo.OSArchitecture}";
+        string expected = string.Format(expectedTemplate, ProductInfo.Version, os, ProductInfo.Runtime[5..]);
+        Assert.That(ProductInfo.PublicClientId, Is.EqualTo(expected));
+    }
 }

--- a/src/Nethermind/Nethermind.Core/ProductInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ProductInfo.cs
@@ -43,6 +43,7 @@ public static class ProductInfo
         {
             { "name", Name },
             { "version", $"v{Version}" },
+            { "versionPostfix", "" },
             { "os", $"{OS.ToLowerInvariant()}-{OSArchitecture}" },
             { "runtime", $"dotnet{Runtime[5..]}" }
         };
@@ -85,6 +86,12 @@ public static class ProductInfo
 
     public static string Version { get; }
 
+    public static string VersionPostfix
+    {
+        get => ClientIdParts["versionPostfix"];
+        set => ClientIdParts["versionPostfix"] = value;
+    }
+
     public static string Network { get; set; } = string.Empty;
 
     public static string Instance { get; set; } = string.Empty;
@@ -97,7 +104,7 @@ public static class ProductInfo
 
     public static string PublicClientId { get; private set; }
 
-    public const string DefaultPublicClientIdFormat = "{name}/{version}/{os}/{runtime}";
+    public const string DefaultPublicClientIdFormat = "{name}/{version}{versionPostfix}/{os}/{runtime}";
 
     public static void InitializePublicClientId(string formatString) =>
         PublicClientId = FormatClientId(formatString);

--- a/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
@@ -65,6 +65,7 @@ public class MonitoringModule(IMetricsConfig metricsConfig, IInitConfig initConf
 
         ProductInfo.PruningMode = pruningConfig.Mode.ToString();
 
+        bool isArchive = pruningConfig.Mode == PruningMode.None;
         ProductInfo.VersionPostfix = flatDbConfig.Enabled
             ? flatDbConfig.Layout switch
             {
@@ -75,8 +76,8 @@ public class MonitoringModule(IMetricsConfig metricsConfig, IInitConfig initConf
             }
             : initConfig.StateDbKeyScheme switch
             {
-                INodeStorage.KeyScheme.Hash => "-hash",
-                INodeStorage.KeyScheme.HalfPath => "-halfpath",
+                INodeStorage.KeyScheme.Hash => isArchive ? "-hashArchive" : "-hash",
+                INodeStorage.KeyScheme.HalfPath => isArchive ? "-halfpathArchive" : "-halfpath",
                 _ => ""
             };
 

--- a/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
@@ -15,8 +15,8 @@ using Nethermind.Logging;
 using Nethermind.Monitoring;
 using Nethermind.Monitoring.Config;
 using Nethermind.Monitoring.Metrics;
+using Nethermind.Api;
 using Nethermind.Serialization.Rlp;
-using Nethermind.Trie;
 
 namespace Nethermind.Init.Modules;
 

--- a/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Autofac;
 using DotNetty.Buffers;
+using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -16,10 +17,11 @@ using Nethermind.Monitoring;
 using Nethermind.Monitoring.Config;
 using Nethermind.Monitoring.Metrics;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Trie;
 
 namespace Nethermind.Init.Modules;
 
-public class MonitoringModule(IMetricsConfig metricsConfig) : Module
+public class MonitoringModule(IMetricsConfig metricsConfig, IInitConfig initConfig, IFlatDbConfig flatDbConfig) : Module
 {
     protected override void Load(ContainerBuilder builder)
     {
@@ -62,6 +64,22 @@ public class MonitoringModule(IMetricsConfig metricsConfig) : Module
 
 
         ProductInfo.PruningMode = pruningConfig.Mode.ToString();
+
+        ProductInfo.VersionPostfix = flatDbConfig.Enabled
+            ? flatDbConfig.Layout switch
+            {
+                FlatLayout.Flat => "-flat",
+                FlatLayout.FlatInTrie => "-flatInTrie",
+                FlatLayout.PreimageFlat => "-preimageFlat",
+                _ => ""
+            }
+            : initConfig.StateDbKeyScheme switch
+            {
+                INodeStorage.KeyScheme.Hash => "-hash",
+                INodeStorage.KeyScheme.HalfPath => "-halfpath",
+                _ => ""
+            };
+
         Metrics.Version = VersionToMetrics.ConvertToNumber(ProductInfo.Version);
 
         IMetricsController controller = new MetricsController(metricsConfig);

--- a/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MonitoringModule.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Autofac;
 using DotNetty.Buffers;
-using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Specs;

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -59,7 +59,10 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             .AddSource(new ConfigRegistrationSource())
             .AddModule(new BlockProcessingModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BlockTreeModule(configProvider.GetConfig<IReceiptConfig>(), configProvider.GetConfig<ILogIndexConfig>()))
-            .AddModule(new MonitoringModule(configProvider.GetConfig<IMetricsConfig>()))
+            .AddModule(new MonitoringModule(
+                configProvider.GetConfig<IMetricsConfig>(),
+                configProvider.GetConfig<IInitConfig>(),
+                configProvider.GetConfig<IFlatDbConfig>()))
             .AddSingleton<ISpecProvider, ChainSpecBasedSpecProvider>()
 
             .AddKeyedSingleton<IProtectedPrivateKey>(IProtectedPrivateKey.NodeKey, (ctx) => ctx.Resolve<INethermindApi>().NodeKey!)


### PR DESCRIPTION
## Changes

- Adds `VersionPostfix` to `ProductInfo` backed by `ClientIdParts`, appended after the version segment in the public client ID format (`{name}/{version}{versionPostfix}/{os}/{runtime}`)
- `MonitoringModule` derives the postfix from config at startup (no DB detection, avoids init order issues):
  - Flat DB enabled: `-flat` / `-flatInTrie` / `-preimageFlat`
  - HalfPath scheme: `-halfpath` / `-halfpathArchive` (when `PruningMode.None`)
  - Hash scheme: `-hash` / `-hashArchive` (when `PruningMode.None`)
  - Default (`Current`): no postfix — existing behavior unchanged

**Examples:** `Nethermind/v1.30.0+a-halfpath/linux-x64/dotnet8.0.0`, `Nethermind/v1.30.0+a-hashArchive/linux-x64/dotnet8.0.0`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [x] Added parameterized unit tests for `VersionPostfix` in `ProductInfoTest`
- [ ] Verify `web3_clientVersion` returns the correct postfix on a running node with different configs

🤖 This PR was created with [Claude Code](https://claude.ai/claude-code)