### PR TITLE
fix: EIP-8024 missing immediate must decode as zero, not graceful STOP

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -68,6 +68,20 @@ public class Eip8024Tests : VirtualMachineTestsBase
         new UInt256(result.ReturnValue, true).Should().Be((UInt256)expectedReturn);
     }
 
+    private static IEnumerable<TestCaseData> MissingImmediateSuccessTestCases()
+    {
+        yield return new TestCaseData(PushNValues(145).Op(Instruction.DUPN).Done).SetName("DupN_MissingImmediate_DecodesAsZero");
+        yield return new TestCaseData(PushNValues(146).Op(Instruction.SWAPN).Done).SetName("SwapN_MissingImmediate_DecodesAsZero");
+        yield return new TestCaseData(PushNValues(17).Op(Instruction.EXCHANGE).Done).SetName("Exchange_MissingImmediate_DecodesAsZero");
+    }
+
+    [TestCaseSource(nameof(MissingImmediateSuccessTestCases))]
+    public void MissingImmediate_AtEndOfCode_DecodesAsZero(byte[] code)
+    {
+        TestAllTracerWithOutput result = Execute(code);
+        result.StatusCode.Should().Be(StatusCode.Success);
+    }
+
     private static IEnumerable<TestCaseData> FailureTestCases()
     {
         // Disallowed immediates (91-127 for DUPN/SWAPN, 82-127 for EXCHANGE)
@@ -80,12 +94,12 @@ public class Eip8024Tests : VirtualMachineTestsBase
         yield return new TestCaseData(PushNValues(10).Op(Instruction.SWAPN).Data(0x80).Done).SetName("SwapN_StackUnderflow");
         yield return new TestCaseData(PushNValues(2).Op(Instruction.EXCHANGE).Data(0x9d).Done).SetName("Exchange_StackUnderflow");
 
-        // Missing immediate at end of code: truncated instruction fails
+        // Missing immediate at end of code decodes as 0, then fails if the stack is too shallow.
         yield return new TestCaseData(new byte[] { 0xe6 }).SetName("DupN_MissingImmediate");
         yield return new TestCaseData(new byte[] { 0xe7 }).SetName("SwapN_MissingImmediate");
         yield return new TestCaseData(new byte[] { 0xe8 }).SetName("Exchange_MissingImmediate");
 
-        // Regression: PUSH1 0x42, DUPN with no immediate — must fail, not graceful STOP
+        // Regression: PUSH1 0x42, DUPN with no immediate must underflow, not gracefully STOP.
         yield return new TestCaseData(new byte[] { 0x60, 0x42, 0xe6 }).SetName("DupN_TruncatedAfterPush");
 
         // Max depth: immediate 0x5a -> depth=235, only 234 items

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -80,8 +80,13 @@ public class Eip8024Tests : VirtualMachineTestsBase
         yield return new TestCaseData(PushNValues(10).Op(Instruction.SWAPN).Data(0x80).Done).SetName("SwapN_StackUnderflow");
         yield return new TestCaseData(PushNValues(2).Op(Instruction.EXCHANGE).Data(0x9d).Done).SetName("Exchange_StackUnderflow");
 
-        // Missing immediate at end of code is now a graceful STOP (EIP-8024 spec)
-        // Moved to EndOfCode_ActsAsStop test below
+        // Missing immediate at end of code: truncated instruction fails
+        yield return new TestCaseData(new byte[] { 0xe6 }).SetName("DupN_MissingImmediate");
+        yield return new TestCaseData(new byte[] { 0xe7 }).SetName("SwapN_MissingImmediate");
+        yield return new TestCaseData(new byte[] { 0xe8 }).SetName("Exchange_MissingImmediate");
+
+        // Regression: PUSH1 0x42, DUPN with no immediate — must fail, not graceful STOP
+        yield return new TestCaseData(new byte[] { 0x60, 0x42, 0xe6 }).SetName("DupN_TruncatedAfterPush");
 
         // Max depth: immediate 0x5a -> depth=235, only 234 items
         yield return new TestCaseData(PushZeros(234).Op(Instruction.DUPN).Data(0x5a).Done).SetName("DupN_MaxDepth_235");
@@ -119,17 +124,6 @@ public class Eip8024Tests : VirtualMachineTestsBase
         TestAllTracerWithOutput result = Execute(Activation, 100000, code);
         result.StatusCode.Should().Be(StatusCode.Success);
         AssertGas(result, expectedGas);
-    }
-
-    [TestCase(new byte[] { 0xe6 }, TestName = "DupN_MissingImmediate")]
-    [TestCase(new byte[] { 0xe7 }, TestName = "SwapN_MissingImmediate")]
-    [TestCase(new byte[] { 0xe8 }, TestName = "Exchange_MissingImmediate")]
-    public void EndOfCode_ActsAsStop(byte[] code)
-    {
-        // When DUPN/SWAPN/EXCHANGE appears at end of code with no immediate byte,
-        // it acts as a graceful STOP per EIP-8024 spec.
-        TestAllTracerWithOutput result = Execute(code);
-        result.StatusCode.Should().Be(StatusCode.Success);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -80,13 +80,8 @@ public class Eip8024Tests : VirtualMachineTestsBase
         yield return new TestCaseData(PushNValues(10).Op(Instruction.SWAPN).Data(0x80).Done).SetName("SwapN_StackUnderflow");
         yield return new TestCaseData(PushNValues(2).Op(Instruction.EXCHANGE).Data(0x9d).Done).SetName("Exchange_StackUnderflow");
 
-        // Missing immediate at end of code: truncated instruction fails
-        yield return new TestCaseData(new byte[] { 0xe6 }).SetName("DupN_MissingImmediate");
-        yield return new TestCaseData(new byte[] { 0xe7 }).SetName("SwapN_MissingImmediate");
-        yield return new TestCaseData(new byte[] { 0xe8 }).SetName("Exchange_MissingImmediate");
-
-        // Regression: PUSH1 0x42, DUPN with no immediate — must fail, not graceful STOP
-        yield return new TestCaseData(new byte[] { 0x60, 0x42, 0xe6 }).SetName("DupN_TruncatedAfterPush");
+        // Missing immediate at end of code is now a graceful STOP (EIP-8024 spec)
+        // Moved to EndOfCode_ActsAsStop test below
 
         // Max depth: immediate 0x5a -> depth=235, only 234 items
         yield return new TestCaseData(PushZeros(234).Op(Instruction.DUPN).Data(0x5a).Done).SetName("DupN_MaxDepth_235");
@@ -124,6 +119,17 @@ public class Eip8024Tests : VirtualMachineTestsBase
         TestAllTracerWithOutput result = Execute(Activation, 100000, code);
         result.StatusCode.Should().Be(StatusCode.Success);
         AssertGas(result, expectedGas);
+    }
+
+    [TestCase(new byte[] { 0xe6 }, TestName = "DupN_MissingImmediate")]
+    [TestCase(new byte[] { 0xe7 }, TestName = "SwapN_MissingImmediate")]
+    [TestCase(new byte[] { 0xe8 }, TestName = "Exchange_MissingImmediate")]
+    public void EndOfCode_ActsAsStop(byte[] code)
+    {
+        // When DUPN/SWAPN/EXCHANGE appears at end of code with no immediate byte,
+        // it acts as a graceful STOP per EIP-8024 spec.
+        TestAllTracerWithOutput result = Execute(code);
+        result.StatusCode.Should().Be(StatusCode.Success);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
@@ -171,9 +171,14 @@ namespace Nethermind.Evm.Test
             for (int i = 0; i <= byte.MaxValue; i++)
             {
                 logger.Info($"============ Testing opcode {i}==================");
-                byte[] code = Prepare.EvmCode
-                    .Op((byte)i)
-                    .Done;
+                Instruction opcode = (Instruction)i;
+
+                // EIP-8024 opcodes require an immediate byte; a bare opcode returns BadInstruction
+                // due to truncated immediate, not because the opcode is invalid. Provide a valid
+                // immediate (0x80) so the test checks opcode validity rather than immediate presence.
+                byte[] code = opcode is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE
+                    ? Prepare.EvmCode.Op((byte)i).Data(0x80).Done
+                    : Prepare.EvmCode.Op((byte)i).Done;
 
                 bool isValidOpcode = ((Instruction)i != Instruction.INVALID) && validOpcodes.Contains((Instruction)i);
                 TestAllTracerWithOutput result = Execute((blockNumber, timestamp ?? 0), 1_000_000, code);

--- a/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
@@ -173,9 +173,8 @@ namespace Nethermind.Evm.Test
                 logger.Info($"============ Testing opcode {i}==================");
                 Instruction opcode = (Instruction)i;
 
-                // EIP-8024 opcodes require an immediate byte; a bare opcode returns BadInstruction
-                // due to truncated immediate, not because the opcode is invalid. Provide a valid
-                // immediate (0x80) so the test checks opcode validity rather than immediate presence.
+                // Provide an in-range EIP-8024 immediate so the test checks opcode validity rather
+                // than end-of-code immediate decoding or stack behavior.
                 byte[] code = opcode is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE
                     ? Prepare.EvmCode.Op((byte)i).Data(0x80).Done
                     : Prepare.EvmCode.Op((byte)i).Done;

--- a/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
@@ -171,14 +171,9 @@ namespace Nethermind.Evm.Test
             for (int i = 0; i <= byte.MaxValue; i++)
             {
                 logger.Info($"============ Testing opcode {i}==================");
-                Instruction opcode = (Instruction)i;
-
-                // EIP-8024 opcodes require an immediate byte; a bare opcode returns BadInstruction
-                // due to truncated immediate, not because the opcode is invalid. Provide a valid
-                // immediate (0x80) so the test checks opcode validity rather than immediate presence.
-                byte[] code = opcode is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE
-                    ? Prepare.EvmCode.Op((byte)i).Data(0x80).Done
-                    : Prepare.EvmCode.Op((byte)i).Done;
+                byte[] code = Prepare.EvmCode
+                    .Op((byte)i)
+                    .Done;
 
                 bool isValidOpcode = ((Instruction)i != Instruction.INVALID) && validOpcodes.Contains((Instruction)i);
                 TestAllTracerWithOutput result = Execute((blockNumber, timestamp ?? 0), 1_000_000, code);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -621,11 +621,16 @@ public static partial class EvmInstructions
                 : EvmExceptionType.None;
     }
 
+    // EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte ReadEip8024ImmediateOrZero(ReadOnlySpan<byte> code, int programCounter)
+        => programCounter < code.Length ? code[programCounter] : (byte)0;
+
     /// <summary>
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.
     /// </summary>
     /// <remarks>
-    /// Handles bounds checking, reading the immediate, and advancing the program counter.
+    /// Handles reading the immediate and advancing the program counter.
     /// Branchless formula: n = (x + 145) % 256.
     /// Valid range: 0-90 (n=145-235) and 128-255 (n=17-144).
     /// Disallowed range: 0x5b-0x7f (91-127) to avoid JUMPDEST/PUSH patterns.
@@ -635,13 +640,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        if (programCounter >= code.Length)
-        {
-            depth = 0;
-            return false;
-        }
-
-        byte imm = code[programCounter];
+        byte imm = ReadEip8024ImmediateOrZero(code, programCounter);
         depth = (imm + 145) & 0xFF;
 
         if ((uint)(imm - 0x5B) <= 0x24)
@@ -655,7 +654,7 @@ public static partial class EvmInstructions
     /// Reads and decodes an immediate for EIP-8024 EXCHANGE instruction.
     /// </summary>
     /// <remarks>
-    /// Handles bounds checking, reading the immediate, and advancing the program counter.
+    /// Handles reading the immediate and advancing the program counter.
     /// Branchless formula: k = x ^ 143 (XOR with 0x8F).
     /// Valid range: 0-81 (k mapped via XOR) and 128-255. Invalid range: 82-127.
     /// Returns stack indices ready for direct use with stack.Exchange.
@@ -665,13 +664,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        if (programCounter >= code.Length)
-        {
-            n = m = 0;
-            return false;
-        }
-
-        byte imm = code[programCounter];
+        byte imm = ReadEip8024ImmediateOrZero(code, programCounter);
 
         int k = imm ^ 0x8F;
         int q = k >> 4;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -582,9 +582,10 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        return !TryDecodeSingle(vm, ref programCounter, out int depth)
-            ? EvmExceptionType.BadInstruction
-            : stack.Dup<TTracingInst>(depth);
+        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
+            return StopOrBadInstruction(vm, programCounter);
+
+        return stack.Dup<TTracingInst>(depth);
     }
 
     /// <summary>
@@ -598,9 +599,10 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        return !TryDecodeSingle(vm, ref programCounter, out int depth)
-            ? EvmExceptionType.BadInstruction
-            : stack.Swap<TTracingInst>(depth + 1);
+        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
+            return StopOrBadInstruction(vm, programCounter);
+
+        return stack.Swap<TTracingInst>(depth + 1);
     }
 
     /// <summary>
