### PR TITLE
EIP-7981 — Access list token floor pricing

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
@@ -23,6 +23,9 @@ public class AccessList : IEnumerable<(Address Address, AccessList.StorageKeysEn
         _keys = keys;
     }
 
+    /// <summary>Serialized byte size of a single storage key.</summary>
+    public const int StorageKeySize = 32;
+
     public static AccessList Empty { get; } = new(new List<(Address, int)>(), new List<UInt256>());
 
     public bool IsEmpty => _addresses.Count == 0;

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -385,6 +385,11 @@ namespace Nethermind.Core.Specs
         bool IsEip7976Enabled { get; }
 
         /// <summary>
+        /// Access List Token Floor Pricing
+        /// </summary>
+        bool IsEip7981Enabled { get; }
+
+        /// <summary>
         /// Should transactions be validated against chainId.
         /// </summary>
         /// <remarks>Backward compatibility for early Kovan blocks.</remarks>

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -94,6 +94,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsOpJovianEnabled => spec.IsOpJovianEnabled;
     public virtual bool IsEip7623Enabled => spec.IsEip7623Enabled;
     public virtual bool IsEip7976Enabled => spec.IsEip7976Enabled;
+    public virtual bool IsEip7981Enabled => spec.IsEip7981Enabled;
     public virtual bool ValidateChainId => spec.ValidateChainId;
     public virtual ulong TargetBlobCount => spec.TargetBlobCount;
     public virtual ulong MaxBlobCount => spec.MaxBlobCount;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Eip2930;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7981: access list token floor pricing.
+/// Uses OverridableReleaseSpec until pyspec fixtures include EIP-7981.
+/// </summary>
+[TestFixture]
+public class Eip7981Tests
+{
+    private static readonly IReleaseSpec Spec = new OverridableReleaseSpec(Amsterdam.Instance) { IsEip7976Enabled = true, IsEip7981Enabled = true };
+    private static long FloorPerToken => Spec.GasCosts.TotalCostFloorPerToken;
+    private static long NonZeroMultiplier => Spec.GasCosts.TxDataNonZeroMultiplier;
+
+    private static IEnumerable<TestCaseData> AccessListOnlyCases()
+    {
+        // Address = 20 bytes; new formula: 20 * 4 = 80 tokens (all bytes × multiplier)
+        yield return new TestCaseData(
+            new AccessList.Builder().AddAddress(Address.Zero).Build(), 80L
+        ).SetName("Single zero address: 80 tokens");
+
+        // Any address is 20 bytes × 4 = 80 tokens regardless of byte values
+        yield return new TestCaseData(
+            new AccessList.Builder().AddAddress(new Address("0xAB000000000000000000000000000000000000CD")).Build(), 80L
+        ).SetName("Address with non-zero bytes: 80 tokens");
+
+        // Address.Zero (80) + UInt256.Zero (32 * 4 = 128) = 208 tokens
+        yield return new TestCaseData(
+            new AccessList.Builder().AddAddress(Address.Zero).AddStorage(UInt256.Zero).Build(), 208L
+        ).SetName("Address + zero storage key: 208 tokens");
+
+        // Address.Zero (80) + UInt256.One (128) = 208 tokens (byte values don't matter)
+        yield return new TestCaseData(
+            new AccessList.Builder().AddAddress(Address.Zero).AddStorage(UInt256.One).Build(), 208L
+        ).SetName("Address + non-zero storage key: 208 tokens");
+
+        // Two addresses: 2 * 80 = 160 tokens
+        yield return new TestCaseData(
+            new AccessList.Builder().AddAddress(Address.Zero).AddAddress(new Address("0x0000000000000000000000000000000000000001")).Build(), 160L
+        ).SetName("Two addresses: 160 tokens");
+    }
+
+    [TestCaseSource(nameof(AccessListOnlyCases))]
+    public void Access_list_token_pricing(AccessList accessList, long expectedTokens)
+    {
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        (int addressCount, int storageKeyCount) = accessList.Count;
+        long expectedStandard = GasCostOf.Transaction
+            + addressCount * GasCostOf.AccessAccountListEntry
+            + storageKeyCount * GasCostOf.AccessStorageListEntry
+            + FloorPerToken * expectedTokens;
+        long expectedFloor = GasCostOf.Transaction + FloorPerToken * expectedTokens;
+
+        cost.Should().Be(new EthereumIntrinsicGas(Standard: expectedStandard, FloorGas: expectedFloor));
+    }
+
+    [Test]
+    public void Token_floor_not_applied_before_eip7981()
+    {
+        AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Prague.Instance);
+        cost.Should().Be(new EthereumIntrinsicGas(
+            Standard: GasCostOf.Transaction + GasCostOf.AccessAccountListEntry,
+            FloorGas: GasCostOf.Transaction));
+    }
+
+    [Test]
+    public void Calldata_and_access_list_both_contribute_to_floor()
+    {
+        // Data: [0] under EIP-7976 floor → 1 byte * 4 (multiplier) = 4 calldata floor tokens
+        // Access list: Address.Zero = 80 tokens
+        // Total floor tokens = 4 + 80 = 84; floor = 21000 + 84 * 16 = 22344
+        AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();
+        Transaction transaction = new() { To = Address.Zero, Data = new byte[] { 0 }, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+        cost.Should().Be(new EthereumIntrinsicGas(
+            Standard: GasCostOf.Transaction + GasCostOf.TxDataZero + GasCostOf.AccessAccountListEntry + FloorPerToken * 80,
+            FloorGas: GasCostOf.Transaction + FloorPerToken * (1 * NonZeroMultiplier + 80)));
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
@@ -104,17 +104,49 @@ public class Eip7981Tests
             FloorGas: GasCostOf.Transaction));
     }
 
-    [Test]
-    public void Calldata_and_access_list_both_contribute_to_floor()
+    private static IEnumerable<TestCaseData> CalldataWithAccessListCases()
     {
-        // Data: [0] under EIP-7976 floor → 1 byte * 4 (multiplier) = 4 calldata floor tokens
-        // Access list: Address.Zero = 80 tokens
-        // Total floor tokens = 4 + 80 = 84; floor = 21000 + 84 * 16 = 22344
-        AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();
-        Transaction transaction = new() { To = Address.Zero, Data = new byte[] { 0 }, AccessList = accessList };
+        // 1 zero byte + 1 address: standard wins
+        // Standard = 21000 + 4 + 2400 + 80*16 = 24684
+        // Floor = 21000 + (4 + 80)*16 = 22344
+        yield return new TestCaseData(new byte[] { 0 }, 1, 0, 24684L, 22344L)
+            .SetName("1 zero byte + 1 address: standard wins");
+
+        // 40 zero bytes + 1 address: exact tie (floor == standard)
+        // Standard = 21000 + 40*4 + 2400 + 1280 = 24840
+        // Floor = 21000 + (160 + 80)*16 = 24840
+        yield return new TestCaseData(new byte[40], 1, 0, 24840L, 24840L)
+            .SetName("40 zero bytes + 1 address: exact tie");
+
+        // 41 zero bytes + 1 address: floor wins by 60 (smallest count)
+        // Standard = 21000 + 41*4 + 2400 + 1280 = 24844
+        // Floor = 21000 + (164 + 80)*16 = 24904
+        yield return new TestCaseData(new byte[41], 1, 0, 24844L, 24904L)
+            .SetName("41 zero bytes + 1 address: floor wins by 60");
+
+        // 100 zero bytes + 1 address + 1 key: floor dominates
+        // Standard = 21000 + 400 + 2400 + 1900 + (80+128)*16 = 29028
+        // Floor = 21000 + (400 + 80 + 128)*16 = 30728
+        yield return new TestCaseData(new byte[100], 1, 1, 29028L, 30728L)
+            .SetName("100 zero bytes + 1 address + 1 key: floor dominates");
+    }
+
+    [TestCaseSource(nameof(CalldataWithAccessListCases))]
+    public void Calldata_with_access_list_floor_pricing(byte[] data, int addressCount, int storageKeyCount, long expectedStandard, long expectedFloor)
+    {
+        AccessList.Builder builder = new();
+        for (int i = 0; i < addressCount; i++)
+        {
+            builder.AddAddress(new Address($"0x{i:D40}"));
+            for (int j = 0; j < storageKeyCount; j++)
+            {
+                builder.AddStorage(new UInt256((ulong)(i * storageKeyCount + j)));
+            }
+        }
+
+        AccessList accessList = builder.Build();
+        Transaction transaction = new() { To = Address.Zero, Data = data, AccessList = accessList };
         EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
-        cost.Should().Be(new EthereumIntrinsicGas(
-            Standard: GasCostOf.Transaction + GasCostOf.TxDataZero + GasCostOf.AccessAccountListEntry + FloorPerToken * 80,
-            FloorGas: GasCostOf.Transaction + FloorPerToken * (1 * NonZeroMultiplier + 80)));
+        cost.Should().Be(new EthereumIntrinsicGas(Standard: expectedStandard, FloorGas: expectedFloor));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
@@ -50,6 +50,21 @@ public class Eip7981Tests
         yield return new TestCaseData(
             new AccessList.Builder().AddAddress(Address.Zero).AddAddress(new Address("0x0000000000000000000000000000000000000001")).Build(), 160L
         ).SetName("Two addresses: 160 tokens");
+
+        // 1 address (80) + 3 keys (3 × 128 = 384) = 464 tokens
+        yield return new TestCaseData(
+            new AccessList.Builder()
+                .AddAddress(Address.Zero)
+                .AddStorage(UInt256.Zero)
+                .AddStorage(UInt256.One)
+                .AddStorage(new UInt256(255))
+                .Build(), 464L
+        ).SetName("Address + 3 storage keys: 464 tokens");
+
+        // Empty access list: no addresses, no keys → 0 tokens
+        yield return new TestCaseData(
+            new AccessList.Builder().Build(), 0L
+        ).SetName("Empty access list: 0 tokens");
     }
 
     [TestCaseSource(nameof(AccessListOnlyCases))]
@@ -69,40 +84,6 @@ public class Eip7981Tests
     }
 
     [Test]
