### PR TITLE
Add new default for gnosis and gnosis archive config

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/gnosis.json
+++ b/src/Nethermind/Nethermind.Runner/configs/gnosis.json
@@ -51,5 +51,8 @@
       16,
       16
     ]
+  },
+  "Db": {
+    "SkipCheckingSstFileSizesOnDbOpen": true
   }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/gnosis_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/gnosis_archive.json
@@ -34,5 +34,8 @@
   },
   "Merge": {
     "FinalTotalDifficulty": "8626000110427538733349499292577475819600160930"
+  },
+  "Db": {
+    "SkipCheckingSstFileSizesOnDbOpen": true
   }
 }


### PR DESCRIPTION
## Changes

- Set `Db.SkipCheckingSstFileSizesOnDbOpen=true` as default on gnosis and gnosis archive

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_
