### PR TITLE
fix(merge): allow lower finalized FCUs and add Paris engine pyspec coverage

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Tests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Tests.cs
@@ -27,9 +27,10 @@ public class PragueBlockchainTests : PyspecBlockchainTestFixture<PragueBlockchai
 
 public class OsakaBlockchainTests : PyspecBlockchainTestFixture<OsakaBlockchainTests>;
 
-// Engine blockchain tests — only forks with meaningful Engine API differences
-// (e.g. blobs, execution requests, BAL). Regular BlockchainTests cover earlier forks.
+// Engine blockchain tests - post-merge forks with Engine API-specific coverage.
 // Directory derived from class name by convention (strip "EngineBlockchainTests", lowercase)
+
+public class ParisEngineBlockchainTests : PyspecEngineBlockchainTestFixture<ParisEngineBlockchainTests>;
 
 public class CancunEngineBlockchainTests : PyspecEngineBlockchainTestFixture<CancunEngineBlockchainTests>;
 

--- a/src/Nethermind/Nethermind.Blockchain/IBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockFinalizationManager.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Blockchain
     public interface IBlockFinalizationManager : IDisposable
     {
         /// <summary>
-        /// Last level that was finalize while processing blocks. This level will not be reorganised.
+        /// Current finalized level tracked by the active finalization manager.
         /// </summary>
         long LastFinalizedBlockLevel { get; }
         event EventHandler<FinalizeEventArgs> BlocksFinalized;

--- a/src/Nethermind/Nethermind.Blockchain/ManualFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ManualFinalizationManager.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Blockchain
         public void MarkFinalized(BlockHeader finalizingBlock, BlockHeader finalizedBlock)
         {
             LastFinalizedHash = finalizedBlock.Hash!;
-            LastFinalizedBlockLevel = Math.Max(LastFinalizedBlockLevel, finalizedBlock.Number);
+            LastFinalizedBlockLevel = finalizedBlock.Number;
             BlocksFinalized?.Invoke(this, new FinalizeEventArgs(finalizingBlock, finalizedBlock));
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1003,8 +1003,8 @@ public partial class EngineModuleTests
         }
 
         IReadOnlyList<ExecutionPayload> branch1 = await ProduceBranchV1(rpc, chain, 10, CreateParentBlockRequestOnHead(chain.BlockTree), true);
-        // setHead: false — sibling production with head=safe=finalized=block per slot would
-        // regress finalized below branch1[9] (Casper FFG monotonicity, enforced by the handler).
+        // setHead: false - sibling production here only builds alternative payloads; the reorg
+        // assertions below exercise forkchoice updates explicitly.
         IReadOnlyList<ExecutionPayload> branch2 = await ProduceBranchV1(rpc, chain, 6, branch1[3], setHead: false, TestItem.KeccakC);
 
         await CanReorganizeToLastBlock(chain, branch1, branch2);
@@ -1512,24 +1512,46 @@ public partial class EngineModuleTests
     }
 
     [Test]
