### PR TITLE
Reduce dirty nodes lock contention

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -67,10 +67,10 @@ namespace Nethermind.Core.Crypto
         public long GetHashCode64() => SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<Vector256<byte>, byte>(ref Unsafe.AsRef(in _bytes)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetChainedHashCode(uint previousHash) => (int)BitOperations.Crc32C((uint)Bytes.FastHash(), previousHash);
+        public int GetChainedHashCode(uint previousHash) => (int)BitOperations.Crc32C(previousHash, (uint)Bytes.FastHash());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetChainedHashCode(ulong previousHash) => (int)BitOperations.Crc32C((uint)Bytes.FastHash(), previousHash);
+        public int GetChainedHashCode(ulong previousHash) => (int)BitOperations.Crc32C((uint)previousHash, (previousHash & ~(ulong)uint.MaxValue) | (uint)Bytes.FastHash());
 
         public int CompareTo(ValueHash256 other) => Extensions.Bytes.BytesComparer.Compare(Bytes, other.Bytes);
 

--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -65,7 +66,11 @@ namespace Nethermind.Core.Crypto
 
         public long GetHashCode64() => SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<Vector256<byte>, byte>(ref Unsafe.AsRef(in _bytes)));
 
-        public int GetChainedHashCode(uint previousHash) => Bytes.FastHash() ^ (int)previousHash;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetChainedHashCode(uint previousHash) => (int)BitOperations.Crc32C((uint)Bytes.FastHash(), previousHash);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetChainedHashCode(ulong previousHash) => (int)BitOperations.Crc32C((uint)Bytes.FastHash(), previousHash);
 
         public int CompareTo(ValueHash256 other) => Extensions.Bytes.BytesComparer.Compare(Bytes, other.Bytes);
 

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1745,70 +1745,25 @@ namespace Nethermind.Trie.Test.Pruning
     [Parallelizable(ParallelScope.All)]
     public class TreeStoreInternalBehaviorTests
     {
-        [Test]
-        public void Dirty_node_record_merge_keeps_current_when_neither_persisted()
+        [TestCase(false, false, 4, 2, false, 4, TestName = "Dirty_node_record_merge_keeps_current_when_neither_persisted")]
+        [TestCase(false, false, 2, 5, false, 5, TestName = "Dirty_node_record_merge_advances_last_commit_from_candidate")]
+        [TestCase(true, false, 1, 3, true, 3, TestName = "Dirty_node_record_merge_replaces_persisted_node_with_dirty_candidate")]
+        [TestCase(false, true, 4, 6, false, 6, TestName = "Dirty_node_record_merge_keeps_current_when_candidate_is_persisted")]
+        public void Dirty_node_record_merge_selects_expected_node_and_last_commit(bool currentPersisted, bool candidatePersisted, long currentLastCommit, long candidateLastCommit, bool expectCandidateNode, long expectedLastCommit)
         {
-            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
-            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
-            currentNode.IsPersisted = false;
-            candidateNode.IsPersisted = false;
-            TrieStoreDirtyNodesCache.NodeRecord current = new(currentNode, 4);
-            TrieStoreDirtyNodesCache.NodeRecord candidate = new(candidateNode, 2);
-
-            TrieStoreDirtyNodesCache.MergeRecords(current, candidate).Should().Be(current);
-        }
-
-        [Test]
-        public void Dirty_node_record_merge_advances_last_commit_from_candidate()
-        {
-            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
-            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
-            currentNode.IsPersisted = false;
-            candidateNode.IsPersisted = false;
+            TrieNode currentNode = CreateNode(currentPersisted);
+            TrieNode candidateNode = CreateNode(candidatePersisted);
 
             TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
-                new TrieStoreDirtyNodesCache.NodeRecord(currentNode, 2),
-                new TrieStoreDirtyNodesCache.NodeRecord(candidateNode, 5));
+                CreateRecord(currentNode, currentLastCommit),
+                CreateRecord(candidateNode, candidateLastCommit));
 
-            merged.Node.Should().BeSameAs(currentNode);
-            merged.LastCommit.Should().Be(5);
+            merged.Node.Should().BeSameAs(expectCandidateNode ? candidateNode : currentNode);
+            merged.LastCommit.Should().Be(expectedLastCommit);
         }
 
         [Test]
