### PR TITLE
fix eth_estimategas to execute with available gas and return allowance error for compatiblity with geth

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -282,7 +282,7 @@ public class TransactionProcessorTests(bool eip155Enabled)
         {
             // All balance is consumed by value; nothing left for gas — allowance cap fires before execution.
             Assert.That(err, Is.Not.Null);
-            Assert.That(err, Does.StartWith(GasEstimator.AllowanceExceedanceMsgPrefix));
+            Assert.That(err, Does.StartWith(GasEstimator.GasExceedsAllowanceMsgPrefix));
         }
         else if (txValue + (UInt256)gasLimit > AccountBalance)
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -278,7 +278,13 @@ public class TransactionProcessorTests(bool eip155Enabled)
 
         long estimate = estimator.Estimate(tx, block.Header, tracer, out string? err, 0);
 
-        if (txValue + (UInt256)gasLimit > AccountBalance)
+        if (txValue == AccountBalance)
+        {
+            // All balance is consumed by value; nothing left for gas — allowance cap fires before execution.
+            Assert.That(err, Is.Not.Null);
+            Assert.That(err, Does.StartWith(GasEstimator.AllowanceExceedanceMsgPrefix));
+        }
+        else if (txValue + (UInt256)gasLimit > AccountBalance)
         {
             Assert.That(err, Is.Not.Null); // Should have error
             Assert.That(err, Is.EqualTo("Transaction execution fails"));

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -21,15 +21,22 @@ public class GasEstimator(
     ISpecProvider specProvider,
     IBlocksConfig blocksConfig)
 {
-    /// <summary>
-    /// Error margin used if none other is specified expressed in basis points.
-    /// </summary>
+    /// <summary>Error margin used if none other is specified, expressed in basis points.</summary>
     public const int DefaultErrorMargin = 150;
 
-    /// <summary>Error-message prefix emitted when the required gas exceeds what the sender can afford.</summary>
-    public const string AllowanceExceedanceMsgPrefix = "gas required exceeds allowance";
+    /// <summary>Prefix of the error message emitted when the required gas exceeds what the sender can afford.</summary>
+    public const string GasExceedsAllowanceMsgPrefix = "gas required exceeds allowance";
 
     private const int MaxErrorMargin = 10000;
+    private const double BasisPointsDivisor = 10000d;
+
+    private const string InvalidErrorMarginNegative = "Invalid error margin, cannot be negative.";
+    private static readonly string InvalidErrorMarginTooHigh = $"Invalid error margin, must be lower than {MaxErrorMargin}.";
+    private const string GasEstimationOutOfGas = "Gas estimation failed due to out of gas";
+    private const string TransactionExecutionFails = "Transaction execution fails";
+    private const string InsufficientBalance = "insufficient balance";
+    private const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
+    private const string ExecutionReverted = "execution reverted";
 
     public long Estimate(
         Transaction tx,
@@ -39,207 +46,180 @@ public class GasEstimator(
         int errorMargin = DefaultErrorMargin,
         CancellationToken token = default)
     {
-        err = ValidateErrorMargin(errorMargin);
-        if (err is not null)
-            return 0;
-
-        IReleaseSpec spec = GetReleaseSpec(header);
-        tx.SenderAddress ??= Address.Zero;
-
-        UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress);
-
-        long additionalGas = TryGetAdditionalGasRequired(tx, spec, gasTracer, senderBalance, out err);
-        if (additionalGas != 0 || err is not null)
-            return additionalGas;
-
-        // tx.ValueRef <= senderBalance is guaranteed here (early return above handles the opposite).
-        // Subtract value so the gas allowance cap reflects only what is available for gas, matching Geth's behavior.
-        UInt256 available = senderBalance - tx.ValueRef;
-        long lowerBound = IntrinsicGasCalculator.Calculate(tx, spec).MinimalGas;
-
-        (long leftBound, long rightBound) = GetSearchBounds(tx, header, gasTracer, spec, lowerBound);
-
-        if (leftBound > rightBound)
-        {
-            err = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
-            return 0;
-        }
-
-        // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
-        // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
-        // and fails at intrinsic gas with OOG — producing "gas required exceeds allowance (N)".
-        rightBound = CapByAllowance(tx, available, rightBound);
-
-        // If transaction is simple transfer return intrinsic gas
-        if (IsSimpleTransfer(tx) && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
-            return lowerBound;
-
-        // Execute at the highest allowable gas limit first (Geth parity).
-        // If it fails with OOG (or another gas-related pre-check failure), return allowance exceeded.
-        // If it fails for a non-gas reason (for example revert), return that error immediately.
-        if (!TryExecutableTransaction(tx, header, rightBound, gasTracer, token, out bool isGasRelatedFailure))
-        {
-            err = (gasTracer.OutOfGas || isGasRelatedFailure)
-                ? $"{AllowanceExceedanceMsgPrefix} ({rightBound})"
-                : GetError(gasTracer);
-
-            return 0;
-        }
-
-        return BinarySearchEstimate(leftBound, rightBound, tx, header, gasTracer, errorMargin, token, out err);
+        EstimationResult result = EstimateInternal(tx, header, gasTracer, errorMargin, token);
+        err = result.Error;
+        return result.GasEstimate;
     }
 
-    private static string? ValidateErrorMargin(int errorMargin) =>
-        errorMargin switch
-        {
-            < 0 => "Invalid error margin, cannot be negative.",
-            >= MaxErrorMargin => $"Invalid error margin, must be lower than {MaxErrorMargin}.",
-            _ => null
-        };
-
-    private IReleaseSpec GetReleaseSpec(BlockHeader header) =>
-        specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
-
-    private long TryGetAdditionalGasRequired(
-        Transaction tx,
-        IReleaseSpec spec,
-        EstimateGasTracer gasTracer,
-        UInt256 senderBalance,
-        out string? err)
-    {
-        err = null;
-
-        if (tx.ValueRef == UInt256.Zero || tx.ValueRef <= senderBalance)
-            return 0;
-
-        long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, spec);
-        if (additionalGas == 0)
-            err = GetError(gasTracer, "insufficient balance");
-
-        return additionalGas;
-    }
-
-    private static (long Left, long Right) GetSearchBounds(
-        Transaction tx,
-        BlockHeader header,
-        EstimateGasTracer gasTracer,
-        IReleaseSpec spec,
-        long lowerBound)
-    {
-        // Setting boundaries for binary search - determine lowest and highest gas can be used during the estimation:
-        long left = gasTracer.GasSpent != 0 && gasTracer.GasSpent >= lowerBound
-            ? gasTracer.GasSpent - 1
-            : lowerBound - 1;
-
-        long right = tx.GasLimit != 0 && tx.GasLimit >= lowerBound
-            ? tx.GasLimit
-            : header.GasLimit;
-
-        right = Math.Min(right, spec.GetTxGasLimitCap());
-
-        return (left, right);
-    }
-
-    private static long CapByAllowance(Transaction tx, UInt256 available, long rightBound)
-    {
-        if (tx.MaxFeePerGas == UInt256.Zero)
-            return rightBound;
-
-        long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
-        return Math.Min(rightBound, allowance);
-    }
-
-    private static bool IsSimpleTransfer(Transaction tx) =>
-        tx.To is not null && tx.Data.IsEmpty;
-
-    private long BinarySearchEstimate(
-        long leftBound,
-        long rightBound,
+    private EstimationResult EstimateInternal(
         Transaction tx,
         BlockHeader header,
         EstimateGasTracer gasTracer,
         int errorMargin,
-        CancellationToken token,
-        out string? err)
+        CancellationToken token)
     {
-        err = null;
-        double marginWithDecimals = errorMargin == 0 ? 1 : errorMargin / 10000d + 1;
+        if (ValidateErrorMargin(errorMargin) is { } validationError)
+            return validationError;
 
-        //This approach is similar to Geth, by starting from an optimistic guess the number of iterations is greatly reduced in most cases
-        long optimisticGasEstimate = (long)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * marginWithDecimals);
-        if (optimisticGasEstimate > leftBound && optimisticGasEstimate < rightBound)
-        {
-            if (TryExecutableTransaction(tx, header, optimisticGasEstimate, gasTracer, token))
-                rightBound = optimisticGasEstimate;
-            else
-                leftBound = optimisticGasEstimate;
-        }
+        IReleaseSpec spec = specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
+        tx.SenderAddress ??= Address.Zero;
 
-        long cap = rightBound;
-        //This is similar to Geth's approach by stopping, when the estimation is within a certain margin of error
-        while ((rightBound - leftBound) / (double)leftBound > (marginWithDecimals - 1)
-               && leftBound + 1 < rightBound)
-        {
-            long mid = (leftBound + rightBound) / 2;
-            if (!TryExecutableTransaction(tx, header, mid, gasTracer, token))
-            {
-                leftBound = mid;
-            }
-            else
-            {
-                rightBound = mid;
-            }
-        }
+        UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress!);
 
-        if (rightBound == cap && !TryExecutableTransaction(tx, header, rightBound, gasTracer, token))
-        {
-            err = GetError(gasTracer);
-            return 0;
-        }
+        if (CheckFunds(tx, spec, gasTracer, senderBalance) is { } fundsResult)
+            return fundsResult;
 
-        return rightBound;
+        long intrinsicGas = IntrinsicGasCalculator.Calculate(tx, spec).MinimalGas;
+        long leftBound = Math.Max(gasTracer.GasSpent - 1, intrinsicGas - 1);
+        long rightBound = Math.Min(
+            tx.GasLimit != 0 && tx.GasLimit >= intrinsicGas ? tx.GasLimit : header.GasLimit,
+            spec.GetTxGasLimitCap());
+
+        if (leftBound > rightBound)
+            return EstimationResult.Failure(CannotEstimateGasExceeded);
+
+        // tx.ValueRef <= senderBalance is guaranteed here; subtract so the cap reflects gas budget only.
+        EstimationBounds bounds = CapByAllowance(new EstimationBounds(leftBound, rightBound, intrinsicGas), tx, senderBalance - tx.ValueRef);
+
+        return BinarySearchEstimate(tx, header, gasTracer, bounds, errorMargin, token);
     }
 
