### PR TITLE
fix: restrict health check UI to ports with health module enabled

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
 using NUnit.Framework;
@@ -199,6 +200,34 @@ public class JsonRpcUrlCollectionTests
             { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.Ws, false, _enabledModules) },
             { 8551, new JsonRpcUrl("http", "127.0.0.1", 8551, RpcEndpoint.Http | RpcEndpoint.Ws, true, [ModuleType.Eth, ModuleType.Engine]) },
         }, Is.EquivalentTo(urlCollection)); ;
+    }
+
+    [Test]
+    public void Health_host_patterns_only_include_ports_with_health_module()
+    {
+        JsonRpcConfig jsonRpcConfig = new()
+        {
+            Enabled = true,
+            EnabledModules = [ModuleType.Eth, ModuleType.Web3, ModuleType.Net, ModuleType.Health],
+            AdditionalRpcUrls =
+            [
+                "http://127.0.0.1:1234|http|eth;web3",
+                "http://127.0.0.1:5678|http|eth;health"
+            ]
+        };
+
+        JsonRpcUrlCollection urlCollection = new(Substitute.For<ILogManager>(), jsonRpcConfig, false);
+
+        // Replicate the exact filtering logic from Startup.cs
+        string[] healthHostPatterns = urlCollection.Values
+            .Where(url => url.IsModuleEnabled(ModuleType.Health))
+            .Select(url => $"*:{url.Port}")
+            .ToArray();
+
+        Assert.That(healthHostPatterns, Does.Contain("*:8545"));
+        Assert.That(healthHostPatterns, Does.Contain("*:5678"));
+        Assert.That(healthHostPatterns, Does.Not.Contain("*:1234"));
+        Assert.That(healthHostPatterns, Has.Length.EqualTo(2));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -203,13 +203,12 @@ public class Startup : IStartup
                         endpoints.MapHealthChecksUI(setup => setup.AddCustomStylesheet(Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "nethermind.css")))
                             .RequireHost(healthHostPatterns);
                     }
+                    endpoints.MapDataFeeds(lifetime).RequireHost(healthHostPatterns);
                 }
                 catch (Exception e)
                 {
                     if (logger.IsError) logger.Error("Unable to initialize health checks. Check if you have Nethermind.HealthChecks.dll in your plugins folder.", e);
                 }
-
-                endpoints.MapDataFeeds(lifetime).RequireHost(healthHostPatterns);
             }
         });
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
@@ -181,9 +182,14 @@ public class Startup : IStartup
             builder => builder.UseWebSocketsModules());
         }
 
+        string[] healthHostPatterns = jsonRpcUrlCollection.Values
+            .Where(url => url.IsModuleEnabled(ModuleType.Health))
+            .Select(url => $"*:{url.Port}")
+            .ToArray();
+
         app.UseEndpoints(endpoints =>
         {
-            if (healthChecksConfig.Enabled)
+            if (healthChecksConfig.Enabled && healthHostPatterns.Length > 0)
             {
                 try
                 {
@@ -191,10 +197,11 @@ public class Startup : IStartup
                     {
                         Predicate = _ => true,
                         ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-                    });
+                    }).RequireHost(healthHostPatterns);
                     if (healthChecksConfig.UIEnabled)
                     {
-                        endpoints.MapHealthChecksUI(setup => setup.AddCustomStylesheet(Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "nethermind.css")));
+                        endpoints.MapHealthChecksUI(setup => setup.AddCustomStylesheet(Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "nethermind.css")))
+                            .RequireHost(healthHostPatterns);
                     }
                 }
                 catch (Exception e)
@@ -202,7 +209,7 @@ public class Startup : IStartup
                     if (logger.IsError) logger.Error("Unable to initialize health checks. Check if you have Nethermind.HealthChecks.dll in your plugins folder.", e);
                 }
 
-                endpoints.MapDataFeeds(lifetime);
+                endpoints.MapDataFeeds(lifetime).RequireHost(healthHostPatterns);
             }
         });
 
@@ -238,12 +245,17 @@ public class Startup : IStartup
             }
         }));
 
-        if (healthChecksConfig.Enabled)
+        if (healthChecksConfig.Enabled && healthHostPatterns.Length > 0)
         {
             ManifestEmbeddedFileProvider fileProvider = new(typeof(Startup).Assembly, "wwwroot");
 
-            app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = fileProvider });
-            app.UseStaticFiles(new StaticFileOptions { FileProvider = fileProvider });
+            app.UseWhen(
+                ctx => jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl url) && url.IsModuleEnabled(ModuleType.Health),
+                builder =>
+                {
+                    builder.UseDefaultFiles(new DefaultFilesOptions { FileProvider = fileProvider });
+                    builder.UseStaticFiles(new StaticFileOptions { FileProvider = fileProvider });
+                });
         }
     }
 

--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeedExtensions.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeedExtensions.cs
@@ -21,7 +21,7 @@ public static class DataFeedExtensions
 {
     private static DataFeed _dataFeed;
 
-    public static void MapDataFeeds(this IEndpointRouteBuilder endpoints, ApplicationLifetime lifetime)
+    public static IEndpointConventionBuilder MapDataFeeds(this IEndpointRouteBuilder endpoints, ApplicationLifetime lifetime)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         IServiceProvider services = endpoints.ServiceProvider;
@@ -36,6 +36,6 @@ public static class DataFeedExtensions
 
         _dataFeed = new DataFeed(txPool, specProvider, receiptFinder, blockTree, syncPeerPool, mainProcessingContext, logManager, lifetime.ApplicationStopped);
 
-        endpoints.MapGet("data/events", _dataFeed.ProcessingFeedAsync);
+        return endpoints.MapGet("data/events", _dataFeed.ProcessingFeedAsync);
     }
 }


### PR DESCRIPTION
Fixes #11166

## Changes

- Restrict `MapHealthChecks`, `MapHealthChecksUI`, and `MapDataFeeds` endpoints to ports that have the `health` module enabled using `.RequireHost()` host-pattern filtering
- Wrap static file serving (monitoring dashboard) in `UseWhen` so it only activates on ports with the `health` module
- Change `MapDataFeeds` return type from `void` to `IEndpointConventionBuilder` to allow chaining `.RequireHost()`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Manual testing: configure `AdditionalRpcUrls` with a health-only port and other ports without health (as described in the issue), then verify that only the health-enabled port serves the health check UI.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)