### PR TITLE
EraE refactor: simplify interfaces, deduplicate tests

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/ConcurrentDictionaryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ConcurrentDictionaryExtensions.cs
@@ -113,6 +113,27 @@ public static class ConcurrentDictionaryExtensions
             (_, startValue, amount) => startValue + amount,
             amount
         );
+
+    /// <summary>
+    /// Like <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, Func{TKey, TValue})"/> but
+    /// disposes the value created by <paramref name="factory"/> when another thread wins the race.
+    /// Fast path avoids allocation when the key already exists.
+    /// </summary>
+    public static TValue GetOrAddDisposable<TKey, TValue>(
+        this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TValue> factory)
+        where TKey : notnull
+        where TValue : class, IDisposable
+    {
+        if (dictionary.TryGetValue(key, out TValue? existing))
+            return existing;
+
+        TValue created = factory(key);
+        TValue actual = dictionary.GetOrAdd(key, created);
+        if (!ReferenceEquals(actual, created))
+            created.Dispose();
+        return actual;
+    }
+
 }
 
 

--- a/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EnumerableExtensions.cs
@@ -20,6 +20,32 @@ namespace Nethermind.Core.Extensions
         public static ArrayPoolListRef<T> ToPooledListRef<T>(this IReadOnlyCollection<T> collection) => new(collection.Count, collection);
         public static ArrayPoolListRef<T> ToPooledListRef<T>(this ReadOnlySpan<T> span) => new(span);
 
+        public static (T Min, T Max) MinMax<T>(this IEnumerable<T> source)
+            where T : IComparable<T>
+        {
+            T? min = default;
+            T? max = default;
+            bool hasValue = false;
+            foreach (T item in source)
+            {
+                if (!hasValue)
+                {
+                    min = item;
+                    max = item;
+                    hasValue = true;
+                }
+                else
+                {
+                    if (item.CompareTo(min!) < 0) min = item;
+                    if (item.CompareTo(max!) > 0) max = item;
+                }
+            }
+
+            return hasValue
+                ? (min!, max!)
+                : throw new InvalidOperationException("Sequence contains no elements.");
+        }
+
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> enumerable, Random rng, int maxSize = 100)
         {
             using ArrayPoolList<T> buffer = new(maxSize, enumerable);

--- a/src/Nethermind/Nethermind.EraE.Test/Archive/EraReaderTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Archive/EraReaderTests.cs
@@ -15,13 +15,15 @@ namespace Nethermind.EraE.Test.Archive;
 
 internal class EraReaderTests
 {
-    [Test]
-    public async Task GetBlockByNumber_InPreMergeEpoch_ReturnsCorrectBlockNumbers()
+    [TestCase(3, 0)]
+    [TestCase(0, 3)]
+    public async Task GetBlockByNumber_ReturnsCorrectBlockNumbers(int preMergeCount, int postMergeCount)
     {
-        using TestEraFile file = await TestEraFile.Create(preMergeCount: 3, postMergeCount: 0);
+        int totalCount = preMergeCount + postMergeCount;
+        using TestEraFile file = await TestEraFile.Create(preMergeCount: preMergeCount, postMergeCount: postMergeCount);
         using EraReader sut = new(file.FilePath);
 
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < totalCount; i++)
         {
             (Block block, _) = await sut.GetBlockByNumber(i);
             block.Number.Should().Be(i);
@@ -73,19 +75,6 @@ internal class EraReaderTests
         List<(Block, TxReceipt[])> result = await sut.ToListAsync();
         result.Should().HaveCount(3);
         result.Select(r => r.Item1.Number).Should().BeEquivalentTo([0L, 1L, 2L]);
-    }
-
-    [Test]
-    public async Task GetBlockByNumber_InPostMergeEpoch_ReturnsCorrectBlockNumbers()
-    {
-        using TestEraFile file = await TestEraFile.Create(preMergeCount: 0, postMergeCount: 3);
-        using EraReader sut = new(file.FilePath);
-
-        for (int i = 0; i < 3; i++)
-        {
-            (Block block, _) = await sut.GetBlockByNumber(i);
-            block.Number.Should().Be(i);
-        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.EraE.Test/EraFileFormatComplianceTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/EraFileFormatComplianceTests.cs
@@ -166,7 +166,7 @@ public class EraFileFormatComplianceTests
             e.Length.Should().Be(32, "TotalDifficulty entry must be 32-byte LE uint256"));
     }
 
-    private static List<EntryRecord> ReadAllEntries(string filePath)
+    internal static List<EntryRecord> ReadAllEntries(string filePath)
     {
         List<EntryRecord> entries = [];
         byte[] bytes = File.ReadAllBytes(filePath);
@@ -183,6 +183,6 @@ public class EraFileFormatComplianceTests
         return entries;
     }
 
-    private sealed record EntryRecord(ushort Type, uint Length, long Offset);
+    internal sealed record EntryRecord(ushort Type, uint Length, long Offset);
 
 }

--- a/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
@@ -44,6 +44,7 @@ public class EraExporterTests
     }
 
     [TestCase("checksums_sha256.txt")]
+    [TestCase("checksums.txt")]
     [TestCase("accumulators.txt")]
     public async Task Export_WhenCalled_CreatesMetadataFile(string fileName)
     {

--- a/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Test.Builders;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Nethermind.EraE.Config;
+using Nethermind.EraE.E2Store;
 using EraException = Nethermind.Era1.EraException;
 using Nethermind.EraE.Export;
 using NUnit.Framework;
@@ -168,9 +169,9 @@ public class EraExporterTests
         eraFiles.Should().HaveCount(1, "one epoch for blocks 1-15");
 
         List<ushort> types = EraFileFormatComplianceTests.ReadAllEntries(eraFiles[0]).Select(e => e.Type).ToList();
-        types.Should().NotContain(0x0b, "post-merge epochs have no Proof entries");
-        types.Should().NotContain(0x06, "post-merge epochs have no TotalDifficulty entries");
-        types.Should().NotContain(0x07, "post-merge epochs have no AccumulatorRoot entry");
+        types.Should().NotContain(EntryTypes.Proof, "post-merge epochs have no Proof entries");
+        types.Should().NotContain(EntryTypes.TotalDifficulty, "post-merge epochs have no TotalDifficulty entries");
+        types.Should().NotContain(EntryTypes.AccumulatorRoot, "post-merge epochs have no AccumulatorRoot entry");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
@@ -43,27 +43,16 @@ public class EraExporterTests
         eraFiles.Length.Should().Be(expectedEraFiles);
     }
 
