### PR TITLE
chore(tools): enforce code style in build, apply dotnet format

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -3,8 +3,10 @@
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/tools/DocGen/ConfigGenerator.cs
+++ b/tools/DocGen/ConfigGenerator.cs
@@ -16,8 +16,8 @@ internal static class ConfigGenerator
 
         string startMark = "<!--[start autogen]-->";
         string endMark = "<!--[end autogen]-->";
-        var excluded = Enumerable.Empty<string>();
-        var types = Directory
+        IEnumerable<string> excluded = Enumerable.Empty<string>();
+        IOrderedEnumerable<Type> types = Directory
             .GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Nethermind.*.dll")
             .SelectMany(a => Assembly.LoadFrom(a).GetExportedTypes())
             .Where(t => t.IsInterface && typeof(IConfig).IsAssignableFrom(t) &&
@@ -29,8 +29,8 @@ internal static class ConfigGenerator
         // Delete the temp file if it exists
         File.Delete(tempFileName);
 
-        using var readStream = new StreamReader(File.OpenRead(fileName));
-        using var writeStream = new StreamWriter(File.OpenWrite(tempFileName));
+        using StreamReader readStream = new(File.OpenRead(fileName));
+        using StreamWriter writeStream = new(File.OpenWrite(tempFileName));
 
         writeStream.NewLine = "\n";
 
@@ -46,7 +46,7 @@ internal static class ConfigGenerator
 
         writeStream.WriteLine();
 
-        foreach (var type in types)
+        foreach (Type type in types)
             WriteMarkdown(writeStream, type);
 
         bool skip = true;
@@ -74,12 +74,12 @@ internal static class ConfigGenerator
 
     private static void WriteMarkdown(StreamWriter file, Type configType)
     {
-        var categoryAttr = configType.GetCustomAttribute<ConfigCategoryAttribute>();
+        ConfigCategoryAttribute? categoryAttr = configType.GetCustomAttribute<ConfigCategoryAttribute>();
 
         if (categoryAttr?.HiddenFromDocs ?? false)
             return;
 
-        var props = configType.GetProperties(BindingFlags.Instance | BindingFlags.Public).OrderBy(p => p.Name);
+        IOrderedEnumerable<PropertyInfo> props = configType.GetProperties(BindingFlags.Instance | BindingFlags.Public).OrderBy(p => p.Name);
 
         if (!props.Any())
             return;
@@ -94,9 +94,9 @@ internal static class ConfigGenerator
 
             """);
 
-        foreach (var prop in props)
+        foreach (PropertyInfo prop in props)
         {
-            var configAttr = prop.GetCustomAttribute<ConfigItemAttribute>();
+            ConfigItemAttribute? configAttr = prop.GetCustomAttribute<ConfigItemAttribute>();
 
             if (configAttr?.HiddenFromDocs ?? true)
                 continue;
@@ -165,11 +165,11 @@ internal static class ConfigGenerator
 
                 """);
 
-            var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public);
+            FieldInfo[] fields = type.GetFields(BindingFlags.Static | BindingFlags.Public);
 