-        public void Dirty_node_record_merge_replaces_persisted_node_with_dirty_candidate()
-        {
-            TrieNode persistedNode = new(NodeType.Unknown, TestItem.KeccakA);
-            persistedNode.IsPersisted = true;
-            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
-            candidateNode.IsPersisted = false;
-
-            TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
-                new TrieStoreDirtyNodesCache.NodeRecord(persistedNode, 1),
-                new TrieStoreDirtyNodesCache.NodeRecord(candidateNode, 3));
-
-            merged.Node.Should().BeSameAs(candidateNode);
-            merged.LastCommit.Should().Be(3);
-        }
-
-        [Test]
-        public void Dirty_node_record_merge_keeps_current_when_candidate_is_persisted()
-        {
-            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
-            currentNode.IsPersisted = false;
-            TrieNode persistedCandidateNode = new(NodeType.Unknown, TestItem.KeccakA);
-            persistedCandidateNode.IsPersisted = true;
-
-            TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
-                new TrieStoreDirtyNodesCache.NodeRecord(currentNode, 4),
-                new TrieStoreDirtyNodesCache.NodeRecord(persistedCandidateNode, 6));
-
-            merged.Node.Should().BeSameAs(currentNode);
-            merged.LastCommit.Should().Be(6);
-        }
-
-        [TestCase(false)]
-        [TestCase(true)]
-        public void Persisted_hash_recorder_handles_revisited_keys(bool deleteOldNodes)
+        public void Persisted_hash_recorder_handles_revisited_keys([Values] bool deleteOldNodes)
         {
             ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes = new();
             HashAndTinyPath key = new(TestItem.KeccakA, new TinyTreePath(TreePath.Empty));
@@ -1828,5 +1783,10 @@ namespace Nethermind.Trie.Test.Pruning
 
             persistedHashes.Count.Should().Be(1);
         }
+
+        private static TrieNode CreateNode(bool isPersisted) =>
+            new(NodeType.Unknown, TestItem.KeccakA) { IsPersisted = isPersisted };
+
+        private static TrieStoreDirtyNodesCache.NodeRecord CreateRecord(TrieNode node, long lastCommit) => new(node, lastCommit);
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1737,6 +1738,95 @@ namespace Nethermind.Trie.Test.Pruning
             };
 
             commitBlock1.Should().NotThrow();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class TreeStoreInternalBehaviorTests
