### PR TITLE
refactor(test): de-duplicate StateComposition tests

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
@@ -228,7 +228,7 @@ public class TrieDiffWalkerTests
         StateCompositionStats scan2 = v2.GetStats(2, root2);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(scan2);
 
-        TestDataBuilders.AssertAccountCumulativeEquals(updated, expected);
+        TestDataBuilders.AssertAccountTrieFieldsEqual(updated, expected);
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class TrieDiffWalkerTests
         tree.Accept(v4, root4);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(v4.GetStats(4, root4));
 
-        TestDataBuilders.AssertAccountCumulativeEquals(cumulative, expected, "after 4 blocks");
+        TestDataBuilders.AssertAccountTrieFieldsEqual(cumulative, expected, "after 4 blocks");
     }
 
     [Test]
@@ -369,7 +369,7 @@ public class TrieDiffWalkerTests
         tree.Accept(v2, root2);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(v2.GetStats(2, root2));
 
-        TestDataBuilders.AssertAccountCumulativeEquals(updated, expected);
+        TestDataBuilders.AssertAccountTrieFieldsEqual(updated, expected);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Diff;
+using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.StateComposition.Visitors;
 using Nethermind.Trie.Pruning;
 using NUnit.Framework;
@@ -227,15 +228,7 @@ public class TrieDiffWalkerTests
         StateCompositionStats scan2 = v2.GetStats(2, root2);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(scan2);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(updated.AccountsTotal, Is.EqualTo(expected.AccountsTotal), "AccountsTotal mismatch");
-            Assert.That(updated.ContractsTotal, Is.EqualTo(expected.ContractsTotal), "ContractsTotal mismatch");
-            Assert.That(updated.AccountTrieBranches, Is.EqualTo(expected.AccountTrieBranches), "AccountTrieBranches mismatch");
-            Assert.That(updated.AccountTrieExtensions, Is.EqualTo(expected.AccountTrieExtensions), "AccountTrieExtensions mismatch");
-            Assert.That(updated.AccountTrieLeaves, Is.EqualTo(expected.AccountTrieLeaves), "AccountTrieLeaves mismatch");
-            Assert.That(updated.AccountTrieBytes, Is.EqualTo(expected.AccountTrieBytes), "AccountTrieBytes mismatch");
-        }
+        TestDataBuilders.AssertAccountCumulativeEquals(updated, expected);
     }
 
     [Test]
@@ -280,15 +273,7 @@ public class TrieDiffWalkerTests
         tree.Accept(v4, root4);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(v4.GetStats(4, root4));
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cumulative.AccountsTotal, Is.EqualTo(expected.AccountsTotal), "AccountsTotal after 4 blocks");
-            Assert.That(cumulative.ContractsTotal, Is.EqualTo(expected.ContractsTotal), "ContractsTotal after 4 blocks");
-            Assert.That(cumulative.AccountTrieBranches, Is.EqualTo(expected.AccountTrieBranches), "AccountTrieBranches after 4 blocks");
-            Assert.That(cumulative.AccountTrieExtensions, Is.EqualTo(expected.AccountTrieExtensions), "AccountTrieExtensions after 4 blocks");
-            Assert.That(cumulative.AccountTrieLeaves, Is.EqualTo(expected.AccountTrieLeaves), "AccountTrieLeaves after 4 blocks");
-            Assert.That(cumulative.AccountTrieBytes, Is.EqualTo(expected.AccountTrieBytes), "AccountTrieBytes after 4 blocks");
-        }
+        TestDataBuilders.AssertAccountCumulativeEquals(cumulative, expected, "after 4 blocks");
     }
 
     [Test]