-            foreach (var field in fields)
+            foreach (FieldInfo field in fields)
             {
-                var attr = field.GetCustomAttribute<DescriptionAttribute>();
+                DescriptionAttribute? attr = field.GetCustomAttribute<DescriptionAttribute>();
                 string? description = string.IsNullOrEmpty(attr?.Description) ? null : $": {attr.Description}";
 
                 file.WriteLine($"    - `{field.Name}`{description}");

--- a/tools/DocGen/DBSizeGenerator.cs
+++ b/tools/DocGen/DBSizeGenerator.cs
@@ -36,7 +36,7 @@ internal static class DBSizeGenerator
 
         dbSizeSourcePath ??= AppDomain.CurrentDomain.BaseDirectory;
 
-        var chains = Directory
+        List<string?> chains = Directory
             .GetFiles(dbSizeSourcePath)
             .Select(Path.GetFileNameWithoutExtension)
             .OrderBy(c =>
@@ -59,8 +59,8 @@ internal static class DBSizeGenerator
         // Delete the temp file if it exists
         File.Delete(tempFileName);
 
-        using var readStream = new StreamReader(File.OpenRead(fileName));
-        using var writeStream = new StreamWriter(File.OpenWrite(tempFileName));
+        using StreamReader readStream = new(File.OpenRead(fileName));
+        using StreamWriter writeStream = new(File.OpenWrite(tempFileName));
 
         writeStream.NewLine = "\n";
 
@@ -117,7 +117,7 @@ internal static class DBSizeGenerator
     private static void WriteChainSize(StreamWriter file, string dbSizeSourcePath, string chain)
     {
         string path = Path.Join(dbSizeSourcePath, $"{chain}.json");
-        using var json = JsonDocument.Parse(File.ReadAllText(path));
+        using JsonDocument json = JsonDocument.Parse(File.ReadAllText(path));
 
         if (json.RootElement.ValueKind != JsonValueKind.Object)
             return;
@@ -129,7 +129,7 @@ internal static class DBSizeGenerator
 
             """);
 
-        var items = json.RootElement.EnumerateObject();
+        JsonElement.ObjectEnumerator items = json.RootElement.EnumerateObject();
 
         foreach (string db in _dbList)
         {
@@ -159,7 +159,7 @@ internal static class DBSizeGenerator
 
     private static string GetLatestVersion(string path)
     {
-        using var versionsJson = File.OpenRead(Path.Join(path, "versions.json"));
+        using FileStream versionsJson = File.OpenRead(Path.Join(path, "versions.json"));
         string[] versions = JsonSerializer.Deserialize<string[]>(versionsJson)!;
 
         return versions[0];

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -33,7 +33,7 @@ internal static class JsonRpcGenerator
             typeof(IRpcRpcModule).FullName,
             typeof(ISubscribeRpcModule).FullName
         };
-        var types = _assemblies.SelectMany(a => Assembly.Load(a).GetTypes())
+        IOrderedEnumerable<Type> types = _assemblies.SelectMany(a => Assembly.Load(a).GetTypes())
             .Where(t => t.IsInterface && typeof(IRpcModule).IsAssignableFrom(t) &&
                 !excluded.Any(x => x is not null && (t.FullName?.Contains(x, StringComparison.Ordinal) ?? false)))
             .OrderBy(t => t.Name);
@@ -48,11 +48,11 @@ internal static class JsonRpcGenerator
             }
         }
 
-        var methodMap = new Dictionary<string, IEnumerable<MethodInfo>>();
+        Dictionary<string, IEnumerable<MethodInfo>> methodMap = new();
 
-        foreach (var type in types)
+        foreach (Type type in types)
         {
-            var attr = type.GetCustomAttribute<RpcModuleAttribute>();
+            RpcModuleAttribute? attr = type.GetCustomAttribute<RpcModuleAttribute>();
 
             if (attr is null)
             {
@@ -61,7 +61,7 @@ internal static class JsonRpcGenerator
             }
 
             string ns = attr.ModuleType.ToLowerInvariant();
-            var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            MethodInfo[] methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
 
             if (!methodMap.TryAdd(ns, methods))
                 methodMap[ns] = methodMap[ns].Concat(methods);
@@ -76,7 +76,7 @@ internal static class JsonRpcGenerator
 
         int i = 0;
 
-        foreach (var (ns, methods) in methodMap)
+        foreach ((string ns, IEnumerable<MethodInfo> methods) in methodMap)
         {
             methodMap[ns] = methods.OrderBy(m => m.Name);
 
@@ -88,8 +88,8 @@ internal static class JsonRpcGenerator
     {
         string fileName = Path.Join(path, $"{ns}.md");
 
-        using var stream = File.Open(fileName, FileMode.Create);
-        using var file = new StreamWriter(stream);
+        using FileStream stream = File.Open(fileName, FileMode.Create);
+        using StreamWriter file = new(stream);
         file.NewLine = "\n";
 
         file.WriteLine($"""
@@ -104,9 +104,9 @@ internal static class JsonRpcGenerator
 
             """);
 
-        foreach (var method in methods)
+        foreach (MethodInfo method in methods)
         {
-            var attr = method.GetCustomAttribute<JsonRpcMethodAttribute>();
+            JsonRpcMethodAttribute? attr = method.GetCustomAttribute<JsonRpcMethodAttribute>();
 
             if (attr is null || !attr.IsImplemented)
                 continue;
@@ -151,7 +151,7 @@ internal static class JsonRpcGenerator
 
     private static void WriteParameters(StreamWriter file, MethodInfo method)
     {
-        var parameters = method.GetParameters();
+        ParameterInfo[] parameters = method.GetParameters();
 
         if (parameters.Length == 0)
             return;
@@ -163,9 +163,9 @@ internal static class JsonRpcGenerator
 
         int i = 1;
 
-        foreach (var p in parameters)
+        foreach (ParameterInfo p in parameters)
         {
-            var attr = p.GetCustomAttribute<JsonRpcParameterAttribute>();
+            JsonRpcParameterAttribute? attr = p.GetCustomAttribute<JsonRpcParameterAttribute>();
 
             file.Write($"{i++}. `{p.Name}`: ");
 
@@ -254,7 +254,7 @@ internal static class JsonRpcGenerator
 
         if (!jsonType.Equals(_objectTypeName, StringComparison.Ordinal))
         {
-            if (TryGetEnumerableItemType(type, out var itemType, out bool isDictionary))
+            if (TryGetEnumerableItemType(type, out Type? itemType, out bool isDictionary))
             {
                 file.Write($"{(isDictionary ? "map" : "array")} of ");
 
@@ -269,9 +269,9 @@ internal static class JsonRpcGenerator
         if (!omitTypeName)
             file.WriteLine(_objectTypeName);
 
-        var properties = GetSerializableProperties(type);
+        IEnumerable<PropertyInfo> properties = GetSerializableProperties(type);
 
-        foreach (var prop in properties)
+        foreach (PropertyInfo prop in properties)
         {
             string propJsonType = GetJsonTypeName(prop.PropertyType);
 
@@ -280,7 +280,7 @@ internal static class JsonRpcGenerator
             if (propJsonType.Equals(_objectTypeName, StringComparison.Ordinal))
                 WriteExpandedType(file, prop.PropertyType, indentation + 2, true, parentTypes.Append(type.FullName));
             else if (propJsonType.Contains($" of {_objectTypeName}", StringComparison.Ordinal) &&
-                TryGetEnumerableItemType(prop.PropertyType, out var itemType, out bool _))
+                TryGetEnumerableItemType(prop.PropertyType, out Type? itemType, out bool _))
                 WriteExpandedType(file, itemType!, indentation + 2, true, parentTypes.Append(type.FullName));
         }
     }
@@ -289,7 +289,7 @@ internal static class JsonRpcGenerator
     {
         file.Flush();
 
-        using var sourceFile = File.OpenRead(fileName);
+        using FileStream sourceFile = File.OpenRead(fileName);
 
         try
         {
@@ -303,7 +303,7 @@ internal static class JsonRpcGenerator
 
     private static string GetJsonTypeName(Type type)
     {
-        var underlyingType = Nullable.GetUnderlyingType(type);
+        Type? underlyingType = Nullable.GetUnderlyingType(type);
 
         if (underlyingType is not null)
             return GetJsonTypeName(underlyingType);
@@ -311,7 +311,7 @@ internal static class JsonRpcGenerator
         if (type.IsEnum)
             return "_integer_";
 
-        if (TryGetEnumerableItemType(type, out var itemType, out bool isDictionary))
+        if (TryGetEnumerableItemType(type, out Type? itemType, out bool isDictionary))
             return $"{(isDictionary ? "map" : "array")} of {GetJsonTypeName(itemType!)}";
 
         return type.Name switch
@@ -337,7 +337,7 @@ internal static class JsonRpcGenerator
 
     private static Type GetReturnType(Type type)
     {
-        var returnType = type.IsGenericType
+        Type returnType = type.IsGenericType
             ? type.GetGenericTypeDefinition() == typeof(Task<>)
                 ? type.GetGenericArguments()[0].GetGenericArguments()[0]
                 : type.GetGenericArguments()[0]
@@ -361,7 +361,7 @@ internal static class JsonRpcGenerator
     {
         if (type.IsArray && type.HasElementType)
         {
-            var elementType = type.GetElementType();
+            Type? elementType = type.GetElementType();
 
             // Ignore a byte array as it is treated as a hex string
             if (elementType == typeof(byte))

--- a/tools/DocGen/MetricsGenerator.cs
+++ b/tools/DocGen/MetricsGenerator.cs
@@ -19,7 +19,7 @@ internal static partial class MetricsGenerator
         string startMark = "<!--[start autogen]-->";
         string endMark = "<!--[end autogen]-->";
         string[] excluded = Array.Empty<string>();
-        var types = Directory
+        IOrderedEnumerable<Type> types = Directory
             .GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Nethermind.*.dll")
             .SelectMany(a => Assembly.LoadFile(a).GetExportedTypes())
             .Where(t => t.Name.Equals("Metrics", StringComparison.Ordinal) &&
@@ -31,8 +31,8 @@ internal static partial class MetricsGenerator
         // Delete the temp file if it exists
         File.Delete(tempFileName);
 
-        using var readStream = new StreamReader(File.OpenRead(fileName));
-        using var writeStream = new StreamWriter(File.OpenWrite(tempFileName));
+        using StreamReader readStream = new(File.OpenRead(fileName));
+        using StreamWriter writeStream = new(File.OpenWrite(tempFileName));
 
         writeStream.NewLine = "\n";
 
@@ -48,7 +48,7 @@ internal static partial class MetricsGenerator
 
         writeStream.WriteLine();
 
-        foreach (var type in types)
+        foreach (Type type in types)
             WriteMarkdown(writeStream, type);
 
         bool skip = true;
@@ -76,7 +76,7 @@ internal static partial class MetricsGenerator
 
     private static void WriteMarkdown(StreamWriter file, Type metricsType)
     {
-        var props = metricsType
+        IOrderedEnumerable<PropertyInfo> props = metricsType
             .GetProperties()
             .OrderBy(p => p.Name);
 
@@ -88,9 +88,9 @@ internal static partial class MetricsGenerator
 
             """);
 
-        foreach (var prop in props)
+        foreach (PropertyInfo prop in props)
         {
-            var attr = prop.GetCustomAttribute<DescriptionAttribute>();
+            DescriptionAttribute? attr = prop.GetCustomAttribute<DescriptionAttribute>();
             string param = _regex.Replace(prop.Name, m => $"_{m.Value.ToLowerInvariant()}");
 
             file.WriteLine($"- #### `nethermind{param}` \\{{#{param[1..]}\\}}");

--- a/tools/EngineApiProxy/Config/ProxyConfig.cs
+++ b/tools/EngineApiProxy/Config/ProxyConfig.cs
@@ -96,8 +96,5 @@ public class ProxyConfig
     /// </summary>
     public string NewPayloadMethod { get; set; } = "engine_newPayloadV4";
 
-    public override string ToString()
-    {
-        return $"EC Endpoint: {ExecutionClientEndpoint}, CL Endpoint: {ConsensusClientEndpoint ?? "not set"}, Listen Port: {ListenPort}, Log Level: {LogLevel}, LogFile: {LogFile ?? "console only"}, ValidateAllBlocks: {ValidateAllBlocks}, ValidationMode: {ValidationMode}, GetPayloadMethod: {GetPayloadMethod}, NewPayloadMethod: {NewPayloadMethod}, RequestTimeout: {RequestTimeoutSeconds}s";
-    }
+    public override string ToString() => $"EC Endpoint: {ExecutionClientEndpoint}, CL Endpoint: {ConsensusClientEndpoint ?? "not set"}, Listen Port: {ListenPort}, Log Level: {LogLevel}, LogFile: {LogFile ?? "console only"}, ValidateAllBlocks: {ValidateAllBlocks}, ValidationMode: {ValidationMode}, GetPayloadMethod: {GetPayloadMethod}, NewPayloadMethod: {NewPayloadMethod}, RequestTimeout: {RequestTimeoutSeconds}s";
 }

--- a/tools/EngineApiProxy/EngineApiProxy.slnx
+++ b/tools/EngineApiProxy/EngineApiProxy.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="EngineApiProxy.csproj" />
+</Solution>

--- a/tools/EngineApiProxy/Handlers/ForkChoiceUpdatedHandler.cs
+++ b/tools/EngineApiProxy/Handlers/ForkChoiceUpdatedHandler.cs
@@ -49,17 +49,14 @@ public class ForkChoiceUpdatedHandler : IDisposable
         _cacheCleanupTimer = new System.Threading.Timer(CleanupExpiredCacheEntries, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
-    public async Task<JsonRpcResponse> HandleRequest(JsonRpcRequest request)
+    public async Task<JsonRpcResponse> HandleRequest(JsonRpcRequest request) => _config.ValidationMode switch
     {
-        return _config.ValidationMode switch
-        {
-            ValidationMode.NewPayload => await HandleNewPayloadMode(request),
-            ValidationMode.Merged => await HandleMergedMode(request),
-            ValidationMode.Lighthouse => await HandleLighthouseMode(request),
-            ValidationMode.ForkChoiceUpdated => await HandleForkChoiceUpdatedMode(request),
-            _ => await HandleForkChoiceUpdatedMode(request)
-        };
-    }
+        ValidationMode.NewPayload => await HandleNewPayloadMode(request),
+        ValidationMode.Merged => await HandleMergedMode(request),
+        ValidationMode.Lighthouse => await HandleLighthouseMode(request),
+        ValidationMode.ForkChoiceUpdated => await HandleForkChoiceUpdatedMode(request),
+        _ => await HandleForkChoiceUpdatedMode(request)
+    };
 
     private async Task<JsonRpcResponse> HandleNewPayloadMode(JsonRpcRequest request)
     {
@@ -214,7 +211,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
 
     private async Task<JsonRpcResponse> ProcessWithoutValidation(JsonRpcRequest request)
     {
-        var response = await _requestForwarder.ForwardRequestToExecutionClient(request);
+        JsonRpcResponse response = await _requestForwarder.ForwardRequestToExecutionClient(request);
 
         // If response contains payloadId, store it for tracking
         if (response.Result is JObject resultObj &&
@@ -229,7 +226,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
 
             if (!string.IsNullOrEmpty(payloadId) && !string.IsNullOrEmpty(headBlockHashStr))
             {
-                var headBlockHash = new Hash256(Bytes.FromHexString(headBlockHashStr));
+                Hash256 headBlockHash = new(Bytes.FromHexString(headBlockHashStr));
                 _payloadTracker.TrackPayload(headBlockHash, payloadId);
                 _logger.Debug($"Tracked payloadId {payloadId} for head block {headBlockHash}");
             }
@@ -267,12 +264,12 @@ public class ForkChoiceUpdatedHandler : IDisposable
             {
                 _logger.Info($"Merged validation flow successfully got payloadId {payloadId}");
                 // Track this payload ID with the hash so it can be found later
-                var headBlockHash = new Hash256(Bytes.FromHexString(headBlockHashStr));
+                Hash256 headBlockHash = new(Bytes.FromHexString(headBlockHashStr));
                 _payloadTracker.TrackPayload(headBlockHash, payloadId);
             }
 
             // 2. Create a response without payloadId to return to CL
-            var response = new JsonRpcResponse
+            JsonRpcResponse response = new()
             {
                 Id = request.Id,
                 Result = new JObject
@@ -315,16 +312,16 @@ public class ForkChoiceUpdatedHandler : IDisposable
                 string requestFingerprint = ComputeRequestFingerprint(request);
 
                 // Check if we've seen this exact request recently
-                if (_lhResponseCache.TryGetValue(requestFingerprint, out var cachedResponse))
+                if (_lhResponseCache.TryGetValue(requestFingerprint, out JsonRpcResponse? cachedResponse))
                 {
-                    if (_lhCacheTimestamps.TryGetValue(requestFingerprint, out var timestamp))
+                    if (_lhCacheTimestamps.TryGetValue(requestFingerprint, out DateTime timestamp))
                     {
                         if (DateTime.UtcNow - timestamp < _lhCacheExpiryTime)
                         {
                             _logger.Info($"LH mode: Duplicate FCU request detected (fingerprint: {requestFingerprint[..Math.Min(10, requestFingerprint.Length)]}...), returning cached response to CL");
 
                             // Update ID to match the current request
-                            var clonedResponse = CloneResponseWithNewId(cachedResponse, request.Id);
+                            JsonRpcResponse clonedResponse = CloneResponseWithNewId(cachedResponse, request.Id);
                             return clonedResponse;
                         }
                         else
@@ -357,7 +354,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                 {
                     try
                     {
-                        var headBlockHash = new Hash256(Bytes.FromHexString(headBlockHashStr));
+                        Hash256 headBlockHash = new(Bytes.FromHexString(headBlockHashStr));
                         _payloadTracker.AssociateParentBeaconBlockRoot(headBlockHash, extractedParentBeaconBlockRoot);
                         _logger.Debug($"Pre-emptively stored parentBeaconBlockRoot {extractedParentBeaconBlockRoot} for head block {headBlockHash}");
                     }
@@ -368,7 +365,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                 }
 
                 // Forward the original request to EL
-                var response = await _requestForwarder.ForwardRequestToExecutionClient(request);
+                JsonRpcResponse response = await _requestForwarder.ForwardRequestToExecutionClient(request);
 
                 // If response contains payloadId, store it for tracking
                 if (response.Result is JObject resultObj &&
@@ -379,7 +376,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                     if (!string.IsNullOrEmpty(payloadId) && !string.IsNullOrEmpty(headBlockHashStr))
                     {
                         // Track this payload ID with the hash so it can be found later
-                        var headBlockHash = new Hash256(Bytes.FromHexString(headBlockHashStr));
+                        Hash256 headBlockHash = new(Bytes.FromHexString(headBlockHashStr));
 
                         // Extract parent beacon block root if available in request
                         string? parentBeaconBlockRoot = ExtractParentBeaconBlockRoot(request);
@@ -423,7 +420,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                 _logger.Info("LH mode: FCU request without payload attributes, forwarding normally. This usually means the node is not synced yet.");
 
                 // Forward the original request to EL
-                var response = await _requestForwarder.ForwardRequestToExecutionClient(request);
+                JsonRpcResponse response = await _requestForwarder.ForwardRequestToExecutionClient(request);
 
                 // Process response normally
                 if (response.Result is JObject resultObj &&
@@ -439,7 +436,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                     if (!string.IsNullOrEmpty(payloadId) && !string.IsNullOrEmpty(headBlockHashStr))
                     {
                         // Track this payload ID with the hash so it can be found later
-                        var headBlockHash = new Hash256(Bytes.FromHexString(headBlockHashStr));
+                        Hash256 headBlockHash = new(Bytes.FromHexString(headBlockHashStr));
 
                         // Extract parent beacon block root if available in request
                         string? parentBeaconBlockRoot = ExtractParentBeaconBlockRoot(request);
@@ -481,15 +478,13 @@ public class ForkChoiceUpdatedHandler : IDisposable
     /// <summary>
     /// Creates a clone of a response with a new ID to match the current request
     /// </summary>
-    private static JsonRpcResponse CloneResponseWithNewId(JsonRpcResponse response, object? newId)
+    private static JsonRpcResponse CloneResponseWithNewId(JsonRpcResponse response, object? newId) => new()
     {
-        return new JsonRpcResponse
-        {
-            Id = newId,
-            Result = response.Result is not null
+        Id = newId,
+        Result = response.Result is not null
                 ? JsonConvert.DeserializeObject<JToken>(JsonConvert.SerializeObject(response.Result))
                 : null,
-            Error = response.Error is not null
+        Error = response.Error is not null
                 ? new JsonRpcError
                 {
                     Code = response.Error.Code,
@@ -499,8 +494,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
                         : null
                 }
                 : null
-        };
-    }
+    };
 
     private static string ExtractHeadBlockHash(JsonRpcRequest request)
     {
@@ -535,7 +529,7 @@ public class ForkChoiceUpdatedHandler : IDisposable
         try
         {
             int removedCount = 0;
-            var now = DateTime.UtcNow;
+            DateTime now = DateTime.UtcNow;
 
             // Find and remove expired entries
             List<string> expiredKeys = new();

--- a/tools/EngineApiProxy/Handlers/ForkChoiceUpdatedHandler.cs
+++ b/tools/EngineApiProxy/Handlers/ForkChoiceUpdatedHandler.cs
@@ -482,18 +482,18 @@ public class ForkChoiceUpdatedHandler : IDisposable
     {
         Id = newId,
         Result = response.Result is not null
-                ? JsonConvert.DeserializeObject<JToken>(JsonConvert.SerializeObject(response.Result))
-                : null,
+            ? JsonConvert.DeserializeObject<JToken>(JsonConvert.SerializeObject(response.Result))
+            : null,
         Error = response.Error is not null
-                ? new JsonRpcError
-                {
-                    Code = response.Error.Code,
-                    Message = response.Error.Message,
-                    Data = response.Error.Data is not null
-                        ? JsonConvert.DeserializeObject<JToken>(JsonConvert.SerializeObject(response.Error.Data))
-                        : null
-                }
-                : null
+            ? new JsonRpcError
+            {
+                Code = response.Error.Code,
+                Message = response.Error.Message,
+                Data = response.Error.Data is not null
+                    ? JsonConvert.DeserializeObject<JToken>(JsonConvert.SerializeObject(response.Error.Data))
+                    : null
+            }
+            : null
     };
 
     private static string ExtractHeadBlockHash(JsonRpcRequest request)

--- a/tools/EngineApiProxy/Handlers/GetPayloadHandler.cs
+++ b/tools/EngineApiProxy/Handlers/GetPayloadHandler.cs
@@ -27,7 +27,7 @@ public class GetPayloadHandler(
         try
         {
             // Forward the request to EC
-            var response = await _requestForwarder.ForwardRequestToExecutionClient(request);
+            JsonRpcResponse response = await _requestForwarder.ForwardRequestToExecutionClient(request);
 
             return response;
         }

--- a/tools/EngineApiProxy/Handlers/NewPayloadHandler.cs
+++ b/tools/EngineApiProxy/Handlers/NewPayloadHandler.cs
@@ -103,8 +103,8 @@ public class NewPayloadHandler(
                 }
 
                 // Extract blobVersionedHashes from incoming request (params[1]) and store them
-                var parentHashObj = new Hash256(Bytes.FromHexString(parentHash));
-                var incomingBlobHashes = BlobHashComputer.ExtractBlobVersionedHashes(request.Params);
+                Hash256 parentHashObj = new(Bytes.FromHexString(parentHash));
+                JArray incomingBlobHashes = BlobHashComputer.ExtractBlobVersionedHashes(request.Params);
                 if (incomingBlobHashes.Count > 0)
                 {
                     string[] hashArray = BlobHashComputer.ToStringArray(incomingBlobHashes);
@@ -178,10 +178,10 @@ public class NewPayloadHandler(
             try
             {
                 // Convert parentHash to Hash256 to look up in the payload tracker
-                var parentHashObj = new Hash256(Bytes.FromHexString(parentHash));
+                Hash256 parentHashObj = new(Bytes.FromHexString(parentHash));
 
                 // Extract blobVersionedHashes from incoming request (params[1])
-                var incomingBlobHashes = BlobHashComputer.ExtractBlobVersionedHashes(request.Params);
+                JArray incomingBlobHashes = BlobHashComputer.ExtractBlobVersionedHashes(request.Params);
                 if (incomingBlobHashes.Count > 0)
                 {
                     // Store the blob versioned hashes for this block for later retrieval
@@ -191,7 +191,7 @@ public class NewPayloadHandler(
                 }
 
                 // Try to get payloadId associated with this parent hash
-                if (_payloadTracker.TryGetPayloadId(parentHashObj, out var payloadId) && !string.IsNullOrEmpty(payloadId))
+                if (_payloadTracker.TryGetPayloadId(parentHashObj, out string? payloadId) && !string.IsNullOrEmpty(payloadId))
                 {
                     _logger.Info($"Found payloadId {payloadId} for parent hash {parentHash}, starting validation");
 
@@ -215,7 +215,7 @@ public class NewPayloadHandler(
             _payloadTracker.RegisterNewPayload(blockHash, parentHash);
 
             // Forward the original request to get the actual response
-            var response = await _requestForwarder.ForwardRequestToExecutionClient(request);
+            JsonRpcResponse response = await _requestForwarder.ForwardRequestToExecutionClient(request);
 
             // Log the response status for monitoring
             if (response.Result is JObject result && result["status"] is not null)
@@ -234,36 +234,33 @@ public class NewPayloadHandler(
         }
     }
 
-    private static JsonRpcRequest GenerateSyntheticFcuRequest(JsonRpcRequest originalRequest, string parentHash)
+    private static JsonRpcRequest GenerateSyntheticFcuRequest(JsonRpcRequest originalRequest, string parentHash) => originalRequest.Method switch
     {
-        return originalRequest.Method switch
-        {
-            "engine_newPayloadV3" or "engine_newPayloadV4" => new JsonRpcRequest(
-                "engine_forkchoiceUpdatedV3",
-                new JArray(
-                    new JObject
-                    {
-                        [HeadBlockHashKey] = parentHash,
-                        [FinalizedBlockHashKey] = ZeroHash,
-                        [SafeBlockHashKey] = ZeroHash
-                    }
-                ),
-                Guid.NewGuid().ToString()
+        "engine_newPayloadV3" or "engine_newPayloadV4" => new JsonRpcRequest(
+            "engine_forkchoiceUpdatedV3",
+            new JArray(
+                new JObject
+                {
+                    [HeadBlockHashKey] = parentHash,
+                    [FinalizedBlockHashKey] = ZeroHash,
+                    [SafeBlockHashKey] = ZeroHash
+                }
             ),
-            _ => new JsonRpcRequest(
-                "engine_forkchoiceUpdated",
-                new JArray(
-                    new JObject
-                    {
-                        [HeadBlockHashKey] = parentHash,
-                        [FinalizedBlockHashKey] = ZeroHash,
-                        [SafeBlockHashKey] = ZeroHash
-                    }
-                ),
-                Guid.NewGuid().ToString()
-            )
-        };
-    }
+            Guid.NewGuid().ToString()
+        ),
+        _ => new JsonRpcRequest(
+            "engine_forkchoiceUpdated",
+            new JArray(
+                new JObject
+                {
+                    [HeadBlockHashKey] = parentHash,
+                    [FinalizedBlockHashKey] = ZeroHash,
+                    [SafeBlockHashKey] = ZeroHash
+                }
+            ),
+            Guid.NewGuid().ToString()
+        )
+    };
 
     private static string ExtractBlockHashFromPayload(JsonRpcRequest request)
     {
@@ -317,7 +314,7 @@ public class NewPayloadHandler(
             return string.Empty;
 
         // The parentBeaconBlockRoot is the third parameter in the NewPayloadV4 request
-        var parentBeaconBlockRoot = parameters[2];
+        JToken? parentBeaconBlockRoot = parameters[2];
         if (parentBeaconBlockRoot is null || parentBeaconBlockRoot.Type == JTokenType.Null)
             return string.Empty;
 

--- a/tools/EngineApiProxy/Models/JsonRpcRequest.cs
+++ b/tools/EngineApiProxy/Models/JsonRpcRequest.cs
@@ -34,8 +34,5 @@ public class JsonRpcRequest
         Id = id;
     }
 
-    public override string ToString()
-    {
-        return $"{{method: {Method}, id: {Id}, params: {Params?.ToString() ?? "null"}}}";
-    }
+    public override string ToString() => $"{{method: {Method}, id: {Id}, params: {Params?.ToString() ?? "null"}}}";
 }

--- a/tools/EngineApiProxy/Models/JsonRpcResponse.cs
+++ b/tools/EngineApiProxy/Models/JsonRpcResponse.cs
@@ -30,10 +30,7 @@ public class JsonRpcResponse
         Error = error;
     }
 
-    public static JsonRpcResponse CreateErrorResponse(object? id, int code, string message)
-    {
-        return new JsonRpcResponse(id, null, new JsonRpcError { Code = code, Message = message });
-    }
+    public static JsonRpcResponse CreateErrorResponse(object? id, int code, string message) => new(id, null, new JsonRpcError { Code = code, Message = message });
 }
 
 public class JsonRpcError

--- a/tools/EngineApiProxy/Models/MessageQueue.cs
+++ b/tools/EngineApiProxy/Models/MessageQueue.cs
@@ -59,7 +59,7 @@ public class MessageQueue(ILogManager logManager)
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var queuedMessage = new QueuedMessage(message);
+        QueuedMessage queuedMessage = new(message);
         _messageQueue.Enqueue(queuedMessage);
 
         if (message.Id is not null)
@@ -84,14 +84,14 @@ public class MessageQueue(ILogManager logManager)
             return null;
         }
 
-        if (_messageQueue.TryDequeue(out var message))
+        if (_messageQueue.TryDequeue(out QueuedMessage? message))
         {
             if (message.Request.Id is not null)
             {
                 string messageId = message.Request.Id.ToString()!;
                 _messageById.TryRemove(messageId, out _);
             }
-            var host = message.Request.OriginalHeaders?.FirstOrDefault(h => h.Key == "Host").Value;
+            string? host = message.Request.OriginalHeaders?.FirstOrDefault(h => h.Key == "Host").Value;
             _logger.Debug($"Dequeued message: {message.Request.Method} with id {message.Request.Id} from {host}");
             return message;
         }
@@ -128,7 +128,7 @@ public class MessageQueue(ILogManager logManager)
         }
 
         string messageId = id.ToString() ?? string.Empty;
-        return _messageById.TryGetValue(messageId, out var message) ? message : null;
+        return _messageById.TryGetValue(messageId, out QueuedMessage? message) ? message : null;
     }
 
     /// <summary>

--- a/tools/EngineApiProxy/Models/PayloadTracker.cs
+++ b/tools/EngineApiProxy/Models/PayloadTracker.cs
@@ -76,7 +76,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="headBlockHash">The hash of the head block</param>
     /// <returns>The associated Payload ID or null if not found</returns>
     public string? GetPayloadId(Hash256 headBlockHash)
-        => _headBlockToPayloadId.TryGetValue(headBlockHash, out var payloadId) ? payloadId : null;
+        => _headBlockToPayloadId.TryGetValue(headBlockHash, out string? payloadId) ? payloadId : null;
 
     /// <summary>
     /// Tries to get the Payload ID associated with a head block hash
@@ -100,7 +100,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="payloadId">The Payload ID</param>
     /// <returns>The associated head block hash or null if not found</returns>
     public Hash256? GetHeadBlock(string payloadId)
-        => _payloadIdToHeadBlock.TryGetValue(payloadId, out var headBlockHash) ? headBlockHash : null;
+        => _payloadIdToHeadBlock.TryGetValue(payloadId, out Hash256? headBlockHash) ? headBlockHash : null;
 
     /// <summary>
     /// Removes a Payload ID and its associated head block hash from tracking
@@ -108,7 +108,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="payloadId">The Payload ID to remove</param>
     public void RemovePayload(string payloadId)
     {
-        if (_payloadIdToHeadBlock.TryRemove(payloadId, out var headBlockHash))
+        if (_payloadIdToHeadBlock.TryRemove(payloadId, out Hash256? headBlockHash))
         {
             _headBlockToPayloadId.TryRemove(headBlockHash, out _);
             _logger.Debug($"Removed tracking for payload {payloadId}");
@@ -121,7 +121,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="headBlockHash">The head block hash to remove</param>
     public void RemoveHeadBlock(Hash256 headBlockHash)
     {
-        if (_headBlockToPayloadId.TryRemove(headBlockHash, out var payloadId))
+        if (_headBlockToPayloadId.TryRemove(headBlockHash, out string? payloadId))
         {
             _payloadIdToHeadBlock.TryRemove(payloadId, out _);
 
@@ -186,7 +186,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="headBlockHash">The hash of the head block</param>
     /// <returns>The associated parent beacon block root or null if not found</returns>
     public string? GetParentBeaconBlockRoot(Hash256 headBlockHash)
-        => _headBlockToParentBeaconBlockRoot.TryGetValue(headBlockHash, out var parentBeaconBlockRoot) ? parentBeaconBlockRoot : null;
+        => _headBlockToParentBeaconBlockRoot.TryGetValue(headBlockHash, out string? parentBeaconBlockRoot) ? parentBeaconBlockRoot : null;
 
     /// <summary>
     /// Associates a parent beacon block root with a head block hash
@@ -229,7 +229,7 @@ public class PayloadTracker(ILogManager logManager)
     /// <param name="headBlockHash">The hash of the head block</param>
     /// <returns>The associated blob versioned hashes or null if not found</returns>
     public string[]? GetBlobVersionedHashes(Hash256 headBlockHash)
-        => _headBlockToBlobVersionedHashes.TryGetValue(headBlockHash, out var blobVersionedHashes) ? blobVersionedHashes : null;
+        => _headBlockToBlobVersionedHashes.TryGetValue(headBlockHash, out string[]? blobVersionedHashes) ? blobVersionedHashes : null;
 
     /// <summary>
     /// Tries to get the blob versioned hashes associated with a head block hash

--- a/tools/EngineApiProxy/Program.cs
+++ b/tools/EngineApiProxy/Program.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using Nethermind.EngineApiProxy.Config;
-using Nethermind.Logging;
 using Nethermind.Logging.NLog;
 using NLog;
 using NLog.Config;
@@ -16,65 +15,65 @@ public class Program
     public static async Task<int> Main(string[] args)
     {
         // Create command line options
-        var executionClientOption = new Option<string?>(
+        Option<string?> executionClientOption = new(
             name: "--ec-endpoint",
             description: "The URL of the execution client API endpoint");
         executionClientOption.AddAlias("-e");
 
-        var consensusClientOption = new Option<string?>(
+        Option<string?> consensusClientOption = new(
             name: "--cl-endpoint",
             description: "The URL of the consensus client API endpoint (optional)");
         consensusClientOption.AddAlias("-c");
 
-        var portOption = new Option<int>(
+        Option<int> portOption = new(
             name: "--port",
             description: "The port to listen for consensus client requests",
             getDefaultValue: () => 8551);
         portOption.AddAlias("-p");
 
-        var logLevelOption = new Option<string>(
+        Option<string> logLevelOption = new(
             name: "--log-level",
             description: "Log level (Trace, Debug, Info, Warn, Error)",
             getDefaultValue: () => "Info");
         logLevelOption.AddAlias("-l");
 
-        var logFileOption = new Option<string?>(
+        Option<string?> logFileOption = new(
             name: "--log-file",
             description: "Path to log file (if not specified, only console logging is used)",
             getDefaultValue: () => null);
 
-        var validateAllBlocksOption = new Option<bool>(
+        Option<bool> validateAllBlocksOption = new(
             name: "--validate-all-blocks",
             description: "Enable validation for all blocks, including those where CL doesn't request validation",
             getDefaultValue: () => false);
 
-        var feeRecipientOption = new Option<string>(
+        Option<string> feeRecipientOption = new(
             name: "--fee-recipient",
             description: "Default fee recipient address for generated payload attributes",
             getDefaultValue: () => "0x8943545177806ed17b9f23f0a21ee5948ecaa776");
 
-        var validationModeOption = new Option<ValidationMode>(
+        Option<ValidationMode> validationModeOption = new(
             name: "--validation-mode",
             description: "Mode for block validation (ForkChoiceUpdated, NewPayload, Merged, or Lighthouse)",
             getDefaultValue: () => ValidationMode.Lighthouse);
 
-        var requestTimeoutOption = new Option<int>(
+        Option<int> requestTimeoutOption = new(
             name: "--request-timeout",
             description: "Timeout in seconds for HTTP requests to EL/CL clients",
             getDefaultValue: () => 60);
 
-        var getPayloadMethodOption = new Option<string>(
+        Option<string> getPayloadMethodOption = new(
             name: "--get-payload-method",
             description: "Engine API method to use when getting payloads for validation (e.g., engine_getPayloadV3, engine_getPayloadV4)",
             getDefaultValue: () => "engine_getPayloadV4");
 
-        var newPayloadMethodOption = new Option<string>(
+        Option<string> newPayloadMethodOption = new(
             name: "--new-payload-method",
             description: "Engine API method to use when sending new payloads for validation (e.g., engine_newPayloadV3, engine_newPayloadV4)",
             getDefaultValue: () => "engine_newPayloadV4");
 
         // Create root command with options
-        var rootCommand = new RootCommand("Nethermind Engine API Proxy");
+        RootCommand rootCommand = new("Nethermind Engine API Proxy");
         rootCommand.AddOption(executionClientOption);
         rootCommand.AddOption(consensusClientOption);
         rootCommand.AddOption(portOption);
@@ -91,27 +90,27 @@ public class Program
         {
             try
             {
-                var ecEndpoint = context.ParseResult.GetValueForOption(executionClientOption);
-                var clEndpoint = context.ParseResult.GetValueForOption(consensusClientOption);
-                var port = context.ParseResult.GetValueForOption(portOption);
-                var logLevel = context.ParseResult.GetValueForOption(logLevelOption) ?? "Info";
-                var logFile = context.ParseResult.GetValueForOption(logFileOption);
-                var validateAllBlocks = context.ParseResult.GetValueForOption(validateAllBlocksOption);
-                var feeRecipient = context.ParseResult.GetValueForOption(feeRecipientOption) ?? "0x8943545177806ed17b9f23f0a21ee5948ecaa776";
-                var validationMode = context.ParseResult.GetValueForOption(validationModeOption);
-                var requestTimeout = context.ParseResult.GetValueForOption(requestTimeoutOption);
-                var getPayloadMethod = context.ParseResult.GetValueForOption(getPayloadMethodOption) ?? "engine_getPayloadV4";
-                var newPayloadMethod = context.ParseResult.GetValueForOption(newPayloadMethodOption) ?? "engine_newPayloadV4";
+                string? ecEndpoint = context.ParseResult.GetValueForOption(executionClientOption);
+                string? clEndpoint = context.ParseResult.GetValueForOption(consensusClientOption);
+                int port = context.ParseResult.GetValueForOption(portOption);
+                string logLevel = context.ParseResult.GetValueForOption(logLevelOption) ?? "Info";
+                string? logFile = context.ParseResult.GetValueForOption(logFileOption);
+                bool validateAllBlocks = context.ParseResult.GetValueForOption(validateAllBlocksOption);
+                string feeRecipient = context.ParseResult.GetValueForOption(feeRecipientOption) ?? "0x8943545177806ed17b9f23f0a21ee5948ecaa776";
+                ValidationMode validationMode = context.ParseResult.GetValueForOption(validationModeOption);
+                int requestTimeout = context.ParseResult.GetValueForOption(requestTimeoutOption);
+                string getPayloadMethod = context.ParseResult.GetValueForOption(getPayloadMethodOption) ?? "engine_getPayloadV4";
+                string newPayloadMethod = context.ParseResult.GetValueForOption(newPayloadMethodOption) ?? "engine_newPayloadV4";
 
                 // Configure logging
-                var logManager = new NLogManager();
+                NLogManager logManager = new();
 
                 // Ensure all logs appear in console output
                 ConfigureConsoleLogging(logLevel);
 
                 logManager.SetGlobalVariable("logLevel", logLevel);
 
-                var logger = logManager.GetClassLogger<Program>();
+                Logging.ILogger logger = logManager.GetClassLogger<Program>();
 
                 // Configure file logging only if log file is specified
                 if (!string.IsNullOrWhiteSpace(logFile))
@@ -143,7 +142,7 @@ public class Program
                 }
 
                 // Create and configure proxy
-                var config = new ProxyConfig
+                ProxyConfig config = new()
                 {
                     ExecutionClientEndpoint = ecEndpoint,
                     ConsensusClientEndpoint = clEndpoint,
@@ -161,11 +160,11 @@ public class Program
                 logger.Info($"Starting Engine API Proxy with configuration: {config}");
 
                 // Create and start proxy
-                var proxy = new ProxyServer(config, logManager);
+                ProxyServer proxy = new(config, logManager);
                 await proxy.StartAsync();
 
                 // Wait for Ctrl+C
-                var cancellationTokenSource = new CancellationTokenSource();
+                CancellationTokenSource cancellationTokenSource = new();
                 Console.CancelKeyPress += (sender, e) =>
                 {
                     e.Cancel = true;
@@ -197,10 +196,10 @@ public class Program
     private static void ConfigureConsoleLogging(string logLevel)
     {
         // Access NLog's configuration
-        var config = LogManager.Configuration ?? new LoggingConfiguration();
+        LoggingConfiguration config = LogManager.Configuration ?? new LoggingConfiguration();
 
         // Create console target
-        var consoleTarget = new ColoredConsoleTarget("console")
+        ColoredConsoleTarget consoleTarget = new("console")
         {
             Layout = "${longdate}|${level:uppercase=true}|${message} ${exception:format=tostring}"
         };
@@ -209,8 +208,8 @@ public class Program
         config.AddTarget(consoleTarget);
 
         // Add rule for console target with specified log level
-        var level = NLog.LogLevel.FromString(logLevel);
-        var rule = new LoggingRule("*", level, consoleTarget);
+        NLog.LogLevel level = NLog.LogLevel.FromString(logLevel);
+        LoggingRule rule = new("*", level, consoleTarget);
         config.LoggingRules.Add(rule);
 
         // Apply configuration
@@ -220,10 +219,10 @@ public class Program
     private static void ConfigureFileLogging(string logDirectory, string logFileName, string logLevel)
     {
         // Access NLog's configuration
-        var config = LogManager.Configuration ?? new LoggingConfiguration();
+        LoggingConfiguration config = LogManager.Configuration ?? new LoggingConfiguration();
 
         // Create file target with JSON format
-        var fileTarget = new FileTarget("file")
+        FileTarget fileTarget = new("file")
         {
             FileName = Path.Combine(logDirectory, logFileName),
             Layout = "${longdate}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}",
@@ -238,8 +237,8 @@ public class Program
         config.AddTarget(fileTarget);
 
         // Add rule for file target with specified log level
-        var level = NLog.LogLevel.FromString(logLevel);
-        var rule = new LoggingRule("*", level, fileTarget);
+        NLog.LogLevel level = NLog.LogLevel.FromString(logLevel);
+        LoggingRule rule = new("*", level, fileTarget);
         config.LoggingRules.Add(rule);
 
         // Apply configuration

--- a/tools/EngineApiProxy/ProxyServer.cs
+++ b/tools/EngineApiProxy/ProxyServer.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
 using Nethermind.EngineApiProxy.Config;
 using Nethermind.EngineApiProxy.Handlers;
 using Nethermind.EngineApiProxy.Models;
@@ -83,15 +84,15 @@ public class ProxyServer
         _requestForwarder = new RequestForwarder(_httpClient, config, logManager);
 
         // Initialize specialized components
-        var blockDataFetcher = new BlockDataFetcher(_httpClient, logManager, _consensusClient);
+        BlockDataFetcher blockDataFetcher = new(_httpClient, logManager, _consensusClient);
         // Set CL endpoint on block data fetcher for reference
         if (_consensusClient is not null)
         {
             blockDataFetcher.ConsensusClientEndpoint = _config.ConsensusClientEndpoint;
         }
 
-        var payloadAttributesGenerator = new PayloadAttributesGenerator(config, logManager);
-        var requestOrchestrator = new RequestOrchestrator(
+        PayloadAttributesGenerator payloadAttributesGenerator = new(config, logManager);
+        RequestOrchestrator requestOrchestrator = new(
             _httpClient,
             blockDataFetcher,
             payloadAttributesGenerator,
@@ -127,14 +128,14 @@ public class ProxyServer
             _requestForwarder,
             logManager);
 
-        var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
+        WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
         {
             Args = [$"--urls=http://*:{_config.ListenPort}"]
         });
         builder.Services.AddSingleton(this);
         builder.Services.AddRouting();
 
-        var app = builder.Build();
+        WebApplication app = builder.Build();
         app.UseRouting();
         app.MapPost("/", HandleCLJsonRpcRequest);
 
@@ -234,7 +235,7 @@ public class ProxyServer
     private async Task HandleCLJsonRpcRequest(HttpContext context)
     {
         string requestBody;
-        using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8))
+        using (StreamReader reader = new(context.Request.Body, Encoding.UTF8))
         {
             requestBody = await reader.ReadToEndAsync();
         }
@@ -244,7 +245,7 @@ public class ProxyServer
         string method;
         try
         {
-            var requestObj = JObject.Parse(requestBody);
+            JObject requestObj = JObject.Parse(requestBody);
             method = requestObj["method"]?.ToString() ?? "unknown";
         }
         catch
@@ -267,7 +268,7 @@ public class ProxyServer
             request.OriginalHeaders = context.Request.Headers.ToDictionary(h => h.Key, h => h.Value.ToString());
 
             // Check if there's an Authorization header and set it on the HttpClient for all future requests
-            if (context.Request.Headers.TryGetValue("Authorization", out var authHeader))
+            if (context.Request.Headers.TryGetValue("Authorization", out StringValues authHeader))
             {
                 _logger.Trace("Found Authorization header in client request, storing for future internal requests");
                 _httpClient.DefaultRequestHeaders.Remove("Authorization");

--- a/tools/EngineApiProxy/Services/BlockDataFetcher.cs
+++ b/tools/EngineApiProxy/Services/BlockDataFetcher.cs
@@ -41,17 +41,17 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
         try
         {
             // Create JSON-RPC request
-            var request = new JsonRpcRequest(
+            JsonRpcRequest request = new(
                 "eth_getBlockByHash",
                 [blockHash, true], // Include transaction objects
                 Guid.NewGuid().ToString());
 
             // Send request to EC
-            var requestJson = JsonConvert.SerializeObject(request);
-            var httpContent = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            string requestJson = JsonConvert.SerializeObject(request);
+            StringContent httpContent = new(requestJson, Encoding.UTF8, "application/json");
 
             // Create a request message instead of using PostAsync directly
-            var requestMessage = new HttpRequestMessage(HttpMethod.Post, "")
+            HttpRequestMessage requestMessage = new(HttpMethod.Post, "")
             {
                 Content = httpContent
             };
@@ -61,7 +61,7 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
             // Copy all authorization headers from the HttpClient
             if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 if (!string.IsNullOrEmpty(authHeader))
                 {
                     _logger.Debug($"Adding Authorization header to block data fetch request for hash: {blockHash}");
@@ -77,16 +77,16 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
 
             _logger.Debug($"Sending block data fetch request with Authorization header: {authHeaderAdded}");
             _logger.Debug($"PR -> EL|{request.Method}|V|{requestJson}");
-            var response = await _httpClient.SendAsync(requestMessage);
+            HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error($"Failed to get block data. Status: {response.StatusCode}");
                 return null;
             }
 
-            var responseJson = await response.Content.ReadAsStringAsync();
+            string responseJson = await response.Content.ReadAsStringAsync();
             _logger.Debug($"EL -> PR|{request.Method}|V|{responseJson}");
-            var jsonResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
+            JsonRpcResponse? jsonResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
 
             if (jsonResponse?.Result is JObject blockData)
             {
@@ -115,17 +115,17 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
         try
         {
             // Create JSON-RPC request
-            var request = new JsonRpcRequest(
+            JsonRpcRequest request = new(
                 "eth_getBlockByNumber",
                 ["latest", true], // Include transaction objects
                 Guid.NewGuid().ToString());
 
             // Send request to EC
-            var requestJson = JsonConvert.SerializeObject(request);
-            var httpContent = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            string requestJson = JsonConvert.SerializeObject(request);
+            StringContent httpContent = new(requestJson, Encoding.UTF8, "application/json");
 
             // Create a request message instead of using PostAsync directly
-            var requestMessage = new HttpRequestMessage(HttpMethod.Post, "")
+            HttpRequestMessage requestMessage = new(HttpMethod.Post, "")
             {
                 Content = httpContent
             };
@@ -135,7 +135,7 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
             // Copy all authorization headers from the HttpClient
             if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 if (!string.IsNullOrEmpty(authHeader))
                 {
                     _logger.Debug("Adding Authorization header to latest block fetch request");
@@ -150,15 +150,15 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
             }
 
             _logger.Debug($"Sending latest block fetch request with Authorization header: {authHeaderAdded}");
-            var response = await _httpClient.SendAsync(requestMessage);
+            HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error($"Failed to get latest block data. Status: {response.StatusCode}");
                 return null;
             }
 
-            var responseJson = await response.Content.ReadAsStringAsync();
-            var jsonResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
+            string responseJson = await response.Content.ReadAsStringAsync();
+            JsonRpcResponse? jsonResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
 
             if (jsonResponse?.Result is JObject blockData)
             {
@@ -193,20 +193,20 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
 
         try
         {
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "/eth/v1/beacon/headers/head");
+            HttpRequestMessage requestMessage = new(HttpMethod.Get, "/eth/v1/beacon/headers/head");
 
             _logger.Info("PR -> CL|B|/eth/v1/beacon/headers/head");
-            var response = await _consensusClient.SendAsync(requestMessage);
+            HttpResponseMessage response = await _consensusClient.SendAsync(requestMessage);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error($"Failed to get beacon block header. Status: {response.StatusCode}");
                 return null;
             }
 
-            var responseJson = await response.Content.ReadAsStringAsync();
+            string responseJson = await response.Content.ReadAsStringAsync();
             _logger.Info($"CL -> PR|B|/eth/v1/beacon/headers/head|{responseJson}");
 
-            var responseObj = JObject.Parse(responseJson);
+            JObject responseObj = JObject.Parse(responseJson);
             _logger.Debug("Successfully received head beacon block header");
 
             return responseObj;
@@ -235,20 +235,20 @@ public class BlockDataFetcher(HttpClient httpClient, ILogManager logManager, Htt
 
         try
         {
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/eth/v1/beacon/blocks/{blockId}");
+            HttpRequestMessage requestMessage = new(HttpMethod.Get, $"/eth/v1/beacon/blocks/{blockId}");
 
             _logger.Info($"PR -> CL|B|/eth/v1/beacon/blocks/{blockId}");
-            var response = await _consensusClient.SendAsync(requestMessage);
+            HttpResponseMessage response = await _consensusClient.SendAsync(requestMessage);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error($"Failed to get beacon block. Status: {response.StatusCode}");
                 return null;
             }
 
-            var responseJson = await response.Content.ReadAsStringAsync();
+            string responseJson = await response.Content.ReadAsStringAsync();
             _logger.Info($"CL -> PR|B|/eth/v1/beacon/blocks/{blockId}|{responseJson.Substring(0, Math.Min(200, responseJson.Length))}...");
 
-            var responseObj = JObject.Parse(responseJson);
+            JObject responseObj = JObject.Parse(responseJson);
             _logger.Debug($"Successfully received beacon block with ID: {blockId}");
 
             return responseObj;

--- a/tools/EngineApiProxy/Services/PayloadAttributesGenerator.cs
+++ b/tools/EngineApiProxy/Services/PayloadAttributesGenerator.cs
@@ -43,7 +43,7 @@ public class PayloadAttributesGenerator(ProxyConfig config, ILogManager logManag
             string parentBeaconBlockRoot = blockData["parentBeaconBlockRoot"]?.ToString() ?? GenerateRandomHash();
 
             // Create payload attributes
-            var payloadAttributes = new JObject
+            JObject payloadAttributes = new()
             {
                 ["timestamp"] = nextTimestamp,
                 ["prevRandao"] = prevRandao,
@@ -83,10 +83,7 @@ public class PayloadAttributesGenerator(ProxyConfig config, ILogManager logManag
     /// Generates a random prevRandao value (32 bytes)
     /// </summary>
     /// <returns>Random prevRandao as 0x-prefixed hex string</returns>
-    private static string GenerateRandomPrevRandao()
-    {
-        return GenerateRandomHash();
-    }
+    private static string GenerateRandomPrevRandao() => GenerateRandomHash();
 
     /// <summary>
     /// Generates a random 32-byte hash

--- a/tools/EngineApiProxy/Services/RequestOrchestrator.cs
+++ b/tools/EngineApiProxy/Services/RequestOrchestrator.cs
@@ -72,7 +72,7 @@ public class RequestOrchestrator(
         {
             // Check if Authorization header is present in original request
             if (originalRequest.OriginalHeaders is not null &&
-                originalRequest.OriginalHeaders.TryGetValue("Authorization", out var authHeader))
+                originalRequest.OriginalHeaders.TryGetValue("Authorization", out string? authHeader))
             {
                 _logger.Debug($"Original request contains Authorization header: {authHeader.Substring(0, Math.Min(10, authHeader.Length))}...");
             }
@@ -84,7 +84,7 @@ public class RequestOrchestrator(
             // Check if DefaultRequestHeaders has Authorization
             if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 _logger.Debug($"HttpClient DefaultRequestHeaders contains Authorization: {authHeaderValue?.Substring(0, Math.Min(10, authHeaderValue?.Length ?? 0))}...");
             }
             else
@@ -100,12 +100,12 @@ public class RequestOrchestrator(
                 return string.Empty;
             }
 
-            JObject payloadAttributes = new JObject();
+            JObject payloadAttributes = new();
 
             // Original behavior for non-LH modes
             if (!fromCL)
             {
-                var blockData = await _blockFetcher.GetBlockByHash(headBlockHash);
+                JObject? blockData = await _blockFetcher.GetBlockByHash(headBlockHash);
                 if (blockData is null)
                 {
                     _logger.Warn($"Failed to fetch block data for hash: {headBlockHash}");
@@ -118,7 +118,7 @@ public class RequestOrchestrator(
             else
             {
                 // Get the head block data
-                var beaconBlockHeader = await _blockFetcher.GetBeaconBlockHeader();
+                JObject? beaconBlockHeader = await _blockFetcher.GetBeaconBlockHeader();
                 if (beaconBlockHeader is null)
                 {
                     _logger.Warn("Failed to fetch beacon block header");
@@ -126,7 +126,7 @@ public class RequestOrchestrator(
                 }
                 headBlockHash = beaconBlockHeader["data"]?["root"]?.ToString() ?? string.Empty;
 
-                var blockData = await _blockFetcher.GetBeaconBlock(headBlockHash);
+                JObject? blockData = await _blockFetcher.GetBeaconBlock(headBlockHash);
                 if (blockData is null)
                 {
                     _logger.Warn($"Failed to fetch block data for hash: {headBlockHash}");
@@ -134,7 +134,7 @@ public class RequestOrchestrator(
                 }
                 else
                 {
-                    var payload = blockData["data"]?["message"]?["body"]?["execution_payload"]?.ToObject<JObject>();
+                    JObject? payload = blockData["data"]?["message"]?["body"]?["execution_payload"]?.ToObject<JObject>();
                     if (payload is null)
                     {
                         _logger.Warn($"Failed to fetch payload for hash: {headBlockHash}");
@@ -149,7 +149,7 @@ public class RequestOrchestrator(
             }
 
             // 3. Clone the request and add payload attributes
-            var modifiedRequest = CloneRequest(originalRequest);
+            JsonRpcRequest modifiedRequest = CloneRequest(originalRequest);
             modifiedRequest.Params ??= [];
 
             // Make sure we explicitly copy the originalRequest headers to ensure auth is preserved
@@ -180,7 +180,7 @@ public class RequestOrchestrator(
 
             // 4. Send modified FCU to execution client
             _logger.Debug($"Sending modified FCU with payload attributes: {modifiedRequest}");
-            var fcuResponse = await SendJsonRpcRequest(modifiedRequest);
+            JsonRpcResponse fcuResponse = await SendJsonRpcRequest(modifiedRequest);
 
             // 5. Extract payload ID from response
             if (fcuResponse.Result is JObject resultObj && resultObj["payloadId"] is not null)
@@ -231,7 +231,7 @@ public class RequestOrchestrator(
         try
         {
             // Get payload ID from the tracking system
-            var headBlock = _payloadTracker.GetHeadBlock(payloadId);
+            Hash256? headBlock = _payloadTracker.GetHeadBlock(payloadId);
             if (headBlock is null)
             {
                 _logger.Error($"No head block found for payloadId {payloadId}");
@@ -242,7 +242,7 @@ public class RequestOrchestrator(
             await Task.Delay(500);
 
             // Get the payload and process it, passing along the parentBeaconBlockRoot
-            var response = await GetAndProcessPayload(payloadId, headBlock, parentBeaconBlockRoot);
+            JsonRpcResponse response = await GetAndProcessPayload(payloadId, headBlock, parentBeaconBlockRoot);
 
             // Check if the response indicates success
             if (response.Error is not null)
@@ -294,7 +294,7 @@ public class RequestOrchestrator(
             }
 
             // Create getPayload request
-            var getPayloadRequest = new JsonRpcRequest(
+            JsonRpcRequest getPayloadRequest = new(
                 _config.GetPayloadMethod,
                 new JArray(payloadId),
                 Guid.NewGuid().ToString());
@@ -302,7 +302,7 @@ public class RequestOrchestrator(
             // Make sure any authorization headers from HttpClient are included
             if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 if (!string.IsNullOrEmpty(authHeaderValue))
                 {
                     getPayloadRequest.OriginalHeaders = new Dictionary<string, string>
@@ -314,7 +314,7 @@ public class RequestOrchestrator(
             }
 
             // Send request to get the payload
-            var payloadResponse = await SendJsonRpcRequest(getPayloadRequest);
+            JsonRpcResponse payloadResponse = await SendJsonRpcRequest(getPayloadRequest);
 
             // Check for error in response
             if (payloadResponse.Error is not null)
@@ -334,7 +334,7 @@ public class RequestOrchestrator(
                 try
                 {
                     // Extract blobsBundle and compute versioned hashes
-                    var blobsBundle = payload["blobsBundle"] as JObject;
+                    JObject? blobsBundle = payload["blobsBundle"] as JObject;
                     JArray blobVersionedHashes = _blobHashComputer.ComputeVersionedHashes(blobsBundle);
 
                     // Store blob versioned hashes in tracker for this head block
@@ -347,12 +347,12 @@ public class RequestOrchestrator(
 
                     // Create newPayload request from the payload
                     _logger.Info($"Creating newPayload request from payload with parentBeaconBlockRoot: {parentBeaconBlockRoot}");
-                    var newPayloadRequest = CreateNewPayloadRequest(payload, parentBeaconBlockRoot, blobVersionedHashes);
+                    JsonRpcRequest newPayloadRequest = CreateNewPayloadRequest(payload, parentBeaconBlockRoot, blobVersionedHashes);
 
                     // Copy auth headers to new request too
                     if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
                     {
-                        var authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                        string? authHeaderValue = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                         if (!string.IsNullOrEmpty(authHeaderValue))
                         {
                             newPayloadRequest.OriginalHeaders = new Dictionary<string, string>
@@ -365,7 +365,7 @@ public class RequestOrchestrator(
 
                     // Send newPayload request
                     _logger.Debug($"Sending synthetic newPayload request: {newPayloadRequest}");
-                    var newPayloadResponse = await SendJsonRpcRequest(newPayloadRequest);
+                    JsonRpcResponse newPayloadResponse = await SendJsonRpcRequest(newPayloadRequest);
 
                     // Check if newPayload resulted in an error
                     if (newPayloadResponse.Error is not null)
@@ -414,7 +414,7 @@ public class RequestOrchestrator(
         try
         {
             // Extract the executionPayload from the response
-            var executionPayload = payload["executionPayload"] ?? payload;
+            JToken executionPayload = payload["executionPayload"] ?? payload;
 
             // Use provided blobVersionedHashes or empty array
             blobVersionedHashes ??= new JArray();
@@ -431,10 +431,10 @@ public class RequestOrchestrator(
                     try
                     {
                         // Try to get the parentBeaconBlockRoot from the PayloadTracker
-                        var hash = new Hash256(Bytes.FromHexString(blockHash));
+                        Hash256 hash = new(Bytes.FromHexString(blockHash));
 
                         // First try the fast-path TryGet method to avoid multiple lookups
-                        if (_payloadTracker.TryGetParentBeaconBlockRoot(hash, out var trackedParentBeaconBlockRoot) &&
+                        if (_payloadTracker.TryGetParentBeaconBlockRoot(hash, out string? trackedParentBeaconBlockRoot) &&
                             !string.IsNullOrEmpty(trackedParentBeaconBlockRoot))
                         {
                             parentBeaconBlockRoot = trackedParentBeaconBlockRoot;
@@ -464,7 +464,7 @@ public class RequestOrchestrator(
             }
 
             // Create the parameter array for the newPayload request
-            var parameters = new JArray
+            JArray parameters = new()
             {
                 executionPayload,          // First parameter: executionPayload
                 blobVersionedHashes,       // Second parameter: blobVersionedHashes
@@ -497,14 +497,14 @@ public class RequestOrchestrator(
         try
         {
             // Serialize request
-            var requestJson = JsonConvert.SerializeObject(request);
+            string requestJson = JsonConvert.SerializeObject(request);
             string targetHost = _httpClient.BaseAddress?.ToString() ?? "unknown";
             _logger.Debug($"Forwarding validation request to EL at: {targetHost}");
             _logger.Info($"PR -> EL|{request.Method}|V|{requestJson}");
-            var httpContent = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            StringContent httpContent = new(requestJson, Encoding.UTF8, "application/json");
 
             // Create a request message instead of using PostAsync
-            var requestMessage = new HttpRequestMessage(HttpMethod.Post, "")
+            HttpRequestMessage requestMessage = new(HttpMethod.Post, "")
             {
                 Content = httpContent
             };
@@ -513,7 +513,7 @@ public class RequestOrchestrator(
 
             // First, check if the request already has an Authorization header
             if (request.OriginalHeaders is not null &&
-                request.OriginalHeaders.TryGetValue("Authorization", out var requestAuthHeader) &&
+                request.OriginalHeaders.TryGetValue("Authorization", out string? requestAuthHeader) &&
                 !string.IsNullOrEmpty(requestAuthHeader))
             {
                 requestMessage.Headers.TryAddWithoutValidation("Authorization", requestAuthHeader);
@@ -524,7 +524,7 @@ public class RequestOrchestrator(
             // Next, try to get the Authorization header from the HttpClient's default headers
             if (!authHeaderAdded && _httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var httpClientAuthHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? httpClientAuthHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 if (!string.IsNullOrEmpty(httpClientAuthHeader))
                 {
                     requestMessage.Headers.TryAddWithoutValidation("Authorization", httpClientAuthHeader);
@@ -536,7 +536,7 @@ public class RequestOrchestrator(
             // Then, copy any remaining original headers if present
             if (request.OriginalHeaders is not null)
             {
-                foreach (var header in request.OriginalHeaders)
+                foreach (KeyValuePair<string, string> header in request.OriginalHeaders)
                 {
                     // Skip content-related headers and the Authorization header we already added
                     if (!header.Key.StartsWith("Content-", StringComparison.OrdinalIgnoreCase) &&
@@ -554,10 +554,10 @@ public class RequestOrchestrator(
 
             // Send request
             _logger.Debug($"Sending request with method: {request.Method}, HasAuth: {authHeaderAdded}, Target: {targetHost}");
-            var response = await _httpClient.SendAsync(requestMessage);
+            HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
             if (!response.IsSuccessStatusCode)
             {
-                var errorContent = await response.Content.ReadAsStringAsync();
+                string errorContent = await response.Content.ReadAsStringAsync();
                 _logger.Error($"HTTP request failed with status code: {response.StatusCode}, Content: {errorContent}");
 
                 // Return an error response instead of throwing in tests
@@ -565,13 +565,13 @@ public class RequestOrchestrator(
             }
 
             // Parse response
-            var responseJson = await response.Content.ReadAsStringAsync();
+            string responseJson = await response.Content.ReadAsStringAsync();
             _logger.Debug($"Received response from EL at: {targetHost}");
             _logger.Info($"EL -> PR|{request.Method}|V|{responseJson}");
 
             try
             {
-                var jsonRpcResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
+                JsonRpcResponse? jsonRpcResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseJson);
                 if (jsonRpcResponse is null)
                 {
                     _logger.Error($"Failed to deserialize JSON-RPC response: {responseJson}");
@@ -608,18 +608,15 @@ public class RequestOrchestrator(
     /// </summary>
     /// <param name="request">The request to clone</param>
     /// <returns>A clone of the request</returns>
-    private static JsonRpcRequest CloneRequest(JsonRpcRequest request)
-    {
-        return new JsonRpcRequest(
+    private static JsonRpcRequest CloneRequest(JsonRpcRequest request) => new(
             request.Method,
             request.Params?.DeepClone() as JArray,
             request.Id)
-        {
-            OriginalHeaders = request.OriginalHeaders is not null
+    {
+        OriginalHeaders = request.OriginalHeaders is not null
                 ? new Dictionary<string, string>(request.OriginalHeaders)
                 : null
-        };
-    }
+    };
 
     /// <summary>
     /// Checks if the execution payload for the given payloadId matches the expected block hash
@@ -635,7 +632,7 @@ public class RequestOrchestrator(
         try
         {
             // Get the head block hash from the payload tracker
-            var headBlock = _payloadTracker.GetHeadBlock(payloadId);
+            Hash256? headBlock = _payloadTracker.GetHeadBlock(payloadId);
             if (headBlock is null)
             {
                 _logger.Error($"No head block found for payloadId {payloadId}");
@@ -643,12 +640,12 @@ public class RequestOrchestrator(
             }
 
             // Get the payload using the existing method
-            var payloadResponse = await GetAndProcessPayload(payloadId, headBlock);
+            JsonRpcResponse payloadResponse = await GetAndProcessPayload(payloadId, headBlock);
 
             // Extract the block hash from the response
             if (payloadResponse.Result is JObject payload)
             {
-                var executionPayload = payload["executionPayload"]?.ToObject<JObject>();
+                JObject? executionPayload = payload["executionPayload"]?.ToObject<JObject>();
                 if (executionPayload is not null)
                 {
                     string? synthBlockHash = executionPayload["blockHash"]?.ToString();

--- a/tools/EngineApiProxy/Utilities/BlobHashComputer.cs
+++ b/tools/EngineApiProxy/Utilities/BlobHashComputer.cs
@@ -11,7 +11,7 @@ namespace Nethermind.EngineApiProxy.Utilities;
 /// <summary>
 /// Computes versioned hashes from KZG commitments for blob transactions (EIP-4844)
 /// </summary>
-public class BlobHashComputer
+public class BlobHashComputer(ILogManager logManager)
 {
     /// <summary>
     /// Size of a KZG commitment in bytes
@@ -28,12 +28,7 @@ public class BlobHashComputer
     /// </summary>
     public const byte KzgVersionByte = 0x01;
 
-    private readonly ILogger _logger;
-
-    public BlobHashComputer(ILogManager logManager)
-    {
-        _logger = logManager?.GetClassLogger<BlobHashComputer>() ?? throw new ArgumentNullException(nameof(logManager));
-    }
+    private readonly ILogger _logger = logManager?.GetClassLogger<BlobHashComputer>() ?? throw new ArgumentNullException(nameof(logManager));
 
     /// <summary>
     /// Computes a versioned hash from a single KZG commitment.
@@ -84,7 +79,7 @@ public class BlobHashComputer
     /// <returns>A JArray of versioned hash hex strings</returns>
     public JArray ComputeVersionedHashes(JObject? blobsBundle)
     {
-        var result = new JArray();
+        JArray result = new();
 
         if (blobsBundle is null)
         {
@@ -92,7 +87,7 @@ public class BlobHashComputer
             return result;
         }
 
-        var commitments = blobsBundle["commitments"] as JArray;
+        JArray? commitments = blobsBundle["commitments"] as JArray;
         if (commitments is null || commitments.Count == 0)
         {
             _logger.Debug("No commitments in blobsBundle, returning empty versioned hashes array");
@@ -102,7 +97,7 @@ public class BlobHashComputer
         _logger.Info($"Processing block with {commitments.Count} blobs");
 
         int successCount = 0;
-        foreach (var commitment in commitments)
+        foreach (JToken commitment in commitments)
         {
             string? commitmentHex = commitment?.ToString();
             if (string.IsNullOrEmpty(commitmentHex))
@@ -137,7 +132,7 @@ public class BlobHashComputer
             return new JArray();
         }
 
-        var blobHashes = requestParams[1];
+        JToken? blobHashes = requestParams[1];
 
         // Handle null or JTokenType.Null
         if (blobHashes is null || blobHashes.Type == JTokenType.Null)

--- a/tools/EngineApiProxy/Utilities/RequestForwarder.cs
+++ b/tools/EngineApiProxy/Utilities/RequestForwarder.cs
@@ -33,10 +33,10 @@ public class RequestForwarder(
             {
                 _logger.Debug($"PR -> EL|{request.Method}|{requestJson}");
             }
-            var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            StringContent content = new(requestJson, Encoding.UTF8, "application/json");
 
             // Create a request message instead of using PostAsync directly
-            var requestMessage = new HttpRequestMessage(HttpMethod.Post, "")
+            HttpRequestMessage requestMessage = new(HttpMethod.Post, "")
             {
                 Content = content
             };
@@ -47,7 +47,7 @@ public class RequestForwarder(
                 _logger.Debug($"Forwarding {request.OriginalHeaders.Count} original headers from client request");
 
                 // Log the presence of Authorization header in original headers
-                if (request.OriginalHeaders.TryGetValue("Authorization", out var origAuthHeader))
+                if (request.OriginalHeaders.TryGetValue("Authorization", out string? origAuthHeader))
                 {
                     _logger.Trace($"Found Authorization header in original request headers: {origAuthHeader.Substring(0, Math.Min(10, origAuthHeader.Length))}...");
                 }
@@ -57,13 +57,13 @@ public class RequestForwarder(
                 }
 
                 // Special handling for Authorization header
-                if (request.OriginalHeaders.TryGetValue("Authorization", out var authHeader))
+                if (request.OriginalHeaders.TryGetValue("Authorization", out string? authHeader))
                 {
                     requestMessage.Headers.TryAddWithoutValidation("Authorization", authHeader);
                     _logger.Debug("Added Authorization header from original request headers");
                 }
 
-                foreach (var header in request.OriginalHeaders)
+                foreach (KeyValuePair<string, string> header in request.OriginalHeaders)
                 {
                     // Skip content-related headers that will be set by HttpClient
                     // Also skip Authorization which was handled separately
@@ -87,7 +87,7 @@ public class RequestForwarder(
             // Always check the HttpClient's DefaultRequestHeaders for Authorization as a fallback
             if (!requestMessage.Headers.Contains("Authorization") && _httpClient.DefaultRequestHeaders.Contains("Authorization"))
             {
-                var authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
+                string? authHeader = _httpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
                 if (!string.IsNullOrEmpty(authHeader))
                 {
                     _logger.Debug("Adding Authorization header from HttpClient DefaultRequestHeaders as fallback");
@@ -135,7 +135,7 @@ public class RequestForwarder(
                 return JsonRpcResponse.CreateErrorResponse(request.Id, -32603, $"Proxy error: EL error: {response.StatusCode}");
             }
 
-            var jsonRpcResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseBody);
+            JsonRpcResponse? jsonRpcResponse = JsonConvert.DeserializeObject<JsonRpcResponse>(responseBody);
             if (jsonRpcResponse is null)
             {
                 return JsonRpcResponse.CreateErrorResponse(request.Id, -32603, "Proxy error: Invalid response from EL");

--- a/tools/Evm/T8n/Errors/GethErrorMappings.cs
+++ b/tools/Evm/T8n/Errors/GethErrorMappings.cs
@@ -11,13 +11,10 @@ public class GethErrorMappings
     private const string MissingTxToError = "TxMissingTo: Must be set.";
     private const string MissingTxToGethError = "rlp: input string too short for common.Address, decoding into (types.Transaction)(types.BlobTx).To";
 
-    public static string GetErrorMapping(string error, params object[] arguments)
+    public static string GetErrorMapping(string error, params object[] arguments) => error switch
     {
-        return error switch
-        {
-            WrongTransactionNonceError => string.Format(WrongTransactionNonceGethError, arguments),
-            MissingTxToError => string.Format(MissingTxToGethError),
-            _ => error
-        };
-    }
+        WrongTransactionNonceError => string.Format(WrongTransactionNonceGethError, arguments),
+        MissingTxToError => string.Format(MissingTxToGethError),
+        _ => error
+    };
 }

--- a/tools/Evm/T8n/Errors/T8nException.cs
+++ b/tools/Evm/T8n/Errors/T8nException.cs
@@ -7,20 +7,11 @@ namespace Evm.T8n.Errors;
 
 public class T8nException : Exception, IExceptionWithExitCode
 {
-    public T8nException(Exception e, int exitCode) : base(e.Message, e)
-    {
-        ExitCode = exitCode;
-    }
+    public T8nException(Exception e, int exitCode) : base(e.Message, e) => ExitCode = exitCode;
 
-    public T8nException(Exception e, string message, int exitCode) : base(message, e)
-    {
-        ExitCode = exitCode;
-    }
+    public T8nException(Exception e, string message, int exitCode) : base(message, e) => ExitCode = exitCode;
 
-    public T8nException(string message, int exitCode) : base(message)
-    {
-        ExitCode = exitCode;
-    }
+    public T8nException(string message, int exitCode) : base(message) => ExitCode = exitCode;
 
     public int ExitCode { get; }
 }

--- a/tools/Evm/T8n/JsonConverters/AccountStateJsonConverter.cs
+++ b/tools/Evm/T8n/JsonConverters/AccountStateJsonConverter.cs
@@ -15,10 +15,7 @@ public class AccountStateJsonConverter : JsonConverter<AccountState>
 {
     private readonly EthereumJsonSerializer _ethereumJsonSerializer = new();
 
-    public override AccountState? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        return _ethereumJsonSerializer.Deserialize<AccountState>(ref reader);
-    }
+    public override AccountState? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => _ethereumJsonSerializer.Deserialize<AccountState>(ref reader);
 
     public override void Write(Utf8JsonWriter writer, AccountState value, JsonSerializerOptions options)
     {
@@ -46,7 +43,7 @@ public class AccountStateJsonConverter : JsonConverter<AccountState>
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
             if (value.Storage.Count > 0)
             {
-                var storage = value.Storage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToUInt256());
+                Dictionary<UInt256, UInt256> storage = value.Storage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToUInt256());
                 writer.WritePropertyName("storage"u8);
                 JsonSerializer.Serialize(writer, storage, options);
             }

--- a/tools/Evm/T8n/JsonTypes/InputData.cs
+++ b/tools/Evm/T8n/JsonTypes/InputData.cs
@@ -29,11 +29,11 @@ public class InputData
         }
         else if (Txs is not null && TransactionMetaDataList is not null)
         {
-            var ecdsa = new EthereumEcdsa(chainId);
+            EthereumEcdsa ecdsa = new(chainId);
 
             for (int i = 0; i < Txs.Length; i++)
             {
-                var transaction = (Transaction)Txs[i].ToTransaction();
+                Transaction transaction = (Transaction)Txs[i].ToTransaction();
                 transaction.SenderAddress = null; // t8n does not accept SenderAddress from input, so need to reset senderAddress
 
                 SignTransaction(transaction, TransactionMetaDataList[i], (LegacyTransactionForRpc)Txs[i]);
@@ -53,7 +53,7 @@ public class InputData
     {
         if (transactionMetaData.SecretKey is not null)
         {
-            var privateKey = new PrivateKey(transactionMetaData.SecretKey);
+            PrivateKey privateKey = new(transactionMetaData.SecretKey);
             transaction.SenderAddress = privateKey.Address;
 
             EthereumEcdsa ecdsa = new(transaction.ChainId ?? TestBlockchainIds.ChainId);

--- a/tools/Evm/T8n/JsonTypes/T8nExecutionResult.cs
+++ b/tools/Evm/T8n/JsonTypes/T8nExecutionResult.cs
@@ -36,11 +36,11 @@ public class T8nExecutionResult
         LogEntry[] logEntries = txReport.SuccessfulTransactionReceipts
             .SelectMany(receipt => receipt.Logs ?? Enumerable.Empty<LogEntry>())
             .ToArray();
-        var bloom = new Bloom(logEntries);
-        var gasUsed = blockReceiptsTracer.TxReceipts.Length == 0 ? 0 : (ulong)blockReceiptsTracer.LastReceipt.GasUsedTotal;
+        Bloom bloom = new(logEntries);
+        ulong gasUsed = blockReceiptsTracer.TxReceipts.Length == 0 ? 0 : (ulong)blockReceiptsTracer.LastReceipt.GasUsedTotal;
         ulong? blobGasUsed = test.Spec.IsEip4844Enabled ? BlobGasCalculator.CalculateBlobGas(txReport.ValidTransactions.ToArray()) : null;
 
-        var postState = new PostState
+        PostState postState = new()
         {
             StateRoot = stateProvider.StateRoot,
             TxRoot = txRoot,
@@ -104,8 +104,8 @@ public class T8nExecutionResult
         if (!stateProvider.AccountExists(address)) return null;
 
         stateProvider.TryGetAccount(address, out AccountStruct account);
-        var code = stateProvider.GetCode(address);
-        var accountState = new AccountState
+        byte[]? code = stateProvider.GetCode(address);
+        AccountState accountState = new()
         {
             Nonce = account.Nonce,
             Balance = account.Balance,

--- a/tools/Evm/T8n/JsonTypes/T8nOutput.cs
+++ b/tools/Evm/T8n/JsonTypes/T8nOutput.cs
@@ -24,8 +24,5 @@ public class T8nOutput
         ExitCode = exitCode;
     }
 
-    public bool IsEmpty()
-    {
-        return Result is null && Body is null && Alloc is null;
-    }
+    public bool IsEmpty() => Result is null && Body is null && Alloc is null;
 }

--- a/tools/Evm/T8n/T8nCommand.cs
+++ b/tools/Evm/T8n/T8nCommand.cs
@@ -32,7 +32,7 @@ public static class T8nCommand
 
         cmd.SetAction(parseResult =>
         {
-            var arguments = T8nCommandArguments.FromParseResult(parseResult);
+            T8nCommandArguments arguments = T8nCommandArguments.FromParseResult(parseResult);
 
             T8nOutput t8nOutput = new();
             try

--- a/tools/Evm/T8n/T8nCommandArguments.cs
+++ b/tools/Evm/T8n/T8nCommandArguments.cs
@@ -28,7 +28,7 @@ public class T8nCommandArguments
 
     public static T8nCommandArguments FromParseResult(ParseResult parseResult)
     {
-        var arguments = new T8nCommandArguments
+        T8nCommandArguments arguments = new()
         {
             OutputBody = parseResult.GetValue(T8nCommandOptions.OutputBodyOpt),
             Trace = parseResult.GetValue(T8nCommandOptions.TraceOpt),
@@ -37,55 +37,55 @@ public class T8nCommandArguments
             TraceReturnData = parseResult.GetValue(T8nCommandOptions.TraceReturnDataOpt)
         };
 
-        var inputAlloc = parseResult.GetValue(T8nCommandOptions.InputAllocOpt);
+        string? inputAlloc = parseResult.GetValue(T8nCommandOptions.InputAllocOpt);
         if (inputAlloc is not null)
         {
             arguments.InputAlloc = inputAlloc;
         }
 
-        var inputEnv = parseResult.GetValue(T8nCommandOptions.InputEnvOpt);
+        string? inputEnv = parseResult.GetValue(T8nCommandOptions.InputEnvOpt);
         if (inputEnv is not null)
         {
             arguments.InputEnv = inputEnv;
         }
 
-        var inputTxs = parseResult.GetValue(T8nCommandOptions.InputTxsOpt);
+        string? inputTxs = parseResult.GetValue(T8nCommandOptions.InputTxsOpt);
         if (inputTxs is not null)
         {
             arguments.InputTxs = inputTxs;
         }
 
-        var outputAlloc = parseResult.GetValue(T8nCommandOptions.OutputAllocOpt);
+        string? outputAlloc = parseResult.GetValue(T8nCommandOptions.OutputAllocOpt);
         if (outputAlloc is not null)
         {
             arguments.OutputAlloc = outputAlloc;
         }
 
-        var outputResult = parseResult.GetValue(T8nCommandOptions.OutputResultOpt);
+        string? outputResult = parseResult.GetValue(T8nCommandOptions.OutputResultOpt);
         if (outputResult is not null)
         {
             arguments.OutputResult = outputResult;
         }
 
-        var outputBasedir = parseResult.GetValue(T8nCommandOptions.OutputBaseDirOpt);
+        string? outputBasedir = parseResult.GetValue(T8nCommandOptions.OutputBaseDirOpt);
         if (outputBasedir is not null)
         {
             arguments.OutputBaseDir = outputBasedir;
         }
 
-        var stateFork = parseResult.GetValue(T8nCommandOptions.StateForkOpt);
+        string? stateFork = parseResult.GetValue(T8nCommandOptions.StateForkOpt);
         if (stateFork is not null)
         {
             arguments.StateFork = stateFork;
         }
 
-        var stateReward = parseResult.GetValue(T8nCommandOptions.StateRewardOpt);
+        string? stateReward = parseResult.GetValue(T8nCommandOptions.StateRewardOpt);
         if (stateReward is not null)
         {
             arguments.StateReward = stateReward;
         }
 
-        var stateChainId = parseResult.GetValue(T8nCommandOptions.StateChainIdOpt);
+        ulong? stateChainId = parseResult.GetValue(T8nCommandOptions.StateChainIdOpt);
         if (stateChainId.HasValue)
         {
             arguments.StateChainId = stateChainId.Value;

--- a/tools/Evm/T8n/T8nExecutor.cs
+++ b/tools/Evm/T8n/T8nExecutor.cs
@@ -53,7 +53,7 @@ public static class T8nExecutor
         GeneralStateTestBase.InitializeTestState(test.Alloc, stateProvider, test.SpecProvider);
 
         Block block = test.ConstructBlock();
-        var withdrawalProcessor = new WithdrawalProcessor(stateProvider, _logManager);
+        WithdrawalProcessor withdrawalProcessor = new(stateProvider, _logManager);
         withdrawalProcessor.ProcessWithdrawals(block, test.Spec);
 
         ApplyRewards(block, stateProvider, test.Spec, test.SpecProvider);
@@ -80,7 +80,7 @@ public static class T8nExecutor
 
         int txIndex = 0;
         TransactionExecutionReport transactionExecutionReport = new();
-        var txValidator = new TxValidator(test.StateChainId);
+        TxValidator txValidator = new(test.StateChainId);
 
         foreach (Transaction transaction in test.Transactions)
         {
@@ -90,7 +90,7 @@ public static class T8nExecutor
             {
                 if (txIsValid.Error is not null)
                 {
-                    var error = GethErrorMappings.GetErrorMapping(txIsValid.Error);
+                    string error = GethErrorMappings.GetErrorMapping(txIsValid.Error);
                     transactionExecutionReport.RejectedTransactionReceipts.Add(new RejectedTx(txIndex, error));
                 }
                 continue;
@@ -113,7 +113,7 @@ public static class T8nExecutor
             }
             else if (!transactionResult.TransactionExecuted && transaction.SenderAddress is not null)
             {
-                var error = GethErrorMappings.GetErrorMapping(transactionResult.ErrorDescription,
+                string error = GethErrorMappings.GetErrorMapping(transactionResult.ErrorDescription,
                     transaction.SenderAddress.ToString(true),
                     transaction.Nonce, stateProvider.GetNonce(transaction.SenderAddress));
 
@@ -138,7 +138,7 @@ public static class T8nExecutor
 
     private static void ApplyRewards(Block block, IWorldState stateProvider, IReleaseSpec spec, ISpecProvider specProvider)
     {
-        var rewardCalculator = new RewardCalculator(specProvider);
+        RewardCalculator rewardCalculator = new(specProvider);
         BlockReward[] rewards = rewardCalculator.CalculateRewards(block);
 
         foreach (BlockReward reward in rewards)

--- a/tools/Evm/T8n/T8nInputProcessor.cs
+++ b/tools/Evm/T8n/T8nInputProcessor.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Ethereum.Test.Base;
 using Evm.T8n.Errors;
 using Evm.T8n.JsonTypes;
 using Nethermind.Core.Specs;
@@ -31,7 +30,7 @@ public static class T8nInputProcessor
 
         T8nValidator.ApplyChecks(inputData.Env, specProvider, spec);
 
-        var gethTraceOptions = new GethTraceOptions
+        GethTraceOptions gethTraceOptions = new()
         {
             EnableMemory = arguments.TraceMemory,
             DisableStack = arguments.TraceNoStack

--- a/tools/Evm/T8n/T8nInputReader.cs
+++ b/tools/Evm/T8n/T8nInputReader.cs
@@ -58,7 +58,7 @@ public static class T8nInputReader
     {
         try
         {
-            var fileContent = File.ReadAllText(filePath);
+            string fileContent = File.ReadAllText(filePath);
             return EthereumJsonSerializer.Deserialize<T>(fileContent);
         }
         catch (FileNotFoundException e)
@@ -73,7 +73,7 @@ public static class T8nInputReader
 
     private static InputData ReadStdInput()
     {
-        using var reader = new StreamReader(Console.OpenStandardInput());
+        using StreamReader reader = new(Console.OpenStandardInput());
         try
         {
             return EthereumJsonSerializer.Deserialize<InputData>(reader.ReadToEnd());

--- a/tools/HiveCompare/Models/HiveTestResult.cs
+++ b/tools/HiveCompare/Models/HiveTestResult.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace HiveCompare.Models
 {

--- a/tools/HiveConsensusWorkflowGenerator/Program.cs
+++ b/tools/HiveConsensusWorkflowGenerator/Program.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text.Json;
 
 namespace HiveConsensusWorkflowGenerator;
@@ -18,16 +16,16 @@ public static class Program
         // Sort the tests by size in descending order
         List<KeyValuePair<string, long>> sortedTests = pathsToBeTested.OrderByDescending(kv => kv.Value).ToList();
 
-        SortedList<long, List<string>> groupedTestNames = new SortedList<long, List<string>>();
+        SortedList<long, List<string>> groupedTestNames = new();
 
-        foreach (var test in sortedTests)
+        foreach (KeyValuePair<string, long> test in sortedTests)
         {
             long size = 0;
             List<string>? testsList = null;
 
             if (groupedTestNames.Count == MaxJobsCount)
             {
-                var smallestGroup = groupedTestNames.First();
+                KeyValuePair<long, List<string>> smallestGroup = groupedTestNames.First();
                 testsList = new List<string>(smallestGroup.Value);
                 size = smallestGroup.Key;
                 testsList.Add(test.Key);

--- a/tools/JitAsm/DisassemblyParser.cs
+++ b/tools/JitAsm/DisassemblyParser.cs
@@ -24,7 +24,7 @@ internal static partial class DisassemblyParser
             return string.Empty;
         }
 
-        var result = new StringBuilder();
+        StringBuilder result = new();
         MatchCollection matches = MethodHeaderPattern().Matches(jitOutput);
 
         if (matches.Count == 0)
@@ -44,20 +44,20 @@ internal static partial class DisassemblyParser
         for (int i = startIdx; i < matches.Count; i++)
         {
             Match match = matches[i];
-            var startIndex = match.Index;
+            int startIndex = match.Index;
 
             // Find the end of this method's disassembly
             int endIndex = (i + 1 < matches.Count) ? matches[i + 1].Index : jitOutput.Length;
 
             // Extract this method's disassembly
-            var methodAsm = jitOutput[startIndex..endIndex].TrimEnd();
+            string methodAsm = jitOutput[startIndex..endIndex].TrimEnd();
 
             // Find "Total bytes of code" line and include it
             Match totalBytesMatch = MethodEndPattern().Match(methodAsm);
             if (totalBytesMatch.Success)
             {
                 // Find end of line after "Total bytes of code"
-                var lineEnd = methodAsm.IndexOf('\n', totalBytesMatch.Index);
+                int lineEnd = methodAsm.IndexOf('\n', totalBytesMatch.Index);
                 if (lineEnd > 0)
                 {
                     methodAsm = methodAsm[..(lineEnd + 1)].TrimEnd();
@@ -89,12 +89,12 @@ internal static partial class DisassemblyParser
         for (int i = 0; i < matches.Count; i++)
         {
             Match match = matches[i];
-            var methodName = match.Groups["method"].Value;
-            var startIndex = match.Index;
+            string methodName = match.Groups["method"].Value;
+            int startIndex = match.Index;
 
             int endIndex = (i + 1 < matches.Count) ? matches[i + 1].Index : jitOutput.Length;
 
-            var methodAsm = jitOutput[startIndex..endIndex].TrimEnd();
+            string methodAsm = jitOutput[startIndex..endIndex].TrimEnd();
 
             yield return new MethodDisassembly
             {

--- a/tools/JitAsm/InstructionAnnotator.cs
+++ b/tools/JitAsm/InstructionAnnotator.cs
@@ -93,7 +93,7 @@ internal static partial class InstructionAnnotator
 
     public static string Annotate(string disassembly, InstructionDb db)
     {
-        var sb = new StringBuilder();
+        StringBuilder sb = new();
         List<string> lines = JoinContinuationLines(disassembly.Split('\n'));
 
         foreach (string rawLine in lines)
@@ -123,7 +123,7 @@ internal static partial class InstructionAnnotator
                 string pattern = ClassifyOperands(operandsRaw, mnemonic);
 
                 // Try the original mnemonic first, then any alias
-                string lookupMnemonic = MnemonicAliases.TryGetValue(mnemonic, out var alias)
+                string lookupMnemonic = MnemonicAliases.TryGetValue(mnemonic, out string? alias)
                     ? alias : mnemonic;
                 InstructionInfo? info = db.Lookup(mnemonic, pattern)
                     ?? (lookupMnemonic != mnemonic ? db.Lookup(lookupMnemonic, pattern) : null);
@@ -150,7 +150,7 @@ internal static partial class InstructionAnnotator
                 string mnemonic = zeroMatch.Groups["mnemonic"].Value.ToLowerInvariant();
                 if (!ShouldSkipAnnotation(mnemonic, ""))
                 {
-                    string zeroLookup = MnemonicAliases.TryGetValue(mnemonic, out var zAlias)
+                    string zeroLookup = MnemonicAliases.TryGetValue(mnemonic, out string? zAlias)
                         ? zAlias : mnemonic;
                     InstructionInfo? info = db.Lookup(mnemonic, "")
                         ?? (zeroLookup != mnemonic ? db.Lookup(zeroLookup, "") : null);
@@ -179,7 +179,7 @@ internal static partial class InstructionAnnotator
     /// </summary>
     private static List<string> JoinContinuationLines(string[] rawLines)
     {
-        var result = new List<string>(rawLines.Length);
+        List<string> result = new(rawLines.Length);
         for (int i = 0; i < rawLines.Length; i++)
         {
             string line = rawLines[i].TrimEnd('\r');
@@ -281,7 +281,7 @@ internal static partial class InstructionAnnotator
 
         // Split operands by comma, but respect brackets for memory operands
         List<string> operands = SplitOperands(operandsRaw);
-        var parts = new List<string>();
+        List<string> parts = new();
 
         for (int i = 0; i < operands.Count; i++)
         {
@@ -305,7 +305,7 @@ internal static partial class InstructionAnnotator
 
     private static List<string> SplitOperands(string operands)
     {
-        var result = new List<string>();
+        List<string> result = new();
         int depth = 0;
         int start = 0;
 
@@ -426,7 +426,7 @@ internal static partial class InstructionAnnotator
 
     private static string FormatAnnotation(InstructionInfo info)
     {
-        var sb = new StringBuilder();
+        StringBuilder sb = new();
         sb.Append("; [");
         sb.Append($"TP:{info.Throughput:F2}");
         sb.Append($" | Lat:{info.Latency,2}");

--- a/tools/JitAsm/InstructionDb.cs
+++ b/tools/JitAsm/InstructionDb.cs
@@ -13,19 +13,14 @@ internal sealed class InstructionInfo
     public string? Ports { get; init; }
 }
 
-internal sealed class InstructionDb
+internal sealed class InstructionDb(string archName)
 {
     private const string Magic = "UOPS";
     private const ushort Version = 2;
 
     private readonly Dictionary<string, List<InstructionInfo>> _instructions = new(StringComparer.OrdinalIgnoreCase);
 
-    public string ArchName { get; }
-
-    public InstructionDb(string archName)
-    {
-        ArchName = archName;
-    }
+    public string ArchName { get; } = archName;
 
     public void Add(InstructionInfo info)
     {
@@ -73,20 +68,18 @@ internal sealed class InstructionDb
         return null;
     }
 
-    private static string RelaxPattern(string pattern)
-    {
+    private static string RelaxPattern(string pattern) =>
         // Normalize register widths: r8/r16/r32/r64 → r, m8/m16/m32/m64/m128/m256/m512 → m, imm8/imm32 → imm
-        return pattern
+        pattern
             .Replace("r64", "r").Replace("r32", "r").Replace("r16", "r").Replace("r8", "r")
             .Replace("m512", "m").Replace("m256", "m").Replace("m128", "m")
             .Replace("m64", "m").Replace("m32", "m").Replace("m16", "m").Replace("m8", "m")
             .Replace("imm32", "imm").Replace("imm8", "imm");
-    }
 
     public void Save(string path)
     {
         using FileStream stream = File.Create(path);
-        using var writer = new BinaryWriter(stream);
+        using BinaryWriter writer = new(stream);
 
         // Header
         writer.Write(Magic.ToCharArray());
@@ -115,7 +108,7 @@ internal sealed class InstructionDb
     public static InstructionDb Load(string path)
     {
         using FileStream stream = File.OpenRead(path);
-        using var reader = new BinaryReader(stream);
+        using BinaryReader reader = new(stream);
 
         // Header
         char[] magic = reader.ReadChars(4);
@@ -129,7 +122,7 @@ internal sealed class InstructionDb
         string archName = reader.ReadString();
         int entryCount = reader.ReadInt32();
 
-        var db = new InstructionDb(archName);
+        InstructionDb db = new(archName);
 
         for (int i = 0; i < entryCount; i++)
         {

--- a/tools/JitAsm/InstructionDbBuilder.cs
+++ b/tools/JitAsm/InstructionDbBuilder.cs
@@ -34,23 +34,20 @@ internal static class InstructionDbBuilder
         ["ZEN2"] = ["ZEN+"],
     };
 
-    public static string ResolveArchName(string cliValue)
-    {
-        return ArchMap.TryGetValue(cliValue, out var name) ? name : cliValue.ToUpperInvariant();
-    }
+    public static string ResolveArchName(string cliValue) => ArchMap.TryGetValue(cliValue, out string? name) ? name : cliValue.ToUpperInvariant();
 
     public static IReadOnlyCollection<string> SupportedArchitectures => ArchMap.Keys;
 
     public static InstructionDb Build(string xmlPath, string archCliValue)
     {
         string targetArch = ResolveArchName(archCliValue);
-        string[] fallbacks = FallbackChain.TryGetValue(targetArch, out var fb) ? fb : [];
+        string[] fallbacks = FallbackChain.TryGetValue(targetArch, out string[]? fb) ? fb : [];
 
-        var db = new InstructionDb(targetArch);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        InstructionDb db = new(targetArch);
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
 
         using FileStream stream = File.OpenRead(xmlPath);
-        using var reader = XmlReader.Create(stream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore });
+        using XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore });
 
         while (reader.Read())
         {
@@ -68,7 +65,7 @@ internal static class InstructionDbBuilder
 
             // Read the instruction subtree
             string instructionXml = reader.ReadOuterXml();
-            var instrDoc = new XmlDocument();
+            XmlDocument instrDoc = new();
             instrDoc.LoadXml(instructionXml);
             XmlElement instrNode = instrDoc.DocumentElement!;
 
@@ -143,7 +140,7 @@ internal static class InstructionDbBuilder
 
     private static string BuildOperandPattern(XmlElement instrNode)
     {
-        var parts = new List<string>();
+        List<string> parts = new();
         foreach (XmlNode child in instrNode.ChildNodes)
         {
             if (child is not XmlElement operandEl || operandEl.Name != "operand")
@@ -199,36 +196,30 @@ internal static class InstructionDbBuilder
         };
     }
 
-    private static string ClassifyMem(string? width)
+    private static string ClassifyMem(string? width) => width switch
     {
-        return width switch
-        {
-            "8" => "m8",
-            "16" => "m16",
-            "32" => "m32",
-            "64" => "m64",
-            "128" => "m128",
-            "256" => "m256",
-            "512" => "m512",
-            _ => "m"
-        };
-    }
+        "8" => "m8",
+        "16" => "m16",
+        "32" => "m32",
+        "64" => "m64",
+        "128" => "m128",
+        "256" => "m256",
+        "512" => "m512",
+        _ => "m"
+    };
 
-    private static string ClassifyImm(string? width)
+    private static string ClassifyImm(string? width) => width switch
     {
-        return width switch
-        {
-            "8" => "imm8",
-            "16" => "imm16",
-            "32" => "imm32",
-            _ => "imm"
-        };
-    }
+        "8" => "imm8",
+        "16" => "imm16",
+        "32" => "imm32",
+        _ => "imm"
+    };
 
     private static XmlElement? FindMeasurement(XmlElement instrNode, string targetArch, string[] fallbacks)
     {
         // Try target arch first, then fallbacks
-        var archsToTry = new List<string> { targetArch };
+        List<string> archsToTry = new() { targetArch };
         archsToTry.AddRange(fallbacks);
 
         foreach (string archName in archsToTry)

--- a/tools/JitAsm/JitRunner.cs
+++ b/tools/JitAsm/JitRunner.cs
@@ -52,9 +52,9 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
         (string? executablePath, string? argumentPrefix) = GetExecutablePath();
 
         // Build the method pattern for JitDisasm
-        var methodPattern = BuildMethodPattern();
+        string methodPattern = BuildMethodPattern();
 
-        var startInfo = new ProcessStartInfo
+        ProcessStartInfo startInfo = new()
         {
             FileName = executablePath,
             UseShellExecute = false,
@@ -84,7 +84,7 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
             startInfo.EnvironmentVariables["JITASM_VERBOSE"] = "1";
 
         // Build arguments for internal runner
-        var args = new StringBuilder();
+        StringBuilder args = new();
         if (argumentPrefix is not null)
         {
             args.Append(EscapeArg(argumentPrefix));
@@ -135,7 +135,7 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
 
         try
         {
-            using var process = Process.Start(startInfo);
+            using Process? process = Process.Start(startInfo);
             if (process is null)
             {
                 return new JitResult { Success = false, Error = "Failed to start process" };
@@ -146,12 +146,12 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
 
             await process.WaitForExitAsync();
 
-            var stdout = await stdoutTask;
-            var stderr = await stderrTask;
+            string stdout = await stdoutTask;
+            string stderr = await stderrTask;
 
             // Parse the JIT output from stdout (JIT diagnostics can go to either stream)
             // In tier1 mode, multiple compilations are captured; take only the last (Tier-1)
-            var disassembly = DisassemblyParser.Parse(stdout, lastOnly: tier1);
+            string disassembly = DisassemblyParser.Parse(stdout, lastOnly: tier1);
 
             if (string.IsNullOrWhiteSpace(disassembly))
             {
@@ -188,13 +188,11 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
         }
     }
 
-    private string BuildMethodPattern()
-    {
+    private string BuildMethodPattern() =>
         // Build pattern for DOTNET_JitDisasm
         // Just use the method name - the JIT will match any method with this name
         // Type filtering is done post-hoc by parsing the output
-        return methodName;
-    }
+        methodName;
 
     /// <summary>
     /// Returns the executable path and any prefix arguments needed (e.g., DLL path for dotnet host).
@@ -202,15 +200,15 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
     private static (string FileName, string? ArgumentPrefix) GetExecutablePath()
     {
         // Get the path to the current executable
-        var currentExe = Environment.ProcessPath;
+        string? currentExe = Environment.ProcessPath;
         if (currentExe is not null && File.Exists(currentExe))
         {
             // When running via "dotnet run", ProcessPath is the dotnet host, not our tool.
             // Detect this by checking if it ends with "dotnet" (or "dotnet.exe").
-            var exeName = Path.GetFileNameWithoutExtension(currentExe);
+            string exeName = Path.GetFileNameWithoutExtension(currentExe);
             if (exeName.Equals("dotnet", StringComparison.OrdinalIgnoreCase))
             {
-                var assemblyLocation = typeof(JitRunner).Assembly.Location;
+                string assemblyLocation = typeof(JitRunner).Assembly.Location;
                 if (!string.IsNullOrEmpty(assemblyLocation))
                 {
                     return ("dotnet", assemblyLocation);
@@ -221,15 +219,15 @@ internal sealed class JitRunner(string assemblyPath, string? typeName, string me
         }
 
         // Fallback to assembly location
-        var location = typeof(JitRunner).Assembly.Location;
+        string location = typeof(JitRunner).Assembly.Location;
         if (!string.IsNullOrEmpty(location))
         {
             // For .dll, try to find the corresponding .exe
-            var directory = Path.GetDirectoryName(location)!;
-            var baseName = Path.GetFileNameWithoutExtension(location);
+            string directory = Path.GetDirectoryName(location)!;
+            string baseName = Path.GetFileNameWithoutExtension(location);
 
             // Try .exe first (Windows)
-            var exePath = Path.Combine(directory, baseName + ".exe");
+            string exePath = Path.Combine(directory, baseName + ".exe");
             if (File.Exists(exePath))
             {
                 return (exePath, null);

--- a/tools/JitAsm/MethodResolver.cs
+++ b/tools/JitAsm/MethodResolver.cs
@@ -31,7 +31,7 @@ internal sealed class MethodResolver(Assembly assembly)
 
     public MethodInfo? ResolveMethod(string? typeName, string methodName, string? typeParams, string? classTypeParams = null)
     {
-        var candidates = new List<(Type Type, MethodInfo Method)>();
+        List<(Type Type, MethodInfo Method)> candidates = new();
 
         if (typeName is not null)
         {
@@ -77,7 +77,7 @@ internal sealed class MethodResolver(Assembly assembly)
                 // If the type is a generic type definition and we have class type params, try to construct it
                 if (type.IsGenericTypeDefinition && classTypeParams is not null)
                 {
-                    var typeParamCount = classTypeParams.Split(',').Length;
+                    int typeParamCount = classTypeParams.Split(',').Length;
                     if (type.GetGenericArguments().Length == typeParamCount)
                     {
                         Type? constructed = MakeGenericType(type, classTypeParams);
@@ -111,11 +111,11 @@ internal sealed class MethodResolver(Assembly assembly)
         // If type params are specified, filter to only methods with matching generic param count
         if (typeParams is not null)
         {
-            var genericParamCount = typeParams.Split(',').Length;
+            int genericParamCount = typeParams.Split(',').Length;
             if (verbose)
                 Console.Error.WriteLine($"[DEBUG] Looking for generic methods with {genericParamCount} type params");
 
-            var genericMatches = candidates.Where(c => c.Method.IsGenericMethodDefinition &&
+            List<(Type Type, MethodInfo Method)> genericMatches = candidates.Where(c => c.Method.IsGenericMethodDefinition &&
                 c.Method.GetGenericArguments().Length == genericParamCount).ToList();
 
             if (verbose)
@@ -129,7 +129,7 @@ internal sealed class MethodResolver(Assembly assembly)
         else
         {
             // Prefer non-generic methods if no type params specified
-            var nonGeneric = candidates.Where(c => !c.Method.IsGenericMethodDefinition).ToList();
+            List<(Type Type, MethodInfo Method)> nonGeneric = candidates.Where(c => !c.Method.IsGenericMethodDefinition).ToList();
             if (nonGeneric.Count > 0)
             {
                 candidates = nonGeneric;
@@ -158,8 +158,8 @@ internal sealed class MethodResolver(Assembly assembly)
 
     private Type? MakeGenericType(Type genericTypeDefinition, string classTypeParams)
     {
-        var typeNames = classTypeParams.Split(',', StringSplitOptions.TrimEntries);
-        var types = new Type[typeNames.Length];
+        string[] typeNames = classTypeParams.Split(',', StringSplitOptions.TrimEntries);
+        Type[] types = new Type[typeNames.Length];
 
         bool verbose = Environment.GetEnvironmentVariable("JITASM_VERBOSE") == "1";
 
@@ -228,7 +228,7 @@ internal sealed class MethodResolver(Assembly assembly)
         {
             if (t.FullName is not null && typeName.StartsWith(t.FullName + "+"))
             {
-                var nestedName = typeName[(t.FullName.Length + 1)..];
+                string nestedName = typeName[(t.FullName.Length + 1)..];
                 Type? nested = t.GetNestedType(nestedName, BindingFlags.Public | BindingFlags.NonPublic);
                 if (nested is not null) return nested;
             }
@@ -239,7 +239,7 @@ internal sealed class MethodResolver(Assembly assembly)
         {
             try
             {
-                var refAssembly = Assembly.Load(refName);
+                Assembly refAssembly = Assembly.Load(refName);
                 type = refAssembly.GetType(typeName);
                 if (type is not null) return type;
 
@@ -275,7 +275,7 @@ internal sealed class MethodResolver(Assembly assembly)
         }
 
         bool verbose = Environment.GetEnvironmentVariable("JITASM_VERBOSE") == "1";
-        var methods = type.GetMethods(flags).Where(m => m.Name == methodName).ToList();
+        List<MethodInfo> methods = type.GetMethods(flags).Where(m => m.Name == methodName).ToList();
         if (verbose)
         {
             Console.Error.WriteLine($"[DEBUG] FindMethods on {type.FullName} for '{methodName}': found {methods.Count} methods");
@@ -301,8 +301,8 @@ internal sealed class MethodResolver(Assembly assembly)
             return method;
         }
 
-        var typeNames = typeParams.Split(',', StringSplitOptions.TrimEntries);
-        var types = new Type[typeNames.Length];
+        string[] typeNames = typeParams.Split(',', StringSplitOptions.TrimEntries);
+        Type[] types = new Type[typeNames.Length];
 
         if (verbose)
             Console.Error.WriteLine($"[DEBUG] MakeGenericIfNeeded: resolving {typeNames.Length} type params: {string.Join(", ", typeNames)}");
@@ -353,7 +353,7 @@ internal sealed class MethodResolver(Assembly assembly)
         {
             try
             {
-                var refAssembly = Assembly.Load(refName);
+                Assembly refAssembly = Assembly.Load(refName);
                 type = refAssembly.GetType(typeName);
                 if (type is not null) return type;
 
@@ -383,7 +383,7 @@ internal sealed class MethodResolver(Assembly assembly)
             return [];
         }
 
-        var results = new List<MethodInfo>();
+        List<MethodInfo> results = new();
         foreach (Type type in assembly.GetTypes())
         {
             results.AddRange(FindMethods(type, methodName));

--- a/tools/JitAsm/Program.cs
+++ b/tools/JitAsm/Program.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.CommandLine;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
@@ -78,7 +79,7 @@ internal static class Program
 
     private static int RunCli(string[] args)
     {
-        var rootCommand = new RootCommand("JIT Assembly Disassembler - Generate JIT assembly output for .NET methods")
+        RootCommand rootCommand = new("JIT Assembly Disassembler - Generate JIT assembly output for .NET methods")
         {
             AssemblyOption,
             TypeOption,
@@ -96,15 +97,15 @@ internal static class Program
         rootCommand.SetAction(parseResult =>
         {
             FileInfo assembly = parseResult.GetValue(AssemblyOption)!;
-            var typeName = parseResult.GetValue(TypeOption);
-            var methodName = parseResult.GetValue(MethodOption)!;
-            var typeParams = parseResult.GetValue(TypeParamsOption);
-            var classTypeParams = parseResult.GetValue(ClassTypeParamsOption);
-            var skipCctor = parseResult.GetValue(SkipCctorOption);
-            var fullOpts = parseResult.GetValue(FullOptsOption);
-            var annotate = !parseResult.GetValue(NoAnnotateOption);
-            var arch = parseResult.GetValue(ArchOption)!;
-            var verbose = parseResult.GetValue(VerboseOption);
+            string? typeName = parseResult.GetValue(TypeOption);
+            string methodName = parseResult.GetValue(MethodOption)!;
+            string? typeParams = parseResult.GetValue(TypeParamsOption);
+            string? classTypeParams = parseResult.GetValue(ClassTypeParamsOption);
+            bool skipCctor = parseResult.GetValue(SkipCctorOption);
+            bool fullOpts = parseResult.GetValue(FullOptsOption);
+            bool annotate = !parseResult.GetValue(NoAnnotateOption);
+            string arch = parseResult.GetValue(ArchOption)!;
+            bool verbose = parseResult.GetValue(VerboseOption);
 
             exitCode = Execute(assembly, typeName, methodName, typeParams, classTypeParams, skipCctor, fullOpts, annotate, arch, verbose);
         });
@@ -142,7 +143,7 @@ internal static class Program
             AnsiConsole.WriteLine();
         }
 
-        var runner = new JitRunner(assembly.FullName, typeName, methodName, typeParams, classTypeParams, verbose, tier1);
+        JitRunner runner = new(assembly.FullName, typeName, methodName, typeParams, classTypeParams, verbose, tier1);
 
         InstructionDb? instructionDb = annotate ? LoadOrBuildInstructionDb(arch, verbose) : null;
 
@@ -171,7 +172,7 @@ internal static class Program
         if (verbose && result.DetectedCctors.Count > 0)
         {
             AnsiConsole.MarkupLine("[blue]Detected static constructors:[/]");
-            foreach (var cctor in result.DetectedCctors)
+            foreach (string cctor in result.DetectedCctors)
             {
                 AnsiConsole.MarkupLine($"  [grey]- {Markup.Escape(cctor)}[/]");
             }
@@ -221,7 +222,7 @@ internal static class Program
         {
             try
             {
-                var db = InstructionDb.Load(dbPath);
+                InstructionDb db = InstructionDb.Load(dbPath);
                 string targetArch = InstructionDbBuilder.ResolveArchName(arch);
                 if (db.ArchName == targetArch)
                 {
@@ -251,7 +252,7 @@ internal static class Program
         }
 
         AnsiConsole.MarkupLine($"[blue]Building instruction database for {arch}...[/]");
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
         InstructionDb builtDb = InstructionDbBuilder.Build(xmlPath, arch);
         stopwatch.Stop();
 
@@ -282,8 +283,8 @@ internal static class Program
             return 1;
         }
 
-        var assemblyPath = args[0];
-        var methodName = args[1];
+        string assemblyPath = args[0];
+        string methodName = args[1];
         string? typeName = null;
         string? typeParams = null;
         string? classTypeParams = null;
@@ -320,13 +321,13 @@ internal static class Program
         // Build assembly name → file path mapping from the deps.json file.
         // This resolves both project references (in the same directory) and
         // NuGet packages (from the global packages cache).
-        var assemblyDir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
+        string assemblyDir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
         Dictionary<string, string> assemblyMap = BuildAssemblyMap(assemblyPath, assemblyDir, verbose);
 
         AssemblyLoadContext.Default.Resolving += (context, name) =>
         {
             // First check the target assembly's directory
-            var localPath = Path.Combine(assemblyDir, name.Name + ".dll");
+            string localPath = Path.Combine(assemblyDir, name.Name + ".dll");
             if (File.Exists(localPath))
             {
                 if (verbose)
@@ -335,7 +336,7 @@ internal static class Program
             }
 
             // Then check deps.json mapped paths
-            if (assemblyMap.TryGetValue(name.Name!, out var mappedPath) && File.Exists(mappedPath))
+            if (assemblyMap.TryGetValue(name.Name!, out string? mappedPath) && File.Exists(mappedPath))
             {
                 if (verbose)
                     Console.Error.WriteLine($"[DEBUG] AssemblyResolve: {name.Name} → {mappedPath} (deps.json)");
@@ -361,7 +362,7 @@ internal static class Program
             }
 
             // Initialize static constructors if requested
-            foreach (var cctorTypeName in cctorsToInit)
+            foreach (string cctorTypeName in cctorsToInit)
             {
                 Type? cctorType = ResolveType(assembly, cctorTypeName, verbose);
                 if (cctorType is not null)
@@ -377,7 +378,7 @@ internal static class Program
             }
 
             // Resolve the method
-            var resolver = new MethodResolver(assembly);
+            MethodResolver resolver = new(assembly);
             MethodInfo? method = resolver.ResolveMethod(typeName, methodName, typeParams, classTypeParams);
 
             if (method is null)
@@ -394,7 +395,7 @@ internal static class Program
             if (tier1)
             {
                 ParameterInfo[] parameters = method.GetParameters();
-                var invokeArgs = new object?[parameters.Length];
+                object?[] invokeArgs = new object?[parameters.Length];
                 object? target = method.IsStatic ? null : TryCreateInstance(method.DeclaringType!);
 
                 void InvokeN(int count)
@@ -431,7 +432,7 @@ internal static class Program
                 // PrepareMethod alone may not trigger DOTNET_JitDisasm output for
                 // methods from dynamically loaded assemblies.
                 ParameterInfo[] parameters = method.GetParameters();
-                var invokeArgs = new object?[parameters.Length];
+                object?[] invokeArgs = new object?[parameters.Length];
                 object? target = method.IsStatic ? null : TryCreateInstance(method.DeclaringType!);
                 try { method.Invoke(target, invokeArgs); }
                 catch { /* Expected - args are null/default */ }
@@ -481,7 +482,7 @@ internal static class Program
         {
             try
             {
-                var refAssembly = Assembly.Load(refName);
+                Assembly refAssembly = Assembly.Load(refName);
                 type = refAssembly.GetType(typeName);
                 if (type is not null)
                 {
@@ -517,7 +518,7 @@ internal static class Program
     /// </summary>
     private static Dictionary<string, string> BuildAssemblyMap(string assemblyPath, string assemblyDir, bool verbose)
     {
-        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> map = new(StringComparer.OrdinalIgnoreCase);
         string depsPath = Path.ChangeExtension(assemblyPath, ".deps.json");
         if (!File.Exists(depsPath))
             return map;
@@ -528,7 +529,7 @@ internal static class Program
         try
         {
             using FileStream stream = File.OpenRead(depsPath);
-            using var doc = JsonDocument.Parse(stream);
+            using JsonDocument doc = JsonDocument.Parse(stream);
 
             JsonElement root = doc.RootElement;
             if (!root.TryGetProperty("targets", out JsonElement targets))

--- a/tools/JitAsm/StaticCtorDetector.cs
+++ b/tools/JitAsm/StaticCtorDetector.cs
@@ -43,12 +43,12 @@ internal static partial class StaticCtorDetector
 
     public static IReadOnlyList<string> DetectStaticCtors(string disassemblyOutput)
     {
-        var detectedTypes = new HashSet<string>(StringComparer.Ordinal);
+        HashSet<string> detectedTypes = new(StringComparer.Ordinal);
 
         // Detect direct .cctor calls
         foreach (Match match in CctorCallPattern().Matches(disassemblyOutput))
         {
-            var typeName = NormalizeTypeName(match.Groups["type"].Value);
+            string typeName = NormalizeTypeName(match.Groups["type"].Value);
             if (!string.IsNullOrEmpty(typeName))
             {
                 detectedTypes.Add(typeName);
@@ -61,7 +61,7 @@ internal static partial class StaticCtorDetector
             int typesBeforeHelperScan = detectedTypes.Count;
 
             // Look for type references near the helper calls (±3 lines)
-            var lines = disassemblyOutput.Split('\n');
+            string[] lines = disassemblyOutput.Split('\n');
             for (int i = 0; i < lines.Length; i++)
             {
                 if (StaticHelperPattern().IsMatch(lines[i]))
@@ -72,7 +72,7 @@ internal static partial class StaticCtorDetector
                         Match typeMatch = TypeCommentPattern().Match(lines[j]);
                         if (typeMatch.Success)
                         {
-                            var typeName = NormalizeTypeName(typeMatch.Groups["type"].Value);
+                            string typeName = NormalizeTypeName(typeMatch.Groups["type"].Value);
                             if (!string.IsNullOrEmpty(typeName) && IsValidTypeName(typeName))
                             {
                                 detectedTypes.Add(typeName);
@@ -82,7 +82,7 @@ internal static partial class StaticCtorDetector
                         Match fieldMatch = StaticFieldAccessPattern().Match(lines[j]);
                         if (fieldMatch.Success)
                         {
-                            var typeName = NormalizeTypeName(fieldMatch.Groups["type"].Value);
+                            string typeName = NormalizeTypeName(fieldMatch.Groups["type"].Value);
                             if (!string.IsNullOrEmpty(typeName) && IsValidTypeName(typeName))
                             {
                                 detectedTypes.Add(typeName);
@@ -103,14 +103,14 @@ internal static partial class StaticCtorDetector
             {
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    var line = lines[i];
+                    string line = lines[i];
                     // Check current line and continuation lines after bare "call" instructions
                     if (line.TrimStart().StartsWith("call") || (i > 0 && lines[i - 1].TrimEnd().EndsWith("call")))
                     {
                         Match callMatch = CallTargetTypePattern().Match(line);
                         if (callMatch.Success)
                         {
-                            var typeName = NormalizeTypeName(callMatch.Groups["type"].Value);
+                            string typeName = NormalizeTypeName(callMatch.Groups["type"].Value);
                             if (!string.IsNullOrEmpty(typeName) && IsValidTypeName(typeName))
                             {
                                 detectedTypes.Add(typeName);
@@ -121,7 +121,7 @@ internal static partial class StaticCtorDetector
             }
         }
 
-        var result = new List<string>(detectedTypes);
+        List<string> result = new(detectedTypes);
         result.Sort(StringComparer.Ordinal);
         return result;
     }
@@ -129,11 +129,11 @@ internal static partial class StaticCtorDetector
     private static string NormalizeTypeName(string typeName)
     {
         // Remove generic arity suffix if present (e.g., `1, `2)
-        var tickIndex = typeName.IndexOf('`');
+        int tickIndex = typeName.IndexOf('`');
         if (tickIndex > 0)
         {
             // Keep up to and including the backtick and number for proper type resolution
-            var endIndex = tickIndex + 1;
+            int endIndex = tickIndex + 1;
             while (endIndex < typeName.Length && char.IsDigit(typeName[endIndex]))
             {
                 endIndex++;
@@ -163,7 +163,7 @@ internal static partial class StaticCtorDetector
             return false;
 
         // Should not be just a keyword or register name
-        var lowered = typeName.ToLowerInvariant();
+        string lowered = typeName.ToLowerInvariant();
         string[] invalidNames = ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rsp", "rbp",
                                  "eax", "ebx", "ecx", "edx", "esi", "edi", "esp", "ebp",
                                  "ptr", "dword", "qword", "byte", "word"];

--- a/tools/Kute/Nethermind.Tools.Kute.Test/ApplicationTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/ApplicationTests.cs
@@ -49,7 +49,7 @@ public class ApplicationTests
 
     private static IMessageProvider<string> LinesProvider(string lines)
     {
-        var stringProvider = Substitute.For<IMessageProvider<string>>();
+        IMessageProvider<string> stringProvider = Substitute.For<IMessageProvider<string>>();
         stringProvider.Messages().Returns(lines.Split('\n').ToAsyncEnumerable());
 
         return stringProvider;
@@ -57,11 +57,11 @@ public class ApplicationTests
 
     private static IJsonRpcSubmitter ConstantSubmitter(string jsonResponse)
     {
-        var submitter = Substitute.For<IJsonRpcSubmitter>();
+        IJsonRpcSubmitter submitter = Substitute.For<IJsonRpcSubmitter>();
         submitter.Submit(Arg.Any<JsonRpc.Request>()).Returns(async (_) =>
         {
-            var content = new StringContent(jsonResponse, System.Text.Encoding.UTF8, "application/json");
-            var httpResponse = new HttpResponseMessage { Content = content };
+            StringContent content = new(jsonResponse, System.Text.Encoding.UTF8, "application/json");
+            HttpResponseMessage httpResponse = new() { Content = content };
             return await JsonRpc.Response.FromHttpResponseAsync(httpResponse);
         });
 
@@ -70,7 +70,7 @@ public class ApplicationTests
 
     private static IJsonRpcMethodFilter ConstantFilter(bool shouldSubmit)
     {
-        var filter = Substitute.For<IJsonRpcMethodFilter>();
+        IJsonRpcMethodFilter filter = Substitute.For<IJsonRpcMethodFilter>();
         filter.ShouldSubmit(Arg.Any<string>()).Returns(shouldSubmit);
         return filter;
     }
@@ -84,14 +84,14 @@ public class ApplicationTests
     [TestCaseSource(nameof(Processors))]
     public async Task NoFiltering(IAsyncProcessor processor)
     {
-        var messageProvider = new JsonRpcMessageProvider(LinesProvider(TestInput));
-        var jsonRpcSubmitter = ConstantSubmitter(ResponseOK);
-        var validator = new ComposedJsonRpcValidator([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
-        var responseTracer = Substitute.For<IResponseTracer>();
-        var reporter = Substitute.For<IMetricsReporter>();
-        var filter = ConstantFilter(shouldSubmit: true);
+        JsonRpcMessageProvider messageProvider = new(LinesProvider(TestInput));
+        IJsonRpcSubmitter jsonRpcSubmitter = ConstantSubmitter(ResponseOK);
+        ComposedJsonRpcValidator validator = new([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
+        IResponseTracer responseTracer = Substitute.For<IResponseTracer>();
+        IMetricsReporter reporter = Substitute.For<IMetricsReporter>();
+        IJsonRpcMethodFilter filter = ConstantFilter(shouldSubmit: true);
 
-        var app = new Application(
+        Application app = new(
             processor,
             messageProvider,
             jsonRpcSubmitter,
@@ -113,14 +113,14 @@ public class ApplicationTests
     [TestCaseSource(nameof(Processors))]
     public async Task NoFiltering_UnwrapBatches(IAsyncProcessor processor)
     {
-        var messageProvider = new UnwrapBatchJsonRpcMessageProvider(new JsonRpcMessageProvider(LinesProvider(TestInput)));
-        var jsonRpcSubmitter = ConstantSubmitter(ResponseOK);
-        var validator = new ComposedJsonRpcValidator([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
-        var responseTracer = Substitute.For<IResponseTracer>();
-        var reporter = Substitute.For<IMetricsReporter>();
-        var filter = ConstantFilter(shouldSubmit: true);
+        UnwrapBatchJsonRpcMessageProvider messageProvider = new(new JsonRpcMessageProvider(LinesProvider(TestInput)));
+        IJsonRpcSubmitter jsonRpcSubmitter = ConstantSubmitter(ResponseOK);
+        ComposedJsonRpcValidator validator = new([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
+        IResponseTracer responseTracer = Substitute.For<IResponseTracer>();
+        IMetricsReporter reporter = Substitute.For<IMetricsReporter>();
+        IJsonRpcMethodFilter filter = ConstantFilter(shouldSubmit: true);
 
-        var app = new Application(
+        Application app = new(
             processor,
             messageProvider,
             jsonRpcSubmitter,
@@ -148,14 +148,14 @@ public class ApplicationTests
         [{"method": "eth_getBlockByNumber"}, {"method": "engine_exchangeCapabilities"}]
         """;
 
-        var messageProvider = new JsonRpcMessageProvider(LinesProvider(lines));
-        var jsonRpcSubmitter = ConstantSubmitter(ResponseError);
-        var validator = new ComposedJsonRpcValidator([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
-        var responseTracer = Substitute.For<IResponseTracer>();
-        var reporter = Substitute.For<IMetricsReporter>();
-        var filter = new ComposedJsonRpcMethodFilter([new PatternJsonRpcMethodFilter("eth_.*")]);
+        JsonRpcMessageProvider messageProvider = new(LinesProvider(lines));
+        IJsonRpcSubmitter jsonRpcSubmitter = ConstantSubmitter(ResponseError);
+        ComposedJsonRpcValidator validator = new([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
+        IResponseTracer responseTracer = Substitute.For<IResponseTracer>();
+        IMetricsReporter reporter = Substitute.For<IMetricsReporter>();
+        ComposedJsonRpcMethodFilter filter = new([new PatternJsonRpcMethodFilter("eth_.*")]);
 
-        var app = new Application(
+        Application app = new(
             processor,
             messageProvider,
             jsonRpcSubmitter,
@@ -182,14 +182,14 @@ public class ApplicationTests
         [{"method": "eth_getBlockByNumber"}, {"method": "engine_exchangeCapabilities"}]
         """;
 
-        var messageProvider = new UnwrapBatchJsonRpcMessageProvider(new JsonRpcMessageProvider(LinesProvider(lines)));
-        var jsonRpcSubmitter = ConstantSubmitter(ResponseError);
-        var validator = new ComposedJsonRpcValidator([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
-        var responseTracer = Substitute.For<IResponseTracer>();
-        var reporter = Substitute.For<IMetricsReporter>();
-        var filter = new ComposedJsonRpcMethodFilter([new PatternJsonRpcMethodFilter("engine_.*")]);
+        UnwrapBatchJsonRpcMessageProvider messageProvider = new(new JsonRpcMessageProvider(LinesProvider(lines)));
+        IJsonRpcSubmitter jsonRpcSubmitter = ConstantSubmitter(ResponseError);
+        ComposedJsonRpcValidator validator = new([new NonErrorJsonRpcValidator(), new NewPayloadJsonRpcValidator()]);
+        IResponseTracer responseTracer = Substitute.For<IResponseTracer>();
+        IMetricsReporter reporter = Substitute.For<IMetricsReporter>();
+        ComposedJsonRpcMethodFilter filter = new([new PatternJsonRpcMethodFilter("engine_.*")]);
 
-        var app = new Application(
+        Application app = new(
             processor,
             messageProvider,
             jsonRpcSubmitter,

--- a/tools/Kute/Nethermind.Tools.Kute.Test/AsyncProcessorTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/AsyncProcessorTests.cs
@@ -12,12 +12,12 @@ public class AsyncProcessorTests
     [Test]
     public async Task SequentialProcessor_SequentialTasks()
     {
-        var processor = new SequentialProcessor();
+        SequentialProcessor processor = new();
         int taskCount = 4;
-        var source = Enumerable.Range(1, taskCount).ToAsyncEnumerable();
+        IAsyncEnumerable<int> source = Enumerable.Range(1, taskCount).ToAsyncEnumerable();
 
         int counter = 0;
-        var t = new Timer();
+        Timer t = new();
         using (t.Time())
         {
             await processor.Process(source, async (item) =>
@@ -35,12 +35,12 @@ public class AsyncProcessorTests
     [Test]
     public async Task ConcurrentProcessor_ConcurrentTasks()
     {
-        var processor = new ConcurrentProcessor(maxDegreeOfParallelism: 5);
+        ConcurrentProcessor processor = new(maxDegreeOfParallelism: 5);
         int taskCount = 10;
-        var source = Enumerable.Range(1, taskCount).ToAsyncEnumerable();
+        IAsyncEnumerable<int> source = Enumerable.Range(1, taskCount).ToAsyncEnumerable();
 
         int counter = 0;
-        var t = new Timer();
+        Timer t = new();
         using (t.Time())
         {
             await processor.Process(source, async (item) =>

--- a/tools/Kute/Nethermind.Tools.Kute.Test/AuthTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/AuthTests.cs
@@ -15,12 +15,12 @@ public class AuthTests
     [Test]
     public void CreateValidJWT()
     {
-        var clock = Substitute.For<ISystemClock>();
+        ISystemClock clock = Substitute.For<ISystemClock>();
         clock.UtcNow.Returns(DateTimeOffset.UnixEpoch);
-        var secretProvider = Substitute.For<ISecretProvider>();
+        ISecretProvider secretProvider = Substitute.For<ISecretProvider>();
         secretProvider.Secret.Returns("11ade2f6d95da8d71515d8c446d2a9cfbaefd1de40d78ccbea5c49315dc30237");
 
-        var auth = new JwtAuth(clock, secretProvider);
+        JwtAuth auth = new(clock, secretProvider);
         string token = auth.AuthToken;
 
         token.Should().BeEquivalentTo("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjB9.tWzIC8uadmVRHxZrv1TK57PyW95hmGrS0PgsV7FiFvw");
@@ -29,14 +29,14 @@ public class AuthTests
     [Test]
     public void RefreshAuthAfterTTL()
     {
-        var clock = Substitute.For<ISystemClock>();
-        var secretProvider = Substitute.For<ISecretProvider>();
+        ISystemClock clock = Substitute.For<ISystemClock>();
+        ISecretProvider secretProvider = Substitute.For<ISecretProvider>();
         secretProvider.Secret.Returns("11ade2f6d95da8d71515d8c446d2a9cfbaefd1de40d78ccbea5c49315dc30237");
 
-        var initialTime = DateTimeOffset.UnixEpoch;
-        var ttl = TimeSpan.FromSeconds(10);
+        DateTimeOffset initialTime = DateTimeOffset.UnixEpoch;
+        TimeSpan ttl = TimeSpan.FromSeconds(10);
 
-        var auth = new TtlAuth(new JwtAuth(clock, secretProvider), clock, ttl);
+        TtlAuth auth = new(new JwtAuth(clock, secretProvider), clock, ttl);
 
         // Initial time
         {

--- a/tools/Kute/Nethermind.Tools.Kute.Test/JsonRpcFilterTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/JsonRpcFilterTests.cs
@@ -40,7 +40,7 @@ public class JsonRpcFilterTests
     [TestCaseSource(nameof(UnlimitedMethodTestCases))]
     public void AcceptsUnlimitedMethods(List<string> patterns, List<string> methodsNames)
     {
-        var filter = CreateFilter(patterns);
+        IJsonRpcMethodFilter filter = CreateFilter(patterns);
 
         foreach (string methodName in methodsNames)
         {
@@ -74,7 +74,7 @@ public class JsonRpcFilterTests
     [TestCaseSource(nameof(UnlimitedMethodNegativeTestCases))]
     public void RejectsUnlimitedMethods(List<string> patterns, List<string> methodsNames)
     {
-        var filter = CreateFilter(patterns);
+        IJsonRpcMethodFilter filter = CreateFilter(patterns);
 
         foreach (string methodName in methodsNames)
         {
@@ -112,7 +112,7 @@ public class JsonRpcFilterTests
     [TestCaseSource(nameof(LimitedMethodTestCases))]
     public void AcceptsLimitedMethods(List<string> patterns, string methodName, int count)
     {
-        var filter = CreateFilter(patterns);
+        IJsonRpcMethodFilter filter = CreateFilter(patterns);
 
         for (int i = 0; i < count; i++)
         {
@@ -123,7 +123,5 @@ public class JsonRpcFilterTests
 
     private static IJsonRpcMethodFilter CreateFilter(IEnumerable<string> patterns) =>
         new ComposedJsonRpcMethodFilter(
-            patterns
-                .Select(pattern => new PatternJsonRpcMethodFilter(pattern) as IJsonRpcMethodFilter)
-                .ToList());
+            [.. patterns.Select(pattern => new PatternJsonRpcMethodFilter(pattern) as IJsonRpcMethodFilter)]);
 }

--- a/tools/Kute/Nethermind.Tools.Kute.Test/JsonRpcValidatorTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/JsonRpcValidatorTests.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Tools.Kute.Test;
 
 public class JsonRpcValidatorTests
 {
-    private static IJsonRpcValidator _validator =
+    private static readonly IJsonRpcValidator _validator =
         new BatchJsonRpcValidator(
             new ComposedJsonRpcValidator(
                 new NonErrorJsonRpcValidator(),
@@ -21,7 +21,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_ResponseHasError()
     {
-        var response = CreateErrorResponse();
+        JsonRpc.Response response = CreateErrorResponse();
         bool result = _validator.IsValid(CreateSingleRequest("eth_getBlockByNumber"), response);
 
         result.Should().BeFalse();
@@ -30,7 +30,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsValid_When_MethodNameIsNull()
     {
-        var response = CreateResponse(status: Status.VALID);
+        JsonRpc.Response response = CreateResponse(status: Status.VALID);
         bool result = _validator.IsValid(CreateSingleRequest(null), response);
 
         result.Should().BeTrue();
@@ -39,7 +39,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsValid_When_MethodNameIsUnexpected()
     {
-        var response = CreateResponse(status: Status.VALID);
+        JsonRpc.Response response = CreateResponse(status: Status.VALID);
         bool result = _validator.IsValid(CreateSingleRequest("eth_getBlockByNumber"), response);
 
         result.Should().BeTrue();
@@ -48,9 +48,9 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsValid_NotNewPayload_When_ResponseHasNoError()
     {
-        foreach (var status in new[] { Status.VALID, Status.INVALID })
+        foreach (Status status in new[] { Status.VALID, Status.INVALID })
         {
-            var response = CreateResponse(status);
+            JsonRpc.Response response = CreateResponse(status);
             bool result = _validator.IsValid(CreateSingleRequest("eth_getBlockByNumber"), response);
 
             result.Should().BeTrue();
@@ -60,11 +60,11 @@ public class JsonRpcValidatorTests
     [Test]
     public void Validates_NewPayload_When_ResponseIsNotNull()
     {
-        foreach (var status in new[] { Status.VALID, Status.INVALID })
+        foreach (Status status in new[] { Status.VALID, Status.INVALID })
         {
             foreach (string? methodName in new[] { "engine_newPayloadV2", "engine_newPayloadV3", "engine_newPayloadV4" })
             {
-                var response = CreateResponse(status);
+                JsonRpc.Response response = CreateResponse(status);
                 bool result = _validator.IsValid(CreateSingleRequest(methodName), response);
 
                 result.Should().Be(status == Status.VALID);
@@ -75,7 +75,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsValid_When_AllBatchItemsAreValid()
     {
-        var response = CreateBatchResponse(CreateResponse(status: Status.VALID));
+        JsonRpc.Response response = CreateBatchResponse(CreateResponse(status: Status.VALID));
         bool result = _validator.IsValid(CreateBatchRequest(CreateSingleRequest("engine_newPayload")), response);
 
         result.Should().BeTrue();
@@ -84,7 +84,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_BatchResponseContainsInvalid()
     {
-        var response = CreateBatchResponse(CreateResponse(status: Status.INVALID));
+        JsonRpc.Response response = CreateBatchResponse(CreateResponse(status: Status.INVALID));
         bool result = _validator.IsValid(CreateBatchRequest(CreateSingleRequest("engine_newPayload")), response);
 
         result.Should().BeFalse();
@@ -93,7 +93,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_BatchHasMissingResponses()
     {
-        var response = CreateBatchResponse(CreateResponse(status: Status.VALID, 1));
+        JsonRpc.Response response = CreateBatchResponse(CreateResponse(status: Status.VALID, 1));
         bool result = _validator.IsValid(
             CreateBatchRequest(CreateSingleRequest("engine_newPayload", 1), CreateSingleRequest("eth_logs", 2)), response);
 
@@ -103,7 +103,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_BatchHasExtraResponses()
     {
-        var response = CreateBatchResponse(CreateResponse(status: Status.VALID, 1), CreateResponse(status: Status.VALID, 2));
+        JsonRpc.Response response = CreateBatchResponse(CreateResponse(status: Status.VALID, 1), CreateResponse(status: Status.VALID, 2));
         bool result = _validator.IsValid(CreateBatchRequest(CreateSingleRequest("engine_newPayload", 1)), response);
 
         result.Should().BeFalse();
@@ -112,7 +112,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_BatchHasMismatchedPairs()
     {
-        var response = CreateBatchResponse(CreateResponse(status: Status.VALID, 2));
+        JsonRpc.Response response = CreateBatchResponse(CreateResponse(status: Status.VALID, 2));
         bool result = _validator.IsValid(CreateBatchRequest(CreateSingleRequest("engine_newPayload", 1)), response);
 
         result.Should().BeFalse();
@@ -121,7 +121,7 @@ public class JsonRpcValidatorTests
     [Test]
     public void IsInvalid_When_BatchHasSingleResponse()
     {
-        var response = CreateResponse(status: Status.VALID, 1);
+        JsonRpc.Response response = CreateResponse(status: Status.VALID, 1);
         bool result = _validator.IsValid(CreateBatchRequest(CreateSingleRequest("engine_newPayload", 1)), response);
 
         result.Should().BeFalse();
@@ -139,8 +139,8 @@ public class JsonRpcValidatorTests
 
     private static JsonRpc.Request.Batch CreateBatchRequest(params IEnumerable<JsonRpc.Request> items)
     {
-        var sb = new StringBuilder("[");
-        foreach (var item in items)
+        StringBuilder sb = new("[");
+        foreach (JsonRpc.Request item in items)
         {
             sb.Append(item.ToJsonString()).Append(',');
         }
@@ -158,18 +158,15 @@ public class JsonRpcValidatorTests
         INVALID
     }
 
-    private static JsonRpc.Response CreateResponse(Status status, int id = 1)
-    {
-        return new JsonRpc.Response(
+    private static JsonRpc.Response CreateResponse(Status status, int id = 1) => new(
             JsonNode.Parse(
                 $$$"""{"jsonrpc":"2.0","id": {{{id}}},"result":{"status": "{{{status}}}"}}"""
         )!);
-    }
 
     private static JsonRpc.Response CreateBatchResponse(params IEnumerable<JsonRpc.Response> items)
     {
-        var sb = new StringBuilder("[");
-        foreach (var item in items)
+        StringBuilder sb = new("[");
+        foreach (JsonRpc.Response item in items)
         {
             sb.Append(item.ToJsonString()).Append(',');
         }
@@ -181,11 +178,8 @@ public class JsonRpcValidatorTests
         return new JsonRpc.Response(JsonNode.Parse(json)!);
     }
 
-    private static JsonRpc.Response CreateErrorResponse()
-    {
-        return new JsonRpc.Response(
+    private static JsonRpc.Response CreateErrorResponse() => new(
             JsonNode.Parse(
                 """{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error"}}"""
         )!);
-    }
 }

--- a/tools/Kute/Nethermind.Tools.Kute.Test/MessageProviderTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/MessageProviderTests.cs
@@ -19,11 +19,11 @@ public class MessageProviderTests
         [{"jsonrpc":"2.0","id":3,"result":"0x456"},{"jsonrpc":"2.0","id":4,"error":{"code":-32602,"message":"Invalid params"}}]
         """;
 
-        var stringProvider = Substitute.For<IMessageProvider<string>>();
+        IMessageProvider<string> stringProvider = Substitute.For<IMessageProvider<string>>();
         stringProvider.Messages().Returns(lines.Split('\n').ToAsyncEnumerable());
 
-        var provider = new JsonRpcMessageProvider(stringProvider);
-        var jsonRpcs = await provider.Messages().ToListAsync();
+        JsonRpcMessageProvider provider = new(stringProvider);
+        List<JsonRpc> jsonRpcs = await provider.Messages().ToListAsync();
 
         jsonRpcs.Should().HaveCount(3);
         jsonRpcs[0].Should().BeOfType<JsonRpc.Request.Single>();
@@ -39,11 +39,11 @@ public class MessageProviderTests
         [{"jsonrpc":"2.0","id":1,"result":"0x123"},{"jsonrpc":"2.0","id":2,"result":"0x456"}]
         """;
 
-        var stringProvider = Substitute.For<IMessageProvider<string>>();
+        IMessageProvider<string> stringProvider = Substitute.For<IMessageProvider<string>>();
         stringProvider.Messages().Returns(lines.Split('\n').ToAsyncEnumerable());
 
-        var provider = new UnwrapBatchJsonRpcMessageProvider(new JsonRpcMessageProvider(stringProvider));
-        var jsonRpcs = await provider.Messages().ToListAsync();
+        UnwrapBatchJsonRpcMessageProvider provider = new(new JsonRpcMessageProvider(stringProvider));
+        List<JsonRpc> jsonRpcs = await provider.Messages().ToListAsync();
 
         jsonRpcs.Should().HaveCount(3);
         jsonRpcs[0].Should().BeOfType<JsonRpc.Request.Single>();

--- a/tools/Kute/Nethermind.Tools.Kute.Test/MetricsTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/MetricsTests.cs
@@ -26,22 +26,22 @@ public class MetricsTests
     [Test]
     public async Task MemoryMetricsReporter_GeneratesValidReport()
     {
-        var reporter = new MemoryMetricsReporter();
+        MemoryMetricsReporter reporter = new();
 
-        var totalTimer = new Timer();
+        Timer totalTimer = new();
         using (totalTimer.Time())
         {
-            var single = Single(42, "method1");
-            var batch = Batch(Single(43), Single(44), Single(45));
+            JsonRpc.Request.Single single = Single(42, "method1");
+            JsonRpc.Request.Batch batch = Batch(Single(43), Single(44), Single(45));
 
-            var singleTimer = new Timer();
+            Timer singleTimer = new();
             using (singleTimer.Time())
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(50));
             }
             await reporter.Single(single, singleTimer.Elapsed);
 
-            var batchTimer = new Timer();
+            Timer batchTimer = new();
             using (batchTimer.Time())
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(50));
@@ -51,7 +51,7 @@ public class MetricsTests
 
         await reporter.Total(totalTimer.Elapsed);
 
-        var report = reporter.Report();
+        MetricsReport report = reporter.Report();
 
         report.TotalTime.Should().BeGreaterThan(TimeSpan.FromMilliseconds(90));
         report.TotalTime.Should().BeLessThan(TimeSpan.FromMilliseconds(110));
@@ -68,11 +68,11 @@ public class MetricsTests
     [Test]
     public async Task ComposedMetricsReporter_DelegatesToAllReporters()
     {
-        var A = Substitute.For<IMetricsReporter>();
-        var B = Substitute.For<IMetricsReporter>();
-        var single = Single(1);
-        var batch = Batch(Single(2), Single(3));
-        var reporter = new ComposedMetricsReporter(A, B);
+        IMetricsReporter A = Substitute.For<IMetricsReporter>();
+        IMetricsReporter B = Substitute.For<IMetricsReporter>();
+        JsonRpc.Request.Single single = Single(1);
+        JsonRpc.Request.Batch batch = Batch(Single(2), Single(3));
+        ComposedMetricsReporter reporter = new(A, B);
 
         await reporter.Message();
         await reporter.Response();

--- a/tools/Kute/Nethermind.Tools.Kute.Test/TimerTests.cs
+++ b/tools/Kute/Nethermind.Tools.Kute.Test/TimerTests.cs
@@ -11,7 +11,7 @@ public class TimerTests
     [Test]
     public async Task Timer_ComputesElapsedTime()
     {
-        var t = new Timer();
+        Timer t = new();
         using (t.Time())
         {
             await Task.Delay(TimeSpan.FromMilliseconds(100));
@@ -24,7 +24,7 @@ public class TimerTests
     [Test]
     public async Task Timer_AddsAllElapsedTimes()
     {
-        var t = new Timer();
+        Timer t = new();
         using (t.Time())
         {
             await Task.Delay(TimeSpan.FromMilliseconds(50));
@@ -41,7 +41,7 @@ public class TimerTests
     [Test]
     public async Task Timer_IgnoresTimeOutsideOfUsing()
     {
-        var t = new Timer();
+        Timer t = new();
         using (t.Time())
         {
             await Task.Delay(TimeSpan.FromMilliseconds(50));

--- a/tools/Kute/Nethermind.Tools.Kute/Application.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Application.cs
@@ -11,38 +11,27 @@ using Nethermind.Tools.Kute.AsyncProcessor;
 
 namespace Nethermind.Tools.Kute;
 
-public sealed class Application
-{
-    private readonly IAsyncProcessor _processor;
-    private readonly IMessageProvider<JsonRpc> _msgProvider;
-    private readonly IJsonRpcSubmitter _submitter;
-    private readonly IJsonRpcValidator _validator;
-    private readonly IResponseTracer _responseTracer;
-    private readonly IMetricsReporter _reporter;
-    private readonly IJsonRpcMethodFilter _methodFilter;
-
-    public Application(
-        IAsyncProcessor processor,
-        IMessageProvider<JsonRpc> msgProvider,
-        IJsonRpcSubmitter submitter,
-        IJsonRpcValidator validator,
-        IResponseTracer responseTracer,
-        IMetricsReporter reporter,
-        IJsonRpcMethodFilter methodFilter
+public sealed class Application(
+    IAsyncProcessor processor,
+    IMessageProvider<JsonRpc> msgProvider,
+    IJsonRpcSubmitter submitter,
+    IJsonRpcValidator validator,
+    IResponseTracer responseTracer,
+    IMetricsReporter reporter,
+    IJsonRpcMethodFilter methodFilter
     )
-    {
-        _processor = processor;
-        _msgProvider = msgProvider;
-        _submitter = submitter;
-        _validator = validator;
-        _responseTracer = responseTracer;
-        _reporter = reporter;
-        _methodFilter = methodFilter;
-    }
+{
+    private readonly IAsyncProcessor _processor = processor;
+    private readonly IMessageProvider<JsonRpc> _msgProvider = msgProvider;
+    private readonly IJsonRpcSubmitter _submitter = submitter;
+    private readonly IJsonRpcValidator _validator = validator;
+    private readonly IResponseTracer _responseTracer = responseTracer;
+    private readonly IMetricsReporter _reporter = reporter;
+    private readonly IJsonRpcMethodFilter _methodFilter = methodFilter;
 
     public async Task Run(CancellationToken token = default)
     {
-        var totalTimer = new Timer();
+        Timer totalTimer = new();
         using (totalTimer.Time())
         {
             await _processor.Process(_msgProvider.Messages(token), async jsonRpc =>
@@ -69,7 +58,7 @@ public sealed class Application
                 {
                     JsonRpc.Response response;
 
-                    var timer = new Timer();
+                    Timer timer = new();
                     using (timer.Time())
                     {
                         response = await _submitter.Submit(batch, token);
@@ -104,7 +93,7 @@ public sealed class Application
 
                     JsonRpc.Response response;
 
-                    var timer = new Timer();
+                    Timer timer = new();
                     using (timer.Time())
                     {
                         response = await _submitter.Submit(single, token);

--- a/tools/Kute/Nethermind.Tools.Kute/AsyncProcessor/ConcurrentProcessor.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/AsyncProcessor/ConcurrentProcessor.cs
@@ -3,20 +3,15 @@
 
 namespace Nethermind.Tools.Kute.AsyncProcessor;
 
-public sealed class ConcurrentProcessor : IAsyncProcessor
+public sealed class ConcurrentProcessor(int maxDegreeOfParallelism) : IAsyncProcessor
 {
-    private readonly int _maxDegreeOfParallelism;
-
-    public ConcurrentProcessor(int maxDegreeOfParallelism)
-    {
-        _maxDegreeOfParallelism = maxDegreeOfParallelism;
-    }
+    private readonly int _maxDegreeOfParallelism = maxDegreeOfParallelism;
 
     public async Task Process<T>(IAsyncEnumerable<T> source, Func<T, Task> process, CancellationToken token = default)
     {
-        var tasks = new List<Task>();
-        var semaphore = new SemaphoreSlim(_maxDegreeOfParallelism);
-        await foreach (var t in source)
+        List<Task> tasks = new();
+        SemaphoreSlim semaphore = new(_maxDegreeOfParallelism);
+        await foreach (T? t in source)
         {
             await semaphore.WaitAsync(token);
             tasks.Add(Task.Run(async () =>

--- a/tools/Kute/Nethermind.Tools.Kute/AsyncProcessor/SequentialProcessor.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/AsyncProcessor/SequentialProcessor.cs
@@ -7,7 +7,7 @@ public sealed class SequentialProcessor : IAsyncProcessor
 {
     public async Task Process<T>(IAsyncEnumerable<T> source, Func<T, Task> process, CancellationToken token = default)
     {
-        await foreach (var t in source)
+        await foreach (T? t in source)
         {
             await process(t);
         }

--- a/tools/Kute/Nethermind.Tools.Kute/Auth/JwtAuth.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Auth/JwtAuth.cs
@@ -23,15 +23,14 @@ public sealed class JwtAuth : IAuth
         _clock = clock;
 
         string hexSecret = secretProvider.Secret;
-        _key = new(Enumerable.Range(0, hexSecret.Length)
+        _key = new([.. Enumerable.Range(0, hexSecret.Length)
             .Where(x => x % 2 == 0)
-            .Select(x => Convert.ToByte(hexSecret.Substring(x, 2), 16))
-            .ToArray());
+            .Select(x => Convert.ToByte(hexSecret.Substring(x, 2), 16))]);
     }
 
     private string GenerateAuthToken()
     {
-        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        JsonWebTokenHandler handler = new() { SetDefaultTimesOnTokenCreation = false };
 
         return handler.CreateToken(new SecurityTokenDescriptor
         {

--- a/tools/Kute/Nethermind.Tools.Kute/Auth/TtlAuth.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Auth/TtlAuth.cs
@@ -5,20 +5,13 @@ using Nethermind.Tools.Kute.SystemClock;
 
 namespace Nethermind.Tools.Kute.Auth;
 
-public sealed class TtlAuth : IAuth
+public sealed class TtlAuth(IAuth auth, ISystemClock clock, TimeSpan ttl) : IAuth
 {
-    private readonly IAuth _auth;
-    private readonly ISystemClock _clock;
-    private readonly TimeSpan _ttl;
+    private readonly IAuth _auth = auth;
+    private readonly ISystemClock _clock = clock;
+    private readonly TimeSpan _ttl = ttl;
 
     private LastAuth? _lastAuth;
-
-    public TtlAuth(IAuth auth, ISystemClock clock, TimeSpan ttl)
-    {
-        _auth = auth;
-        _clock = clock;
-        _ttl = ttl;
-    }
 
     public string AuthToken
     {

--- a/tools/Kute/Nethermind.Tools.Kute/Config.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Config.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using Nethermind.Tools.Kute.Metrics;
 
 namespace Nethermind.Tools.Kute;
@@ -94,11 +95,11 @@ public static class Config
 
     public static Option<Dictionary<string, string>> Labels { get; } = new("--labels", "-l")
     {
-        DefaultValueFactory = _ => new Dictionary<string, string>(),
+        DefaultValueFactory = _ => [],
         CustomParser = r =>
         {
-            var labels = new Dictionary<string, string>();
-            foreach (var token in r.Tokens)
+            Dictionary<string, string> labels = new();
+            foreach (Token token in r.Tokens)
             {
                 foreach (string pair in token.Value.Split(','))
                 {

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
@@ -59,9 +59,11 @@ public abstract class JsonRpc
             public string? Id { get => _id.Value; }
 
             public Batch(JsonNode node) : base(node) => _id = new(() =>
-                Items().FirstOrDefault()?.Id is { } first && Items().LastOrDefault()?.Id is { } last
-                    ? $"{first}:{last}"
-                    : null);
+                _node.AsArray() is { Count: > 0 } arr
+                    && arr[0]?["id"] is { } firstId
+                    && arr[^1]?["id"] is { } lastId
+                        ? $"{(Int64)firstId}:{(Int64)lastId}"
+                        : null);
 
             public IEnumerable<Single?> Items()
             {

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
@@ -59,20 +59,9 @@ public abstract class JsonRpc
             public string? Id { get => _id.Value; }
 
             public Batch(JsonNode node) : base(node) => _id = new(() =>
-                                                                     {
-                                                                         if (Items().Any())
-                                                                         {
-                                                                             string? first = Items().First()?.Id;
-                                                                             string? last = Items().Last()?.Id;
-
-                                                                             if (first is not null && last is not null)
-                                                                             {
-                                                                                 return $"{first}:{last}";
-                                                                             }
-                                                                         }
-
-                                                                         return null;
-                                                                     });
+                Items().FirstOrDefault()?.Id is { } first && Items().LastOrDefault()?.Id is { } last
+                    ? $"{first}:{last}"
+                    : null);
 
             public IEnumerable<Single?> Items()
             {
@@ -93,14 +82,7 @@ public abstract class JsonRpc
         public string? Id { get => _id.Value; }
 
         public Response(JsonNode node) : base(node) => _id = new(() =>
-                                                                {
-                                                                    if (_node["id"] is { } id)
-                                                                    {
-                                                                        return ((Int64)id).ToString();
-                                                                    }
-
-                                                                    return null;
-                                                                });
+            _node["id"] is { } id ? ((Int64)id).ToString() : null);
 
         public static async Task<Response> FromHttpResponseAsync(HttpResponseMessage response, CancellationToken token = default)
         {

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpc.cs
@@ -9,10 +9,7 @@ public abstract class JsonRpc
 {
     private readonly JsonNode _node;
 
-    private JsonRpc(JsonNode node)
-    {
-        _node = node;
-    }
+    private JsonRpc(JsonNode node) => _node = node;
 
     public string ToJsonString() => _node.ToJsonString();
     public JsonNode Json => _node;
@@ -61,28 +58,25 @@ public abstract class JsonRpc
 
             public string? Id { get => _id.Value; }
 
-            public Batch(JsonNode node) : base(node)
-            {
-                _id = new(() =>
-                {
-                    if (Items().Any())
-                    {
-                        string? first = Items().First()?.Id;
-                        string? last = Items().Last()?.Id;
+            public Batch(JsonNode node) : base(node) => _id = new(() =>
+                                                                     {
+                                                                         if (Items().Any())
+                                                                         {
+                                                                             string? first = Items().First()?.Id;
+                                                                             string? last = Items().Last()?.Id;
 
-                        if (first is not null && last is not null)
-                        {
-                            return $"{first}:{last}";
-                        }
-                    }
+                                                                             if (first is not null && last is not null)
+                                                                             {
+                                                                                 return $"{first}:{last}";
+                                                                             }
+                                                                         }
 
-                    return null;
-                });
-            }
+                                                                         return null;
+                                                                     });
 
             public IEnumerable<Single?> Items()
             {
-                foreach (var node in _node.AsArray())
+                foreach (JsonNode? node in _node.AsArray())
                 {
                     yield return node is null ? null : new Single(node);
                 }
@@ -98,23 +92,20 @@ public abstract class JsonRpc
 
         public string? Id { get => _id.Value; }
 
-        public Response(JsonNode node) : base(node)
-        {
-            _id = new(() =>
-            {
-                if (_node["id"] is { } id)
-                {
-                    return ((Int64)id).ToString();
-                }
+        public Response(JsonNode node) : base(node) => _id = new(() =>
+                                                                {
+                                                                    if (_node["id"] is { } id)
+                                                                    {
+                                                                        return ((Int64)id).ToString();
+                                                                    }
 
-                return null;
-            });
-        }
+                                                                    return null;
+                                                                });
 
         public static async Task<Response> FromHttpResponseAsync(HttpResponseMessage response, CancellationToken token = default)
         {
-            var content = await response.Content.ReadAsStreamAsync(token);
-            var node = await JsonNode.ParseAsync(content, cancellationToken: token);
+            Stream content = await response.Content.ReadAsStreamAsync(token);
+            JsonNode? node = await JsonNode.ParseAsync(content, cancellationToken: token);
 
             return new Response(node!);
         }

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/ComposedJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/ComposedJsonRpcMethodFilter.cs
@@ -3,16 +3,10 @@
 
 namespace Nethermind.Tools.Kute.JsonRpcMethodFilter;
 
-public sealed class ComposedJsonRpcMethodFilter : IJsonRpcMethodFilter
+public sealed class ComposedJsonRpcMethodFilter(List<IJsonRpcMethodFilter> filters) : IJsonRpcMethodFilter
 {
-    private readonly List<IJsonRpcMethodFilter> _filters;
-    private readonly bool _hasNoFilters;
-
-    public ComposedJsonRpcMethodFilter(List<IJsonRpcMethodFilter> filters)
-    {
-        _filters = filters;
-        _hasNoFilters = filters.Count == 0;
-    }
+    private readonly List<IJsonRpcMethodFilter> _filters = filters;
+    private readonly bool _hasNoFilters = filters.Count == 0;
 
     public bool ShouldSubmit(string methodName) => _hasNoFilters || _filters.Any(f => f.ShouldSubmit(methodName));
 }

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/LimitedJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/LimitedJsonRpcMethodFilter.cs
@@ -3,17 +3,11 @@
 
 namespace Nethermind.Tools.Kute.JsonRpcMethodFilter;
 
-public sealed class LimitedJsonRpcMethodFilter : IJsonRpcMethodFilter
+public sealed class LimitedJsonRpcMethodFilter(IJsonRpcMethodFilter filter, int limit) : IJsonRpcMethodFilter
 {
-    private readonly IJsonRpcMethodFilter _filter;
+    private readonly IJsonRpcMethodFilter _filter = filter;
 
-    private int _usagesLeft;
-
-    public LimitedJsonRpcMethodFilter(IJsonRpcMethodFilter filter, int limit)
-    {
-        _filter = filter;
-        _usagesLeft = limit;
-    }
+    private int _usagesLeft = limit;
 
     public bool ShouldSubmit(string methodName)
     {

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/PatternJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/PatternJsonRpcMethodFilter.cs
@@ -12,7 +12,7 @@ public sealed class PatternJsonRpcMethodFilter : IJsonRpcMethodFilter
     {
         string[] splitted = pattern.Split(PatternSeparator);
 
-        var regex = new RegexJsonRpcMethodFilter(splitted[0]);
+        RegexJsonRpcMethodFilter regex = new(splitted[0]);
         _filter = splitted.Length switch
         {
             1 => regex,

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
@@ -5,14 +5,9 @@ using System.Text.RegularExpressions;
 
 namespace Nethermind.Tools.Kute.JsonRpcMethodFilter;
 
-public sealed class RegexJsonRpcMethodFilter : IJsonRpcMethodFilter
+public sealed class RegexJsonRpcMethodFilter(string pattern) : IJsonRpcMethodFilter
 {
-    private readonly Regex _pattern;
-
-    public RegexJsonRpcMethodFilter(string pattern)
-    {
-        _pattern = new Regex(pattern);
-    }
+    private readonly Regex _pattern = new(pattern);
 
     public bool ShouldSubmit(string methodName) => _pattern.IsMatch(methodName);
 }

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcSubmitter/HttpJsonRpcSubmitter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcSubmitter/HttpJsonRpcSubmitter.cs
@@ -8,22 +8,15 @@ using Nethermind.Tools.Kute.Auth;
 
 namespace Nethermind.Tools.Kute.JsonRpcSubmitter;
 
-public sealed class HttpJsonRpcSubmitter : IJsonRpcSubmitter
+public sealed class HttpJsonRpcSubmitter(HttpClient httpClient, IAuth auth, string hostAddress) : IJsonRpcSubmitter
 {
-    private readonly Uri _uri;
-    private readonly HttpClient _httpClient;
-    private readonly IAuth _auth;
-
-    public HttpJsonRpcSubmitter(HttpClient httpClient, IAuth auth, string hostAddress)
-    {
-        _httpClient = httpClient;
-        _auth = auth;
-        _uri = new Uri(hostAddress);
-    }
+    private readonly Uri _uri = new(hostAddress);
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly IAuth _auth = auth;
 
     public async Task<JsonRpc.Response> Submit(JsonRpc.Request rpc, CancellationToken token = default)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, _uri)
+        HttpRequestMessage request = new(HttpMethod.Post, _uri)
         {
             Headers = { Authorization = new AuthenticationHeaderValue("Bearer", _auth.AuthToken) },
             Content = new StringContent(rpc.ToJsonString(), Encoding.UTF8, MediaTypeNames.Application.Json),

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/BatchJsonRpcValidator.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/BatchJsonRpcValidator.cs
@@ -5,14 +5,9 @@ using System.Text.Json.Nodes;
 
 namespace Nethermind.Tools.Kute.JsonRpcValidator;
 
-public sealed class BatchJsonRpcValidator : IJsonRpcValidator
+public sealed class BatchJsonRpcValidator(IJsonRpcValidator singleValidator) : IJsonRpcValidator
 {
-    private readonly IJsonRpcValidator _singleValidator;
-
-    public BatchJsonRpcValidator(IJsonRpcValidator singleValidator)
-    {
-        _singleValidator = singleValidator;
-    }
+    private readonly IJsonRpcValidator _singleValidator = singleValidator;
 
     public bool IsValid(JsonRpc.Request request, JsonRpc.Response response)
     {
@@ -27,14 +22,14 @@ public sealed class BatchJsonRpcValidator : IJsonRpcValidator
                         return false;
                     }
 
-                    var responses = response.Json
+                    List<JsonRpc.Response> responses = response.Json
                         .AsArray()
                         .Select(r => new JsonRpc.Response(r!))
                         .Where(r => r.Id is not null)
                         .OrderBy(r => r.Id)
                         .ToList();
 
-                    var requests = batch
+                    List<JsonRpc.Request.Single> requests = batch
                         .Items()
                         .Select(r => r!)
                         .Where(r => r.Id is not null)
@@ -43,7 +38,7 @@ public sealed class BatchJsonRpcValidator : IJsonRpcValidator
 
                     if (responses.Count != requests.Count) return false;
 
-                    foreach (var (req, res) in requests.Zip(responses))
+                    foreach ((JsonRpc.Request.Single? req, JsonRpc.Response? res) in requests.Zip(responses))
                     {
                         if (req.Id != res.Id) return false;
                         if (_singleValidator.IsInvalid(req, res)) return false;

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/ComposedJsonRpcValidator.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/ComposedJsonRpcValidator.cs
@@ -3,14 +3,9 @@
 
 namespace Nethermind.Tools.Kute.JsonRpcValidator;
 
-public sealed class ComposedJsonRpcValidator : IJsonRpcValidator
+public sealed class ComposedJsonRpcValidator(params List<IJsonRpcValidator> validators) : IJsonRpcValidator
 {
-    private readonly List<IJsonRpcValidator> _validators;
-
-    public ComposedJsonRpcValidator(params List<IJsonRpcValidator> validators)
-    {
-        _validators = validators;
-    }
+    private readonly List<IJsonRpcValidator> _validators = validators;
 
     public bool IsValid(JsonRpc.Request request, JsonRpc.Response response) => _validators.All(validator => validator.IsValid(request, response));
 }

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/Eth/NewPayloadJsonRpcValidator.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcValidator/Eth/NewPayloadJsonRpcValidator.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Tools.Kute.JsonRpcValidator.Eth;
 
 public sealed class NewPayloadJsonRpcValidator : IJsonRpcValidator
 {
-    private readonly Regex _pattern = new Regex("engine_newPayload", RegexOptions.Compiled);
+    private readonly Regex _pattern = new("engine_newPayload", RegexOptions.Compiled);
 
     public bool IsValid(JsonRpc.Request request, JsonRpc.Response response)
     {

--- a/tools/Kute/Nethermind.Tools.Kute/MessageProvider/FileMessageProvider.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/MessageProvider/FileMessageProvider.cs
@@ -3,18 +3,13 @@
 
 namespace Nethermind.Tools.Kute.MessageProvider;
 
-public sealed class FileMessageProvider : IMessageProvider<string>
+public sealed class FileMessageProvider(string filePath) : IMessageProvider<string>
 {
-    private readonly string _filePath;
-
-    public FileMessageProvider(string filePath)
-    {
-        _filePath = filePath;
-    }
+    private readonly string _filePath = filePath;
 
     public IAsyncEnumerable<string> Messages(CancellationToken token = default)
     {
-        var pathInfo = new FileInfo(_filePath);
+        FileInfo pathInfo = new(_filePath);
         if (pathInfo.Attributes.HasFlag(FileAttributes.Directory))
         {
             return Directory.GetFiles(_filePath)

--- a/tools/Kute/Nethermind.Tools.Kute/MessageProvider/JsonRpcMessageProvider.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/MessageProvider/JsonRpcMessageProvider.cs
@@ -6,20 +6,15 @@ using System.Text.Json.Nodes;
 
 namespace Nethermind.Tools.Kute.MessageProvider;
 
-public sealed class JsonRpcMessageProvider : IMessageProvider<JsonRpc>
+public sealed class JsonRpcMessageProvider(IMessageProvider<string> provider) : IMessageProvider<JsonRpc>
 {
-    private readonly IMessageProvider<string> _provider;
-
-    public JsonRpcMessageProvider(IMessageProvider<string> provider)
-    {
-        _provider = provider;
-    }
+    private readonly IMessageProvider<string> _provider = provider;
 
     public async IAsyncEnumerable<JsonRpc> Messages([EnumeratorCancellation] CancellationToken token = default)
     {
         await foreach (string msg in _provider.Messages(token))
         {
-            var node = JsonNode.Parse(msg);
+            JsonNode? node = JsonNode.Parse(msg);
 
             switch (node)
             {

--- a/tools/Kute/Nethermind.Tools.Kute/MessageProvider/UnwrapBatchJsonRpcMessageProvider.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/MessageProvider/UnwrapBatchJsonRpcMessageProvider.cs
@@ -5,23 +5,18 @@ using System.Runtime.CompilerServices;
 
 namespace Nethermind.Tools.Kute.MessageProvider;
 
-public sealed class UnwrapBatchJsonRpcMessageProvider : IMessageProvider<JsonRpc>
+public sealed class UnwrapBatchJsonRpcMessageProvider(IMessageProvider<JsonRpc> provider) : IMessageProvider<JsonRpc>
 {
-    private readonly IMessageProvider<JsonRpc> _provider;
-
-    public UnwrapBatchJsonRpcMessageProvider(IMessageProvider<JsonRpc> provider)
-    {
-        _provider = provider;
-    }
+    private readonly IMessageProvider<JsonRpc> _provider = provider;
 
     public async IAsyncEnumerable<JsonRpc> Messages([EnumeratorCancellation] CancellationToken token = default)
     {
-        await foreach (var jsonRpc in _provider.Messages(token))
+        await foreach (JsonRpc jsonRpc in _provider.Messages(token))
         {
             switch (jsonRpc)
             {
                 case JsonRpc.Request.Batch batch:
-                    foreach (var single in batch.Items())
+                    foreach (JsonRpc.Request.Single? single in batch.Items())
                     {
                         if (single is not null)
                         {

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/ComposedMetricsReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/ComposedMetricsReporter.cs
@@ -3,14 +3,9 @@
 
 namespace Nethermind.Tools.Kute.Metrics;
 
-public sealed class ComposedMetricsReporter : IMetricsReporter
+public sealed class ComposedMetricsReporter(params IMetricsReporter[] reporters) : IMetricsReporter
 {
-    private readonly IMetricsReporter[] _reporters;
-
-    public ComposedMetricsReporter(params IMetricsReporter[] reporters)
-    {
-        _reporters = reporters;
-    }
+    private readonly IMetricsReporter[] _reporters = reporters;
 
     public async Task Message(CancellationToken token = default)
     {

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/ConsoleProgressReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/ConsoleProgressReporter.cs
@@ -10,10 +10,7 @@ public sealed class ConsoleProgressReporter : IMetricsReporter
     private readonly SemaphoreSlim _semaphore;
     private int _messageCount = 1;
 
-    public ConsoleProgressReporter()
-    {
-        _semaphore = new SemaphoreSlim(1);
-    }
+    public ConsoleProgressReporter() => _semaphore = new SemaphoreSlim(1);
 
     public async Task Message(CancellationToken token = default)
     {
@@ -26,7 +23,7 @@ public sealed class ConsoleProgressReporter : IMetricsReporter
                 Console.Error.Write($"Progress: 1");
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             sb.Append('\b', (_messageCount - 1).ToString().Length);
             sb.Append(_messageCount);

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/ConsoleTotalReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/ConsoleTotalReporter.cs
@@ -3,21 +3,15 @@
 
 namespace Nethermind.Tools.Kute.Metrics;
 
-public sealed class ConsoleTotalReporter : IMetricsReporter
+public sealed class ConsoleTotalReporter(IMetricsReportProvider provider, IMetricsReportFormatter formatter) : IMetricsReporter
 {
-    private readonly IMetricsReportProvider _provider;
-    private readonly IMetricsReportFormatter _formatter;
-
-    public ConsoleTotalReporter(IMetricsReportProvider provider, IMetricsReportFormatter formatter)
-    {
-        _provider = provider;
-        _formatter = formatter;
-    }
+    private readonly IMetricsReportProvider _provider = provider;
+    private readonly IMetricsReportFormatter _formatter = formatter;
 
     public async Task Total(TimeSpan elapsed, CancellationToken token = default)
     {
-        var report = _provider.Report();
-        await using var stream = Console.OpenStandardOutput();
+        MetricsReport report = _provider.Report();
+        await using Stream stream = Console.OpenStandardOutput();
         await _formatter.WriteAsync(stream, report, token);
     }
 }

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/HtmlMetricsReportFormatter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/HtmlMetricsReportFormatter.cs
@@ -26,7 +26,7 @@ public sealed class HtmlMetricsReportFormatter : IMetricsReportFormatter
         await JsonSerializer.SerializeAsync(stream, report, cancellationToken: token);
         await stream.WriteAsync(_encoding.GetBytes("\n</script>\n"), token);
 
-        await using var resourceStream = _assembly.GetManifestResourceStream(_reportTemplate)!;
+        await using Stream resourceStream = _assembly.GetManifestResourceStream(_reportTemplate)!;
         await resourceStream.CopyToAsync(stream, token);
     }
 }

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/JsonMetricsReportFormatter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/JsonMetricsReportFormatter.cs
@@ -7,8 +7,5 @@ namespace Nethermind.Tools.Kute.Metrics;
 
 public sealed class JsonMetricsReportFormatter : IMetricsReportFormatter
 {
-    public async Task WriteAsync(Stream stream, MetricsReport report, CancellationToken token = default)
-    {
-        await JsonSerializer.SerializeAsync(stream, report, cancellationToken: token);
-    }
+    public async Task WriteAsync(Stream stream, MetricsReport report, CancellationToken token = default) => await JsonSerializer.SerializeAsync(stream, report, cancellationToken: token);
 }

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/MemoryMetricsReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/MemoryMetricsReporter.cs
@@ -42,7 +42,7 @@ public sealed class MemoryMetricsReporter
         string? methodName = single.MethodName;
         if (id is not null && methodName is not null)
         {
-            var newMethodDict = new ConcurrentDictionary<string, TimeSpan>
+            ConcurrentDictionary<string, TimeSpan> newMethodDict = new()
             {
                 [id] = elapsed,
             };
@@ -64,22 +64,19 @@ public sealed class MemoryMetricsReporter
         return Task.CompletedTask;
     }
 
-    public MetricsReport Report()
+    public MetricsReport Report() => new()
     {
-        return new MetricsReport
-        {
-            TotalMessages = _messages,
-            Failed = _failed,
-            Succeeded = _succeeded,
-            Ignored = _ignored,
-            Responses = _responses,
-            TotalTime = _totalRunningTime,
-            Singles = _singles.ToDictionary(
+        TotalMessages = _messages,
+        Failed = _failed,
+        Succeeded = _succeeded,
+        Ignored = _ignored,
+        Responses = _responses,
+        TotalTime = _totalRunningTime,
+        Singles = _singles.ToDictionary(
                 kvp => kvp.Key,
                 IReadOnlyDictionary<string, TimeSpan> (kvp) => kvp.Value.ToDictionary(
                     ikvp => ikvp.Key,
                     ikvp => ikvp.Value)),
-            Batches = _batches.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
-        };
-    }
+        Batches = _batches.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+    };
 }

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/MetricsReport.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/MetricsReport.cs
@@ -58,10 +58,10 @@ public sealed record MetricsReport
     public required IReadOnlyDictionary<string, TimeSpan> Batches { get; init; }
 
     private Dictionary<string, TimeMetrics>? _singlesMetrics;
-    public Dictionary<string, TimeMetrics> SinglesMetrics => _singlesMetrics ??= Singles.ToDictionary(kvp => kvp.Key, kvp => TimeMetrics.From(kvp.Value.Values.ToList()));
+    public Dictionary<string, TimeMetrics> SinglesMetrics => _singlesMetrics ??= Singles.ToDictionary(kvp => kvp.Key, kvp => TimeMetrics.From([.. kvp.Value.Values]));
 
     private TimeMetrics? _batchesMetrics;
-    public TimeMetrics BatchesMetrics => _batchesMetrics ??= TimeMetrics.From(Batches.Values.ToList());
+    public TimeMetrics BatchesMetrics => _batchesMetrics ??= TimeMetrics.From([.. Batches.Values]);
 }
 
 public interface IMetricsReportProvider

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/PrettyMetricsReportFormatter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/PrettyMetricsReportFormatter.cs
@@ -7,7 +7,7 @@ public sealed class PrettyMetricsReportFormatter : IMetricsReportFormatter
 {
     public async Task WriteAsync(Stream stream, MetricsReport report, CancellationToken token = default)
     {
-        await using var writer = new StreamWriter(stream);
+        await using StreamWriter writer = new(stream);
         await writer.WriteLineAsync("=== Report ===", token);
         await writer.WriteLineAsync($"Total Time: {report.TotalTime.TotalSeconds} s", token);
         await writer.WriteLineAsync($"Total Messages: {report.TotalMessages}\n", token);
@@ -16,7 +16,7 @@ public sealed class PrettyMetricsReportFormatter : IMetricsReportFormatter
         await writer.WriteLineAsync($"Ignored: {report.Ignored}", token);
         await writer.WriteLineAsync($"Responses: {report.Responses}\n", token);
         await writer.WriteLineAsync("Singles:", token);
-        foreach ((string? methodName, var metrics) in report.SinglesMetrics)
+        foreach ((string? methodName, TimeMetrics? metrics) in report.SinglesMetrics)
         {
             await writer.WriteLineAsync($"  {methodName}:", token);
             await writer.WriteLineAsync($"    Count: {report.Singles[methodName].Count}", token);
@@ -37,8 +37,5 @@ public sealed class PrettyMetricsReportFormatter : IMetricsReportFormatter
 
 internal static class StreamWriterExt
 {
-    public static async Task WriteLineAsync(this StreamWriter writer, string value, CancellationToken token)
-    {
-        await writer.WriteLineAsync(value.AsMemory(), token);
-    }
+    public static async Task WriteLineAsync(this StreamWriter writer, string value, CancellationToken token) => await writer.WriteLineAsync(value.AsMemory(), token);
 }

--- a/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Metrics/PrometheusPushGatewayMetricsReporter.cs
@@ -30,8 +30,8 @@ public sealed class PrometheusPushGatewayMetricsReporter : IMetricsReporter
         string? user,
         string? password)
     {
-        var registry = new CollectorRegistry();
-        var factory = new MetricFactory(registry);
+        CollectorRegistry registry = new();
+        MetricFactory factory = new(registry);
 
         _messageCounter = factory.CreateCounter(GetMetricName("messages_total"), "");
         _succeededCounter = factory.CreateCounter(GetMetricName("messages_succeeded"), "");
@@ -44,7 +44,7 @@ public sealed class PrometheusPushGatewayMetricsReporter : IMetricsReporter
         string instanceLabel = labels.TryGetValue("instance", out string? instance) ? instance : Guid.NewGuid().ToString();
         labels.Remove("instance");
 
-        var httpClient = new HttpClient();
+        HttpClient httpClient = new();
         if (user is not null && password is not null)
         {
             string authParameter = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{password}"));

--- a/tools/Kute/Nethermind.Tools.Kute/Program.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Program.cs
@@ -62,7 +62,7 @@ public static class Program
             // Disable proxy auto-detection to avoid timeout (~2s) on Windows.
             // Each Kute invocation is a separate process, so the proxy lookup
             // would otherwise be paid on every single measured request.
-            var handler = new SocketsHttpHandler
+            SocketsHttpHandler handler = new()
             {
                 UseProxy = false,
                 AutomaticDecompression = DecompressionMethods.None,
@@ -82,8 +82,8 @@ public static class Program
         );
         collection.AddSingleton<IMessageProvider<JsonRpc>>(_ =>
         {
-            FileMessageProvider ofStrings = new FileMessageProvider(parseResult.GetValue(Config.MessagesFilePath)!);
-            JsonRpcMessageProvider ofJsonRpc = new JsonRpcMessageProvider(ofStrings);
+            FileMessageProvider ofStrings = new(parseResult.GetValue(Config.MessagesFilePath)!);
+            JsonRpcMessageProvider ofJsonRpc = new(ofStrings);
             IMessageProvider<JsonRpc> provider = parseResult.GetValue(Config.UnwrapBatch)
                 ? new UnwrapBatchJsonRpcMessageProvider(ofJsonRpc)
                 : ofJsonRpc;
@@ -128,13 +128,13 @@ public static class Program
             });
         collection.AddSingleton<IMetricsReporter>(provider =>
         {
-            MemoryMetricsReporter memoryReporter = new MemoryMetricsReporter();
-            ConsoleTotalReporter consoleReporter = new ConsoleTotalReporter(memoryReporter, provider.GetRequiredService<IMetricsReportFormatter>());
+            MemoryMetricsReporter memoryReporter = new();
+            ConsoleTotalReporter consoleReporter = new(memoryReporter, provider.GetRequiredService<IMetricsReportFormatter>());
             IMetricsReporter progressReporter = parseResult.GetValue(Config.ShowProgress)
                 ? new ConsoleProgressReporter()
                 : new NullMetricsReporter();
 
-            Dictionary<string, string> labels = parseResult.GetValue(Config.Labels) ?? new();
+            Dictionary<string, string> labels = parseResult.GetValue(Config.Labels) ?? [];
             string? prometheusGateway = parseResult.GetValue(Config.PrometheusPushGateway);
             string? prometheusGatewayUser = parseResult.GetValue(Config.PrometheusPushGatewayUser);
             string? prometheusGatewayPassword = parseResult.GetValue(Config.PrometheusPushGatewayPassword);

--- a/tools/Kute/Nethermind.Tools.Kute/ResponseTracer/FileResponseTracer.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/ResponseTracer/FileResponseTracer.cs
@@ -3,14 +3,9 @@
 
 namespace Nethermind.Tools.Kute.ResponseTracer;
 
-public sealed class FileResponseTracer : IResponseTracer
+public sealed class FileResponseTracer(string tracesFilePath) : IResponseTracer
 {
-    private readonly string _tracesFilePath;
-
-    public FileResponseTracer(string tracesFilePath)
-    {
-        _tracesFilePath = tracesFilePath;
-    }
+    private readonly string _tracesFilePath = tracesFilePath;
 
     public async Task TraceResponse(JsonRpc.Response response, CancellationToken token = default)
     {

--- a/tools/Kute/Nethermind.Tools.Kute/SecretProvider/FileSecretProvider.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/SecretProvider/FileSecretProvider.cs
@@ -3,14 +3,9 @@
 
 namespace Nethermind.Tools.Kute.SecretProvider;
 
-public sealed class FileSecretProvider : ISecretProvider
+public sealed class FileSecretProvider(string filePath) : ISecretProvider
 {
-    private readonly string _filePath;
-
-    public FileSecretProvider(string filePath)
-    {
-        _filePath = filePath;
-    }
+    private readonly string _filePath = filePath;
 
     private static bool IsHex(char c) =>
         c is >= '0' and <= '9'

--- a/tools/Kute/Nethermind.Tools.Kute/Timer.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/Timer.cs
@@ -9,25 +9,13 @@ public sealed class Timer
 {
     public TimeSpan Elapsed { get; private set; } = TimeSpan.Zero;
 
-    public IDisposable Time()
+    public IDisposable Time() => new Context(this);
+
+    private readonly struct Context(Timer timer) : IDisposable
     {
-        return new Context(this);
-    }
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly Timer _timer = timer;
 
-    private readonly struct Context : IDisposable
-    {
-        private readonly Stopwatch _stopwatch;
-        private readonly Timer _timer;
-
-        public Context(Timer timer)
-        {
-            _stopwatch = Stopwatch.StartNew();
-            _timer = timer;
-        }
-
-        public void Dispose()
-        {
-            _timer.Elapsed += _stopwatch.Elapsed;
-        }
+        public void Dispose() => _timer.Elapsed += _stopwatch.Elapsed;
     }
 }

--- a/tools/PgoTrim/PgoTrim.slnx
+++ b/tools/PgoTrim/PgoTrim.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="PgoTrim.csproj" />
+</Solution>

--- a/tools/PgoTrim/Program.cs
+++ b/tools/PgoTrim/Program.cs
@@ -32,7 +32,7 @@ for (int i = 0; i < args.Length; i++)
             break;
         default:
             if (inputPath is null) inputPath = args[i];
-            else if (outputPath is null) outputPath = args[i];
+            else outputPath ??= args[i];
             break;
     }
 }

--- a/tools/SchemaGenerator/Program.cs
+++ b/tools/SchemaGenerator/Program.cs
@@ -11,7 +11,7 @@ Type[] types = [
     ..Directory.GetFiles(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".", "Nethermind.*.dll").SelectMany(f => GetConfigTypes(Assembly.LoadFrom(f))),
     ];
 
-AssemblyName assemblyName = new AssemblyName("Nethermind.Config");
+AssemblyName assemblyName = new("Nethermind.Config");
 AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
 ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
 
@@ -73,7 +73,5 @@ void CreateProperty(TypeBuilder typeBuilder, Type classType)
     propertyBuilder.SetSetMethod(setMethodBuilder);
 }
 
-IEnumerable<Type> GetConfigTypes(Assembly assembly)
-{
-    return assembly.GetTypes().Where(t => iConfigType.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract);
-}
+IEnumerable<Type> GetConfigTypes(Assembly assembly) =>
+    assembly.GetTypes().Where(t => iConfigType.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract);

--- a/tools/SendBlobs/FundsDistributor.cs
+++ b/tools/SendBlobs/FundsDistributor.cs
@@ -13,22 +13,14 @@ using Nethermind.Serialization.Rlp;
 
 namespace SendBlobs;
 
-internal class FundsDistributor
+internal class FundsDistributor(IJsonRpcClient rpcClient, ulong chainId, string? keyFilePath, ILogManager logManager)
 {
     private static readonly TxDecoder TxDecoderInstance = TxDecoder.Instance;
 
-    private readonly IJsonRpcClient _rpcClient;
-    private readonly ulong _chainId;
-    private readonly string? _keyFilePath;
-    private readonly ILogManager _logManager;
-
-    public FundsDistributor(IJsonRpcClient rpcClient, ulong chainId, string? keyFilePath, ILogManager logManager)
-    {
-        _rpcClient = rpcClient ?? throw new ArgumentNullException(nameof(rpcClient));
-        _chainId = chainId;
-        _keyFilePath = keyFilePath;
-        _logManager = logManager;
-    }
+    private readonly IJsonRpcClient _rpcClient = rpcClient ?? throw new ArgumentNullException(nameof(rpcClient));
+    private readonly ulong _chainId = chainId;
+    private readonly string? _keyFilePath = keyFilePath;
+    private readonly ILogManager _logManager = logManager;
 
     /// <summary>
     /// Distribute the available funds from an address to a number of newly generated private keys.
@@ -54,7 +46,7 @@ internal class FundsDistributor
             maxPriorityFeePerGas = await _rpcClient.GetMaxPriorityFeePerGasAsync();
         }
 
-        UInt256 balance = new UInt256(Bytes.FromHexString(balanceString));
+        UInt256 balance = new(Bytes.FromHexString(balanceString));
 
         if (balance == 0)
             throw new AccountException($"Balance on provided signer {distributeFrom.Address} is 0.");
@@ -133,12 +125,12 @@ internal class FundsDistributor
 
         ILogger log = _logManager.GetClassLogger<FundsDistributor>();
         List<string> txHashes = [];
-        foreach (var signer in privateSigners)
+        foreach (Signer signer in privateSigners)
         {
             string balanceString = await _rpcClient.GetBalanceAsync(signer.Address);
             ulong nonce = await _rpcClient.GetTransactionCountAsync(signer.Address);
 
-            UInt256 balance = new UInt256(Bytes.FromHexString(balanceString));
+            UInt256 balance = new(Bytes.FromHexString(balanceString));
 
             ulong nonceValue = nonce;
 

--- a/tools/SendBlobs/RpcClientExtensions.cs
+++ b/tools/SendBlobs/RpcClientExtensions.cs
@@ -50,7 +50,7 @@ internal static class RpcClientExtensions
         {
             object syncingResult = await PostWithRetry<object>(rpcClient, nameof(IEthRpcModule.eth_syncing));
 
-            return syncingResult is bool isSyncing && isSyncing is false;
+            return syncingResult is bool isSyncing && !isSyncing;
         }
 
         public async Task<string> GetBalanceAsync(Address address, string blockTag = Latest) => await PostWithRetry<string>(rpcClient, nameof(IEthRpcModule.eth_getBalance), address, blockTag);

--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -149,7 +149,7 @@ internal static class SetupCli
             return Array.Empty<(int count, int blobCount, string @break)>();
 
         ReadOnlySpan<char> chars = options.AsSpan();
-        List<(int, int, string)> result = new List<(int, int, string)>();
+        List<(int, int, string)> result = new();
 
         ReadOnlySpan<char> nextComma;
         int offSet = 0;


### PR DESCRIPTION
Stacked on top of #10044 (targets the `feat/cl-proxy-tool` branch).

## Summary
- Add `<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` to `tools/Directory.Build.props` so the root `.editorconfig` IDE rules (IDE0008 var ban, IDE0022, IDE0090, etc.) fail the build for tool projects the same way they already do under `src/Nethermind/`.
- Add missing `.slnx` files for `EngineApiProxy` and `PgoTrim` so `dotnet format` has a usable workspace entry point.
- Run `dotnet format` across all tool slnx files and hand-fix the residual IDE0008/IDE0090 cases the auto-fixer can't resolve in place (mostly `var` → explicit types and `new Foo(...)` → target-typed `new(...)`).

## Why
`.editorconfig` already declares `csharp_style_var_*_false:error` and related IDE rules, but build-time enforcement was gated by `EnforceCodeStyleInBuild`, which was only set under `src/Nethermind/Directory.Build.props`. Tool projects silently drifted with `var` everywhere and other style violations. This closes the gap so tool code is held to the same bar as the main codebase.

## Test plan
- [x] `dotnet build <slnx> -c Release` passes with **0 errors, 0 warnings** for all 12 tool slnx files:
  - EngineApiProxy, PgoTrim, DocGen, Evm, HiveCompare, HiveConsensusWorkflowGenerator, JitAsm, Kute, SchemaGenerator, SendBlobs, StatelessInputGen, TxParser.
- [ ] CI style/build checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)