### PR TITLE
feat(logging): add DebugError/DebugWarn helpers with Kind property for Seq

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -117,7 +117,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
         catch (Exception ex)
         {
-            if (_logger.IsDebug) _logger.Warn($"DEBUG/ERROR Error pre-warming {suggestedBlock.Number}. {ex}");
+            _logger.DebugWarn($"Error pre-warming {suggestedBlock.Number}. {ex}");
         }
         finally
         {
@@ -162,7 +162,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
         catch (Exception ex)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Error pre-warming withdrawal", ex);
+            _logger.DebugError("Error pre-warming withdrawal", ex);
         }
     }
 
@@ -230,7 +230,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
         catch (Exception ex)
         {
-            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Error pre-warming transactions", ex);
+            _logger.DebugError($"Error pre-warming transactions", ex);
         }
     }
 
@@ -285,7 +285,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
         catch (Exception ex)
         {
-            if (blockState.PreWarmer._logger.IsDebug) blockState.PreWarmer._logger.Error($"DEBUG/ERROR Error pre-warming cache {tx.Hash}", ex);
+            blockState.PreWarmer._logger.DebugError($"Error pre-warming cache {tx.Hash}", ex);
         }
     }
 
@@ -324,7 +324,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             }
             catch (Exception ex)
             {
-                if (PreWarmer._logger.IsDebug) PreWarmer._logger.Error($"DEBUG/ERROR Error pre-warming addresses", ex);
+                PreWarmer._logger.DebugError($"Error pre-warming addresses", ex);
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -230,7 +230,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
         catch (Exception ex)
         {
-            _logger.DebugError($"Error pre-warming transactions", ex);
+            _logger.DebugError("Error pre-warming transactions", ex);
         }
     }
 
@@ -324,7 +324,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             }
             catch (Exception ex)
             {
-                PreWarmer._logger.DebugError($"Error pre-warming addresses", ex);
+                PreWarmer._logger.DebugError("Error pre-warming addresses", ex);
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
@@ -60,5 +60,21 @@ namespace Nethermind.Logging.NLog
         {
             if (IsError) _logger.Error(ex, text);
         }
+
+        public void Warn(string text, LogEventKind kind)
+        {
+            if (!IsWarn) return;
+            LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Warn, _logger.Name, text);
+            evt.Properties["Kind"] = kind.ToString();
+            _logger.Log(evt);
+        }
+
+        public void Error(string text, LogEventKind kind, Exception ex = null)
+        {
+            if (!IsError) return;
+            LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Error, _logger.Name, ex, null, text);
+            evt.Properties["Kind"] = kind.ToString();
+            _logger.Log(evt);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
@@ -61,11 +61,14 @@ namespace Nethermind.Logging.NLog
             if (IsError) _logger.Error(ex, text);
         }
 
+        // Static cache of enum names to avoid the per-call allocation of Enum.ToString().
+        private static readonly string[] s_kindNames = Enum.GetNames<LogEventKind>();
+
         public void Warn(string text, LogEventKind kind)
         {
             if (!IsWarn) return;
             LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Warn, _logger.Name, text);
-            evt.Properties["Kind"] = kind.ToString();
+            evt.Properties["Kind"] = s_kindNames[(int)kind];
             _logger.Log(evt);
         }
 
@@ -73,7 +76,7 @@ namespace Nethermind.Logging.NLog
         {
             if (!IsError) return;
             LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Error, _logger.Name, ex, null, text);
-            evt.Properties["Kind"] = kind.ToString();
+            evt.Properties["Kind"] = s_kindNames[(int)kind];
             _logger.Log(evt);
         }
     }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogLogger.cs
@@ -61,14 +61,11 @@ namespace Nethermind.Logging.NLog
             if (IsError) _logger.Error(ex, text);
         }
 
-        // Static cache of enum names to avoid the per-call allocation of Enum.ToString().
-        private static readonly string[] s_kindNames = Enum.GetNames<LogEventKind>();
-
         public void Warn(string text, LogEventKind kind)
         {
             if (!IsWarn) return;
             LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Warn, _logger.Name, text);
-            evt.Properties["Kind"] = s_kindNames[(int)kind];
+            evt.Properties["Kind"] = Enum.GetName(kind);
             _logger.Log(evt);
         }
 
@@ -76,7 +73,7 @@ namespace Nethermind.Logging.NLog
         {
             if (!IsError) return;
             LogEventInfo evt = LogEventInfo.Create(global::NLog.LogLevel.Error, _logger.Name, ex, null, text);
-            evt.Properties["Kind"] = s_kindNames[(int)kind];
+            evt.Properties["Kind"] = Enum.GetName(kind);
             _logger.Log(evt);
         }
     }

--- a/src/Nethermind/Nethermind.Logging/ILogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogger.cs
@@ -79,6 +79,100 @@ public struct ILogger : IEquatable<ILogger>
         if (IsWarn) _logger.Warn(text);
     }
 