@@ -384,14 +369,7 @@ public class TrieDiffWalkerTests
         tree.Accept(v2, root2);
         CumulativeTrieStats expected = CumulativeTrieStats.FromScanStats(v2.GetStats(2, root2));
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(updated.AccountsTotal, Is.EqualTo(expected.AccountsTotal), "AccountsTotal");
-            Assert.That(updated.AccountTrieBranches, Is.EqualTo(expected.AccountTrieBranches), "AccountTrieBranches");
-            Assert.That(updated.AccountTrieExtensions, Is.EqualTo(expected.AccountTrieExtensions), "AccountTrieExtensions");
-            Assert.That(updated.AccountTrieLeaves, Is.EqualTo(expected.AccountTrieLeaves), "AccountTrieLeaves");
-            Assert.That(updated.AccountTrieBytes, Is.EqualTo(expected.AccountTrieBytes), "AccountTrieBytes");
-        }
+        TestDataBuilders.AssertAccountCumulativeEquals(updated, expected);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.StateComposition.Test/Helpers/TestDataBuilders.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Helpers/TestDataBuilders.cs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System.Collections.Immutable;
+using Nethermind.StateComposition.Data;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.StateComposition.Test.Helpers;
+
+/// <summary>
+/// Shared fixtures for the StateComposition test suite. Centralises the
+/// <see cref="CumulativeTrieStats"/> builders and <see cref="IStateCompositionConfig"/>
+/// substitute that multiple fixtures otherwise copy verbatim — keeps defaults in one
+/// place so a signature change shows up as a single edit rather than a sprawl.
+/// </summary>
+internal static class TestDataBuilders
+{
+    /// <summary>
+    /// Baseline with all structural counters zeroed. Optional overrides match
+    /// the init-only fields on <see cref="CumulativeTrieStats"/>.
+    /// </summary>
+    public static CumulativeTrieStats EmptyBaseline(long codeBytes = 0, long[]? histogram = null) =>
+        BuildStats(codeBytes: codeBytes, hist: ImmutableArray.Create(
+            histogram ?? new long[CumulativeTrieStats.SlotHistogramLength]));
+
+    /// <summary>
+    /// Fully parameterised builder. Any field omitted defaults to zero/empty so tests
+    /// only spell out the values that matter to the assertion.
+    /// </summary>
+    public static CumulativeTrieStats BuildStats(
+        long accountsTotal = 0,
+        long contractsTotal = 0,
+        long storageSlotsTotal = 0,
+        long accountTrieBranches = 0,
+        long accountTrieExtensions = 0,
+        long accountTrieLeaves = 0,
+        long accountTrieBytes = 0,
+        long storageTrieBranches = 0,
+        long storageTrieExtensions = 0,
+        long storageTrieLeaves = 0,
+        long storageTrieBytes = 0,
+        long contractsWithStorage = 0,
+        long emptyAccounts = 0,
+        long codeBytes = 0,
+        ImmutableArray<long> hist = default) =>
+        new(
+            AccountsTotal: accountsTotal,
+            ContractsTotal: contractsTotal,
+            StorageSlotsTotal: storageSlotsTotal,
+            AccountTrieBranches: accountTrieBranches,
+            AccountTrieExtensions: accountTrieExtensions,
+            AccountTrieLeaves: accountTrieLeaves,
+            AccountTrieBytes: accountTrieBytes,
+            StorageTrieBranches: storageTrieBranches,
+            StorageTrieExtensions: storageTrieExtensions,
+            StorageTrieLeaves: storageTrieLeaves,
+            StorageTrieBytes: storageTrieBytes,
+            ContractsWithStorage: contractsWithStorage,
+            EmptyAccounts: emptyAccounts)
+        {
+            CodeBytesTotal = codeBytes,
+            SlotCountHistogram = hist.IsDefault
+                ? ImmutableArray.Create(new long[CumulativeTrieStats.SlotHistogramLength])
+                : hist,
+        };
+
+    /// <summary>
+    /// Mock <see cref="IStateCompositionConfig"/> with the defaults shared by every
+    /// Service-level fixture. Callers can override fields via the optional params.
+    /// </summary>
+    public static IStateCompositionConfig CreateTestConfig(
+        int scanParallelism = 4,
+        long scanMemoryBudgetBytes = 1_000_000_000L,
+        int scanQueueTimeoutSeconds = 5,
+        int topNContracts = 20,
+        bool excludeStorage = false,
+        bool persistSnapshots = false,
+        bool trackDepthIncrementally = false)
+    {
+        IStateCompositionConfig config = Substitute.For<IStateCompositionConfig>();
+        config.ScanParallelism.Returns(scanParallelism);
+        config.ScanMemoryBudgetBytes.Returns(scanMemoryBudgetBytes);
+        config.ScanQueueTimeoutSeconds.Returns(scanQueueTimeoutSeconds);
+        config.TopNContracts.Returns(topNContracts);
+        config.ExcludeStorage.Returns(excludeStorage);
+        config.PersistSnapshots.Returns(persistSnapshots);
+        config.TrackDepthIncrementally.Returns(trackDepthIncrementally);
+        return config;
+    }
+
+    /// <summary>
+    /// Field-by-field comparison of the diff-tracked portion of <see cref="CumulativeTrieStats"/>.
+    /// Covers the six fields shared by the round-trip assertions in <c>TrieDiffWalkerTests</c>.
+    /// </summary>
+    public static void AssertAccountCumulativeEquals(
+        CumulativeTrieStats actual, CumulativeTrieStats expected, string? context = null)
+    {
+        string prefix = context is null ? string.Empty : context + " — ";
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual.AccountsTotal, Is.EqualTo(expected.AccountsTotal), prefix + "AccountsTotal");
+            Assert.That(actual.ContractsTotal, Is.EqualTo(expected.ContractsTotal), prefix + "ContractsTotal");
+            Assert.That(actual.AccountTrieBranches, Is.EqualTo(expected.AccountTrieBranches), prefix + "AccountTrieBranches");
+            Assert.That(actual.AccountTrieExtensions, Is.EqualTo(expected.AccountTrieExtensions), prefix + "AccountTrieExtensions");
+            Assert.That(actual.AccountTrieLeaves, Is.EqualTo(expected.AccountTrieLeaves), prefix + "AccountTrieLeaves");
+            Assert.That(actual.AccountTrieBytes, Is.EqualTo(expected.AccountTrieBytes), prefix + "AccountTrieBytes");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.StateComposition.Test/Helpers/TestDataBuilders.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Helpers/TestDataBuilders.cs
@@ -92,10 +92,12 @@ internal static class TestDataBuilders
     }
 
     /// <summary>
