### PR TITLE
fix(sync): restore ActivatedSyncFeed dispose guard

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ActivatedSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ActivatedSyncFeed.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Synchronization.ParallelSync
 {
     public abstract class ActivatedSyncFeed<T> : SyncFeed<T>, IDisposable
     {
-        private readonly bool _disposed = false;
+        private bool _disposed;
 
         protected ActivatedSyncFeed() => StateChanged += OnStateChanged;
 
@@ -42,7 +42,11 @@ namespace Nethermind.Synchronization.ParallelSync
 
         protected abstract SyncMode ActivationSyncModes { get; }
 
-        public virtual void Dispose() => StateChanged -= OnStateChanged;
+        public virtual void Dispose()
+        {
+            _disposed = true;
+            StateChanged -= OnStateChanged;
+        }
 
         public virtual void InitializeFeed() { }
     }


### PR DESCRIPTION
## Changes

- Remove the accidental `readonly` modifier from the `_disposed` flag in `ActivatedSyncFeed`
- Set `_disposed = true` from `Dispose()` before unsubscribing the state-change handler
- Restore the intended post-dispose guard so disposed feeds cannot be reactivated through later state-change notifications

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj --filter "FullyQualifiedName~Sha256PrecompileTests|FullyQualifiedName~Ripemd160PrecompileTests" -v minimal --no-progress --output Normal`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No