### PR TITLE
HistoryPruner: self-bootstrap in TryPruneHistory instead of relying on SyncServer

### DIFF
--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -193,9 +193,9 @@ public class HistoryPrunerTests
         CheckHeadPreserved(testBlockchain, blocks);
     }
 
-    [TestCase(0, 100000, false)]
-    [TestCase(100, 10, true)]
-    public void Validates_config(int minHistoryRetentionEpochs, int retentionEpochs, bool shouldThrow)
+    [TestCase(0, 100000u, false)]
+    [TestCase(100, 10u, true)]
+    public void Validates_config(int minHistoryRetentionEpochs, uint retentionEpochs, bool shouldThrow)
     {
         IHistoryConfig historyConfig = new HistoryConfig
         {

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -43,164 +43,53 @@ public class HistoryPrunerTests
         SnapSync = true
     };
 
-    [Test]
-    public async Task Can_prune_blocks_older_than_specified_epochs()
+    private static IEnumerable<TestCaseData> PruningCases()
     {
         const int blocks = 100;
-        const int cutoff = 36;
 
-        IHistoryConfig historyConfig = new HistoryConfig
-        {
-            Pruning = PruningModes.Rolling,
-            RetentionEpochs = 2,
-            PruningInterval = 0
-        };
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 2, PruningInterval = 0 },
+            /*syncPivot:*/ (long)blocks,
+            /*primeWithOldestRead:*/ true,
+            /*expectedPruneBelow:*/ 36L,
+            /*finalCutoff:*/ 36L
+        ).SetName("Can_prune_blocks_older_than_specified_epochs");
 
-        using BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create(BuildContainer(historyConfig));
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 2, PruningInterval = 0 },
+            /*syncPivot:*/ (long)blocks,
+            /*primeWithOldestRead:*/ false, // regression: pruner must self-bootstrap without external OldestBlockHeader call
+            /*expectedPruneBelow:*/ 36L,
+            /*finalCutoff:*/ 36L
+        ).SetName("Can_prune_without_prior_oldest_block_read");
 
-        List<Hash256> blockHashes = [];
-        blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        for (int i = 0; i < blocks; i++)
-        {
-            await testBlockchain.AddBlock();
-            blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        }
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.UseAncientBarriers, RetentionEpochs = 100 /* no effect in UseAncientBarriers mode */, PruningInterval = 0 },
+            /*syncPivot:*/ (long)blocks,
+            /*primeWithOldestRead:*/ true,
+            /*expectedPruneBelow:*/ BeaconGenesisBlockNumber,
+            /*finalCutoff:*/ BeaconGenesisBlockNumber
+        ).SetName("Can_prune_to_ancient_barriers");
 
-        Block head = testBlockchain.BlockTree.Head;
-        Assert.That(head, Is.Not.Null);
-        testBlockchain.BlockTree.SyncPivot = (blocks, Hash256.Zero);
-
-        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
-
-        CheckOldestAndCutoff(1, cutoff, historyPruner);
-
-        historyPruner.TryPruneHistory(CancellationToken.None);
-
-        CheckGenesisPreserved(testBlockchain, blockHashes[0]);
-        for (int i = 1; i <= blocks; i++)
-        {
-            if (i < cutoff)
-            {
-                CheckBlockPruned(testBlockchain, blockHashes, i);
-            }
-            else
-            {
-                CheckBlockPreserved(testBlockchain, blockHashes, i);
-            }
-        }
-
-        CheckHeadPreserved(testBlockchain, blocks);
-        CheckOldestAndCutoff(cutoff, cutoff, historyPruner);
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.UseAncientBarriers, PruningInterval = 0 },
+            /*syncPivot:*/ 20L, // below BeaconGenesisBlockNumber — sync pivot caps the prune boundary
+            /*primeWithOldestRead:*/ true,
+            /*expectedPruneBelow:*/ 20L,
+            /*finalCutoff:*/ BeaconGenesisBlockNumber
+        ).SetName("Prunes_up_to_sync_pivot");
     }
 
-    [Test]
-    public async Task Can_prune_without_prior_oldest_block_read()
-    {
-        const int blocks = 100;
-        const int cutoff = 36;
-
-        IHistoryConfig historyConfig = new HistoryConfig
-        {
-            Pruning = PruningModes.Rolling,
-            RetentionEpochs = 2,
-            PruningInterval = 0
-        };
-
-        using BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create(BuildContainer(historyConfig));
-
-        List<Hash256> blockHashes = [];
-        blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        for (int i = 0; i < blocks; i++)
-        {
-            await testBlockchain.AddBlock();
-            blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        }
-
-        Block head = testBlockchain.BlockTree.Head;
-        Assert.That(head, Is.Not.Null);
-        testBlockchain.BlockTree.SyncPivot = (blocks, Hash256.Zero);
-
-        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
-
-        historyPruner.TryPruneHistory(CancellationToken.None);
-
-        CheckGenesisPreserved(testBlockchain, blockHashes[0]);
-        for (int i = 1; i <= blocks; i++)
-        {
-            if (i < cutoff)
-            {
-                CheckBlockPruned(testBlockchain, blockHashes, i);
-            }
-            else
-            {
-                CheckBlockPreserved(testBlockchain, blockHashes, i);
-            }
-        }
-
-        CheckHeadPreserved(testBlockchain, blocks);
-        CheckOldestAndCutoff(cutoff, cutoff, historyPruner);
-    }
-
-    [Test]
-    public async Task Can_prune_to_ancient_barriers()
+    [TestCaseSource(nameof(PruningCases))]
+    public async Task Prunes_history(
+        IHistoryConfig historyConfig,
+        long syncPivot,
+        bool primeWithOldestRead,
+        long expectedPruneBelow,
+        long finalCutoff)
     {
         const int blocks = 100;
 
-        IHistoryConfig historyConfig = new HistoryConfig
-        {
-            Pruning = PruningModes.UseAncientBarriers,
-            RetentionEpochs = 100, // should have no effect
-            PruningInterval = 0
-        };
-        using BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create(BuildContainer(historyConfig));
-
-        List<Hash256> blockHashes = [];
-        blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        for (int i = 0; i < blocks; i++)
-        {
-            await testBlockchain.AddBlock();
-            blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
-        }
-
-        Block head = testBlockchain.BlockTree.Head;
-        Assert.That(head, Is.Not.Null);
-        testBlockchain.BlockTree.SyncPivot = (blocks, Hash256.Zero);
-
-        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
-
-        CheckOldestAndCutoff(1, BeaconGenesisBlockNumber, historyPruner);
-
-        historyPruner.TryPruneHistory(CancellationToken.None);
-
-        CheckGenesisPreserved(testBlockchain, blockHashes[0]);
-
-        for (int i = 1; i <= blocks; i++)
-        {
-            if (i < BeaconGenesisBlockNumber)
-            {
-                CheckBlockPruned(testBlockchain, blockHashes, i);
-            }
-            else
-            {
-                CheckBlockPreserved(testBlockchain, blockHashes, i);
-            }
-        }
-
-        CheckHeadPreserved(testBlockchain, blocks);
-        CheckOldestAndCutoff(BeaconGenesisBlockNumber, BeaconGenesisBlockNumber, historyPruner);
-    }
-
-    [Test]
-    public async Task Prunes_up_to_sync_pivot()
-    {
-        const int blocks = 100;
-        const long syncPivot = 20;
-
-        IHistoryConfig historyConfig = new HistoryConfig
-        {
-            Pruning = PruningModes.UseAncientBarriers,
-            PruningInterval = 0
-        };
         using BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create(BuildContainer(historyConfig));
 
         List<Hash256> blockHashes = [];
@@ -217,26 +106,22 @@ public class HistoryPrunerTests
 
         HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
 
-        CheckOldestAndCutoff(1, BeaconGenesisBlockNumber, historyPruner);
+        if (primeWithOldestRead)
+            CheckOldestAndCutoff(1, finalCutoff, historyPruner);
 
         historyPruner.TryPruneHistory(CancellationToken.None);
 
         CheckGenesisPreserved(testBlockchain, blockHashes[0]);
-
         for (int i = 1; i <= blocks; i++)
         {
-            if (i < syncPivot)
-            {
+            if (i < expectedPruneBelow)
                 CheckBlockPruned(testBlockchain, blockHashes, i);
-            }
             else
-            {
                 CheckBlockPreserved(testBlockchain, blockHashes, i);
-            }
         }
 
         CheckHeadPreserved(testBlockchain, blocks);
-        CheckOldestAndCutoff(syncPivot, BeaconGenesisBlockNumber, historyPruner);
+        CheckOldestAndCutoff(expectedPruneBelow, finalCutoff, historyPruner);
     }
 
     [Test]
@@ -308,59 +193,37 @@ public class HistoryPrunerTests
         CheckHeadPreserved(testBlockchain, blocks);
     }
 
-    [Test]
-    public void Can_accept_valid_config()
+    [TestCase(0, 100000, false)]
+    [TestCase(100, 10, true)]
+    public void Validates_config(int minHistoryRetentionEpochs, int retentionEpochs, bool shouldThrow)
     {
-        IHistoryConfig validHistoryConfig = new HistoryConfig
+        IHistoryConfig historyConfig = new HistoryConfig
         {
             Pruning = PruningModes.Rolling,
-            RetentionEpochs = 100000,
+            RetentionEpochs = retentionEpochs,
         };
-
+        ISpecProvider specProvider = new TestSpecProvider(new ReleaseSpec { MinHistoryRetentionEpochs = minHistoryRetentionEpochs });
         IDbProvider dbProvider = Substitute.For<IDbProvider>();
         dbProvider.MetadataDb.Returns(new TestMemDb());
 
-        Assert.DoesNotThrow(() => new HistoryPruner(
-            Substitute.For<IBlockTree>(),
-            Substitute.For<IReceiptStorage>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<IChainLevelInfoRepository>(),
-            dbProvider,
-            validHistoryConfig,
-            BlocksConfig,
-            SyncConfig,
-            new ProcessExitSource(new()),
-            Substitute.For<IBackgroundTaskScheduler>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            LimboLogs.Instance));
-    }
-
-    [Test]
-    public void Can_reject_invalid_config()
-    {
-        IHistoryConfig invalidHistoryConfig = new HistoryConfig
-        {
-            Pruning = PruningModes.Rolling,
-            RetentionEpochs = 10,
-        };
-
-        ISpecProvider specProvider = new TestSpecProvider(new ReleaseSpec() { MinHistoryRetentionEpochs = 100 });
-        IDbProvider dbProvider = Substitute.For<IDbProvider>();
-        dbProvider.MetadataDb.Returns(new TestMemDb());
-
-        Assert.Throws<HistoryPruner.HistoryPrunerException>(() => new HistoryPruner(
+        TestDelegate action = () => new HistoryPruner(
             Substitute.For<IBlockTree>(),
             Substitute.For<IReceiptStorage>(),
             specProvider,
             Substitute.For<IChainLevelInfoRepository>(),
             dbProvider,
-            invalidHistoryConfig,
+            historyConfig,
             BlocksConfig,
             SyncConfig,
             new ProcessExitSource(new()),
             Substitute.For<IBackgroundTaskScheduler>(),
             Substitute.For<IBlockProcessingQueue>(),
-            LimboLogs.Instance));
+            LimboLogs.Instance);
+
+        if (shouldThrow)
+            Assert.Throws<HistoryPruner.HistoryPrunerException>(action);
+        else
+            Assert.DoesNotThrow(action);
     }
 
     private static void CheckGenesisPreserved(BasicTestBlockchain testBlockchain, Hash256 genesisHash)

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -94,6 +94,54 @@ public class HistoryPrunerTests
     }
 
     [Test]
+    public async Task Can_prune_without_prior_oldest_block_read()
+    {
+        const int blocks = 100;
+        const int cutoff = 36;
+
+        IHistoryConfig historyConfig = new HistoryConfig
+        {
+            Pruning = PruningModes.Rolling,
+            RetentionEpochs = 2,
+            PruningInterval = 0
+        };
+
+        using BasicTestBlockchain testBlockchain = await BasicTestBlockchain.Create(BuildContainer(historyConfig));
+
+        List<Hash256> blockHashes = [];
+        blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
+        for (int i = 0; i < blocks; i++)
+        {
+            await testBlockchain.AddBlock();
+            blockHashes.Add(testBlockchain.BlockTree.Head!.Hash!);
+        }
+
+        Block head = testBlockchain.BlockTree.Head;
+        Assert.That(head, Is.Not.Null);
+        testBlockchain.BlockTree.SyncPivot = (blocks, Hash256.Zero);
+
+        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
+
+        historyPruner.TryPruneHistory(CancellationToken.None);
+
+        CheckGenesisPreserved(testBlockchain, blockHashes[0]);
+        for (int i = 1; i <= blocks; i++)
+        {
+            if (i < cutoff)
+            {
+                CheckBlockPruned(testBlockchain, blockHashes, i);
+            }
+            else
+            {
+                CheckBlockPreserved(testBlockchain, blockHashes, i);
+            }
+        }
+
+        CheckHeadPreserved(testBlockchain, blocks);
+        CheckOldestAndCutoff(cutoff, cutoff, historyPruner);
+    }
+
+    [Test]
     public async Task Can_prune_to_ancient_barriers()
     {
         const int blocks = 100;

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -293,7 +293,6 @@ public class HistoryPruner : IHistoryPruner
     {
         if (_blockTree.Head is null ||
             _blockTree.SyncPivot.BlockNumber == 0 ||
-            !_hasLoadedDeletePointer ||
             !ShouldPruneHistory(out ulong? cutoffTimestamp))
         {
             SkipLocalPruning();


### PR DESCRIPTION
## Changes

- `HistoryPruner.TryPruneHistory`: remove the redundant pre-lock `!_hasLoadedDeletePointer` gate so the pruner self-bootstraps on first entry instead of depending on `SyncServer.OnNewRange` to call `OldestBlockHeader` at a `%32` block boundary. The inner path at `HistoryPruner.cs:309` already calls `TryLoadDeletePointer()` and handles failure — the outer check only served to suppress bootstrap until an external caller primed it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

### Root cause

On a node whose head never crosses a `%32` block boundary after startup (frozen snapshot, peerless, no CL attached), history pruning never runs even when `--History.Pruning=Rolling` is configured. `_hasLoadedDeletePointer` only flips when `TryLoadDeletePointer()` runs, and in production that only happens via the `OldestBlockHeader` getter, which is only called from `SyncServer.OnNewRange` (`SyncServer.cs:472`) gated on `block.Number % 32 == 0` (`SyncServer.cs:469`). Nothing inside `HistoryPruner` observes or controls that condition, so the pruner waits on an external event that may never fire.

### Why safe

- Concurrency unchanged: `_currentlyPruning` atomic still prevents concurrent pruning tasks; `_pruneLock` still serializes actual work inside `TryPruneHistory`.
- Cost: one extra `Monitor.TryEnter`/`Monitor.Exit` per trigger during the brief startup window before bootstrap — one-time, not steady state. After first load, `TryLoadDeletePointer()` early-returns at line 531 with no DB read.
- Pre-lock `ShouldPruneHistory` call remains valid before bootstrap: reads `_deletePointer` (default 0) and `_lastPrunedTimestamp` (default null); both branches return sensibly and let the flow fall into the lock path where bootstrap + prune happen atomically.

### Relationship to #9677

The pre-lock gate was introduced in #9677 as a fast-path optimization. This PR removes only that one line and preserves every other improvement from #9677 (atomic `_currentlyPruning`, exclusive scheduling, `TryScheduleTask` rename)