@@ -614,12 +616,25 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        return !TryDecodePair(vm, ref programCounter, out int n, out int m)
-            ? EvmExceptionType.BadInstruction
-            : !stack.Exchange<TTracingInst>(n, m)
-                ? EvmExceptionType.StackUnderflow
-                : EvmExceptionType.None;
+        if (!TryDecodePair(vm, ref programCounter, out int n, out int m))
+            return StopOrBadInstruction(vm, programCounter);
+
+        if (!stack.Exchange<TTracingInst>(n, m))
+            return EvmExceptionType.StackUnderflow;
+
+        return EvmExceptionType.None;
     }
+
+    /// <summary>
+    /// Returns Stop if the program counter is at or past end of code, otherwise BadInstruction.
+    /// Used by EIP-8024 to distinguish end-of-code (graceful stop) from disallowed immediate.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static EvmExceptionType StopOrBadInstruction<TGasPolicy>(VirtualMachine<TGasPolicy> vm, int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => programCounter >= vm.VmState.Env.CodeInfo.CodeSpan.Length
+            ? EvmExceptionType.Stop
+            : EvmExceptionType.BadInstruction;
 
     /// <summary>
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -582,10 +582,9 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
-            return StopOrBadInstruction(vm, programCounter);
-
-        return stack.Dup<TTracingInst>(depth);
+        return !TryDecodeSingle(vm, ref programCounter, out int depth)
+            ? EvmExceptionType.BadInstruction
+            : stack.Dup<TTracingInst>(depth);
     }
 
     /// <summary>