+    {
+        [Test]
+        public void Dirty_node_record_merge_keeps_current_when_neither_persisted()
+        {
+            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
+            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
+            currentNode.IsPersisted = false;
+            candidateNode.IsPersisted = false;
+            TrieStoreDirtyNodesCache.NodeRecord current = new(currentNode, 4);
+            TrieStoreDirtyNodesCache.NodeRecord candidate = new(candidateNode, 2);
+
+            TrieStoreDirtyNodesCache.MergeRecords(current, candidate).Should().Be(current);
+        }
+
+        [Test]
+        public void Dirty_node_record_merge_advances_last_commit_from_candidate()
+        {
+            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
+            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
+            currentNode.IsPersisted = false;
+            candidateNode.IsPersisted = false;
+
+            TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
+                new TrieStoreDirtyNodesCache.NodeRecord(currentNode, 2),
+                new TrieStoreDirtyNodesCache.NodeRecord(candidateNode, 5));
+
+            merged.Node.Should().BeSameAs(currentNode);
+            merged.LastCommit.Should().Be(5);
+        }
+
+        [Test]
+        public void Dirty_node_record_merge_replaces_persisted_node_with_dirty_candidate()
+        {
+            TrieNode persistedNode = new(NodeType.Unknown, TestItem.KeccakA);
+            persistedNode.IsPersisted = true;
+            TrieNode candidateNode = new(NodeType.Unknown, TestItem.KeccakA);
+            candidateNode.IsPersisted = false;
+
+            TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
+                new TrieStoreDirtyNodesCache.NodeRecord(persistedNode, 1),
+                new TrieStoreDirtyNodesCache.NodeRecord(candidateNode, 3));
+
+            merged.Node.Should().BeSameAs(candidateNode);
+            merged.LastCommit.Should().Be(3);
+        }
+
+        [Test]
+        public void Dirty_node_record_merge_keeps_current_when_candidate_is_persisted()
+        {
+            TrieNode currentNode = new(NodeType.Unknown, TestItem.KeccakA);
+            currentNode.IsPersisted = false;
+            TrieNode persistedCandidateNode = new(NodeType.Unknown, TestItem.KeccakA);
+            persistedCandidateNode.IsPersisted = true;
+
+            TrieStoreDirtyNodesCache.NodeRecord merged = TrieStoreDirtyNodesCache.MergeRecords(
+                new TrieStoreDirtyNodesCache.NodeRecord(currentNode, 4),
+                new TrieStoreDirtyNodesCache.NodeRecord(persistedCandidateNode, 6));
+
+            merged.Node.Should().BeSameAs(currentNode);
+            merged.LastCommit.Should().Be(6);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Persisted_hash_recorder_handles_revisited_keys(bool deleteOldNodes)
+        {
+            ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes = new();
+            HashAndTinyPath key = new(TestItem.KeccakA, new TinyTreePath(TreePath.Empty));
+
+            TrieStore.RecordPersistedHash(persistedHashes, key, TestItem.KeccakB, deleteOldNodes);
+            TrieStore.RecordPersistedHash(persistedHashes, key, TestItem.KeccakC, deleteOldNodes);
+
+            if (deleteOldNodes)
+            {
+                TrieStore.RecordPersistedHash(persistedHashes, key, TestItem.KeccakD, deleteOldNodes);
+                persistedHashes[key].Should().BeNull();
+            }
+            else
+            {
+                persistedHashes[key].Should().Be(TestItem.KeccakB);
+            }
+
+            persistedHashes.Count.Should().Be(1);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/HashAndTinyPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/HashAndTinyPath.cs
@@ -15,9 +15,5 @@ internal readonly struct HashAndTinyPath(Hash256? hash, in TinyTreePath path) : 
 
     public bool Equals(HashAndTinyPath other) => addr == other.addr && path.Equals(in other.path);
     public override bool Equals(object? obj) => obj is HashAndTinyPath other && Equals(other);
-    public override int GetHashCode()
-    {
-        int addressHash = addr?.GetHashCode() ?? 0x55555555;
-        return path.GetHashCode() ^ addressHash;
-    }
+    public override int GetHashCode() => path.GetChainedHashCode((uint)(addr?.GetHashCode() ?? 0x55555555));
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core.Crypto;
 
@@ -46,6 +47,9 @@ public readonly struct TinyTreePath : IEquatable<TinyTreePath>
     public override bool Equals(object? obj) => obj is TinyTreePath other && Equals(other);
     // Need more variance than straightforward long.GetHashCode() as it determines lock contention in ConcurrentDictionary
     public override int GetHashCode() => (int)BitOperations.Crc32C((uint)_data, ((ulong)_data & 0xffff_ffff_0000_0000) | ~(uint)_data);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int GetChainedHashCode(uint seed) => (int)BitOperations.Crc32C(seed, (ulong)_data);
 
     public static bool operator ==(in TinyTreePath left, in TinyTreePath right)
     {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -101,10 +101,11 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         _dirtyNodes = new TrieStoreDirtyNodesCache[_shardedDirtyNodeCount];
         _dirtyNodesTasks = new Task[_shardedDirtyNodeCount];
         _persistedHashes = new ConcurrentDictionary<HashAndTinyPath, Hash256?>[_shardedDirtyNodeCount];
+        TrieStoreDirtyNodesCache.GetDictionarySizing(out int concurrencyLevel, out int initialBuckets);
         for (int i = 0; i < _shardedDirtyNodeCount; i++)
         {
             _dirtyNodes[i] = new TrieStoreDirtyNodesCache(this, !_nodeStorage.RequirePath, keepRoot: _deleteOldNodes, _logger);
-            _persistedHashes[i] = new ConcurrentDictionary<HashAndTinyPath, Hash256>();
+            _persistedHashes[i] = new ConcurrentDictionary<HashAndTinyPath, Hash256?>(concurrencyLevel, initialBuckets);
         }
     }
 
@@ -849,25 +850,29 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             int shardIdx = GetNodeShardIdx(treePath, tn.Keccak);
 
             HashAndTinyPath key = new(address, new TinyTreePath(treePath));
+            RecordPersistedHash(_persistedHashes[shardIdx], key, tn.Keccak, _deleteOldNodes);
+        }
+    }
 
