### PR TITLE
test(sync): fix flaky StateSyncFeedTests timeout handling

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -154,7 +154,8 @@ namespace Nethermind.Synchronization.Test.FastSync
                 mock.SetFilter(new[] { remote.StateTree.RootHash }));
             IStateSyncTestOperation local = container.Resolve<IStateSyncTestOperation>();
             SafeContext ctx = container.Resolve<SafeContext>();
-            await ActivateAndWait(ctx, 1000);
+            // Peers only serve the root; expected to time out before completing the tree.
+            await ActivateAndWait(ctx, 1000, failOnTimeout: false);
 
             ctx.Pool.WakeUpAll();
             foreach (SyncPeerMock mock in ctx.SyncPeerMocks)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -42,7 +42,7 @@ public abstract class StateSyncFeedTestsBase(
     int defaultPeerCount = 1,
     int defaultPeerMaxRandomLatency = 0)
 {
-    public const int TimeoutLength = 20000;
+    public const int TimeoutLength = 60000;
 
     // Chain length used for test block trees, use a constant to avoid shared state
     private const int TestChainLength = 100;
@@ -145,7 +145,7 @@ public abstract class StateSyncFeedTestsBase(
         return containerBuilder;
     }
 
-    protected async Task ActivateAndWait(SafeContext safeContext, int timeout = TimeoutLength)
+    protected async Task ActivateAndWait(SafeContext safeContext, int timeout = TimeoutLength, bool failOnTimeout = true)
     {
         // Note: The `RunContinuationsAsynchronously` is very important, or the thread might continue synchronously
         // which causes unexpected hang.
@@ -161,9 +161,14 @@ public abstract class StateSyncFeedTestsBase(
         safeContext.Feed.SyncModeSelectorOnChanged(SyncMode.StateNodes | SyncMode.FastBlocks);
         safeContext.StartDispatcher(safeContext.CancellationToken);
 
-        await Task.WhenAny(
+        Task completed = await Task.WhenAny(
             dormantAgainSource.Task,
             Task.Delay(timeout));
+
+        if (failOnTimeout && completed != dormantAgainSource.Task)
+        {
+            Assert.Fail($"State sync did not reach Dormant within {timeout}ms.");
+        }
     }
 
     protected class SafeContext(


### PR DESCRIPTION
## Changes

- Raise `StateSyncFeedTestsBase.TimeoutLength` from 20s to 60s so slow GitHub Actions runners (especially the `[TestFixture(4, 100)]` variant with 4 peers × up to 100ms random latency) have enough time to converge.
- `ActivateAndWait` now calls `Assert.Fail` with a clear message when the feed doesn't reach `Dormant` within the timeout, instead of silently returning and letting the subsequent `CompareTrees` call surface a confusing tree-diff ("MISSING 0x…" vs. full dump).
- `Can_download_in_multiple_connections` opts out via `failOnTimeout: false` because it deliberately filters peers to only serve the root hash and expects the first `ActivateAndWait` to time out.

Fixes a sporadic CI failure in `Scenario_plus_one_code` (and similar scenarios) where the wait hit the 20s cap and the test then reported a tree comparison mismatch rather than the real cause — the sync never completed.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Test-only change. Local build of `Nethermind.Synchronization.Test` passes.