### PR TITLE
ci(hive): remove build-block-from-mempool from known failures

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -1,7 +1,6 @@
 # rpc-compat
 
 testing_buildBlockV1/build-block-empty-transactions (nethermind)
-testing_buildBlockV1/build-block-from-mempool (nethermind)
 testing_buildBlockV1/build-block-with-transactions (nethermind)
 
 # graphql


### PR DESCRIPTION
## Changes

- Remove `testing_buildBlockV1/build-block-from-mempool` from the known hive failures list
- The upstream fix in https://github.com/ethereum/execution-apis/pull/783 resolved the test spec issue; the test now passes in CI ([run](https://github.com/NethermindEth/nethermind/actions/runs/24659109207/job/72100316492))

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Verified in hive rpc-compat CI run that `build-block-from-mempool` now passes.

**Note:** `build-block-empty-transactions` and `build-block-with-transactions` still fail due to a separate gas limit target issue (will be addressed in a follow-up PR).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No