-    public async Task forkchoiceUpdated_rejects_spec_ordering_violations()
+    public async Task forkchoiceUpdated_accepts_lower_finalized_than_previous_but_rejects_safe_before_finalized()
     {
         using MergeTestBlockchain chain =
             await CreateBlockchain(null, new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = chain.EngineRpcModule;
 
-        IReadOnlyList<ExecutionPayload> blocks = await ProduceBranchV1(rpc, chain, 4, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        IReadOnlyList<ExecutionPayload> blocks = await ProduceBranchV1(rpc, chain, 4, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
 
-        ForkchoiceStateV1 setup = new(headBlockHash: blocks[2].BlockHash, finalizedBlockHash: blocks[2].BlockHash, safeBlockHash: blocks[2].BlockHash);
-        (await rpc.engine_forkchoiceUpdatedV1(setup)).Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        ForkchoiceStateV1 lowerFinalized = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[1].BlockHash, safeBlockHash: blocks[2].BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> lowerFinalizedResult = await rpc.engine_forkchoiceUpdatedV1(lowerFinalized);
+        lowerFinalizedResult.ErrorCode.Should().Be(0);
+        lowerFinalizedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
 
-        // Casper FFG monotonicity: new finalized below previously-accepted finalized.
-        ForkchoiceStateV1 monotonicity = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[0].BlockHash, safeBlockHash: blocks[0].BlockHash);
-        (await rpc.engine_forkchoiceUpdatedV1(monotonicity)).ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState);
-
-        // Spec ordering: safe must be at or after finalized.
+        // Request-local spec ordering: safe must be at or after finalized.
         ForkchoiceStateV1 ordering = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[2].BlockHash, safeBlockHash: blocks[1].BlockHash);
         (await rpc.engine_forkchoiceUpdatedV1(ordering)).ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState);
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_should_allow_lower_finalized_than_previous_when_building_payload()
+    {
+        using MergeTestBlockchain chain =
+            await CreateBlockchain(null, new MergeConfig() { TerminalTotalDifficulty = "0" });
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> blocks = await ProduceBranchV1(rpc, chain, 4, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
+
+        PayloadAttributes payloadAttributes = new()
+        {
+            Timestamp = blocks[3].Timestamp + 1,
+            PrevRandao = TestItem.KeccakB,
+            SuggestedFeeRecipient = TestItem.AddressC,
+        };
+
+        ForkchoiceStateV1 repeatedHead = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[1].BlockHash, safeBlockHash: blocks[2].BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(repeatedHead, payloadAttributes);
+
+        result.ErrorCode.Should().Be(0);
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        result.Data.PayloadId.Should().NotBeNull();
     }
 
     [TestCase(false, TestName = "forkchoiceUpdated_rejects_repeated_finalized_when_head_on_sibling_branch")]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1520,10 +1520,19 @@ public partial class EngineModuleTests
 
         IReadOnlyList<ExecutionPayload> blocks = await ProduceBranchV1(rpc, chain, 4, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
 
+        ForkchoiceStateV1 higherFinalized = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[2].BlockHash, safeBlockHash: blocks[2].BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> higherFinalizedResult = await rpc.engine_forkchoiceUpdatedV1(higherFinalized);
+        higherFinalizedResult.ErrorCode.Should().Be(0);
+        higherFinalizedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockFinalizationManager.LastFinalizedHash.Should().Be(blocks[2].BlockHash);
+        chain.BlockFinalizationManager.LastFinalizedBlockLevel.Should().Be(blocks[2].BlockNumber);
+
         ForkchoiceStateV1 lowerFinalized = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[1].BlockHash, safeBlockHash: blocks[2].BlockHash);
         ResultWrapper<ForkchoiceUpdatedV1Result> lowerFinalizedResult = await rpc.engine_forkchoiceUpdatedV1(lowerFinalized);
         lowerFinalizedResult.ErrorCode.Should().Be(0);
         lowerFinalizedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockFinalizationManager.LastFinalizedHash.Should().Be(blocks[1].BlockHash);
+        chain.BlockFinalizationManager.LastFinalizedBlockLevel.Should().Be(blocks[1].BlockNumber);
 
         // Request-local spec ordering: safe must be at or after finalized.
         ForkchoiceStateV1 ordering = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[2].BlockHash, safeBlockHash: blocks[1].BlockHash);
@@ -1545,6 +1554,11 @@ public partial class EngineModuleTests
             PrevRandao = TestItem.KeccakB,
             SuggestedFeeRecipient = TestItem.AddressC,
         };
+
+        ForkchoiceStateV1 higherFinalized = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[2].BlockHash, safeBlockHash: blocks[2].BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> higherFinalizedResult = await rpc.engine_forkchoiceUpdatedV1(higherFinalized);
+        higherFinalizedResult.ErrorCode.Should().Be(0);
+        higherFinalizedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
 
         ForkchoiceStateV1 repeatedHead = new(headBlockHash: blocks[3].BlockHash, finalizedBlockHash: blocks[1].BlockHash, safeBlockHash: blocks[2].BlockHash);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(repeatedHead, payloadAttributes);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -525,6 +525,36 @@ public partial class EngineModuleTests
     }
 
     [Test]
+    public async Task ForkChoiceUpdatedV3_should_allow_lower_finalized_than_previous_when_building_payload()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
+        {
+            NewPayloadBlockProcessingTimeout = 1000
+        });
+        IEngineRpcModule rpcModule = chain.EngineRpcModule;
+
+        ExecutionPayloadV3 block1 = await AddNewBlockV3(rpcModule, chain);
+        ExecutionPayloadV3 block2 = await AddNewBlockV3(rpcModule, chain);
+        ExecutionPayloadV3 block3 = await AddNewBlockV3(rpcModule, chain);
+
+        PayloadAttributes payloadAttributes = new()
+        {
+            Timestamp = block3.Timestamp + 1,
+            PrevRandao = TestItem.KeccakH,
+            SuggestedFeeRecipient = TestItem.AddressF,
+            Withdrawals = [],
+            ParentBeaconBlockRoot = TestItem.KeccakE
+        };
+
+        ForkchoiceStateV1 repeatedHead = new(headBlockHash: block3.BlockHash, finalizedBlockHash: block1.BlockHash, safeBlockHash: block2.BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpcModule.engine_forkchoiceUpdatedV3(repeatedHead, payloadAttributes);
+
+        result.ErrorCode.Should().Be(0);
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        result.Data.PayloadId.Should().NotBeNull();
+    }
+
+    [Test]
     public async Task GetBlobsV1_should_throw_if_more_than_128_requested_blobs([Values(128, 129)] int requestSize)
     {
         MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -546,6 +546,11 @@ public partial class EngineModuleTests
             ParentBeaconBlockRoot = TestItem.KeccakE
         };
 