-    [Test]
-    public async Task Export_WhenCalled_CreatesChecksumsFile()
+    [TestCase("checksums_sha256.txt")]
+    [TestCase("accumulators.txt")]
+    public async Task Export_WhenCalled_CreatesMetadataFile(string fileName)
     {
         await using IContainer container = EraETestModule.BuildContainerBuilderWithBlockTreeOfLength(32).Build();
 
         string tmpDirectory = container.ResolveTempDirPath();
         await container.Resolve<IEraExporter>().Export(tmpDirectory, 0, 0);
 
-        System.IO.File.Exists(System.IO.Path.Combine(tmpDirectory, EraExporter.ChecksumsSHA256FileName))
-            .Should().BeTrue();
-    }
-
-    [Test]
-    public async Task Export_WhenCalled_CreatesAccumulatorsFile()
-    {
-        await using IContainer container = EraETestModule.BuildContainerBuilderWithBlockTreeOfLength(32).Build();
-
-        string tmpDirectory = container.ResolveTempDirPath();
-        await container.Resolve<IEraExporter>().Export(tmpDirectory, 0, 0);
-
-        System.IO.File.Exists(System.IO.Path.Combine(tmpDirectory, EraExporter.AccumulatorFileName))
+        System.IO.File.Exists(System.IO.Path.Combine(tmpDirectory, fileName))
             .Should().BeTrue();
     }
 
@@ -177,30 +166,11 @@ public class EraExporterTests
         string[] eraFiles = Directory.GetFiles(tmpDirectory, $"*{EraPathUtils.FileExtension}");
         eraFiles.Should().HaveCount(1, "one epoch for blocks 1-15");
 
-        List<ushort> types = ReadAllEntryTypes(eraFiles[0]);
-        types.Should().NotContain(EntryTypeProof, "post-merge epochs have no Proof entries");
-        types.Should().NotContain(EntryTypeTotalDifficulty, "post-merge epochs have no TotalDifficulty entries");
-        types.Should().NotContain(EntryTypeAccumulatorRoot, "post-merge epochs have no AccumulatorRoot entry");
+        List<ushort> types = EraFileFormatComplianceTests.ReadAllEntries(eraFiles[0]).Select(e => e.Type).ToList();
+        types.Should().NotContain(0x0b, "post-merge epochs have no Proof entries");
+        types.Should().NotContain(0x06, "post-merge epochs have no TotalDifficulty entries");
+        types.Should().NotContain(0x07, "post-merge epochs have no AccumulatorRoot entry");
     }
-
-    private static List<ushort> ReadAllEntryTypes(string filePath)
-    {
-        List<ushort> types = [];
-        byte[] bytes = File.ReadAllBytes(filePath);
-        long pos = 0;
-        while (pos + 8 <= bytes.Length)
-        {
-            ushort type = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan((int)pos, 2));
-            uint length = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan((int)pos + 2, 4));
-            types.Add(type);
-            pos += 8 + length;
-        }
-        return types;
-    }
-
-    private const ushort EntryTypeProof = 0x0b;
-    private const ushort EntryTypeTotalDifficulty = 0x06;
-    private const ushort EntryTypeAccumulatorRoot = 0x07;
 
     [Test]
     public void Export_WhenLastBlockBodyNotAvailable_ThrowsInvalidOperationException()

--- a/src/Nethermind/Nethermind.EraE.Test/Store/EraStoreTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Store/EraStoreTests.cs
@@ -25,8 +25,7 @@ public class EraStoreTests
 
         using IEraStore eraStore = ctx.Resolve<IEraStoreFactory>().Create(tmpDirectory, null);
 
-        eraStore.FirstBlock.Should().Be(from);
-        eraStore.LastBlock.Should().Be(to);
+        eraStore.BlockRange.Should().Be((from, to));
     }
 
     [Test]
@@ -35,7 +34,7 @@ public class EraStoreTests
         await using EraStoreEnv env = await CreateDefaultEraStoreEnv();
 
         (Block? block, TxReceipt[]? receipts) = await env.EraStore.FindBlockAndReceipts(
-            env.EraStore.FirstBlock, ensureValidated: false);
+            env.EraStore.BlockRange.First, ensureValidated: false);
 
         block.Should().NotBeNull();
         receipts.Should().NotBeNull();
@@ -57,7 +56,7 @@ public class EraStoreTests
     {
         await using EraStoreEnv env = await CreateDefaultEraStoreEnv();
 
-        long targetBlock = env.EraStore.FirstBlock + 5;
+        long targetBlock = env.EraStore.BlockRange.First + 5;
         (Block? block, _) = await env.EraStore.FindBlockAndReceipts(targetBlock, ensureValidated: false);
 
         block!.Number.Should().Be(targetBlock);
@@ -89,7 +88,7 @@ public class EraStoreTests
         string tmpDirectory = ctx.ResolveTempDirPath();
 
         using IEraStore eraStore = ctx.Resolve<IEraStoreFactory>().Create(tmpDirectory, null);
-        long nextStart = eraStore.NextEraStart(eraStore.FirstBlock);
+        long nextStart = eraStore.NextEraStart(eraStore.BlockRange.First);
 
         nextStart.Should().Be(eraSize, "first era covers blocks 0..eraSize-1");
     }
@@ -123,7 +122,7 @@ public class EraStoreTests
         using IEraStore eraStore = ctx.Resolve<IEraStoreFactory>().Create(tmpDirectory, trusted);
 
         Assert.That(
-            async () => await eraStore.FindBlockAndReceipts(eraStore.FirstBlock, ensureValidated: true),
+            async () => await eraStore.FindBlockAndReceipts(eraStore.BlockRange.First, ensureValidated: true),
             Throws.Nothing);
     }
 