-    public void Address_with_multiple_storage_keys()
-    {
-        // 1 address (80) + 3 keys (3 × 128 = 384) = 464 tokens
-        AccessList accessList = new AccessList.Builder()
-            .AddAddress(Address.Zero)
-            .AddStorage(UInt256.Zero)
-            .AddStorage(UInt256.One)
-            .AddStorage(new UInt256(255))
-            .Build();
-        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
-
-        long expectedTokens = 464L;
-        long expectedStandard = GasCostOf.Transaction
-            + 1 * GasCostOf.AccessAccountListEntry
-            + 3 * GasCostOf.AccessStorageListEntry
-            + FloorPerToken * expectedTokens;
-        long expectedFloor = GasCostOf.Transaction + FloorPerToken * expectedTokens;
-
-        cost.Should().Be(new EthereumIntrinsicGas(Standard: expectedStandard, FloorGas: expectedFloor));
-    }
-
-    [Test]
-    public void Empty_access_list_contributes_zero_tokens()
-    {
-        AccessList accessList = new AccessList.Builder().Build();
-        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
-        cost.Should().Be(new EthereumIntrinsicGas(
-            Standard: GasCostOf.Transaction,
-            FloorGas: GasCostOf.Transaction));
-    }
-
-    [Test]
     public void Null_access_list_contributes_zero_tokens()
     {
         Transaction transaction = new() { To = Address.Zero, AccessList = null };
@@ -110,32 +91,6 @@ public class Eip7981Tests
         cost.Should().Be(new EthereumIntrinsicGas(
             Standard: GasCostOf.Transaction,
             FloorGas: GasCostOf.Transaction));
-    }
-
-    [Test]
-    public void Large_access_list_floor_exceeds_standard()
-    {
-        // 10 addresses (800 tokens) + 10 keys each (12800 tokens) = 13600 tokens
-        // Floor = 21000 + 13600 * 16 = 238600
-        // Standard = 21000 + 10*2400 + 100*1900 + 13600*16 = 21000 + 24000 + 190000 + 217600 = 452600
-        AccessList.Builder builder = new();
-        for (int i = 0; i < 10; i++)
-        {
-            builder.AddAddress(new Address($"0x{i:D40}"));
-            for (int j = 0; j < 10; j++)
-            {
-                builder.AddStorage(new UInt256((ulong)(i * 10 + j)));
-            }
-        }
-
-        AccessList accessList = builder.Build();
-        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
-        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
-
-        long expectedTokens = (10 * 20L + 100 * 32L) * NonZeroMultiplier;
-        long expectedFloor = GasCostOf.Transaction + FloorPerToken * expectedTokens;
-        cost.FloorGas.Should().Be(expectedFloor);
-        cost.Standard.Should().BeGreaterThan(cost.FloorGas);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
@@ -15,33 +15,29 @@ namespace Nethermind.Evm.Test;
 
 /// <summary>
 /// Tests for EIP-7981: access list token floor pricing.
-/// Uses OverridableReleaseSpec until pyspec fixtures include EIP-7981.
 /// </summary>
 [TestFixture]
 public class Eip7981Tests
 {
     private static readonly IReleaseSpec Spec = new OverridableReleaseSpec(Amsterdam.Instance) { IsEip7976Enabled = true, IsEip7981Enabled = true };
     private static long FloorPerToken => Spec.GasCosts.TotalCostFloorPerToken;
-    private static long NonZeroMultiplier => Spec.GasCosts.TxDataNonZeroMultiplier;
 
     private static IEnumerable<TestCaseData> AccessListOnlyCases()
     {
-        // Address = 20 bytes; new formula: 20 * 4 = 80 tokens (all bytes × multiplier)
+        // 20 bytes × 4 = 80 tokens
         yield return new TestCaseData(
             new AccessList.Builder().AddAddress(Address.Zero).Build(), 80L
         ).SetName("Single zero address: 80 tokens");
 
-        // Any address is 20 bytes × 4 = 80 tokens regardless of byte values
         yield return new TestCaseData(
             new AccessList.Builder().AddAddress(new Address("0xAB000000000000000000000000000000000000CD")).Build(), 80L
         ).SetName("Address with non-zero bytes: 80 tokens");
 
-        // Address.Zero (80) + UInt256.Zero (32 * 4 = 128) = 208 tokens
+        // Address (80) + storage key (32 * 4 = 128) = 208 tokens
         yield return new TestCaseData(
             new AccessList.Builder().AddAddress(Address.Zero).AddStorage(UInt256.Zero).Build(), 208L
         ).SetName("Address + zero storage key: 208 tokens");
 
-        // Address.Zero (80) + UInt256.One (128) = 208 tokens (byte values don't matter)
         yield return new TestCaseData(
             new AccessList.Builder().AddAddress(Address.Zero).AddStorage(UInt256.One).Build(), 208L
         ).SetName("Address + non-zero storage key: 208 tokens");

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7981Tests.cs
@@ -69,6 +69,76 @@ public class Eip7981Tests
     }
 
     [Test]
+    public void Address_with_multiple_storage_keys()
+    {
+        // 1 address (80) + 3 keys (3 × 128 = 384) = 464 tokens
+        AccessList accessList = new AccessList.Builder()
+            .AddAddress(Address.Zero)
+            .AddStorage(UInt256.Zero)
+            .AddStorage(UInt256.One)
+            .AddStorage(new UInt256(255))
+            .Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        long expectedTokens = 464L;
+        long expectedStandard = GasCostOf.Transaction
+            + 1 * GasCostOf.AccessAccountListEntry
+            + 3 * GasCostOf.AccessStorageListEntry
+            + FloorPerToken * expectedTokens;
+        long expectedFloor = GasCostOf.Transaction + FloorPerToken * expectedTokens;
+
+        cost.Should().Be(new EthereumIntrinsicGas(Standard: expectedStandard, FloorGas: expectedFloor));
+    }
+
+    [Test]
+    public void Empty_access_list_contributes_zero_tokens()
+    {
+        AccessList accessList = new AccessList.Builder().Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+        cost.Should().Be(new EthereumIntrinsicGas(
+            Standard: GasCostOf.Transaction,
+            FloorGas: GasCostOf.Transaction));
+    }
+
+    [Test]
+    public void Null_access_list_contributes_zero_tokens()
+    {
+        Transaction transaction = new() { To = Address.Zero, AccessList = null };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+        cost.Should().Be(new EthereumIntrinsicGas(
+            Standard: GasCostOf.Transaction,
+            FloorGas: GasCostOf.Transaction));
+    }
+
+    [Test]
+    public void Large_access_list_floor_exceeds_standard()
+    {
+        // 10 addresses (800 tokens) + 10 keys each (12800 tokens) = 13600 tokens
+        // Floor = 21000 + 13600 * 16 = 238600
+        // Standard = 21000 + 10*2400 + 100*1900 + 13600*16 = 21000 + 24000 + 190000 + 217600 = 452600
+        AccessList.Builder builder = new();
+        for (int i = 0; i < 10; i++)
+        {
+            builder.AddAddress(new Address($"0x{i:D40}"));
+            for (int j = 0; j < 10; j++)
+            {
+                builder.AddStorage(new UInt256((ulong)(i * 10 + j)));
+            }
+        }
+
+        AccessList accessList = builder.Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        long expectedTokens = (10 * 20L + 100 * 32L) * NonZeroMultiplier;
+        long expectedFloor = GasCostOf.Transaction + FloorPerToken * expectedTokens;
+        cost.FloorGas.Should().Be(expectedFloor);
+        cost.Standard.Should().BeGreaterThan(cost.FloorGas);
+    }
+
+    [Test]
     public void Token_floor_not_applied_before_eip7981()
     {
         AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -318,14 +318,15 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public static IntrinsicGas<EthereumGasPolicy> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec)
     {
         long tokensInCallData = IGasPolicy<EthereumGasPolicy>.CalculateTokensInCallData(tx, spec);
+        long floorTokensInAccessList = IGasPolicy<EthereumGasPolicy>.CalculateFloorTokensInAccessList(tx, spec);
         (long authRegularCost, long authStateCost) = IGasPolicy<EthereumGasPolicy>.AuthorizationListCost(tx, spec);
 
         long regularGas = GasCostOf.Transaction
                           + DataCost(tx, spec, tokensInCallData)
                           + CreateCost(tx, spec)
-                          + IGasPolicy<EthereumGasPolicy>.AccessListCost(tx, spec)
+                          + IGasPolicy<EthereumGasPolicy>.AccessListCost(tx, spec, floorTokensInAccessList)
                           + authRegularCost;
-        long floorCost = IGasPolicy<EthereumGasPolicy>.CalculateFloorCost(tx, spec, tokensInCallData);
+        long floorCost = IGasPolicy<EthereumGasPolicy>.CalculateFloorCost(tx, spec, tokensInCallData, floorTokensInAccessList);
         long createStateCost = CreateStateCost(tx, spec);
         long totalStateCost = authStateCost + createStateCost;
         return spec.IsEip8037Enabled

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -389,16 +389,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     /// Every byte costs TxDataNonZeroMultiplier tokens regardless of value,
     /// matching the EIP-7976 calldata floor formula.
     /// </summary>
-    public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec)
-    {
-        if (!spec.IsEip7981Enabled) return 0L;
-
-        AccessList? accessList = transaction.AccessList;
-        if (accessList is null) return 0L;
-
-        (int addressCount, int storageKeyCount) = accessList.Count;
-        return (addressCount * 20L + storageKeyCount * 32L) * spec.GasCosts.TxDataNonZeroMultiplier;
-    }
+    public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
+        spec.IsEip7981Enabled && transaction.AccessList is { Count: var count }
+            ? (count.AddressesCount * 20L + count.StorageKeysCount * 32L) * spec.GasCosts.TxDataNonZeroMultiplier
+            : 0L;
 
     public static long AccessListCost(Transaction transaction, IReleaseSpec spec, long floorTokensInAccessList)
     {

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -384,21 +384,36 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return totalZeros + (data.Length - totalZeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
-    public static long AccessListCost(Transaction transaction, IReleaseSpec spec)
+    /// <summary>
+    /// Counts floor tokens in the access list for floor cost pricing (EIP-7981).
+    /// Every byte costs TxDataNonZeroMultiplier tokens regardless of value,
+    /// matching the EIP-7976 calldata floor formula.
+    /// </summary>
+    public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec)
+    {
+        if (!spec.IsEip7981Enabled) return 0L;
+
+        AccessList? accessList = transaction.AccessList;
+        if (accessList is null) return 0L;
+
+        (int addressCount, int storageKeyCount) = accessList.Count;
+        return (addressCount * 20L + storageKeyCount * 32L) * spec.GasCosts.TxDataNonZeroMultiplier;
+    }
+
+    public static long AccessListCost(Transaction transaction, IReleaseSpec spec, long floorTokensInAccessList)
     {
         AccessList? accessList = transaction.AccessList;
-        if (accessList is not null)
-        {
-            if (!spec.UseTxAccessLists)
-            {
-                ThrowInvalidDataException(spec);
-            }
+        if (accessList is null) return 0;
 
-            (int addressesCount, int storageKeysCount) = accessList.Count;
-            return addressesCount * GasCostOf.AccessAccountListEntry + storageKeysCount * GasCostOf.AccessStorageListEntry;
+        if (!spec.UseTxAccessLists)
+        {
+            ThrowInvalidDataException(spec);
         }
 
-        return 0;
+        (int addressesCount, int storageKeysCount) = accessList.Count;
+        return addressesCount * GasCostOf.AccessAccountListEntry
+            + storageKeysCount * GasCostOf.AccessStorageListEntry
+            + spec.GasCosts.TotalCostFloorPerToken * floorTokensInAccessList;
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowInvalidDataException(IReleaseSpec spec) =>
@@ -435,12 +450,12 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
     /// <summary>
-    /// Calculates the calldata floor cost for a transaction.
+    /// Calculates the calldata floor cost for a transaction, including EIP-7981 access list tokens.
     /// </summary>
-    protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData) => spec switch
+    protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData, long floorTokensInAccessList) => spec switch
     {
-        { IsEip7976Enabled: true } => GasCostOf.Transaction + CalculateFloorTokensInCallData(transaction, spec) * spec.GasCosts.TotalCostFloorPerToken,
-        { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
+        { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
+        { IsEip7623Enabled: true } => GasCostOf.Transaction + (tokensInCallData + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0L
     };
 }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -389,8 +389,8 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     /// Returns 0 when floor pricing is not active.
     /// </summary>
     public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
-        spec.IsEip7981Enabled && transaction.AccessList is { Count: var count }
-            ? (count.AddressesCount * Address.Size + count.StorageKeysCount * AccessList.StorageKeySize) * spec.GasCosts.TxDataNonZeroMultiplier
+        spec.IsEip7981Enabled && transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) }
+            ? (addressesCount * Address.Size + storageKeysCount * AccessList.StorageKeySize) * spec.GasCosts.TxDataNonZeroMultiplier
             : 0L;
 
     public static long AccessListCost(Transaction transaction, IReleaseSpec spec, long floorTokensInAccessList)

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -385,9 +385,8 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     /// <summary>
-    /// Counts floor tokens in the access list for floor cost pricing (EIP-7981).
-    /// Every byte costs TxDataNonZeroMultiplier tokens regardless of value,
-    /// matching the EIP-7976 calldata floor formula.
+    /// Computes the total floor tokens for all access list entries.
+    /// Returns 0 when floor pricing is not active.
     /// </summary>
     public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
         spec.IsEip7981Enabled && transaction.AccessList is { Count: var count }
@@ -444,12 +443,12 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
     /// <summary>
-    /// Calculates the calldata floor cost for a transaction, including EIP-7981 access list tokens.
+    /// Calculates the transaction data floor cost (calldata + access list tokens).
     /// </summary>
     protected static long CalculateFloorCost(Transaction transaction, IReleaseSpec spec, long tokensInCallData, long floorTokensInAccessList) => spec switch
     {
         { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
-        { IsEip7623Enabled: true } => GasCostOf.Transaction + (tokensInCallData + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
+        { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0L
     };
 }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -390,7 +390,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     /// </summary>
     public static long CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
         spec.IsEip7981Enabled && transaction.AccessList is { Count: var count }
-            ? (count.AddressesCount * 20L + count.StorageKeysCount * 32L) * spec.GasCosts.TxDataNonZeroMultiplier
+            ? (count.AddressesCount * Address.Size + count.StorageKeysCount * AccessList.StorageKeySize) * spec.GasCosts.TxDataNonZeroMultiplier
             : 0L;
 
     public static long AccessListCost(Transaction transaction, IReleaseSpec spec, long floorTokensInAccessList)

--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -35,5 +35,6 @@ public static class IntrinsicGasCalculator
         Calculate<EthereumGasPolicy>(transaction, releaseSpec);
 
     public static long AccessListCost(Transaction transaction, IReleaseSpec releaseSpec) =>
-        IGasPolicy<EthereumGasPolicy>.AccessListCost(transaction, releaseSpec);
+        IGasPolicy<EthereumGasPolicy>.AccessListCost(transaction, releaseSpec,
+            IGasPolicy<EthereumGasPolicy>.CalculateFloorTokensInAccessList(transaction, releaseSpec));
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Json;
 using Nethermind.Core;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
@@ -534,42 +535,58 @@ public partial class EthRpcModuleTests
     }
 
     private static readonly OverridableReleaseSpec Eip7976Spec = new(Prague.Instance) { IsEip7976Enabled = true };
+    private static readonly OverridableReleaseSpec Eip7981Spec = new(Prague.Instance) { IsEip7976Enabled = true, IsEip7981Enabled = true };
 
     private static IEnumerable<TestCaseData> EstimateGasFloorCostCases()
     {
         // EIP-7976: 100 zero bytes → floor = 21000 + 100 * 4 * 16 = 27400
         long eip7976Floor100 = GasCostOf.Transaction + 100 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * Eip7976Spec.GasCosts.TotalCostFloorPerToken;
-        yield return new TestCaseData(Eip7976Spec, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
+        yield return new TestCaseData(Eip7976Spec, new byte[100], 100_000L, null,
+                $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor100.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: data heavy tx returns floor cost");
 
         // EIP-7623: 100 zero bytes → floor = 21000 + 100 * 10 = 22000
         long eip7623Floor100 = GasCostOf.Transaction + 100 * Prague.Instance.GasCosts.TotalCostFloorPerToken;
-        yield return new TestCaseData(Prague.Instance, new byte[100], 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7623Floor100.ToHexString(true)}\",\"id\":67}}")
+        yield return new TestCaseData(Prague.Instance, new byte[100], 100_000L, null,
+                $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7623Floor100.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7623: data heavy tx returns lower floor");
 
         // EIP-7976: gas limit below intrinsic gas
         const long belowFloor = GasCostOf.Transaction + GasCostOf.TxDataZero;
-        yield return new TestCaseData(Eip7976Spec, new byte[] { 0 }, belowFloor, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}")
+        yield return new TestCaseData(Eip7976Spec, new byte[] { 0 }, belowFloor, null,
+                "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"gas limit below intrinsic gas\"},\"id\":67}")
             .SetName("EIP-7976: insufficient gas for floor");
 
         // EIP-7976: mixed calldata (0x00001122 = 2 zero + 2 nonzero bytes)
         long eip7976Floor4 = GasCostOf.Transaction + 4 * Eip7976Spec.GasCosts.TxDataNonZeroMultiplier * Eip7976Spec.GasCosts.TotalCostFloorPerToken;
-        yield return new TestCaseData(Eip7976Spec, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
+        yield return new TestCaseData(Eip7976Spec, new byte[] { 0x00, 0x00, 0x11, 0x22 }, 100_000L, null,
+                $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: mixed calldata returns floor");
+
+        // EIP-7981: access list with 1 address (80 tokens × 16 = 1280 added to standard)
+        // Standard = 21000 + 2400 + 1280 = 24680, floor = 21000 + 1280 = 22280, standard wins
+        long eip7981Standard = GasCostOf.Transaction + GasCostOf.AccessAccountListEntry
+            + 80 * Eip7981Spec.GasCosts.TotalCostFloorPerToken;
+        yield return new TestCaseData(Eip7981Spec, Array.Empty<byte>(), 100_000L,
+                new AccessList.Builder().AddAddress(Address.Zero).Build(),
+                $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7981Standard.ToHexString(true)}\",\"id\":67}}")
+            .SetName("EIP-7981: access list token floor in standard cost");
     }
 
     [TestCaseSource(nameof(EstimateGasFloorCostCases))]
-    public async Task Eth_estimateGas_floor_cost(IReleaseSpec spec, byte[] data, long gasLimit, string expectedJson)
+    public async Task Eth_estimateGas_floor_cost(IReleaseSpec spec, byte[] data, long gasLimit, AccessList accessList, string expectedJson)
     {
         TestSpecProvider specProvider = new(spec);
         using Context ctx = await Context.Create(specProvider);
 
-        Transaction tx = Build.A.Transaction
+        TransactionBuilder<Transaction> txBuilder = Build.A.Transaction
             .WithTo(TestItem.AddressB)
             .WithGasLimit(gasLimit)
-            .WithData(data)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
+            .WithData(data);
+        if (accessList is not null)
+            txBuilder.WithAccessList(accessList);
+        Transaction tx = txBuilder.SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+
         EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
         transaction.GasPrice = null;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -543,7 +543,7 @@ public partial class EthRpcModuleTests
     }
 
     private static readonly OverridableReleaseSpec Eip7976Spec = new(Prague.Instance) { IsEip7976Enabled = true };
-    private static readonly OverridableReleaseSpec Eip7981Spec = new(Prague.Instance) { IsEip7976Enabled = true, IsEip7981Enabled = true };
+    private static readonly OverridableReleaseSpec Eip7981Spec = new(Amsterdam.Instance) { IsEip7976Enabled = true, IsEip7981Enabled = true };
 
     private static IEnumerable<TestCaseData> EstimateGasFloorCostCases()
     {
@@ -571,14 +571,21 @@ public partial class EthRpcModuleTests
                 $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7976Floor4.ToHexString(true)}\",\"id\":67}}")
             .SetName("EIP-7976: mixed calldata returns floor");
 
-        // EIP-7981: access list with 1 address (80 tokens × 16 = 1280 added to standard)
-        // Standard = 21000 + 2400 + 1280 = 24680, floor = 21000 + 1280 = 22280, standard wins
+        // EIP-7981: access list with 1 address, no calldata — standard wins
         long eip7981Standard = GasCostOf.Transaction + GasCostOf.AccessAccountListEntry
             + 80 * Eip7981Spec.GasCosts.TotalCostFloorPerToken;
         yield return new TestCaseData(Eip7981Spec, Array.Empty<byte>(), 100_000L,
                 new AccessList.Builder().AddAddress(Address.Zero).Build(),
                 $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7981Standard.ToHexString(true)}\",\"id\":67}}")
-            .SetName("EIP-7981: access list token floor in standard cost");
+            .SetName("EIP-7981: standard wins with access list");
+
+        // EIP-7981: 100 zero bytes + 1 address — floor wins
+        long eip7981Floor = GasCostOf.Transaction
+            + (100 * Eip7981Spec.GasCosts.TxDataNonZeroMultiplier + 80) * Eip7981Spec.GasCosts.TotalCostFloorPerToken;
+        yield return new TestCaseData(Eip7981Spec, new byte[100], 100_000L,
+                new AccessList.Builder().AddAddress(Address.Zero).Build(),
+                $"{{\"jsonrpc\":\"2.0\",\"result\":\"{eip7981Floor.ToHexString(true)}\",\"id\":67}}")
+            .SetName("EIP-7981: floor wins with calldata and access list");
     }
 
     [TestCaseSource(nameof(EstimateGasFloorCostCases))]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -83,13 +83,21 @@ public partial class EthRpcModuleTests
         AssertAccountDoesNotExist(ctx, TestAccount);
     }
 
-    [TestCase(false, 2)]
-    [TestCase(true, 2)]
-    [TestCase(true, 17)]
-    public async Task Eth_create_access_list_calculates_proper_gas(bool optimize, long loads)
+    private static IEnumerable<TestCaseData> CreateAccessListGasCases()
+    {
+        yield return new TestCaseData(false, 2, Berlin.Instance).SetName("Berlin: noOpt, 2");
+        yield return new TestCaseData(true, 2, Berlin.Instance).SetName("Berlin: opt, 2");
+        yield return new TestCaseData(true, 17, Berlin.Instance).SetName("Berlin: opt, 17");
+        yield return new TestCaseData(false, 2, Eip7981Spec).SetName("EIP-7981: noOpt, 2");
+        yield return new TestCaseData(true, 2, Eip7981Spec).SetName("EIP-7981: opt, 2");
+        yield return new TestCaseData(true, 17, Eip7981Spec).SetName("EIP-7981: opt, 17");
+    }
+
+    [TestCaseSource(nameof(CreateAccessListGasCases))]
+    public async Task Eth_create_access_list_calculates_proper_gas(bool optimize, long loads, IReleaseSpec spec)
     {
         TestRpcBlockchain test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
-            .Build(new TestSpecProvider(Berlin.Instance));
+            .Build(new TestSpecProvider(spec));
 
         (byte[] code, _) = GetTestAccessList(loads);
 
@@ -574,7 +582,7 @@ public partial class EthRpcModuleTests
     }
 
     [TestCaseSource(nameof(EstimateGasFloorCostCases))]
-    public async Task Eth_estimateGas_floor_cost(IReleaseSpec spec, byte[] data, long gasLimit, AccessList accessList, string expectedJson)
+    public async Task Eth_estimateGas_floor_cost(IReleaseSpec spec, byte[] data, long gasLimit, AccessList? accessList, string expectedJson)
     {
         TestSpecProvider specProvider = new(spec);
         using Context ctx = await Context.Create(specProvider);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -25,9 +25,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
         {
             private bool NoBaseFee { get; set; }
 
+            protected IReleaseSpec GetSpec(BlockHeader header) => specProvider.GetSpec(header);
+
             protected override Result<Transaction> Prepare(TransactionForRpc call, BlockHeader header)
             {
-                IReleaseSpec spec = specProvider.GetSpec(header);
+                IReleaseSpec spec = GetSpec(header);
                 Result<Transaction> result = call.ToTransaction(validateUserInput: true, spec: spec);
                 if (result.IsError) return result;
 
@@ -144,12 +146,10 @@ namespace Nethermind.JsonRpc.Modules.Eth
         private class CreateAccessListTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider, bool optimize)
             : TxExecutor<AccessListResultForRpc?>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
-            private readonly ISpecProvider _specProvider = specProvider;
-
             protected override ResultWrapper<AccessListResultForRpc?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.CreateAccessList(header, tx, stateOverride, token, optimize);
-                IReleaseSpec spec = _specProvider.GetSpec(header);
+                IReleaseSpec spec = GetSpec(header);
 
                 AccessListResultForRpc rpcAccessListResult = new(
                     accessList: AccessListForRpc.FromAccessList(result.AccessList ?? tx.AccessList),

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -13,7 +13,6 @@ using Nethermind.Facade;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
-using Nethermind.Specs.Forks;
 
 namespace Nethermind.JsonRpc.Modules.Eth
 {
@@ -145,13 +144,16 @@ namespace Nethermind.JsonRpc.Modules.Eth
         private class CreateAccessListTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider, bool optimize)
             : TxExecutor<AccessListResultForRpc?>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
+            private readonly ISpecProvider _specProvider = specProvider;
+
             protected override ResultWrapper<AccessListResultForRpc?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.CreateAccessList(header, tx, stateOverride, token, optimize);
+                IReleaseSpec spec = _specProvider.GetSpec(header);
 
                 AccessListResultForRpc rpcAccessListResult = new(
                     accessList: AccessListForRpc.FromAccessList(result.AccessList ?? tx.AccessList),
-                    gasUsed: GetResultGas(tx, result),
+                    gasUsed: GetResultGas(tx, result, spec),
                     result.Error);
 
                 return result.InputError
@@ -159,15 +161,15 @@ namespace Nethermind.JsonRpc.Modules.Eth
                     : ResultWrapper<AccessListResultForRpc?>.Success(rpcAccessListResult);
             }
 
-            private static UInt256 GetResultGas(Transaction transaction, CallOutput result)
+            private static UInt256 GetResultGas(Transaction transaction, CallOutput result, IReleaseSpec spec)
             {
                 long gas = result.GasSpent;
                 long operationGas = result.OperationGas;
                 if (result.AccessList is not null)
                 {
-                    long oldIntrinsicCost = IntrinsicGasCalculator.AccessListCost(transaction, Berlin.Instance);
+                    long oldIntrinsicCost = IntrinsicGasCalculator.AccessListCost(transaction, spec);
                     transaction.AccessList = result.AccessList;
-                    long newIntrinsicCost = IntrinsicGasCalculator.AccessListCost(transaction, Berlin.Instance);
+                    long newIntrinsicCost = IntrinsicGasCalculator.AccessListCost(transaction, spec);
                     long updatedAccessListCost = newIntrinsicCost - oldIntrinsicCost;
                     if (gas > operationGas)
                     {

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -71,6 +71,7 @@ namespace Nethermind.Specs.Test
         public bool IsOpJovianEnabled { get; set; } = spec.IsOpJovianEnabled;
         public bool IsEip7623Enabled { get; set; } = spec.IsEip7623Enabled;
         public bool IsEip7976Enabled { get; set; } = spec.IsEip7976Enabled;
+        public bool IsEip7981Enabled { get; set; } = spec.IsEip7981Enabled;
         public bool IsEip7918Enabled { get; set; } = spec.IsEip7918Enabled;
         public bool IsEip7883Enabled { get; set; } = spec.IsEip7883Enabled;
         public bool IsEip7934Enabled { get; set; } = spec.IsEip7934Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -152,6 +152,7 @@ public class ChainParameters
     public ulong? Eip7883TransitionTimestamp { get; set; }
     public ulong? Eip7918TransitionTimestamp { get; set; }
     public ulong? Eip7976TransitionTimestamp { get; set; }
+    public ulong? Eip7981TransitionTimestamp { get; set; }
 
     public ulong? Eip7934TransitionTimestamp { get; set; }
     public int Eip7934MaxRlpBlockSize { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -279,6 +279,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.Eip7251ContractAddress = chainSpec.Parameters.Eip7251ContractAddress;
             releaseSpec.IsEip7623Enabled = (chainSpec.Parameters.Eip7623TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip7976Enabled = (chainSpec.Parameters.Eip7976TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip7981Enabled = (chainSpec.Parameters.Eip7981TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip7883Enabled = (chainSpec.Parameters.Eip7883TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             releaseSpec.IsEip7594Enabled = (chainSpec.Parameters.Eip7594TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -186,6 +186,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip7002TransitionTimestamp = chainSpecJson.Params.Eip7002TransitionTimestamp,
             Eip7623TransitionTimestamp = chainSpecJson.Params.Eip7623TransitionTimestamp,
             Eip7976TransitionTimestamp = chainSpecJson.Params.Eip7976TransitionTimestamp,
+            Eip7981TransitionTimestamp = chainSpecJson.Params.Eip7981TransitionTimestamp,
             Eip7883TransitionTimestamp = chainSpecJson.Params.Eip7883TransitionTimestamp,
             Eip7002ContractAddress = chainSpecJson.Params.Eip7002ContractAddress ?? Eip7002Constants.WithdrawalRequestPredeployAddress,
             Eip7251TransitionTimestamp = chainSpecJson.Params.Eip7251TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
@@ -186,9 +186,9 @@ public class GethGenesisLoader(IJsonSerializer serializer) : IChainSpecLoader
             Eip7843TransitionTimestamp = config.AmsterdamTime,
             Eip7928TransitionTimestamp = config.AmsterdamTime,
             Eip7954TransitionTimestamp = config.AmsterdamTime,
-            Eip8024TransitionTimestamp = config.AmsterdamTime,
             Eip7976TransitionTimestamp = config.AmsterdamTime,
             Eip7981TransitionTimestamp = config.AmsterdamTime,
+            Eip8024TransitionTimestamp = config.AmsterdamTime,
             Eip8037TransitionTimestamp = config.AmsterdamTime,
 
             BlobSchedule = blobSchedule

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
@@ -187,6 +187,8 @@ public class GethGenesisLoader(IJsonSerializer serializer) : IChainSpecLoader
             Eip7928TransitionTimestamp = config.AmsterdamTime,
             Eip7954TransitionTimestamp = config.AmsterdamTime,
             Eip8024TransitionTimestamp = config.AmsterdamTime,
+            Eip7976TransitionTimestamp = config.AmsterdamTime,
+            Eip7981TransitionTimestamp = config.AmsterdamTime,
             Eip8037TransitionTimestamp = config.AmsterdamTime,
 
             BlobSchedule = blobSchedule

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -162,6 +162,7 @@ public class ChainSpecParamsJson
     public ulong? Eip7002TransitionTimestamp { get; set; }
     public ulong? Eip7623TransitionTimestamp { get; set; }
     public ulong? Eip7976TransitionTimestamp { get; set; }
+    public ulong? Eip7981TransitionTimestamp { get; set; }
     public Address Eip7002ContractAddress { get; set; }
     public ulong? Eip7251TransitionTimestamp { get; set; }
     public Address Eip7251ContractAddress { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -88,6 +88,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsOpJovianEnabled { get; set; }
     public bool IsEip7623Enabled { get; set; }
     public bool IsEip7976Enabled { get; set; }
+    public bool IsEip7981Enabled { get; set; }
     public bool IsEip7883Enabled { get; set; }
     public bool IsEip5656Enabled { get; set; }
     public bool IsEip6780Enabled { get; set; }


### PR DESCRIPTION
Part of #11258

## Changes

- Implement EIP-7981: access list entries contribute floor tokens to the transaction data floor cost
- Token formula: `floor_tokens_in_access_list = (addresses × 20 + storageKeys × 32) × STANDARD_TOKEN_COST`; count-based arithmetic, no per-byte scanning
- Add `IsEip7981Enabled` flag to `IReleaseSpec`, `ReleaseSpec`, `OverridableReleaseSpec`, `ReleaseSpecDecorator`
- Add chain spec wiring (`ChainParameters`, `ChainSpecParamsJson`, `ChainSpecLoader`, `ChainSpecBasedSpecProvider`)
- `AccessListCost` includes `TotalCostFloorPerToken × floorTokensInAccessList` in the standard cost when EIP-7981 is active
- `CalculateFloorCost` adds access list floor tokens to the floor gas calculation alongside calldata tokens
- Fix `eth_createAccessList` to use block spec instead of hardcoded `Berlin.Instance` for gas delta computation
- EIP-7981 is **not** enabled in Amsterdam fork yet — pyspec test fixtures do not include EIP-7981

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Eip7981Tests` — 13 unit tests: access list token pricing (7 parameterized cases), null access list, pre-7981 disabled behavior, calldata + access list combined floor, floor-wins cases (standard wins, exact tie, floor wins, floor dominates)
- `EthRpcModuleTests.EstimateGas` — `eth_estimateGas` floor cost with access list under EIP-7981 spec
- `EthRpcModuleTests.EstimateGas` — `eth_createAccessList` gas consistency (createAccessList vs estimateGas) under EIP-7981 with 3 spec variants (noOpt/2, opt/2, opt/17)

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EIP-7981 extends the calldata floor cost mechanism (EIP-7623/7976) to include access list data. Each address (20 bytes) and storage key (32 bytes) in the access list contributes floor tokens at `STANDARD_TOKEN_COST` (4) per byte, priced at `TOTAL_COST_FLOOR_PER_TOKEN` (16) gas per token. This increases the minimum gas cost for transactions with large access lists.