-    private static string GetError(EstimateGasTracer gasTracer, string defaultError = "Transaction execution fails") =>
-        gasTracer switch
+    private static EstimationResult? ValidateErrorMargin(int errorMargin) =>
+        errorMargin switch
         {
-            { TopLevelRevert: true } => gasTracer.Error ??
-                                        (gasTracer.ReturnValue?.Length > 0 ?
-                                            $"execution reverted: {gasTracer.ReturnValue.ToHexString(true)}"
-                                            : "execution reverted"),
-            { OutOfGas: true } => "Gas estimation failed due to out of gas",
-            { StatusCode: StatusCode.Failure } => gasTracer.Error ?? "Transaction execution fails",
-            _ => defaultError
+            < 0 => EstimationResult.Failure(InvalidErrorMarginNegative),
+            >= MaxErrorMargin => EstimationResult.Failure(InvalidErrorMarginTooHigh),
+            _ => null
         };
 
-    private static bool IsGasRelatedExecutionFailure(TransactionResult result) =>
-        result.Error is TransactionResult.ErrorType.GasLimitBelowIntrinsicGas
-            or TransactionResult.ErrorType.BlockGasLimitExceeded;
+    // Returns null if funds are sufficient (estimation continues), or a terminal result to return immediately.
+    private static EstimationResult? CheckFunds(Transaction tx, IReleaseSpec spec, EstimateGasTracer gasTracer, UInt256 senderBalance)
+    {
+        if (tx.ValueRef == UInt256.Zero || tx.ValueRef <= senderBalance)
+            return null;
 
-    private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
-        EstimateGasTracer gasTracer, CancellationToken token)
-        => TryExecutableTransaction(transaction, block, gasLimit, gasTracer, token, out _);
+        long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, spec);
+        return additionalGas > 0
+            ? EstimationResult.Success(additionalGas)
+            : EstimationResult.Failure(GetError(gasTracer, InsufficientBalance));
+    }
 
