### PR TITLE
BlockAccessList Parallel IO

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Config;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Test.Validators;
 using Nethermind.Blockchain.Tracing;
-using Nethermind.Config;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.ExecutionRequests;
@@ -221,7 +221,8 @@ namespace Nethermind.AuRa.Test
                 stateProvider,
                 new BeaconBlockRootHandler(transactionProcessor, stateProvider),
                 blockhashProvider,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                new BlocksConfig());
 
             return (branchProcessor, stateProvider, blockTree);
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Config;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Test.Validators;
@@ -35,7 +36,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Evm;
-using Nethermind.Config;
 
 namespace Nethermind.Blockchain.Test;
 
@@ -70,6 +70,7 @@ public class BlockProcessorTests
             new BeaconBlockRootHandler(transactionProcessor, stateProvider),
             Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
+            new BlocksConfig(),
             preWarmer);
 
         return (processor, branchProcessor, stateProvider);

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Config;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.ExecutionRequests;
@@ -28,7 +29,6 @@ using Nethermind.Evm.State;
 using Nethermind.State;
 using NSubstitute;
 using NUnit.Framework;
-using Nethermind.Config;
 
 namespace Nethermind.Blockchain.Test;
 
@@ -111,7 +111,8 @@ public class ReorgTests
             stateProvider,
             new BeaconBlockRootHandler(transactionProcessor, stateProvider),
             blockhashProvider,
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            new BlocksConfig());
 
         _blockchainProcessor = new BlockchainProcessor(
             _blockTree,

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -62,12 +62,12 @@ public interface IBlocksConfig : IConfig
     bool BuildBlocksOnMainState { get; set; }
 
     [ConfigItem(
-        Description = "Parallelize transaction execution with Block access lists.",
+        Description = "Parallelize transaction execution with Block level access lists.",
         DefaultValue = "false")]
     bool ParallelExecution { get; set; }
 
     [ConfigItem(
-        Description = "Use db batch read with parallel execution.",
+        Description = "Use parallel reads with Block level access lists.",
         DefaultValue = "false")]
     bool ParallelExecutionBatchRead { get; set; }
 

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -10,8 +10,11 @@ using FluentAssertions;
 using Microsoft.Extensions.ObjectPool;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Processing;
+using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Container;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
@@ -49,12 +52,16 @@ public class BlockCachePreWarmerTests
             b.AddModule(mainModules);
         });
 
-        // Seed genesis state for all sender accounts and capture the root while still in scope.
+        // Seed genesis state for all sender accounts and storage, then capture the root.
         IWorldState worldState = _processingScope.Resolve<IWorldState>();
         using (worldState.BeginScope(IWorldState.PreGenesis))
         {
             worldState.CreateAccount(TestItem.AddressA, 1_000_000.Ether);
             worldState.CreateAccount(TestItem.AddressB, 1_000_000.Ether);
+            // Seed storage for BAL-based prewarming tests
+            worldState.Set(new StorageCell(TestItem.AddressA, 1), new byte[] { 0x42 });
+            worldState.Set(new StorageCell(TestItem.AddressA, 2), new byte[] { 0x43 });
+            worldState.Set(new StorageCell(TestItem.AddressB, 10), new byte[] { 0x99 });
             worldState.Commit(Osaka.Instance);
             worldState.CommitTree(0);
             _genesisStateRoot = worldState.StateRoot;
@@ -111,7 +118,188 @@ public class BlockCachePreWarmerTests
             "all retained envs must be disposed when the prewarmer is disposed");
     }
 
-    private (BlockCachePreWarmer, ConcurrentBag<IReadOnlyTxProcessorSource> created, ConcurrentBag<IReadOnlyTxProcessorSource> disposed) CreatePreWarmer(int maxPoolSize)
+    /// <summary>
+    /// Verifies that BAL-based prewarming populates the account state cache for all
+    /// addresses listed in the BlockAccessList.
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_WithBal_PopulatesStateCacheForBalAddresses()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
+
+        BlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(
+                Build.An.AccountChanges.WithAddress(TestItem.AddressA).TestObject,
+                Build.An.AccountChanges.WithAddress(TestItem.AddressB).TestObject)
+            .TestObject;
+
+        Block block = Build.A.Block
+            .WithGasLimit(30_000_000)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        await preWarmer.PreWarmCaches(block, BuildParentHeader(), Amsterdam.Instance);
+
+        preBlockCaches.StateCache.TryGetValue(TestItem.AddressA, out _).Should().BeTrue(
+            "AddressA is in the BAL and should be pre-warmed");
+        preBlockCaches.StateCache.TryGetValue(TestItem.AddressB, out _).Should().BeTrue(
+            "AddressB is in the BAL and should be pre-warmed");
+    }
+
+    /// <summary>
+    /// Verifies that BAL-based prewarming populates the storage cache for storage slots
+    /// listed as both changed and read-only in the BAL.
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_WithBal_PopulatesStorageCacheForBalSlots()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
+
+        BlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(
+                Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithStorageChanges(1, new StorageChange(0, 0xFF)) // slot 1 written
+                    .WithStorageReads(2) // slot 2 read-only
+                    .TestObject,
+                Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressB)
+                    .WithStorageReads(10) // slot 10 read-only
+                    .TestObject)
+            .TestObject;
+
+        Block block = Build.A.Block
+            .WithGasLimit(30_000_000)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        await preWarmer.PreWarmCaches(block, BuildParentHeader(), Amsterdam.Instance);
+
+        // Changed slot should be warmed
+        preBlockCaches.StorageCache.TryGetValue(new StorageCell(TestItem.AddressA, 1), out _).Should().BeTrue(
+            "slot 1 (changed) should be pre-warmed via BAL");
+        // Read-only slot should be warmed
+        preBlockCaches.StorageCache.TryGetValue(new StorageCell(TestItem.AddressA, 2), out _).Should().BeTrue(
+            "slot 2 (read-only) should be pre-warmed via BAL");
+        // Storage from a different account
+        preBlockCaches.StorageCache.TryGetValue(new StorageCell(TestItem.AddressB, 10), out _).Should().BeTrue(
+            "slot 10 on AddressB should be pre-warmed via BAL");
+    }
+
+    /// <summary>
+    /// Verifies that when ParallelExecutionBatchRead is disabled, the BAL path is not used
+    /// even when a BAL is present and EIP-7928 is enabled.
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_WithBalButFlagDisabled_SkipsBalPath()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10, parallelExecutionBatchRead: false);
+
+        BlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(
+                Build.An.AccountChanges.WithAddress(TestItem.AddressC).TestObject)
+            .TestObject;
+
+        // Block has < 3 txs — with BAL disabled, prewarming is skipped entirely
+        Block block = Build.A.Block
+            .WithGasLimit(30_000_000)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        await preWarmer.PreWarmCaches(block, BuildParentHeader(), Amsterdam.Instance);
+
+        preBlockCaches.StateCache.TryGetValue(TestItem.AddressC, out _).Should().BeFalse(
+            "BAL path should be skipped when ParallelExecutionBatchRead is disabled");
+    }
+
+    /// <summary>
+    /// Verifies that the BAL path is not triggered for pre-Amsterdam specs even when a
+    /// BAL is attached to the block.
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_WithBalButPreAmsterdam_UsesSpeculativePath()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
+
+        BlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(
+                Build.An.AccountChanges.WithAddress(TestItem.AddressA).TestObject)
+            .TestObject;
+
+        // Block has enough txs to trigger speculative prewarming
+        Block block = Build.A.Block
+            .WithTransactions(BuildTwoSenderBlock().Transactions)
+            .WithGasLimit(30_000_000)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        // Use Osaka which does NOT have EIP-7928 — BAL path should not trigger
+        await preWarmer.PreWarmCaches(block, BuildParentHeader(), Osaka.Instance);
+
+        // AddressA should still be warmed via speculative tx execution (not BAL path)
+        // since it's a sender in the transactions
+        preBlockCaches.StateCache.TryGetValue(TestItem.AddressA, out _).Should().BeTrue(
+            "AddressA should be warmed via speculative execution even without BAL path");
+    }
+
+    /// <summary>
+    /// Verifies the prewarmer gate logic: ParallelExecution ON disables prewarming unless
+    /// ParallelExecutionBatchRead is ON and BALs are available.
+    /// </summary>
+    [TestCase(true, true, true, true, TestName = "ParallelExec ON, BALs ON, BatchRead ON => BAL warming")]
+    [TestCase(true, true, false, false, TestName = "ParallelExec ON, BALs ON, BatchRead OFF => skipped")]
+    [TestCase(true, false, true, false, TestName = "ParallelExec ON, BALs OFF, BatchRead ON => skipped")]
+    [TestCase(true, false, false, false, TestName = "ParallelExec ON, BALs OFF, BatchRead OFF => skipped")]
+    [TestCase(false, true, true, true, TestName = "ParallelExec OFF, BALs ON, BatchRead ON => BAL warming")]
+    [TestCase(false, false, false, true, TestName = "ParallelExec OFF, BALs OFF, BatchRead OFF => speculative")]
+    public async Task PreWarmCaches_GateLogic(bool parallelExecution, bool hasBal, bool batchRead, bool expectWarmed)
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        BlockCachePreWarmer preWarmer = CreatePreWarmerFromConfig(parallelExecution, batchRead);
+
+        BlockAccessList? bal = hasBal
+            ? Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges.WithAddress(TestItem.AddressA).TestObject)
+                .TestObject
+            : null;
+
+        // Use Amsterdam (EIP-7928) when testing BALs, Osaka otherwise
+        IReleaseSpec spec = hasBal ? Amsterdam.Instance : Osaka.Instance;
+
+        Block block = Build.A.Block
+            .WithTransactions(BuildTwoSenderBlock().Transactions)
+            .WithGasLimit(30_000_000)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        await preWarmer.PreWarmCaches(block, BuildParentHeader(), spec);
+
+        preBlockCaches.StateCache.TryGetValue(TestItem.AddressA, out _).Should().Be(expectWarmed,
+            $"ParallelExec={parallelExecution}, BALs={hasBal}, BatchRead={batchRead} => warmed={expectWarmed}");
+    }
+
+    private BlockCachePreWarmer CreatePreWarmerFromConfig(bool parallelExecution, bool parallelExecutionBatchRead)
+    {
+        PrewarmerEnvFactory envFactory = _processingScope.Resolve<PrewarmerEnvFactory>();
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        NodeStorageCache nodeStorageCache = _processingScope.Resolve<NodeStorageCache>();
+
+        BlocksConfig config = new()
+        {
+            PreWarmStateOnBlockProcessing = true,
+            PreWarmStateConcurrency = 2,
+            ParallelExecution = parallelExecution,
+            ParallelExecutionBatchRead = parallelExecutionBatchRead
+        };
+
+        return new BlockCachePreWarmer(envFactory, config, nodeStorageCache, preBlockCaches, LimboLogs.Instance);
+    }
+
+    private (BlockCachePreWarmer, ConcurrentBag<IReadOnlyTxProcessorSource> created, ConcurrentBag<IReadOnlyTxProcessorSource> disposed) CreatePreWarmer(int maxPoolSize, bool parallelExecutionBatchRead = true)
     {
         PrewarmerEnvFactory envFactory = _processingScope.Resolve<PrewarmerEnvFactory>();
         PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
@@ -125,6 +313,7 @@ public class BlockCachePreWarmerTests
             trackingPolicy,
             maxPoolSize: maxPoolSize,
             concurrency: 2,
+            parallelExecutionBatchRead: parallelExecutionBatchRead,
             nodeStorageCache,
             preBlockCaches,
             LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -18,6 +18,7 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Evm.State;
 using Nethermind.Core.Eip2930;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Trie;
@@ -27,6 +28,7 @@ namespace Nethermind.Consensus.Processing;
 public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 {
     private readonly int _concurrencyLevel;
+    private readonly bool _parallelExecutionBatchRead;
     private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool;
     private readonly ILogger _logger;
     private readonly PreBlockCaches _preBlockCaches;
@@ -43,6 +45,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory, preBlockCaches),
         Environment.ProcessorCount * 2,
         blocksConfig.PreWarmStateConcurrency,
+        blocksConfig.ParallelExecutionBatchRead,
         nodeStorageCache,
         preBlockCaches,
         logManager) => _parallelExecutionEnabled = blocksConfig.ParallelExecution;
@@ -51,11 +54,13 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         IPooledObjectPolicy<IReadOnlyTxProcessorSource> poolPolicy,
         int maxPoolSize,
         int concurrency,
+        bool parallelExecutionBatchRead,
         NodeStorageCache nodeStorageCache,
         PreBlockCaches preBlockCaches,
         ILogManager logManager)
     {
         _concurrencyLevel = concurrency == 0 ? Math.Min(Environment.ProcessorCount - 1, 16) : concurrency;
+        _parallelExecutionBatchRead = parallelExecutionBatchRead;
         _envPool = new DefaultObjectPoolProvider { MaximumRetained = maxPoolSize }.Create(poolPolicy);
         _logger = logManager.GetClassLogger<BlockCachePreWarmer>();
         _preBlockCaches = preBlockCaches;
@@ -64,7 +69,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
     public Task PreWarmCaches(Block suggestedBlock, BlockHeader? parent, IReleaseSpec spec, CancellationToken cancellationToken = default, params ReadOnlySpan<IHasAccessList> systemAccessLists)
     {
-        if (_preBlockCaches is not null && !(_parallelExecutionEnabled && spec.BlockLevelAccessListsEnabled))
+        if (_preBlockCaches is not null && (!_parallelExecutionEnabled || (_parallelExecutionBatchRead && spec.BlockLevelAccessListsEnabled)))
         {
             CacheType result = _preBlockCaches.ClearCaches();
             _nodeStorageCache.ClearCaches();
@@ -79,8 +84,13 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 BlockState blockState = new(this, suggestedBlock, parent, spec);
                 ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = _concurrencyLevel, CancellationToken = cancellationToken };
 
+                // BAL makes speculative tx execution redundant
+                BlockAccessList? bal = _parallelExecutionBatchRead && spec.BlockLevelAccessListsEnabled
+                    ? suggestedBlock.BlockAccessList
+                    : null;
+
                 // Run address warmer ahead of transactions warmer, but queue to ThreadPool so it doesn't block the txs
-                AddressWarmer addressWarmer = new(parallelOptions, suggestedBlock, parent, spec, systemAccessLists, this);
+                AddressWarmer addressWarmer = new(parallelOptions, suggestedBlock, parent, spec, systemAccessLists, this, bal);
                 ThreadPool.UnsafeQueueUserWorkItem(addressWarmer, preferLocal: false);
                 // Do not pass the cancellation token to the task, we don't want exceptions to be thrown in the main processing thread
                 return Task.Run(() => PreWarmCachesParallel(blockState, suggestedBlock, parent, spec, parallelOptions, addressWarmer, cancellationToken));
@@ -109,8 +119,11 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
             if (_logger.IsDebug) _logger.Debug($"Started pre-warming caches for block {suggestedBlock.Number}.");
 
-            WarmupTransactions(blockState, parallelOptions);
-            WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
+            if (!addressWarmer.HasBal)
+            {
+                WarmupTransactions(blockState, parallelOptions);
+                WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
+            }
 
             if (_logger.IsDebug) _logger.Debug($"Finished pre-warming caches for block {suggestedBlock.Number}.");
         }
@@ -288,13 +301,16 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
     }
 
-    private class AddressWarmer(ParallelOptions parallelOptions, Block block, BlockHeader parent, IReleaseSpec spec, ReadOnlySpan<IHasAccessList> systemAccessLists, BlockCachePreWarmer preWarmer)
+    private class AddressWarmer(ParallelOptions parallelOptions, Block block, BlockHeader parent, IReleaseSpec spec, ReadOnlySpan<IHasAccessList> systemAccessLists, BlockCachePreWarmer preWarmer, BlockAccessList? bal = null)
         : IThreadPoolWorkItem, IDisposable
     {
         private readonly Block Block = block;
         private readonly BlockCachePreWarmer PreWarmer = preWarmer;
+        private readonly BlockAccessList? Bal = bal;
         private readonly ArrayPoolList<AccessList>? SystemTxAccessLists = GetAccessLists(block, spec, systemAccessLists);
         private readonly ManualResetEventSlim _doneEvent = new(initialState: false);
+
+        public bool HasBal => Bal is not null;
 
         public void Wait() => _doneEvent.Wait();
 
@@ -361,29 +377,101 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                     }
                 }
 
-                AddressWarmingState baseState = new(envPool, block, parent);
+                if (Bal is not null)
+                {
+                    WarmupFromBal(parallelOptions, envPool);
+                }
+                else
+                {
+                    WarmingState<Block> baseState = new(envPool, block, parent);
 
-                ParallelUnbalancedWork.For(
-                    0,
-                    block.Transactions.Length,
-                    parallelOptions,
-                    baseState.InitThreadState,
+                    ParallelUnbalancedWork.For(
+                        0,
+                        block.Transactions.Length,
+                        parallelOptions,
+                        baseState.InitThreadState,
+                    static (i, state) =>
+                    {
+                        Transaction tx = state.Payload.Transactions[i];
+                        Address? sender = tx.SenderAddress;
+
+                        try
+                        {
+                            if (sender is not null)
+                            {
+                                state.Scope!.WorldState.WarmUp(sender);
+                            }
+
+                            Address to = tx.To;
+                            if (to is not null)
+                            {
+                                state.Scope!.WorldState.WarmUp(to);
+                            }
+                        }
+                        catch (MissingTrieNodeException)
+                        {
+                        }
+
+                        return state;
+                    },
+                    WarmingState<Block>.FinallyAction);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore, block completed cancel
+            }
+        }
+
+        private void WarmupFromBal(ParallelOptions parallelOptions, ObjectPool<IReadOnlyTxProcessorSource> envPool)
+        {
+            using ArrayPoolList<AccountChanges> accounts = Bal!.AccountChanges.ToPooledList(Bal!.AccountChanges.Count);
+            if (accounts.Count == 0) return;
+
+            WarmingState<ArrayPoolList<AccountChanges>> baseState = new(envPool, accounts, parent);
+
+            ParallelUnbalancedWork.For(
+                0,
+                accounts.Count,
+                parallelOptions,
+                baseState.InitThreadState,
                 static (i, state) =>
                 {
-                    Transaction tx = state.Block.Transactions[i];
-                    Address? sender = tx.SenderAddress;
+                    AccountChanges ac = state.Payload[i];
+                    IWorldState worldState = state.Scope!.WorldState;
 
                     try
                     {
-                        if (sender is not null)
-                        {
-                            state.Scope!.WorldState.WarmUp(sender);
-                        }
+                        Address address = ac.Address;
+                        worldState.WarmUp(address);
 
-                        Address to = tx.To;
-                        if (to is not null)
+                        // Merge two sorted sequences (ChangedSlots, StorageReads) into one
+                        // ascending pass for better trie path locality
+                        IList<UInt256> changed = ac.ChangedSlots;
+                        int slotIndex = 0;
+                        using SortedSet<UInt256>.Enumerator readEnumerator = ac.StorageReads.GetEnumerator();
+                        bool hasRead = readEnumerator.MoveNext();
+
+                        while (slotIndex < changed.Count || hasRead)
                         {
-                            state.Scope!.WorldState.WarmUp(to);
+                            UInt256 slot;
+                            if (!hasRead)
+                            {
+                                slot = changed[slotIndex++];
+                            }
+                            else
+                            {
+                                slot = readEnumerator.Current;
+                                if (slotIndex < changed.Count && changed[slotIndex].CompareTo(in slot) <= 0)
+                                {
+                                    slot = changed[slotIndex++];
+                                }
+                                else
+                                {
+                                    hasRead = readEnumerator.MoveNext();
+                                }
+                            }
+                            worldState.Get(new StorageCell(address, slot));
                         }
                     }
                     catch (MissingTrieNodeException)
@@ -392,34 +480,29 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
                     return state;
                 },
-                AddressWarmingState.FinallyAction);
-            }
-            catch (OperationCanceledException)
-            {
-                // Ignore, block completed cancel
-            }
+                WarmingState<ArrayPoolList<AccountChanges>>.FinallyAction);
         }
     }
 
-    private readonly struct AddressWarmingState(ObjectPool<IReadOnlyTxProcessorSource> envPool, Block block, BlockHeader parent) : IDisposable
+    private readonly struct WarmingState<TPayload>(ObjectPool<IReadOnlyTxProcessorSource> envPool, TPayload payload, BlockHeader parent) : IDisposable
     {
-        public static Action<AddressWarmingState> FinallyAction { get; } = DisposeThreadState;
+        public static Action<WarmingState<TPayload>> FinallyAction { get; } = DisposeThreadState;
 
         private readonly ObjectPool<IReadOnlyTxProcessorSource> EnvPool = envPool;
         private readonly IReadOnlyTxProcessorSource? Env;
-        public readonly Block Block = block;
+        public readonly TPayload Payload = payload;
         public readonly IReadOnlyTxProcessingScope? Scope;
 
-        private AddressWarmingState(ObjectPool<IReadOnlyTxProcessorSource> envPool, Block block, BlockHeader parent, IReadOnlyTxProcessorSource env, IReadOnlyTxProcessingScope scope) : this(envPool, block, parent)
+        private WarmingState(ObjectPool<IReadOnlyTxProcessorSource> envPool, TPayload payload, BlockHeader parent, IReadOnlyTxProcessorSource env, IReadOnlyTxProcessingScope scope) : this(envPool, payload, parent)
         {
             Env = env;
             Scope = scope;
         }
 
-        public AddressWarmingState InitThreadState()
+        public WarmingState<TPayload> InitThreadState()
         {
             IReadOnlyTxProcessorSource env = EnvPool.Get();
-            return new(EnvPool, Block, parent, env, scope: env.Build(parent));
+            return new(EnvPool, Payload, parent, env, scope: env.Build(parent));
         }
 
         public void Dispose()
@@ -431,7 +514,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             }
         }
 
-        private static void DisposeThreadState(AddressWarmingState state) => state.Dispose();
+        private static void DisposeThreadState(WarmingState<TPayload> state) => state.Dispose();
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.BeaconBlockRoot;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -23,9 +24,11 @@ public class BranchProcessor(
     IBeaconBlockRootHandler beaconBlockRootHandler,
     IBlockhashProvider blockhashProvider,
     ILogManager logManager,
+    IBlocksConfig blocksConfig,
     IBlockCachePreWarmer? preWarmer = null)
     : IBranchProcessor
 {
+    private readonly bool _parallelExecutionBatchRead = blocksConfig.ParallelExecutionBatchRead;
     private readonly ILogger _logger = logManager.GetClassLogger<BranchProcessor>();
     private Task _clearTask = Task.CompletedTask;
 
@@ -197,7 +200,7 @@ public class BranchProcessor(
     }
 
     private Task? PreWarmTransactions(Block suggestedBlock, BlockHeader preBlockBaseBlock, IReleaseSpec spec, CancellationToken token) =>
-        suggestedBlock.Transactions.Length < 3
+        suggestedBlock.Transactions.Length < 3 && !(_parallelExecutionBatchRead && spec.BlockLevelAccessListsEnabled && suggestedBlock.BlockAccessList is not null)
             ? null
             : preWarmer?.PreWarmCaches(suggestedBlock,
                 preBlockBaseBlock,

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -388,7 +388,7 @@ namespace Nethermind.Consensus.Validators
 
         protected virtual bool ValidateBlockAccessListHash(BlockHeader header, IReleaseSpec spec, ref string? error)
         {
-            if (spec.IsEip7928Enabled)
+            if (spec.BlockLevelAccessListsEnabled)
             {
                 if (header.BlockAccessListHash is null)
                 {

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/AccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/AccountChanges.cs
@@ -24,8 +24,11 @@ public class AccountChanges : IEquatable<AccountChanges>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IList<SlotChanges> StorageChanges => _storageChanges.Values;
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public IList<UInt256> ChangedSlots => _storageChanges.Keys;
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public IReadOnlyCollection<UInt256> StorageReads => _storageReads;
+    public SortedSet<UInt256> StorageReads => _storageReads;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IList<BalanceChange> BalanceChanges => _balanceChanges.Values;
@@ -392,8 +395,8 @@ public class AccountChanges : IEquatable<AccountChanges>
 
         if (lastChange.Key == index)
         {
-            changes.RemoveAt(changes.Count - 1);
             change = lastChange.Value;
+            changes.RemoveAt(c - 1);
             return true;
         }
 

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Concurrent;
+#if DEBUG
 using System.Diagnostics;
+#endif
 using Nethermind.Core;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV4.cs
@@ -55,7 +55,7 @@ public class ExecutionPayloadV4 : ExecutionPayloadV3, IExecutionPayloadFactory<E
     }
 
     public override bool ValidateFork(ISpecProvider specProvider)
-         => specProvider.GetSpec(BlockNumber, Timestamp).IsEip7928Enabled;
+         => specProvider.GetSpec(BlockNumber, Timestamp).BlockLevelAccessListsEnabled;
 
 
     /// <summary>


### PR DESCRIPTION
## Changes

When EIP-7928 (Block-Level Access Lists) is active and `Blocks.ParallelExecutionBatchRead` is enabled (default: `true`), the block prewarmer switches from speculative transaction execution to direct parallel I/O driven by the BAL. The BAL lists every account and storage slot touched during block execution, making speculative tx replay redundant.

When `Blocks.ParallelExecution` is enabled, the prewarmer is disabled entirely unless `ParallelExecutionBatchRead` is also enabled with BALs available.

- `AddressWarmer` extended to accept an optional `BlockAccessList`; when present, warms all BAL accounts and storage slots via a sorted merge-iterate of `ChangedSlots` and `StorageReads` for ascending trie path locality
- `PreWarmCachesParallel` skips `WarmupTransactions` and `WarmupWithdrawals` when the BAL path is active
- Prewarmer gate: `(!_parallelExecutionEnabled || (_parallelExecutionBatchRead && spec.BlockLevelAccessListsEnabled))` - parallel execution disables the prewarmer unless batch read + BALs are both available
- `BranchProcessor` respects `ParallelExecutionBatchRead` in the low-tx prewarm guard - only bypasses the `< 3 txs` skip when the flag is enabled, EIP-7928 is active, and a BAL is present
- `WarmingState<TPayload>` generic struct replaces the old `AddressWarmingState` to eliminate duplication between the tx-address and BAL warming paths
- `BlockAccessList.AccountChanges` widened from `IEnumerable` to `IReadOnlyCollection` for `ToPooledList()` with exact capacity sizing
- `AccountChanges.StorageReads` exposed as concrete `SortedSet<StorageRead>` for struct enumerator access (no boxing) in the merge loop
- `AccountChanges.ChangedSlots` - new property returning `SortedList.Keys` as `IList<UInt256>` for O(1) indexed access in the merge loop
- `AccountChanges.PopChange` - replaced LINQ `.Last()` (O(n) enumeration) with O(1) indexed access via `SortedList.Keys[i]`/`.Values[i]`
- Wires up `ParallelExecutionBatchRead` - the previously unused config flag now drives BAL-based prewarmer cache population

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

10 new tests in `BlockCachePreWarmerTests`:
- `PreWarmCaches_WithBal_PopulatesStateCacheForBalAddresses` - BAL accounts warmed into `PreBlockCaches.StateCache`
- `PreWarmCaches_WithBal_PopulatesStorageCacheForBalSlots` - both changed and read-only storage slots warmed into `PreBlockCaches.StorageCache`
- `PreWarmCaches_WithBalButFlagDisabled_SkipsBalPath` - `ParallelExecutionBatchRead` flag gate verified
- `PreWarmCaches_WithBalButPreAmsterdam_UsesSpeculativePath` - spec gate verified, falls back to speculative execution
- 6 parameterized `PreWarmCaches_GateLogic` cases covering the full truth table for `ParallelExecution` x `BALs` x `BatchRead`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No