--- a/src/Nethermind/Nethermind.EraE/Archive/EraWriter.cs
+++ b/src/Nethermind/Nethermind.EraE/Archive/EraWriter.cs
@@ -107,7 +107,7 @@ public sealed class EraWriter : IDisposable
             _startNumber = block.Number;
             _blocksRootContext = new BlocksRootContext(block.Number, block.Header.Timestamp, _specProvider);
             _firstBlock = false;
-            await _e2StoreWriter.WriteEntry(EntryTypes.Version, Array.Empty<byte>(), cancellation);
+            await _e2StoreWriter.WriteEntry(EntryTypes.Version, Memory<byte>.Empty, cancellation);
         }
         else if (block.Number != _startNumber + _headers.Count)
         {

--- a/src/Nethermind/Nethermind.EraE/Archive/EraWriter.cs
+++ b/src/Nethermind/Nethermind.EraE/Archive/EraWriter.cs
@@ -97,10 +97,8 @@ public sealed class EraWriter : IDisposable
 
         if (_finalized)
             throw new EraException("Finalize() has been called; no more blocks can be added.");
-        if (block.Header is null)
-            throw new ArgumentException("Block must have a header.", nameof(block));
-        if (block.Hash is null)
-            throw new ArgumentException("Block must have a hash.", nameof(block));
+        ArgumentNullException.ThrowIfNull(block.Header);
+        ArgumentNullException.ThrowIfNull(block.Hash);
         if (_headers.Count >= MaxEraSize)
             throw new ArgumentException($"Era file cannot contain more than {MaxEraSize} blocks.");
 
@@ -354,11 +352,11 @@ public sealed class EraWriter : IDisposable
 
     private async Task WriteCompressed(ushort entryType, ReadOnlyMemory<byte> data, CancellationToken cancellation)
     {
-        using RecyclableMemoryStream ms = RecyclableStream.GetStream(nameof(EraWriter));
-        using (SnappyStream compressor = new(ms, CompressionMode.Compress, leaveOpen: true))
+        await using RecyclableMemoryStream ms = RecyclableStream.GetStream(nameof(EraWriter));
+        await using (SnappyStream compressor = new(ms, CompressionMode.Compress, leaveOpen: true))
         {
             compressor.Write(data.Span);
-            compressor.Flush();
+            await compressor.FlushAsync(cancellation);
         }
 
         bool ok = ms.TryGetBuffer(out ArraySegment<byte> segment);

--- a/src/Nethermind/Nethermind.EraE/E2Store/E2StoreReader.cs
+++ b/src/Nethermind/Nethermind.EraE/E2Store/E2StoreReader.cs
@@ -118,7 +118,7 @@ public sealed class E2StoreReader : IDisposable
         return (value, (long)entry.Length + EntryHeaderSize);
     }
 
-    public Entry ReadEntry(long position, ushort? expectedType, CancellationToken token = default)
+    private Entry ReadEntry(long position, ushort? expectedType)
     {
         ushort type = ReadUInt16(position);
         uint length = ReadUInt32(position + 2);

--- a/src/Nethermind/Nethermind.EraE/EraCliRunner.cs
+++ b/src/Nethermind/Nethermind.EraE/EraCliRunner.cs
@@ -30,6 +30,8 @@ public class EraCliRunner(
             await eraImporter.Import(eraConfig.ImportDirectory!, eraConfig.From, eraConfig.To, eraConfig.TrustedAccumulatorFile, token);
         }
         else if (!string.IsNullOrEmpty(eraConfig.ExportDirectory))
+        {
             await eraExporter.Export(eraConfig.ExportDirectory!, eraConfig.From, eraConfig.To, token);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.EraE/Exceptions/EraFormatException.cs
+++ b/src/Nethermind/Nethermind.EraE/Exceptions/EraFormatException.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Era1;
+
 namespace Nethermind.EraE.Exceptions;
 
-internal class EraFormatException(string message) : Nethermind.Era1.EraException(message);
+internal class EraFormatException(string message) : EraException(message);

--- a/src/Nethermind/Nethermind.EraE/Export/EraExporter.cs
+++ b/src/Nethermind/Nethermind.EraE/Export/EraExporter.cs
@@ -155,16 +155,18 @@ public class EraExporter(
                     {
                         Hash256 computedRoot = ReceiptTrie.CalculateRoot(specProvider.GetReceiptSpec(block.Number), receipts, _receiptDecoder);
                         if (computedRoot != block.Header.ReceiptsRoot)
+                        {
                             throw new EraException(
                                 $"Receipt root mismatch at block {block.ToString(Block.Format.FullHashAndNumber)}: " +
                                 "the database contains stale or corrupt receipt data. " +
                                 "Re-import from the original ERA source before re-exporting.");
+                        }
                     }
 
                     await eraWriter.Add(block, receipts, cancel);
                     lastBlockHash = block.Hash!;
 
-                    if ((Interlocked.Increment(ref totalProcessed) % ProgressLogInterval) == 0)
+                    if (Interlocked.Increment(ref totalProcessed) % ProgressLogInterval == 0)
                     {
                         progress.Update(totalProcessed);
                         progress.LogProgress();

--- a/src/Nethermind/Nethermind.EraE/Export/EraPathUtils.cs
+++ b/src/Nethermind/Nethermind.EraE/Export/EraPathUtils.cs
@@ -43,7 +43,7 @@ public static class EraPathUtils
 
     public static string Filename(string network, long epoch, Hash256 accumulatorRoot)
     {
-        ArgumentNullException.ThrowIfNullOrEmpty(network);
+        ArgumentException.ThrowIfNullOrEmpty(network);
         ArgumentNullException.ThrowIfNull(accumulatorRoot);
         ArgumentOutOfRangeException.ThrowIfLessThan(epoch, 0);
 

--- a/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
+++ b/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
@@ -60,13 +60,12 @@ public class EraImporter(
 
         using IEraStore eraStore = eraStoreFactory.Create(src, trustedAccumulators);
 
-        long lastBlockInStore = eraStore.LastBlock;
+        (long firstBlockInStore, long lastBlockInStore) = eraStore.BlockRange;
         if (to is 0 or long.MaxValue)
             to = lastBlockInStore;
         else if (to > lastBlockInStore)
             throw new EraImportException($"Store highest block {lastBlockInStore} is lower than requested end {to}.");
 
-        long firstBlockInStore = eraStore.FirstBlock;
         if (from == 0)
             from = firstBlockInStore;
         else if (from < firstBlockInStore)

--- a/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
@@ -111,14 +111,14 @@ public sealed class BlocksRootContext : IDisposable
         _blockHashes.Dispose();
     }
 
-    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider) =>
-        specProvider is null
-            ? AccumulatorType.HistoricalHashesAccumulator
-            : specProvider.GetSpec(forkActivation).IsEip4895Enabled
-                ? AccumulatorType.HistoricalSummaries
-                : specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge
-                    ? AccumulatorType.HistoricalRoots
-                    : AccumulatorType.HistoricalHashesAccumulator;
+    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider)
+    {
+        if (specProvider is null) return AccumulatorType.HistoricalHashesAccumulator;
+        if (specProvider.GetSpec(forkActivation).IsEip4895Enabled) return AccumulatorType.HistoricalSummaries;
+        if (specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge)
+            return AccumulatorType.HistoricalRoots;
+        return AccumulatorType.HistoricalHashesAccumulator;
+    }
 
     private static ValueHash256 UInt256ToHash(ref UInt256 value) =>
         new(MemoryMarshal.Cast<UInt256, byte>(MemoryMarshal.CreateSpan(ref value, 1)));

--- a/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
@@ -66,15 +66,8 @@ public sealed class BlocksRootContext : IDisposable
             case AccumulatorType.HistoricalSummaries:
                 // Post-merge: collect beacon block roots and state roots per slot.
                 // Missed slots are represented by zero hashes (default ValueHash256).
-                if (beaconBlockRoot.HasValue)
-                    _blockRoots.Add(beaconBlockRoot.Value);
-                else
-                    _blockRoots.Add(default);
-
-                if (stateRoot.HasValue)
-                    _stateRoots.Add(stateRoot.Value);
-                else
-                    _stateRoots.Add(default);
+                _blockRoots.Add(beaconBlockRoot ?? default);
+                _stateRoots.Add(stateRoot ?? default);
                 break;
         }
         Populated = true;

--- a/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
@@ -111,22 +111,15 @@ public sealed class BlocksRootContext : IDisposable
         _blockHashes.Dispose();
     }
 
-    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider)
-    {
-        if (specProvider is null)
-            return AccumulatorType.HistoricalHashesAccumulator;
+    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider) =>
+        specProvider is null
+            ? AccumulatorType.HistoricalHashesAccumulator
+            : specProvider.GetSpec(forkActivation).IsEip4895Enabled
+                ? AccumulatorType.HistoricalSummaries
+                : specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge
+                    ? AccumulatorType.HistoricalRoots
+                    : AccumulatorType.HistoricalHashesAccumulator;
 
-        if (specProvider.GetSpec(forkActivation).IsEip4895Enabled)
-            return AccumulatorType.HistoricalSummaries;
-
-        return specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge
-            ? AccumulatorType.HistoricalRoots
-            : AccumulatorType.HistoricalHashesAccumulator;
-    }
-
-    private static ValueHash256 UInt256ToHash(ref UInt256 value)
-    {
-        ReadOnlySpan<byte> bytes = MemoryMarshal.Cast<UInt256, byte>(MemoryMarshal.CreateSpan(ref value, 1));
-        return new ValueHash256(bytes);
-    }
+    private static ValueHash256 UInt256ToHash(ref UInt256 value) =>
+        new(MemoryMarshal.Cast<UInt256, byte>(MemoryMarshal.CreateSpan(ref value, 1)));
 }