+    /// <summary>
+    /// Logs at <see cref="InterfaceLogger.Error"/> severity, but only when <see cref="IsDebug"/> is true.
+    /// Replaces the manual <c>if (logger.IsDebug) logger.Error($"DEBUG/ERROR: ...")</c> idiom.
+    /// Interpolation of the message is skipped entirely when <see cref="IsDebug"/> is false,
+    /// so the callsite pays no allocation cost in the common (disabled) case.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void DebugError(
+        [InterpolatedStringHandlerArgument("")] ref DebugErrorInterpolatedStringHandler handler,
+        Exception ex = null)
+    {
+        if (IsDebug) _logger.Error(handler.ToStringAndClear(), LogEventKind.DebugError, ex);
+    }
+
+    /// <summary>
+    /// Plain-string overload of <see cref="DebugError(ref DebugErrorInterpolatedStringHandler, Exception)"/>
+    /// for callers that pass a literal message with no interpolation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void DebugError(string text, Exception ex = null)
+    {
+        if (IsDebug) _logger.Error("DEBUG/ERROR: " + text, LogEventKind.DebugError, ex);
+    }
+
+    /// <summary>
+    /// Logs at <see cref="InterfaceLogger.Warn"/> severity, but only when <see cref="IsDebug"/> is true.
+    /// Replaces the manual <c>if (logger.IsDebug) logger.Warn($"DEBUG/WARN: ...")</c> idiom.
+    /// Interpolation of the message is skipped entirely when <see cref="IsDebug"/> is false,
+    /// so the callsite pays no allocation cost in the common (disabled) case.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void DebugWarn(
+        [InterpolatedStringHandlerArgument("")] ref DebugWarnInterpolatedStringHandler handler)
+    {
+        if (IsDebug) _logger.Warn(handler.ToStringAndClear(), LogEventKind.DebugWarn);
+    }
+
+    /// <summary>
+    /// Plain-string overload of <see cref="DebugWarn(ref DebugWarnInterpolatedStringHandler)"/>
+    /// for callers that pass a literal message with no interpolation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void DebugWarn(string text)
+    {
+        if (IsDebug) _logger.Warn("DEBUG/WARN: " + text, LogEventKind.DebugWarn);
+    }
+
+    /// <summary>
+    /// Logs at <see cref="InterfaceLogger.Error"/> severity, but only when <see cref="IsTrace"/> is true.
+    /// Replaces the manual <c>if (logger.IsTrace) logger.Error($"TRACE/ERROR: ...")</c> idiom.
+    /// Interpolation of the message is skipped entirely when <see cref="IsTrace"/> is false,
+    /// so the callsite pays no allocation cost in the common (disabled) case.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void TraceError(
+        [InterpolatedStringHandlerArgument("")] ref TraceErrorInterpolatedStringHandler handler,
+        Exception ex = null)
+    {
+        if (IsTrace) _logger.Error(handler.ToStringAndClear(), LogEventKind.TraceError, ex);
+    }
+
+    /// <summary>
+    /// Plain-string overload of <see cref="TraceError(ref TraceErrorInterpolatedStringHandler, Exception)"/>
+    /// for callers that pass a literal message with no interpolation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void TraceError(string text, Exception ex = null)
+    {
+        if (IsTrace) _logger.Error("TRACE/ERROR: " + text, LogEventKind.TraceError, ex);
+    }
+
+    /// <summary>
+    /// Logs at <see cref="InterfaceLogger.Warn"/> severity, but only when <see cref="IsTrace"/> is true.
+    /// Replaces the manual <c>if (logger.IsTrace) logger.Warn($"TRACE/WARN: ...")</c> idiom.
+    /// Interpolation of the message is skipped entirely when <see cref="IsTrace"/> is false,
+    /// so the callsite pays no allocation cost in the common (disabled) case.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void TraceWarn(
+        [InterpolatedStringHandlerArgument("")] ref TraceWarnInterpolatedStringHandler handler)
+    {
+        if (IsTrace) _logger.Warn(handler.ToStringAndClear(), LogEventKind.TraceWarn);
+    }
+
+    /// <summary>
+    /// Plain-string overload of <see cref="TraceWarn(ref TraceWarnInterpolatedStringHandler)"/>
+    /// for callers that pass a literal message with no interpolation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public readonly void TraceWarn(string text)
+    {
+        if (IsTrace) _logger.Warn("TRACE/WARN: " + text, LogEventKind.TraceWarn);
+    }
+
     [Flags]
     private enum LogLevel
     {

--- a/src/Nethermind/Nethermind.Logging/ILogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogger.cs
@@ -87,14 +87,14 @@ public struct ILogger : IEquatable<ILogger>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void DebugError(
-        [InterpolatedStringHandlerArgument("")] ref DebugErrorInterpolatedStringHandler handler,
+        [InterpolatedStringHandlerArgument("")] ref DebugInterpolatedStringHandler handler,
         Exception ex = null)
     {
-        if (IsDebug) _logger.Error(handler.ToStringAndClear(), LogEventKind.DebugError, ex);
+        if (IsDebug) _logger.Error("DEBUG/ERROR: " + handler.ToStringAndClear(), LogEventKind.DebugError, ex);
     }
 
     /// <summary>
-    /// Plain-string overload of <see cref="DebugError(ref DebugErrorInterpolatedStringHandler, Exception)"/>
+    /// Plain-string overload of <see cref="DebugError(ref DebugInterpolatedStringHandler, Exception)"/>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -111,13 +111,13 @@ public struct ILogger : IEquatable<ILogger>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void DebugWarn(
-        [InterpolatedStringHandlerArgument("")] ref DebugWarnInterpolatedStringHandler handler)
+        [InterpolatedStringHandlerArgument("")] ref DebugInterpolatedStringHandler handler)
     {
-        if (IsDebug) _logger.Warn(handler.ToStringAndClear(), LogEventKind.DebugWarn);
+        if (IsDebug) _logger.Warn("DEBUG/WARN: " + handler.ToStringAndClear(), LogEventKind.DebugWarn);
     }
 
     /// <summary>