-    private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
-        EstimateGasTracer gasTracer, CancellationToken token, out bool isGasRelatedFailure)
+    private static EstimationBounds CapByAllowance(EstimationBounds bounds, Transaction tx, UInt256 available)
+    {
+        if (tx.MaxFeePerGas == UInt256.Zero)
+            return bounds;
+
+        long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
+        return bounds with { RightBound = Math.Min(bounds.RightBound, allowance) };
+    }
+
+    private EstimationResult BinarySearchEstimate(
+        Transaction tx, BlockHeader header, EstimateGasTracer gasTracer,
+        EstimationBounds bounds, int errorMargin, CancellationToken token)
+    {
+        // Short-circuit: simple ETH transfers need exactly the intrinsic gas.
+        if (IsSimpleTransfer(tx) && TryExecute(tx, header, bounds.IntrinsicGas, gasTracer, token, out _))
+            return EstimationResult.Success(bounds.IntrinsicGas);
+
+        // Execute at maximum gas first (Geth parity): gas-related failure → allowance error; other → surface directly.
+        if (!TryExecute(tx, header, bounds.RightBound, gasTracer, token, out bool isGasRelatedFailure))
+        {
+            string error = (gasTracer.OutOfGas || isGasRelatedFailure)
+                ? $"{GasExceedsAllowanceMsgPrefix} ({bounds.RightBound})"
+                : GetError(gasTracer);
+            return EstimationResult.Failure(error);
+        }
+
+        double marginMultiplier = errorMargin == 0 ? 1d : errorMargin / BasisPointsDivisor + 1d;
+        long cap = bounds.RightBound;
+        (long leftBound, long rightBound) = TryOptimisticEstimate(tx, header, gasTracer, bounds, marginMultiplier, token);
+
+        // Narrow bounds until within the error margin (Geth approach).
+        while (ShouldContinueSearch(leftBound, rightBound, marginMultiplier - 1d))
+        {
+            long mid = leftBound + (rightBound - leftBound) / 2;
+            if (TryExecute(tx, header, mid, gasTracer, token, out _))
+                rightBound = mid;
+            else
+                leftBound = mid;
+        }
+
+        if (rightBound == cap && !TryExecute(tx, header, rightBound, gasTracer, token, out _))
+            return EstimationResult.Failure(GetError(gasTracer));
+
+        return EstimationResult.Success(rightBound);
+    }
+
+    private (long Left, long Right) TryOptimisticEstimate(
+        Transaction tx, BlockHeader header, EstimateGasTracer gasTracer,
+        EstimationBounds bounds, double marginMultiplier, CancellationToken token)
+    {
+        long leftBound = bounds.LeftBound;
+        long rightBound = bounds.RightBound;
+
+        // Optimistic first guess (Geth approach): reduces binary search iterations in most cases.
+        long optimistic = (long)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * marginMultiplier);
+        if (optimistic > leftBound && optimistic < rightBound)
+        {
+            if (TryExecute(tx, header, optimistic, gasTracer, token, out _))
+                rightBound = optimistic;
+            else
+                leftBound = optimistic;
+        }
+
+        return (leftBound, rightBound);
+    }
+
+    private bool TryExecute(Transaction transaction, BlockHeader header, long gasLimit,
+                             EstimateGasTracer gasTracer, CancellationToken token, out bool isGasRelatedFailure)
     {
         Transaction txClone = new();
         transaction.CopyTo(txClone);
         txClone.GasLimit = gasLimit;
 
-        transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(block, specProvider.GetSpec(block)));
+        transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, specProvider.GetSpec(header)));
         TransactionResult callResult = transactionProcessor.CallAndRestore(txClone, gasTracer.WithCancellation(token));
 
-        if (IsGasRelatedExecutionFailure(callResult))
+        if (IsGasRelatedFailure(callResult))
         {
             isGasRelatedFailure = true;
             return false;
         }
 
         isGasRelatedFailure = false;
-
-        // Transaction succeeds if it executed, has success status, no OutOfGas, and no top-level revert
         return callResult.TransactionExecuted && gasTracer.StatusCode == StatusCode.Success &&
                !gasTracer.OutOfGas && !gasTracer.TopLevelRevert;
+    }
+
+    private static bool IsGasRelatedFailure(TransactionResult result) =>
+        result.Error is TransactionResult.ErrorType.GasLimitBelowIntrinsicGas
+            or TransactionResult.ErrorType.BlockGasLimitExceeded;
+
+    private static bool ShouldContinueSearch(long leftBound, long rightBound, double threshold) =>
+        (rightBound - leftBound) / (double)leftBound > threshold && leftBound + 1 < rightBound;
+
+    private static bool IsSimpleTransfer(Transaction tx) =>
+        tx.To is not null && tx.Data.IsEmpty;
+
+    private static string GetError(EstimateGasTracer gasTracer, string defaultError = TransactionExecutionFails) =>
+        gasTracer switch
+        {
+            { TopLevelRevert: true } => GetRevertError(gasTracer),
+            { OutOfGas: true } => GasEstimationOutOfGas,
+            { StatusCode: StatusCode.Failure } => gasTracer.Error ?? TransactionExecutionFails,
+            _ => defaultError
+        };
+
+    private static string GetRevertError(EstimateGasTracer gasTracer) =>
+        gasTracer.Error ?? (gasTracer.ReturnValue?.Length > 0
+            ? $"{ExecutionReverted}: {gasTracer.ReturnValue.ToHexString(true)}"
+            : ExecutionReverted);
+
+    private readonly record struct EstimationBounds(long LeftBound, long RightBound, long IntrinsicGas);
+
+    private readonly record struct EstimationResult(long GasEstimate, string? Error)
+    {
+        public static EstimationResult Success(long gasEstimate) => new(gasEstimate, null);
+        public static EstimationResult Failure(string error) => new(0, error);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -102,8 +102,8 @@ public class GasEstimator(
                 : GetError(gasTracer);
 
             return 0;
-        }    
-       
+        }
+
         // Execute binary search to find the optimal gas estimation.
         return BinarySearchEstimate(leftBound, rightBound, tx, header, gasTracer, errorMargin, token, out err);
     }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -52,7 +52,7 @@ public class GasEstimator(
 
         // Calculate and return additional gas required in case of insufficient funds.
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress);
-        if (tx.ValueRef != UInt256.Zero && tx.ValueRef > senderBalance && !tx.IsSystem())
+        if (tx.ValueRef != UInt256.Zero && tx.ValueRef > senderBalance)
         {
             long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, releaseSpec);
             if (additionalGas == 0)
@@ -65,7 +65,7 @@ public class GasEstimator(
 
         // tx.ValueRef <= senderBalance is guaranteed for non-system transactions (early return above handles the opposite).
         // Subtract value so the gas allowance cap reflects only what is available for gas, matching Geth's behavior.
-        UInt256 available = !tx.IsSystem() ? senderBalance - tx.ValueRef : senderBalance;
+        UInt256 available = senderBalance - tx.ValueRef;
 
         long lowerBound = IntrinsicGasCalculator.Calculate(tx, releaseSpec).MinimalGas;
 
@@ -87,7 +87,7 @@ public class GasEstimator(
         // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
         // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
         // and fails at intrinsic gas with OOG — producing "gas required exceeds allowance (N)".
-        if (!tx.IsFree() && tx.MaxFeePerGas > UInt256.Zero)
+        if (tx.MaxFeePerGas > UInt256.Zero)
         {
             long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
             rightBound = Math.Min(rightBound, allowance);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -49,6 +49,7 @@ public class GasEstimator(
 
         // Calculate and return additional gas required in case of insufficient funds.
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress);
+        UInt256 available = senderBalance;
         if (tx.ValueRef != UInt256.Zero && tx.ValueRef > senderBalance && !tx.IsSystem())
         {
             long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, releaseSpec);
@@ -80,6 +81,29 @@ public class GasEstimator(
         // If transaction is simple transfer return intrinsic gas
         if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, token, gasTracer)) return lowerBound;
 
+        // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
+        // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
+        // and fails at intrinsic gas with OOG — producing "gas required exceeds allowance (N)".
+        if (!tx.IsFree() && tx.MaxFeePerGas > UInt256.Zero)
+        {
+            long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
+            rightBound = Math.Min(rightBound, allowance);
+        }
+
+        // Execute at the highest allowable gas limit first (Geth parity).
+        // If it fails with OOG the sender cannot afford the tx even at maximum affordable gas.
+        // If it fails for any other reason (revert etc.) return that error immediately.
+        if (!TryExecutableTransaction(tx, header, rightBound, token, gasTracer, out TransactionResult? maxGasResult))
+        {
+            bool gasRelatedFailure = gasTracer.OutOfGas || maxGasResult is null;
+
+            err = gasRelatedFailure
+                ? $"gas required exceeds allowance ({rightBound})"
+                : GetError(gasTracer);
+
+            return 0;
+        }    
+       
         // Execute binary search to find the optimal gas estimation.
         return BinarySearchEstimate(leftBound, rightBound, tx, header, gasTracer, errorMargin, token, out err);
     }
@@ -144,18 +168,34 @@ public class GasEstimator(
             _ => defaultError
         };
 
+    private static bool IsGasRelatedExecutionFailure(TransactionResult result) =>
+        result.Error is TransactionResult.ErrorType.GasLimitBelowIntrinsicGas
+            or TransactionResult.ErrorType.BlockGasLimitExceeded;
+
     private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
         CancellationToken token, EstimateGasTracer gasTracer)
+        => TryExecutableTransaction(transaction, block, gasLimit, token, gasTracer, out _);
+
+    private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
+        CancellationToken token, EstimateGasTracer gasTracer, out TransactionResult? result)
     {
         Transaction txClone = new();
         transaction.CopyTo(txClone);
         txClone.GasLimit = gasLimit;
 
         transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(block, specProvider.GetSpec(block)));
-        TransactionResult result = transactionProcessor.CallAndRestore(txClone, gasTracer.WithCancellation(token));
+        TransactionResult callResult = transactionProcessor.CallAndRestore(txClone, gasTracer.WithCancellation(token));
+
+        if (IsGasRelatedExecutionFailure(callResult))
+        {
+            result = null;
+            return false;
+        }
+
+        result = callResult;
 
         // Transaction succeeds if it executed, has success status, no OutOfGas, and no top-level revert
-        return result.TransactionExecuted && gasTracer.StatusCode == StatusCode.Success &&
+        return callResult.TransactionExecuted && gasTracer.StatusCode == StatusCode.Success &&
                !gasTracer.OutOfGas && !gasTracer.TopLevelRevert;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -31,52 +31,33 @@ public class GasEstimator(
 
     private const int MaxErrorMargin = 10000;
 
-    public long Estimate(Transaction tx, BlockHeader header, EstimateGasTracer gasTracer, out string? err,
-        int errorMargin = DefaultErrorMargin, CancellationToken token = new())
+    public long Estimate(
+        Transaction tx,
+        BlockHeader header,
+        EstimateGasTracer gasTracer,
+        out string? err,
+        int errorMargin = DefaultErrorMargin,
+        CancellationToken token = default)
     {
-        err = null;
+        err = ValidateErrorMargin(errorMargin);
+        if (err is not null)
+            return 0;
 
-        switch (errorMargin)
-        {
-            case < 0:
-                err = "Invalid error margin, cannot be negative.";
-                return 0;
-            case >= MaxErrorMargin:
-                err = $"Invalid error margin, must be lower than {MaxErrorMargin}.";
-                return 0;
-        }
+        IReleaseSpec spec = GetReleaseSpec(header);
+        tx.SenderAddress ??= Address.Zero;
 
-        IReleaseSpec releaseSpec = specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
-
-        tx.SenderAddress ??= Address.Zero; // If sender is not specified, use zero address.
-
-        // Calculate and return additional gas required in case of insufficient funds.
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress);
-        if (tx.ValueRef != UInt256.Zero && tx.ValueRef > senderBalance)
-        {
-            long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, releaseSpec);
-            if (additionalGas == 0)
-            {
-                // If no additional gas can help, it's an insufficient balance error
-                err = GetError(gasTracer, "insufficient balance");
-            }
-            return additionalGas;
-        }
 
-        // tx.ValueRef <= senderBalance is guaranteed for non-system transactions (early return above handles the opposite).
+        long additionalGas = TryGetAdditionalGasRequired(tx, spec, gasTracer, senderBalance, out err);
+        if (additionalGas != 0 || err is not null)
+            return additionalGas;
+
+        // tx.ValueRef <= senderBalance is guaranteed here (early return above handles the opposite).
         // Subtract value so the gas allowance cap reflects only what is available for gas, matching Geth's behavior.
         UInt256 available = senderBalance - tx.ValueRef;
+        long lowerBound = IntrinsicGasCalculator.Calculate(tx, spec).MinimalGas;
 
-        long lowerBound = IntrinsicGasCalculator.Calculate(tx, releaseSpec).MinimalGas;
-
-        // Setting boundaries for binary search - determine lowest and highest gas can be used during the estimation:
-        long leftBound = gasTracer.GasSpent != 0 && gasTracer.GasSpent >= lowerBound
-            ? gasTracer.GasSpent - 1
-            : lowerBound - 1;
-        long rightBound = tx.GasLimit != 0 && tx.GasLimit >= lowerBound
-            ? tx.GasLimit
-            : header.GasLimit;
-        rightBound = Math.Min(rightBound, releaseSpec.GetTxGasLimitCap());
+        (long leftBound, long rightBound) = GetSearchBounds(tx, header, gasTracer, spec, lowerBound);
 
         if (leftBound > rightBound)
         {
@@ -87,14 +68,11 @@ public class GasEstimator(
         // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
         // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
         // and fails at intrinsic gas with OOG — producing "gas required exceeds allowance (N)".
-        if (tx.MaxFeePerGas > UInt256.Zero)
-        {
-            long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
-            rightBound = Math.Min(rightBound, allowance);
-        }
+        rightBound = CapByAllowance(tx, available, rightBound);
 
         // If transaction is simple transfer return intrinsic gas
-        if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token)) return lowerBound;
+        if (IsSimpleTransfer(tx) && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
+            return lowerBound;
 
         // Execute at the highest allowable gas limit first (Geth parity).
         // If it fails with OOG (or another gas-related pre-check failure), return allowance exceeded.
@@ -108,9 +86,71 @@ public class GasEstimator(
             return 0;
         }
 
-        // Execute binary search to find the optimal gas estimation.
         return BinarySearchEstimate(leftBound, rightBound, tx, header, gasTracer, errorMargin, token, out err);
     }
+
+    private static string? ValidateErrorMargin(int errorMargin) =>
+        errorMargin switch
+        {
+            < 0 => "Invalid error margin, cannot be negative.",
+            >= MaxErrorMargin => $"Invalid error margin, must be lower than {MaxErrorMargin}.",
+            _ => null
+        };
+
+    private IReleaseSpec GetReleaseSpec(BlockHeader header) =>
+        specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
+
+    private long TryGetAdditionalGasRequired(
+        Transaction tx,
+        IReleaseSpec spec,
+        EstimateGasTracer gasTracer,
+        UInt256 senderBalance,
+        out string? err)
+    {
+        err = null;
+
+        if (tx.ValueRef == UInt256.Zero || tx.ValueRef <= senderBalance)
+            return 0;
+
+        long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, spec);
+        if (additionalGas == 0)
+            err = GetError(gasTracer, "insufficient balance");
+
+        return additionalGas;
+    }
+
+    private static (long Left, long Right) GetSearchBounds(
+        Transaction tx,
+        BlockHeader header,
+        EstimateGasTracer gasTracer,
+        IReleaseSpec spec,
+        long lowerBound)
+    {
+        // Setting boundaries for binary search - determine lowest and highest gas can be used during the estimation:
+        long left = gasTracer.GasSpent != 0 && gasTracer.GasSpent >= lowerBound
+            ? gasTracer.GasSpent - 1
+            : lowerBound - 1;
+
+        long right = tx.GasLimit != 0 && tx.GasLimit >= lowerBound
+            ? tx.GasLimit
+            : header.GasLimit;
+
+        right = Math.Min(right, spec.GetTxGasLimitCap());
+
+        return (left, right);
+    }
+
+    private static long CapByAllowance(Transaction tx, UInt256 available, long rightBound)
+    {
+        if (tx.MaxFeePerGas == UInt256.Zero)
+            return rightBound;
+
+        long allowance = (long)UInt256.Min(available / tx.MaxFeePerGas, (UInt256)long.MaxValue);
+        return Math.Min(rightBound, allowance);
+    }
+
+    private static bool IsSimpleTransfer(Transaction tx) =>
+        tx.To is not null && tx.Data.IsEmpty;
 
     private long BinarySearchEstimate(
         long leftBound,

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -84,9 +84,6 @@ public class GasEstimator(
             return 0;
         }
 
-        // If transaction is simple transfer return intrinsic gas
-        if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token)) return lowerBound;
-
         // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
         // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
         // and fails at intrinsic gas with OOG — producing "gas required exceeds allowance (N)".
@@ -96,9 +93,12 @@ public class GasEstimator(
             rightBound = Math.Min(rightBound, allowance);
         }
 
+        // If transaction is simple transfer return intrinsic gas
+        if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token)) return lowerBound;
+
         // Execute at the highest allowable gas limit first (Geth parity).
-        // If it fails with OOG the sender cannot afford the tx even at maximum affordable gas.
-        // If it fails for any other reason (revert etc.) return that error immediately.
+        // If it fails with OOG (or another gas-related pre-check failure), return allowance exceeded.
+        // If it fails for a non-gas reason (for example revert), return that error immediately.
         if (!TryExecutableTransaction(tx, header, rightBound, gasTracer, token, out bool isGasRelatedFailure))
         {
             err = (gasTracer.OutOfGas || isGasRelatedFailure)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -71,7 +71,7 @@ public class GasEstimator(
         rightBound = CapByAllowance(tx, available, rightBound);
 
         // If transaction is simple transfer return intrinsic gas
-        if (IsSimpleTransfer(tx) && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
+        if (IsSimpleTransfer(tx) && lowerBound <= rightBound && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
             return lowerBound;
 
         // Execute at the highest allowable gas limit first (Geth parity).

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -26,6 +26,9 @@ public class GasEstimator(
     /// </summary>
     public const int DefaultErrorMargin = 150;
 
+    /// <summary>Error-message prefix emitted when the required gas exceeds what the sender can afford.</summary>
+    public const string AllowanceExceedanceMsgPrefix = "gas required exceeds allowance";
+
     private const int MaxErrorMargin = 10000;
 
     public long Estimate(Transaction tx, BlockHeader header, EstimateGasTracer gasTracer, out string? err,
@@ -49,7 +52,6 @@ public class GasEstimator(
 
         // Calculate and return additional gas required in case of insufficient funds.
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress);
-        UInt256 available = senderBalance;
         if (tx.ValueRef != UInt256.Zero && tx.ValueRef > senderBalance && !tx.IsSystem())
         {
             long additionalGas = gasTracer.CalculateAdditionalGasRequired(tx, releaseSpec);
@@ -60,6 +62,10 @@ public class GasEstimator(
             }
             return additionalGas;
         }
+
+        // tx.ValueRef <= senderBalance is guaranteed for non-system transactions (early return above handles the opposite).
+        // Subtract value so the gas allowance cap reflects only what is available for gas, matching Geth's behavior.
+        UInt256 available = !tx.IsSystem() ? senderBalance - tx.ValueRef : senderBalance;
 
         long lowerBound = IntrinsicGasCalculator.Calculate(tx, releaseSpec).MinimalGas;
 
@@ -79,7 +85,7 @@ public class GasEstimator(
         }
 
         // If transaction is simple transfer return intrinsic gas
-        if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, token, gasTracer)) return lowerBound;
+        if (tx.To is not null && tx.Data.IsEmpty && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token)) return lowerBound;
 
         // Cap rightBound to what the sender can afford (Geth parity: allowance = (balance - value) / gasPrice).
         // With the shrunk gas limit the TransactionProcessor balance check passes, the EVM runs,
@@ -93,12 +99,10 @@ public class GasEstimator(
         // Execute at the highest allowable gas limit first (Geth parity).
         // If it fails with OOG the sender cannot afford the tx even at maximum affordable gas.
         // If it fails for any other reason (revert etc.) return that error immediately.
-        if (!TryExecutableTransaction(tx, header, rightBound, token, gasTracer, out TransactionResult? maxGasResult))
+        if (!TryExecutableTransaction(tx, header, rightBound, gasTracer, token, out bool isGasRelatedFailure))
         {
-            bool gasRelatedFailure = gasTracer.OutOfGas || maxGasResult is null;
-
-            err = gasRelatedFailure
-                ? $"gas required exceeds allowance ({rightBound})"
+            err = (gasTracer.OutOfGas || isGasRelatedFailure)
+                ? $"{AllowanceExceedanceMsgPrefix} ({rightBound})"
                 : GetError(gasTracer);
 
             return 0;
@@ -125,7 +129,7 @@ public class GasEstimator(
         long optimisticGasEstimate = (long)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * marginWithDecimals);
         if (optimisticGasEstimate > leftBound && optimisticGasEstimate < rightBound)
         {
-            if (TryExecutableTransaction(tx, header, optimisticGasEstimate, token, gasTracer))
+            if (TryExecutableTransaction(tx, header, optimisticGasEstimate, gasTracer, token))
                 rightBound = optimisticGasEstimate;
             else
                 leftBound = optimisticGasEstimate;
@@ -137,7 +141,7 @@ public class GasEstimator(
                && leftBound + 1 < rightBound)
         {
             long mid = (leftBound + rightBound) / 2;
-            if (!TryExecutableTransaction(tx, header, mid, token, gasTracer))
+            if (!TryExecutableTransaction(tx, header, mid, gasTracer, token))
             {
                 leftBound = mid;
             }
@@ -147,7 +151,7 @@ public class GasEstimator(
             }
         }
 
-        if (rightBound == cap && !TryExecutableTransaction(tx, header, rightBound, token, gasTracer))
+        if (rightBound == cap && !TryExecutableTransaction(tx, header, rightBound, gasTracer, token))
         {
             err = GetError(gasTracer);
             return 0;
@@ -173,11 +177,11 @@ public class GasEstimator(
             or TransactionResult.ErrorType.BlockGasLimitExceeded;
 
     private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
-        CancellationToken token, EstimateGasTracer gasTracer)
-        => TryExecutableTransaction(transaction, block, gasLimit, token, gasTracer, out _);
+        EstimateGasTracer gasTracer, CancellationToken token)
+        => TryExecutableTransaction(transaction, block, gasLimit, gasTracer, token, out _);
 
     private bool TryExecutableTransaction(Transaction transaction, BlockHeader block, long gasLimit,
-        CancellationToken token, EstimateGasTracer gasTracer, out TransactionResult? result)
+        EstimateGasTracer gasTracer, CancellationToken token, out bool isGasRelatedFailure)
     {
         Transaction txClone = new();
         transaction.CopyTo(txClone);
@@ -188,11 +192,11 @@ public class GasEstimator(
 
         if (IsGasRelatedExecutionFailure(callResult))
         {
-            result = null;
+            isGasRelatedFailure = true;
             return false;
         }
 
-        result = callResult;
+        isGasRelatedFailure = false;
 
         // Transaction succeeds if it executed, has success status, no OutOfGas, and no top-level revert
         return callResult.TransactionExecuted && gasTracer.StatusCode == StatusCode.Success &&

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -71,7 +71,7 @@ public class GasEstimator(
         rightBound = CapByAllowance(tx, available, rightBound);
 
         // If transaction is simple transfer return intrinsic gas
-        if (IsSimpleTransfer(tx) && lowerBound <= rightBound && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
+        if (IsSimpleTransfer(tx) && TryExecutableTransaction(tx, header, lowerBound, gasTracer, token))
             return lowerBound;
 
         // Execute at the highest allowable gas limit first (Geth parity).

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -521,7 +521,7 @@ public class BlockchainBridgeTests
     }
 
     [Test]
-    public void EstimateGas_tx_returns_BlockGasLimitExceededError()
+    public void EstimateGas_tx_block_gas_limit_exceeded_returns_allowance_error()
     {
         BlockHeader header = Build.A.BlockHeader
             .TestObject;
@@ -606,7 +606,7 @@ public class BlockchainBridgeTests
     }
 
     [Test]
-    public void EstimateGas_tx_returns_GasLimitBelowIntrinsicGasError()
+    public void EstimateGas_tx_gas_limit_below_intrinsic_gas_returns_allowance_error()
     {
         BlockHeader header = Build.A.BlockHeader
             .TestObject;

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -531,7 +531,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.EstimateGas(header, tx, 1);
 
-        Assert.That(callOutput.Error, Is.EqualTo("Block gas limit exceeded"));
+        Assert.That(callOutput.Error, Is.EqualTo("gas required exceeds allowance (4000000)"));
     }
 
 
@@ -616,7 +616,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.EstimateGas(header, tx, 1);
 
-        Assert.That(callOutput.Error, Is.EqualTo("gas limit below intrinsic gas"));
+        Assert.That(callOutput.Error, Is.EqualTo("gas required exceeds allowance (4000000)"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -189,8 +189,8 @@ namespace Nethermind.Facade
             string? error = ConstructError(tryCallResult, estimateGasTracer.Error);
 
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
-            bool allowanceFailure = err?.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
-            if (allowanceFailure || error is null)
+            bool? allowanceFailure = err?.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
+            if (allowanceFailure == true || error is null)
                 // Allowance errors take precedence over any earlier revert: the revert was an artifact
                 // of the gas cap, so surfacing it instead of the affordability error would be misleading.
                 error = err;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -192,8 +192,7 @@ namespace Nethermind.Facade
             if (err is not null)
             {
                 bool allowanceFailure = err.StartsWith("gas required exceeds allowance", StringComparison.Ordinal);
-                bool gasRelatedExecutionFailure = tryCallResult.Error is TransactionResult.ErrorType.GasLimitBelowIntrinsicGas or TransactionResult.ErrorType.BlockGasLimitExceeded;
-                if (allowanceFailure || gasRelatedExecutionFailure)
+                if (allowanceFailure)
                     error = err;
                 else
                     error ??= err;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -189,14 +189,11 @@ namespace Nethermind.Facade
             string? error = ConstructError(tryCallResult, estimateGasTracer.Error);
 
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
-            if (err is not null)
-            {
-                bool allowanceFailure = err.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
-                if (allowanceFailure || error is null)
-                    // Allowance errors take precedence over any earlier revert: the revert was an artifact
-                    // of the gas cap, so surfacing it instead of the affordability error would be misleading.
-                    error = err;
-            }
+            bool allowanceFailure = err.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
+            if (allowanceFailure || error is null)
+                // Allowance errors take precedence over any earlier revert: the revert was an artifact
+                // of the gas cap, so surfacing it instead of the affordability error would be misleading.
+                error = err;
 
             return new CallOutput
             {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -191,8 +191,10 @@ namespace Nethermind.Facade
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
             if (err is not null)
             {
-                bool allowanceFailure = err.StartsWith("gas required exceeds allowance", StringComparison.Ordinal);
+                bool allowanceFailure = err.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
                 if (allowanceFailure)
+                    // Allowance errors take precedence over any earlier revert: the revert was an artifact
+                    // of the gas cap, so surfacing it instead of the affordability error would be misleading.
                     error = err;
                 else
                     error ??= err;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -189,7 +189,7 @@ namespace Nethermind.Facade
             string? error = ConstructError(tryCallResult, estimateGasTracer.Error);
 
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
-            bool allowanceFailure = err.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
+            bool allowanceFailure = err?.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
             if (allowanceFailure || error is null)
                 // Allowance errors take precedence over any earlier revert: the revert was an artifact
                 // of the gas cap, so surfacing it instead of the affordability error would be misleading.

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -192,12 +192,10 @@ namespace Nethermind.Facade
             if (err is not null)
             {
                 bool allowanceFailure = err.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
-                if (allowanceFailure)
+                if (allowanceFailure || error is null)
                     // Allowance errors take precedence over any earlier revert: the revert was an artifact
                     // of the gas cap, so surfacing it instead of the affordability error would be misleading.
                     error = err;
-                else
-                    error ??= err;
             }
 
             return new CallOutput

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -189,10 +189,9 @@ namespace Nethermind.Facade
             string? error = ConstructError(tryCallResult, estimateGasTracer.Error);
 
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
-            bool? allowanceFailure = err?.StartsWith(GasEstimator.AllowanceExceedanceMsgPrefix, StringComparison.Ordinal);
-            if (allowanceFailure == true || error is null)
-                // Allowance errors take precedence over any earlier revert: the revert was an artifact
-                // of the gas cap, so surfacing it instead of the affordability error would be misleading.
+            // Allowance errors take precedence over any earlier revert: the revert was an artifact
+            // of the gas cap, so surfacing it instead of the affordability error would be misleading.
+            if (err is not null && (error is null || err.StartsWith(GasEstimator.GasExceedsAllowanceMsgPrefix, StringComparison.Ordinal)))
                 error = err;
 
             return new CallOutput

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -191,7 +191,12 @@ namespace Nethermind.Facade
             long estimate = gasEstimator.Estimate(tx, header, estimateGasTracer, out string? err, errorMargin, cancellationToken);
             if (err is not null)
             {
-                error ??= err;
+                bool allowanceFailure = err.StartsWith("gas required exceeds allowance", StringComparison.Ordinal);
+                bool gasRelatedExecutionFailure = tryCallResult.Error is TransactionResult.ErrorType.GasLimitBelowIntrinsicGas or TransactionResult.ErrorType.BlockGasLimitExceeded;
+                if (allowanceFailure || gasRelatedExecutionFailure)
+                    error = err;
+                else
+                    error ??= err;
             }
 
             return new CallOutput

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -424,6 +424,24 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Estimate_gas_returns_allowance_error_when_balance_insufficient_for_gas_price()
+    {
+        // Geth parity: when sender balance is too low to cover gas at the given gasPrice,
+        // cap rightBound to allowance = balance / gasPrice, execute at that cap, fail OOG,
+        // and return "gas required exceeds allowance (N)".
+        using Context ctx = await Context.CreateWithLondonEnabled();
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0xa9ac1233699bdae25abebae4f9fb54dbb1b44700","to":"0x252568abdeb9de59fd8963dfcd87be2db65f1ce1","gasPrice":"0xBA43B7400"}""")!;
+        object stateOverride = JsonSerializer.Deserialize<object>(
+            """{"0xa9ac1233699bdae25abebae4f9fb54dbb1b44700":{"balance":"0x100000000000"}}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest", stateOverride);
+        JToken.Parse(serialized).Should().BeEquivalentTo(
+            """{"jsonrpc":"2.0","error":{"code":-32000,"message":"gas required exceeds allowance (351)"},"id":67}""");
+    }
+
+    [Test]
     public async Task Eth_estimateGas_ignores_invalid_nonce()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -389,7 +389,7 @@ public partial class EthRpcModuleTests
         string blockResponse = await ctx.Test.TestEthRpc("eth_getBlockByNumber", blockNumber, false);
         long blockGasLimit = Convert.ToInt64(JToken.Parse(blockResponse).SelectToken("result.gasLimit")!.Value<string>(), 16);
 
-        await TestEstimateGasOutOfGas(ctx, null, blockGasLimit, "out of gas");
+        await TestEstimateGasOutOfGas(ctx, null, blockGasLimit, $"gas required exceeds allowance ({blockGasLimit})");
     }
 
     [Test]
@@ -412,7 +412,7 @@ public partial class EthRpcModuleTests
     public async Task Estimate_gas_uses_specified_gas_limit()
     {
         using Context ctx = await Context.Create();
-        await TestEstimateGasOutOfGas(ctx, 30000000, 30000000, "Block gas limit exceeded");
+        await TestEstimateGasOutOfGas(ctx, 30000000, 30000000, $"gas required exceeds allowance ({30000000})");
     }
 
     [Test]
@@ -420,7 +420,7 @@ public partial class EthRpcModuleTests
     {
         using Context ctx = await Context.Create();
         ctx.Test.RpcConfig.GasCap = 50000000;
-        await TestEstimateGasOutOfGas(ctx, 300000000, 50000000, "Block gas limit exceeded");
+        await TestEstimateGasOutOfGas(ctx, 300000000, 50000000, $"gas required exceeds allowance ({50000000})");
     }
 
     [Test]


### PR DESCRIPTION
Fixes Closes Resolves #11122 

## Changes

- Gasestimator to match allowance error in geth estimator

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Will Require end to end testing 

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
