### PR TITLE
ci(claude-review): drop concurrency group

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,10 +18,6 @@
 
 name: Claude Code Review
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Summary

- Removes the workflow-level `concurrency` block from `.github/workflows/claude-review.yml`.
- Fixes self-cancellation where the bot's own `Claude Code is working…` status comment preempts the in-flight review.

## Why

GitHub evaluates `concurrency` at workflow queue time, **before** the job-level `if:` filter runs. Any `issue_comment` on the PR enters the concurrency group and — with `cancel-in-progress: true` — kills any in-flight run in the same group. The replacement run is then skipped by the `@claude` check in `if:`, so no review is ever posted. Observed on #11248 (run [24657751287](https://github.com/NethermindEth/nethermind/actions/runs/24657751287)): the bot's own working-status comment created a second queued run that cancelled the first, then got skipped itself.

The review-path triggers (`pull_request: opened/ready_for_review/unlabeled`, manual `@claude review` comment) don't fire in rapid succession in normal use, so removing `concurrency` entirely is low-risk. The mention path never needed serialization. Worst case is two concurrent reviews if someone double-triggers manually, which we can address later with a conditional group key if it actually happens.

## Test plan

- [ ] Trigger a review on a PR and confirm it runs to completion without being cancelled by the bot's status comment.
- [ ] Post an unrelated `@claude` mention during an in-flight review; both should complete independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)