-            if (_deleteOldNodes)
+    internal static void RecordPersistedHash(
+        ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes,
+        in HashAndTinyPath key,
+        Hash256 hash,
+        bool deleteOldNodes)
+    {
+        if (persistedHashes.TryAdd(key, hash) || !deleteOldNodes)
+        {
+            return;
+        }
+
+        // When deleting old nodes, the first revisit marks the key as ambiguous by switching it to null.
+        // After that, additional revisits are pure read-only probes, so we retry only until that
+        // one-way state transition succeeds instead of routing every revisit through AddOrUpdate.
+        while (persistedHashes.TryGetValue(key, out Hash256? existingHash))
+        {
+            if (existingHash is null || persistedHashes.TryUpdate(key, null, existingHash))
             {
-                _persistedHashes[shardIdx].AddOrUpdate(
-                    key,
-                    static (_, newHash) => newHash,
-                    static (_, hash, _) => null,
-                    tn.Keccak);
-            }
-            else
-            {
-                _persistedHashes[shardIdx].AddOrUpdate(
-                    key,
-                    static (_, newHash) => newHash,
-                    // When not deleting old nodes, key tracking is used to prune in memory cache. It is
-                    // safe to accidentally remove key by taking non-canon block as canon as it will just load
-                    // from disk again.
-                    static (_, hash, _) => hash,
-                    tn.Keccak);
+                return;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -865,11 +865,14 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             return;
         }
 
-        // When deleting old nodes, the first revisit marks the key as ambiguous by switching it to null.
-        // After that, additional revisits are pure read-only probes, so we retry only until that
-        // one-way state transition succeeds instead of routing every revisit through AddOrUpdate.
+        // If TryGetValue returns false the key was removed by NoResizeClear, which runs after (not
+        // during) PruneCache has finished consuming the dictionary. The sentinel is no longer needed
+        // once that pass has completed, so exiting the loop is safe.
         while (persistedHashes.TryGetValue(key, out Hash256? existingHash))
         {
+            // When deleting old nodes, the first revisit marks the key as ambiguous by switching it to null.
+            // After that, additional revisits are pure read-only probes, so we retry only until that
+            // one-way state transition succeeds instead of routing every revisit through AddOrUpdate.
             if (existingHash is null || persistedHashes.TryUpdate(key, null, existingHash))
             {
                 return;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Utils;
 using Nethermind.Logging;
@@ -39,7 +40,9 @@ internal class TrieStoreDirtyNodesCache
 
     internal static void GetDictionarySizing(out int concurrencyLevel, out int initialBuckets)
     {
-        concurrencyLevel = Math.Min(Environment.ProcessorCount * 4, 32);
+        // Core.Cpu.RuntimeInformation.ProcessorCount floors to 1 where Environment.ProcessorCount
+        // can report 0 (zk-evm). ConcurrentDictionary requires concurrencyLevel >= 1.
+        concurrencyLevel = Math.Min(RuntimeInformation.ProcessorCount * 4, 32);
         initialBuckets = TrieStore.HashHelpers.GetPrime(Math.Max(31, concurrencyLevel));
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -37,6 +37,12 @@ internal class TrieStoreDirtyNodesCache
     public readonly long KeyMemoryUsage;
     private readonly bool _keepRoot;
 
+    internal static void GetDictionarySizing(out int concurrencyLevel, out int initialBuckets)
+    {
+        concurrencyLevel = Math.Min(Environment.ProcessorCount * 4, 32);
+        initialBuckets = TrieStore.HashHelpers.GetPrime(Math.Max(31, concurrencyLevel));
+    }
+
     public TrieStoreDirtyNodesCache(TrieStore trieStore, bool storeByHash, bool keepRoot, ILogger logger)
     {
         _trieStore = trieStore;
@@ -51,8 +57,7 @@ internal class TrieStoreDirtyNodesCache
         _keepRoot = keepRoot;
 
         // NOTE: DirtyNodesCache is already sharded.
-        int concurrencyLevel = Math.Min(Environment.ProcessorCount * 4, 32);
-        int initialBuckets = TrieStore.HashHelpers.GetPrime(Math.Max(31, concurrencyLevel));
+        GetDictionarySizing(out int concurrencyLevel, out int initialBuckets);
         if (_storeByHash)
         {
             _byHashObjectCache = new(concurrencyLevel, initialBuckets);
@@ -168,23 +173,44 @@ internal class TrieStoreDirtyNodesCache
         }, cache);
 
     public NodeRecord GetOrAdd(in Key key, NodeRecord record) => _storeByHash
-            ? _byHashObjectCache.AddOrUpdate(key.Keccak, static (key, arg) => arg,
-                RecordReplacementLogic, record)
-            : _byKeyObjectCache.AddOrUpdate(key, static (key, arg) => arg,
-                RecordReplacementLogic, record);
+            ? GetOrAdd(_byHashObjectCache, key.Keccak, record)
+            : GetOrAdd(_byKeyObjectCache, key, record);
 
-    private static NodeRecord RecordReplacementLogic(Key key, NodeRecord current, NodeRecord arg) => RecordReplacementLogic(null, current, arg);
+    private static NodeRecord GetOrAdd<TKey>(ConcurrentDictionary<TKey, NodeRecord> dictionary, TKey key, NodeRecord record)
+        where TKey : notnull
+    {
+        // Avoid AddOrUpdate here: an existing key often merges to the same logical NodeRecord,
+        // and this fast path returns without forcing ConcurrentDictionary's update path.
+        while (true)
+        {
+            if (dictionary.TryGetValue(key, out NodeRecord current))
+            {
+                NodeRecord merged = MergeRecords(current, record);
+                if (merged.Equals(current) || dictionary.TryUpdate(key, merged, current))
+                {
+                    return merged;
+                }
 
-    private static NodeRecord RecordReplacementLogic(Hash256AsKey keyHash, NodeRecord current, NodeRecord arg)
+                continue;
+            }
+
+            if (dictionary.TryAdd(key, record))
+            {
+                return record;
+            }
+        }
+    }
+
+    internal static NodeRecord MergeRecords(NodeRecord current, NodeRecord candidate)
     {
         long lastCommit = current.LastCommit;
-        if (arg.LastCommit > lastCommit)
+        if (candidate.LastCommit > lastCommit)
         {
-            lastCommit = arg.LastCommit;
+            lastCommit = candidate.LastCommit;
         }
 
         TrieNode node = current.Node;
-        if (node.IsPersisted && !arg.Node.IsPersisted)
+        if (node.IsPersisted && !candidate.Node.IsPersisted)
         {
             // This code path happens around 0.8% of the time at 4GB of dirty cache and 16GB total cache.
             //
@@ -194,7 +220,7 @@ internal class TrieStoreDirtyNodesCache
             // the child is removed, but the parent is not and remain in the cache as persisted node.
             // Additionally, it may hold a reference to its child which is marked as persisted even though it was
             // deleted from the cached map.
-            node = arg.Node;
+            node = candidate.Node;
         }
 
         return new NodeRecord(node, lastCommit);
@@ -461,8 +487,8 @@ internal class TrieStoreDirtyNodesCache
         [SkipLocalsInit]
         public override int GetHashCode()
         {
-            int addressHash = Address != default ? Address.GetHashCode() : 1;
-            return Keccak.ValueHash256.GetChainedHashCode((uint)Path.GetHashCode()) ^ addressHash;
+            ulong chainedHash = ((ulong)(uint)Path.GetHashCode() << 32) | (uint)(Address?.GetHashCode() ?? 1);
+            return Keccak.ValueHash256.GetChainedHashCode(chainedHash);
         }
 
         public bool Equals(Key other) => other.Keccak == Keccak && other.Path == Path && other.Address == Address;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -201,6 +201,7 @@ internal class TrieStoreDirtyNodesCache
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static NodeRecord MergeRecords(NodeRecord current, NodeRecord candidate)
     {
         long lastCommit = current.LastCommit;


### PR DESCRIPTION
## Changes

- Hash quality: replace XOR-based hash combines in Hash256.GetChainedHashCode, HashAndTinyPath, and TrieStoreDirtyNodesCache.Key with BitOperations.Crc32C. XOR of two 32-bit hashes cancels when address == path-hash; CRC32C avalanche cuts ConcurrentDictionary bucket collisions and the lock contention that follows. Adds a Hash256.GetChainedHashCode(ulong) overload and a TinyTreePath.GetChainedHashCode(uint seed) helper so callers feed the full 64 bits of path data into the mix instead of the pre-folded 32-bit hash.
- Dictionary sizing: share concurrencyLevel + prime-bucket count between the dirty nodes cache and _persistedHashes via GetDictionarySizing, pre-sizing the previously unsized _persistedHashes dictionaries and avoiding resize storms at startup.
- GetOrAdd rewrite: replace AddOrUpdate with closures by an explicit TryGetValue/Merge/TryUpdate/TryAdd CAS loop. Splits out MergeRecords so the write path can short-circuit the CAS when the merged record equals the current one (the common revisit-with-no-change case AddOrUpdate always paid for).
- Persisted-hash recorder: extract TrieStore.RecordPersistedHash so the delete-old-nodes null-sentinel protocol is directly testable. After the first revisit, subsequent revisits short-circuit on the sticky null without re-running an update factory.
- Tests: add MergeRecords coverage for neither-persisted, advances-last-commit, persisted-current-dirty-candidate, and dirty-current-persisted-candidate branches; plus RecordPersistedHash coverage for both deleteOldNodes modes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes