### PR TITLE
ci: bump mainnet Flat sync timeout to 6h in sync-master-validation

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -93,6 +93,10 @@ jobs:
                   runner_label: (
                     (if $mode == "Flat" then "f-" else "hp-" end)
                     + $run_id + "-master-" + $config.network
+                  ),
+                  timeout: (
+                    if $config.network == "mainnet" and $mode == "Flat" then 360
+                    else $config.timeout end
                   )
                 }]')
 


### PR DESCRIPTION
## Changes

- Override the per-job `timeout` for `network=mainnet` + `mode=Flat` in `sync-master-validation.yml` to **360 minutes (6h)**, up from the 180m default inherited from `scripts/config/testnet-matrix.json`.
- Change is applied inline inside the matrix-building `jq` filter, so the shared `testnet-matrix.json` is untouched and other workflows consuming it (`sync-pr-gate.yml`, `sync-supported-chains.yml`) are unaffected.

### Motivation

The `Sync mainnet (Flat)` job in [run 24526710791](https://github.com/NethermindEth/nethermind/actions/runs/24526710791/job/71699344408) was cancelled after exceeding the 3h limit during the `Wait for sync` step. Flat-mode mainnet sync consistently runs longer than HalfPath; bumping the cap to 6h gives it headroom without affecting other chains/modes.

## Types of changes

- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Validated the modified `jq` filter locally — only `mainnet` + `Flat` receives `timeout: 360`; all other matrix entries keep their original timeout.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)