### PR TITLE
perf(trie): skip TrieNode wrapping for extension children already unresolved to Hash256

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -52,11 +52,11 @@ namespace Nethermind.Trie
                 // Fast path: child was unresolved to a Hash256 (e.g. by pruning) — encode the hash directly
                 // without materializing a TrieNode via FindCachedOrUnknown + ResolveKey.
                 Hash256? childKeccak = item._nodeData[0] as Hash256;
-                CappedArray<byte> childFullRlp = default;
+                TrieNode? nodeRef = null;
                 if (childKeccak is null)
                 {
                     int previousLength = item.AppendChildPath(ref path, 0);
-                    TrieNode nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
+                    nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
                     Debug.Assert(nodeRef is not null,
                         "Extension child is null when encoding.");
 
@@ -64,10 +64,9 @@ namespace Nethermind.Trie
                     path.TruncateMut(previousLength);
 
                     childKeccak = nodeRef.Keccak;
-                    childFullRlp = nodeRef.FullRlp;
                 }
 
-                int contentLength = Rlp.LengthOf(keyBytes) + (childKeccak is null ? childFullRlp.Length : Rlp.LengthOfKeccakRlp);
+                int contentLength = Rlp.LengthOf(keyBytes) + (childKeccak is not null ? Rlp.LengthOfKeccakRlp : nodeRef!.FullRlp.Length);
                 int totalLength = Rlp.LengthOfSequence(contentLength);
 
                 CappedArray<byte> data = bufferPool.SafeRent(totalLength);
@@ -79,7 +78,11 @@ namespace Nethermind.Trie
                 {
                     ArrayPool<byte>.Shared.Return(rentedBuffer);
                 }
-                if (childKeccak is null)
+                if (childKeccak is not null)
+                {
+                    Rlp.Encode(destination, position, childKeccak);
+                }
+                else
                 {
                     // Inline child: happens with a short extension to a branch with a short extension as the only child
                     // so |
@@ -87,11 +90,7 @@ namespace Nethermind.Trie
                     // so E - - - - - - - - - - - - - - -
                     // so |
                     // so |
-                    childFullRlp.AsSpan().CopyTo(destination.Slice(position));
-                }
-                else
-                {
-                    Rlp.Encode(destination, position, childKeccak);
+                    nodeRef!.FullRlp.AsSpan().CopyTo(destination.Slice(position));
                 }
 
                 return data;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -49,15 +49,25 @@ namespace Nethermind.Trie
 
                 HexPrefix.CopyToSpan(hexPrefix, isLeaf: false, keyBytes);
 
-                int previousLength = item.AppendChildPath(ref path, 0);
-                TrieNode nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
-                Debug.Assert(nodeRef is not null,
-                    "Extension child is null when encoding.");
+                // Fast path: child was unresolved to a Hash256 (e.g. by pruning) — encode the hash directly
+                // without materializing a TrieNode via FindCachedOrUnknown + ResolveKey.
+                Hash256? childKeccak = item._nodeData[0] as Hash256;
+                CappedArray<byte> childFullRlp = default;
+                if (childKeccak is null)
+                {
+                    int previousLength = item.AppendChildPath(ref path, 0);
+                    TrieNode nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
+                    Debug.Assert(nodeRef is not null,
+                        "Extension child is null when encoding.");
 
-                nodeRef.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
-                path.TruncateMut(previousLength);
+                    nodeRef.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                    path.TruncateMut(previousLength);
 
-                int contentLength = Rlp.LengthOf(keyBytes) + (nodeRef.Keccak is null ? nodeRef.FullRlp.Length : Rlp.LengthOfKeccakRlp);
+                    childKeccak = nodeRef.Keccak;
+                    childFullRlp = nodeRef.FullRlp;
+                }
+
+                int contentLength = Rlp.LengthOf(keyBytes) + (childKeccak is null ? childFullRlp.Length : Rlp.LengthOfKeccakRlp);
                 int totalLength = Rlp.LengthOfSequence(contentLength);
 
                 CappedArray<byte> data = bufferPool.SafeRent(totalLength);
@@ -69,19 +79,19 @@ namespace Nethermind.Trie
                 {
                     ArrayPool<byte>.Shared.Return(rentedBuffer);
                 }
-                if (nodeRef.Keccak is null)
+                if (childKeccak is null)
                 {
-                    // I think it can only happen if we have a short extension to a branch with a short extension as the only child?
+                    // Inline child: happens with a short extension to a branch with a short extension as the only child
                     // so |
                     // so |
                     // so E - - - - - - - - - - - - - - -
                     // so |
                     // so |
-                    nodeRef.FullRlp.AsSpan().CopyTo(destination.Slice(position));
+                    childFullRlp.AsSpan().CopyTo(destination.Slice(position));
                 }
                 else
                 {
-                    Rlp.Encode(destination, position, nodeRef.Keccak);
+                    Rlp.Encode(destination, position, childKeccak);
                 }
 
                 return data;


### PR DESCRIPTION
## Changes

- `EncodeExtension` now checks `_nodeData[0]` directly and encodes the child's hash inline when it is already a `Hash256` (the state left by `UnresolveChild` during pruning).
- Previous flow went through `GetChildWithChildPath`, which calls `tree.FindCachedOrUnknown` to wrap the hash back into a `TrieNode`, then `ResolveKey` (a no-op because `Keccak` was already set). That work is now skipped on the hot path.
- Mirrors the existing pattern used by branch encoding (`WriteChildrenRlpBranchNonRlp`, `GetChildrenRlpLengthForBranchNonRlp`), where a `Hash256` entry in `_nodeData[i]` is encoded directly.
- Non-`Hash256` cases (null, `_nullNode` / empty from RLP, resolved `TrieNode`, and the rare inline-child `Keccak == null` case for RLP < 32 bytes) fall through to the unchanged path.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Exercised via the existing Trie test suites:

- `Nethermind.Trie.Test` — same pass/fail counts as `master` baseline (two pre-existing flaky failures reproduce without this change).
- `Nethermind.State.Test` — 710 passed, 0 failed.

No behavior change for consumers; the encoded RLP is byte-identical in both paths.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No