+        ForkchoiceStateV1 higherFinalized = new(headBlockHash: block3.BlockHash, finalizedBlockHash: block2.BlockHash, safeBlockHash: block2.BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> higherFinalizedResult = await rpcModule.engine_forkchoiceUpdatedV3(higherFinalized, null);
+        higherFinalizedResult.ErrorCode.Should().Be(0);
+        higherFinalizedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
         ForkchoiceStateV1 repeatedHead = new(headBlockHash: block3.BlockHash, finalizedBlockHash: block1.BlockHash, safeBlockHash: block2.BlockHash);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpcModule.engine_forkchoiceUpdatedV3(repeatedHead, payloadAttributes);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -78,9 +78,12 @@ public class ForkchoiceUpdatedHandler(
         return true;
     }
 
-    // Rejects a finalized/safe entry that fails the numeric spec-ordering bounds (Casper FFG
-    // monotonicity for finalized, safe >= finalized for safe) or the ancestry check against
-    // newHead. L1-derived finality models override this to relax the bounds check while keeping
+    // Rejects a finalized/safe entry that fails the request-local numeric bounds
+    // (finalized/safe cannot be above head, and safe cannot be below finalized)
+    // or the ancestry check against newHead. Cross-request finalized monotonicity is
+    // intentionally not enforced here; CLs may legitimately resend an older finalized
+    // marker on a later FCU as long as that FCU tuple is internally consistent.
+    // L1-derived finality models override this to relax the bounds check while keeping
     // ancestry validation.
     protected virtual ResultWrapper<ForkchoiceUpdatedV1Result>? RejectIfInconsistent(
         BlockHeader? header, long lowerBound, string label, BlockHeader newHeadHeader, string requestStr)
@@ -248,13 +251,12 @@ public class ForkchoiceUpdatedHandler(
             _blockTree.UpdateMainChain(blocks!, true, true);
         }
 
-        // Spec ordering: prevFinalized <= finalized <= safe <= head. Ancestry must be re-validated
-        // on every FCU - the binding is (head, finalized, safe), so a repeated finalized/safe hash
-        // paired with a new head on a sibling branch is still a spec violation.
-        long prevFinalizedLevel = _manualBlockFinalizationManager.LastFinalizedBlockLevel;
+        // Spec ordering within a single FCU: finalized <= safe <= head. Ancestry must be
+        // re-validated on every FCU - the binding is (head, finalized, safe), so a repeated
+        // finalized/safe hash paired with a new head on a sibling branch is still a spec violation.
         long finalizedNumber = finalizedHeader?.Number ?? 0;
 
-        if (RejectIfInconsistent(finalizedHeader, prevFinalizedLevel, "finalized", newHeadHeader, requestStr) is { } finalizedError) return finalizedError;
+        if (RejectIfInconsistent(finalizedHeader, 0, "finalized", newHeadHeader, requestStr) is { } finalizedError) return finalizedError;
         if (RejectIfInconsistent(safeBlockHeader, finalizedNumber, "safe", newHeadHeader, requestStr) is { } safeError) return safeError;
 
         bool nonZeroFinalizedBlockHash = finalizedBlockHash != Keccak.Zero;


### PR DESCRIPTION
## Changes

This fixes a regression introduced after #11187 in engine_forkchoiceUpdated.

The ancestry validation from #11185 remains in place, but the handler no longer rejects a valid FCU just because the new finalizedBlockHash is lower than the previously accepted finalized level. We still enforce request-local ordering and ancestry:

- finalized must be an ancestor of head
- safe must be an ancestor of head
- safe >= finalized
- neither safe nor finalized can be above head

This matches the Hive failures seen in:

- In-Order Consecutive Payload Execution (Paris, Cancun)
- Valid NewPayload->ForkchoiceUpdated on Syncing Client (Paris, Cancun)

Regression coverage added:

- V1 test for lower finalized on repeated FCU
- V1 test for lower finalized while building payloads
- V3/Cancun test for lower finalized while building payloads

This PR also adds ParisEngineBlockchainTests to the Pyspec engine test registry so Paris engine fixtures run in CI as
well.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Other: Moar tests

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes