### PR TITLE
EIP-7976 — Increase calldata floor cost

### DIFF
--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -67,7 +67,8 @@ namespace Nethermind.Core
         public const long TLoad = WarmStateRead; // eip-1153
         public const long TStore = WarmStateRead; // eip-1153
         public const long PerAuthBaseCost = 12500; // eip-7702
-        public const long TotalCostFloorPerTokenEip7623 = 10; // eip-7632
+        public const long TotalCostFloorPerTokenEip7623 = 10; // eip-7623
+        public const long TotalCostFloorPerTokenEip7976 = 16; // eip-7976
 
         // EIP-8037: Two-dimensional gas metering constants.
         // Devnet-3 keeps CPSB hardcoded and replaces it with dynamic CPSB in devnet-4.

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -364,6 +364,11 @@ namespace Nethermind.Core.Specs
         bool IsEip7623Enabled { get; }
 
         /// <summary>
+        ///  Increase calldata floor cost and changes the floor token formula so zero bytes also cost 4 tokens.
+        /// </summary>
+        bool IsEip7976Enabled { get; }
+
+        /// <summary>
         ///  Transaction gas limit cap
         /// </summary>
         bool IsEip7825Enabled { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -364,7 +364,7 @@ namespace Nethermind.Core.Specs
         bool IsEip7623Enabled { get; }
 
         /// <summary>
-        ///  Increase calldata floor cost and changes the floor token formula so zero bytes also cost 4 tokens.
+        ///  Increase Calldata Floor Cost
         /// </summary>
         bool IsEip7976Enabled { get; }
 

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -364,11 +364,6 @@ namespace Nethermind.Core.Specs
         bool IsEip7623Enabled { get; }
 
         /// <summary>
-        ///  Increase Calldata Floor Cost
-        /// </summary>
-        bool IsEip7976Enabled { get; }
-
-        /// <summary>
         ///  Transaction gas limit cap
         /// </summary>
         bool IsEip7825Enabled { get; }
@@ -383,6 +378,11 @@ namespace Nethermind.Core.Specs
         /// </summary>
         bool IsEip7934Enabled { get; }
         int Eip7934MaxRlpBlockSize { get; }
+
+        /// <summary>
+        ///  Increase Calldata Floor Cost
+        /// </summary>
+        bool IsEip7976Enabled { get; }
 
         /// <summary>
         /// Should transactions be validated against chainId.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -93,6 +93,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsOpIsthmusEnabled => spec.IsOpIsthmusEnabled;
     public virtual bool IsOpJovianEnabled => spec.IsOpJovianEnabled;
     public virtual bool IsEip7623Enabled => spec.IsEip7623Enabled;
+    public virtual bool IsEip7976Enabled => spec.IsEip7976Enabled;
     public virtual bool ValidateChainId => spec.ValidateChainId;
     public virtual ulong TargetBlobCount => spec.TargetBlobCount;
     public virtual ulong MaxBlobCount => spec.MaxBlobCount;

--- a/src/Nethermind/Nethermind.Core/Specs/SpecGasCosts.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/SpecGasCosts.cs
@@ -21,6 +21,7 @@ public sealed class SpecGasCosts : IEquatable<SpecGasCosts>
     public readonly long ExpByteCost;
     public readonly long SStoreResetCost;
     public readonly long TxDataNonZeroMultiplier;
+    public readonly long TotalCostFloorPerToken;
 
     public readonly long NetMeteredSStoreCost;
     public readonly long ClearReversalRefund;
@@ -101,6 +102,12 @@ public sealed class SpecGasCosts : IEquatable<SpecGasCosts>
             ? GasCostOf.TxDataNonZeroMultiplierEip2028
             : GasCostOf.TxDataNonZeroMultiplier;
 
+        TotalCostFloorPerToken = spec.IsEip7976Enabled
+            ? GasCostOf.TotalCostFloorPerTokenEip7976
+            : spec.IsEip7623Enabled
+                ? GasCostOf.TotalCostFloorPerTokenEip7623
+                : GasCostOf.Free;
+
         SClearRefund = spec.IsEip3529Enabled
             ? RefundOf.SClearAfterEip3529
             : RefundOf.SClearBeforeEip3529;
@@ -110,8 +117,8 @@ public sealed class SpecGasCosts : IEquatable<SpecGasCosts>
             : RefundOf.DestroyBeforeEip3529;
 
         int hashCode1 = HashCode.Combine(SLoadCost, BalanceCost, ExtCodeCost, ExtCodeHashCost, CallCost, ExpByteCost, sStoreResetCost, netMeteredSStoreCost);
-        int hashCode2 = HashCode.Combine(TxDataNonZeroMultiplier, clearReversalRefund, setReversalRefund, SClearRefund, MaxBlobGasPerBlock, MaxBlobGasPerTx, TargetBlobGasPerBlock, DestroyRefund);
-        _hashCode = HashCode.Combine(hashCode1, hashCode2);
+        int hashCode2 = HashCode.Combine(TxDataNonZeroMultiplier, TotalCostFloorPerToken, clearReversalRefund, setReversalRefund, SClearRefund, MaxBlobGasPerBlock, MaxBlobGasPerTx, TargetBlobGasPerBlock);
+        _hashCode = HashCode.Combine(hashCode1, hashCode2, DestroyRefund);
     }
 
     public long RefundFromReversal<TEip8037>(bool originalIsZero)
@@ -134,6 +141,7 @@ public sealed class SpecGasCosts : IEquatable<SpecGasCosts>
             && ExpByteCost == other.ExpByteCost
             && SStoreResetCost == other.SStoreResetCost
             && TxDataNonZeroMultiplier == other.TxDataNonZeroMultiplier
