### PR TITLE
More fixes

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8024Tests.cs
@@ -68,6 +68,20 @@ public class Eip8024Tests : VirtualMachineTestsBase
         new UInt256(result.ReturnValue, true).Should().Be((UInt256)expectedReturn);
     }
 
+    private static IEnumerable<TestCaseData> MissingImmediateSuccessTestCases()
+    {
+        yield return new TestCaseData(PushNValues(145).Op(Instruction.DUPN).Done).SetName("DupN_MissingImmediate_DecodesAsZero");
+        yield return new TestCaseData(PushNValues(146).Op(Instruction.SWAPN).Done).SetName("SwapN_MissingImmediate_DecodesAsZero");
+        yield return new TestCaseData(PushNValues(17).Op(Instruction.EXCHANGE).Done).SetName("Exchange_MissingImmediate_DecodesAsZero");
+    }
+
+    [TestCaseSource(nameof(MissingImmediateSuccessTestCases))]
+    public void MissingImmediate_AtEndOfCode_DecodesAsZero(byte[] code)
+    {
+        TestAllTracerWithOutput result = Execute(code);
+        result.StatusCode.Should().Be(StatusCode.Success);
+    }
+
     private static IEnumerable<TestCaseData> FailureTestCases()
     {
         // Disallowed immediates (91-127 for DUPN/SWAPN, 82-127 for EXCHANGE)
@@ -80,12 +94,12 @@ public class Eip8024Tests : VirtualMachineTestsBase
         yield return new TestCaseData(PushNValues(10).Op(Instruction.SWAPN).Data(0x80).Done).SetName("SwapN_StackUnderflow");
         yield return new TestCaseData(PushNValues(2).Op(Instruction.EXCHANGE).Data(0x9d).Done).SetName("Exchange_StackUnderflow");
 
-        // Missing immediate at end of code: truncated instruction fails
+        // Missing immediate at end of code decodes as 0, then fails if the stack is too shallow.
         yield return new TestCaseData(new byte[] { 0xe6 }).SetName("DupN_MissingImmediate");
         yield return new TestCaseData(new byte[] { 0xe7 }).SetName("SwapN_MissingImmediate");
         yield return new TestCaseData(new byte[] { 0xe8 }).SetName("Exchange_MissingImmediate");
 
-        // Regression: PUSH1 0x42, DUPN with no immediate — must fail, not graceful STOP
+        // Regression: PUSH1 0x42, DUPN with no immediate must underflow, not gracefully STOP.
         yield return new TestCaseData(new byte[] { 0x60, 0x42, 0xe6 }).SetName("DupN_TruncatedAfterPush");
 
         // Max depth: immediate 0x5a -> depth=235, only 234 items

--- a/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
@@ -173,9 +173,8 @@ namespace Nethermind.Evm.Test
                 logger.Info($"============ Testing opcode {i}==================");
                 Instruction opcode = (Instruction)i;
 
-                // EIP-8024 opcodes require an immediate byte; a bare opcode returns BadInstruction
-                // due to truncated immediate, not because the opcode is invalid. Provide a valid
-                // immediate (0x80) so the test checks opcode validity rather than immediate presence.
+                // Provide an in-range EIP-8024 immediate so the test checks opcode validity rather
+                // than end-of-code immediate decoding or stack behavior.
                 byte[] code = opcode is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE
                     ? Prepare.EvmCode.Op((byte)i).Data(0x80).Done
                     : Prepare.EvmCode.Op((byte)i).Done;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -621,12 +621,16 @@ public static partial class EvmInstructions
                 : EvmExceptionType.None;
     }
 
+    // EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte ReadEip8024ImmediateOrZero(ReadOnlySpan<byte> code, int programCounter)
+        => programCounter < code.Length ? code[programCounter] : (byte)0;
+
     /// <summary>
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.
     /// </summary>
     /// <remarks>
     /// Handles reading the immediate and advancing the program counter.
-    /// EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
     /// Branchless formula: n = (x + 145) % 256.
     /// Valid range: 0-90 (n=145-235) and 128-255 (n=17-144).
     /// Disallowed range: 0x5b-0x7f (91-127) to avoid JUMPDEST/PUSH patterns.
@@ -636,7 +640,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        byte imm = programCounter < code.Length ? code[programCounter] : (byte)0;
+        byte imm = ReadEip8024ImmediateOrZero(code, programCounter);
         depth = (imm + 145) & 0xFF;
 
         if ((uint)(imm - 0x5B) <= 0x24)
@@ -651,7 +655,6 @@ public static partial class EvmInstructions
     /// </summary>
     /// <remarks>
     /// Handles reading the immediate and advancing the program counter.
-    /// EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
     /// Branchless formula: k = x ^ 143 (XOR with 0x8F).
     /// Valid range: 0-81 (k mapped via XOR) and 128-255. Invalid range: 82-127.
     /// Returns stack indices ready for direct use with stack.Exchange.
@@ -661,7 +664,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        byte imm = programCounter < code.Length ? code[programCounter] : (byte)0;
+        byte imm = ReadEip8024ImmediateOrZero(code, programCounter);
 
         int k = imm ^ 0x8F;
         int q = k >> 4;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -625,7 +625,8 @@ public static partial class EvmInstructions
     /// Reads and decodes an immediate for EIP-8024 DUPN/SWAPN instructions.
     /// </summary>
     /// <remarks>
-    /// Handles bounds checking, reading the immediate, and advancing the program counter.
+    /// Handles reading the immediate and advancing the program counter.
+    /// EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
     /// Branchless formula: n = (x + 145) % 256.
     /// Valid range: 0-90 (n=145-235) and 128-255 (n=17-144).
     /// Disallowed range: 0x5b-0x7f (91-127) to avoid JUMPDEST/PUSH patterns.
@@ -635,13 +636,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        if (programCounter >= code.Length)
-        {
-            depth = 0;
-            return false;
-        }
-
-        byte imm = code[programCounter];
+        byte imm = programCounter < code.Length ? code[programCounter] : (byte)0;
         depth = (imm + 145) & 0xFF;
 
         if ((uint)(imm - 0x5B) <= 0x24)
@@ -655,7 +650,8 @@ public static partial class EvmInstructions
     /// Reads and decodes an immediate for EIP-8024 EXCHANGE instruction.
     /// </summary>
     /// <remarks>
-    /// Handles bounds checking, reading the immediate, and advancing the program counter.
+    /// Handles reading the immediate and advancing the program counter.
+    /// EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
     /// Branchless formula: k = x ^ 143 (XOR with 0x8F).
     /// Valid range: 0-81 (k mapped via XOR) and 128-255. Invalid range: 82-127.
     /// Returns stack indices ready for direct use with stack.Exchange.
@@ -665,13 +661,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         ReadOnlySpan<byte> code = vm.VmState.Env.CodeInfo.CodeSpan;
-        if (programCounter >= code.Length)
-        {
-            n = m = 0;
-            return false;
-        }
-
-        byte imm = code[programCounter];
+        byte imm = programCounter < code.Length ? code[programCounter] : (byte)0;
 
         int k = imm ^ 0x8F;
         int q = k >> 4;


### PR DESCRIPTION
EIP-8024 says `code[pc + 1]` beyond the end of code evaluates to `0`, matching `PUSH` behavior

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