@@ -599,10 +598,9 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
-            return StopOrBadInstruction(vm, programCounter);
-
-        return stack.Swap<TTracingInst>(depth + 1);
+        return !TryDecodeSingle(vm, ref programCounter, out int depth)
+            ? EvmExceptionType.BadInstruction
+            : stack.Swap<TTracingInst>(depth + 1);
     }
 
     /// <summary>
@@ -616,25 +614,12 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodePair(vm, ref programCounter, out int n, out int m))
-            return StopOrBadInstruction(vm, programCounter);
-
-        if (!stack.Exchange<TTracingInst>(n, m))
-            return EvmExceptionType.StackUnderflow;
-
-        return EvmExceptionType.None;
+        return !TryDecodePair(vm, ref programCounter, out int n, out int m)
+            ? EvmExceptionType.BadInstruction
+            : !stack.Exchange<TTracingInst>(n, m)
+                ? EvmExceptionType.StackUnderflow
+                : EvmExceptionType.None;
     }
-
-    /// <summary>
-    /// Returns Stop if the program counter is at or past end of code, otherwise BadInstruction.
-    /// Used by EIP-8024 to distinguish end-of-code (graceful stop) from disallowed immediate.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType StopOrBadInstruction<TGasPolicy>(VirtualMachine<TGasPolicy> vm, int programCounter)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        => programCounter >= vm.VmState.Env.CodeInfo.CodeSpan.Length
-            ? EvmExceptionType.Stop
-            : EvmExceptionType.BadInstruction;
 
     /// <summary>
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -614,12 +614,11 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodePair(vm, ref programCounter, out int n, out int m))
-            return EvmExceptionType.BadInstruction;
-
-        return !stack.Exchange<TTracingInst>(n, m)
-            ? EvmExceptionType.StackUnderflow
-            : EvmExceptionType.None;
+        return !TryDecodePair(vm, ref programCounter, out int n, out int m)
+            ? EvmExceptionType.BadInstruction
+            : !stack.Exchange<TTracingInst>(n, m)
+                ? EvmExceptionType.StackUnderflow
+                : EvmExceptionType.None;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -582,10 +582,9 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
-            return StopOrBadInstruction(vm, programCounter);
-
-        return stack.Dup<TTracingInst>(depth);
+        return !TryDecodeSingle(vm, ref programCounter, out int depth)
+            ? EvmExceptionType.BadInstruction
+            : stack.Dup<TTracingInst>(depth);
     }
 
     /// <summary>
@@ -599,10 +598,9 @@ public static partial class EvmInstructions
     {
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
-        if (!TryDecodeSingle(vm, ref programCounter, out int depth))
-            return StopOrBadInstruction(vm, programCounter);
-
-        return stack.Swap<TTracingInst>(depth + 1);
+        return !TryDecodeSingle(vm, ref programCounter, out int depth)
+            ? EvmExceptionType.BadInstruction
+            : stack.Swap<TTracingInst>(depth + 1);
     }
 
     /// <summary>
@@ -617,24 +615,12 @@ public static partial class EvmInstructions
         TGasPolicy.Consume(ref gas, GasCostOf.VeryLow);
 
         if (!TryDecodePair(vm, ref programCounter, out int n, out int m))
-            return StopOrBadInstruction(vm, programCounter);
+            return EvmExceptionType.BadInstruction;
 
-        if (!stack.Exchange<TTracingInst>(n, m))
-            return EvmExceptionType.StackUnderflow;
-
-        return EvmExceptionType.None;
+        return !stack.Exchange<TTracingInst>(n, m)
+            ? EvmExceptionType.StackUnderflow
+            : EvmExceptionType.None;
     }
-
-    /// <summary>
-    /// Returns Stop if the program counter is at or past end of code, otherwise BadInstruction.
-    /// Used by EIP-8024 to distinguish end-of-code (graceful stop) from disallowed immediate.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType StopOrBadInstruction<TGasPolicy>(VirtualMachine<TGasPolicy> vm, int programCounter)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        => programCounter >= vm.VmState.Env.CodeInfo.CodeSpan.Length
-            ? EvmExceptionType.Stop
-            : EvmExceptionType.BadInstruction;
 
     /// <summary>
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.


### PR DESCRIPTION
## Changes

- When DUPN/SWAPN/EXCHANGE appeared at the end of bytecode without their required immediate byte, Nethermind returned a graceful STOP that skipped the opcode entirely - causing a consensus split with Geth at Amsterdam fork activation.
- Root cause: `StopOrBadInstruction` treated `programCounter >= code.Length` as end-of-code and halted execution before the opcode ran. Per the EIP-8024 spec, a missing immediate byte beyond end of code evaluates to zero; the opcode must still execute with that zero-decoded immediate and succeed or fail per the resulting stack/gas state.
- Fix: replaced the bail-out with `ReadEip8024ImmediateOrZero(code, programCounter)`, which returns `0` when the program counter is past end of code. `TryDecodeSingle` / `TryDecodePair` now always decode and advance; the opcode executes normally.
- Net effect: truncated-immediate bytecodes like the original PoC `0x6042e6` now execute the DUPN with decoded depth 145, fail with `StackUnderflow` (single-item stack can't satisfy that depth), and consume gas - matching Geth byte-for-byte.
- `BadInstruction` is still returned for disallowed-immediate ranges (0x5B-0x7F for DUPN/SWAPN, 0x52-0x7F for EXCHANGE); that path is unchanged.
- Removed the now-redundant `StopOrBadInstruction` helper.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New `MissingImmediate_AtEndOfCode_DecodesAsZero` test pins the spec semantics: with a stack deep enough for decoded `depth=145`, DUPN/SWAPN/EXCHANGE at end-of-code succeed.
- `DupN_MissingImmediate` / `SwapN_MissingImmediate` / `Exchange_MissingImmediate` are failure cases where the empty stack can't satisfy the zero-decoded depth - underflow, not graceful STOP.
- `DupN_TruncatedAfterPush` regression test matches the exact PoC bytecode (`0x6042e6`) and asserts the expected underflow failure.
- Updated `InvalidOpcodeTests` to supply an in-range EIP-8024 immediate so the opcode-validity scan isn't conflated with end-of-code immediate decoding.
- Verified with nethtest trace that gas and stack state after execution match Geth exactly.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EIP-8024 DUPN/SWAPN/EXCHANGE with a missing immediate byte now correctly decode the missing byte as zero and execute the opcode (typically failing with stack underflow on truncated bytecodes), instead of returning a graceful STOP. Resolves a consensus split with Geth at Amsterdam fork activation.