-    /// Plain-string overload of <see cref="DebugWarn(ref DebugWarnInterpolatedStringHandler)"/>
+    /// Plain-string overload of <see cref="DebugWarn(ref DebugInterpolatedStringHandler)"/>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -134,14 +134,14 @@ public struct ILogger : IEquatable<ILogger>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void TraceError(
-        [InterpolatedStringHandlerArgument("")] ref TraceErrorInterpolatedStringHandler handler,
+        [InterpolatedStringHandlerArgument("")] ref TraceInterpolatedStringHandler handler,
         Exception ex = null)
     {
-        if (IsTrace) _logger.Error(handler.ToStringAndClear(), LogEventKind.TraceError, ex);
+        if (IsTrace) _logger.Error("TRACE/ERROR: " + handler.ToStringAndClear(), LogEventKind.TraceError, ex);
     }
 
     /// <summary>
-    /// Plain-string overload of <see cref="TraceError(ref TraceErrorInterpolatedStringHandler, Exception)"/>
+    /// Plain-string overload of <see cref="TraceError(ref TraceInterpolatedStringHandler, Exception)"/>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -158,13 +158,13 @@ public struct ILogger : IEquatable<ILogger>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public readonly void TraceWarn(
-        [InterpolatedStringHandlerArgument("")] ref TraceWarnInterpolatedStringHandler handler)
+        [InterpolatedStringHandlerArgument("")] ref TraceInterpolatedStringHandler handler)
     {
-        if (IsTrace) _logger.Warn(handler.ToStringAndClear(), LogEventKind.TraceWarn);
+        if (IsTrace) _logger.Warn("TRACE/WARN: " + handler.ToStringAndClear(), LogEventKind.TraceWarn);
     }
 
     /// <summary>
-    /// Plain-string overload of <see cref="TraceWarn(ref TraceWarnInterpolatedStringHandler)"/>
+    /// Plain-string overload of <see cref="TraceWarn(ref TraceInterpolatedStringHandler)"/>
     /// for callers that pass a literal message with no interpolation.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
@@ -13,6 +13,22 @@ namespace Nethermind.Logging
         void Trace(string text);
         void Error(string text, Exception ex = null);
 
+        /// <summary>
+        /// Logs a warning tagged with a <see cref="LogEventKind"/>. Sinks that support structured
+        /// events (e.g. NLog → Seq) attach the kind as a queryable property so operators can
+        /// filter these events separately from plain warnings. Default implementation drops the
+        /// kind and falls through to <see cref="Warn(string)"/>.
+        /// </summary>
+        void Warn(string text, LogEventKind kind) => Warn(text);
+
+        /// <summary>
+        /// Logs an error tagged with a <see cref="LogEventKind"/>. Sinks that support structured
+        /// events (e.g. NLog → Seq) attach the kind as a queryable property so operators can
+        /// filter these events separately from plain errors. Default implementation drops the
+        /// kind and falls through to <see cref="Error(string, Exception)"/>.
+        /// </summary>
+        void Error(string text, LogEventKind kind, Exception ex = null) => Error(text, ex);
+
         bool IsInfo { get; }
         bool IsWarn { get; }
         bool IsDebug { get; }

--- a/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
+++ b/src/Nethermind/Nethermind.Logging/InterfaceLogger.cs
@@ -19,6 +19,8 @@ namespace Nethermind.Logging
         /// filter these events separately from plain warnings. Default implementation drops the
         /// kind and falls through to <see cref="Warn(string)"/>.
         /// </summary>
+        // Note: the sink may still suppress the event if its own level filter (IsWarn / IsError)
+        // is not satisfied, even when IsDebug / IsTrace is true at the caller.
         void Warn(string text, LogEventKind kind) => Warn(text);
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Logging/LogEventKind.cs
+++ b/src/Nethermind/Nethermind.Logging/LogEventKind.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Logging;
+
+/// <summary>
+/// Tag attached to log events that belong to a specific subcategory of their base severity.
+/// Sinks that support structured properties (e.g. NLog → Seq) publish this as a queryable
+/// <c>Kind</c> field, so operators can filter subcategories in/out of their dashboards without
+/// relying on text patterns inside the log message.
+/// </summary>
+public enum LogEventKind
+{
+    /// <summary>
+    /// An error that is only surfaced because debug-level logging is enabled. Not a real
+    /// operational error on the node's main responsibilities. Emitted via
+    /// <see cref="ILogger.DebugError"/>.
+    /// </summary>
+    DebugError,
+
+    /// <summary>
+    /// A warning that is only surfaced because debug-level logging is enabled. Emitted via
+    /// <see cref="ILogger.DebugWarn"/>.
+    /// </summary>
+    DebugWarn,
+
+    /// <summary>
+    /// An error that is only surfaced because trace-level logging is enabled. Even lower
+    /// signal than <see cref="DebugError"/>. Emitted via <see cref="ILogger.TraceError"/>.
+    /// </summary>
+    TraceError,
+
+    /// <summary>
+    /// A warning that is only surfaced because trace-level logging is enabled. Even lower
+    /// signal than <see cref="DebugWarn"/>. Emitted via <see cref="ILogger.TraceWarn"/>.
+    /// </summary>
+    TraceWarn,
+}

