### PR TITLE
fix: skip AuRa finalization startup walk on post-merge chains (1.37.0-rc2 backport)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
@@ -28,6 +28,7 @@ namespace Nethermind.Consensus.AuRa
         private readonly IValidSealerStrategy _validSealerStrategy;
         private readonly long _twoThirdsMajorityTransition;
         private long _lastFinalizedBlockLevel;
+        private bool _initialized;
         private Hash256 _lastProcessedBlockHash = Keccak.EmptyTreeHash;
         private readonly ValidationStampCollection _consecutiveValidatorsForNotYetFinalizedBlocks = new ValidationStampCollection();
 
@@ -45,14 +46,23 @@ namespace Nethermind.Consensus.AuRa
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
             _validSealerStrategy = validSealerStrategy ?? throw new ArgumentNullException(nameof(validSealerStrategy));
             _twoThirdsMajorityTransition = twoThirdsMajorityTransition;
-            Initialize();
         }
 
         public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
         {
+            if (_initialized)
+            {
+                if (!ReferenceEquals(_branchProcessor, branchProcessor))
+                    throw new InvalidOperationException($"{nameof(SetMainBlockBranchProcessor)} called with a different {nameof(IBranchProcessor)} instance after initialization.");
+                return;
+            }
+
+            _initialized = true;
             _branchProcessor = branchProcessor;
             _branchProcessor.BlockProcessed += OnBlockProcessed;
             _branchProcessor.BlocksProcessing += OnBlocksProcessing;
+
+            Initialize();
         }
 
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -23,6 +23,7 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps;
 public class InitializeBlockchainAuRa(AuRaNethermindApi api, IChainHeadInfoProvider chainHeadInfoProvider, ITxGossipPolicy txGossipPolicy)
     : InitializeBlockchain(api, chainHeadInfoProvider, txGossipPolicy)
 {
+    protected AuRaNethermindApi Api => api;
     private INethermindApi NethermindApi => api;
 
     protected override async Task InitBlockchain()
@@ -38,9 +39,19 @@ public class InitializeBlockchainAuRa(AuRaNethermindApi api, IChainHeadInfoProvi
 
         await base.InitBlockchain();
 
-        // Got cyclic dependency. AuRaBlockFinalizationManager -> IAuraValidator -> AuraBlockProcessor -> AuraBlockFinalizationManager.
-        api.FinalizationManager.SetMainBlockBranchProcessor(api.MainProcessingContext!.BranchProcessor!);
+        WireFinalizationBranchProcessor();
     }
+
+    /// <summary>
+    /// Wires the branch processor into the finalization manager. Override in the merge variant
+    /// to skip wiring on post-merge chains, where AuRa finalization is no longer active and the
+    /// startup catch-up walk would allocate millions of BlockHeaders on long chains like Gnosis.
+    /// </summary>
+    /// <remarks>
+    /// Got cyclic dependency. AuRaBlockFinalizationManager -> IAuraValidator -> AuraBlockProcessor -> AuraBlockFinalizationManager.
+    /// </remarks>
+    protected virtual void WireFinalizationBranchProcessor() =>
+        api.FinalizationManager!.SetMainBlockBranchProcessor(api.MainProcessingContext!.BranchProcessor!);
 
     private IComparer<Transaction> CreateTxPoolTxComparer(TxPriorityContract? txPriorityContract, TxPriorityContract.LocalDataSource? localDataSource)
     {

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -12,11 +12,13 @@ namespace Nethermind.Merge.Plugin;
 public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlockFinalizationManager
 {
     private readonly IAuRaBlockFinalizationManager _auRaBlockFinalizationManager;
+    private readonly IPoSSwitcher _poSSwitcher;
 
     public AuRaMergeFinalizationManager(IManualBlockFinalizationManager manualBlockFinalizationManager, IAuRaBlockFinalizationManager blockFinalizationManager, IPoSSwitcher poSSwitcher)
         : base(manualBlockFinalizationManager, blockFinalizationManager, poSSwitcher)
     {
         _auRaBlockFinalizationManager = blockFinalizationManager;
+        _poSSwitcher = poSSwitcher;
         _auRaBlockFinalizationManager.BlocksFinalized += OnBlockFinalized;
     }
 
@@ -32,6 +34,9 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 
     public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
     {
+        // Skip forwarding post-merge so the inner manager never subscribes to block events
+        // nor runs the startup catch-up walk — AuRa finalization is not active post-merge.
+        if (_poSSwitcher.HasEverReachedTerminalBlock()) return;
         _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
     }
 

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -8,6 +8,7 @@ using Autofac.Core;
 using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
+using Nethermind.Api.Steps;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.InitializationSteps;
 using Nethermind.Consensus.AuRa.Transactions;
@@ -99,6 +100,10 @@ namespace Nethermind.Merge.AuRa
                 .AddDecorator<IUnclesValidator, MergeUnclesValidator>()
                 .AddDecorator<ISealValidator, MergeSealValidator>()
                 .AddDecorator<ISealer, MergeSealer>()
+
+                // Merge-aware override: skips wiring the branch processor on post-merge chains so
+                // the AuRa finalization manager's startup catch-up walk never runs.
+                .AddStep(typeof(InitializeBlockchainAuRaMerge))
                 ;
         }
     }

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Consensus.AuRa.InitializationSteps;
+using Nethermind.Consensus.Transactions;
+using Nethermind.TxPool;
+
+namespace Nethermind.Merge.Plugin;
+
+/// <summary>
+/// Merge-aware variant of <see cref="InitializeBlockchainAuRa"/>. Skips wiring the branch processor
+/// into the AuRa finalization manager on post-merge chains — AuRa finalization is no longer active
+/// there, and otherwise the startup catch-up walk in <c>AuRaBlockFinalizationManager.Initialize</c>
+/// allocates millions of BlockHeaders on long post-merge chains like Gnosis.
+/// </summary>
+public class InitializeBlockchainAuRaMerge(AuRaNethermindApi api, IChainHeadInfoProvider chainHeadInfoProvider, ITxGossipPolicy txGossipPolicy)
+    : InitializeBlockchainAuRa(api, chainHeadInfoProvider, txGossipPolicy)
+{
+    protected override void WireFinalizationBranchProcessor()
+    {
+        if (!Api.Context.Resolve<IPoSSwitcher>().HasEverReachedTerminalBlock())
+            base.WireFinalizationBranchProcessor();
+    }
+}


### PR DESCRIPTION
Backport of #11306 to \`release/1.37.0-rc2\`.

The release branch is pre-#11062 so a literal cherry-pick conflicts heavily; the fix was re-implemented by hand on the older code structure with the same semantics.

## Summary
- On post-merge Gnosis, \`AuRaBlockFinalizationManager\` was still doing its startup catch-up walk, accumulating every un-finalized ancestor into a local \`List<BlockHeader>\`. Heap dumps from affected nodes showed the backing array at 16,777,216 entries (~10GB retained).
- Moved the walk's trigger from the constructor into \`SetMainBlockBranchProcessor\` with an idempotency guard (throws if called with a different \`IBranchProcessor\` instance).
- Added \`InitializeBlockchainAuRaMerge\` that skips wiring the branch processor once \`IPoSSwitcher.HasEverReachedTerminalBlock()\` is true.
- \`AuRaMergeFinalizationManager.SetMainBlockBranchProcessor\` also skips forwarding post-merge as a belt-and-suspenders guard.

## Test plan
- [x] \`Nethermind.AuRa.Test.AuRaBlockFinalizationManagerTests\` — 28/28 pass.
- [ ] Smoke test on a post-merge Gnosis node to confirm no longer stuck at startup and no walk-related allocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)