### PR TITLE
fix(test): replace TrieWarmer Task.Delay with polling

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Eventually.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Eventually.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Test;
+
+public static class Eventually
+{
+    /// <summary>
+    /// Re-runs an assertion until it passes or the configured retry budget is exhausted.
+    /// </summary>
+    /// <typeparam name="TException">The retryable exception type raised by the assertion while waiting.</typeparam>
+    /// <param name="assertion">The assertion to evaluate.</param>
+    /// <param name="attempts">The maximum number of attempts before rethrowing the last failure.</param>
+    /// <param name="delayMilliseconds">The delay between failed attempts in milliseconds.</param>
+    public static async Task AssertAsync<TException>(
+        Action assertion,
+        int attempts = 50,
+        int delayMilliseconds = 10) where TException : Exception
+    {
+        ArgumentNullException.ThrowIfNull(assertion);
+        ArgumentOutOfRangeException.ThrowIfLessThan(attempts, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(delayMilliseconds);
+
+        for (int attempt = 0; attempt < attempts; attempt++)
+        {
+            try
+            {
+                assertion();
+                return;
+            }
+            catch (TException) when (attempt < attempts - 1)
+            {
+                await Task.Delay(delayMilliseconds).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
@@ -10,6 +11,7 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Flat.ScopeProvider;
 using NSubstitute;
+using NSubstitute.Exceptions;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -45,9 +47,7 @@ public class TrieWarmerTests
 
         warmer.PushAddressJob(addressWarmer, address, sequenceId: 1);
 
-        await Task.Delay(200);
-
-        addressWarmer.Received().WarmUpStateTrie(address, 1);
+        await AssertEventuallyAsync(() => addressWarmer.Received().WarmUpStateTrie(address, 1));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
@@ -63,9 +63,7 @@ public class TrieWarmerTests
 
         warmer.PushSlotJob(storageWarmer, index, sequenceId: 5);
 
-        await Task.Delay(200);
-
-        storageWarmer.Received().WarmUpStorageTrie(index, 5);
+        await AssertEventuallyAsync(() => storageWarmer.Received().WarmUpStorageTrie(index, 5));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
@@ -81,11 +79,25 @@ public class TrieWarmerTests
 
         warmer.PushAddressJob(addressWarmer, address, sequenceId: 999);
 
-        await Task.Delay(200);
-
-        addressWarmer.Received().WarmUpStateTrie(address, 999);
+        await AssertEventuallyAsync(() => addressWarmer.Received().WarmUpStateTrie(address, 999));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
+    }
+    private static async Task AssertEventuallyAsync(Action assertion)
+    {
+        const int attempts = 50;
+        for (int attempt = 0; attempt < attempts; attempt++)
+        {
+            try
+            {
+                assertion();
+                return;
+            }
+            catch (ReceivedCallsException) when (attempt < attempts - 1)
+            {
+                await Task.Delay(10);
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -47,7 +47,7 @@ public class TrieWarmerTests
 
         warmer.PushAddressJob(addressWarmer, address, sequenceId: 1);
 
-        await AssertEventuallyAsync(() => addressWarmer.Received().WarmUpStateTrie(address, 1));
+        await Eventually.AssertAsync<ReceivedCallsException>(() => addressWarmer.Received().WarmUpStateTrie(address, 1));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
@@ -63,7 +63,7 @@ public class TrieWarmerTests
 
         warmer.PushSlotJob(storageWarmer, index, sequenceId: 5);
 
-        await AssertEventuallyAsync(() => storageWarmer.Received().WarmUpStorageTrie(index, 5));
+        await Eventually.AssertAsync<ReceivedCallsException>(() => storageWarmer.Received().WarmUpStorageTrie(index, 5));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
@@ -79,25 +79,9 @@ public class TrieWarmerTests
 
         warmer.PushAddressJob(addressWarmer, address, sequenceId: 999);
 
-        await AssertEventuallyAsync(() => addressWarmer.Received().WarmUpStateTrie(address, 999));
+        await Eventually.AssertAsync<ReceivedCallsException>(() => addressWarmer.Received().WarmUpStateTrie(address, 999));
 
         _cts.Cancel();
         await warmer.DisposeAsync();
-    }
-    private static async Task AssertEventuallyAsync(Action assertion)
-    {
-        const int attempts = 50;
-        for (int attempt = 0; attempt < attempts; attempt++)
-        {
-            try
-            {
-                assertion();
-                return;
-            }
-            catch (ReceivedCallsException) when (attempt < attempts - 1)
-            {
-                await Task.Delay(10);
-            }
-        }
     }
 }


### PR DESCRIPTION
## Changes

- Replace the fixed `Task.Delay(200)` waits in `TrieWarmerTests` with an eventually-assert helper
- Poll for the expected NSubstitute call with a bounded retry loop instead of depending on machine timing
- Make the tests less sensitive to slow CI scheduling while keeping the same assertions

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: _Flaky test fix_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj --filter "FullyQualifiedName~TrieWarmerTests" --no-restore -v minimal --no-progress --output Normal`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No