### PR TITLE
fix build - BenchmarkDotNet Version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
     <PackageVersion Include="Autofac" Version="9.1.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.16.0-nightly.20260320.468" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.16.0-nightly.20260320.468" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.16.0-nightly.20260322.472" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.16.0-nightly.20260322.472" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageVersion Include="Ckzg.Bindings" Version="2.1.7.1596" />
     <PackageVersion Include="Collections.Pooled" Version="1.0.82" />


### PR DESCRIPTION
## Summary

Bump `BenchmarkDotNet` and `BenchmarkDotNet.Diagnostics.Windows` from `0.16.0-nightly.20260320.468` to `0.16.0-nightly.20260322.472`.

The pinned `.468` build was unpublished from NuGet and is no longer restorable, which fails the Build matrix on master and every open PR with `NU1603` (treated as error). NuGet auto-resolves to `.472` as the nearest available nightly.

Recurrence of the same failure mode as #11152 (which bumped `.466` → `.468` five days ago).

## CI error

```
error NU1603: Warning As Error: Nethermind.Precompiles.Benchmark.Test depends on
BenchmarkDotNet (>= 0.16.0-nightly.20260320.468) but BenchmarkDotNet
0.16.0-nightly.20260320.468 was not found. BenchmarkDotNet
0.16.0-nightly.20260322.472 was resolved instead.
```