--- a/src/Nethermind/Nethermind.Logging/LoggerInterpolatedStringHandlers.cs
+++ b/src/Nethermind/Nethermind.Logging/LoggerInterpolatedStringHandlers.cs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Logging;
+
+/// <summary>
+/// Interpolated string handler for <see cref="ILogger.DebugError"/>. When <see cref="ILogger.IsDebug"/> is
+/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
+/// allocation cost. When true, the result is prefixed with "DEBUG/ERROR: " before being logged.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct DebugErrorInterpolatedStringHandler
+{
+    private const string Prefix = "DEBUG/ERROR: ";
+
+    private DefaultInterpolatedStringHandler _inner;
+    private readonly bool _enabled;
+
+    public DebugErrorInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    {
+        _enabled = shouldAppend = logger.IsDebug;
+        if (_enabled)
+        {
+            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
+            _inner.AppendLiteral(Prefix);
+        }
+        else
+        {
+            _inner = default;
+        }
+    }
+
+    public void AppendLiteral(string value)
+    {
+        if (_enabled) _inner.AppendLiteral(value);
+    }
+
+    public void AppendFormatted<T>(T value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public void AppendFormatted<T>(T value, string format)
+    {
+        if (_enabled) _inner.AppendFormatted(value, format);
+    }
+
+    public void AppendFormatted(string value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+}
+
+/// <summary>
+/// Interpolated string handler for <see cref="ILogger.DebugWarn"/>. When <see cref="ILogger.IsDebug"/> is
+/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
+/// allocation cost. When true, the result is prefixed with "DEBUG/WARN: " before being logged.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct DebugWarnInterpolatedStringHandler
+{
+    private const string Prefix = "DEBUG/WARN: ";
+
+    private DefaultInterpolatedStringHandler _inner;
+    private readonly bool _enabled;
+
+    public DebugWarnInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    {
+        _enabled = shouldAppend = logger.IsDebug;
+        if (_enabled)
+        {
+            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
+            _inner.AppendLiteral(Prefix);
+        }
+        else
+        {
+            _inner = default;
+        }
+    }
+
+    public void AppendLiteral(string value)
+    {
+        if (_enabled) _inner.AppendLiteral(value);
+    }
+
+    public void AppendFormatted<T>(T value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public void AppendFormatted<T>(T value, string format)
+    {
+        if (_enabled) _inner.AppendFormatted(value, format);
+    }
+
+    public void AppendFormatted(string value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+}
+
+/// <summary>
+/// Interpolated string handler for <see cref="ILogger.TraceError"/>. When <see cref="ILogger.IsTrace"/> is
+/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
+/// allocation cost. When true, the result is prefixed with "TRACE/ERROR: " before being logged.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct TraceErrorInterpolatedStringHandler
+{
+    private const string Prefix = "TRACE/ERROR: ";
+
+    private DefaultInterpolatedStringHandler _inner;
+    private readonly bool _enabled;
+
+    public TraceErrorInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    {
+        _enabled = shouldAppend = logger.IsTrace;
+        if (_enabled)
+        {
+            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
+            _inner.AppendLiteral(Prefix);
+        }
+        else
+        {
+            _inner = default;
+        }
+    }
+
+    public void AppendLiteral(string value)
+    {
+        if (_enabled) _inner.AppendLiteral(value);
+    }
+
+    public void AppendFormatted<T>(T value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public void AppendFormatted<T>(T value, string format)
+    {
+        if (_enabled) _inner.AppendFormatted(value, format);
+    }
+
+    public void AppendFormatted(string value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+}
+
+/// <summary>
+/// Interpolated string handler for <see cref="ILogger.TraceWarn"/>. When <see cref="ILogger.IsTrace"/> is
+/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
+/// allocation cost. When true, the result is prefixed with "TRACE/WARN: " before being logged.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct TraceWarnInterpolatedStringHandler
+{
+    private const string Prefix = "TRACE/WARN: ";
+
+    private DefaultInterpolatedStringHandler _inner;
+    private readonly bool _enabled;
+
+    public TraceWarnInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    {
+        _enabled = shouldAppend = logger.IsTrace;
+        if (_enabled)
+        {
+            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
+            _inner.AppendLiteral(Prefix);
+        }
+        else
+        {
+            _inner = default;
+        }
+    }
+
+    public void AppendLiteral(string value)
+    {
+        if (_enabled) _inner.AppendLiteral(value);
+    }
+
+    public void AppendFormatted<T>(T value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public void AppendFormatted<T>(T value, string format)
+    {
+        if (_enabled) _inner.AppendFormatted(value, format);
+    }
+
+    public void AppendFormatted(string value)
+    {
+        if (_enabled) _inner.AppendFormatted(value);
+    }
+
+    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+}

--- a/src/Nethermind/Nethermind.Logging/LoggerInterpolatedStringHandlers.cs
+++ b/src/Nethermind/Nethermind.Logging/LoggerInterpolatedStringHandlers.cs
@@ -1,206 +1,59 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging;
 
 /// <summary>
-/// Interpolated string handler for <see cref="ILogger.DebugError"/>. When <see cref="ILogger.IsDebug"/> is
-/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
-/// allocation cost. When true, the result is prefixed with "DEBUG/ERROR: " before being logged.
+/// Interpolated string handler for <see cref="ILogger.DebugError"/> / <see cref="ILogger.DebugWarn"/>.
+/// When <see cref="ILogger.IsDebug"/> is false the compiler skips all AppendLiteral/AppendFormatted
+/// calls entirely, so the interpolation pays no allocation cost. The caller method is responsible
+/// for prepending the "DEBUG/ERROR: " or "DEBUG/WARN: " prefix; the handler stays severity-agnostic.
 /// </summary>
 [InterpolatedStringHandler]
-public ref struct DebugErrorInterpolatedStringHandler
+public ref struct DebugInterpolatedStringHandler
 {
-    private const string Prefix = "DEBUG/ERROR: ";
-
     private DefaultInterpolatedStringHandler _inner;
-    private readonly bool _enabled;
 
-    public DebugErrorInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    public DebugInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
     {
-        _enabled = shouldAppend = logger.IsDebug;
-        if (_enabled)
-        {
-            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
-            _inner.AppendLiteral(Prefix);
-        }
-        else
-        {
-            _inner = default;
-        }
+        shouldAppend = logger.IsDebug;
+        _inner = shouldAppend
+            ? new DefaultInterpolatedStringHandler(literalLength, formattedCount)
+            : default;
     }
 
-    public void AppendLiteral(string value)
-    {
-        if (_enabled) _inner.AppendLiteral(value);
-    }
-
-    public void AppendFormatted<T>(T value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public void AppendFormatted<T>(T value, string format)
-    {
-        if (_enabled) _inner.AppendFormatted(value, format);
-    }
-
-    public void AppendFormatted(string value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+    public void AppendLiteral(string value) => _inner.AppendLiteral(value);
+    public void AppendFormatted<T>(T value) => _inner.AppendFormatted(value);
+    public void AppendFormatted<T>(T value, string format) => _inner.AppendFormatted(value, format);
+    public void AppendFormatted(string value) => _inner.AppendFormatted(value);
+    public void AppendFormatted(ReadOnlySpan<char> value) => _inner.AppendFormatted(value);
+    public string ToStringAndClear() => _inner.ToStringAndClear();
 }
 
 /// <summary>
-/// Interpolated string handler for <see cref="ILogger.DebugWarn"/>. When <see cref="ILogger.IsDebug"/> is
-/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
-/// allocation cost. When true, the result is prefixed with "DEBUG/WARN: " before being logged.
+/// Interpolated string handler for <see cref="ILogger.TraceError"/> / <see cref="ILogger.TraceWarn"/>.
+/// Same shape as <see cref="DebugInterpolatedStringHandler"/> but gated on <see cref="ILogger.IsTrace"/>.
 /// </summary>
 [InterpolatedStringHandler]
-public ref struct DebugWarnInterpolatedStringHandler
+public ref struct TraceInterpolatedStringHandler
 {
-    private const string Prefix = "DEBUG/WARN: ";
-
     private DefaultInterpolatedStringHandler _inner;
-    private readonly bool _enabled;
 
-    public DebugWarnInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
+    public TraceInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
     {
-        _enabled = shouldAppend = logger.IsDebug;
-        if (_enabled)
-        {
-            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
-            _inner.AppendLiteral(Prefix);
-        }
-        else
-        {
-            _inner = default;
-        }
+        shouldAppend = logger.IsTrace;
+        _inner = shouldAppend
+            ? new DefaultInterpolatedStringHandler(literalLength, formattedCount)
+            : default;
     }
 
-    public void AppendLiteral(string value)
-    {
-        if (_enabled) _inner.AppendLiteral(value);
-    }
-
-    public void AppendFormatted<T>(T value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public void AppendFormatted<T>(T value, string format)
-    {
-        if (_enabled) _inner.AppendFormatted(value, format);
-    }
-
-    public void AppendFormatted(string value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
-}
-
-/// <summary>
-/// Interpolated string handler for <see cref="ILogger.TraceError"/>. When <see cref="ILogger.IsTrace"/> is
-/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
-/// allocation cost. When true, the result is prefixed with "TRACE/ERROR: " before being logged.
-/// </summary>
-[InterpolatedStringHandler]
-public ref struct TraceErrorInterpolatedStringHandler
-{
-    private const string Prefix = "TRACE/ERROR: ";
-
-    private DefaultInterpolatedStringHandler _inner;
-    private readonly bool _enabled;
-
-    public TraceErrorInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
-    {
-        _enabled = shouldAppend = logger.IsTrace;
-        if (_enabled)
-        {
-            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
-            _inner.AppendLiteral(Prefix);
-        }
-        else
-        {
-            _inner = default;
-        }
-    }
-
-    public void AppendLiteral(string value)
-    {
-        if (_enabled) _inner.AppendLiteral(value);
-    }
-
-    public void AppendFormatted<T>(T value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public void AppendFormatted<T>(T value, string format)
-    {
-        if (_enabled) _inner.AppendFormatted(value, format);
-    }
-
-    public void AppendFormatted(string value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
-}
-
-/// <summary>
-/// Interpolated string handler for <see cref="ILogger.TraceWarn"/>. When <see cref="ILogger.IsTrace"/> is
-/// false the compiler skips all AppendLiteral/AppendFormatted calls, so the interpolation pays no
-/// allocation cost. When true, the result is prefixed with "TRACE/WARN: " before being logged.
-/// </summary>
-[InterpolatedStringHandler]
-public ref struct TraceWarnInterpolatedStringHandler
-{
-    private const string Prefix = "TRACE/WARN: ";
-
-    private DefaultInterpolatedStringHandler _inner;
-    private readonly bool _enabled;
-
-    public TraceWarnInterpolatedStringHandler(int literalLength, int formattedCount, ILogger logger, out bool shouldAppend)
-    {
-        _enabled = shouldAppend = logger.IsTrace;
-        if (_enabled)
-        {
-            _inner = new DefaultInterpolatedStringHandler(literalLength + Prefix.Length, formattedCount);
-            _inner.AppendLiteral(Prefix);
-        }
-        else
-        {
-            _inner = default;
-        }
-    }
-
-    public void AppendLiteral(string value)
-    {
-        if (_enabled) _inner.AppendLiteral(value);
-    }
-
-    public void AppendFormatted<T>(T value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public void AppendFormatted<T>(T value, string format)
-    {
-        if (_enabled) _inner.AppendFormatted(value, format);
-    }
-
-    public void AppendFormatted(string value)
-    {
-        if (_enabled) _inner.AppendFormatted(value);
-    }
-
-    public string ToStringAndClear() => _enabled ? _inner.ToStringAndClear() : string.Empty;
+    public void AppendLiteral(string value) => _inner.AppendLiteral(value);
+    public void AppendFormatted<T>(T value) => _inner.AppendFormatted(value);
+    public void AppendFormatted<T>(T value, string format) => _inner.AppendFormatted(value, format);
+    public void AppendFormatted(string value) => _inner.AppendFormatted(value);
+    public void AppendFormatted(ReadOnlySpan<char> value) => _inner.AppendFormatted(value);
+    public string ToStringAndClear() => _inner.ToStringAndClear();
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -373,7 +373,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
         }
         else if (t.IsFaulted)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Block improvement failed", t.Exception);
+            _logger.DebugError("Block improvement failed", t.Exception);
         }
         else if (t.IsCanceled)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -103,7 +103,7 @@ public partial class EngineRpcModule : IEngineRpcModule
             }
             catch (BlockchainException exception)
             {
-                if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR engine_newPayloadV{version} failed: {exception}");
+                _logger.DebugError($"engine_newPayloadV{version} failed: {exception}");
                 return ResultWrapper<PayloadStatusV1>.Fail(exception.Message, ErrorCodes.UnknownBlockError);
             }
             catch (Exception exception)

--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -78,7 +78,7 @@ public class MonitoringService : IMonitoringService, IAsyncDisposable
                         if (_logger.IsError) _logger.Error($"Cannot reach Pushgateway at {_pushGatewayUrl}", ex);
                         return;
                     }
-                    if (_logger.IsTrace) _logger.Error(ex.Message, ex); // keeping it as Error to log the exception details with it.
+                    _logger.TraceError(ex.Message, ex); // keeping it at Error severity to log exception details
                 }
             };
             MetricPusher metricPusher = new(pusherOptions);

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -278,7 +278,7 @@ public class DiscoveryApp : IDiscoveryApp
         }
         catch (Exception e)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Error during discovery initialization", e);
+            _logger.DebugError("Error during discovery initialization", e);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
@@ -62,9 +62,7 @@ namespace Nethermind.Network.Discovery
                 }
                 catch (Exception)
                 {
-                    if (_logger.IsDebug)
-                        _logger.Error(
-                            $"ERROR/DEBUG peer could not be loaded for {networkNode.NodeId}@{networkNode.Host}:{networkNode.Port}");
+                    _logger.DebugError($"peer could not be loaded for {networkNode.NodeId}@{networkNode.Host}:{networkNode.Port}");
                     continue;
                 }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
@@ -50,7 +50,7 @@ public class NettyDiscoveryV5Handler(ILogManager loggerManager) : NettyDiscovery
         }
         catch (SocketException exception)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Error sending data", exception);
+            _logger.DebugError("Error sending data", exception);
             throw;
         }
     }

--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
@@ -190,7 +190,7 @@ public class NettyDiscoveryHandler(
         }
         catch (Exception e)
         {
-            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Error while processing message, type: {type}, sender: {address}, message: {msg}", e);
+            _logger.DebugError($"Error while processing message, type: {type}, sender: {address}, message: {msg}", e);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
@@ -69,7 +69,7 @@ public class EnrDiscovery : INodeSource
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR failed to parse enr record {nodeRecordText}", e);
+                    _logger.DebugError($"failed to parse enr record {nodeRecordText}", e);
                 }
 
                 if (node is not null)

--- a/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
+++ b/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Network.IP
             }
             catch (Exception e)
             {
-                if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Error while getting external ip from {_url}", e);
+                _logger.DebugError($"Error while getting external ip from {_url}", e);
                 return Task.FromResult((false, (IPAddress)null));
             }
         }

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Network
                 }
                 catch (Exception)
                 {
-                    if (_logger.IsDebug) _logger.Error($"ERROR/DEBUG peer could not be loaded for {networkNode.NodeId}@{networkNode.Host}:{networkNode.Port}");
+                    _logger.DebugError($"peer could not be loaded for {networkNode.NodeId}@{networkNode.Host}:{networkNode.Port}");
                     continue;
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -440,7 +440,7 @@ namespace Nethermind.Network.P2P
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DebugDisconnectProtocolFailed(IProtocolHandler handler, Exception e)
-                => _logger.Error($"DEBUG/ERROR Failed to disconnect {handler.Name} correctly", e);
+                => _logger.DebugError($"Failed to disconnect {handler.Name} correctly", e);
         }
 
         private readonly Lock _sessionStateLock = new();
@@ -536,7 +536,7 @@ namespace Nethermind.Network.P2P
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DebugNoDisconnectedSubscriptions()
-                => _logger.Error($"DEBUG/ERROR  No subscriptions for session disconnected event on {this}");
+                => _logger.DebugError($"No subscriptions for session disconnected event on {this}");
         }
 
         private async Task DisconnectAsync(DisconnectType disconnectType)

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -409,7 +409,7 @@ namespace Nethermind.Network
             }
             catch (Exception e)
             {
-                if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Candidate peers cleanup failed", e);
+                _logger.DebugError("Candidate peers cleanup failed", e);
             }
         }
 
@@ -844,7 +844,7 @@ namespace Nethermind.Network
             }
             catch (Exception ex)
             {
-                if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Error trying to initiate connection with peer: {candidate.Node:s}", ex);
+                _logger.DebugError($"Error trying to initiate connection with peer: {candidate.Node:s}", ex);
                 return false;
             }
 

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Network
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error($"DEBUG/ERROR Error during send ping messages: {ex}");
+                    _logger.DebugError($"Error during send ping messages: {ex}");
                 }
             }
         }
@@ -165,7 +165,7 @@ namespace Nethermind.Network
             }
             catch (Exception e)
             {
-                if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Error during ping timer stop", e);
+                _logger.DebugError("Error during ping timer stop", e);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
@@ -93,7 +93,7 @@ public class DataFeed
         }
         catch (Exception e)
         {
-            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Http request {nameof(DataFeed)} errored", e);
+            _logger.DebugError($"Http request {nameof(DataFeed)} errored", e);
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1770,7 +1770,7 @@ namespace Nethermind.Serialization.Rlp
             string message = string.IsNullOrEmpty(limit.CollectionExpression)
                 ? $"Collection count of {count} is over limit {limit.Limit} or {bytesLeft} bytes left"
                 : $"Collection count {limit.CollectionExpression} of {count} is over limit {limit.Limit} or {bytesLeft} bytes left";
-            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR: {message}; {new StackTrace()}");
+            _logger.DebugError($"{message}; {new StackTrace()}");
             throw new RlpLimitException(message);
         }
 

--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -84,7 +84,7 @@ public class ShutterKeyValidator(
 
         if (decryptionKeys.Keys.Count == 0)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Invalid Shutter decryption keys received: expected placeholder key.");
+            _logger.DebugError("Invalid Shutter decryption keys received: expected placeholder key.");
             return false;
         }
 
@@ -102,7 +102,7 @@ public class ShutterKeyValidator(
             }
             catch (Bls.BlsException e)
             {
-                if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Invalid Shutter decryption keys received.", e);
+                _logger.DebugError("Invalid Shutter decryption keys received.", e);
                 return false;
             }
 

--- a/src/Nethermind/Nethermind.Shutter/ShutterP2P.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterP2P.cs
@@ -194,7 +194,7 @@ public class ShutterP2P : IShutterP2P
         }
         catch (InvalidProtocolBufferException e)
         {
-            if (_logger.IsDebug) _logger.Warn($"DEBUG/ERROR Could not parse Shutter decryption keys: {e}");
+            _logger.DebugWarn($"Could not parse Shutter decryption keys: {e}");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -166,7 +166,7 @@ public class ShutterTxLoader(
         }
         catch (ShutterCrypto.ShutterCryptoException e)
         {
-            _logger.DebugError($"Could not decode encrypted Shutter transaction", e);
+            _logger.DebugError("Could not decode encrypted Shutter transaction", e);
         }
         catch (Bls.BlsException e)
         {

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -166,23 +166,23 @@ public class ShutterTxLoader(
         }
         catch (ShutterCrypto.ShutterCryptoException e)
         {
-            if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Could not decode encrypted Shutter transaction", e);
+            _logger.DebugError($"Could not decode encrypted Shutter transaction", e);
         }
         catch (Bls.BlsException e)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Could not decrypt Shutter transaction with invalid key", e);
+            _logger.DebugError("Could not decrypt Shutter transaction with invalid key", e);
         }
         catch (RlpException e)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Could not decode decrypted Shutter transaction", e);
+            _logger.DebugError("Could not decode decrypted Shutter transaction", e);
         }
         catch (ArgumentException e)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Could not recover Shutter transaction sender address", e);