--- a/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
@@ -116,16 +116,12 @@ public sealed class BlocksRootContext : IDisposable
         if (specProvider is null)
             return AccumulatorType.HistoricalHashesAccumulator;
 
-        IReleaseSpec spec = specProvider.GetSpec(forkActivation);
-        if (spec.IsEip4895Enabled)
+        if (specProvider.GetSpec(forkActivation).IsEip4895Enabled)
             return AccumulatorType.HistoricalSummaries;
 
-        // Paris (The Merge) has no distinct execution-layer EIP flag; use MergeBlockNumber.
-        ForkActivation? mergeBlock = specProvider.MergeBlockNumber;
-        if (mergeBlock.HasValue && forkActivation.BlockNumber >= mergeBlock.Value.BlockNumber)
-            return AccumulatorType.HistoricalRoots;
-
-        return AccumulatorType.HistoricalHashesAccumulator;
+        return specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge
+            ? AccumulatorType.HistoricalRoots
+            : AccumulatorType.HistoricalHashesAccumulator;
     }
 
     private static ValueHash256 UInt256ToHash(ref UInt256 value)

--- a/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/BlocksRootContext.cs
@@ -111,14 +111,14 @@ public sealed class BlocksRootContext : IDisposable
         _blockHashes.Dispose();
     }
 
-    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider)
-    {
-        if (specProvider is null) return AccumulatorType.HistoricalHashesAccumulator;
-        if (specProvider.GetSpec(forkActivation).IsEip4895Enabled) return AccumulatorType.HistoricalSummaries;
-        if (specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge)
-            return AccumulatorType.HistoricalRoots;
-        return AccumulatorType.HistoricalHashesAccumulator;
-    }
+    private static AccumulatorType GetAccumulatorType(ForkActivation forkActivation, ISpecProvider? specProvider) =>
+        specProvider switch
+        {
+            null => AccumulatorType.HistoricalHashesAccumulator,
+            _ when specProvider.GetSpec(forkActivation).IsEip4895Enabled => AccumulatorType.HistoricalSummaries,
+            _ when specProvider.MergeBlockNumber is { BlockNumber: var merge } && forkActivation.BlockNumber >= merge => AccumulatorType.HistoricalRoots,
+            _ => AccumulatorType.HistoricalHashesAccumulator
+        };
 
     private static ValueHash256 UInt256ToHash(ref UInt256 value) =>
         new(MemoryMarshal.Cast<UInt256, byte>(MemoryMarshal.CreateSpan(ref value, 1)));

--- a/src/Nethermind/Nethermind.EraE/Proofs/HistoricalSummariesRpcProvider.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/HistoricalSummariesRpcProvider.cs
@@ -76,29 +76,22 @@ public sealed class HistoricalSummariesRpcProvider(
 
     private static HistoricalSummary[] ParseHistoricalSummaries(JsonElement root)
     {
-        if (!root.TryGetProperty("data", out JsonElement data))
-            return [];
-
-        if (!data.TryGetProperty("historical_summaries", out JsonElement historicalSummaries))
-            return [];
-
-        if (historicalSummaries.ValueKind != JsonValueKind.Array)
+        if (!root.TryGetProperty("data", out JsonElement data)
+            || !data.TryGetProperty("historical_summaries", out JsonElement historicalSummaries)
+            || historicalSummaries.ValueKind != JsonValueKind.Array)
             return [];
 
         List<HistoricalSummary> summaries = new(historicalSummaries.GetArrayLength());
         foreach (JsonElement summary in historicalSummaries.EnumerateArray())
         {
-            if (!summary.TryGetProperty("block_summary_root", out JsonElement blockSummaryRootEl))
-                continue;
-            if (!summary.TryGetProperty("state_summary_root", out JsonElement stateSummaryRootEl))
-                continue;
-
-            string? blockSummaryRoot = blockSummaryRootEl.GetString();
-            string? stateSummaryRoot = stateSummaryRootEl.GetString();
-            if (blockSummaryRoot is null || stateSummaryRoot is null)
-                continue;
-
-            summaries.Add(HistoricalSummary.From(blockSummaryRoot, stateSummaryRoot));
+            if (summary.TryGetProperty("block_summary_root", out JsonElement blockSummaryRootEl)
+                && summary.TryGetProperty("state_summary_root", out JsonElement stateSummaryRootEl))
+            {
+                string? blockSummaryRoot = blockSummaryRootEl.GetString();
+                string? stateSummaryRoot = stateSummaryRootEl.GetString();
+                if (blockSummaryRoot is not null && stateSummaryRoot is not null)
+                    summaries.Add(HistoricalSummary.From(blockSummaryRoot, stateSummaryRoot));
+            }
         }
 
         return [.. summaries];

--- a/src/Nethermind/Nethermind.EraE/Proofs/Validator.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/Validator.cs
@@ -45,8 +45,9 @@ public class Validator
     {
         if (!TrustedAccumulatorsProvided()) return true;
         ValueHash256? trusted = GetAccumulatorForEpoch(blockNumber / SlotsPerHistoricalRoot);
-        if (trusted is null) throw new EraVerificationException("Trusted accumulator root was not provided.");
-        return trusted.Equals(accumulatorRoot);
+        return trusted is null
+            ? throw new EraVerificationException("Trusted accumulator root was not provided.")
+            : trusted.Equals(accumulatorRoot);
     }
 
     public async Task VerifyBlocksRootContext(BlocksRootContext context)
@@ -61,9 +62,7 @@ public class Validator
             case AccumulatorType.HistoricalRoots:
                 if (_slotTime is null) throw new EraVerificationException("Beacon chain genesis timestamp is not available for HistoricalRoots verification.");
                 long slot = (long)_slotTime.GetSlot(context.StartingBlockTimestamp!.Value);
-                ValueHash256? trustedRoot = GetHistoricalRoot(slot);
-                if (trustedRoot is null)
-                    throw new EraVerificationException("Historical root not found.");
+                ValueHash256? trustedRoot = GetHistoricalRoot(slot) ?? throw new EraVerificationException("Historical root not found.");
                 if (!trustedRoot.Equals(context.HistoricalRoot))
                     throw new EraVerificationException("Computed historical root does not match trusted historical root.");
                 break;
@@ -71,9 +70,7 @@ public class Validator
             case AccumulatorType.HistoricalSummaries:
                 if (_slotTime is null) throw new EraVerificationException("Beacon chain genesis timestamp is not available for HistoricalSummaries verification.");
                 long summarySlot = (long)_slotTime.GetSlot(context.StartingBlockTimestamp!.Value);
-                HistoricalSummary? trustedSummary = await GetHistoricalSummary(summarySlot);
-                if (trustedSummary is null)
-                    throw new EraVerificationException("Historical summary not found.");
+                HistoricalSummary? trustedSummary = await GetHistoricalSummary(summarySlot) ?? throw new EraVerificationException("Historical summary not found.");
                 if (!trustedSummary.Value.BlockSummaryRoot.Equals(context.HistoricalSummary.BlockSummaryRoot))
                     throw new EraVerificationException("Computed block summary root does not match trusted historical block summary root.");
                 if (!trustedSummary.Value.StateSummaryRoot.Equals(context.HistoricalSummary.StateSummaryRoot))
@@ -82,29 +79,27 @@ public class Validator
         }
     }
 
-    private bool TrustedAccumulatorsProvided() =>
-        _trustedAccumulators is { Count: > 0 };
+    private bool TrustedAccumulatorsProvided() => _trustedAccumulators is { Count: > 0 };
 
-    private ValueHash256? GetAccumulatorForEpoch(long epochIdx)
-    {
-        if (_trustedAccumulators is not null && _trustedAccumulators.Count > epochIdx)
-            return _trustedAccumulators[(int)epochIdx];
-        return null;
-    }
+    private ValueHash256? GetAccumulatorForEpoch(long epochIdx) =>
+        _trustedAccumulators is not null && _trustedAccumulators.Count > epochIdx
+            ? _trustedAccumulators[(int)epochIdx]
+            : null;
 
     private ValueHash256? GetHistoricalRoot(long slotNumber)
     {
         long idx = slotNumber / SlotsPerHistoricalRoot;
-        if (_trustedHistoricalRoots is not null && _trustedHistoricalRoots.Count > idx)
-            return _trustedHistoricalRoots[(int)idx];
-        return null;
+        return _trustedHistoricalRoots is not null && _trustedHistoricalRoots.Count > idx
+            ? _trustedHistoricalRoots[(int)idx]
+            : null;
     }
 
     private async Task<HistoricalSummary?> GetHistoricalSummary(long slotNumber)
     {
         long idx = slotNumber / SlotsPerHistoricalRoot;
-        if (_historicalSummariesProvider is null) return null;
-        return await _historicalSummariesProvider.GetHistoricalSummary((int)idx);
+        return _historicalSummariesProvider is null
+            ? null
+            : await _historicalSummariesProvider.GetHistoricalSummary((int)idx);
     }
 
 }

