### PR TITLE
feat(analyzers): add NETH002 to detect excessively deep lambda indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -106,4 +106,5 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true
 dotnet_diagnostic.CA1507.severity = warning
 dotnet_diagnostic.CA1510.severity = warning
 dotnet_diagnostic.CA2208.severity = suggestion
+dotnet_diagnostic.NETH002.severity = error
 

--- a/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Nethermind.Analyzers.Test;
+
+public class LambdaIndentationAnalyzerTests
+{
+    // MaxIndentOffset = 24: body column - statement column must exceed 24 to trigger.
+    // Tests run at column 0 base, so a statement at col 4 needs body at col 29+ to fire.
+
+    [Test]
+    public async Task Deep_aligned_lambda_body_reports_diagnostic()
+    {
+        // The `{` opening the lambda block is at column 33 (0-based), statement starts at col 4.
+        // Offset = 29 > 24 → fires.
+        string source = """
+            using System.Linq;
+            class C
+            {
+                void M(int[] data)
+                {
+                    _ = data.Select(x =>
+                                             {|#0:{|}
+                                                 return x * 2;
+                                             });
+                }
+            }
+            """;
+
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "25", "24"));
+    }
+
+    [TestCase(
+        // Normal indent: body `{` sits one extra level past the statement
+        """
+        using System.Linq;
+        class C
+        {
+            void M(int[] data)
+            {
+                _ = data.Select(x =>
+                {
+                    return x * 2;
+                });
+            }
+        }
+        """,
+        TestName = "Normal_indented_lambda_no_diagnostic")]
+    [TestCase(
+        // Single-line lambda: arrow and body on the same line — never fires
+        """
+        using System.Linq;
+        class C
+        {
+            void M(int[] data)
+            {
+                _ = data.Select(x => x * 2);
+            }
+        }
+        """,
+        TestName = "Single_line_lambda_no_diagnostic")]
+    [TestCase(
+        // Expression body (not block), multi-line but normal depth
+        """
+        using System.Linq;
+        class C
+        {
+            void M(int[] data)
+            {
+                _ = data.Select(x =>
+                    x * 2);
+            }
+        }
+        """,
+        TestName = "Expression_body_normal_depth_no_diagnostic")]
+    public async Task No_diagnostic(string source) => await Verify(source);
+
+    private static DiagnosticResult Diagnostic() =>
+        CSharpAnalyzerVerifier<LambdaIndentationAnalyzer, DefaultVerifier>
+            .Diagnostic(LambdaIndentationAnalyzer.DiagnosticId);
+
+    private static async Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<LambdaIndentationAnalyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+}

--- a/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
@@ -10,14 +10,13 @@ namespace Nethermind.Analyzers.Test;
 
 public class LambdaIndentationAnalyzerTests
 {
-    // MaxIndentOffset = 24: body column - statement column must exceed 24 to trigger.
-    // Tests run at column 0 base, so a statement at col 4 needs body at col 29+ to fire.
+    // MaxIndentOffset = 4: body column - arrow-line first-token column must exceed 4 to trigger.
 
     [Test]
     public async Task Deep_aligned_lambda_body_reports_diagnostic()
     {
-        // The `{` opening the lambda block is at column 33 (0-based), statement starts at col 4.
-        // Offset = 29 > 24 → fires.
+        // The `{` opening the lambda block is at column 33 (0-based), arrow line starts at col 8.
+        // Offset = 25 > 4 → fires.
         string source = """
             using System.Linq;
             class C
@@ -28,6 +27,68 @@ public class LambdaIndentationAnalyzerTests
                                              {|#0:{|}
                                                  return x * 2;
                                              });
+                }
+            }
+            """;
+
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "25", "4"));
+    }
+
+    [Test]
+    public async Task Arrow_on_own_line_deep_body_reports_diagnostic()
+    {
+        // Arrow `=>` wraps to its own line at col 12. Body `{` at col 33. Offset = 33 - 12 = 21 > 4 → fires.
+        string source = """
+            using System.Linq;
+            class C
+            {
+                void M(int[] data)
+                {
+                    _ = data.Select(x
+                        =>
+                                             {|#0:{|}
+                                                 return x * 2;
+                                             });
+                }
+            }
+            """;
+
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "21", "4"));
+    }
+
+    [Test]
+    public async Task Nested_lambda_deep_body_reports_diagnostic()
+    {
+        // Inner lambda body at col 33, arrow line first token `_` at col 8. Offset = 25 > 4 → fires.
+        string source = """
+            using System.Linq;
+            class C
+            {
+                void M(int[][] data)
+                {
+                    _ = data.Select(xs => xs.Select(x =>
+                                             {|#0:{|}
+                                                 return x * 2;
+                                             }));
+                }
+            }
+            """;
+
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "25", "4"));
+    }
+
+    [Test]
+    public async Task Expression_body_too_deep_reports_diagnostic()
+    {
+        // Expression body (no block) at col 33, arrow line starts at col 8. Offset = 25 > 4 → fires.
+        string source = """
+            using System.Linq;
+            class C
+            {
+                void M(int[] data)
+                {
+                    _ = data.Select(x =>
+                                             {|#0:x|} * 2);
                 }
             }
             """;
@@ -78,6 +139,23 @@ public class LambdaIndentationAnalyzerTests
         }
         """,
         TestName = "Expression_body_normal_depth_no_diagnostic")]
+    [TestCase(
+        // Arrow on its own line, body at normal depth
+        """
+        using System.Linq;
+        class C
+        {
+            void M(int[] data)
+            {
+                _ = data.Select(x
+                    =>
+                    {
+                        return x * 2;
+                    });
+            }
+        }
+        """,
+        TestName = "Arrow_on_own_line_normal_depth_no_diagnostic")]
     public async Task No_diagnostic(string source) => await Verify(source);
 
     private static DiagnosticResult Diagnostic() =>

--- a/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Analyzers.Test/LambdaIndentationAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class LambdaIndentationAnalyzerTests
             }
             """;
 
-        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "25", "24"));
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("33", "25", "4"));
     }
 
     [TestCase(

--- a/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,4 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 NETH001 | Usage | Warning | Local variable assigned from new expression is never read. Remove or use discard. Suppressed by [ConstructorWithSideEffect].
-NETH002 | Style | Warning | Multi-line lambda body is indented more than 24 columns past its containing statement. Extract to a local function or variable.
+NETH002 | Style | Warning | Multi-line lambda body is indented more than 4 columns past the arrow line. Reindent to use normal block indentation.

--- a/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 NETH001 | Usage | Warning | Local variable assigned from new expression is never read. Remove or use discard. Suppressed by [ConstructorWithSideEffect].
+NETH002 | Style | Warning | Multi-line lambda body is indented more than 24 columns past its containing statement. Extract to a local function or variable.

--- a/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
@@ -21,7 +21,7 @@ public sealed class LambdaIndentationAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "NETH002";
 
     /// <summary>Maximum allowed column offset of the lambda body relative to its containing statement.</summary>
-    public const int MaxIndentOffset = 24;
+    public const int MaxIndentOffset = 4;
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
@@ -59,21 +59,30 @@ public sealed class LambdaIndentationAnalyzer : DiagnosticAnalyzer
 
         int bodyColumn = bodyFirstToken.GetLocation().GetLineSpan().StartLinePosition.Character;
 
-        // Walk up to the nearest statement or member declaration to get the baseline column
-        SyntaxNode? container = lambda.Parent;
-        while (container is not null
-               && container is not StatementSyntax
-               && container is not MemberDeclarationSyntax
-               && container is not AccessorDeclarationSyntax)
+        // Baseline: indentation of the line that contains the lambda arrow (=>).
+        // This correctly handles fluent chains where the lambda is already indented
+        // several levels — we only care about depth relative to that line, not the
+        // outermost statement or member declaration.
+        FileLinePositionSpan arrowSpan = lambda.ArrowToken.GetLocation().GetLineSpan();
+        SyntaxToken arrowLineFirstToken = lambda.ArrowToken.GetPreviousToken();
+        // Walk back to find the first token on the same line as the arrow
+        while (arrowLineFirstToken != default
+               && arrowLineFirstToken.GetLocation().GetLineSpan().StartLinePosition.Line
+                  == arrowSpan.StartLinePosition.Line)
         {
-            container = container.Parent;
+            SyntaxToken prev = arrowLineFirstToken.GetPreviousToken();
+            if (prev == default
+                || prev.GetLocation().GetLineSpan().StartLinePosition.Line
+                   != arrowSpan.StartLinePosition.Line)
+                break;
+            arrowLineFirstToken = prev;
         }
 
-        if (container is null)
-            return;
+        int arrowLineColumn = arrowLineFirstToken == default
+            ? 0
+            : arrowLineFirstToken.GetLocation().GetLineSpan().StartLinePosition.Character;
 
-        int containerColumn = container.GetFirstToken().GetLocation().GetLineSpan().StartLinePosition.Character;
-        int offset = bodyColumn - containerColumn;
+        int offset = bodyColumn - arrowLineColumn;
 
         if (offset > MaxIndentOffset)
         {

--- a/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Nethermind.Analyzers;
+
+/// <summary>
+/// Reports multi-line lambda expressions whose body is indented so far to the right
+/// (due to Roslyn aligning it to the opening parenthesis of the enclosing call) that
+/// readability suffers. The fix is to extract the body to a local function or a
+/// separately-declared variable.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LambdaIndentationAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NETH002";
+
+    /// <summary>Maximum allowed column offset of the lambda body relative to its containing statement.</summary>
+    public const int MaxIndentOffset = 24;
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        title: "Lambda body is excessively deep",
+        messageFormat: "Lambda body starts at column {0}, which is {1} columns past the containing statement (max {2}). Reindent the lambda body to use normal block indentation.",
+        category: "Style",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A multi-line lambda body is indented so far right that it hurts readability. " +
+                     "This usually happens when Roslyn aligns the body to the opening parenthesis of " +
+                     "the enclosing method call. Reindent the lambda body manually to use normal block indentation.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            Analyze,
+            SyntaxKind.SimpleLambdaExpression,
+            SyntaxKind.ParenthesizedLambdaExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        LambdaExpressionSyntax lambda = (LambdaExpressionSyntax)context.Node;
+
+        SyntaxToken bodyFirstToken = lambda.Body.GetFirstToken();
+
+        // Only flag multi-line lambdas: body must start on a different line than the arrow
+        if (lambda.ArrowToken.GetLocation().GetLineSpan().EndLinePosition.Line
+            == bodyFirstToken.GetLocation().GetLineSpan().StartLinePosition.Line)
+            return;
+
+        int bodyColumn = bodyFirstToken.GetLocation().GetLineSpan().StartLinePosition.Character;
+
+        // Walk up to the nearest statement or member declaration to get the baseline column
+        SyntaxNode? container = lambda.Parent;
+        while (container is not null
+               && container is not StatementSyntax
+               && container is not MemberDeclarationSyntax
+               && container is not AccessorDeclarationSyntax)
+        {
+            container = container.Parent;
+        }
+
+        if (container is null)
+            return;
+
+        int containerColumn = container.GetFirstToken().GetLocation().GetLineSpan().StartLinePosition.Character;
+        int offset = bodyColumn - containerColumn;
+
+        if (offset > MaxIndentOffset)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, bodyFirstToken.GetLocation(), bodyColumn, offset, MaxIndentOffset));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
@@ -78,8 +78,12 @@ public sealed class LambdaIndentationAnalyzer : DiagnosticAnalyzer
             arrowLineFirstToken = prev;
         }
 
+        // If the arrow is the first token on its line, the walk-back lands on the
+        // previous line. Fall back to the arrow token's own column in that case.
         int arrowLineColumn = arrowLineFirstToken == default
-            ? 0
+            || arrowLineFirstToken.GetLocation().GetLineSpan().StartLinePosition.Line
+               != arrowSpan.StartLinePosition.Line
+            ? arrowSpan.StartLinePosition.Character
             : arrowLineFirstToken.GetLocation().GetLineSpan().StartLinePosition.Character;
 
         int offset = bodyColumn - arrowLineColumn;

--- a/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Analyzers/LambdaIndentationAnalyzer.cs
@@ -12,8 +12,8 @@ namespace Nethermind.Analyzers;
 /// <summary>
 /// Reports multi-line lambda expressions whose body is indented so far to the right
 /// (due to Roslyn aligning it to the opening parenthesis of the enclosing call) that
-/// readability suffers. The fix is to extract the body to a local function or a
-/// separately-declared variable.
+/// readability suffers. The fix is to reindent the lambda body to use normal block
+/// indentation.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class LambdaIndentationAnalyzer : DiagnosticAnalyzer

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
@@ -29,10 +29,10 @@ public class BadBlockStore(IDb blockDb, long maxSize) : IBadBlockStore
     }
 
     public IEnumerable<Block> GetAll() => blockDb.GetAllValues(true).Select(bytes =>
-                                               {
-                                                   Rlp.ValueDecoderContext ctx = ((byte[]?)bytes ?? []).AsRlpValueContext();
-                                                   return _blockDecoder.Decode(ref ctx);
-                                               });
+    {
+        Rlp.ValueDecoderContext ctx = ((byte[]?)bytes ?? []).AsRlpValueContext();
+        return _blockDecoder.Decode(ref ctx);
+    });
 
     private void TruncateToMaxSize()
     {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaGasLimitOverrideFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/AuRaGasLimitOverrideFactory.cs
@@ -32,11 +32,11 @@ public class AuRaGasLimitOverrideFactory(
         {
             AuRaContractGasLimitOverride gasLimitCalculator = new(
                 blockGasLimitContractTransitions.Select(blockGasLimitContractTransition =>
-                        new BlockGasLimitContract(
-                            abiEncoder,
-                            blockGasLimitContractTransition.Value,
-                            blockGasLimitContractTransition.Key,
-                            envFactory.Create()))
+                    new BlockGasLimitContract(
+                        abiEncoder,
+                        blockGasLimitContractTransition.Value,
+                        blockGasLimitContractTransition.Key,
+                        envFactory.Create()))
                     .ToArray<IBlockGasLimitContract>(),
                 gasLimitOverrideCache,
                 auraConfig.Minimum2MlnGasPerBlockWhenUsingBlockGasLimitContract,

--- a/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
+++ b/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
@@ -73,7 +73,7 @@ public static class TypeDiscovery
             LoadOnce(loadedAssemblies, considered);
 
             foreach (KeyValuePair<string, Assembly> kv in considered.Where(static kv =>
-                         kv.Key.StartsWith("Nethermind") || (_pluginType is not null && FindNethermindBasedTypes(kv.Value, _pluginType).Any())))
+                kv.Key.StartsWith("Nethermind") || (_pluginType is not null && FindNethermindBasedTypes(kv.Value, _pluginType).Any())))
             {
                 _assembliesWithNethermindTypes.Add(kv.Value);
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -45,16 +45,16 @@ public class MergeSynchronizer(
     }
 
     private void StartBeaconHeadersComponents() => beaconHeaderComponent.Dispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
-                                                        {
-                                                            if (t.IsFaulted)
-                                                            {
-                                                                if (_logger.IsError) _logger.Error("Beacon headers downloader failed", t.Exception);
-                                                            }
-                                                            else
-                                                            {
-                                                                if (_logger.IsInfo) _logger.Info("Beacon headers task completed.");
-                                                            }
-                                                        });
+    {
+        if (t.IsFaulted)
+        {
+            if (_logger.IsError) _logger.Error("Beacon headers downloader failed", t.Exception);
+        }
+        else
+        {
+            if (_logger.IsInfo) _logger.Info("Beacon headers task completed.");
+        }
+    });
 
     private void WireMultiSyncModeSelector() => baseSynchronizer.WireFeedWithModeSelector(beaconHeaderComponent.Feed);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -345,7 +345,7 @@ public class SyncPeerPoolTests
         await Task.Delay(100);
 
         Assert.That(() =>
-                syncPeer.ReceivedCalls().Count(call => call.GetMethodInfo().Name == "GetHeadBlockHeader"),
+            syncPeer.ReceivedCalls().Count(call => call.GetMethodInfo().Name == "GetHeadBlockHeader"),
             Is.EqualTo(2).After(1000, 100)
         );
     }

--- a/src/Nethermind/Nethermind.Wallet.Test/WalletTests.cs
+++ b/src/Nethermind/Nethermind.Wallet.Test/WalletTests.cs
@@ -88,9 +88,9 @@ public class WalletTests
 
     [OneTimeTearDown]
     public void TearDown() => Parallel.ForEach(_wallets, static wallet =>
-                                   {
-                                       wallet.Dispose();
-                                   });
+    {
+        wallet.Dispose();
+    });
 
     public enum WalletType
     {


### PR DESCRIPTION
## Changes

- Adds **NETH002** `LambdaIndentationAnalyzer` to `Nethermind.Analyzers` — fires when a multi-line lambda body is indented more than 4 columns past the indentation of the line containing the lambda arrow (`=>`). This catches the Roslyn behaviour of aligning lambda bodies to the opening parenthesis of the enclosing call, which pushes them far to the right.
- Sets `NETH002` to `error` severity in `.editorconfig`
- Fixes all 6 existing infractions across the codebase (`BadBlockStore`, `TypeDiscovery`, `MergeSynchronizer`, `AuRaGasLimitOverrideFactory`, `SyncPeerPoolTests`, `WalletTests`)

## Type of change

- [x] Refactor (non-breaking change that improves code quality)
- [x] Tests

## Testing

- New `LambdaIndentationAnalyzerTests` with 4 test cases (positive + 3 negative)
- Full solution builds clean with no NETH002 errors