### PR TITLE
WIP: ci(claude-review): dual-skill subagent dispatch

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -141,7 +141,15 @@ jobs:
                   "Bash(curl *)",
                   "Bash(wget *)",
                   "Bash(env *)",
-                  "Bash(printenv *)"
+                  "Bash(printenv *)",
+                  "Bash(gh auth*)",
+                  "Bash(gh secret*)",
+                  "Bash(gh workflow run*)",
+                  "Bash(gh repo delete*)",
+                  "Bash(git push*)",
+                  "Bash(git remote*)",
+                  "Bash(git config*)",
+                  "Bash(git clone*)"
                 ]
               }
             }
@@ -206,7 +214,15 @@ jobs:
                   "Bash(curl *)",
                   "Bash(wget *)",
                   "Bash(env *)",
-                  "Bash(printenv *)"
+                  "Bash(printenv *)",
+                  "Bash(gh auth*)",
+                  "Bash(gh secret*)",
+                  "Bash(gh workflow run*)",
+                  "Bash(gh repo delete*)",
+                  "Bash(git push*)",
+                  "Bash(git remote*)",
+                  "Bash(git config*)",
+                  "Bash(git clone*)"
                 ]
               }
             }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -108,16 +108,6 @@ jobs:
         with:
           fetch-depth: 100
 
-      # The action auto-restores .claude/ from the PR base branch (see
-      # anthropics/claude-code-action restore-config.ts SENSITIVE_PATHS) but
-      # does NOT touch .agents/. Our skills under .claude/skills/ symlink
-      # into .agents/skills/, so we must overlay .agents/ from master too —
-      # otherwise the symlinks dangle on PR branches that predate the skills.
-      - name: Overlay .agents from master
-        run: |
-          git fetch origin master --depth=1 --no-recurse-submodules
-          git checkout origin/master -- .agents || true
-
       # Review path: runs for auto-triggers and for @claude comments mentioning "review".
       # - `track_progress: true` renders the v0.x-style tracking comment with checkboxes.
       # - The prompt is fixed (overrides whatever the user wrote in the comment), so Claude
@@ -170,7 +160,7 @@ jobs:
             - `review` — deep Nethermind-flavored code review. Useful for non-trivial logic changes, new features, or subsystem refactors. Skip for pure docs/CI/comment-only diffs.
             - `resource-leak-audit` — IDisposable / CancellationTokenSource / ArrayPool / event-subscription / async-lifecycle audit. Use only when the diff touches resource management, disposal, or async coordination.
 
-            **If you decide to run a skill, you MUST dispatch it via the Agent tool in a subagent** — do NOT invoke the Skill tool directly in the main context. This keeps skill output isolated so you can merge findings deliberately.
+            **If you decide to run a skill, you MUST dispatch it via the Agent tool in a subagent, and the subagent MUST invoke the Skill tool.** Do not invoke Skill directly in the main context, and do not write a dispatch prompt that lets the subagent complete the task without calling Skill.
 
             After the subagent returns, merge its findings with your own and deduplicate by file:line before reporting.
 
@@ -186,7 +176,7 @@ jobs:
 
             Set `mergeable: false` in the structured output if any Critical, High, or Medium findings exist that have not been explicitly acknowledged with rationale in prior PR comments. Otherwise `mergeable: true`.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-sonnet-4-6
             --json-schema '{"type":"object","properties":{"mergeable":{"type":"boolean","description":"False if any Critical, High, or Medium findings remain unresolved and unexplained"},"critical_count":{"type":"integer"},"high_count":{"type":"integer"},"medium_count":{"type":"integer"},"summary":{"type":"string"}},"required":["mergeable","critical_count","high_count","medium_count","summary"]}'
 
       # Mention path: any other `@claude ...` interaction (no "review" keyword). No prompt
@@ -220,7 +210,7 @@ jobs:
               }
             }
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-sonnet-4-6
 
       # After a successful review, read the structured verdict from the previous step and
       # post a commit status on the PR head SHA:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -176,7 +176,6 @@ jobs:
 
             Set `mergeable: false` in the structured output if any Critical, High, or Medium findings exist that have not been explicitly acknowledged with rationale in prior PR comments. Otherwise `mergeable: true`.
           claude_args: |
