### PR TITLE
fix(db): make RocksDbReader disposable, unify ReadOptions cleanup

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -140,7 +140,6 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         private readonly Snapshot _snapshot;
         private readonly ReadOptions _sharedReadOptions;
         private readonly ReadOptions _sharedCacheMissReadOptions;
-        private readonly RocksDbSharp.Native _rocksDbNative;
         private int _disposed;
 
         // Use a flat array indexed by enum ordinal instead of Dictionary<T, IReadOnlyKeyValueStore>.
@@ -150,7 +149,6 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot)
         {
             _snapshot = snapshot;
-            _rocksDbNative = columnsDb._rocksDbNative;
 
             // Create two shared ReadOptions for all column readers instead of 2 per reader.
             // ReadOptions in RocksDbSharp has a finalizer but no IDisposable — creating many
@@ -247,16 +245,10 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
 
             // Explicitly destroy native ReadOptions handles to prevent finalizer queue buildup.
             // GC.SuppressFinalize prevents the finalizer from running on already-destroyed handles.
-            DestroyReadOptions(_sharedReadOptions);
-            DestroyReadOptions(_sharedCacheMissReadOptions);
+            RocksDbReader.DestroyReadOptions(_sharedReadOptions);
+            RocksDbReader.DestroyReadOptions(_sharedCacheMissReadOptions);
 
             _snapshot.Dispose();
-        }
-
-        private void DestroyReadOptions(ReadOptions options)
-        {
-            _rocksDbNative.rocksdb_readoptions_destroy(options.Handle);
-            GC.SuppressFinalize(options);
         }
 
         // Non-boxing enum-to-int conversion. JIT eliminates dead branches at

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1911,6 +1911,17 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         Snapshot snapshot
     ) : RocksDbReader(mainDb, readOptionsFactory, null, columnFamily), IKeyValueStoreSnapshot
     {
-        public void Dispose() => snapshot.Dispose();
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            DisposeOwnedReadOptions();
+            snapshot.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1892,7 +1892,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
 
         Iterator iterator = CreateIterator(readOptions, cf);
-        return new RocksdbSortedView(iterator, iterateLowerBound, iterateUpperBound);
+        return new RocksdbSortedView(iterator, readOptions, iterateLowerBound, iterateUpperBound);
     }
 
     public IKeyValueStoreSnapshot CreateSnapshot()

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1481,6 +1481,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             dbMetricsUpdater.Dispose();
         }
 
+        _reader.Dispose();
+
         if (_perTableDbConfig.FlushOnExit) InnerFlush(false);
         ReleaseUnmanagedResources();
 
@@ -1913,14 +1915,14 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     {
         private int _disposed;
 
-        public void Dispose()
+        public override void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
                 return;
             }
 
-            DisposeOwnedReadOptions();
+            base.Dispose();
             snapshot.Dispose();
         }
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1906,7 +1906,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }, null, snapshot);
     }
 
-    public class RocksDbSnapshot(
+    public sealed class RocksDbSnapshot(
         DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
         ColumnFamilyHandle? columnFamily,

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -34,12 +34,34 @@ public class RocksDbReader(DbOnTheRocks mainDb,
 
     private readonly ReadOptions _options = options;
     private readonly ReadOptions _hintCacheMissOptions = hintCacheMissOptions;
+    private readonly bool _ownsReadOptions;
 
     public RocksDbReader(DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
         DbOnTheRocks.IteratorManager? iteratorManager = null,
         ColumnFamilyHandle? columnFamily = null)
-        : this(mainDb, readOptionsFactory(), readOptionsFactory(), readOptionsFactory, iteratorManager, columnFamily) => _hintCacheMissOptions.SetFillCache(false);
+        : this(mainDb, readOptionsFactory(), readOptionsFactory(), readOptionsFactory, iteratorManager, columnFamily)
+    {
+        _ownsReadOptions = true;
+        _hintCacheMissOptions.SetFillCache(false);
+    }
+
+    protected void DisposeOwnedReadOptions()
+    {
+        if (!_ownsReadOptions)
+        {
+            return;
+        }
+
+        DestroyReadOptions(_options);
+        DestroyReadOptions(_hintCacheMissOptions);
+    }
+
+    private static void DestroyReadOptions(ReadOptions options)
+    {
+        RocksDbSharp.Native.Instance.rocksdb_readoptions_destroy(options.Handle);
+        GC.SuppressFinalize(options);
+    }
 
     public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -25,7 +25,7 @@ public class RocksDbReader(DbOnTheRocks mainDb,
     ReadOptions hintCacheMissOptions,
     Func<ReadOptions> readOptionsFactory,
     DbOnTheRocks.IteratorManager? iteratorManager = null,
-    ColumnFamilyHandle? columnFamily = null) : ISortedKeyValueStore
+    ColumnFamilyHandle? columnFamily = null) : ISortedKeyValueStore, IDisposable
 {
     private readonly DbOnTheRocks _mainDb = mainDb;
     private readonly Func<ReadOptions> _readOptionsFactory = readOptionsFactory;
@@ -46,7 +46,7 @@ public class RocksDbReader(DbOnTheRocks mainDb,
         _hintCacheMissOptions.SetFillCache(false);
     }
 
-    protected void DisposeOwnedReadOptions()
+    public virtual void Dispose()
     {
         if (!_ownsReadOptions)
         {
@@ -57,7 +57,11 @@ public class RocksDbReader(DbOnTheRocks mainDb,
         DestroyReadOptions(_hintCacheMissOptions);
     }
 
-    private static void DestroyReadOptions(ReadOptions options)
+    /// <summary>
+    /// Destroys a native ReadOptions handle and suppresses its finalizer to prevent
+    /// finalizer queue buildup from short-lived ReadOptions instances.
+    /// </summary>
+    internal static void DestroyReadOptions(ReadOptions options)
     {
         RocksDbSharp.Native.Instance.rocksdb_readoptions_destroy(options.Handle);
         GC.SuppressFinalize(options);

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Nethermind.Core;
 using RocksDbSharp;
 
@@ -35,6 +36,7 @@ public class RocksDbReader(DbOnTheRocks mainDb,
     private readonly ReadOptions _options = options;
     private readonly ReadOptions _hintCacheMissOptions = hintCacheMissOptions;
     private readonly bool _ownsReadOptions;
+    private int _disposed;
 
     public RocksDbReader(DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
@@ -48,7 +50,7 @@ public class RocksDbReader(DbOnTheRocks mainDb,
 
     public virtual void Dispose()
     {
-        if (!_ownsReadOptions)
+        if (!_ownsReadOptions || Interlocked.Exchange(ref _disposed, 1) != 0)
         {
             return;
         }
@@ -138,6 +140,6 @@ public class RocksDbReader(DbOnTheRocks mainDb,
         }
 
         Iterator iterator = _mainDb.CreateIterator(readOptions, _columnFamily);
-        return new RocksdbSortedView(iterator, iterateLowerBound, iterateUpperBound);
+        return new RocksdbSortedView(iterator, readOptions, iterateLowerBound, iterateUpperBound);
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksdbSortedView.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksdbSortedView.cs
@@ -8,9 +8,10 @@ using RocksDbSharp;
 
 namespace Nethermind.Db.Rocks;
 
-internal class RocksdbSortedView(Iterator iterator, IntPtr lowerBound = default, IntPtr upperBound = default) : ISortedView
+internal class RocksdbSortedView(Iterator iterator, ReadOptions readOptions, IntPtr lowerBound = default, IntPtr upperBound = default) : ISortedView
 {
     private readonly Iterator _iterator = iterator;
+    private readonly ReadOptions _readOptions = readOptions;
     private readonly IntPtr _lowerBound = lowerBound;
     private readonly IntPtr _upperBound = upperBound;
     private bool _started = false;
@@ -18,6 +19,7 @@ internal class RocksdbSortedView(Iterator iterator, IntPtr lowerBound = default,
     public void Dispose()
     {
         _iterator.Dispose();
+        RocksDbReader.DestroyReadOptions(_readOptions);
         if (_lowerBound != IntPtr.Zero)
         {
             Marshal.FreeHGlobal(_lowerBound);

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -389,6 +389,23 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
+        public void Snapshot_dispose_cleans_up_read_options()
+        {
+            IKeyValueStoreWithSnapshot withSnapshot = (IKeyValueStoreWithSnapshot)_db;
+
+            _db[[1, 2, 3]] = [4, 5, 6];
+
+            IKeyValueStoreSnapshot snapshot = withSnapshot.CreateSnapshot();
+            AssertCanGetViaAllMethod(snapshot, [1, 2, 3], [4, 5, 6]);
+
+            // Dispose should clean up owned ReadOptions without throwing
+            snapshot.Dispose();
+
+            // Double dispose must be safe
+            snapshot.Dispose();
+        }
+
+        [Test]
         public void Smoke_test_large_writes_with_nowal()
         {
             IWriteBatch writeBatch = _db.StartWriteBatch();


### PR DESCRIPTION
Follow-up to #11196, Replaces it

## Changes

- `RocksDbReader` now implements `IDisposable` with a `virtual Dispose()` method (renamed from `protected DisposeOwnedReadOptions()`)
- `RocksDbSnapshot` uses `override Dispose()` instead of `new` + calling `DisposeOwnedReadOptions()`
- Unified `DestroyReadOptions` as `internal static` on `RocksDbReader`; removed duplicate instance method and `_rocksDbNative` field from `ColumnDbSnapshot`
- Fixed pre-existing leak: `DbOnTheRocks.Dispose()` now calls `_reader.Dispose()` to clean up factory-created ReadOptions
- Added regression test `Snapshot_dispose_cleans_up_read_options` covering dispose and double-dispose safety

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No