### PR TITLE
fix: disable parallel BAL for nonce-loading flows, fix account existence checks

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -225,6 +226,34 @@ public class BlockProcessorTests
             NullBlockTracer.Instance);
 
         Assert.That(processedBlocks, Has.Length.EqualTo(1), "block should process successfully without a prewarmer");
+    }
+
+    [TestCase(ProcessingOptions.LoadNonceFromState, TestName = "PrepareForProcessing_disables_parallel_bal_for_LoadNonceFromState")]
+    [TestCase(ProcessingOptions.Trace, TestName = "PrepareForProcessing_disables_parallel_bal_for_Trace")]
+    public void PrepareForProcessing_disables_parallel_bal_for_nonce_loading_flows(ProcessingOptions processingOptions)
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Amsterdam.Instance);
+        BlockAccessListManager balManager = new(
+            stateProvider,
+            specProvider,
+            Substitute.For<IBlockhashProvider>(),
+            LimboLogs.Instance,
+            new BlocksConfig { ParallelExecution = true },
+            new WithdrawalProcessorFactory(LimboLogs.Instance));
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithBlockAccessList(new BlockAccessList())
+            .TestObject;
+
+        balManager.PrepareForProcessing(block, specProvider.GetSpec(block.Header), processingOptions);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(balManager.Enabled, Is.True);
+            Assert.That(balManager.ParallelExecutionEnabled, Is.False);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -70,7 +70,8 @@ public class BlockAccessListManager(
         if (Enabled)
         {
             _isBuilding = options.ContainsFlag(ProcessingOptions.ProducingBlock);
-            ParallelExecutionEnabled = blocksConfig.ParallelExecution && !_isBuilding;
+            bool loadsNonceFromState = options.ContainsFlag(ProcessingOptions.LoadNonceFromState);
+            ParallelExecutionEnabled = blocksConfig.ParallelExecution && !_isBuilding && !loadsNonceFromState;
             Reset();
             _gasRemaining = suggestedBlock.GasUsed;
 

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using NUnit.Framework;
@@ -29,6 +30,7 @@ namespace Nethermind.Store.Test;
 public class TracedAccessWorldStateTests
 {
     private static readonly IReleaseSpec Spec = Amsterdam.Instance;
+    private static readonly ILogManager Logger = LimboLogs.Instance;
 
     /// <summary>
     /// Creates a <see cref="TracedAccessWorldState"/> wrapping a real <see cref="WorldState"/>,
@@ -51,6 +53,35 @@ public class TracedAccessWorldStateTests
         TracedAccessWorldState tws = new(inner, parallel: false);
         IDisposable scope = tws.BeginScope(baseBlock);
         tws.SetIndex(0);
+        return (tws, scope);
+    }
+
+    private static (TracedAccessWorldState tws, IDisposable scope) CreateParallelTracingState(
+        int blockAccessIndex,
+        Action<BlockAccessList> balSetup,
+        Action<IWorldState>? genesisSetup = null)
+    {
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            genesisSetup?.Invoke(inner);
+            inner.Commit(Spec, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject;
+        BlockAccessList suggestedBal = new();
+        balSetup(suggestedBal);
+
+        BlockAccessListBasedWorldState balWorldState = new(inner, blockAccessIndex, Logger);
+        Block block = Build.A.Block.WithHeader(baseBlock).WithBlockAccessList(suggestedBal).TestObject;
+        balWorldState.Setup(block);
+
+        TracedAccessWorldState tws = new(balWorldState, parallel: true);
+        IDisposable scope = tws.BeginScope(baseBlock);
+        tws.SetIndex(blockAccessIndex);
         return (tws, scope);
     }
 
@@ -289,6 +320,99 @@ public class TracedAccessWorldStateTests
             {
                 Assert.That(result, Is.True);
                 Assert.That(tws.GetGeneratingBlockAccessList().HasAccount(TestItem.AddressA), Is.True);
+            }
+        }
+    }
+
+    [Test]
+    public void ParallelValueCreatedAccount_IsTreatedAsExistingWithinTransaction()
+    {
+        (TracedAccessWorldState tws, IDisposable scope) = CreateParallelTracingState(
+            blockAccessIndex: 0,
+            balSetup: bal =>
+            {
+                bal.AddAccountRead(TestItem.AddressB);
+                AccountChanges accountChanges = bal.GetAccountChanges(TestItem.AddressB)!;
+                accountChanges.AddBalanceChange(new BalanceChange(-1, 0));
+                accountChanges.EmptyBeforeBlock = true;
+            });
+
+        using (scope)
+        {
+            bool created = tws.AddToBalanceAndCreateIfNotExists(TestItem.AddressB, 1, Spec, out UInt256 oldBalance);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(created, Is.True);
+                Assert.That(oldBalance, Is.EqualTo(UInt256.Zero));
+                Assert.That(tws.AccountExists(TestItem.AddressB), Is.True);
+                Assert.That(tws.IsDeadAccount(TestItem.AddressB), Is.False);
+            }
+        }
+    }
+
+    [Test]
+    public void ParallelZeroBalanceTransition_FallsBackToUnderlyingExistence()
+    {
+        (TracedAccessWorldState tws, IDisposable scope) = CreateParallelTracingState(
+            blockAccessIndex: 0,
+            balSetup: bal =>
+            {
+                bal.AddAccountRead(TestItem.AddressA);
+                AccountChanges accountChanges = bal.GetAccountChanges(TestItem.AddressA)!;
+                accountChanges.AddBalanceChange(new BalanceChange(-1, 1));
+                accountChanges.AddNonceChange(new NonceChange(-1, 1));
+                accountChanges.ExistedBeforeBlock = true;
+            },
+            genesisSetup: ws =>
+            {
+                ws.CreateAccount(TestItem.AddressA, 1);
+                ws.IncrementNonce(TestItem.AddressA, 1, out _);
+            });
+
+        using (scope)
+        {
+            tws.SubtractFromBalance(TestItem.AddressA, 1, Spec, out UInt256 oldBalance);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(oldBalance, Is.EqualTo(UInt256.One));
+                Assert.That(tws.AccountExists(TestItem.AddressA), Is.True);
+                Assert.That(tws.IsDeadAccount(TestItem.AddressA), Is.False);
+            }
+        }
+    }
+
+    [Test]
+    public void ParallelEmptyCodeTransition_FallsBackToUnderlyingExistence()
+    {
+        byte[] existingCode = [0x60, 0x00];
+        (TracedAccessWorldState tws, IDisposable scope) = CreateParallelTracingState(
+            blockAccessIndex: 0,
+            balSetup: bal =>
+            {
+                bal.AddAccountRead(TestItem.AddressA);
+                AccountChanges accountChanges = bal.GetAccountChanges(TestItem.AddressA)!;
+                accountChanges.AddBalanceChange(new BalanceChange(-1, 1));
+                accountChanges.AddCodeChange(new CodeChange(-1, existingCode));
+                accountChanges.ExistedBeforeBlock = true;
+            },
+            genesisSetup: ws =>
+            {
+                ws.CreateAccount(TestItem.AddressA, 1);
+                ws.InsertCode(TestItem.AddressA, ValueKeccak.Compute(existingCode), existingCode, Spec);
+            });
+
+        using (scope)
+        {
+            byte[] emptyCode = [];
+            tws.InsertCode(TestItem.AddressA, ValueKeccak.Compute(emptyCode), emptyCode, Spec);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(tws.AccountExists(TestItem.AddressA), Is.True);
+                Assert.That(tws.IsDeadAccount(TestItem.AddressA), Is.False);
+                Assert.That(tws.GetCode(TestItem.AddressA), Is.Empty);
             }
         }
     }

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -340,10 +340,28 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     private bool? AccountExistsCurrent(Address address)
     {
         AccountChanges? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
-        if (accountChanges is not null && accountChanges.NonceChanges.Count == 1)
+        if (accountChanges is null)
         {
-            // if nonce is changed in this tx must exist
-            // could have been created this tx
+            return null;
+        }
+
+        if (accountChanges.NonceChanges.Count > 0)
+        {
+            // A nonce change can only happen for an account that already exists at this point in the tx.
+            return true;
+        }
+
+        if (accountChanges.BalanceChanges.Count > 0 &&
+            !accountChanges.BalanceChanges[^1].PostBalance.IsZero)
+        {
+            // Parallel BAL execution can create accounts with a balance-only transition before the
+            // underlying world state reflects that creation.
+            return true;
+        }
+
+        if (accountChanges.CodeChanges.Count > 0 &&
+            accountChanges.CodeChanges[^1].NewCode.Length > 0)
+        {
             return true;
         }
 


### PR DESCRIPTION
## Changes

Fixes for parallel BAL execution: disable parallel mode for nonce-loading flows and fix account existence checks in `TracedAccessWorldState`.

- `BlockAccessListManager.PrepareForProcessing` - disable parallel execution when `ProcessingOptions.LoadNonceFromState` is set (covers `Trace` and `LoadNonceFromState` flows). Parallel BAL execution assumes nonces are derived from the BAL; when the processing pipeline needs to load nonces from state (e.g. tracing, tx pool nonce recovery), parallel mode must be disabled to avoid incorrect nonce resolution
- `TracedAccessWorldState.AccountExistsCurrent` - expanded account existence logic for parallel BAL execution:
  - Any nonce change implies the account exists (previously only checked `Count == 1`, now handles `Count > 0`)
  - Non-zero balance after a balance change implies existence (parallel execution can create accounts via balance-only transitions before the underlying world state reflects that creation)
  - Non-empty code after a code change implies existence
  - These checks prevent false negatives where `AccountExists` returns `false` for accounts that were created or modified within the current transaction during parallel execution
- Tests added for both fixes

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `PrepareForProcessing_disables_parallel_bal_for_LoadNonceFromState` - verifies `ParallelExecutionEnabled` is `false` when `LoadNonceFromState` option is set
- `PrepareForProcessing_disables_parallel_bal_for_Trace` - verifies `ParallelExecutionEnabled` is `false` when `Trace` option is set (which includes `LoadNonceFromState`)
- `ParallelValueCreatedAccount_IsTreatedAsExistingWithinTransaction` - verifies that an account created via `AddToBalanceAndCreateIfNotExists` during parallel execution is seen as existing
- `ParallelZeroBalanceTransition_FallsBackToUnderlyingExistence` - verifies that subtracting balance to zero does not falsely report the account as non-existent when it has a nonce
- `ParallelEmptyCodeTransition_FallsBackToUnderlyingExistence` - verifies that clearing code does not falsely report the account as non-existent when it has balance

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No