### PR TITLE
perf(state): avoid copy on BulkSet via ArrayPoolList ownership transfer

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -264,6 +264,37 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         GuardDispose();
         return _array.AsSpan(0, _count);
     }
+
+    /// <summary>
+    /// Transfers ownership of the underlying rented array to a new <see cref="ArrayPoolListRef{T}"/>
+    /// without copying. After this call the <see cref="ArrayPoolList{T}"/> is marked disposed and
+    /// its own <see cref="Dispose"/> becomes a no-op; the returned ref struct is responsible for
+    /// returning the array to the pool.
+    /// </summary>
+    public ArrayPoolListRef<T> ToRef()
+    {
+        GuardDispose();
+        if (_arrayPool != SafeArrayPool<T>.Shared)
+        {
+            ThrowUnsupportedPool();
+        }
+
+        T[] array = _array;
+        int capacity = _capacity;
+        int count = _count;
+
+        _array = [];
+        _capacity = 0;
+        _count = 0;
+        _disposed = true;
+
+        return new ArrayPoolListRef<T>(array, capacity, count);
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnsupportedPool() => throw new InvalidOperationException(
+            $"{nameof(ToRef)} is only supported when {nameof(ArrayPoolList<T>)} uses {nameof(SafeArrayPool<T>)}.Shared.");
+    }
     public Memory<T> AsMemory()
     {
         GuardDispose();

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolListRef.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolListRef.cs
@@ -30,6 +30,13 @@ public ref struct ArrayPoolListRef<T>
         _count = startingCount;
     }
 
+    internal ArrayPoolListRef(T[] array, int capacity, int count)
+    {
+        _array = array;
+        _capacity = capacity;
+        _count = count;
+    }
+
     public readonly int Count => _count;
     public readonly int Capacity => _capacity;
     public void Add(T item) => ArrayPoolListCore<T>.Add(SafeArrayPool<T>.Shared, ref _array, ref _capacity, ref _count, item);

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -85,9 +85,8 @@ namespace Nethermind.State
 
             public void Dispose()
             {
-                using ArrayPoolListRef<PatriciaTree.BulkSetEntry> asRef = new(_bulkWrite.AsSpan());
+                using ArrayPoolListRef<PatriciaTree.BulkSetEntry> asRef = _bulkWrite.ToRef();
                 tree.BulkSet(asRef);
-                _bulkWrite.Dispose();
             }
         }
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -225,6 +225,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         public void Dispose()
         {
             bool hasSet = _wasSetCalled || _hasSelfDestruct;
+            int bulkCount = 0;
             if (_bulkWrite is not null)
             {
                 if (_hasSelfDestruct)
@@ -232,11 +233,9 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     storageTree.RootHash = Keccak.EmptyTreeHash;
                 }
 
-                using ArrayPoolListRef<PatriciaTree.BulkSetEntry> asRef =
-                    new(_bulkWrite.AsSpan());
+                bulkCount = _bulkWrite.Count;
+                using ArrayPoolListRef<PatriciaTree.BulkSetEntry> asRef = _bulkWrite.ToRef();
                 storageTree.BulkSet(asRef);
-
-                _bulkWrite?.Dispose();
             }
 
             if (hasSet)
@@ -247,7 +246,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                 }
                 else
                 {
-                    storageTree.UpdateRootHash(_bulkWrite?.Count > 64);
+                    storageTree.UpdateRootHash(bulkCount > 64);
                 }
                 onRootUpdated(address, storageTree.RootHash);
             }


### PR DESCRIPTION
## Changes

- Add `ArrayPoolList<T>.ToRef()` that hands the underlying rented array to an `ArrayPoolListRef<T>` without copying, then marks the source disposed so its own `Dispose` is a no-op. Guarded to only work with `SafeArrayPool<T>.Shared` (the pool `ArrayPoolListRef` returns to).
- Replace the `new ArrayPoolListRef<…>(_bulkWrite.AsSpan())` + explicit `_bulkWrite.Dispose()` pattern with `_bulkWrite.ToRef()` in:
  - `StateTree.StateTreeBulkSetter.Dispose` (state trie bulk write)
  - `TrieStoreScopeProvider.StorageTreeBulkWriteBatch.Dispose` (storage trie bulk write; reused by both the pruning trie-store path and the flat world state via `FlatStorageTree`)

Net effect: `BulkSet` now receives the original rented buffer directly instead of a freshly-copied one, on both the state and storage hot paths, for both pruning and flat world-state backends.

## Types of changes

- [x] Optimization
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Behavior-preserving — `BulkSet` receives the same elements in the same order; only the allocation path changes. Covered by existing `PatriciaTreeBulkSetterTests` and state/storage integration tests. Reproducible-benchmarks workflow should show state/storage bulk-write improvements.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No