-            --model claude-sonnet-4-6
             --json-schema '{"type":"object","properties":{"mergeable":{"type":"boolean","description":"False if any Critical, High, or Medium findings remain unresolved and unexplained"},"critical_count":{"type":"integer"},"high_count":{"type":"integer"},"medium_count":{"type":"integer"},"summary":{"type":"string"}},"required":["mergeable","critical_count","high_count","medium_count","summary"]}'
 
       # Mention path: any other `@claude ...` interaction (no "review" keyword). No prompt
@@ -209,8 +208,6 @@ jobs:
                 ]
               }
             }
-          claude_args: |
-            --model claude-sonnet-4-6
 
       # After a successful review, read the structured verdict from the previous step and
       # post a commit status on the PR head SHA:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -105,6 +105,18 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 100
+
+      # The action auto-restores .claude/ from the PR base branch (see
+      # anthropics/claude-code-action restore-config.ts SENSITIVE_PATHS) but
+      # does NOT touch .agents/. Our skills under .claude/skills/ symlink
+      # into .agents/skills/, so we must overlay .agents/ from master too —
+      # otherwise the symlinks dangle on PR branches that predate the skills.
+      - name: Overlay .agents from master
+        run: |
+          git fetch origin master --depth=1 --no-recurse-submodules
+          git checkout origin/master -- .agents || true
 
       # Review path: runs for auto-triggers and for @claude comments mentioning "review".
       # - `track_progress: true` renders the v0.x-style tracking comment with checkboxes.
@@ -113,6 +125,8 @@ jobs:
       # - `--json-schema` forces Claude's final result message into a structured JSON we
       #   parse in the status-posting step below. This JSON is NOT shown to humans — Claude
       #   still posts rich prose comments via the gh/MCP tools; the JSON is just the verdict.
+      # - `settings` block scopes permissions: exfiltration vectors (curl/wget/env/printenv)
+      #   are explicitly denied so the OAuth token can't leak through shell tools.
       - name: Run Claude Code (review path)
         timeout-minutes: 20
         if: steps.detect.outputs.is_review == 'true'
@@ -121,15 +135,46 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(git *)",
+                  "Bash(gh:*)",
+                  "WebFetch",
+                  "Agent",
+                  "Skill",
+                  "mcp__github_inline_comment__create_inline_comment"
+                ],
+                "deny": [
+                  "Bash(curl:*)",
+                  "Bash(wget:*)",
+                  "Bash(env:*)",
+                  "Bash(printenv:*)"
+                ]
+              }
+            }
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Before doing anything else, run `git fetch --deepen=100 origin` — the action re-fetches shallow internally, so `fetch-depth: 100` on checkout alone isn't enough for `git merge-base` / `git show`.
 
             Review this pull request focusing on:
             - Correctness, edge cases, and potential regressions
             - Security implications
             - Performance (this is a hot-path Ethereum execution client)
             - Adherence to repo rules in CONTRIBUTING.md and .agents/rules/
+
+            Skills to consider — use ONLY when clearly relevant to this PR. Do not force them on every review.
+            - `review` — deep Nethermind-flavored code review. Useful for non-trivial logic changes, new features, or subsystem refactors. Skip for pure docs/CI/comment-only diffs.
+            - `resource-leak-audit` — IDisposable / CancellationTokenSource / ArrayPool / event-subscription / async-lifecycle audit. Use only when the diff touches resource management, disposal, or async coordination.
+
+            **If you decide to run a skill, you MUST dispatch it via the Agent tool in a subagent** — do NOT invoke the Skill tool directly in the main context. This keeps skill output isolated so you can merge findings deliberately.
+
+            After the subagent returns, merge its findings with your own and deduplicate by file:line before reporting.
+
+            **Observability — required in your top-level PR comment, before the findings:** include a `### Skill Decisions` block that lists, for each skill above, `used` or `skipped` and a one-sentence reason tied to this specific PR (e.g. "skipped — no disposable/async surface in diff", "used — adds new CTS in TxBroadcaster.cs"). This makes the triage decision auditable.
 
             Categorize each finding by severity:
             - **Critical**: blocks merge, likely production impact
@@ -141,7 +186,7 @@ jobs:
 
             Set `mergeable: false` in the structured output if any Critical, High, or Medium findings exist that have not been explicitly acknowledged with rationale in prior PR comments. Otherwise `mergeable: true`.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh:*),WebFetch"
+            --model claude-opus-4-6
             --json-schema '{"type":"object","properties":{"mergeable":{"type":"boolean","description":"False if any Critical, High, or Medium findings remain unresolved and unexplained"},"critical_count":{"type":"integer"},"high_count":{"type":"integer"},"medium_count":{"type":"integer"},"summary":{"type":"string"}},"required":["mergeable","critical_count","high_count","medium_count","summary"]}'
 
       # Mention path: any other `@claude ...` interaction (no "review" keyword). No prompt
@@ -155,8 +200,27 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(git *)",
+                  "Bash(gh:*)",
+                  "WebFetch",
+                  "Agent",
+                  "Skill",
+                  "mcp__github_inline_comment__create_inline_comment"
+                ],
+                "deny": [
+                  "Bash(curl:*)",
+                  "Bash(wget:*)",
+                  "Bash(env:*)",
+                  "Bash(printenv:*)"
+                ]
+              }
+            }
           claude_args: |
-            --allowedTools "Bash(gh:*),WebFetch"
+            --model claude-opus-4-6
 
       # After a successful review, read the structured verdict from the previous step and
       # post a commit status on the PR head SHA:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -130,17 +130,17 @@ jobs:
               "permissions": {
                 "allow": [
                   "Bash(git *)",
-                  "Bash(gh:*)",
+                  "Bash(gh *)",
                   "WebFetch",
                   "Agent",
                   "Skill",
                   "mcp__github_inline_comment__create_inline_comment"
                 ],
                 "deny": [
-                  "Bash(curl:*)",
-                  "Bash(wget:*)",
-                  "Bash(env:*)",
-                  "Bash(printenv:*)"
+                  "Bash(curl *)",
+                  "Bash(wget *)",
+                  "Bash(env *)",
+                  "Bash(printenv *)"
                 ]
               }
             }
@@ -194,17 +194,17 @@ jobs:
               "permissions": {
                 "allow": [
                   "Bash(git *)",
-                  "Bash(gh:*)",
+                  "Bash(gh *)",
                   "WebFetch",
                   "Agent",
                   "Skill",
                   "mcp__github_inline_comment__create_inline_comment"
                 ],
                 "deny": [
-                  "Bash(curl:*)",
-                  "Bash(wget:*)",
-                  "Bash(env:*)",
-                  "Bash(printenv:*)"
+                  "Bash(curl *)",
+                  "Bash(wget *)",
+                  "Bash(env *)",
+                  "Bash(printenv *)"
                 ]
               }
             }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -134,7 +134,8 @@ jobs:
                   "WebFetch",
                   "Agent",
                   "Skill",
-                  "mcp__github_inline_comment__create_inline_comment"
+                  "mcp__github_inline_comment__create_inline_comment",
+                  "mcp__github_comment__update_claude_comment"
                 ],
                 "deny": [
                   "Bash(curl *)",
@@ -198,7 +199,8 @@ jobs:
                   "WebFetch",
                   "Agent",
                   "Skill",
-                  "mcp__github_inline_comment__create_inline_comment"
+                  "mcp__github_inline_comment__create_inline_comment",
+                  "mcp__github_comment__update_claude_comment"
                 ],
                 "deny": [
                   "Bash(curl *)",


### PR DESCRIPTION
## Changes

- **Dual-skill dispatch via subagents** — main agent may delegate to a subagent that invokes the \`review\` skill or \`resource-leak-audit\` skill when the PR surface is relevant. Skills are opt-in (soft guidance, not forced on every review).
- **Mandatory subagent invocation** — if a skill is used, it must go through a subagent and the subagent itself must invoke the Skill tool. No direct Skill calls in main context.
- **\`### Skill Decisions\` observability block** — main agent must report which skills were used or skipped with a one-sentence PR-specific reason, making triage decisions auditable.
- **Scoped permissions** — \`settings\` block with explicit allow-list (git, gh, WebFetch, Agent, Skill, inline-comment MCP) and deny-list for exfiltration vectors (curl, wget, env, printenv).
- **fetch-depth: 100** on checkout, plus a \`git fetch --deepen=100\` instruction in the prompt (the action's internal fetch re-shallows).
- Mention path also gets the scoped \`settings\` block for consistency.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No