-    /// Field-by-field comparison of the diff-tracked portion of <see cref="CumulativeTrieStats"/>.
-    /// Covers the six fields shared by the round-trip assertions in <c>TrieDiffWalkerTests</c>.
+    /// Asserts equality of the six account-trie fields plus <see cref="CumulativeTrieStats.AccountsTotal"/>
+    /// and <see cref="CumulativeTrieStats.ContractsTotal"/>. Intentionally does NOT cover the storage-trie
+    /// side (<c>StorageSlotsTotal</c>, <c>StorageTrieBranches/Extensions/Leaves/Bytes</c>) —
+    /// callers that exercise storage tries should assert those fields directly.
     /// </summary>
-    public static void AssertAccountCumulativeEquals(
+    public static void AssertAccountTrieFieldsEqual(
         CumulativeTrieStats actual, CumulativeTrieStats expected, string? context = null)
     {
         string prefix = context is null ? string.Empty : context + " — ";

--- a/src/Nethermind/Nethermind.StateComposition.Test/MetricsCodeAndSlotsTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/MetricsCodeAndSlotsTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Immutable;
 using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Test.Helpers;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.StateComposition.Test/MetricsCodeAndSlotsTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/MetricsCodeAndSlotsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Nethermind.StateComposition.Data;
+using Nethermind.StateComposition.Test.Helpers;
 using NUnit.Framework;
 
 namespace Nethermind.StateComposition.Test;
@@ -21,32 +22,10 @@ public class MetricsCodeAndSlotsTests
     [SetUp]
     public void ClearHistogram() => Metrics.StateCompSlotCountHistogram.Clear();
 
-    private static ImmutableArray<long> ZeroHistogram() => [.. new long[16]];
-
-    private static CumulativeTrieStats BuildStats(long codeBytes, ImmutableArray<long> hist) =>
-        new(
-            AccountsTotal: 0,
-            ContractsTotal: 0,
-            StorageSlotsTotal: 0,
-            AccountTrieBranches: 0,
-            AccountTrieExtensions: 0,
-            AccountTrieLeaves: 0,
-            AccountTrieBytes: 0,
-            StorageTrieBranches: 0,
-            StorageTrieExtensions: 0,
-            StorageTrieLeaves: 0,
-            StorageTrieBytes: 0,
-            ContractsWithStorage: 0,
-            EmptyAccounts: 0)
-        {
-            CodeBytesTotal = codeBytes,
-            SlotCountHistogram = hist,
-        };
-
     [Test]
     public void UpdateFromCumulativeStats_PublishesCodeBytesTotal()
     {
-        Metrics.UpdateFromCumulativeStats(BuildStats(codeBytes: 42_000_000, hist: ZeroHistogram()));
+        Metrics.UpdateFromCumulativeStats(TestDataBuilders.BuildStats(codeBytes: 42_000_000));
 
         Assert.That(Metrics.StateCompCodeBytesTotal, Is.EqualTo(42_000_000));
     }
@@ -57,7 +36,7 @@ public class MetricsCodeAndSlotsTests
         // Each bucket gets a distinct value so we detect index swaps.
         long[] vals = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160];
 
-        Metrics.UpdateFromCumulativeStats(BuildStats(codeBytes: 0, hist: [.. vals]));
+        Metrics.UpdateFromCumulativeStats(TestDataBuilders.BuildStats(hist: [.. vals]));
 
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -14,9 +13,9 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
-using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Service;
 using Nethermind.StateComposition.Snapshots;
+using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.Trie;
 using NSubstitute;
 using NUnit.Framework;
@@ -39,42 +38,11 @@ public class StateCompositionServiceIncrementalRecoveryTests
     private static StateCompositionSnapshotStore CreateSnapshotStore() =>
         new(new MemDb(), LimboLogs.Instance);
 
-    private static IStateCompositionConfig CreateConfig()
-    {
-        IStateCompositionConfig config = Substitute.For<IStateCompositionConfig>();
-        config.ScanParallelism.Returns(4);
-        config.ScanMemoryBudgetBytes.Returns(1_000_000_000L);
-        config.ScanQueueTimeoutSeconds.Returns(5);
-        config.TopNContracts.Returns(20);
-        config.ExcludeStorage.Returns(false);
-        config.PersistSnapshots.Returns(false);
-        config.TrackDepthIncrementally.Returns(true);
-        return config;
-    }
-
-    private static CumulativeTrieStats EmptyBaseline() =>
-        new(
-            AccountsTotal: 0,
-            ContractsTotal: 0,
-            StorageSlotsTotal: 0,
-            AccountTrieBranches: 0,
-            AccountTrieExtensions: 0,
-            AccountTrieLeaves: 0,
-            AccountTrieBytes: 0,
-            StorageTrieBranches: 0,
-            StorageTrieExtensions: 0,
-            StorageTrieLeaves: 0,
-            StorageTrieBytes: 0,
-            ContractsWithStorage: 0,
-            EmptyAccounts: 0)
-        {
-            CodeBytesTotal = 0,
-            SlotCountHistogram = ImmutableArray.Create(
-                new long[CumulativeTrieStats.SlotHistogramLength]),
-        };
+    private static IStateCompositionConfig CreateConfig() =>
+        TestDataBuilders.CreateTestConfig(trackDepthIncrementally: true);
 
     private static void SeedBaseline(StateCompositionStateHolder holder, long blockNumber, Hash256 stateRoot) =>
-        holder.InitializeIncremental(EmptyBaseline(), blockNumber, stateRoot);
+        holder.InitializeIncremental(TestDataBuilders.EmptyBaseline(), blockNumber, stateRoot);
 
     [Test]
     public void InvalidateBaseline_ClearsLastProcessedStateRoot_ButPreservesTrackers()

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceTests.cs
@@ -21,6 +21,7 @@ using Nethermind.State;
 using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Service;
 using Nethermind.StateComposition.Snapshots;
+using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.StateComposition.Visitors;
 using NSubstitute;
 using NUnit.Framework;
@@ -30,16 +31,7 @@ namespace Nethermind.StateComposition.Test.Service;
 [TestFixture]
 public class StateCompositionServiceTests
 {
-    private static IStateCompositionConfig CreateValidConfig()
-    {
-        IStateCompositionConfig config = Substitute.For<IStateCompositionConfig>();
-        config.ScanParallelism.Returns(4);
-        config.ScanMemoryBudgetBytes.Returns(1_000_000_000L);
-        config.ScanQueueTimeoutSeconds.Returns(5);
-        config.TopNContracts.Returns(20);
-        config.ExcludeStorage.Returns(false);
-        return config;
-    }
+    private static IStateCompositionConfig CreateValidConfig() => TestDataBuilders.CreateTestConfig();
 
     // Build a realistic DI container using the canonical PseudoNethermindModule +
     // TestEnvironmentModule pair (see .agents/rules/test-infrastructure.md) so

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionStateHolderTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionStateHolderTests.cs
@@ -30,9 +30,6 @@ public class StateCompositionStateHolderTests
 {
     private static readonly Hash256 AnyRoot = Keccak.Compute("root");
 
-    private static CumulativeTrieStats EmptyBaseline(long codeBytes = 0, long[]? histogram = null) =>
-        TestDataBuilders.EmptyBaseline(codeBytes, histogram);
-
     private static TrieDiff DiffWithPayloads(
         IReadOnlyList<SlotCountChange>? slotCountChanges = null,
         IReadOnlyList<CodeHashChange>? codeHashChanges = null) =>
@@ -73,7 +70,7 @@ public class StateCompositionStateHolderTests
     public void ApplyIncrementalDiff_AddNewCodeHash_AddsToCodeBytesTotal()
     {
         ValueHash256 proxy = Keccak.Compute("proxy").ValueHash256;
-        StateCompositionStateHolder holder = HolderWithBaseline(EmptyBaseline());
+        StateCompositionStateHolder holder = HolderWithBaseline(TestDataBuilders.EmptyBaseline());
 
         TrieDiff diff = DiffWithPayloads(codeHashChanges:
         [
@@ -95,7 +92,7 @@ public class StateCompositionStateHolderTests
         ValueHash256 proxy = Keccak.Compute("proxy").ValueHash256;
         ValueHash256 acc1 = Keccak.Compute("a1").ValueHash256;
         ValueHash256 acc2 = Keccak.Compute("a2").ValueHash256;
-        StateCompositionStateHolder holder = HolderWithBaseline(EmptyBaseline());
+        StateCompositionStateHolder holder = HolderWithBaseline(TestDataBuilders.EmptyBaseline());
 
         int lookups = 0;
         int Lookup(ValueHash256 h)
@@ -132,7 +129,7 @@ public class StateCompositionStateHolderTests
         ValueHash256 acc2 = Keccak.Compute("a2").ValueHash256;
 
         StateCompositionStateHolder holder = HolderWithBaseline(
-            EmptyBaseline(codeBytes: 1024),
+            TestDataBuilders.EmptyBaseline(codeBytes: 1024),
             codeHashRefcounts: new Dictionary<ValueHash256, int> { [proxy] = 2 },
             codeHashSizes: new Dictionary<ValueHash256, int> { [proxy] = 1024 });
 
@@ -169,7 +166,7 @@ public class StateCompositionStateHolderTests
         ValueHash256 acc = Keccak.Compute("acc").ValueHash256;
 
         StateCompositionStateHolder holder = HolderWithBaseline(
-            EmptyBaseline(codeBytes: 1024),
+            TestDataBuilders.EmptyBaseline(codeBytes: 1024),
             codeHashRefcounts: new Dictionary<ValueHash256, int> { [oldImpl] = 1 },
             codeHashSizes: new Dictionary<ValueHash256, int> { [oldImpl] = 1024 });
 
@@ -189,7 +186,7 @@ public class StateCompositionStateHolderTests
     {
         // Fresh contract lands with 5 slots — bucket = floor(log2(6)) = 2.
         ValueHash256 acc = Keccak.Compute("acc").ValueHash256;
-        StateCompositionStateHolder holder = HolderWithBaseline(EmptyBaseline());
+        StateCompositionStateHolder holder = HolderWithBaseline(TestDataBuilders.EmptyBaseline());
 
         TrieDiff diff = DiffWithPayloads(slotCountChanges:
         [
@@ -221,7 +218,7 @@ public class StateCompositionStateHolderTests
         long[] seedHist = new long[CumulativeTrieStats.SlotHistogramLength];
         seedHist[startBucket] = 1;
         StateCompositionStateHolder holder = HolderWithBaseline(
-            EmptyBaseline(histogram: seedHist),
+            TestDataBuilders.EmptyBaseline(histogram: seedHist),
             slotCountByAddress: new Dictionary<ValueHash256, long> { [acc] = 3 });
 
         TrieDiff diff = DiffWithPayloads(slotCountChanges:
@@ -249,7 +246,7 @@ public class StateCompositionStateHolderTests
         long[] seedHist = new long[CumulativeTrieStats.SlotHistogramLength];
         seedHist[bucket] = 1;
         StateCompositionStateHolder holder = HolderWithBaseline(
-            EmptyBaseline(histogram: seedHist),
+            TestDataBuilders.EmptyBaseline(histogram: seedHist),
             slotCountByAddress: new Dictionary<ValueHash256, long> { [acc] = 10 });
 
         TrieDiff diff = DiffWithPayloads(slotCountChanges:
@@ -274,7 +271,7 @@ public class StateCompositionStateHolderTests
 
         long[] seed = new long[CumulativeTrieStats.SlotHistogramLength];
         seed[2] = 5;
-        StateCompositionStateHolder holder = HolderWithBaseline(EmptyBaseline(histogram: seed));
+        StateCompositionStateHolder holder = HolderWithBaseline(TestDataBuilders.EmptyBaseline(histogram: seed));
         ImmutableArray<long> capturedBaseline = holder.IncrementalStats.SlotCountHistogram;
 
         TrieDiff diff = DiffWithPayloads(slotCountChanges:

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionStateHolderTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionStateHolderTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Diff;
 using Nethermind.StateComposition.Service;
+using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.StateComposition.Visitors;
 using NUnit.Framework;
 
@@ -30,25 +31,7 @@ public class StateCompositionStateHolderTests
     private static readonly Hash256 AnyRoot = Keccak.Compute("root");
 
     private static CumulativeTrieStats EmptyBaseline(long codeBytes = 0, long[]? histogram = null) =>
-        new(
-            AccountsTotal: 0,
-            ContractsTotal: 0,
-            StorageSlotsTotal: 0,
-            AccountTrieBranches: 0,
-            AccountTrieExtensions: 0,
-            AccountTrieLeaves: 0,
-            AccountTrieBytes: 0,
-            StorageTrieBranches: 0,
-            StorageTrieExtensions: 0,
-            StorageTrieLeaves: 0,
-            StorageTrieBytes: 0,
-            ContractsWithStorage: 0,
-            EmptyAccounts: 0)
-        {
-            CodeBytesTotal = codeBytes,
-            SlotCountHistogram = ImmutableArray.Create(
-                histogram ?? new long[CumulativeTrieStats.SlotHistogramLength]),
-        };
+        TestDataBuilders.EmptyBaseline(codeBytes, histogram);
 
     private static TrieDiff DiffWithPayloads(
         IReadOnlyList<SlotCountChange>? slotCountChanges = null,

--- a/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/SnapshotRoundTripTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/SnapshotRoundTripTests.cs
@@ -25,6 +25,10 @@ namespace Nethermind.StateComposition.Test.Snapshots;
 [TestFixture]
 public class SnapshotRoundTripTests
 {
+    // Uses the positional constructor directly (not TestDataBuilders.BuildStats) because
+    // RoundTrip_DefaultHistogram_DecodesAsZeroFilledLength16 deliberately feeds `default`
+    // into the encoder — the shared helper normalises default→zeros before encoding,
+    // which would hide the edge case under test.
     private static CumulativeTrieStats BuildStats(long codeBytes, ImmutableArray<long> slotHist) =>
         new(
             AccountsTotal: 100,

--- a/src/Nethermind/Nethermind.StateComposition.Test/Visitors/SlotCountHistogramTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Visitors/SlotCountHistogramTests.cs
@@ -15,31 +15,14 @@ namespace Nethermind.StateComposition.Test.Visitors;
 [TestFixture]
 public class SlotCountHistogramTests
 {
-    [Test]
-    public void SlotCountHistogram_BucketsLogScale()
-    {
-        // Expected bucket = min(15, floor(log2(slotCount + 1))).
-        //   1 slot  → floor(log2(2)) = 1
-        //   3 slots → floor(log2(4)) = 2
-        //   7 slots → floor(log2(8)) = 3
-        //   1023    → floor(log2(1024)) = 10
-        //   1 << 20 → clamped to 15
-        (long slots, int expectedBucket)[] cases =
-        [
-            (1, 1),
-            (3, 2),
-            (7, 3),
-            (1023, 10),
-            (1 << 20, 15),
-        ];
-
-        foreach ((long slots, int expectedBucket) in cases)
-        {
-            int actual = VisitorCounters.ComputeSlotBucket(slots);
-            Assert.That(actual, Is.EqualTo(expectedBucket),
-                $"slotCount={slots}");
-        }
-    }
+    // Expected bucket = min(15, floor(log2(slotCount + 1))).
+    [TestCase(1L, 1)]
+    [TestCase(3L, 2)]
+    [TestCase(7L, 3)]
+    [TestCase(1023L, 10)]
+    [TestCase(1L << 20, 15)]
+    public void SlotCountHistogram_BucketsLogScale(long slots, int expectedBucket) =>
+        Assert.That(VisitorCounters.ComputeSlotBucket(slots), Is.EqualTo(expectedBucket));
 
     [Test]
     public void SlotCountHistogram_SumMatchesContractsWithStorage()
@@ -47,25 +30,8 @@ public class SlotCountHistogramTests
         VisitorCounters counters = new();
 
         // Simulate four contracts with storage, slot counts: 1, 3, 1023, 0.
-        // Each contract is a BeginStorageTrie -> N × TrackStorageNode(leaf) -> Flush cycle.
-        (long slots, int expectedBucket)[] contracts =
-        [
-            (1, 1),
-            (3, 2),
-            (1023, 10),
-            (0, 0),
-        ];
-
-        long withStorage = 0;
-        foreach ((long slots, int _) in contracts)
-        {
-            counters.ContractsWithStorage++;
-            withStorage++;
-            counters.BeginStorageTrie(default, default);
-            for (long i = 0; i < slots; i++)
-                counters.TrackStorageNode(depth: 1, byteSize: 1, isLeaf: true, isBranch: false);
-            counters.Flush();
-        }
+        long[] slotsPerContract = [1, 3, 1023, 0];
+        foreach (long slots in slotsPerContract) AddStorageContract(counters, slots);
 
         long histogramSum = 0;
         for (int i = 0; i < VisitorCounters.MaxTrackedDepth; i++)
@@ -73,12 +39,15 @@ public class SlotCountHistogramTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(histogramSum, Is.EqualTo(withStorage),
+            Assert.That(histogramSum, Is.EqualTo(slotsPerContract.Length),
                 "histogram sum must equal ContractsWithStorage");
 
-            foreach ((long slots, int expectedBucket) in contracts)
+            foreach (long slots in slotsPerContract)
+            {
+                int expectedBucket = VisitorCounters.ComputeSlotBucket(slots);
                 Assert.That(counters.SlotCountHistogram[expectedBucket], Is.GreaterThan(0),
                     $"bucket {expectedBucket} populated for slots={slots}");
+            }
         }
     }
 
@@ -89,24 +58,10 @@ public class SlotCountHistogramTests
         VisitorCounters b = new();
 
         // Thread A sees two contracts with 3 slots (bucket 2) and one with 1023 (bucket 10).
-        foreach (long slots in new long[] { 3, 3, 1023 })
-        {
-            a.ContractsWithStorage++;
-            a.BeginStorageTrie(default, default);
-            for (long i = 0; i < slots; i++)
-                a.TrackStorageNode(1, 1, isLeaf: true, isBranch: false);
-            a.Flush();
-        }
+        foreach (long slots in (long[])[3, 3, 1023]) AddStorageContract(a, slots);
 
         // Thread B sees one contract with 3 slots (bucket 2) and one with 1 slot (bucket 1).
-        foreach (long slots in new long[] { 3, 1 })
-        {
-            b.ContractsWithStorage++;
-            b.BeginStorageTrie(default, default);
-            for (long i = 0; i < slots; i++)
-                b.TrackStorageNode(1, 1, isLeaf: true, isBranch: false);
-            b.Flush();
-        }
+        foreach (long slots in (long[])[3, 1]) AddStorageContract(b, slots);
 
         VisitorCounters merged = new();
         merged.MergeFrom(a);
@@ -119,5 +74,14 @@ public class SlotCountHistogramTests
             Assert.That(merged.SlotCountHistogram[10], Is.EqualTo(1)); // one 1023-slot contract
             Assert.That(merged.ContractsWithStorage, Is.EqualTo(5));
         }
+    }
+
+    private static void AddStorageContract(VisitorCounters counters, long slots)
+    {
+        counters.ContractsWithStorage++;
+        counters.BeginStorageTrie(default, default);
+        for (long i = 0; i < slots; i++)
+            counters.TrackStorageNode(depth: 1, byteSize: 1, isLeaf: true, isBranch: false);
+        counters.Flush();
     }
 }

--- a/src/Nethermind/Nethermind.StateComposition.Test/Visitors/StateCompositionVisitorTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Visitors/StateCompositionVisitorTests.cs
@@ -46,33 +46,24 @@ public class StateCompositionVisitorTests
         Assert.That(dist.AvgBranchOccupancy, Is.EqualTo(3.0));
     }
 
-    [Test]
-    public void Visitor_ClassifiesContracts()
+    // Two SimulateAccounts batches per case: (count, hasCode, hasStorage) × 2, then expected totals.
+    [TestCase(5, false, false, 5, true, false, 10, 5, 0, TestName = "ClassifiesContracts_EOAsVsContracts")]
+    [TestCase(3, true, true, 2, true, false, 5, 5, 3, TestName = "TracksContractsWithStorage")]
+    public void Visitor_ClassifiesAccounts(
+        int n1, bool code1, bool storage1,
+        int n2, bool code2, bool storage2,
+        int expectedAccounts, int expectedContracts, int expectedWithStorage)
     {
-        SimulateAccounts(5, hasCode: false, hasStorage: false);
-        SimulateAccounts(5, hasCode: true, hasStorage: false);
+        SimulateAccounts(n1, hasCode: code1, hasStorage: storage1);
+        SimulateAccounts(n2, hasCode: code2, hasStorage: storage2);
 
         StateCompositionStats stats = _visitor.GetStats(1, null);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(stats.AccountsTotal, Is.EqualTo(10));
-            Assert.That(stats.ContractsTotal, Is.EqualTo(5));
-        }
-    }
-
-    [Test]
-    public void Visitor_TracksContractsWithStorage()
-    {
-        SimulateAccounts(3, hasCode: true, hasStorage: true);
-        SimulateAccounts(2, hasCode: true, hasStorage: false);
-
-        StateCompositionStats stats = _visitor.GetStats(1, null);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(stats.ContractsTotal, Is.EqualTo(5));
-            Assert.That(stats.ContractsWithStorage, Is.EqualTo(3));
+            Assert.That(stats.AccountsTotal, Is.EqualTo(expectedAccounts));
+            Assert.That(stats.ContractsTotal, Is.EqualTo(expectedContracts));
+            Assert.That(stats.ContractsWithStorage, Is.EqualTo(expectedWithStorage));
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Core.Crypto;
 using Nethermind.StateComposition.Data;
 using Nethermind.StateComposition.Visitors;
@@ -12,6 +13,11 @@ namespace Nethermind.StateComposition.Test.Visitors;
 [TestFixture]
 public class VisitorCountersTests
 {
+    // Mirrors TopNTracker.EntryComparer (which is internal — exposing it through a
+    // public test method signature triggers CS0051). Defined here so TestCaseSource
+    // can dispatch the three CompareBy* method groups through a single typed handle.
+    public delegate int EntryComparer(in TopContractEntry a, in TopContractEntry b);
+
     [Test]
     public void VisitorCounters_MergeFrom_AggregatesCorrectly()
     {
@@ -122,44 +128,34 @@ public class VisitorCountersTests
         Assert.That(a.TopN.TopByDepthCount, Is.EqualTo(2));
     }
 
-    [TestCase("Depth")]
-    [TestCase("TotalNodes")]
-    [TestCase("ValueNodes")]
-    public void Comparator_DeterministicTiebreaking(string comparator)
+    // For each primary key, two entries with identical primary value but a
+    // different secondary must produce strict ordering so the heap never
+    // compares equal. `b` is constructed to win the tiebreak so the comparer
+    // returns < 0 for every case.
+    private static IEnumerable<TestCaseData> TiebreakCases()
     {
-        // For each primary key, two entries with identical primary value but
-        // different secondary (MaxDepth or TotalNodes) must produce a strict
-        // ordering so the heap never compares equal.
-        TopContractEntry a;
-        TopContractEntry b;
-        int result;
+        yield return new TestCaseData(
+            new TopContractEntry { MaxDepth = 10, TotalNodes = 100, ValueNodes = 50 },
+            new TopContractEntry { MaxDepth = 10, TotalNodes = 200, ValueNodes = 50 },
+            (EntryComparer)TopNTracker.CompareByDepth)
+            .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByDepth");
 
-        switch (comparator)
-        {
-            case "Depth":
-                // Same MaxDepth → tiebreak on TotalNodes DESC
-                a = new() { MaxDepth = 10, TotalNodes = 100, ValueNodes = 50 };
-                b = new() { MaxDepth = 10, TotalNodes = 200, ValueNodes = 50 };
-                result = TopNTracker.CompareByDepth(in a, in b);
-                break;
-            case "TotalNodes":
-                // Same TotalNodes → tiebreak on MaxDepth DESC
-                a = new() { TotalNodes = 200, MaxDepth = 5, ValueNodes = 50 };
-                b = new() { TotalNodes = 200, MaxDepth = 10, ValueNodes = 50 };
-                result = TopNTracker.CompareByTotalNodes(in a, in b);
-                break;
-            case "ValueNodes":
-                // Same ValueNodes → tiebreak on MaxDepth DESC
-                a = new() { ValueNodes = 100, MaxDepth = 5, TotalNodes = 50 };
-                b = new() { ValueNodes = 100, MaxDepth = 10, TotalNodes = 50 };
-                result = TopNTracker.CompareByValueNodes(in a, in b);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null);
-        }
+        yield return new TestCaseData(
+            new TopContractEntry { TotalNodes = 200, MaxDepth = 5, ValueNodes = 50 },
+            new TopContractEntry { TotalNodes = 200, MaxDepth = 10, ValueNodes = 50 },
+            (EntryComparer)TopNTracker.CompareByTotalNodes)
+            .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByTotalNodes");
 
-        Assert.That(result, Is.LessThan(0)); // b wins the tiebreak → a < b
+        yield return new TestCaseData(
+            new TopContractEntry { ValueNodes = 100, MaxDepth = 5, TotalNodes = 50 },
+            new TopContractEntry { ValueNodes = 100, MaxDepth = 10, TotalNodes = 50 },
+            (EntryComparer)TopNTracker.CompareByValueNodes)
+            .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByValueNodes");
     }
+
+    [TestCaseSource(nameof(TiebreakCases))]
+    public void Comparator_DeterministicTiebreaking(TopContractEntry a, TopContractEntry b, EntryComparer cmp) =>
+        Assert.That(cmp(in a, in b), Is.LessThan(0));
 
     [Test]
     public void VisitorCounters_BeginStorageTrie_PreservesOwner()


### PR DESCRIPTION
Stacked on top of #10995 — targets that branch, not master. Merge #10995 first (or rebase this onto master after) before this can land on master.

## Changes

- Extract shared `TestDataBuilders` helper (`EmptyBaseline`, `BuildStats`, `CreateTestConfig`, `AssertAccountCumulativeEquals`) — eliminates copy-pasted `CumulativeTrieStats` / `IStateCompositionConfig` fixtures across service, metrics, and diff-walker tests.
- Parameterise the slot-bucket check in `SlotCountHistogramTests` with `[TestCase]`; extract the shared `BeginStorageTrie` + `TrackStorageNode` + `Flush` cycle into one helper.
- Merge `Visitor_ClassifiesContracts` + `Visitor_TracksContractsWithStorage` into a single `[TestCase]`-parameterised `Visitor_ClassifiesAccounts` — broadens per-case coverage to three totals.
- Replace `Comparator_DeterministicTiebreaking`'s `[TestCase("string")]` + switch dispatch with a proper `[TestCaseSource]` that carries typed `TopContractEntry` pairs and the comparer method group directly.
- Collapse repeated six-field `CumulativeTrieStats` assertions in `TrieDiffWalkerTests` into `TestDataBuilders.AssertAccountCumulativeEquals`.

Net: **+201 / −234 LOC** across 10 files (new helper + 9 test edits). Tests: **81 → 85 passing** (extra count is from `[TestCase]` expansion, not new tests).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Pure test-file refactor. Existing 85 tests pass (`dotnet test --project Nethermind.StateComposition.Test ... -c release`). No production code touched.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No