### PR TITLE
fix(expb): default <<AMOUNT>> placeholder for push and PR triggers

### DIFF
--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -524,10 +524,18 @@ jobs:
           DOCKER_TAG: ${{ needs.resolve.outputs.clean_branch }}
           DELAY_SECONDS: ${{ needs.resolve.outputs.delay_seconds }}
           AMOUNT: ${{ needs.resolve.outputs.amount }}
+          PAYLOAD_SET: ${{ matrix.payload_set }}
           SCENARIO_NAME: ${{ env.SCENARIO_NAME }}
           ADDITIONAL_EXTRA_FLAGS: ${{ needs.resolve.outputs.additional_extra_flags }}
         run: |
           set -euo pipefail
+          if [[ -z "${AMOUNT}" ]]; then
+            if [[ "${PAYLOAD_SET}" == "realblocks" ]]; then
+              AMOUNT="1000"
+            else
+              AMOUNT="100"
+            fi
+          fi
           flags_file="$(mktemp)"
           printf '%s' "${ADDITIONAL_EXTRA_FLAGS}" \
             | tr '\r' '\n' \


### PR DESCRIPTION
## Summary
- For `pull_request` and `push` (master merge) triggers, the `resolve` job sets `amount=""` because it can't pick a single default when the matrix iterates over both `superblocks` and `realblocks` payload sets
- The sed replacement `${AMOUNT:+-e ...}` becomes a no-op when `AMOUNT` is empty, leaving the literal `<<AMOUNT>>` in the rendered config
- Fix: default `AMOUNT` in the benchmark job's render step where `matrix.payload_set` is available — 1000 for realblocks, 100 for superblocks (matching existing `workflow_dispatch` logic)

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- Trigger workflow via master merge or `reproducible-benchmark` label on a PR and verify `<<AMOUNT>>` is replaced in the rendered config