--- a/src/Nethermind/Nethermind.EraE/Proofs/Validator.cs
+++ b/src/Nethermind/Nethermind.EraE/Proofs/Validator.cs
@@ -34,7 +34,7 @@ public class Validator
                 specProvider.BeaconChainGenesisTimestamp.Value * 1000,
                 new Timestamper(),
                 TimeSpan.FromSeconds(secondsPerSlot),
-                TimeSpan.FromSeconds(0));
+                TimeSpan.Zero);
         }
         _trustedAccumulators = trustedAccumulators;
         _trustedHistoricalRoots = trustedHistoricalRoots;

--- a/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
@@ -17,7 +17,7 @@ namespace Nethermind.EraE.Store;
 
 public sealed class EraStore : IEraStore
 {
-    private readonly char[] _eraSeparator = ['-'];
+    private static readonly char[] _eraSeparator = ['-'];
 
     private readonly ISpecProvider _specProvider;
     private readonly IBlockValidator _blockValidator;

--- a/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.IO.Abstractions;
-using System.Runtime.CompilerServices;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -26,7 +25,7 @@ public sealed class EraStore : IEraStore
     private readonly Proofs.Validator? _validator;
 
     private readonly Dictionary<long, string> _epochs;
-    private readonly Dictionary<long, ValueHash256> _checksumsByEpoch;
+    private readonly Dictionary<long, ValueHash256> _checksumsByEpoch = new();
 
     private readonly ConcurrentDictionary<long, bool> _verifiedEpochs = new();
     private readonly ConcurrentDictionary<long, SemaphoreSlim> _epochLocks = new();
@@ -38,14 +37,12 @@ public sealed class EraStore : IEraStore
     private readonly int _verifyConcurrency;
     private bool _disposed;
 
-    private readonly Lazy<long> _firstBlock;
-    private readonly Lazy<long> _lastBlock;
+    private readonly Lazy<(long First, long Last)> _blockRange;
 
-    public long FirstBlock => _firstBlock.Value;
-    public long LastBlock => _lastBlock.Value;
+    public (long First, long Last) BlockRange => _blockRange.Value;
 
-    private int LastEpoch { get; set; }
-    private int FirstEpoch { get; set; } = int.MaxValue;
+    private int LastEpoch { get; }
+    private int FirstEpoch { get; } = int.MaxValue;
 
     public EraStore(
         ISpecProvider specProvider,
@@ -71,7 +68,6 @@ public sealed class EraStore : IEraStore
         _maxOpenFile = Environment.ProcessorCount * 2;
         _verifyConcurrency = verifyConcurrency == 0 ? Environment.ProcessorCount : verifyConcurrency;
 
-        _checksumsByEpoch = new Dictionary<long, ValueHash256>();
         foreach (string line in fileSystem.File.ReadAllLines(Path.Join(directory, EraExporter.ChecksumsSHA256FileName)))
         {
             (long checksumEpoch, ValueHash256 hash) = EraPathUtils.ParseChecksumEntry(line);
@@ -79,7 +75,7 @@ public sealed class EraStore : IEraStore
         }
 
         bool hasEraFile = false;
-        _epochs = new Dictionary<long, string>();
+        _epochs = [];
 
         foreach (string file in EraPathUtils.GetAllEraFiles(directory, networkName, fileSystem))
         {
@@ -96,32 +92,25 @@ public sealed class EraStore : IEraStore
         if (!hasEraFile)
             throw new EraException($"No relevant erae files in directory {directory}.");
 
-        _firstBlock = new Lazy<long>(() =>
+        _blockRange = new Lazy<(long, long)>(() =>
         {
-            using EraRenter _ = RentReader(FirstEpoch, out EraReader reader);
-            return reader.FirstBlock;
-        });
-        _lastBlock = new Lazy<long>(() =>
-        {
-            using EraRenter _ = RentReader(LastEpoch, out EraReader reader);
-            return reader.LastBlock;
+            using EraRenter f = RentReader(FirstEpoch, out EraReader firstReader);
+            using EraRenter l = RentReader(LastEpoch, out EraReader lastReader);
+            return (firstReader.FirstBlock, lastReader.LastBlock);
         });
     }
 
     private long GetEpochNumber(long blockNumber) => blockNumber / _maxEraSize;
 
-    private EraReader GetReader(long epoch)
-    {
-        if (!_epochs.TryGetValue(epoch, out string? path))
-            throw new ArgumentOutOfRangeException(nameof(epoch), epoch, "Epoch not available.");
-        return new EraReader(new E2StoreReader(path));
-    }
+    private EraReader GetReader(long epoch) => !_epochs.TryGetValue(epoch, out string? path)
+        ? throw new ArgumentOutOfRangeException(nameof(epoch), epoch, "Epoch not available.")
+        : new EraReader(new E2StoreReader(path));
 
     private async ValueTask EnsureEpochVerified(long epoch, EraReader reader, CancellationToken cancellation)
     {
         if (_verifiedEpochs.TryGetValue(epoch, out bool verified) && verified) return;
 
-        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, _ => new SemaphoreSlim(1, 1));
+        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, static _ => new SemaphoreSlim(1, 1));
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {
@@ -166,7 +155,7 @@ public sealed class EraStore : IEraStore
 
     public async Task<(Block?, TxReceipt[]?)> FindBlockAndReceipts(long number, bool ensureValidated = true, CancellationToken cancellation = default)
     {
-        ThrowIfNegative(number);
+        ArgumentOutOfRangeException.ThrowIfNegative(number);
 
         long epoch = GetEpochNumber(number);
         if (!_epochs.ContainsKey(epoch))
@@ -211,12 +200,6 @@ public sealed class EraStore : IEraStore
         reader.Dispose();
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ThrowIfNegative(long number)
-    {
-        if (number < 0)
-            throw new ArgumentOutOfRangeException(nameof(number), number, "Cannot be negative.");
-    }
 
 
     private readonly struct EraRenter(EraStore store, EraReader reader, long epoch) : IDisposable

--- a/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
@@ -110,7 +110,12 @@ public sealed class EraStore : IEraStore
     {
         if (_verifiedEpochs.TryGetValue(epoch, out bool verified) && verified) return;
 
-        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, static _ => new SemaphoreSlim(1, 1));
+        if (!_epochLocks.TryGetValue(epoch, out SemaphoreSlim? epochLock))
+        {
+            SemaphoreSlim created = new(1, 1);
+            epochLock = _epochLocks.GetOrAdd(epoch, created);
+            if (!ReferenceEquals(epochLock, created)) created.Dispose();
+        }
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {

--- a/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
@@ -200,8 +200,6 @@ public sealed class EraStore : IEraStore
         reader.Dispose();
     }
 
-
-
     private readonly struct EraRenter(EraStore store, EraReader reader, long epoch) : IDisposable
     {
         public void Dispose() => store.ReturnReader(epoch, reader);

--- a/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStore.cs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Concurrent;
 using System.IO.Abstractions;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.EraE.Archive;
@@ -11,7 +13,6 @@ using Nethermind.EraE.E2Store;
 using EraException = Nethermind.Era1.EraException;
 using EraVerificationException = Nethermind.Era1.Exceptions.EraVerificationException;
 using Nethermind.EraE.Export;
-using NonBlocking;
 
 namespace Nethermind.EraE.Store;
 
@@ -110,12 +111,7 @@ public sealed class EraStore : IEraStore
     {
         if (_verifiedEpochs.TryGetValue(epoch, out bool verified) && verified) return;
 
-        if (!_epochLocks.TryGetValue(epoch, out SemaphoreSlim? epochLock))
-        {
-            SemaphoreSlim created = new(1, 1);
-            epochLock = _epochLocks.GetOrAdd(epoch, created);
-            if (!ReferenceEquals(epochLock, created)) created.Dispose();
-        }
+        SemaphoreSlim epochLock = _epochLocks.GetOrAddDisposable(epoch, static _ => new SemaphoreSlim(1, 1));
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {

--- a/src/Nethermind/Nethermind.EraE/Store/EraStoreFactory.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/EraStoreFactory.cs
@@ -47,9 +47,7 @@ public class EraStoreFactory(
 
         if (remoteClient is null)
         {
-            if (localStore is null)
-                throw new EraException($"No eraE files found in '{src}' and no remote URL is configured.");
-            return localStore;
+            return localStore ?? throw new EraException($"No eraE files found in '{src}' and no remote URL is configured.");
         }
 
         string downloadDir = !string.IsNullOrWhiteSpace(eraConfig.RemoteDownloadDirectory)

--- a/src/Nethermind/Nethermind.EraE/Store/HttpRemoteEraClient.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/HttpRemoteEraClient.cs
@@ -42,8 +42,7 @@ public sealed class HttpRemoteEraClient : IRemoteEraClient, IDisposable
 
         Dictionary<int, RemoteEraEntry> manifest = new();
 
-        string? line;
-        while ((line = await reader.ReadLineAsync(cancellation).ConfigureAwait(false)) is not null)
+        while (await reader.ReadLineAsync(cancellation).ConfigureAwait(false) is { } line)
         {
             if (string.IsNullOrWhiteSpace(line)) continue;
 

--- a/src/Nethermind/Nethermind.EraE/Store/IEraStore.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/IEraStore.cs
@@ -8,8 +8,7 @@ namespace Nethermind.EraE.Store;
 public interface IEraStore : IDisposable
 {
     Task<(Block?, TxReceipt[]?)> FindBlockAndReceipts(long number, bool ensureValidated = true, CancellationToken cancellation = default);
-    long LastBlock { get; }
-    long FirstBlock { get; }
+    (long First, long Last) BlockRange { get; }
 
     bool HasEpoch(long blockNumber);
 

--- a/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.EraE.Archive;
 using EraException = Nethermind.Era1.EraException;
 using EraVerificationException = Nethermind.Era1.Exceptions.EraVerificationException;
-using NonBlocking;
 
 namespace Nethermind.EraE.Store;
 
@@ -181,12 +182,7 @@ public sealed class RemoteEraStoreDecorator : IEraStore
 
         string destinationPath = Path.Join(_downloadDir, entry.Filename);
 
-        if (!_epochLocks.TryGetValue(epoch, out SemaphoreSlim? epochLock))
-        {
-            SemaphoreSlim created = new(1, 1);
-            epochLock = _epochLocks.GetOrAdd(epoch, created);
-            if (!ReferenceEquals(epochLock, created)) created.Dispose();
-        }
+        SemaphoreSlim epochLock = _epochLocks.GetOrAddDisposable(epoch, static _ => new SemaphoreSlim(1, 1));
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {

--- a/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
@@ -3,6 +3,7 @@
 
 using System.Security.Cryptography;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.EraE.Archive;
 using EraException = Nethermind.Era1.EraException;
 using EraVerificationException = Nethermind.Era1.Exceptions.EraVerificationException;
@@ -11,7 +12,7 @@ using NonBlocking;
 namespace Nethermind.EraE.Store;
 
 // Thread-safety model:
-//   Setup paths  (FirstBlock, LastBlock, NextEraStart) — called sequentially during initialization,
+//   Setup paths  (BlockRange, NextEraStart) — called sequentially during initialization,
 //                never from an async context; sync-over-async via GetAwaiter().GetResult() is safe.
 //   Read paths   (FindBlockAndReceipts) — called concurrently by multiple importer worker tasks;
 //                protected by per-epoch semaphores and a manifest lock.
@@ -30,8 +31,7 @@ public sealed class RemoteEraStoreDecorator : IEraStore
     private readonly SemaphoreSlim _manifestLock = new(1, 1);
 
     // One semaphore per epoch prevents concurrent duplicate downloads.
-    // Lazy<T> ensures only one SemaphoreSlim is created per epoch even if GetOrAdd races.
-    private readonly ConcurrentDictionary<int, Lazy<SemaphoreSlim>> _epochLocks = new();
+    private readonly ConcurrentDictionary<int, SemaphoreSlim> _epochLocks = new();
 
     // Verified epoch paths — populated after successful SHA-256 check
     private readonly ConcurrentDictionary<int, string> _verifiedEpochs = new();
@@ -41,8 +41,7 @@ public sealed class RemoteEraStoreDecorator : IEraStore
     private readonly ConcurrentDictionary<int, EraReader> _openedReaders = new();
 
     // Setup path — sequential, sync-over-async is safe (see thread-safety model above)
-    public long FirstBlock => GetFirstBlockAsync().GetAwaiter().GetResult();
-    public long LastBlock => GetLastBlockAsync().GetAwaiter().GetResult();
+    public (long First, long Last) BlockRange => GetBlockRangeAsync().GetAwaiter().GetResult();
 
     public RemoteEraStoreDecorator(
         IEraStore? localStore,
@@ -98,8 +97,8 @@ public sealed class RemoteEraStoreDecorator : IEraStore
     {
         _localStore?.Dispose();
         _manifestLock.Dispose();
-        foreach (Lazy<SemaphoreSlim> s in _epochLocks.Values)
-            if (s.IsValueCreated) s.Value.Dispose();
+        foreach (SemaphoreSlim s in _epochLocks.Values)
+            s.Dispose();
         foreach (EraReader reader in _openedReaders.Values)
             reader.Dispose();
     }
@@ -137,29 +136,21 @@ public sealed class RemoteEraStoreDecorator : IEraStore
         public void Dispose() => store.ReturnReader(epoch, reader);
     }
 
-    private async Task<long> GetFirstBlockAsync(CancellationToken cancellation = default)
+    private async Task<(long First, long Last)> GetBlockRangeAsync(CancellationToken cancellation = default)
     {
-        if (_localStore is not null) return _localStore.FirstBlock;
+        if (_localStore is not null) return _localStore.BlockRange;
 
         IReadOnlyDictionary<int, RemoteEraEntry> manifest = await GetManifestAsync(cancellation).ConfigureAwait(false);
         if (manifest.Count == 0) throw new EraException("Remote eraE manifest is empty.");
 
-        // Exact: era epochs are aligned to maxEraSize boundaries, so first epoch always starts at epoch * maxEraSize.
-        return (long)manifest.Keys.Min() * _maxEraSize;
-    }
+        (int minEpoch, int maxEpoch) = manifest.Keys.MinMax();
 
-    private async Task<long> GetLastBlockAsync(CancellationToken cancellation = default)
-    {
-        if (_localStore is not null) return _localStore.LastBlock;
-
-        IReadOnlyDictionary<int, RemoteEraEntry> manifest = await GetManifestAsync(cancellation).ConfigureAwait(false);
-        if (manifest.Count == 0) throw new EraException("Remote eraE manifest is empty.");
-
-        // Upper-bound estimate: avoids downloading the last (potentially huge) epoch file just for validation.
+        // First is exact: era epochs are aligned to maxEraSize boundaries.
+        // Last is upper-bound estimate: avoids downloading the last (potentially huge) epoch file just for validation.
         // The actual last block may be slightly lower for a non-full final epoch.
         // FindBlockAndReceipts returns (null, null) when number > reader.LastBlock, so importers that
         // rely on this value (to=0 / auto mode) will stop naturally at the real end.
-        return (long)(manifest.Keys.Max() + 1) * _maxEraSize - 1;
+        return ((long)minEpoch * _maxEraSize, (long)(maxEpoch + 1) * _maxEraSize - 1);
     }
 
     private async Task<IReadOnlyDictionary<int, RemoteEraEntry>> GetManifestAsync(CancellationToken cancellation = default)
@@ -190,7 +181,7 @@ public sealed class RemoteEraStoreDecorator : IEraStore
 
         string destinationPath = Path.Join(_downloadDir, entry.Filename);
 
-        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, static _ => new Lazy<SemaphoreSlim>(() => new SemaphoreSlim(1, 1))).Value;
+        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, static _ => new SemaphoreSlim(1, 1));
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {

--- a/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
@@ -181,7 +181,12 @@ public sealed class RemoteEraStoreDecorator : IEraStore
 
         string destinationPath = Path.Join(_downloadDir, entry.Filename);
 
-        SemaphoreSlim epochLock = _epochLocks.GetOrAdd(epoch, static _ => new SemaphoreSlim(1, 1));
+        if (!_epochLocks.TryGetValue(epoch, out SemaphoreSlim? epochLock))
+        {
+            SemaphoreSlim created = new(1, 1);
+            epochLock = _epochLocks.GetOrAdd(epoch, created);
+            if (!ReferenceEquals(epochLock, created)) created.Dispose();
+        }
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {


### PR DESCRIPTION
Targets: #10812

## Summary
- Merge `FirstBlock`/`LastBlock` into single `BlockRange` tuple on `IEraStore`
- Add `MinMax<T>` extension to replace LINQ `.Min()`/`.Max()` calls
- Simplify code style: expression bodies, ternary returns, null coalescing
- Use static throw helpers (`ArgumentNullException.ThrowIfNull`, `ArgumentOutOfRangeException.ThrowIfNegative`)
- Remove `Lazy<SemaphoreSlim>` wrappers from epoch locks
- Deduplicate tests: parameterize with `TestCase`, share `ReadAllEntries` helper
- Minor cleanups: static field, `TimeSpan.Zero`, `Memory<byte>.Empty`

## Test plan
- [ ] All existing EraE tests pass
- [ ] Build succeeds with no warnings

## Changes

- [x] Code refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)