### PR TITLE
fix: use pattern matching in TrieNode.Decoder (IDE0019)

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -51,9 +51,8 @@ namespace Nethermind.Trie
 
                 // Fast path: child was unresolved to a Hash256 (e.g. by pruning) — encode the hash directly
                 // without materializing a TrieNode via FindCachedOrUnknown + ResolveKey.
-                Hash256? childKeccak = item._nodeData[0] as Hash256;
                 TrieNode? nodeRef = null;
-                if (childKeccak is null)
+                if (item._nodeData[0] is not Hash256 childKeccak)
                 {
                     int previousLength = item.AppendChildPath(ref path, 0);
                     nodeRef = item.GetChildWithChildPath(tree, ref path, 0);


### PR DESCRIPTION
## Changes

- Fix IDE0019 build error in `TrieNode.Decoder.cs` by replacing `as` + null check with `is not` pattern matching
- .NET SDK 10.0.203 analyzer detects this more aggressively, causing build failure via `TreatWarningsAsErrors`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No