### PR TITLE
Enforce EIP-3675 uncle ban at the spec level

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -269,8 +269,7 @@ public abstract class BlockchainTestBase
         List<(Block Block, string ExpectedException)> correctRlp = DecodeRlps(test, failOnInvalidRlp);
         for (int i = 0; i < correctRlp.Count; i++)
         {
-            // Mimic the actual behaviour where block goes through validating sync manager
-            correctRlp[i].Block.Header.IsPostMerge = correctRlp[i].Block.Difficulty == 0;
+            // IsPostMerge is set by MergeProcessingRecoveryStep / PoSSwitcher during the pipeline.
 
             // For tests with reorgs, find the actual parent header from block tree
             parentHeader = blockTree.FindHeader(correctRlp[i].Block.ParentHash) ?? parentHeader;

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -269,7 +269,8 @@ public abstract class BlockchainTestBase
         List<(Block Block, string ExpectedException)> correctRlp = DecodeRlps(test, failOnInvalidRlp);
         for (int i = 0; i < correctRlp.Count; i++)
         {
-            // IsPostMerge is set by MergeProcessingRecoveryStep / PoSSwitcher during the pipeline.
+            // Setting IsPostMerge here would bypass PoSSwitcher and hide divergences
+            // between CI and hive's production pipeline (the bug this test path exists to catch).
 
             // For tests with reorgs, find the actual parent header from block tree
             parentHeader = blockTree.FindHeader(correctRlp[i].Block.ParentHash) ?? parentHeader;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -352,7 +352,7 @@ namespace Nethermind.Specs.ChainSpecStyle
         // on TTD-driven chains with no such later transitions are not detected here - runtime
         // MergeHeaderValidator (UnclesHash == empty via PoSSwitcher) is the safety net.
         private static bool IsPostMergeRelease(ChainSpec chainSpec, long releaseStartBlock, ulong? releaseStartTimestamp) =>
-            chainSpec.Parameters.TerminalTotalDifficulty == UInt256.Zero
+            chainSpec.Parameters.TerminalTotalDifficulty?.IsZero == true
             || releaseStartBlock > (chainSpec.Parameters.TerminalPoWBlockNumber ?? long.MaxValue)
             || (chainSpec.Parameters.Eip4895TransitionTimestamp ?? ulong.MaxValue) <= (releaseStartTimestamp ?? 0);
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -346,7 +346,9 @@ namespace Nethermind.Specs.ChainSpecStyle
         // Shanghai (EIP-4895) is the first post-Paris timestamp-activated fork, so TTD-driven
         // chains like mainnet cross into post-merge once they reach it - that's the only
         // non-obvious branch below. TTD=0 covers PoS-from-genesis; TerminalPoWBlockNumber
-        // covers chainspecs that pin the boundary explicitly.
+        // covers chainspecs that pin the boundary explicitly. The Paris-Shanghai window on
+        // TTD-driven chains with no explicit terminal block is not detectable here - runtime
+        // MergeHeaderValidator (UnclesHash == empty via PoSSwitcher) is the safety net.
         private static bool IsPostMergeRelease(ChainSpec chainSpec, long releaseStartBlock, ulong? releaseStartTimestamp) =>
             chainSpec.Parameters.TerminalTotalDifficulty == UInt256.Zero
             || releaseStartBlock > (chainSpec.Parameters.TerminalPoWBlockNumber ?? long.MaxValue)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -345,9 +345,11 @@ namespace Nethermind.Specs.ChainSpecStyle
 
         // Shanghai (EIP-4895) is the first post-Paris timestamp-activated fork, so TTD-driven
         // chains like mainnet cross into post-merge once they reach it - that's the only
-        // non-obvious branch below. TTD=0 covers PoS-from-genesis; TerminalPoWBlockNumber
-        // covers chainspecs that pin the boundary explicitly. The Paris-Shanghai window on
-        // TTD-driven chains with no explicit terminal block is not detectable here - runtime
+        // non-obvious branch below. TTD=0 covers PoS-from-genesis. TerminalPoWBlockNumber
+        // fires only when releaseStartBlock advances past it, which requires the chainspec to
+        // carry post-merge block-number transitions (TerminalPoWBlockNumber is excluded from
+        // AddTransitions above, so it creates no spec boundary of its own). Paris-era blocks
+        // on TTD-driven chains with no such later transitions are not detected here - runtime
         // MergeHeaderValidator (UnclesHash == empty via PoSSwitcher) is the safety net.
         private static bool IsPostMergeRelease(ChainSpec chainSpec, long releaseStartBlock, ulong? releaseStartTimestamp) =>
             chainSpec.Parameters.TerminalTotalDifficulty == UInt256.Zero

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -182,7 +182,8 @@ namespace Nethermind.Specs.ChainSpecStyle
         protected virtual ReleaseSpec CreateReleaseSpec(ChainSpec chainSpec, long releaseStartBlock, ulong? releaseStartTimestamp = null)
         {
             ReleaseSpec releaseSpec = CreateEmptyReleaseSpec();
-            releaseSpec.MaximumUncleCount = 2;
+            // EIP-3675: zero uncles post-merge. Runtime fallback is MergeHeaderValidator.
+            releaseSpec.MaximumUncleCount = IsPostMergeRelease(chainSpec, releaseStartBlock, releaseStartTimestamp) ? 0 : 2;
             releaseSpec.DifficultyBoundDivisor = 1;
             releaseSpec.IsTimeAdjustmentPostOlympic = true; // TODO: this is Duration, review
             releaseSpec.MaximumExtraDataSize = chainSpec.Parameters.MaximumExtraDataSize;
@@ -341,6 +342,15 @@ namespace Nethermind.Specs.ChainSpecStyle
                 }
             }
         }
+
+        // Shanghai (EIP-4895) is the first post-Paris timestamp-activated fork, so TTD-driven
+        // chains like mainnet cross into post-merge once they reach it - that's the only
+        // non-obvious branch below. TTD=0 covers PoS-from-genesis; TerminalPoWBlockNumber
+        // covers chainspecs that pin the boundary explicitly.
+        private static bool IsPostMergeRelease(ChainSpec chainSpec, long releaseStartBlock, ulong? releaseStartTimestamp) =>
+            chainSpec.Parameters.TerminalTotalDifficulty == UInt256.Zero
+            || releaseStartBlock > (chainSpec.Parameters.TerminalPoWBlockNumber ?? long.MaxValue)
+            || (chainSpec.Parameters.Eip4895TransitionTimestamp ?? ulong.MaxValue) <= (releaseStartTimestamp ?? 0);
 
         public void UpdateMergeTransitionInfo(long? blockNumber, UInt256? terminalTotalDifficulty = null)
         {

--- a/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
@@ -6,8 +6,9 @@ namespace Nethermind.Specs.Forks;
 public class Paris() : NamedReleaseSpec<Paris>(GrayGlacier.Instance)
 {
     public override void Apply(ReleaseSpec spec) => spec.Name = "Paris";
-    // Note: EIP-3675 uncle ban is pinned on Shanghai and later, not Paris. MainnetSpecProvider
-    // returns Paris.Instance for the terminal PoW block (ParisBlockNumber = 15537393) due to an
-    // off-by-one in its block-range resolution, so spec-gating at Paris would reject a
-    // consensus-valid PoW block. Shanghai is the first boundary that is unambiguously post-merge.
+    // Note: the EIP-3675 uncle ban lives on Shanghai, not here. MainnetSpecProvider's
+    // GrayGlacier→Paris boundary is `< ParisBlockNumber`, so block 15537393 (the terminal PoW
+    // block) falls under Paris.Instance - making Paris a mixed-era spec that covers both the
+    // terminal PoW block and the post-merge window up to Shanghai. Pinning MaximumUncleCount=0
+    // here would spec-reject a consensus-valid PoW block if it carried uncles.
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
@@ -5,5 +5,10 @@ namespace Nethermind.Specs.Forks;
 
 public class Paris() : NamedReleaseSpec<Paris>(GrayGlacier.Instance)
 {
-    public override void Apply(ReleaseSpec spec) => spec.Name = "Paris";
+    public override void Apply(ReleaseSpec spec)
+    {
+        spec.Name = "Paris";
+        // EIP-3675: uncles are forbidden from the merge onwards.
+        spec.MaximumUncleCount = 0;
+    }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/15_Paris.cs
@@ -5,10 +5,9 @@ namespace Nethermind.Specs.Forks;
 
 public class Paris() : NamedReleaseSpec<Paris>(GrayGlacier.Instance)
 {
-    public override void Apply(ReleaseSpec spec)
-    {
-        spec.Name = "Paris";
-        // EIP-3675: uncles are forbidden from the merge onwards.
-        spec.MaximumUncleCount = 0;
-    }
+    public override void Apply(ReleaseSpec spec) => spec.Name = "Paris";
+    // Note: EIP-3675 uncle ban is pinned on Shanghai and later, not Paris. MainnetSpecProvider
+    // returns Paris.Instance for the terminal PoW block (ParisBlockNumber = 15537393) due to an
+    // off-by-one in its block-range resolution, so spec-gating at Paris would reject a
+    // consensus-valid PoW block. Shanghai is the first boundary that is unambiguously post-merge.
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/16_Shanghai.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/16_Shanghai.cs
@@ -13,5 +13,9 @@ public class Shanghai() : NamedReleaseSpec<Shanghai>(Paris.Instance)
         spec.IsEip3860Enabled = true;
         spec.IsEip4895Enabled = true;
         spec.WithdrawalTimestamp = MainnetSpecProvider.ShanghaiBlockTimestamp;
+        // EIP-3675: uncles are forbidden from the merge onwards. Pinned here (not Paris) because
+        // MainnetSpecProvider maps the terminal PoW block to Paris.Instance, so spec-gating at
+        // Paris would reject a consensus-valid pre-merge block. Shanghai is unambiguously post-merge.
+        spec.MaximumUncleCount = 0;
     }
 }


### PR DESCRIPTION
## Changes

- Pin MaximumUncleCount=0 for post-merge releases so the consensus rule is enforced at the fork gate (BlockValidator.ValidateUncles) rather than only through MergeHeaderValidator's UnclesHash==empty check, which depends on PoSSwitcher resolving IsPostMerge correctly.
- Paris.Apply now sets spec.MaximumUncleCount=0; all post-Paris NamedReleaseSpec forks inherit 0 (Shanghai through Amsterdam).
- ChainSpecBasedSpecProvider gates MaximumUncleCount via a new IsPostMergeRelease helper covering TTD=0 (PoS-from-genesis), TerminalPoWBlockNumber, and Shanghai-or-later by timestamp (the signal that lets TTD-driven chains like mainnet register post-merge at spec-construction time).
- BlockchainTestBase drops the IsPostMerge=(Difficulty==0) shortcut so CI exercises the real PoSSwitcher path and matches hive's production semantics; PoSSwitcher.GetBlockConsensusInfo already has the same difficulty==0 fallback when TotalDifficulty is null.
- Verified: UncleFromSideChain_Cancun/Prague still reject via the spec gate; Ethereum.Blockchain.Block.Test (1146), Legacy (2539), and Nethermind.Specs.Test (208) all pass.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Other: Tests

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes