### PR TITLE
ZiskGuest: enable stacktrace data to facilitate possible GVM resolution

### DIFF
--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -44,7 +44,6 @@ build: dotnet-build
 		bflat build --arch riscv64 --os linux --stdlib dotnet --libc zisk \
 		--no-pie \
 		--no-pthread \
-		--no-stacktrace-data \
 		--no-globalization \
 		--nostdlibrefs \
 		$(BFLAT_REFS) \


### PR DESCRIPTION
Tests show that GVM resolution depends on metadata that is being stripped away if --no-stacktrace-data is added to the bflat's command line.

This patch removes this flag and improves guest's ability to perform GVM resolution, reducing number of unpredictable bugs.


## Changes

- Re-enable stack trace data in bflat build.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes (in a separate bflat repository)
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