+            && TotalCostFloorPerToken == other.TotalCostFloorPerToken
             && NetMeteredSStoreCost == other.NetMeteredSStoreCost
             && ClearReversalRefund == other.ClearReversalRefund
             && SetReversalRefund == other.SetReversalRefund

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7623Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7623Tests.cs
@@ -20,7 +20,7 @@ public class Eip7623Tests : VirtualMachineTestsBase
         Transaction transaction = new() { Data = new byte[] { 1 }, To = Address.Zero };
         EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
         cost.Should().Be(new EthereumIntrinsicGas(Standard: GasCostOf.Transaction + GasCostOf.TxDataNonZeroEip2028,
-            FloorGas: GasCostOf.Transaction + GasCostOf.TotalCostFloorPerTokenEip7623 * 4));
+            FloorGas: GasCostOf.Transaction + Spec.GasCosts.TotalCostFloorPerToken * 4));
     }
 
     [Test]
@@ -29,6 +29,6 @@ public class Eip7623Tests : VirtualMachineTestsBase
         Transaction transaction = new() { Data = new byte[] { 0 }, To = Address.Zero };
         EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
         cost.Should().Be(new EthereumIntrinsicGas(Standard: GasCostOf.Transaction + GasCostOf.TxDataZero,
-            FloorGas: GasCostOf.Transaction + GasCostOf.TotalCostFloorPerTokenEip7623));
+            FloorGas: GasCostOf.Transaction + Spec.GasCosts.TotalCostFloorPerToken));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -43,6 +43,8 @@ public class Eip7976Tests
     {
         Transaction transaction = new() { Data = new byte[] { 1 }, To = null };
         EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec);
+        // Standard: 21000 (base) + 32000 (tx creation) + InitCodeWord * 1 + 1 * 16 (1 non-zero byte) = 53,018
+        // Floor Gas Cost: 21000 (base) + 1 * 4 * 16 (1 non-zero byte) = 21,064
         cost.Should().Be(new EthereumIntrinsicGas(Standard: 53_018, FloorGas: 21_064));
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7976: Increase Calldata Floor Cost.
+/// Verifies both standard and floor gas for various calldata patterns.
+/// </summary>
+[TestFixture]
+public class Eip7976Tests
+{
+    private static IReleaseSpec Eip7976Spec()
+    {
+        return new OverridableReleaseSpec(Prague.Instance)
+        {
+            IsEip7976Enabled = true
+        };
+    }
+
+    // Roughtly
+    // Standard: 21000 + zero*4 + nonzero*16
+    // Floor: 21000 + byteCount * 4 * 16
+    [TestCase(new byte[] { 1 }, 21_016, 21_064, TestName = "Single nonzero byte")]
+    [TestCase(new byte[] { 0 }, 21_004, 21_064, TestName = "Single zero byte")]
+    [TestCase(new byte[] { 0, 0, 1, 1 }, 21_040, 21_256, TestName = "Multi byte mixed data")]
+    [TestCase(new byte[0], 21_000, 21_000, TestName = "Empty data is just transaction base")]
+    public void Intrinsic_gas_with_eip7976(byte[] data, long expectedStandard, long expectedFloor)
+    {
+        Transaction transaction = new() { Data = data, To = Address.Zero };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec());
+        cost.Should().Be(new EthereumIntrinsicGas(expectedStandard, expectedFloor));
+    }
+
+    [Test]
+    public void Contract_creation_standard_exceeds_floor()
+    {
+        Transaction transaction = new() { Data = new byte[] { 1 }, To = null };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec());
+        cost.Should().Be(new EthereumIntrinsicGas(Standard: 53_018, FloorGas: 21_064));
+    }
+
+    [Test]
+    public void Disabled_eip7976_falls_back_to_eip7623()
+    {
+        // 1 zero byte -> tokens = 1, floor = 21000 + 1 * 10 = 21010
+        Transaction transaction = new() { Data = new byte[] { 0 }, To = Address.Zero };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Prague.Instance);
+        cost.Should().Be(new EthereumIntrinsicGas(21_004, 21_010));
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -3,19 +3,12 @@
 
 using FluentAssertions;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
-using Nethermind.Core.Test.Builders;
-using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
 
-/// <summary>
-/// Tests for EIP-7976: Increase Calldata Floor Cost.
-/// Verifies both standard and floor gas for various calldata patterns.
-/// </summary>
 [TestFixture]
 public class Eip7976Tests
 {

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -19,15 +19,12 @@ namespace Nethermind.Evm.Test;
 [TestFixture]
 public class Eip7976Tests
 {
-    private static IReleaseSpec Eip7976Spec()
+    private static OverridableReleaseSpec Eip7976Spec => new OverridableReleaseSpec(Prague.Instance)
     {
-        return new OverridableReleaseSpec(Prague.Instance)
-        {
-            IsEip7976Enabled = true
-        };
-    }
+        IsEip7976Enabled = true
+    };
 
-    // Roughtly
+    // Roughly
     // Standard: 21000 + zero*4 + nonzero*16
     // Floor: 21000 + byteCount * 4 * 16
     [TestCase(new byte[] { 1 }, 21_016, 21_064, TestName = "Single nonzero byte")]
@@ -37,7 +34,7 @@ public class Eip7976Tests
     public void Intrinsic_gas_with_eip7976(byte[] data, long expectedStandard, long expectedFloor)
     {
         Transaction transaction = new() { Data = data, To = Address.Zero };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec());
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec);
         cost.Should().Be(new EthereumIntrinsicGas(expectedStandard, expectedFloor));
     }
 
@@ -45,7 +42,7 @@ public class Eip7976Tests
     public void Contract_creation_standard_exceeds_floor()
     {
         Transaction transaction = new() { Data = new byte[] { 1 }, To = null };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec());
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec);
         cost.Should().Be(new EthereumIntrinsicGas(Standard: 53_018, FloorGas: 21_064));
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Specs.Forks;
-using Nethermind.Specs.Test;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -12,41 +14,31 @@ namespace Nethermind.Evm.Test;
 [TestFixture]
 public class Eip7976Tests
 {
-    private static OverridableReleaseSpec Eip7976Spec => new OverridableReleaseSpec(Prague.Instance)
+    // EIP-7976 floor: 21000 + byteCount * nonzeroMultiplier(4) * 16
+    // EIP-7623 floor: 21000 + tokens * 10  (tokens = zeros*1 + nonzeros*multiplier)
+    // Standard: 21000 + zero*4 + nonzero*16 (+ 32000 + InitCodeWord for contract creation)
+    private static IEnumerable<TestCaseData> IntrinsicGasCases()
     {
-        IsEip7976Enabled = true
-    };
+        // Contract creation uses NoEip8037 to isolate EIP-7976 floor cost from EIP-8037 state gas, auth list cost changes
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 1 }, 21_016L, 21_064L)
+            .SetName("EIP-7976: single nonzero byte");
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 0 }, 21_004L, 21_064L)
+            .SetName("EIP-7976: single zero byte");
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 0, 0, 1, 1 }, 21_040L, 21_256L)
+            .SetName("EIP-7976: mixed data");
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, Array.Empty<byte>(), 21_000L, 21_000L)
+            .SetName("EIP-7976: empty data");
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, null, new byte[] { 1 }, 53_018L, 21_064L)
+            .SetName("EIP-7976: contract creation standard exceeds floor");
+        yield return new TestCaseData(Prague.Instance, Address.Zero, new byte[] { 0 }, 21_004L, 21_010L)
+            .SetName("EIP-7623 fallback: single zero byte");
+    }
 
-    // Roughly
-    // Standard: 21000 + zero*4 + nonzero*16
-    // Floor: 21000 + byteCount * 4 * 16
-    [TestCase(new byte[] { 1 }, 21_016, 21_064, TestName = "Single nonzero byte")]
-    [TestCase(new byte[] { 0 }, 21_004, 21_064, TestName = "Single zero byte")]
-    [TestCase(new byte[] { 0, 0, 1, 1 }, 21_040, 21_256, TestName = "Multi byte mixed data")]
-    [TestCase(new byte[0], 21_000, 21_000, TestName = "Empty data is just transaction base")]
-    public void Intrinsic_gas_with_eip7976(byte[] data, long expectedStandard, long expectedFloor)
+    [TestCaseSource(nameof(IntrinsicGasCases))]
+    public void Intrinsic_gas_calculation(IReleaseSpec spec, Address? to, byte[] data, long expectedStandard, long expectedFloor)
     {
-        Transaction transaction = new() { Data = data, To = Address.Zero };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec);
+        Transaction transaction = new() { Data = data, To = to };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, spec);
         cost.Should().Be(new EthereumIntrinsicGas(expectedStandard, expectedFloor));
-    }
-
-    [Test]
-    public void Contract_creation_standard_exceeds_floor()
-    {
-        Transaction transaction = new() { Data = new byte[] { 1 }, To = null };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Eip7976Spec);
-        // Standard: 21000 (base) + 32000 (tx creation) + InitCodeWord * 1 + 1 * 16 (1 non-zero byte) = 53,018
-        // Floor Gas Cost: 21000 (base) + 1 * 4 * 16 (1 non-zero byte) = 21,064
-        cost.Should().Be(new EthereumIntrinsicGas(Standard: 53_018, FloorGas: 21_064));
-    }
-
-    [Test]
-    public void Disabled_eip7976_falls_back_to_eip7623()
-    {
-        // 1 zero byte -> tokens = 1, floor = 21000 + 1 * 10 = 21010
-        Transaction transaction = new() { Data = new byte[] { 0 }, To = Address.Zero };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Prague.Instance);
-        cost.Should().Be(new EthereumIntrinsicGas(21_004, 21_010));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -14,21 +15,22 @@ namespace Nethermind.Evm.Test;
 [TestFixture]
 public class Eip7976Tests
 {
+    private static readonly IReleaseSpec Eip7976Spec = new OverridableReleaseSpec(Prague.Instance) { IsEip7976Enabled = true };
+
     // EIP-7976 floor: 21000 + byteCount * nonzeroMultiplier(4) * 16
-    // EIP-7623 floor: 21000 + tokens * 10  (tokens = zeros*1 + nonzeros*multiplier)
+    // EIP-7623 floor: 21000 + tokens * 10  (tokens = zeros*1 + non-zeros*multiplier)
     // Standard: 21000 + zero*4 + nonzero*16 (+ 32000 + InitCodeWord for contract creation)
     private static IEnumerable<TestCaseData> IntrinsicGasCases()
     {
-        // We use NoEip8037 to isolate EIP-7976 floor cost from EIP-8037 state gas, auth list cost changes
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 1 }, 21_016L, 21_064L)
+        yield return new TestCaseData(Eip7976Spec, Address.Zero, new byte[] { 1 }, 21_016L, 21_064L)
             .SetName("EIP-7976: single nonzero byte");
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 0 }, 21_004L, 21_064L)
+        yield return new TestCaseData(Eip7976Spec, Address.Zero, new byte[] { 0 }, 21_004L, 21_064L)
             .SetName("EIP-7976: single zero byte");
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 0, 0, 1, 1 }, 21_040L, 21_256L)
+        yield return new TestCaseData(Eip7976Spec, Address.Zero, new byte[] { 0, 0, 1, 1 }, 21_040L, 21_256L)
             .SetName("EIP-7976: mixed data");
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, Array.Empty<byte>(), 21_000L, 21_000L)
+        yield return new TestCaseData(Eip7976Spec, Address.Zero, Array.Empty<byte>(), 21_000L, 21_000L)
             .SetName("EIP-7976: empty data");
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, null, new byte[] { 1 }, 53_018L, 21_064L)
+        yield return new TestCaseData(Eip7976Spec, null, new byte[] { 1 }, 53_018L, 21_064L)
             .SetName("EIP-7976: contract creation standard exceeds floor");
         yield return new TestCaseData(Prague.Instance, Address.Zero, new byte[] { 0 }, 21_004L, 21_010L)
             .SetName("EIP-7623 fallback: single zero byte");

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -19,7 +19,7 @@ public class Eip7976Tests
     // Standard: 21000 + zero*4 + nonzero*16 (+ 32000 + InitCodeWord for contract creation)
     private static IEnumerable<TestCaseData> IntrinsicGasCases()
     {
-        // Contract creation uses NoEip8037 to isolate EIP-7976 floor cost from EIP-8037 state gas, auth list cost changes
+        // We use NoEip8037 to isolate EIP-7976 floor cost from EIP-8037 state gas, auth list cost changes
         yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 1 }, 21_016L, 21_064L)
             .SetName("EIP-7976: single nonzero byte");
         yield return new TestCaseData(Amsterdam.NoEip8037Instance, Address.Zero, new byte[] { 0 }, 21_004L, 21_064L)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7976Tests.cs
@@ -17,8 +17,8 @@ public class Eip7976Tests
 {
     private static readonly IReleaseSpec Eip7976Spec = new OverridableReleaseSpec(Prague.Instance) { IsEip7976Enabled = true };
 
-    // EIP-7976 floor: 21000 + byteCount * nonzeroMultiplier(4) * 16
-    // EIP-7623 floor: 21000 + tokens * 10  (tokens = zeros*1 + non-zeros*multiplier)
+    // EIP-7976 floor: 21000 + byteCount * STANDARD_TOKEN_COST(4) * TOTAL_COST_FLOOR_PER_TOKEN(16)
+    // EIP-7623 floor: 21000 + tokens * 10  (tokens = zeros + nonzeros * STANDARD_TOKEN_COST)
     // Standard: 21000 + zero*4 + nonzero*16 (+ 32000 + InitCodeWord for contract creation)
     private static IEnumerable<TestCaseData> IntrinsicGasCases()
     {

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -325,7 +325,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
                           + CreateCost(tx, spec)
                           + IGasPolicy<EthereumGasPolicy>.AccessListCost(tx, spec)
                           + authRegularCost;
-        long floorCost = IGasPolicy<EthereumGasPolicy>.CalculateFloorCost(tokensInCallData, spec);
+        long floorCost = IGasPolicy<EthereumGasPolicy>.CalculateFloorCost(tx, spec, tokensInCallData);
         long createStateCost = CreateStateCost(tx, spec);
         long totalStateCost = authStateCost + createStateCost;
         return spec.IsEip8037Enabled

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -431,23 +431,18 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
             throw new InvalidDataException($"Transaction with an authorization list received within the context of {releaseSpec.Name}. EIP-7702 is not enabled.");
     }
 
+    private static long CalculateFloorTokensInCallData(Transaction transaction, IReleaseSpec spec) =>
+        transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
+
     /// <summary>
     /// Calculates the calldata floor cost for a transaction.
     /// </summary>
-    protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData)
+    protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData) => spec switch
     {
-        if (spec.IsEip7976Enabled)
-        {
-            long floorTokensInCallData = transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
-            return GasCostOf.Transaction + floorTokensInCallData * spec.GasCosts.TotalCostFloorPerToken;
-        }
-        else if (spec.IsEip7623Enabled)
-        {
-            return GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken;
-        }
-
-        return 0L;
-    }
+        { IsEip7976Enabled: true } => GasCostOf.Transaction + CalculateFloorTokensInCallData(transaction, spec) * spec.GasCosts.TotalCostFloorPerToken,
+        { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
+        _ => 0L
+    };
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -439,7 +439,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     {
         if (spec.IsEip7976Enabled)
         {
-            long floorTokensInCallData = transaction.Data.Length * spec.GetTxDataNonZeroMultiplier();
+            long floorTokensInCallData = transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
             return GasCostOf.Transaction + floorTokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7976;
         }
         else if (spec.IsEip7623Enabled)

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -384,6 +384,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return totalZeros + (data.Length - totalZeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
+
     public static long AccessListCost(Transaction transaction, IReleaseSpec spec)
     {
         AccessList? accessList = transaction.AccessList;
@@ -431,10 +432,28 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
             throw new InvalidDataException($"Transaction with an authorization list received within the context of {releaseSpec.Name}. EIP-7702 is not enabled.");
     }
 
-    protected static long CalculateFloorCost(long tokensInCallData, IReleaseSpec spec) =>
-        spec.IsEip7623Enabled
-            ? GasCostOf.Transaction + tokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7623
-            : 0L;
+    /// <summary>
+    /// Calculates the calldata floor cost for a transaction.
+    /// EIP-7976 uses uniform byte weighting (all bytes treated as non-zero) with TOTAL_COST_FLOOR_PER_TOKEN of 16.
+    /// EIP-7623 uses differentiated zero/non-zero token counting with TOTAL_COST_FLOOR_PER_TOKEN of 10.
+    /// The floor applies to regular gas only (independent of state gas in EIP-8037).
+    /// </summary>
+    protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData)
+    {
+        // EIP-7976 supersedes EIP-7623: floor_tokens_in_calldata = total_bytes * nonzero_multiplier (uniform weighting)
+        if (spec.IsEip7976Enabled)
+        {
+            long floorTokensInCallData = transaction.Data.Length * spec.GetTxDataNonZeroMultiplier();
+            return GasCostOf.Transaction + floorTokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7976;
+        }
+        // EIP-7623: tokens_in_calldata uses differentiated zero/non-zero byte costs
+        else if (spec.IsEip7623Enabled)
+        {
+            return GasCostOf.Transaction + tokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7623;
+        }
+
+        return 0L;
+    }
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -384,7 +384,6 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return totalZeros + (data.Length - totalZeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
-
     public static long AccessListCost(Transaction transaction, IReleaseSpec spec)
     {
         AccessList? accessList = transaction.AccessList;
@@ -440,11 +439,11 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         if (spec.IsEip7976Enabled)
         {
             long floorTokensInCallData = transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
-            return GasCostOf.Transaction + floorTokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7976;
+            return GasCostOf.Transaction + floorTokensInCallData * spec.GasCosts.TotalCostFloorPerToken;
         }
         else if (spec.IsEip7623Enabled)
         {
-            return GasCostOf.Transaction + tokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7623;
+            return GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken;
         }
 
         return 0L;

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -434,19 +434,14 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>
     /// Calculates the calldata floor cost for a transaction.
-    /// EIP-7976 uses uniform byte weighting (all bytes treated as non-zero) with TOTAL_COST_FLOOR_PER_TOKEN of 16.
-    /// EIP-7623 uses differentiated zero/non-zero token counting with TOTAL_COST_FLOOR_PER_TOKEN of 10.
-    /// The floor applies to regular gas only (independent of state gas in EIP-8037).
     /// </summary>
     protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData)
     {
-        // EIP-7976 supersedes EIP-7623: floor_tokens_in_calldata = total_bytes * nonzero_multiplier (uniform weighting)
         if (spec.IsEip7976Enabled)
         {
             long floorTokensInCallData = transaction.Data.Length * spec.GetTxDataNonZeroMultiplier();
             return GasCostOf.Transaction + floorTokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7976;
         }
-        // EIP-7623: tokens_in_calldata uses differentiated zero/non-zero byte costs
         else if (spec.IsEip7623Enabled)
         {
             return GasCostOf.Transaction + tokensInCallData * GasCostOf.TotalCostFloorPerTokenEip7623;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -9,6 +10,7 @@ using FluentAssertions.Execution;
 using FluentAssertions.Json;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Container;
 using Nethermind.Evm;
@@ -531,18 +533,38 @@ public partial class EthRpcModuleTests
         JToken.Parse(serialized).Should().BeEquivalentTo("""{"jsonrpc":"2.0","error":{"code":3,"message":"execution reverted","data":"0x"},"id":67}""");
     }
 
-    [Test]
-    public async Task Eth_estimateGas_eip7976_data_heavy_tx_returns_floor_cost()
+    private static IEnumerable<TestCaseData> EstimateGasFloorCostCases()
     {
-        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
-        TestSpecProvider specProvider = new(releaseSpec);
+        // EIP-7976: 100 zero bytes → floor = 21000 + 100 * 4 * 16 = 27400
+        long eip7976Floor100 = GasCostOf.Transaction + 100 * Amsterdam.NoEip8037Instance.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
+            .SetName("EIP-7976: data heavy tx returns floor cost");
+
+        // EIP-7623: 100 zero bytes → floor = 21000 + 100 * 10 = 22000
+        const long eip7623Floor100 = GasCostOf.Transaction + 100 * GasCostOf.TotalCostFloorPerTokenEip7623;
+        yield return new TestCaseData(Prague.Instance, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7623Floor100.ToHexString(true)}\",\"id\":67}}")
+            .SetName("EIP-7623: data heavy tx returns lower floor");
+
+        // EIP-7976: gas limit below intrinsic gas
+        const long belowFloor = GasCostOf.Transaction + GasCostOf.TxDataZero;
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[] { 0 }, belowFloor, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}")
+            .SetName("EIP-7976: insufficient gas for floor");
+
+        // EIP-7976: mixed calldata (0x00001122 = 2 zero + 2 nonzero bytes)
+        long eip7976Floor4 = GasCostOf.Transaction + 4 * Amsterdam.NoEip8037Instance.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
+            .SetName("EIP-7976: mixed calldata returns floor");
+    }
+
+    [TestCaseSource(nameof(EstimateGasFloorCostCases))]
+    public async Task Eth_estimateGas_floor_cost(IReleaseSpec spec, byte[] data, long gasLimit, string expectedJson)
+    {
+        TestSpecProvider specProvider = new(spec);
         using Context ctx = await Context.Create(specProvider);
 
-        const int dataLength = 100;
-        byte[] data = new byte[dataLength]; // all zero bytes
         Transaction tx = Build.A.Transaction
             .WithTo(TestItem.AddressB)
-            .WithGasLimit(100000)
+            .WithGasLimit(gasLimit)
             .WithData(data)
             .SignedAndResolved(TestItem.PrivateKeyA)
             .TestObject;
@@ -551,82 +573,7 @@ public partial class EthRpcModuleTests
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
 
-        long expectedFloor = GasCostOf.Transaction
-                             + dataLength * releaseSpec.GasCosts.TxDataNonZeroMultiplier *
-                             GasCostOf.TotalCostFloorPerTokenEip7976;
-        Assert.That(serialized,
-            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
-    }
-
-    [Test]
-    public async Task Eth_estimateGas_eip7623_data_heavy_tx_returns_lower_floor()
-    {
-        TestSpecProvider specProvider = new(Prague.Instance);
-        using Context ctx = await Context.Create(specProvider);
-
-        const int dataLength = 100;
-        byte[] data = new byte[dataLength]; // all zero bytes
-        Transaction tx = Build.A.Transaction
-            .WithTo(TestItem.AddressB)
-            .WithGasLimit(100000)
-            .WithData(data)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
-        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
-        transaction.GasPrice = null;
-
-        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
-
-        // EIP-7623: zero bytes count as 1 token each
-        const long expectedFloor = GasCostOf.Transaction
-                                   + dataLength * GasCostOf.TotalCostFloorPerTokenEip7623;
-        Assert.That(serialized,
-            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
-    }
-
-    [Test]
-    public async Task Eth_estimateGas_eip7976_insufficient_gas_for_floor()
-    {
-        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
-        TestSpecProvider specProvider = new(releaseSpec);
-        using Context ctx = await Context.Create(specProvider);
-
-        const long standardCost = GasCostOf.Transaction + GasCostOf.TxDataZero; // below floor
-        Transaction tx = Build.A.Transaction
-            .WithTo(TestItem.AddressB)
-            .WithGasLimit(standardCost)
-            .WithData([0])
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
-        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
-        transaction.GasPrice = null;
-
-        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
-
-        Assert.That(serialized,
-            Is.EqualTo(
-                "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}"));
-    }
-
-    [Test]
-    public async Task Eth_estimateGas_eip7976_mixed_calldata_returns_floor()
-    {
-        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
-        TestSpecProvider specProvider = new(releaseSpec);
-        using Context ctx = await Context.Create(specProvider);
-
-        // 0x00001122 = 2 zero bytes + 2 nonzero bytes
-        const int dataLength = 4;
-        TransactionForRpc transaction = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
-            $"{{\"from\":\"{TestItem.AddressA}\",\"to\":\"{TestItem.AddressB}\",\"data\":\"0x00001122\"}}");
-
-        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
-
-        long expectedFloor = GasCostOf.Transaction
-                             + dataLength * releaseSpec.GasCosts.TxDataNonZeroMultiplier *
-                             GasCostOf.TotalCostFloorPerTokenEip7976;
-        Assert.That(serialized,
-            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
+        Assert.That(serialized, Is.EqualTo(expectedJson));
     }
 
     private static async Task TestEstimateGasOutOfGas(Context ctx, long? specifiedGasLimit, long expectedGasLimit, string message)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -538,12 +538,12 @@ public partial class EthRpcModuleTests
     private static IEnumerable<TestCaseData> EstimateGasFloorCostCases()
     {
         // EIP-7976: 100 zero bytes → floor = 21000 + 100 * 4 * 16 = 27400
-        long eip7976Floor100 = GasCostOf.Transaction + 100 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        long eip7976Floor100 = GasCostOf.Transaction + 100 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * Eip7976Spec.GasCosts.TotalCostFloorPerToken;
         yield return new TestCaseData(Eip7976Spec, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: data heavy tx returns floor cost");
 
         // EIP-7623: 100 zero bytes → floor = 21000 + 100 * 10 = 22000
-        const long eip7623Floor100 = GasCostOf.Transaction + 100 * GasCostOf.TotalCostFloorPerTokenEip7623;
+        long eip7623Floor100 = GasCostOf.Transaction + 100 * Prague.Instance.GasCosts.TotalCostFloorPerToken;
         yield return new TestCaseData(Prague.Instance, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7623Floor100.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7623: data heavy tx returns lower floor");
 
@@ -553,7 +553,7 @@ public partial class EthRpcModuleTests
             .SetName("EIP-7976: insufficient gas for floor");
 
         // EIP-7976: mixed calldata (0x00001122 = 2 zero + 2 nonzero bytes)
-        long eip7976Floor4 = GasCostOf.Transaction + 4 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        long eip7976Floor4 = GasCostOf.Transaction + 4 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * Eip7976Spec.GasCosts.TotalCostFloorPerToken;
         yield return new TestCaseData(Eip7976Spec, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: mixed calldata returns floor");
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -531,6 +531,104 @@ public partial class EthRpcModuleTests
         JToken.Parse(serialized).Should().BeEquivalentTo("""{"jsonrpc":"2.0","error":{"code":3,"message":"execution reverted","data":"0x"},"id":67}""");
     }
 
+    [Test]
+    public async Task Eth_estimateGas_eip7976_data_heavy_tx_returns_floor_cost()
+    {
+        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
+        TestSpecProvider specProvider = new(releaseSpec);
+        using Context ctx = await Context.Create(specProvider);
+
+        const int dataLength = 100;
+        byte[] data = new byte[dataLength]; // all zero bytes
+        Transaction tx = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithGasLimit(100000)
+            .WithData(data)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.GasPrice = null;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+
+        const long expectedFloor = GasCostOf.Transaction
+                                   + dataLength * GasCostOf.TxDataNonZeroMultiplierEip2028 *
+                                   GasCostOf.TotalCostFloorPerTokenEip7976;
+        Assert.That(serialized,
+            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_eip7623_data_heavy_tx_returns_lower_floor()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        const int dataLength = 100;
+        byte[] data = new byte[dataLength]; // all zero bytes
+        Transaction tx = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithGasLimit(100000)
+            .WithData(data)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.GasPrice = null;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+
+        // EIP-7623: zero bytes count as 1 token each
+        const long expectedFloor = GasCostOf.Transaction
+                                   + dataLength * GasCostOf.TotalCostFloorPerTokenEip7623;
+        Assert.That(serialized,
+            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_eip7976_insufficient_gas_for_floor()
+    {
+        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
+        TestSpecProvider specProvider = new(releaseSpec);
+        using Context ctx = await Context.Create(specProvider);
+
+        const long standardCost = GasCostOf.Transaction + GasCostOf.TxDataZero; // below floor
+        Transaction tx = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithGasLimit(standardCost)
+            .WithData([0])
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.GasPrice = null;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+
+        Assert.That(serialized,
+            Is.EqualTo(
+                "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}"));
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_eip7976_mixed_calldata_returns_floor()
+    {
+        OverridableReleaseSpec releaseSpec = new(Prague.Instance) { IsEip7976Enabled = true };
+        TestSpecProvider specProvider = new(releaseSpec);
+        using Context ctx = await Context.Create(specProvider);
+
+        // 0x00001122 = 2 zero bytes + 2 nonzero bytes
+        const int dataLength = 4;
+        TransactionForRpc transaction = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
+            $"{{\"from\":\"{TestItem.AddressA}\",\"to\":\"{TestItem.AddressB}\",\"data\":\"0x00001122\"}}");
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+
+        const long expectedFloor = GasCostOf.Transaction
+                                   + dataLength * GasCostOf.TxDataNonZeroMultiplierEip2028 *
+                                   GasCostOf.TotalCostFloorPerTokenEip7976;
+        Assert.That(serialized,
+            Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
+    }
+
     private static async Task TestEstimateGasOutOfGas(Context ctx, long? specifiedGasLimit, long expectedGasLimit, string message)
     {
         string gasParam = specifiedGasLimit.HasValue ? $", \"gas\": \"0x{specifiedGasLimit.Value:X}\"" : "";

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -551,9 +551,9 @@ public partial class EthRpcModuleTests
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
 
-        const long expectedFloor = GasCostOf.Transaction
-                                   + dataLength * GasCostOf.TxDataNonZeroMultiplierEip2028 *
-                                   GasCostOf.TotalCostFloorPerTokenEip7976;
+        long expectedFloor = GasCostOf.Transaction
+                             + dataLength * releaseSpec.GasCosts.TxDataNonZeroMultiplier *
+                             GasCostOf.TotalCostFloorPerTokenEip7976;
         Assert.That(serialized,
             Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
     }
@@ -622,9 +622,9 @@ public partial class EthRpcModuleTests
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
 
-        const long expectedFloor = GasCostOf.Transaction
-                                   + dataLength * GasCostOf.TxDataNonZeroMultiplierEip2028 *
-                                   GasCostOf.TotalCostFloorPerTokenEip7976;
+        long expectedFloor = GasCostOf.Transaction
+                             + dataLength * releaseSpec.GasCosts.TxDataNonZeroMultiplier *
+                             GasCostOf.TotalCostFloorPerTokenEip7976;
         Assert.That(serialized,
             Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{expectedFloor.ToHexString(true)}\",\"id\":67}}"));
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -533,11 +533,13 @@ public partial class EthRpcModuleTests
         JToken.Parse(serialized).Should().BeEquivalentTo("""{"jsonrpc":"2.0","error":{"code":3,"message":"execution reverted","data":"0x"},"id":67}""");
     }
 
+    private static readonly OverridableReleaseSpec Eip7976Spec = new(Prague.Instance) { IsEip7976Enabled = true };
+
     private static IEnumerable<TestCaseData> EstimateGasFloorCostCases()
     {
         // EIP-7976: 100 zero bytes → floor = 21000 + 100 * 4 * 16 = 27400
-        long eip7976Floor100 = GasCostOf.Transaction + 100 * Amsterdam.NoEip8037Instance.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
+        long eip7976Floor100 = GasCostOf.Transaction + 100 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        yield return new TestCaseData(Eip7976Spec, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: data heavy tx returns floor cost");
 
         // EIP-7623: 100 zero bytes → floor = 21000 + 100 * 10 = 22000
@@ -547,12 +549,12 @@ public partial class EthRpcModuleTests
 
         // EIP-7976: gas limit below intrinsic gas
         const long belowFloor = GasCostOf.Transaction + GasCostOf.TxDataZero;
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[] { 0 }, belowFloor, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}")
+        yield return new TestCaseData(Eip7976Spec, new byte[] { 0 }, belowFloor, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}")
             .SetName("EIP-7976: insufficient gas for floor");
 
         // EIP-7976: mixed calldata (0x00001122 = 2 zero + 2 nonzero bytes)
-        long eip7976Floor4 = GasCostOf.Transaction + 4 * Amsterdam.NoEip8037Instance.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
-        yield return new TestCaseData(Amsterdam.NoEip8037Instance, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
+        long eip7976Floor4 = GasCostOf.Transaction + 4 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TotalCostFloorPerTokenEip7976;
+        yield return new TestCaseData(Eip7976Spec, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: mixed calldata returns floor");
     }
 

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -70,6 +70,7 @@ namespace Nethermind.Specs.Test
         public bool IsOpIsthmusEnabled { get; set; } = spec.IsOpIsthmusEnabled;
         public bool IsOpJovianEnabled { get; set; } = spec.IsOpJovianEnabled;
         public bool IsEip7623Enabled { get; set; } = spec.IsEip7623Enabled;
+        public bool IsEip7976Enabled { get; set; } = spec.IsEip7976Enabled;
         public bool IsEip7918Enabled { get; set; } = spec.IsEip7918Enabled;
         public bool IsEip7883Enabled { get; set; } = spec.IsEip7883Enabled;
         public bool IsEip7934Enabled { get; set; } = spec.IsEip7934Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -144,14 +144,14 @@ public class ChainParameters
     public ulong? OpHoloceneTransitionTimestamp { get; set; }
     public ulong? OpIsthmusTransitionTimestamp { get; set; }
 
-    public ulong? Eip7623TransitionTimestamp { get; set; }
-    public ulong? Eip7976TransitionTimestamp { get; set; }
     public ulong? Eip7594TransitionTimestamp { get; set; }
+    public ulong? Eip7623TransitionTimestamp { get; set; }
     public ulong? Eip7778TransitionTimestamp { get; set; }
     public ulong? Eip7823TransitionTimestamp { get; set; }
-    public ulong? Eip7883TransitionTimestamp { get; set; }
     public ulong? Eip7825TransitionTimestamp { get; set; }
+    public ulong? Eip7883TransitionTimestamp { get; set; }
     public ulong? Eip7918TransitionTimestamp { get; set; }
+    public ulong? Eip7976TransitionTimestamp { get; set; }
 
     public ulong? Eip7934TransitionTimestamp { get; set; }
     public int Eip7934MaxRlpBlockSize { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -145,6 +145,7 @@ public class ChainParameters
     public ulong? OpIsthmusTransitionTimestamp { get; set; }
 
     public ulong? Eip7623TransitionTimestamp { get; set; }
+    public ulong? Eip7976TransitionTimestamp { get; set; }
     public ulong? Eip7594TransitionTimestamp { get; set; }
     public ulong? Eip7778TransitionTimestamp { get; set; }
     public ulong? Eip7823TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -277,6 +277,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip7251Enabled = (chainSpec.Parameters.Eip7251TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.Eip7251ContractAddress = chainSpec.Parameters.Eip7251ContractAddress;
             releaseSpec.IsEip7623Enabled = (chainSpec.Parameters.Eip7623TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip7976Enabled = (chainSpec.Parameters.Eip7976TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip7883Enabled = (chainSpec.Parameters.Eip7883TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             releaseSpec.IsEip7594Enabled = (chainSpec.Parameters.Eip7594TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -185,6 +185,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
                 () => chainSpecJson.Params.ChainId == BlockchainIds.Mainnet ? Eip6110Constants.MainnetDepositContractAddress : null),
             Eip7002TransitionTimestamp = chainSpecJson.Params.Eip7002TransitionTimestamp,
             Eip7623TransitionTimestamp = chainSpecJson.Params.Eip7623TransitionTimestamp,
+            Eip7976TransitionTimestamp = chainSpecJson.Params.Eip7976TransitionTimestamp,
             Eip7883TransitionTimestamp = chainSpecJson.Params.Eip7883TransitionTimestamp,
             Eip7002ContractAddress = chainSpecJson.Params.Eip7002ContractAddress ?? Eip7002Constants.WithdrawalRequestPredeployAddress,
             Eip7251TransitionTimestamp = chainSpecJson.Params.Eip7251TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -161,6 +161,7 @@ public class ChainSpecParamsJson
     public Address DepositContractAddress { get; set; }
     public ulong? Eip7002TransitionTimestamp { get; set; }
     public ulong? Eip7623TransitionTimestamp { get; set; }
+    public ulong? Eip7976TransitionTimestamp { get; set; }
     public Address Eip7002ContractAddress { get; set; }
     public ulong? Eip7251TransitionTimestamp { get; set; }
     public Address Eip7251ContractAddress { get; set; }

--- a/src/Nethermind/Nethermind.Specs/Forks/25_Amsterdam.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/25_Amsterdam.cs
@@ -19,7 +19,6 @@ public class Amsterdam() : NamedReleaseSpec<Amsterdam>(BPO5.Instance)
         spec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
         spec.IsEip8024Enabled = true;
         spec.IsEip8037Enabled = true;
-        spec.IsEip7976Enabled = true;
     }
 
     public static IReleaseSpec NoEip8037Instance { get; } = new Amsterdam { IsEip8037Enabled = false };

--- a/src/Nethermind/Nethermind.Specs/Forks/25_Amsterdam.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/25_Amsterdam.cs
@@ -19,6 +19,7 @@ public class Amsterdam() : NamedReleaseSpec<Amsterdam>(BPO5.Instance)
         spec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
         spec.IsEip8024Enabled = true;
         spec.IsEip8037Enabled = true;
+        spec.IsEip7976Enabled = true;
     }
 
     public static IReleaseSpec NoEip8037Instance { get; } = new Amsterdam { IsEip8037Enabled = false };

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -87,6 +87,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsOpIsthmusEnabled { get; set; }
     public bool IsOpJovianEnabled { get; set; }
     public bool IsEip7623Enabled { get; set; }
+    public bool IsEip7976Enabled { get; set; }
     public bool IsEip7883Enabled { get; set; }
     public bool IsEip5656Enabled { get; set; }
     public bool IsEip6780Enabled { get; set; }


### PR DESCRIPTION
Part of #11258

## Changes

- Implement EIP-7976: increase calldata floor cost (`TOTAL_COST_FLOOR_PER_TOKEN = 16`, uniform `totalBytes × 4` token formula)
- Add `IsEip7976Enabled` flag to `IReleaseSpec`, `ReleaseSpec`, `OverridableReleaseSpec`, `ReleaseSpecDecorator`
- Add chain spec wiring (`ChainParameters`, `ChainSpecParamsJson`, `ChainSpecLoader`, `ChainSpecBasedSpecProvider`)
- Add `TotalCostFloorPerTokenEip7976 = 16` constant in `GasCostOf`
- Update `CalculateFloorCost` in `IGasPolicy` to check `IsEip7976Enabled` before `IsEip7623Enabled`, using the EIP-7976 uniform byte formula
- EIP-7976 is **not** enabled in Amsterdam fork yet — pyspec test fixtures are not updated for EIP-8037 (two-dimensional gas), so enabling 7976 in Amsterdam causes pyspec test failures. Tests use `OverridableReleaseSpec` until fixtures catch up.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Eip7976Tests` — 6 parameterized intrinsic gas cases (nonzero byte, zero byte, mixed, empty, contract creation, EIP-7623 fallback)
- `EthRpcModuleTests.EstimateGas` — 4 floor cost RPC cases (data heavy, lower floor, insufficient gas, mixed calldata)

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EIP-7976 increases the calldata floor cost from 10 to 16 gas per token and applies a uniform byte-count formula (`totalBytes × 4`) instead of the EIP-7623 zero/nonzero distinction. This changes the minimum gas cost for data-heavy transactions.