### PR TITLE
Additional BAL hive tests

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -107,7 +107,13 @@ public abstract class BlockchainTestBase
             await KzgPolynomialCommitments.InitializeAsync();
         }
 
-        DifficultyCalculator.Wrapped = new EthashDifficultyCalculator(specProvider);
+        // Per-test fresh instance instead of the shared static wrapper: tests run with
+        // [Parallelizable(ParallelScope.All)] and a shared Wrapped field is racy, which only
+        // matters once something actually consumes the calculator via DI (the difficulty-aware
+        // seal validator below). Keep the static wrapper field for backward compatibility, but
+        // hand the container a fresh instance bound to this test's specProvider.
+        IDifficultyCalculator difficultyCalculator = new EthashDifficultyCalculator(specProvider);
+        DifficultyCalculator.Wrapped = difficultyCalculator;
         IRewardCalculator rewardCalculator = new RewardCalculator(specProvider);
         bool isPostMerge = test.Network != London.Instance &&
                            test.Network != Berlin.Instance &&
@@ -142,10 +148,10 @@ public abstract class BlockchainTestBase
             .AddSingleton(specProvider)
             .AddSingleton(_logManager)
             .AddSingleton(rewardCalculator)
-            .AddSingleton<IDifficultyCalculator>(DifficultyCalculator)
+            .AddSingleton<IDifficultyCalculator>(difficultyCalculator)
             // Replace NullSealEngine with a validator that enforces pre-Merge Ethash difficulty
             // matching, so legacy invalid-block fixtures (wrongDifficulty_*) are actually rejected.
-            .AddSingleton<ISealValidator, IDifficultyCalculator>(diffCalc => new DifficultyOnlySealValidator(diffCalc))
+            .AddSingleton<ISealValidator>(new DifficultyOnlySealValidator(difficultyCalculator))
             .AddSingleton<ITxPool>(NullTxPool.Instance);
 
         // Wire in the merge module for any post-Merge test (engine API flow OR post-Paris

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -143,9 +143,16 @@ public abstract class BlockchainTestBase
             .AddSingleton(_logManager)
             .AddSingleton(rewardCalculator)
             .AddSingleton<IDifficultyCalculator>(DifficultyCalculator)
+            // Replace NullSealEngine with a validator that enforces pre-Merge Ethash difficulty
+            // matching, so legacy invalid-block fixtures (wrongDifficulty_*) are actually rejected.
+            .AddSingleton<ISealValidator, IDifficultyCalculator>(diffCalc => new DifficultyOnlySealValidator(diffCalc))
             .AddSingleton<ITxPool>(NullTxPool.Instance);
 
-        if (isEngineTest)
+        // Wire in the merge module for any post-Merge test (engine API flow OR post-Paris
+        // RLP-fed blockchain test). The merge module decorates IHeaderValidator with the
+        // EIP-3675 post-Merge field rules (difficulty=0, nonce=0, empty UnclesHash) which the
+        // base HeaderValidator does not enforce, and which legacy invalid-block fixtures rely on.
+        if (isEngineTest || isPostMerge)
         {
             containerBuilder.AddModule(new TestMergeModule(configProvider));
         }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -498,6 +498,11 @@ public abstract class BlockchainTestBase
                 byte[] rlpBytes = Bytes.FromHexString(testBlockJson.Rlp!);
                 Block suggestedBlock = Rlp.Decode<Block>(rlpBytes);
 
+                // EEST omits blockHeader (and the parsed body fields) for invalid-block fixtures
+                // because there is no canonical header for a block that must be rejected. The
+                // hash/uncle assertions only make sense when the fixture provides a header, but
+                // the block itself must still be enrolled so that validation actually runs and
+                // ExpectException is honoured.
                 if (testBlockJson.BlockHeader is not null)
                 {
                     Assert.That(suggestedBlock.Header.Hash, Is.EqualTo(new Hash256(testBlockJson.BlockHeader.Hash)));
@@ -506,9 +511,9 @@ public abstract class BlockchainTestBase
                     {
                         Assert.That(suggestedBlock.Uncles[uncleIndex].Hash, Is.EqualTo(new Hash256(testBlockJson.UncleHeaders![uncleIndex].Hash)));
                     }
-
-                    correctRlp.Add((suggestedBlock, testBlockJson.ExpectException));
                 }
+
+                correctRlp.Add((suggestedBlock, testBlockJson.ExpectException));
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -46,32 +46,9 @@ namespace Ethereum.Test.Base;
 
 public abstract class BlockchainTestBase
 {
-    private static readonly ILogger _logger;
     private static readonly ILogManager _logManager = new TestLogManager(LogLevel.Warn);
-    private static DifficultyCalculatorWrapper DifficultyCalculator { get; }
+    private static readonly ILogger _logger = _logManager.GetClassLogger<BlockchainTestBase>();
     private const int _genesisProcessingTimeoutMs = 30000;
-
-    static BlockchainTestBase()
-    {
-        DifficultyCalculator = new DifficultyCalculatorWrapper();
-        _logger = _logManager.GetClassLogger<BlockchainTestBase>();
-    }
-
-    private class DifficultyCalculatorWrapper : IDifficultyCalculator
-    {
-        public IDifficultyCalculator? Wrapped { get; set; }
-
-        public UInt256 Calculate(BlockHeader header, BlockHeader parent)
-        {
-            if (Wrapped is null)
-            {
-                throw new InvalidOperationException(
-                    $"Cannot calculate difficulty before the {nameof(Wrapped)} calculator is set.");
-            }
-
-            return Wrapped.Calculate(header, parent);
-        }
-    }
 
     protected async Task<EthereumTestResult> RunTest(BlockchainTest test, Stopwatch? stopwatch = null, bool failOnInvalidRlp = true, ITestBlockTracer? tracer = null)
     {
@@ -107,13 +84,9 @@ public abstract class BlockchainTestBase
             await KzgPolynomialCommitments.InitializeAsync();
         }
 
-        // Per-test fresh instance instead of the shared static wrapper: tests run with
-        // [Parallelizable(ParallelScope.All)] and a shared Wrapped field is racy, which only
-        // matters once something actually consumes the calculator via DI (the difficulty-aware
-        // seal validator below). Keep the static wrapper field for backward compatibility, but
-        // hand the container a fresh instance bound to this test's specProvider.
+        // Per-test fresh instance bound to this test's specProvider. Tests run with
+        // [Parallelizable(ParallelScope.All)] so anything shared-mutable across tests would race.
         IDifficultyCalculator difficultyCalculator = new EthashDifficultyCalculator(specProvider);
-        DifficultyCalculator.Wrapped = difficultyCalculator;
         IRewardCalculator rewardCalculator = new RewardCalculator(specProvider);
         bool isPostMerge = test.Network != London.Instance &&
                            test.Network != Berlin.Instance &&

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -292,10 +292,14 @@ public abstract class BlockchainTestBase
             Assert.That(correctRlp[i].Block.Hash, Is.Not.Null, $"null hash in {test.Name} block {i}");
 
             bool expectsException = correctRlp[i].ExpectedException is not null;
-            // Validate block structure first (mimics SyncServer validation)
+            // Validate block structure first (mimics SyncServer validation). Pre-validation is
+            // not authoritative for invalid-block fixtures: many EEST exceptions (state root,
+            // BAL hash, BAL gas-limit floor, etc.) are only detectable post-execution. So an
+            // expected-to-fail block may pass pre-validation here; rejection is then expected
+            // to come from the processor (synchronous InvalidBlockException) or from the
+            // end-of-test LastBlockHash check after the chain head is settled.
             if (blockValidator.ValidateSuggestedBlock(correctRlp[i].Block, parentHeader, out string? validationError))
             {
-                Assert.That(!expectsException, $"Expected block {correctRlp[i].Block.Hash} to fail with '{correctRlp[i].ExpectedException}', but it passed validation");
                 try
                 {
                     // All validations passed, suggest the block

--- a/src/Nethermind/Ethereum.Test.Base/DifficultyOnlySealValidator.cs
+++ b/src/Nethermind/Ethereum.Test.Base/DifficultyOnlySealValidator.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Consensus;
+using Nethermind.Core;
+
+namespace Ethereum.Test.Base;
+
+/// <summary>
+/// Test seal validator that skips PoW seal verification (too expensive for unit tests) but does
+/// enforce the pre-Merge "header.Difficulty == calculated difficulty" rule via the supplied
+/// <see cref="IDifficultyCalculator"/>. Mirrors the difficulty branch of
+/// <c>EthashSealValidator.ValidateParams</c> without the Ethash hash work.
+/// </summary>
+internal sealed class DifficultyOnlySealValidator(IDifficultyCalculator difficultyCalculator) : ISealValidator
+{
+    private readonly IDifficultyCalculator _difficultyCalculator = difficultyCalculator ?? throw new ArgumentNullException(nameof(difficultyCalculator));
+
+    public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
+    {
+        // Genesis (parent absent) carries the chainspec-declared difficulty; nothing to compare against.
+        if (parent is null) return true;
+
+        // Post-Merge difficulty rules are enforced by MergeHeaderValidator, not via the seal validator.
+        if (header.Difficulty.IsZero) return true;
+
+        return _difficultyCalculator.Calculate(header, parent) == header.Difficulty;
+    }
+
+    public bool ValidateSeal(BlockHeader header, bool force) => true;
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
@@ -294,4 +294,52 @@ public class BlockValidatorTests
             Assert.That(error, Does.StartWith("BlockAccessListGasLimitExceeded"));
         }
     }
+
+    [TestCase(30_000, true)]
+    [TestCase(29_999, false)]
+    public void ValidateProcessedBlock_Enforces_bal_item_gas_limit_boundary_for_rlp_imported_blocks(long gasLimit, bool expectedValid)
+    {
+        // Hive eels/consume-rlp feeds blocks via RLP, which leaves Block.BlockAccessList null
+        // (BlockDecoder does not decode BAL). The pre-execution check in
+        // ValidateBlockLevelAccessList is gated on a non-null BAL and therefore skipped, so
+        // ValidateProcessedBlock must catch the floor against the BAL produced during execution.
+        BlockHeader parent = Build.A.BlockHeader.TestObject;
+        BlockAccessList bal = Build.A.BlockAccessList.WithPrecompileChanges(parent.Hash!, timestamp: 12).TestObject;
+        byte[] encodedBal = Rlp.Encode(bal).Bytes;
+        Hash256 balHash = new(ValueKeccak.Compute(encodedBal).Bytes);
+
+        Block suggestedBlock = Build.A.Block
+            .WithParent(parent)
+            .WithGasLimit(gasLimit)
+            .WithBlobGasUsed(0)
+            .WithWithdrawals([])
+            .WithBlockAccessListHash(balHash)
+            .TestObject;
+
+        Block processedBlock = Build.A.Block
+            .WithParent(parent)
+            .WithGasLimit(gasLimit)
+            .WithBlobGasUsed(0)
+            .WithWithdrawals([])
+            .WithBlockAccessList(bal)
+            .WithEncodedBlockAccessList(encodedBal)
+            .WithBlockAccessListHash(balHash)
+            .TestObject;
+        processedBlock.GeneratedBlockAccessList = bal;
+
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+        BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, new CustomSpecProvider(((ForkActivation)0, Amsterdam.Instance)), LimboLogs.Instance);
+
+        bool isValid = sut.ValidateProcessedBlock(processedBlock, [], suggestedBlock, out string? error);
+
+        Assert.That(isValid, Is.EqualTo(expectedValid));
+        if (expectedValid)
+        {
+            Assert.That(error, Is.Null);
+        }
+        else
+        {
+            Assert.That(error, Does.StartWith("BlockAccessListGasLimitExceeded"));
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -156,6 +156,25 @@ public class BlockValidator(
     /// <returns><c>true</c> if the <paramref name="processedBlock"/> is valid; otherwise, <c>false</c>.</returns>
     public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, out string? error)
     {
+        // EIP-7928: enforce the BAL item gas-limit floor against the BAL produced during
+        // execution. The pre-execution check in ValidateBlockLevelAccessList only fires when
+        // the suggested block carries a BAL (engine-API path); RLP-imported blocks have a
+        // null suggested BAL and the agreed gas limit must still be validated against the
+        // generated BAL here.
+        IReleaseSpec spec = _specProvider.GetSpec(suggestedBlock.Header);
+        if (spec.BlockLevelAccessListsEnabled
+            && suggestedBlock.BlockAccessList is null
+            && processedBlock.GeneratedBlockAccessList is not null)
+        {
+            int itemCount = processedBlock.GeneratedBlockAccessList.ItemCount();
+            if (itemCount * GasCostOf.BlockAccessListItem > suggestedBlock.Header.GasLimit)
+            {
+                error = BlockErrorMessages.BlockAccessListGasLimitExceeded(itemCount, suggestedBlock.Header.GasLimit);
+                if (_logger.IsWarn) _logger.Warn($"BAL item count {itemCount} exceeds block gas limit bound in block {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}.");
+                return false;
+            }
+        }
+
         if (processedBlock.Header.Hash == suggestedBlock.Header.Hash)
         {
             error = null;

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -161,16 +161,15 @@ public class BlockValidator(
         // the suggested block carries a BAL (engine-API path); RLP-imported blocks have a
         // null suggested BAL and the agreed gas limit must still be validated against the
         // generated BAL here.
-        IReleaseSpec spec = _specProvider.GetSpec(suggestedBlock.Header);
-        if (spec.BlockLevelAccessListsEnabled
-            && suggestedBlock.BlockAccessList is null
-            && processedBlock.GeneratedBlockAccessList is not null)
+        if (suggestedBlock.BlockAccessList is null
+            && processedBlock.GeneratedBlockAccessList is not null
+            && _specProvider.GetSpec(suggestedBlock.Header).BlockLevelAccessListsEnabled)
         {
             int itemCount = processedBlock.GeneratedBlockAccessList.ItemCount();
             if (itemCount * GasCostOf.BlockAccessListItem > suggestedBlock.Header.GasLimit)
             {
                 error = BlockErrorMessages.BlockAccessListGasLimitExceeded(itemCount, suggestedBlock.Header.GasLimit);
-                if (_logger.IsWarn) _logger.Warn($"BAL item count {itemCount} exceeds block gas limit bound in block {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}.");
+                if (_logger.IsWarn) _logger.Warn($"Block level access list item count {itemCount} exceeds block gas limit bound in block {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}.");
                 return false;
             }
         }

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -144,6 +144,9 @@ namespace Nethermind.Consensus.Validators
 
         protected virtual bool ValidateBlockNumber(BlockHeader header, BlockHeader parent, ref string? error)
         {
+            // No parent-relative block-number check at genesis (parent is null only when ValidateParent already accepted genesis).
+            if (parent is null) return true;
+
             if (header.Number != parent.Number + 1)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - block number is not parent + 1");
@@ -256,6 +259,10 @@ namespace Nethermind.Consensus.Validators
 
         protected virtual bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error)
         {
+            // ValidateParent (called earlier in the chain) accepts a null parent only for genesis.
+            // Gas-limit-vs-parent comparisons don't apply at genesis, so skip them.
+            if (parent is null) return true;
+
             long adjustedParentGasLimit = Eip1559GasLimitAdjuster.AdjustGasLimit(spec, parent.GasLimit, header.Number);
             long maxGasLimitDifference = adjustedParentGasLimit / spec.GasLimitBoundDivisor;
 
@@ -290,6 +297,9 @@ namespace Nethermind.Consensus.Validators
 
         protected virtual bool ValidateTimestamp(BlockHeader header, BlockHeader parent, ref string? error)
         {
+            // No parent-relative timestamp check at genesis (parent is null only when ValidateParent already accepted genesis).
+            if (parent is null) return true;
+
             bool timestampMoreThanAtParent = header.Timestamp > parent.Timestamp;
             if (!timestampMoreThanAtParent)
             {

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -311,6 +311,13 @@ namespace Nethermind.Consensus.Validators
 
         protected virtual bool ValidateTotalDifficulty(BlockHeader header, BlockHeader parent, ref string? error)
         {
+            // Same class of null-parent exposure as ValidateBlockNumber/GasLimitRange/Timestamp:
+            // ValidateParent accepts null for genesis, but the non-zero-total-difficulty branch
+            // below dereferences parent. No current fixture triggers this (TotalDifficulty is
+            // typically null on uncle headers), but the guard keeps the method consistent with
+            // its siblings.
+            if (parent is null) return true;
+
             bool result = true;
 
             if (header.TotalDifficulty is not null)


### PR DESCRIPTION
## Changes

Fixes a hive `eels/consume-rlp` failure where two Amsterdam EIP-7928 BAL tests incorrectly passed (`test_bal_gas_limit_boundary[below_boundary]` and `test_gas_limit_below_minimum[gas_limit_5000_1]`). Expands the Pyspec test framework so this class of invalid-block fixture is actually exercised, and fixes the latent validation gaps that expansion surfaced.

### The primary fix - EIP-7928 BAL gas-limit floor on the RLP path

`BlockDecoder` does not decode BAL bytes from the RLP body, so RLP-imported blocks (hive `consume-rlp`, p2p sync) always have `Block.BlockAccessList == null`. The pre-execution check in `ValidateBlockLevelAccessList` gates on a non-null BAL, so the `itemCount * GasCostOf.BlockAccessListItem <= gasLimit` rule was silently skipped. During processing the BAL is regenerated (`ParallelWorldState.GeneratedBlockAccessList`) and the header `BlockAccessListHash` matches — so the block was accepted despite the gas-limit floor being violated.

Fix: validate the floor against `processedBlock.GeneratedBlockAccessList` inside `ValidateProcessedBlock`, before the hash-equal early return, only on the RLP path (suggested BAL null) when `spec.BlockLevelAccessListsEnabled`.

### Test-framework structural fix

`BlockchainTestBase.DecodeRlps` only enrolled blocks where `testBlockJson.BlockHeader is not null`, which meant every EEST invalid-block fixture (they omit `blockHeader` because there's no canonical header for a block that must be rejected) was silently dropped - including the BAL boundary test. Moved `correctRlp.Add` out of the `BlockHeader` gate and removed the over-strict `"Expected to fail with X but it passed validation"` assertion (post-execution rules like state-root, BAL hash, and the BAL gas-limit floor cannot fail pre-validation; the end-of-test `LastBlockHash` check is authoritative).

### Latent bugs the framework expansion revealed, now fixed

- **Post-Merge consensus rules** (EIP-3675: difficulty=0, nonce=0, UnclesHash=Keccak(rlp([]))) weren't enforced in the test environment because `MergeHeaderValidator` was only wired when `isEngineTest`. Now wired for any post-Merge test (fixes ~60 uncle-related + 3 post-Paris difficulty failures).
- **Pre-Paris difficulty validation** wasn't happening because the test seal validator was `NullSealEngine`. Added `DifficultyOnlySealValidator` that implements the difficulty branch of `EthashSealValidator.ValidateParams` without the expensive PoW hash work (fixes 3 `wrongDifficulty_*` failures).
- **`HeaderValidator` NullReferenceException on genesis-level uncle headers**: `ValidateParent` accepts a null parent for genesis, but `ValidateGasLimitRange`, `ValidateTimestamp`, and `ValidateBlockNumber` unconditionally dereferenced it. Added null-parent guards 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New boundary regression in `BlockValidatorTests.ValidateProcessedBlock_Enforces_bal_item_gas_limit_boundary_for_rlp_imported_blocks` (`30_000` valid, `29_999` invalid) that fails before the validator fix and passes after.
- `Eip7928BlockChainTests` (Pyspec) now actually exercises `test_bal_gas_limit_boundary[below_boundary]`: fails with `LAST BLOCK HASH` mismatch without the validator fix, green with it.
- Full regression sweep: `Ethereum.Legacy.Blockchain.Block.Test` 2539/2539, `Ethereum.Blockchain.Block.Test` 1146/1146, `Eip7928BlockChainTests` 574/574, `CancunBlockchainTests` 8389/8389, `BlockValidatorTests` + `ShardBlobBlockValidatorTests` 39/39 — all green.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Hive dashboard run that reported the original BAL failures: https://hive.ethpandaops.io/#/test/bal/1776762759-6340c22976e6ae27be715bd116690199 (suite `eels/consume-rlp`, 2/44457 failed on `nethermind_default 1.37.0-unstable+29561c2a`).

The `HeaderValidator` null-parent guards are minimal defensive changes; they only take effect when an uncle's parent is absent from the block tree and the header is genesis-level (`Number == 0`), a narrow sliver that was crashing instead of correctly falling through.