### PR TITLE
fix: drop BlobCountLimit to stop peer churn during sync

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -10,8 +10,6 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     : BaseEIP1559TxDecoder<T>(TxType.Blob, transactionFactory) where T : Transaction, new()
 {
-    private static readonly RlpLimit BlobCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
-
     public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
         ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
@@ -88,7 +86,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     {
         base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
-        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobCountLimit, innerSize: Hash256.Size);
+        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays();
     }
 
     protected override void EncodePayload(Transaction transaction, RlpStream stream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -110,9 +108,9 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
             }
         }
 
-        byte[][] blobs = decoderContext.DecodeByteArrays(BlobCountLimit);
-        byte[][] commitments = decoderContext.DecodeByteArrays(BlobCountLimit);
-        byte[][] proofs = decoderContext.DecodeByteArrays(BlobCountLimit);
+        byte[][] blobs = decoderContext.DecodeByteArrays();
+        byte[][] commitments = decoderContext.DecodeByteArrays();
+        byte[][] proofs = decoderContext.DecodeByteArrays();
 
         transaction.NetworkWrapper = new ShardBlobNetworkWrapper(blobs, commitments, proofs, version);
     }


### PR DESCRIPTION
## Summary

- Removes the 128-item `BlobCountLimit` cap that `release/1.37.0-rc2` added via #10697 on `Transaction.BlobVersionedHashes` (and on blobs/commitments/proofs inside `ShardBlobNetworkWrapper`)
- Restores the exact behaviour that shipped in `1.36.2` and is currently on `master` — safest possible minimal diff for a release branch: 1 file, −6 / +4 lines

## Why

On a live sync, ~90% of `DisconnectReason.MessageLimitsBreached` kicks come from this one decode site. The observed collection counts (384 / 512 / 640 / 768) are all exact multiples of 128 and the `bytes-left` arithmetic matches 48-byte G1 cell proofs, not 32-byte versioned hashes — so the decoder is landing on PeerDAS V1 cell-proof bytes on some tx-gossip path. `1.36.2` shipped Fusaka/PeerDAS support without this cap and is reported to work fine against the same peers.

Every major client (Geth, reth, besu, erigon, and even Nethermind peers themselves) trips this cap, so it is categorically not a malicious-peer filter — it is unnecessary churn against the network. Each trip triggers `Session.InitiateDisconnect(MessageLimitsBreached)` via [ProtocolHandlerBase.cs:77-82](../../../blob/release/1.37.0-rc2/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs#L77-L82), directly slowing sync.

The per-tx blob count is still enforced downstream by `TxValidator` / `BlockValidator`, so no consensus-level guard is removed by this change.

## Alternatives considered

- Bumping the limit (e.g. 128 → 4096): does not help. Count check passes, but the `innerSize: Hash256.Size` per-item check fires next and throws `RlpException` → `BreachOfProtocol` → peer still kicked, just with a different reason.
- Fixing the underlying decoder misalignment with PeerDAS V1 wrappers: out of scope for a release-branch fix. Should be tracked as a follow-up on `master`.

## Test plan

- [ ] Unit tests in `Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs` still pass
- [ ] Live sync on Hoodi / Holesky: `MessageLimitsBreached` disconnects for blob tx decodes go to zero
- [ ] Peer count recovers, sync throughput returns to 1.36.2 levels