+            _logger.DebugError("Could not recover Shutter transaction sender address", e);
         }
         catch (InvalidDataException e)
         {
-            if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Decrypted Shutter transaction had no signature", e);
+            _logger.DebugError("Decrypted Shutter transaction had no signature", e);
         }
 
         return null;

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxSource.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxSource.cs
@@ -45,7 +45,7 @@ public class ShutterTxSource(
         }
         catch (SlotTime.SlotCalculationException e)
         {
-            if (_logger.IsDebug) _logger.Warn($"DEBUG/ERROR Could not calculate Shutter building slot: {e}");
+            _logger.DebugWarn($"Could not calculate Shutter building slot: {e}");
             return [];
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -127,7 +127,7 @@ namespace Nethermind.Synchronization.Blocks
             }
             catch (Exception ex)
             {
-                if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Unhandled exception in {nameof(BlockDownloader)}: {ex}");
+                _logger.DebugError($"Unhandled exception in {nameof(BlockDownloader)}: {ex}");
                 return null;
             }
             finally
@@ -652,7 +652,7 @@ namespace Nethermind.Synchronization.Blocks
                     }
                     else
                     {
-                        if (_logger.IsDebug) _logger.Error($"DEBUG/ERROR Block download from {peerInfo} failed. {t.Exception}");
+                        _logger.DebugError($"Block download from {peerInfo} failed. {t.Exception}");
                         // ReSharper disable once RedundantAssignment
                         reason = $"sync fault";
 #if DEBUG

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -457,7 +457,7 @@ namespace Nethermind.Synchronization.Peers
                 }
                 catch (Exception exception)
                 {
-                    if (_logger.IsDebug) _logger.Error("DEBUG/ERROR Allocations upgrade failure", exception);
+                    _logger.DebugError("Allocations upgrade failure", exception);
                 }
                 finally
                 {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
@@ -47,8 +47,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
                 catch (Exception e)
                 {
-                    if (Logger.IsDebug)
-                        Logger.Error($"DEBUG/ERROR Error after dispatching the snap sync request. Request: {batch}", e);
+                    Logger.DebugError($"Error after dispatching the snap sync request. Request: {batch}", e);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDownloader.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Synchronization.StateSync
             }
             catch (Exception e)
             {
-                if (Logger.IsTrace) Logger.Error("DEBUG/ERROR Error after dispatching the state sync request", e);
+                Logger.TraceError("Error after dispatching the state sync request", e);
             }
             finally
             {

--- a/src/Nethermind/Nethermind.TxPool/RetryCache.cs
+++ b/src/Nethermind/Nethermind.TxPool/RetryCache.cs
@@ -79,7 +79,7 @@ public sealed class RetryCache<TMessage, TResourceId> : IAsyncDisposable
                                         }
                                         catch (Exception ex)
                                         {
-                                            if (_logger.IsTrace) _logger.Error($"Failed to send retry request to {retryHandler} for {item.ResourceId}", ex);
+                                            _logger.TraceError($"Failed to send retry request to {retryHandler} for {item.ResourceId}", ex);
                                         }
                                     }
                                 }
@@ -111,7 +111,7 @@ public sealed class RetryCache<TMessage, TResourceId> : IAsyncDisposable
 
         if (_expiringQueueCounter > _expiringQueueLimit)
         {
-            if (_logger.IsDebug) _logger.Warn($"{typeof(TResourceId)} retry queue is full");
+            _logger.DebugWarn($"{typeof(TResourceId)} retry queue is full");
 
             return AnnounceResult.RequestRequired;
         }


### PR DESCRIPTION
## Summary

Replaces the error-prone manual guard idiom with typed helpers:

```csharp
// before
if (_logger.IsDebug) _logger.Error(\$\"DEBUG/ERROR: {whatever}\", ex);

// after
_logger.DebugError(\$\"{whatever}\", ex);
```

Two wins:

1. **Consistency** — an audit of the 32 existing call sites turned up one missing prefix (`RetryCache`) and one reversed `ERROR/DEBUG` prefix (`NodesLoader`, `DiscoveryPersistenceManager`). The new helpers make those mistakes impossible.

2. **Structured filtering in Seq** — the helpers attach a \`Kind\` property (\`\"DebugError\"\` / \`\"DebugWarn\"\`) via NLog's \`LogEventInfo.Properties\`. Seq operators can filter \`Kind = \"DebugError\"\` and keep debug-gated errors out of the main error stream. The \`DEBUG/ERROR: \` message prefix is preserved for plain-text sinks and existing grep-based dashboards.

## Performance

Equivalent to the manual idiom. Uses C# 10 \`[InterpolatedStringHandler]\` so the message isn't built when \`IsDebug\` is false — same skip path as the current guard. Only overhead when disabled is one extra \`NoInlining\` method call (~1-2 ns); these call sites are exception / peer-error paths, never hot-path block processing.

## Files

- \`Nethermind.Logging/ILogger.cs\` — adds \`DebugError\` / \`DebugWarn\` (handler + plain-string overloads) and \`DebugErrorKind\` / \`DebugWarnKind\` const tags.
- \`Nethermind.Logging/DebugInterpolatedStringHandlers.cs\` (new) — the two \`ref struct\` handlers.
- \`Nethermind.Logging/InterfaceLogger.cs\` — extends sink interface with tagged \`Warn\` / \`Error\` overloads. Default interface methods drop the \`Kind\` and fall back to untagged methods, so existing sinks (Console, Limbo, Null, etc.) need no change.
- \`Nethermind.Logging.NLog/NLogLogger.cs\` — overrides tagged methods to attach \`Kind\` via \`LogEventInfo.Properties\`.

## Call-site fixes

Also migrates the three buggy sites found during the audit:
- \`Nethermind.TxPool/RetryCache.cs\` (was missing the prefix)
- \`Nethermind.Network/NodesLoader.cs\` (had \`ERROR/DEBUG\` reversed)
- \`Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs\` (same)

The remaining ~29 correctly-prefixed sites can be migrated in a mechanical follow-up; this PR stays small so the API is easy to review.

## Seq query example

Once landed, operators filtering debug-gated errors out of critical alerts:

\`\`\`
Kind <> \"DebugError\" AND @Level = \"Error\"
\`\`\`

or specifically looking at them:

\`\`\`
Kind = \"DebugError\"
\`\`\`

## Test plan

- [ ] CI build passes on all TFMs
- [ ] Existing logger unit tests still pass
- [ ] Manual: run a node with Seq integration, trigger a \`DebugError\` (e.g. force a decode error), verify \`Kind\` field appears in Seq
- [ ] Manual: run a node with plain file logging, verify \`DEBUG/ERROR: \` prefix still appears in logs