### PR TITLE
Add BAL warmup layer: HintBal, cache-gated ReadBalAsync, trie warmer integration

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -71,6 +71,65 @@ public class BlockProcessorTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public void ProcessOne_WithBlockAccessList_CallsHintBal()
+    {
+        BlockProcessor processor = CreateProcessorWithMockedState(out IWorldState stateProvider);
+        BlockAccessList bal = new();
+        Block block = Build.A.Block.WithBlockAccessList(bal).TestObject;
+
+        try
+        {
+            processor.ProcessOne(block, ProcessingOptions.None, NullBlockTracer.Instance,
+                HoodiSpecProvider.Instance.GenesisSpec, CancellationToken.None);
+        }
+        catch
+        {
+            // Downstream processing against a mocked IWorldState will fail after HintBal;
+            // we only care whether HintBal was invoked.
+        }
+
+        stateProvider.Received(1).HintBal(bal);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void ProcessOne_WithoutBlockAccessList_DoesNotCallHintBal()
+    {
+        BlockProcessor processor = CreateProcessorWithMockedState(out IWorldState stateProvider);
+        Block block = Build.A.Block.TestObject;
+        Assert.That(block.BlockAccessList, Is.Null);
+
+        try
+        {
+            processor.ProcessOne(block, ProcessingOptions.None, NullBlockTracer.Instance,
+                HoodiSpecProvider.Instance.GenesisSpec, CancellationToken.None);
+        }
+        catch
+        {
+            // Same as above — downstream failure is not what this test verifies.
+        }
+
+        stateProvider.DidNotReceive().HintBal(Arg.Any<BlockAccessList>());
+    }
+
+    private static BlockProcessor CreateProcessorWithMockedState(out IWorldState stateProvider)
+    {
+        stateProvider = Substitute.For<IWorldState>();
+        ITransactionProcessor txProcessor = Substitute.For<ITransactionProcessor>();
+        return new BlockProcessor(
+            HoodiSpecProvider.Instance,
+            TestBlockValidator.AlwaysValid,
+            NoBlockRewards.Instance,
+            new BlockProcessor.BlockValidationTransactionsExecutor(new ExecuteTransactionProcessorAdapter(txProcessor), stateProvider),
+            stateProvider,
+            NullReceiptStorage.Instance,
+            new BeaconBlockRootHandler(txProcessor, stateProvider),
+            Substitute.For<IBlockhashStore>(),
+            LimboLogs.Instance,
+            new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
+            new ExecutionRequestsProcessor(txProcessor));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void Prepared_block_contains_author_field()
     {
         (_, BranchProcessor branchProcessor, _) = CreateProcessorAndBranch();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -67,6 +67,9 @@ public partial class BlockProcessor(
             }
         }
 
+        if (suggestedBlock.BlockAccessList is not null)
+            stateProvider.HintBal(suggestedBlock.BlockAccessList);
+
         ApplyDaoTransition(suggestedBlock);
         Block block = PrepareBlockForProcessing(suggestedBlock);
         TxReceipt[] receipts = ProcessBlock(block, blockTracer, options, spec, token);

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -5,17 +5,19 @@ using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Evm.State;
+using Nethermind.Logging;
 using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILifetimeScope parentLifetime)
+public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManager logManager, ILifetimeScope parentLifetime)
 {
     public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches)
     {
         PrewarmerScopeProvider worldState = new(
             worldStateManager.CreateResettableWorldState(),
             preBlockCaches,
+            logManager,
             populatePreBlockCache: true
         );
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Collections.Pooled;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
@@ -288,6 +289,7 @@ public class WitnessGeneratingWorldState(IWorldState inner, IStateReader stateRe
     public void ResetTransient() => inner.ResetTransient();
 
     public IDisposable BeginScope(BlockHeader? baseBlock) => inner.BeginScope(baseBlock);
+    public void HintBal(BlockAccessList bal) => inner.HintBal(bal);
 
     public void CreateEmptyAccountIfDeleted(Address address)
     {

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
@@ -23,6 +24,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     const BlockHeader? PreGenesis = null;
 
     IDisposable BeginScope(BlockHeader? baseBlock);
+    void HintBal(BlockAccessList bal);
     bool IsInScope { get; }
     IWorldStateScopeProvider ScopeProvider { get; }
     new ref readonly UInt256 GetBalance(Address address);

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 
@@ -66,6 +69,46 @@ public interface IWorldStateScopeProvider
         /// first.
         /// </summary>
         void Commit(long blockNumber);
+
+        /// <summary>
+        /// Hint that the given Block Access List will be accessed during block execution.
+        /// For prewarmer scopes, this triggers asynchronous prefetching of all addresses
+        /// and storage slots listed in the BAL into the prewarmer cache.
+        /// Non-prewarmer scopes may ignore this hint.
+        /// </summary>
+        /// <param name="bal">The Block Access List describing addresses and storage slots to prefetch.</param>
+        void HintBal(BlockAccessList bal);
+
+        /// <summary>
+        /// Reads all account and storage data referenced by the Block Access List from
+        /// the underlying trie/db and pushes the results to <paramref name="sink"/>.
+        /// </summary>
+        /// <param name="bal">The Block Access List to read.</param>
+        /// <param name="sink">The sink that receives each account/storage read result.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        /// <returns>A task that completes when all BAL entries have been read.</returns>
+        Task ReadBalAsync(BlockAccessList bal, IAsyncBalReaderSink sink, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Sink that receives account and storage values read from the underlying
+    /// trie/db during a BAL (Block Access List) scan.
+    /// </summary>
+    public interface IAsyncBalReaderSink
+    {
+        /// <summary>
+        /// Called when an account has been read for the given address.
+        /// </summary>
+        /// <param name="address">The account address from the BAL.</param>
+        /// <param name="account">The account data, or null if the account does not exist.</param>
+        void OnAccountRead(Address address, Account? account);
+
+        /// <summary>
+        /// Called when a storage slot has been read for the given cell.
+        /// </summary>
+        /// <param name="storageCell">The storage cell (address + slot index).</param>
+        /// <param name="value">The storage value bytes.</param>
+        void OnStorageRead(in StorageCell storageCell, byte[] value);
     }
 
     public interface ICodeDb

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -109,6 +109,28 @@ public interface IWorldStateScopeProvider
         /// <param name="storageCell">The storage cell (address + slot index).</param>
         /// <param name="value">The storage value bytes.</param>
         void OnStorageRead(in StorageCell storageCell, byte[] value);
+
+        /// <summary>
+        /// Returns whether the BAL reader should still fetch the given account.
+        /// Implementations backed by a cache can return <c>false</c> and hand back the
+        /// cached <paramref name="account"/> to let the reader skip the fetch.
+        /// </summary>
+        /// <param name="address">The account address from the BAL.</param>
+        /// <param name="account">The cached account, or null when not cached.</param>
+        /// <returns><c>true</c> if the reader should fetch; <c>false</c> if it should skip.</returns>
+        bool StillNeeded(Address address, out Account? account)
+        {
+            account = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether the BAL reader should still fetch the given storage cell.
+        /// Implementations backed by a cache can return <c>false</c> to let the reader skip the fetch.
+        /// </summary>
+        /// <param name="storageCell">The storage cell from the BAL.</param>
+        /// <returns><c>true</c> if the reader should fetch; <c>false</c> if it should skip.</returns>
+        bool StillNeeded(in StorageCell storageCell) => true;
     }
 
     public interface ICodeDb

--- a/src/Nethermind/Nethermind.Evm/State/WrappedWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/WrappedWorldState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
@@ -41,6 +42,9 @@ public class WrappedWorldState(IWorldState innerWorldState) : IWorldState
 
     public virtual IDisposable BeginScope(BlockHeader? baseBlock)
         => _innerWorldState.BeginScope(baseBlock);
+
+    public virtual void HintBal(BlockAccessList bal)
+        => _innerWorldState.HintBal(bal);
 
     public virtual void ClearStorage(Address address)
         => _innerWorldState.ClearStorage(address);

--- a/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Container;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
+using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie;
 
@@ -50,6 +51,7 @@ public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
                     return new PrewarmerScopeProvider(
                         worldStateScopeProvider,
                         ctx.Resolve<PreBlockCaches>(),
+                        ctx.Resolve<ILogManager>(),
                         populatePreBlockCache: false
                     );
                 })

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -241,7 +241,11 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
         if (totalSlots > 0)
         {
-            using ArrayPoolList<(Address Address, IWorldStateScopeProvider.IStorageTree Tree, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
+            // Read via the snapshot bundle directly, skipping the cached FlatStorageTree wrapper.
+            // The wrapper's Get calls HintGet -> PushSlotJob, which enqueues into the SPMC slot buffer;
+            // letting parallel workers share the cached tree would corrupt that buffer.
+            // HintBal still drives trie warmup via a per-account non-cached FlatStorageTree + PushSlotJobMpmc.
+            using ArrayPoolList<(Address Address, int SelfDestructIdx, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
             int jobIdx = 0;
             for (int i = 0; i < accountCount; i++)
             {
@@ -252,25 +256,26 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
                 AccountChanges accountChanges = accountChangesList[i];
                 Address address = accountChanges.Address;
-                IWorldStateScopeProvider.IStorageTree storageTree = CreateStorageTree(address);
+                int selfDestructIdx = _snapshotBundle.DetermineSelfDestructSnapshotIdx(address);
 
                 foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
-                    jobs[jobIdx++] = (address, storageTree, slotChanges.Slot);
+                    jobs[jobIdx++] = (address, selfDestructIdx, slotChanges.Slot);
 
                 foreach (StorageRead storageRead in accountChanges.StorageReads)
-                    jobs[jobIdx++] = (address, storageTree, storageRead.Key);
+                    jobs[jobIdx++] = (address, selfDestructIdx, storageRead.Key);
             }
 
             try
             {
                 Parallel.For(0, totalSlots, parallelOptions, (s) =>
                 {
-                    (Address address, IWorldStateScopeProvider.IStorageTree tree, UInt256 slot) = jobs[s];
+                    (Address address, int selfDestructIdx, UInt256 slot) = jobs[s];
                     StorageCell cell = new(address, in slot);
                     if (!sink.StillNeeded(in cell))
                         return;
 
-                    byte[] value = tree.Get(in slot);
+                    byte[]? raw = _snapshotBundle.GetSlot(address, in slot, selfDestructIdx);
+                    byte[] value = raw is null || raw.Length == 0 ? StorageTree.ZeroBytes : raw;
                     sink.OnStorageRead(in cell, value);
                 });
             }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -5,11 +5,13 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Threading;
 using Nethermind.Db;
 using Nethermind.Evm.State;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Trie;
 
@@ -110,6 +112,164 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         if (_snapshotBundle.ShouldQueuePrewarm(address))
         {
             _warmer.PushAddressJob(this, address, _hintSequenceId);
+        }
+    }
+
+    public void HintBal(BlockAccessList bal) { }
+
+    public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+    {
+        // Phase 1: Bulk read all accounts from the state trie
+        int accountCount = 0;
+        foreach (AccountChanges _ in bal.AccountChanges)
+            accountCount++;
+
+        if (accountCount == 0)
+            return Task.CompletedTask;
+
+        AccountChanges[] accountChangesList = new AccountChanges[accountCount];
+        int idx = 0;
+        foreach (AccountChanges ac in bal.AccountChanges)
+        {
+            accountChangesList[idx] = ac;
+            idx++;
+        }
+
+        // Precompute keccak hashes and radix sort for disk cache locality
+        int[] sortedOrder = RadixSortAddresses(accountChangesList, accountCount);
+
+        Account?[] accounts = new Account?[accountCount];
+        Parallel.For(0, accountCount, (i) =>
+        {
+            int orig = sortedOrder[i];
+            Address address = accountChangesList[orig].Address;
+            Account? account = _snapshotBundle.GetAccount(address);
+            accounts[orig] = account;
+            sink.OnAccountRead(address, account);
+        });
+
+        // HintGet sequentially — triggers warmer jobs and snapshot cache updates
+        for (int i = 0; i < accountCount; i++)
+            HintGet(accountChangesList[i].Address, accounts[i]);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Phase 2: Per-account bulk read of storage slots
+        for (int i = 0; i < accountCount; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            AccountChanges accountChanges = accountChangesList[i];
+            Account? account = accounts[i];
+
+            int slotCount = accountChanges.StorageChanges.Count + accountChanges.StorageReads.Count;
+            if (slotCount == 0 || account is null)
+                continue;
+
+            Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+            if (storageRoot == Keccak.EmptyTreeHash)
+                continue;
+
+            Address address = accountChanges.Address;
+            IWorldStateScopeProvider.IStorageTree storageTree = CreateStorageTree(address);
+
+            UInt256[] slotIndices = new UInt256[slotCount];
+            int si = 0;
+
+            foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                slotIndices[si++] = slotChanges.Slot;
+
+            foreach (StorageRead storageRead in accountChanges.StorageReads)
+                slotIndices[si++] = storageRead.Key;
+
+            // Radix sort storage slot hashes for disk cache locality
+            int[] slotOrder = RadixSortStorageSlots(slotIndices, slotCount);
+
+            byte[][] slotValues = new byte[slotCount][];
+            Parallel.For(0, slotCount, (si2) =>
+            {
+                int orig = slotOrder[si2];
+                byte[] value = storageTree.Get(in slotIndices[orig]);
+                slotValues[orig] = value;
+                StorageCell cell = new(address, slotIndices[orig]);
+                sink.OnStorageRead(in cell, value);
+            });
+
+            // HintGet sequentially — triggers warmer jobs
+            for (int si2 = 0; si2 < slotCount; si2++)
+                storageTree.HintGet(in slotIndices[si2], slotValues[si2]);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static int[] RadixSortAddresses(AccountChanges[] accountChanges, int count)
+    {
+        ValueHash256[] hashes = new ValueHash256[count];
+        for (int i = 0; i < count; i++)
+            hashes[i] = KeccakCache.Compute(accountChanges[i].Address.Bytes);
+
+        return RadixSortByHash(hashes, count);
+    }
+
+    private static int[] RadixSortStorageSlots(UInt256[] slotIndices, int count)
+    {
+        ValueHash256[] hashes = new ValueHash256[count];
+        for (int i = 0; i < count; i++)
+            StorageTree.ComputeKeyWithLookup(in slotIndices[i], ref hashes[i]);
+
+        return RadixSortByHash(hashes, count);
+    }
+
+    private static int[] RadixSortByHash(ValueHash256[] hashes, int count)
+    {
+        int[] idx0 = new int[count];
+        int[] idx1 = new int[count];
+        ValueHash256[] buf = new ValueHash256[count];
+
+        for (int i = 0; i < count; i++)
+            idx0[i] = i;
+
+        Span<int> counts = stackalloc int[256];
+        bool flipped = false;
+
+        for (int p = 3; p >= 0; p--)
+        {
+            RadixPassWithIndices(
+                flipped ? buf : hashes,
+                flipped ? hashes : buf,
+                flipped ? idx1 : idx0,
+                flipped ? idx0 : idx1,
+                count, p, counts);
+            flipped = !flipped;
+        }
+
+        return flipped ? idx1 : idx0;
+    }
+
+    private static void RadixPassWithIndices(
+        ReadOnlySpan<ValueHash256> hashSrc, Span<ValueHash256> hashDst,
+        ReadOnlySpan<int> idxSrc, Span<int> idxDst,
+        int len, int byteIndex, Span<int> counts)
+    {
+        counts.Clear();
+        for (int i = 0; i < len; i++)
+            counts[hashSrc[i].BytesAsSpan[byteIndex]]++;
+
+        int total = 0;
+        for (int b = 0; b < 256; b++)
+        {
+            int c = counts[b];
+            counts[b] = total;
+            total += c;
+        }
+
+        for (int i = 0; i < len; i++)
+        {
+            byte key = hashSrc[i].BytesAsSpan[byteIndex];
+            int pos = counts[key]++;
+            hashDst[pos] = hashSrc[i];
+            idxDst[pos] = idxSrc[i];
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -198,7 +198,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         if (accountCount == 0)
             return Task.CompletedTask;
 
-        AccountChanges[] accountChangesList = new AccountChanges[accountCount];
+        using ArrayPoolList<AccountChanges> accountChangesList = new(accountCount, accountCount);
         int copyIdx = 0;
         foreach (AccountChanges ac in bal.AccountChanges)
             accountChangesList[copyIdx++] = ac;
@@ -206,7 +206,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         ParallelOptions parallelOptions = new() { CancellationToken = cancellationToken };
 
         // Phase 1: parallel account fetch, gated by the sink
-        Account?[] accounts = new Account?[accountCount];
+        using ArrayPoolList<Account?> accounts = new(accountCount, accountCount);
         int skippedAccounts = 0;
         try
         {
@@ -243,8 +243,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         int skippedStorageFlat = 0;
         if (totalSlots > 0)
         {
-            (Address Address, IWorldStateScopeProvider.IStorageTree Tree, UInt256 Slot)[] jobs =
-                new (Address, IWorldStateScopeProvider.IStorageTree, UInt256)[totalSlots];
+            using ArrayPoolList<(Address Address, IWorldStateScopeProvider.IStorageTree Tree, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
             int jobIdx = 0;
             for (int i = 0; i < accountCount; i++)
             {

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -115,7 +115,50 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         }
     }
 
-    public void HintBal(BlockAccessList bal) { }
+    public void HintBal(BlockAccessList bal)
+    {
+        int snapshot = _hintSequenceId;
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                foreach (AccountChanges accountChanges in bal.AccountChanges)
+                {
+                    if (_hintSequenceId != snapshot || _pausePrewarmer) return;
+
+                    Address address = accountChanges.Address;
+                    _warmer.PushAddressJob(this, address, snapshot);
+
+                    int slotCount = accountChanges.StorageChanges.Count + accountChanges.StorageReads.Count;
+                    if (slotCount == 0) continue;
+
+                    Account? account = _snapshotBundle.GetAccount(address);
+                    Hash256 storageRoot = account?.StorageRoot ?? Keccak.EmptyTreeHash;
+                    if (storageRoot == Keccak.EmptyTreeHash) continue;
+
+                    // Non-cached per-warmup tree — the main thread's CreateStorageTreeImpl still
+                    // builds its own cached instance the first time it's asked.
+                    FlatStorageTree storageWarmer = new(
+                        this,
+                        _warmer,
+                        _snapshotBundle,
+                        _configuration,
+                        _concurrencyQuota,
+                        storageRoot,
+                        address,
+                        _logManager);
+
+                    foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                        _warmer.PushSlotJobMpmc(storageWarmer, slotChanges.Slot, snapshot);
+
+                    foreach (StorageRead storageRead in accountChanges.StorageReads)
+                        _warmer.PushSlotJobMpmc(storageWarmer, storageRead.Key, snapshot);
+                }
+            }
+            catch (ObjectDisposedException) { }
+        });
+    }
 
     public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
     {

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -34,10 +34,11 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     private bool _isDisposed = false;
 
     // The sequence id is for stopping trie warmer for doing work while committing. Incrementing this value invalidates
-    // tasks within the trie warmer's ring buffer.
-    private int _hintSequenceId = 0;
+    // tasks within the trie warmer's ring buffer. Volatile so the background HintBal task sees increments without
+    // conflicting with the Interlocked writer.
+    private volatile int _hintSequenceId = 0;
     private StateId _currentStateId;
-    internal bool _pausePrewarmer = false;
+    internal volatile bool _pausePrewarmer = false;
 
     // Tracked HintBal background task — mirrors PrewarmerScopeProvider's _balCts/_balTask pattern.
     private CancellationTokenSource? _hintBalCts;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -30,6 +30,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     private readonly PatriciaTree _warmupStateTree;
     private readonly StateTree _stateTree;
     private readonly Dictionary<AddressAsKey, FlatStorageTree> _storages = new();
+    private readonly Lock _storagesLock = new();
     private bool _isDisposed = false;
 
     // The sequence id is for stopping trie warmer for doing work while committing. Incrementing this value invalidates
@@ -37,6 +38,10 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     private int _hintSequenceId = 0;
     private StateId _currentStateId;
     internal bool _pausePrewarmer = false;
+
+    // Tracked HintBal background task — mirrors PrewarmerScopeProvider's _balCts/_balTask pattern.
+    private CancellationTokenSource? _hintBalCts;
+    private Task? _hintBalTask;
 
     public FlatWorldStateScope(
         StateId currentStateId,
@@ -81,8 +86,19 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     public void Dispose()
     {
         if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return;
+        CancelHintBal();
         _snapshotBundle.Dispose();
         _warmer.OnExitScope();
+    }
+
+    private void CancelHintBal()
+    {
+        _hintBalCts?.Cancel();
+        try { _hintBalTask?.GetAwaiter().GetResult(); }
+        catch { }
+        _hintBalCts?.Dispose();
+        _hintBalCts = null;
+        _hintBalTask = null;
     }
 
     public Hash256 RootHash => _stateTree.RootHash;
@@ -117,14 +133,20 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
     public void HintBal(BlockAccessList bal)
     {
+        // Cancel any previous HintBal task and start a new one. Tracks the task so
+        // Dispose / next HintBal can stop it cleanly, matching PrewarmerScopeProvider's pattern.
+        CancelHintBal();
+        _hintBalCts = new CancellationTokenSource();
+        CancellationToken token = _hintBalCts.Token;
         int snapshot = _hintSequenceId;
 
-        _ = Task.Run(() =>
+        _hintBalTask = Task.Run(() =>
         {
             try
             {
                 foreach (AccountChanges accountChanges in bal.AccountChanges)
                 {
+                    if (token.IsCancellationRequested) return;
                     if (_hintSequenceId != snapshot || _pausePrewarmer) return;
 
                     Address address = accountChanges.Address;
@@ -150,14 +172,21 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                         _logManager);
 
                     foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                    {
+                        if (token.IsCancellationRequested) return;
                         _warmer.PushSlotJobMpmc(storageWarmer, slotChanges.Slot, snapshot);
+                    }
 
                     foreach (StorageRead storageRead in accountChanges.StorageReads)
+                    {
+                        if (token.IsCancellationRequested) return;
                         _warmer.PushSlotJobMpmc(storageWarmer, storageRead.Key, snapshot);
+                    }
                 }
             }
+            catch (OperationCanceledException) { }
             catch (ObjectDisposedException) { }
-        });
+        }, token);
     }
 
     public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
@@ -174,23 +203,29 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         foreach (AccountChanges ac in bal.AccountChanges)
             accountChangesList[copyIdx++] = ac;
 
+        ParallelOptions parallelOptions = new() { CancellationToken = cancellationToken };
+
         // Phase 1: parallel account fetch, gated by the sink
         Account?[] accounts = new Account?[accountCount];
         int skippedAccounts = 0;
-        Parallel.For(0, accountCount, (i) =>
+        try
         {
-            Address address = accountChangesList[i].Address;
-            if (!sink.StillNeeded(address, out Account? cached))
+            Parallel.For(0, accountCount, parallelOptions, (i) =>
             {
-                accounts[i] = cached;
-                Interlocked.Increment(ref skippedAccounts);
-                return;
-            }
+                Address address = accountChangesList[i].Address;
+                if (!sink.StillNeeded(address, out Account? cached))
+                {
+                    accounts[i] = cached;
+                    Interlocked.Increment(ref skippedAccounts);
+                    return;
+                }
 
-            Account? account = _snapshotBundle.GetAccount(address);
-            accounts[i] = account;
-            sink.OnAccountRead(address, account);
-        });
+                Account? account = _snapshotBundle.GetAccount(address);
+                accounts[i] = account;
+                sink.OnAccountRead(address, account);
+            });
+        }
+        catch (OperationCanceledException) { return Task.CompletedTask; }
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -229,19 +264,23 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                     jobs[jobIdx++] = (address, storageTree, storageRead.Key);
             }
 
-            Parallel.For(0, totalSlots, (s) =>
+            try
             {
-                (Address address, IWorldStateScopeProvider.IStorageTree tree, UInt256 slot) = jobs[s];
-                StorageCell cell = new(address, in slot);
-                if (!sink.StillNeeded(in cell))
+                Parallel.For(0, totalSlots, parallelOptions, (s) =>
                 {
-                    Interlocked.Increment(ref skippedStorageFlat);
-                    return;
-                }
+                    (Address address, IWorldStateScopeProvider.IStorageTree tree, UInt256 slot) = jobs[s];
+                    StorageCell cell = new(address, in slot);
+                    if (!sink.StillNeeded(in cell))
+                    {
+                        Interlocked.Increment(ref skippedStorageFlat);
+                        return;
+                    }
 
-                byte[] value = tree.Get(in slot);
-                sink.OnStorageRead(in cell, value);
-            });
+                    byte[] value = tree.Get(in slot);
+                    sink.OnStorageRead(in cell, value);
+                });
+            }
+            catch (OperationCanceledException) { }
         }
 
         LogBalSkipRates(accountCount, skippedAccounts, totalSlots, skippedStorageFlat);
@@ -277,21 +316,27 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
     private FlatStorageTree CreateStorageTreeImpl(Address address)
     {
-        ref FlatStorageTree? storage = ref CollectionsMarshal.GetValueRefOrAddDefault(_storages, address, out bool exists);
-        if (exists) return storage!;
+        // _storages is accessed concurrently — the HintBal/ReadBalAsync Task.Run may call
+        // CreateStorageTree from a worker thread while the main processing thread also
+        // reads/writes via scope.Get/WriteBatch paths. Dictionary is not thread-safe.
+        lock (_storagesLock)
+        {
+            ref FlatStorageTree? storage = ref CollectionsMarshal.GetValueRefOrAddDefault(_storages, address, out bool exists);
+            if (exists) return storage!;
 
-        Hash256 storageRoot = Get(address)?.StorageRoot ?? Keccak.EmptyTreeHash;
-        storage = new FlatStorageTree(
-            this,
-            _warmer,
-            _snapshotBundle,
-            _configuration,
-            _concurrencyQuota,
-            storageRoot,
-            address,
-            _logManager);
+            Hash256 storageRoot = Get(address)?.StorageRoot ?? Keccak.EmptyTreeHash;
+            storage = new FlatStorageTree(
+                this,
+                _warmer,
+                _snapshotBundle,
+                _configuration,
+                _concurrencyQuota,
+                storageRoot,
+                address,
+                _logManager);
 
-        return storage;
+            return storage;
+        }
     }
 
     public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) =>
@@ -300,6 +345,9 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     public void Commit(long blockNumber)
     {
         _pausePrewarmer = true;
+        // Drain HintBal task before iterating _storages — Commit's foreach isn't locked
+        // and the task may otherwise be mid-CreateStorageTreeImpl when we start iterating.
+        CancelHintBal();
 
         using ArrayPoolListRef<Task> commitTask = new(_storages.Count);
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -327,8 +327,13 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         }
     }
 
-    public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) =>
-        new WriteBatch(this, estimatedAccountNum, _logManager.GetClassLogger<WriteBatch>());
+    public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
+    {
+        // Cancel HintBal background warmup — write batches are processor-intensive and already parallelized,
+        // so the warmer thread shouldn't compete for CPU or touch _storages while we mutate it.
+        CancelHintBal();
+        return new WriteBatch(this, estimatedAccountNum, _logManager.GetClassLogger<WriteBatch>());
+    }
 
     public void Commit(long blockNumber)
     {

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -119,7 +119,6 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
     public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
     {
-        // Phase 1: Bulk read all accounts from the state trie
         int accountCount = 0;
         foreach (AccountChanges _ in bal.AccountChanges)
             accountCount++;
@@ -128,149 +127,92 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             return Task.CompletedTask;
 
         AccountChanges[] accountChangesList = new AccountChanges[accountCount];
-        int idx = 0;
+        int copyIdx = 0;
         foreach (AccountChanges ac in bal.AccountChanges)
-        {
-            accountChangesList[idx] = ac;
-            idx++;
-        }
+            accountChangesList[copyIdx++] = ac;
 
-        // Precompute keccak hashes and radix sort for disk cache locality
-        int[] sortedOrder = RadixSortAddresses(accountChangesList, accountCount);
-
+        // Phase 1: parallel account fetch, gated by the sink
         Account?[] accounts = new Account?[accountCount];
+        int skippedAccounts = 0;
         Parallel.For(0, accountCount, (i) =>
         {
-            int orig = sortedOrder[i];
-            Address address = accountChangesList[orig].Address;
+            Address address = accountChangesList[i].Address;
+            if (!sink.StillNeeded(address, out Account? cached))
+            {
+                accounts[i] = cached;
+                Interlocked.Increment(ref skippedAccounts);
+                return;
+            }
+
             Account? account = _snapshotBundle.GetAccount(address);
-            accounts[orig] = account;
+            accounts[i] = account;
             sink.OnAccountRead(address, account);
         });
 
-        // HintGet sequentially — triggers warmer jobs and snapshot cache updates
-        for (int i = 0; i < accountCount; i++)
-            HintGet(accountChangesList[i].Address, accounts[i]);
-
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Phase 2: Per-account bulk read of storage slots
+        // Phase 2: flatten (address, tree, slot) jobs and read in one parallel pass
+        int totalSlots = 0;
         for (int i = 0; i < accountCount; i++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            AccountChanges accountChanges = accountChangesList[i];
             Account? account = accounts[i];
-
-            int slotCount = accountChanges.StorageChanges.Count + accountChanges.StorageReads.Count;
-            if (slotCount == 0 || account is null)
-                continue;
-
+            if (account is null) continue;
             Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
-            if (storageRoot == Keccak.EmptyTreeHash)
-                continue;
-
-            Address address = accountChanges.Address;
-            IWorldStateScopeProvider.IStorageTree storageTree = CreateStorageTree(address);
-
-            UInt256[] slotIndices = new UInt256[slotCount];
-            int si = 0;
-
-            foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
-                slotIndices[si++] = slotChanges.Slot;
-
-            foreach (StorageRead storageRead in accountChanges.StorageReads)
-                slotIndices[si++] = storageRead.Key;
-
-            // Radix sort storage slot hashes for disk cache locality
-            int[] slotOrder = RadixSortStorageSlots(slotIndices, slotCount);
-
-            byte[][] slotValues = new byte[slotCount][];
-            Parallel.For(0, slotCount, (si2) =>
-            {
-                int orig = slotOrder[si2];
-                byte[] value = storageTree.Get(in slotIndices[orig]);
-                slotValues[orig] = value;
-                StorageCell cell = new(address, slotIndices[orig]);
-                sink.OnStorageRead(in cell, value);
-            });
-
-            // HintGet sequentially — triggers warmer jobs
-            for (int si2 = 0; si2 < slotCount; si2++)
-                storageTree.HintGet(in slotIndices[si2], slotValues[si2]);
+            if (storageRoot == Keccak.EmptyTreeHash) continue;
+            totalSlots += accountChangesList[i].StorageChanges.Count + accountChangesList[i].StorageReads.Count;
         }
 
+        int skippedStorageFlat = 0;
+        if (totalSlots > 0)
+        {
+            (Address Address, IWorldStateScopeProvider.IStorageTree Tree, UInt256 Slot)[] jobs =
+                new (Address, IWorldStateScopeProvider.IStorageTree, UInt256)[totalSlots];
+            int jobIdx = 0;
+            for (int i = 0; i < accountCount; i++)
+            {
+                Account? account = accounts[i];
+                if (account is null) continue;
+                Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                if (storageRoot == Keccak.EmptyTreeHash) continue;
+
+                AccountChanges accountChanges = accountChangesList[i];
+                Address address = accountChanges.Address;
+                IWorldStateScopeProvider.IStorageTree storageTree = CreateStorageTree(address);
+
+                foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                    jobs[jobIdx++] = (address, storageTree, slotChanges.Slot);
+
+                foreach (StorageRead storageRead in accountChanges.StorageReads)
+                    jobs[jobIdx++] = (address, storageTree, storageRead.Key);
+            }
+
+            Parallel.For(0, totalSlots, (s) =>
+            {
+                (Address address, IWorldStateScopeProvider.IStorageTree tree, UInt256 slot) = jobs[s];
+                StorageCell cell = new(address, in slot);
+                if (!sink.StillNeeded(in cell))
+                {
+                    Interlocked.Increment(ref skippedStorageFlat);
+                    return;
+                }
+
+                byte[] value = tree.Get(in slot);
+                sink.OnStorageRead(in cell, value);
+            });
+        }
+
+        LogBalSkipRates(accountCount, skippedAccounts, totalSlots, skippedStorageFlat);
         return Task.CompletedTask;
     }
 
-    private static int[] RadixSortAddresses(AccountChanges[] accountChanges, int count)
+    private void LogBalSkipRates(int accountCount, int skippedAccounts, int totalSlots, int skippedStorageFlat)
     {
-        ValueHash256[] hashes = new ValueHash256[count];
-        for (int i = 0; i < count; i++)
-            hashes[i] = KeccakCache.Compute(accountChanges[i].Address.Bytes);
+        ILogger logger = _logManager.GetClassLogger<FlatWorldStateScope>();
+        if (!logger.IsInfo) return;
 
-        return RadixSortByHash(hashes, count);
-    }
-
-    private static int[] RadixSortStorageSlots(UInt256[] slotIndices, int count)
-    {
-        ValueHash256[] hashes = new ValueHash256[count];
-        for (int i = 0; i < count; i++)
-            StorageTree.ComputeKeyWithLookup(in slotIndices[i], ref hashes[i]);
-
-        return RadixSortByHash(hashes, count);
-    }
-
-    private static int[] RadixSortByHash(ValueHash256[] hashes, int count)
-    {
-        int[] idx0 = new int[count];
-        int[] idx1 = new int[count];
-        ValueHash256[] buf = new ValueHash256[count];
-
-        for (int i = 0; i < count; i++)
-            idx0[i] = i;
-
-        Span<int> counts = stackalloc int[256];
-        bool flipped = false;
-
-        for (int p = 3; p >= 0; p--)
-        {
-            RadixPassWithIndices(
-                flipped ? buf : hashes,
-                flipped ? hashes : buf,
-                flipped ? idx1 : idx0,
-                flipped ? idx0 : idx1,
-                count, p, counts);
-            flipped = !flipped;
-        }
-
-        return flipped ? idx1 : idx0;
-    }
-
-    private static void RadixPassWithIndices(
-        ReadOnlySpan<ValueHash256> hashSrc, Span<ValueHash256> hashDst,
-        ReadOnlySpan<int> idxSrc, Span<int> idxDst,
-        int len, int byteIndex, Span<int> counts)
-    {
-        counts.Clear();
-        for (int i = 0; i < len; i++)
-            counts[hashSrc[i].BytesAsSpan[byteIndex]]++;
-
-        int total = 0;
-        for (int b = 0; b < 256; b++)
-        {
-            int c = counts[b];
-            counts[b] = total;
-            total += c;
-        }
-
-        for (int i = 0; i < len; i++)
-        {
-            byte key = hashSrc[i].BytesAsSpan[byteIndex];
-            int pos = counts[key]++;
-            hashDst[pos] = hashSrc[i];
-            idxDst[pos] = idxSrc[i];
-        }
+        double accountSkipPct = accountCount == 0 ? 0 : 100.0 * skippedAccounts / accountCount;
+        double slotSkipPct = totalSlots == 0 ? 0 : 100.0 * skippedStorageFlat / totalSlots;
+        logger.Info($"[BAL] accounts={accountCount} skipped={skippedAccounts} ({accountSkipPct:F1}%) slots={totalSlots} skipped={skippedStorageFlat} ({slotSkipPct:F1}%)");
     }
 
     public IWorldStateScopeProvider.ICodeDb CodeDb { get; }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -207,7 +207,6 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
         // Phase 1: parallel account fetch, gated by the sink
         using ArrayPoolList<Account?> accounts = new(accountCount, accountCount);
-        int skippedAccounts = 0;
         try
         {
             Parallel.For(0, accountCount, parallelOptions, (i) =>
@@ -216,7 +215,6 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                 if (!sink.StillNeeded(address, out Account? cached))
                 {
                     accounts[i] = cached;
-                    Interlocked.Increment(ref skippedAccounts);
                     return;
                 }
 
@@ -240,7 +238,6 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             totalSlots += accountChangesList[i].StorageChanges.Count + accountChangesList[i].StorageReads.Count;
         }
 
-        int skippedStorageFlat = 0;
         if (totalSlots > 0)
         {
             using ArrayPoolList<(Address Address, IWorldStateScopeProvider.IStorageTree Tree, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
@@ -270,10 +267,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                     (Address address, IWorldStateScopeProvider.IStorageTree tree, UInt256 slot) = jobs[s];
                     StorageCell cell = new(address, in slot);
                     if (!sink.StillNeeded(in cell))
-                    {
-                        Interlocked.Increment(ref skippedStorageFlat);
                         return;
-                    }
 
                     byte[] value = tree.Get(in slot);
                     sink.OnStorageRead(in cell, value);
@@ -282,18 +276,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             catch (OperationCanceledException) { }
         }
 
-        LogBalSkipRates(accountCount, skippedAccounts, totalSlots, skippedStorageFlat);
         return Task.CompletedTask;
-    }
-
-    private void LogBalSkipRates(int accountCount, int skippedAccounts, int totalSlots, int skippedStorageFlat)
-    {
-        ILogger logger = _logManager.GetClassLogger<FlatWorldStateScope>();
-        if (!logger.IsInfo) return;
-
-        double accountSkipPct = accountCount == 0 ? 0 : 100.0 * skippedAccounts / accountCount;
-        double slotSkipPct = totalSlots == 0 ? 0 : 100.0 * skippedStorageFlat / totalSlots;
-        logger.Info($"[BAL] accounts={accountCount} skipped={skippedAccounts} ({accountSkipPct:F1}%) slots={totalSlots} skipped={skippedStorageFlat} ({slotSkipPct:F1}%)");
     }
 
     public IWorldStateScopeProvider.ICodeDb CodeDb { get; }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ITrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ITrieWarmer.cs
@@ -13,6 +13,16 @@ public interface ITrieWarmer
         in UInt256? index,
         int sequenceId);
 
+    /// <summary>
+    /// Like <see cref="PushSlotJob"/>, but safe to call from multiple producer threads.
+    /// Routes through the MPMC job buffer so background <c>HintBal</c> enqueuers do not violate the
+    /// single-producer invariant of the main-thread slot buffer.
+    /// </summary>
+    public void PushSlotJobMpmc(
+        IStorageWarmer storageTree,
+        in UInt256 index,
+        int sequenceId);
+
     public void PushAddressJob(
         IAddressWarmer scope,
         Address? path,

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/NoopTrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/NoopTrieWarmer.cs
@@ -10,6 +10,8 @@ public class NoopTrieWarmer : ITrieWarmer
 {
     public void PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256? index, int sequenceId) { }
 
+    public void PushSlotJobMpmc(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId) { }
+
     public void PushAddressJob(ITrieWarmer.IAddressWarmer scope, Address? path, int sequenceId) { }
 
     public void OnEnterScope() { }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -296,6 +296,12 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         if (_slotJobBuffer.TryEnqueue(new SlotJob(storageTree, index.GetValueOrDefault(), sequenceId))) MaybeWakeupFast();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PushSlotJobMpmc(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId)
+    {
+        if (_jobBufferMultiThreaded.TryEnqueue(new Job(storageTree, null, index, sequenceId))) MaybeWakeupFast();
+    }
+
     public void OnEnterScope()
     {
         // Drain any existing job

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using Autofac;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
 using NUnit.Framework;
@@ -147,5 +151,96 @@ public class ScopeProviderTests(bool useFlat)
 
             writeBatch.Set(TestItem.AddressA, null);
         }
+    }
+
+    [Test]
+    public void Test_ReadBalAsync_MatchesIndividualReads()
+    {
+        using Context ctx = new(useFlat);
+
+        // Setup: write accounts with storage
+        Hash256 stateRoot;
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(2))
+            {
+                writeBatch.Set(TestItem.AddressA, new Account(100, 100));
+                writeBatch.Set(TestItem.AddressB, new Account(200, 200));
+
+                using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 2))
+                {
+                    storageA.Set(1, [10, 20]);
+                    storageA.Set(2, [30, 40]);
+                }
+
+                using (IWorldStateScopeProvider.IStorageWriteBatch storageB = writeBatch.CreateStorageWriteBatch(TestItem.AddressB, 1))
+                {
+                    storageB.Set(5, [50, 60]);
+                }
+            }
+
+            scope.Commit(1);
+            stateRoot = scope.RootHash;
+        }
+
+        // Build a BAL referencing these accounts and storage slots
+        BlockAccessList bal = new();
+        bal.AddAccountRead(TestItem.AddressA);
+        bal.AddAccountRead(TestItem.AddressB);
+        bal.AddAccountRead(TestItem.AddressC); // not in state — should be null
+        bal.AddStorageRead(TestItem.AddressA, 1);
+        bal.AddStorageRead(TestItem.AddressA, 2);
+        bal.AddStorageRead(TestItem.AddressB, 5);
+
+        // Collect results via ReadBalAsync
+        CollectingBalSink sink = new();
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject))
+        {
+            scope.ReadBalAsync(bal, sink, CancellationToken.None).Wait();
+
+            // Verify accounts match individual reads
+            sink.Accounts.Should().ContainKey(TestItem.AddressA);
+            sink.Accounts[TestItem.AddressA]!.Balance.Should().Be(100);
+
+            sink.Accounts.Should().ContainKey(TestItem.AddressB);
+            sink.Accounts[TestItem.AddressB]!.Balance.Should().Be(200);
+
+            sink.NullAccounts.Should().Contain(TestItem.AddressC);
+
+            // Verify storage matches individual reads
+            IWorldStateScopeProvider.IStorageTree storageTreeA = scope.CreateStorageTree(TestItem.AddressA);
+            IWorldStateScopeProvider.IStorageTree storageTreeB = scope.CreateStorageTree(TestItem.AddressB);
+
+            StorageCell cellA1 = new(TestItem.AddressA, 1);
+            StorageCell cellA2 = new(TestItem.AddressA, 2);
+            StorageCell cellB5 = new(TestItem.AddressB, 5);
+
+            sink.Storage.Should().ContainKey(cellA1);
+            sink.Storage[cellA1].Should().BeEquivalentTo(storageTreeA.Get(1));
+
+            sink.Storage.Should().ContainKey(cellA2);
+            sink.Storage[cellA2].Should().BeEquivalentTo(storageTreeA.Get(2));
+
+            sink.Storage.Should().ContainKey(cellB5);
+            sink.Storage[cellB5].Should().BeEquivalentTo(storageTreeB.Get(5));
+        }
+    }
+
+    private class CollectingBalSink : IWorldStateScopeProvider.IAsyncBalReaderSink
+    {
+        public Dictionary<Address, Account> Accounts { get; } = new();
+        public HashSet<Address> NullAccounts { get; } = new();
+        public Dictionary<StorageCell, byte[]> Storage { get; } = new();
+
+        public void OnAccountRead(Address address, Account account)
+        {
+            if (account is null)
+                NullAccounts.Add(address);
+            else
+                Accounts[address] = account;
+        }
+
+        public void OnStorageRead(in StorageCell storageCell, byte[] value)
+            => Storage[storageCell] = value;
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -226,13 +226,14 @@ public class ScopeProviderTests(bool useFlat)
         }
     }
 
+#nullable enable
     private class CollectingBalSink : IWorldStateScopeProvider.IAsyncBalReaderSink
     {
         public Dictionary<Address, Account> Accounts { get; } = new();
         public HashSet<Address> NullAccounts { get; } = new();
         public Dictionary<StorageCell, byte[]> Storage { get; } = new();
 
-        public void OnAccountRead(Address address, Account account)
+        public void OnAccountRead(Address address, Account? account)
         {
             if (account is null)
                 NullAccounts.Add(address);
@@ -243,4 +244,5 @@ public class ScopeProviderTests(bool useFlat)
         public void OnStorageRead(in StorageCell storageCell, byte[] value)
             => Storage[storageCell] = value;
     }
+#nullable disable
 }

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -226,6 +226,76 @@ public class ScopeProviderTests(bool useFlat)
         }
     }
 
+    [Test]
+    public void Test_HintBal_DoesNotThrow()
+    {
+        using Context ctx = new(useFlat);
+
+        Hash256 stateRoot;
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(2))
+            {
+                writeBatch.Set(TestItem.AddressA, new Account(100, 100));
+                writeBatch.Set(TestItem.AddressB, new Account(200, 200));
+
+                using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
+                {
+                    storageA.Set(1, [10, 20]);
+                }
+            }
+
+            scope.Commit(1);
+            stateRoot = scope.RootHash;
+        }
+
+        BlockAccessList bal = new();
+        bal.AddAccountRead(TestItem.AddressA);
+        bal.AddAccountRead(TestItem.AddressB);
+        bal.AddStorageRead(TestItem.AddressA, 1);
+
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject))
+        {
+            Assert.DoesNotThrow(() => scope.HintBal(bal));
+            // Dispose exits the using — must not throw either (covers the Cancel path).
+        }
+    }
+
+    [Test]
+    public void Test_HintBal_Smoke_PrewarmerWrapped()
+    {
+        using Context ctx = new(useFlat);
+
+        Hash256 stateRoot;
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+            {
+                writeBatch.Set(TestItem.AddressA, new Account(100, 100));
+                using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
+                {
+                    storageA.Set(1, [10, 20]);
+                }
+            }
+
+            scope.Commit(1);
+            stateRoot = scope.RootHash;
+        }
+
+        // populatePreBlockCache: false targets the main-processing scope where HintBal actually runs.
+        PreBlockCaches caches = new();
+        PrewarmerScopeProvider prewarmer = new(ctx.ScopeProvider, caches, LimboLogs.Instance, populatePreBlockCache: false);
+
+        BlockAccessList bal = new();
+        bal.AddAccountRead(TestItem.AddressA);
+        bal.AddStorageRead(TestItem.AddressA, 1);
+
+        using (IWorldStateScopeProvider.IScope scope = prewarmer.BeginScope(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject))
+        {
+            Assert.DoesNotThrow(() => scope.HintBal(bal));
+        }
+    }
+
 #nullable enable
     private class CollectingBalSink : IWorldStateScopeProvider.IAsyncBalReaderSink
     {

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using Autofac;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Resettables;
@@ -815,6 +818,11 @@ public class StorageProviderTests(bool useFlat)
             public Account Get(Address address) => baseScope.Get(address);
 
             public void HintGet(Address address, Account account) => baseScope.HintGet(address, account);
+
+            public void HintBal(BlockAccessList bal) => baseScope.HintBal(bal);
+
+            public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+                => baseScope.ReadBalAsync(bal, sink, cancellationToken);
 
             public IWorldStateScopeProvider.ICodeDb CodeDb => baseScope.CodeDb;
 

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -761,7 +761,7 @@ public class StorageProviderTests(bool useFlat)
 
             if (preBlockCaches is not null)
             {
-                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, populatePreBlockCache: true);
+                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, LimboLogs.Instance, populatePreBlockCache: true);
             }
 
             if (trackWrittenData)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -200,6 +200,15 @@ public class PrewarmerScopeProvider(
 
             public void OnStorageRead(in StorageCell storageCell, byte[] value)
                 => storageCache.Set(in storageCell, value);
+
+            public bool StillNeeded(Address address, out Account? account)
+            {
+                AddressAsKey key = address;
+                return !stateCache.TryGetValue(in key, out account);
+            }
+
+            public bool StillNeeded(in StorageCell storageCell)
+                => !storageCache.TryGetValue(in storageCell, out _);
         }
 
         private Account? GetFromBaseTree(in AddressAsKey address) => baseScope.Get(address);

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Metric;
@@ -51,9 +54,20 @@ public class PrewarmerScopeProvider(
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
         private long _writeBatchTime = 0;
+        private CancellationTokenSource? _balCts;
+        private Task? _balTask;
+
+        private void CancelBal()
+        {
+            _balCts?.Cancel();
+            _balTask?.GetAwaiter().GetResult();
+            _balTask = null;
+        }
 
         public void Dispose()
         {
+            CancelBal();
+            _balCts?.Dispose();
             if (_measureMetric && _writeBatchTime != 0)
             {
                 _metricObserver.Observe(Stopwatch.GetTimestamp() - _writeBatchTime, _labels.WriteBatchToScopeDisposeTime);
@@ -71,6 +85,9 @@ public class PrewarmerScopeProvider(
 
         public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
         {
+            // Cancel BAL background read — write batches are processor-intensive and already parallelized
+            CancelBal();
+
             if (!_measureMetric)
             {
                 return baseScope.StartWriteBatch(estimatedAccountNum);
@@ -87,6 +104,8 @@ public class PrewarmerScopeProvider(
 
         public void Commit(long blockNumber)
         {
+            CancelBal();
+
             if (!_measureMetric)
             {
                 baseScope.Commit(blockNumber);
@@ -150,6 +169,38 @@ public class PrewarmerScopeProvider(
         }
 
         public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
+
+        public void HintBal(BlockAccessList bal)
+        {
+            if (!populatePreBlockCache)
+            {
+                return;
+            }
+
+            CancelBal();
+            _balCts = new CancellationTokenSource();
+            CacheSink cacheSink = new(preBlockCache, storageCache);
+            CancellationToken token = _balCts.Token;
+            _balTask = Task.Run(() => baseScope.ReadBalAsync(bal, cacheSink, token));
+        }
+
+        public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+            => baseScope.ReadBalAsync(bal, sink, cancellationToken);
+
+        private sealed class CacheSink(
+            SeqlockCache<AddressAsKey, Account> stateCache,
+            SeqlockCache<StorageCell, byte[]> storageCache
+        ) : IWorldStateScopeProvider.IAsyncBalReaderSink
+        {
+            public void OnAccountRead(Address address, Account? account)
+            {
+                AddressAsKey key = address;
+                stateCache.Set(in key, account);
+            }
+
+            public void OnStorageRead(in StorageCell storageCell, byte[] value)
+                => storageCache.Set(in storageCell, value);
+        }
 
         private Account? GetFromBaseTree(in AddressAsKey address) => baseScope.Get(address);
     }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -60,7 +60,11 @@ public class PrewarmerScopeProvider(
         private void CancelBal()
         {
             _balCts?.Cancel();
-            _balTask?.GetAwaiter().GetResult();
+            try
+            {
+                _balTask?.GetAwaiter().GetResult();
+            }
+            catch { }
             _balTask = null;
         }
 
@@ -181,7 +185,22 @@ public class PrewarmerScopeProvider(
             _balCts = new CancellationTokenSource();
             CacheSink cacheSink = new(preBlockCache, storageCache);
             CancellationToken token = _balCts.Token;
-            _balTask = Task.Run(() => baseScope.ReadBalAsync(bal, cacheSink, token));
+            _balTask = Task.Run(() =>
+            {
+                try
+                {
+                    baseScope.ReadBalAsync(bal, cacheSink, token);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(ex);
+                }
+            });
+
+            // Trie warmup runs alongside cache population — baseScope.HintBal spawns its own task
+            // on the flat scope and is a no-op on the trie scope.
+            baseScope.HintBal(bal);
         }
 
         public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -176,7 +176,9 @@ public class PrewarmerScopeProvider(
 
         public void HintBal(BlockAccessList bal)
         {
-            if (!populatePreBlockCache)
+            // Skip on prewarmer-env scope (populatePreBlockCache=true) — HintBal only runs
+            // on the main processing scope, which is the one BalReplayBlockProcessor targets.
+            if (populatePreBlockCache)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Metric;
 using Nethermind.Db;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
+using Nethermind.Logging;
 
 namespace Nethermind.State;
 
@@ -34,17 +35,18 @@ internal class PrewarmerGetTimeLabels(bool isPrewarmer)
 public class PrewarmerScopeProvider(
     IWorldStateScopeProvider baseProvider,
     PreBlockCaches preBlockCaches,
+    ILogManager logManager,
     bool populatePreBlockCache = true
 ) : IWorldStateScopeProvider, IPreBlockCaches
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, logManager, populatePreBlockCache);
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !populatePreBlockCache;
 
-    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, bool populatePreBlockCache) : IWorldStateScopeProvider.IScope
+    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, ILogManager logManager, bool populatePreBlockCache) : IWorldStateScopeProvider.IScope
     {
         private readonly IWorldStateScopeProvider.IScope baseScope = baseScope;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache = preBlockCaches.StateCache;
@@ -53,6 +55,7 @@ public class PrewarmerScopeProvider(
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+        private readonly ILogger _logger = logManager.GetClassLogger<ScopeWrapper>();
         private long _writeBatchTime = 0;
         private CancellationTokenSource? _balCts;
         private Task? _balTask;
@@ -66,12 +69,13 @@ public class PrewarmerScopeProvider(
             }
             catch { }
             _balTask = null;
+            _balCts?.Dispose();
+            _balCts = null;
         }
 
         public void Dispose()
         {
             CancelBal();
-            _balCts?.Dispose();
             if (_measureMetric && _writeBatchTime != 0)
             {
                 _metricObserver.Observe(Stopwatch.GetTimestamp() - _writeBatchTime, _labels.WriteBatchToScopeDisposeTime);
@@ -187,16 +191,16 @@ public class PrewarmerScopeProvider(
             _balCts = new CancellationTokenSource();
             CacheSink cacheSink = new(preBlockCache, storageCache);
             CancellationToken token = _balCts.Token;
-            _balTask = Task.Run(() =>
+            _balTask = Task.Run(async () =>
             {
                 try
                 {
-                    baseScope.ReadBalAsync(bal, cacheSink, token);
+                    await baseScope.ReadBalAsync(bal, cacheSink, token);
                 }
                 catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine(ex);
+                    if (_logger.IsError) _logger.Error("HintBal background task faulted", ex);
                 }
             });
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -110,7 +110,9 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     sink.OnAccountRead(address, account);
                 });
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException) { return Task.CompletedTask; }
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Phase 2: flat (address, private-tree, slot) jobs in one parallel pass
             int totalSlots = 0;

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -72,7 +72,6 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
         public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
         {
-            // Phase 1: Bulk read all accounts from the state trie
             int accountCount = 0;
             foreach (AccountChanges _ in bal.AccountChanges)
                 accountCount++;
@@ -81,155 +80,106 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                 return Task.CompletedTask;
 
             AccountChanges[] accountChangesList = new AccountChanges[accountCount];
-            int idx = 0;
+            int copyIdx = 0;
             foreach (AccountChanges ac in bal.AccountChanges)
-            {
-                accountChangesList[idx] = ac;
-                idx++;
-            }
+                accountChangesList[copyIdx++] = ac;
 
-            // Precompute keccak hashes and radix sort for disk cache locality
-            int[] sortedOrder = RadixSortAddresses(accountChangesList, accountCount);
+            // Phase 1 uses a private StateTree so the main-path tree instance is not touched
+            // from the BAL reader thread pool.
+            StateTree privateStateTree = _scopeProvider.CreateStateTree();
+            privateStateTree.RootHash = _backingStateTree.RootHash;
 
+            ParallelOptions options = new() { CancellationToken = cancellationToken };
             Account?[] accounts = new Account?[accountCount];
-            Parallel.For(0, accountCount, (i) =>
+            int skippedAccounts = 0;
+
+            try
             {
-                int orig = sortedOrder[i];
-                Address address = accountChangesList[orig].Address;
-                Account? account = _backingStateTree.Get(address);
-                accounts[orig] = account;
-
-                _loadedAccounts.TryAdd(address, account);
-                sink.OnAccountRead(address, account);
-            });
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Phase 2: Per-account bulk read of storage slots
-            for (int i = 0; i < accountCount; i++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                AccountChanges accountChanges = accountChangesList[i];
-                Account? account = accounts[i];
-
-                int slotCount = accountChanges.StorageChanges.Count + accountChanges.StorageReads.Count;
-                if (slotCount == 0 || account is null)
-                    continue;
-
-                Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
-                if (storageRoot == Keccak.EmptyTreeHash)
-                    continue;
-
-                Address address = accountChanges.Address;
-                StorageTree storageTree = _scopeProvider.CreateStorageTree(address, storageRoot);
-                _storages[address] = storageTree;
-
-                UInt256[] slotIndices = new UInt256[slotCount];
-                int si = 0;
-
-                foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
-                    slotIndices[si++] = slotChanges.Slot;
-
-                foreach (StorageRead storageRead in accountChanges.StorageReads)
-                    slotIndices[si++] = storageRead.Key;
-
-                // Radix sort storage slot hashes for disk cache locality
-                int[] slotOrder = RadixSortStorageSlots(slotIndices, slotCount);
-
-                Parallel.For(0, slotCount, (si2) =>
+                Parallel.For(0, accountCount, options, (i) =>
                 {
-                    int orig = slotOrder[si2];
-                    byte[] decodedValue = storageTree.Get(in slotIndices[orig]);
-                    StorageCell cell = new(address, slotIndices[orig]);
-                    sink.OnStorageRead(in cell, decodedValue);
+                    Address address = accountChangesList[i].Address;
+                    if (!sink.StillNeeded(address, out Account? cached))
+                    {
+                        accounts[i] = cached;
+                        Interlocked.Increment(ref skippedAccounts);
+                        return;
+                    }
+
+                    Account? account = privateStateTree.Get(address);
+                    accounts[i] = account;
+                    sink.OnAccountRead(address, account);
                 });
             }
+            catch (OperationCanceledException) { }
 
+            // Phase 2: flat (address, private-tree, slot) jobs in one parallel pass
+            int totalSlots = 0;
+            for (int i = 0; i < accountCount; i++)
+            {
+                Account? account = accounts[i];
+                if (account is null) continue;
+                Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                if (storageRoot == Keccak.EmptyTreeHash) continue;
+                totalSlots += accountChangesList[i].StorageChanges.Count + accountChangesList[i].StorageReads.Count;
+            }
+
+            int skippedSlots = 0;
+            if (totalSlots > 0)
+            {
+                (Address Address, StorageTree Tree, UInt256 Slot)[] jobs =
+                    new (Address, StorageTree, UInt256)[totalSlots];
+                int jobIdx = 0;
+                for (int i = 0; i < accountCount; i++)
+                {
+                    Account? account = accounts[i];
+                    if (account is null) continue;
+                    Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                    if (storageRoot == Keccak.EmptyTreeHash) continue;
+
+                    AccountChanges accountChanges = accountChangesList[i];
+                    Address address = accountChanges.Address;
+                    // Private per-account storage tree; main thread's LookupStorageTree creates its own.
+                    StorageTree storageTree = _scopeProvider.CreateStorageTree(address, storageRoot);
+
+                    foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                        jobs[jobIdx++] = (address, storageTree, slotChanges.Slot);
+
+                    foreach (StorageRead storageRead in accountChanges.StorageReads)
+                        jobs[jobIdx++] = (address, storageTree, storageRead.Key);
+                }
+
+                try
+                {
+                    Parallel.For(0, totalSlots, options, (s) =>
+                    {
+                        (Address address, StorageTree tree, UInt256 slot) = jobs[s];
+                        StorageCell cell = new(address, in slot);
+                        if (!sink.StillNeeded(in cell))
+                        {
+                            Interlocked.Increment(ref skippedSlots);
+                            return;
+                        }
+
+                        byte[] value = tree.Get(in slot);
+                        sink.OnStorageRead(in cell, value);
+                    });
+                }
+                catch (OperationCanceledException) { }
+            }
+
+            LogBalTrieSkipRates(accountCount, skippedAccounts, totalSlots, skippedSlots);
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Radix sort addresses by their keccak hash (bytes 0-3) for trie locality.
-        /// Returns an index array representing the sorted order.
-        /// </summary>
-        private static int[] RadixSortAddresses(AccountChanges[] accountChanges, int count)
+        private void LogBalTrieSkipRates(int accountCount, int skippedAccounts, int totalSlots, int skippedSlots)
         {
-            ValueHash256[] hashes = new ValueHash256[count];
-            for (int i = 0; i < count; i++)
-                hashes[i] = KeccakCache.Compute(accountChanges[i].Address.Bytes);
+            ILogger logger = _logManager.GetClassLogger<TrieStoreWorldStateBackendScope>();
+            if (!logger.IsInfo) return;
 
-            return RadixSortByHash(hashes, count);
+            double accountSkipPct = accountCount == 0 ? 0 : 100.0 * skippedAccounts / accountCount;
+            double slotSkipPct = totalSlots == 0 ? 0 : 100.0 * skippedSlots / totalSlots;
+            logger.Info($"[BAL trie] accounts={accountCount} skipped={skippedAccounts} ({accountSkipPct:F1}%) slots={totalSlots} skipped={skippedSlots} ({slotSkipPct:F1}%)");
         }
-
-        /// <summary>
-        /// Radix sort storage slots by their keccak hash (bytes 0-3) for trie locality.
-        /// Returns an index array representing the sorted order.
-        /// </summary>
-        private static int[] RadixSortStorageSlots(UInt256[] slotIndices, int count)
-        {
-            ValueHash256[] hashes = new ValueHash256[count];
-            for (int i = 0; i < count; i++)
-                StorageTree.ComputeKeyWithLookup(in slotIndices[i], ref hashes[i]);
-
-            return RadixSortByHash(hashes, count);
-        }
-
-        /// <summary>
-        /// LSD radix sort on bytes 0-3 of the hash. Returns sorted index array.
-        /// </summary>
-        private static int[] RadixSortByHash(ValueHash256[] hashes, int count)
-        {
-            int[] idx0 = new int[count];
-            int[] idx1 = new int[count];
-            ValueHash256[] buf = new ValueHash256[count];
-
-            for (int i = 0; i < count; i++)
-                idx0[i] = i;
-
-            Span<int> counts = stackalloc int[256];
-            bool flipped = false;
-
-            for (int p = 3; p >= 0; p--)
-            {
-                RadixPassWithIndices(
-                    flipped ? buf : hashes,
-                    flipped ? hashes : buf,
-                    flipped ? idx1 : idx0,
-                    flipped ? idx0 : idx1,
-                    count, p, counts);
-                flipped = !flipped;
-            }
-
-            return flipped ? idx1 : idx0;
-        }
-
-        private static void RadixPassWithIndices(
-            ReadOnlySpan<ValueHash256> hashSrc, Span<ValueHash256> hashDst,
-            ReadOnlySpan<int> idxSrc, Span<int> idxDst,
-            int len, int byteIndex, Span<int> counts)
-        {
-            counts.Clear();
-            for (int i = 0; i < len; i++)
-                counts[hashSrc[i].BytesAsSpan[byteIndex]]++;
-
-            int total = 0;
-            for (int b = 0; b < 256; b++)
-            {
-                int c = counts[b];
-                counts[b] = total;
-                total += c;
-            }
-
-            for (int i = 0; i < len; i++)
-            {
-                byte key = hashSrc[i].BytesAsSpan[byteIndex];
-                int pos = counts[key]++;
-                hashDst[pos] = hashSrc[i];
-                idxDst[pos] = idxSrc[i];
-            }
-        }
-
 
         public IWorldStateScopeProvider.ICodeDb CodeDb => _codeDb1;
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.State;
@@ -66,6 +67,169 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         }
 
         public void HintGet(Address address, Account? account) => _loadedAccounts.TryAdd(address, account);
+
+        public void HintBal(BlockAccessList bal) { }
+
+        public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+        {
+            // Phase 1: Bulk read all accounts from the state trie
+            int accountCount = 0;
+            foreach (AccountChanges _ in bal.AccountChanges)
+                accountCount++;
+
+            if (accountCount == 0)
+                return Task.CompletedTask;
+
+            AccountChanges[] accountChangesList = new AccountChanges[accountCount];
+            int idx = 0;
+            foreach (AccountChanges ac in bal.AccountChanges)
+            {
+                accountChangesList[idx] = ac;
+                idx++;
+            }
+
+            // Precompute keccak hashes and radix sort for disk cache locality
+            int[] sortedOrder = RadixSortAddresses(accountChangesList, accountCount);
+
+            Account?[] accounts = new Account?[accountCount];
+            Parallel.For(0, accountCount, (i) =>
+            {
+                int orig = sortedOrder[i];
+                Address address = accountChangesList[orig].Address;
+                Account? account = _backingStateTree.Get(address);
+                accounts[orig] = account;
+
+                _loadedAccounts.TryAdd(address, account);
+                sink.OnAccountRead(address, account);
+            });
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Phase 2: Per-account bulk read of storage slots
+            for (int i = 0; i < accountCount; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                AccountChanges accountChanges = accountChangesList[i];
+                Account? account = accounts[i];
+
+                int slotCount = accountChanges.StorageChanges.Count + accountChanges.StorageReads.Count;
+                if (slotCount == 0 || account is null)
+                    continue;
+
+                Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                if (storageRoot == Keccak.EmptyTreeHash)
+                    continue;
+
+                Address address = accountChanges.Address;
+                StorageTree storageTree = _scopeProvider.CreateStorageTree(address, storageRoot);
+                _storages[address] = storageTree;
+
+                UInt256[] slotIndices = new UInt256[slotCount];
+                int si = 0;
+
+                foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
+                    slotIndices[si++] = slotChanges.Slot;
+
+                foreach (StorageRead storageRead in accountChanges.StorageReads)
+                    slotIndices[si++] = storageRead.Key;
+
+                // Radix sort storage slot hashes for disk cache locality
+                int[] slotOrder = RadixSortStorageSlots(slotIndices, slotCount);
+
+                Parallel.For(0, slotCount, (si2) =>
+                {
+                    int orig = slotOrder[si2];
+                    byte[] decodedValue = storageTree.Get(in slotIndices[orig]);
+                    StorageCell cell = new(address, slotIndices[orig]);
+                    sink.OnStorageRead(in cell, decodedValue);
+                });
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Radix sort addresses by their keccak hash (bytes 0-3) for trie locality.
+        /// Returns an index array representing the sorted order.
+        /// </summary>
+        private static int[] RadixSortAddresses(AccountChanges[] accountChanges, int count)
+        {
+            ValueHash256[] hashes = new ValueHash256[count];
+            for (int i = 0; i < count; i++)
+                hashes[i] = KeccakCache.Compute(accountChanges[i].Address.Bytes);
+
+            return RadixSortByHash(hashes, count);
+        }
+
+        /// <summary>
+        /// Radix sort storage slots by their keccak hash (bytes 0-3) for trie locality.
+        /// Returns an index array representing the sorted order.
+        /// </summary>
+        private static int[] RadixSortStorageSlots(UInt256[] slotIndices, int count)
+        {
+            ValueHash256[] hashes = new ValueHash256[count];
+            for (int i = 0; i < count; i++)
+                StorageTree.ComputeKeyWithLookup(in slotIndices[i], ref hashes[i]);
+
+            return RadixSortByHash(hashes, count);
+        }
+
+        /// <summary>
+        /// LSD radix sort on bytes 0-3 of the hash. Returns sorted index array.
+        /// </summary>
+        private static int[] RadixSortByHash(ValueHash256[] hashes, int count)
+        {
+            int[] idx0 = new int[count];
+            int[] idx1 = new int[count];
+            ValueHash256[] buf = new ValueHash256[count];
+
+            for (int i = 0; i < count; i++)
+                idx0[i] = i;
+
+            Span<int> counts = stackalloc int[256];
+            bool flipped = false;
+
+            for (int p = 3; p >= 0; p--)
+            {
+                RadixPassWithIndices(
+                    flipped ? buf : hashes,
+                    flipped ? hashes : buf,
+                    flipped ? idx1 : idx0,
+                    flipped ? idx0 : idx1,
+                    count, p, counts);
+                flipped = !flipped;
+            }
+
+            return flipped ? idx1 : idx0;
+        }
+
+        private static void RadixPassWithIndices(
+            ReadOnlySpan<ValueHash256> hashSrc, Span<ValueHash256> hashDst,
+            ReadOnlySpan<int> idxSrc, Span<int> idxDst,
+            int len, int byteIndex, Span<int> counts)
+        {
+            counts.Clear();
+            for (int i = 0; i < len; i++)
+                counts[hashSrc[i].BytesAsSpan[byteIndex]]++;
+
+            int total = 0;
+            for (int b = 0; b < 256; b++)
+            {
+                int c = counts[b];
+                counts[b] = total;
+                total += c;
+            }
+
+            for (int i = 0; i < len; i++)
+            {
+                byte key = hashSrc[i].BytesAsSpan[byteIndex];
+                int pos = counts[key]++;
+                hashDst[pos] = hashSrc[i];
+                idxDst[pos] = idxSrc[i];
+            }
+        }
+
 
         public IWorldStateScopeProvider.ICodeDb CodeDb => _codeDb1;
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -91,7 +91,6 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
             ParallelOptions options = new() { CancellationToken = cancellationToken };
             using ArrayPoolList<Account?> accounts = new(accountCount, accountCount);
-            int skippedAccounts = 0;
 
             try
             {
@@ -101,7 +100,6 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     if (!sink.StillNeeded(address, out Account? cached))
                     {
                         accounts[i] = cached;
-                        Interlocked.Increment(ref skippedAccounts);
                         return;
                     }
 
@@ -125,7 +123,6 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                 totalSlots += accountChangesList[i].StorageChanges.Count + accountChangesList[i].StorageReads.Count;
             }
 
-            int skippedSlots = 0;
             if (totalSlots > 0)
             {
                 using ArrayPoolList<(Address Address, StorageTree Tree, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
@@ -156,10 +153,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                         (Address address, StorageTree tree, UInt256 slot) = jobs[s];
                         StorageCell cell = new(address, in slot);
                         if (!sink.StillNeeded(in cell))
-                        {
-                            Interlocked.Increment(ref skippedSlots);
                             return;
-                        }
 
                         byte[] value = tree.Get(in slot);
                         sink.OnStorageRead(in cell, value);
@@ -168,18 +162,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                 catch (OperationCanceledException) { }
             }
 
-            LogBalTrieSkipRates(accountCount, skippedAccounts, totalSlots, skippedSlots);
             return Task.CompletedTask;
-        }
-
-        private void LogBalTrieSkipRates(int accountCount, int skippedAccounts, int totalSlots, int skippedSlots)
-        {
-            ILogger logger = _logManager.GetClassLogger<TrieStoreWorldStateBackendScope>();
-            if (!logger.IsInfo) return;
-
-            double accountSkipPct = accountCount == 0 ? 0 : 100.0 * skippedAccounts / accountCount;
-            double slotSkipPct = totalSlots == 0 ? 0 : 100.0 * skippedSlots / totalSlots;
-            logger.Info($"[BAL trie] accounts={accountCount} skipped={skippedAccounts} ({accountSkipPct:F1}%) slots={totalSlots} skipped={skippedSlots} ({slotSkipPct:F1}%)");
         }
 
         public IWorldStateScopeProvider.ICodeDb CodeDb => _codeDb1;

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -79,7 +79,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             if (accountCount == 0)
                 return Task.CompletedTask;
 
-            AccountChanges[] accountChangesList = new AccountChanges[accountCount];
+            using ArrayPoolList<AccountChanges> accountChangesList = new(accountCount, accountCount);
             int copyIdx = 0;
             foreach (AccountChanges ac in bal.AccountChanges)
                 accountChangesList[copyIdx++] = ac;
@@ -90,7 +90,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             privateStateTree.RootHash = _backingStateTree.RootHash;
 
             ParallelOptions options = new() { CancellationToken = cancellationToken };
-            Account?[] accounts = new Account?[accountCount];
+            using ArrayPoolList<Account?> accounts = new(accountCount, accountCount);
             int skippedAccounts = 0;
 
             try
@@ -126,8 +126,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             int skippedSlots = 0;
             if (totalSlots > 0)
             {
-                (Address Address, StorageTree Tree, UInt256 Slot)[] jobs =
-                    new (Address, StorageTree, UInt256)[totalSlots];
+                using ArrayPoolList<(Address Address, StorageTree Tree, UInt256 Slot)> jobs = new(totalSlots, totalSlots);
                 int jobIdx = 0;
                 for (int i = 0; i < accountCount; i++)
                 {

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -238,12 +238,20 @@ namespace Nethermind.State
 
             return new Reactive.AnonymousDisposable(() =>
             {
-                Reset();
-                _stateProvider.SetScope(null);
-                _currentScope.Dispose();
-                _currentScope = null;
-                _isInScope = false;
-                if (_logger.IsTrace) _logger.Trace($"WorldState scope for baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} closed");
+                try
+                {
+                    Reset();
+                    _stateProvider.SetScope(null);
+                    _currentScope.Dispose();
+                }
+                finally
+                {
+                    // Cleared in finally so a dispose-time exception cannot leave the next
+                    // BranchProcessor.Process call stuck with IsInScope == true.
+                    _currentScope = null;
+                    _isInScope = false;
+                    if (_logger.IsTrace) _logger.Trace($"WorldState scope for baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} closed");
+                }
             });
         }
 

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
@@ -248,6 +249,12 @@ namespace Nethermind.State
 
         public bool IsInScope => _currentScope is not null;
         public IWorldStateScopeProvider ScopeProvider { get; }
+
+        public void HintBal(BlockAccessList bal)
+        {
+            GuardInScope();
+            _currentScope!.HintBal(bal);
+        }
 
         public ref readonly UInt256 GetBalance(Address address)
         {

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.State;
 
@@ -47,5 +50,10 @@ public class WorldStateMetricsScopeProvider(IWorldStateScopeProvider baseProvide
             parent._stateMerkleizationTime += Stopwatch.GetElapsedTime(start).TotalMilliseconds;
             parent._updateMetrics(parent._stateMerkleizationTime);
         }
+
+        public void HintBal(BlockAccessList bal) => baseScope.HintBal(bal);
+
+        public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+            => baseScope.ReadBalAsync(bal, sink, cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.State;
@@ -50,6 +52,11 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
         }
 
         public void HintGet(Address address, Account? account) => innerScope.HintGet(address, account);
+
+        public void HintBal(BlockAccessList bal) => innerScope.HintBal(bal);
+
+        public Task ReadBalAsync(BlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink sink, CancellationToken cancellationToken)
+            => innerScope.ReadBalAsync(bal, sink, cancellationToken);
 
         public IWorldStateScopeProvider.ICodeDb CodeDb => innerScope.CodeDb;
 


### PR DESCRIPTION
## Summary

Adds the BAL-driven prewarming layer on top of `feature/bal-recorder`. Block Access Lists (EIP-7928) are hinted to the world state so the underlying scopes can prefetch accounts and storage in the background while the block executes.

- New `IWorldStateScopeProvider.IScope` surface: `HintBal`, `ReadBalAsync`, plus `IAsyncBalReaderSink` with a default `StillNeeded` gate so cache-resident entries skip the fetch.
- `PrewarmerScopeProvider.ScopeWrapper` kicks off a cache-population task and calls the underlying `baseScope.HintBal` synchronously for trie warmup. `CancelBal` is idempotent and swallow-all so a late background fault cannot escape into `StartWriteBatch` / `Commit` / `Dispose`.
- `FlatWorldStateScope.HintBal` spawns a tracked, cancellable task that enqueues `PushAddressJob` + the new `PushSlotJobMpmc` (safe from multiple producers). `FlatWorldStateScope.ReadBalAsync` drops the radix-sort preamble, flattens storage to a single parallel pass, and uses `StillNeeded` to skip cache hits.
- `TrieStoreScopeProvider.ReadBalAsync` uses a private `StateTree` and per-account private `StorageTree` so BAL reader threads never share the main-path instance. One flat `Parallel.For` per phase with `ParallelOptions.CancellationToken` so cancel is honored mid-loop.
- `WorldState.BeginScope` moves `_currentScope = null; _isInScope = false;` into `finally` so a dispose-time throw cannot block the next scope.
- Scratch buffers in both `ReadBalAsync` implementations use `ArrayPoolList<T>` to pool per-block allocations.

## Test plan

- [x] Solution builds clean (`dotnet build -c release Nethermind.slnx`).
- [ ] `Nethermind.State.Test` / `Nethermind.State.Flat.Test` pass.
- [ ] `Nethermind.BalRecorder.Test` passes.
- [ ] Full Nethermind test suite pass.
- [ ] End-to-end with `ReplayBal` enabled against a small era — confirm `[BAL]` / `[BAL trie]` skip-ratio logs and no stray reads during commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)