### PR TITLE
fix: serialize testing_commitBlockV1 payload with EthereumJsonSerializer

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -207,6 +207,7 @@ public class MergePluginTests
             specProvider,
             blockFinder,
             Substitute.For<IBlockTree>(),
+            new EthereumJsonSerializer(),
             LimboLogs.Instance);
 
         PayloadAttributes payloadAttributes = new()
@@ -301,6 +302,7 @@ public class MergePluginTests
             specProvider,
             blockFinder,
             blockTree,
+            new EthereumJsonSerializer(),
             LimboLogs.Instance);
 
         PayloadAttributes payloadAttributes = new()
@@ -359,6 +361,7 @@ public class MergePluginTests
             specProvider,
             blockFinder,
             blockTree,
+            new EthereumJsonSerializer(),
             LimboLogs.Instance);
 
         PayloadAttributes payloadAttributes = new()
@@ -437,6 +440,7 @@ public class MergePluginTests
             specProvider,
             blockFinder,
             blockTree,
+            new EthereumJsonSerializer(),
             LimboLogs.Instance);
 
         PayloadAttributes payloadAttributes = new()

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
@@ -34,6 +33,7 @@ public class TestingRpcModule(
     ISpecProvider specProvider,
     IBlockFinder blockFinder,
     IBlockTree blockTree,
+    IJsonSerializer jsonSerializer,
     ILogManager logManager)
     : ITestingRpcModule
 {
@@ -117,7 +117,7 @@ public class TestingRpcModule(
             try
             {
                 string fileName = $"{processedBlock.Number}.json";
-                string jsonContent = JsonSerializer.Serialize(getPayloadV5Result, EthereumJsonSerializer.JsonOptions);
+                string jsonContent = jsonSerializer.Serialize(getPayloadV5Result);
                 await File.WriteAllTextAsync(fileName, jsonContent);
                 if (_logger.IsDebug) _logger.Debug($"Saved payload to {fileName}");
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -21,6 +21,7 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Proofs;
 using ILogger = Nethermind.Logging.ILogger;
@@ -116,7 +117,7 @@ public class TestingRpcModule(
             try
             {
                 string fileName = $"{processedBlock.Number}.json";
-                string jsonContent = JsonSerializer.Serialize(getPayloadV5Result);
+                string jsonContent = JsonSerializer.Serialize(getPayloadV5Result, EthereumJsonSerializer.JsonOptions);
                 await File.WriteAllTextAsync(fileName, jsonContent);
                 if (_logger.IsDebug) _logger.Debug($"Saved payload to {fileName}");
             }


### PR DESCRIPTION
## Changes

- Use `EthereumJsonSerializer.JsonOptions` when dumping the `GetPayloadV5Result` to `{blockNumber}.json` inside `testing_commitBlockV1`.
- Add the missing `using Nethermind.Serialization.Json;` import.

### Why

The async fire-and-forget `File.WriteAllTextAsync` path used the default `System.Text.Json` options. Those fail to serialize `Hash256` because its `ValueHash256` property is typed `ValueHash256&` (byref), throwing:

```
System.InvalidOperationException: The type 'Nethermind.Core.Crypto.ValueHash256&' of
property 'ValueHash256' on type 'Nethermind.Core.Crypto.Hash256' is invalid for
serialization or deserialization because it is a pointer type, is a ref struct, or
contains generic parameters that have not been replaced by specific types.
```

The catch block then logs `Failed to save payload to file` on every `testing_commitBlockV1` call, and the payload dump never lands on disk.

`EthereumJsonSerializer.JsonOptions` registers `Hash256Converter` and `ValueHash256Converter` (plus the rest of the chain-aware converter set), so the payload now serializes correctly.

### Repro / verification

Against a local node on this branch:

Before the fix — every commit produces one error line:
```
ERROR ... Failed to save payload to file
```

After the fix — no error lines; `{blockNumber}.json` lands in the runner CWD, e.g.:
```
$ head -c 200 4.json
{"blobsBundle":{"commitments":[],"blobs":[],"proofs":[]},"executionRequests":[],
"shouldOverrideBuilder":false,"blockValue":"0x5f7f37b39000","executionPayload":
{"blobGasUsed":"0x0","excessBlobGas":"0x0","baseFeePerGas":"0x23203e91",...
```

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Verified manually by driving `testing_commitBlockV1` three times against a local Nethermind and confirming no new `Failed to save payload to file` log lines and that the per-block JSON files appear. The serialization code path is the pre-existing one on this branch; the fix only swaps the options argument.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No