### PR TITLE
fix: PatriciaTree commit deadlock on bounded scheduler

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -1299,5 +1299,34 @@ namespace Nethermind.Trie.Test
             patriciaTree.Invoking(t => t.WarmUpPath(Bytes.FromHexString("00000000000cc"))).Should().NotThrow();  // Non-existent key
             patriciaTree.Invoking(t => t.WarmUpPath(Bytes.FromHexString("fffffffffffff"))).Should().NotThrow();  // Completely different path
         }
+
+        [Test]
+        public void Commit_DoesNotDeadlock_WhenRunOnBoundedScheduler()
+        {
+            // Commit should not deadlock on a bounded scheduler (e.g. NewBlock P2P message on BackgroundTaskScheduler).
+            ConcurrentExclusiveSchedulerPair schedulerPair = new(TaskScheduler.Default, maxConcurrencyLevel: 1);
+
+            Task task = Task.Factory.StartNew(() =>
+            {
+                MemDb memDb = new();
+                using IPruningTrieStore trieStore = CreateTrieStore(memDb);
+                PatriciaTree tree = new(trieStore, _logManager);
+
+                Span<byte> buffer = stackalloc byte[32];
+                for (int i = 0; i < 100; i++)
+                {
+                    BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+                    Hash256 key = Keccak.Compute(buffer);
+                    tree.Set(key.Bytes, key.BytesToArray());
+                }
+
+                using (trieStore.BeginBlockCommit(0))
+                {
+                    tree.Commit();
+                }
+            }, CancellationToken.None, TaskCreationOptions.None, schedulerPair.ConcurrentScheduler);
+
+            task.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("Commit deadlocked on bounded scheduler");
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -305,13 +305,18 @@ namespace Nethermind.Trie
             void TraceSkipInlineNode(TrieNode node) => _logger.Trace($"Skipping commit of an inlined {node}");
         }
 
-        private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Run(() =>
-        {
-            TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
-            if (!ReferenceEquals(childNode, newChild))
-                node[idx] = newChild;
-            committer.ReturnConcurrencyQuota();
-        });
+        private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Factory.StartNew(
+            _ =>
+            {
+                TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
+                if (!ReferenceEquals(childNode, newChild))
+                    node[idx] = newChild;
+                committer.ReturnConcurrencyQuota();
+            },
+            null,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            TaskScheduler.Default);
 
         public void UpdateRootHash(bool canBeParallel = true)
         {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -305,18 +305,13 @@ namespace Nethermind.Trie
             void TraceSkipInlineNode(TrieNode node) => _logger.Trace($"Skipping commit of an inlined {node}");
         }
 
-        private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Factory.StartNew(
-            _ =>
-            {
-                TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
-                if (!ReferenceEquals(childNode, newChild))
-                    node[idx] = newChild;
-                committer.ReturnConcurrencyQuota();
-            },
-            null,
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            TaskScheduler.Default);
+        private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Run(() =>
+        {
+            TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
+            if (!ReferenceEquals(childNode, newChild))
+                node[idx] = newChild;
+            committer.ReturnConcurrencyQuota();
+        });
 
         public void UpdateRootHash(bool canBeParallel = true)
         {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -305,17 +305,18 @@ namespace Nethermind.Trie
             void TraceSkipInlineNode(TrieNode node) => _logger.Trace($"Skipping commit of an inlined {node}");
         }
 
-        private async Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx)
-        {
-            // Background task
-            await Task.Yield();
-            TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
-            if (!ReferenceEquals(childNode, newChild))
+        private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Factory.StartNew(
+            _ =>
             {
-                node[idx] = newChild;
-            }
-            committer.ReturnConcurrencyQuota();
-        }
+                TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
+                if (!ReferenceEquals(childNode, newChild))
+                    node[idx] = newChild;
+                committer.ReturnConcurrencyQuota();
+            },
+            null,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            TaskScheduler.Default);
 
         public void UpdateRootHash(bool canBeParallel = true)
         {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -319,7 +319,7 @@ namespace Nethermind.Trie
                     committer.ReturnConcurrencyQuota();
                 }
             },
-            null,
+            state: null,
             CancellationToken.None,
             TaskCreationOptions.None,
             TaskScheduler.Default);

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -308,10 +308,16 @@ namespace Nethermind.Trie
         private Task CreateTaskForPath(ICommitter committer, TrieNode node, int maxLevelForConcurrentCommit, TreePath childPath, TrieNode childNode, int idx) => Task.Factory.StartNew(
             _ =>
             {
-                TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
-                if (!ReferenceEquals(childNode, newChild))
-                    node[idx] = newChild;
-                committer.ReturnConcurrencyQuota();
+                try
+                {
+                    TrieNode newChild = Commit(committer, ref childPath, childNode!, maxLevelForConcurrentCommit);
+                    if (!ReferenceEquals(childNode, newChild))
+                        node[idx] = newChild;
+                }
+                finally
+                {
+                    committer.ReturnConcurrencyQuota();
+                }
             },
             null,
             CancellationToken.None,


### PR DESCRIPTION
  - Replace `async Task` + `await Task.Yield()` in `PatriciaTree.CreateTaskForPath` with `Task.Factory.StartNew`                                                                                                                              
                                                                                                                                                                                                                                              
  `await Task.Yield()` schedules the continuation back on the **current** `TaskScheduler`. When running inside a bounded scheduler (e.g. `BackgroundTaskScheduler`(P2P)), child tasks are queued onto the same scheduler. Since the parent is      
  blocked on `Task.WaitAll`, all scheduler slots are occupied, and child tasks never get to run.  

<details><summary>Benchmarks</summary>
<p>

 **master**                                                                                                                                                                                                                                  
  | Method                         | Mean        | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated   |
  |------------------------------- |------------:|----------:|----------:|---------:|---------:|--------:|------------:|                                                                                                                      
  | InsertAndCommit                |  4,559.0 us |  73.43 us |  68.68 us |  82.0313 |  39.0625 |       - |  4734.52 KB |                                                                                                                      
  | InsertAndCommitRepeatedlyTimes | 12,916.8 us | 205.62 us | 260.04 us | 109.3750 | 101.5625 |  7.8125 | 10545.58 KB |                                                                                                                      
  | LargeInsertAndCommit           | 11,557.3 us | 230.57 us | 307.80 us | 125.0000 |  62.5000 | 23.4375 | 10128.07 KB |                                                                                                                      
  | LargeCommit                    |  1,451.5 us |  34.14 us |  99.05 us |        - |        - |       - |  2808.29 KB |                                                                                                                      
                                                                                                                                                                                                                                              
  **This PR**                                                                                                                                                                                                                                 
  | Method                         | Mean        | Error     | StdDev      | Gen0     | Gen1     | Gen2    | Allocated   |                                                                                                                    
  |------------------------------- |------------:|----------:|------------:|---------:|---------:|--------:|------------:|                                                                                                                    
  | InsertAndCommit                |  4,280.6 us |  84.11 us |   125.89 us |  82.0313 |  35.1563 |       - |  4763.53 KB |
  | InsertAndCommitRepeatedlyTimes | 12,109.4 us | 241.88 us |   494.09 us | 203.1250 | 171.8750 | 39.0625 | 10601.92 KB |                                                                                                                    
  | LargeInsertAndCommit           |  6,695.1 us | 507.51 us | 1,456.15 us |        - |        - |       - |  5592.41 KB |                                                                                                                    
  | LargeCommit                    |  1,473.9 us |  37.79 us |   108.42 us |        - |        - |       - |  2838.28 KB | 

</p>
</details> 