### PR TITLE
fix(db): dispose snapshot-owned RocksDB ReadOptions

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1911,6 +1911,17 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         Snapshot snapshot
     ) : RocksDbReader(mainDb, readOptionsFactory, null, columnFamily), IKeyValueStoreSnapshot
     {
-        public void Dispose() => snapshot.Dispose();
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            DisposeOwnedReadOptions();
+            snapshot.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -34,12 +34,34 @@ public class RocksDbReader(DbOnTheRocks mainDb,
 
     private readonly ReadOptions _options = options;
     private readonly ReadOptions _hintCacheMissOptions = hintCacheMissOptions;
+    private readonly bool _ownsReadOptions;
 
     public RocksDbReader(DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
         DbOnTheRocks.IteratorManager? iteratorManager = null,
         ColumnFamilyHandle? columnFamily = null)
-        : this(mainDb, readOptionsFactory(), readOptionsFactory(), readOptionsFactory, iteratorManager, columnFamily) => _hintCacheMissOptions.SetFillCache(false);
+        : this(mainDb, readOptionsFactory(), readOptionsFactory(), readOptionsFactory, iteratorManager, columnFamily)
+    {
+        _ownsReadOptions = true;
+        _hintCacheMissOptions.SetFillCache(false);
+    }
+
+    protected void DisposeOwnedReadOptions()
+    {
+        if (!_ownsReadOptions)
+        {
+            return;
+        }
+
+        DestroyReadOptions(_options);
+        DestroyReadOptions(_hintCacheMissOptions);
+    }
+
+    private static void DestroyReadOptions(ReadOptions options)
+    {
+        RocksDbSharp.Native.Instance.rocksdb_readoptions_destroy(options.Handle);
+        GC.SuppressFinalize(options);
+    }
 
     public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
     {


### PR DESCRIPTION
## Changes

- Track whether `RocksDbReader` owns the `ReadOptions` instances created by the factory constructor
- Add an internal cleanup path for owned read options and call it from `DbOnTheRocks.RocksDbSnapshot.Dispose()`
- Make `RocksDbSnapshot.Dispose()` idempotent while releasing both the snapshot handle and its snapshot-owned read options

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj --filter "FullyQualifiedName~Sha256PrecompileTests|FullyQualifiedName~Ripemd160PrecompileTests" -v minimal --no-progress --output Normal`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No