### PR TITLE
fix: guard AuRa finalization wiring on head state, not config flag

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
@@ -50,6 +50,34 @@ namespace Nethermind.AuRa.Test
             finalizationManager.LastFinalizedBlockLevel.Should().Be(1);
         }
 
+        [Test]
+        public void repeated_SetMainBlockBranchProcessor_with_same_processor_is_idempotent()
+        {
+            // The merge plugin can call SetMainBlockBranchProcessor via both the direct init step
+            // and the wrapper, depending on ordering. The inner manager must tolerate that.
+            BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(3, 1, 1);
+            FinalizeToLevel(1, blockTreeBuilder.ChainLevelInfoRepository);
+
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
+
+            finalizationManager.LastFinalizedBlockLevel.Should().Be(1);
+        }
+
+        [Test]
+        public void SetMainBlockBranchProcessor_with_different_processor_throws()
+        {
+            BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(3, 1, 1);
+            FinalizeToLevel(1, blockTreeBuilder.ChainLevelInfoRepository);
+
+            AuRaBlockFinalizationManager finalizationManager = new(blockTreeBuilder.TestObject, blockTreeBuilder.ChainLevelInfoRepository, _validatorStore, _validSealerStrategy, _logManager);
+            finalizationManager.SetMainBlockBranchProcessor(_blockProcessor);
+
+            IBranchProcessor other = Substitute.For<IBranchProcessor>();
+            Assert.Throws<InvalidOperationException>(() => finalizationManager.SetMainBlockBranchProcessor(other));
+        }
+
         private void FinalizeToLevel(long upperLevel, IChainLevelInfoRepository chainLevelInfoRepository)
         {
             for (long i = 0; i <= upperLevel; i++)

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Consensus.AuRa;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Merge.Plugin;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.AuRa.Test;
+
+public class AuRaMergeFinalizationManagerTests
+{
+    private static (IManualBlockFinalizationManager Manual, IAuRaBlockFinalizationManager AuRa, IPoSSwitcher PoS, IBlockTree BlockTree) CreateMocks() =>
+        (Substitute.For<IManualBlockFinalizationManager>(),
+         Substitute.For<IAuRaBlockFinalizationManager>(),
+         Substitute.For<IPoSSwitcher>(),
+         Substitute.For<IBlockTree>());
+
+    [Test]
+    public void SetMainBlockBranchProcessor_forwards_when_head_is_null()
+    {
+        (IManualBlockFinalizationManager manual, IAuRaBlockFinalizationManager aura, IPoSSwitcher posSwitcher, IBlockTree blockTree) = CreateMocks();
+        blockTree.Head.Returns((Block?)null);
+        using AuRaMergeFinalizationManager wrapper = new(manual, aura, posSwitcher, blockTree);
+
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        wrapper.SetMainBlockBranchProcessor(branchProcessor);
+
+        aura.Received(1).SetMainBlockBranchProcessor(branchProcessor);
+    }
+
+    [Test]
+    public void SetMainBlockBranchProcessor_forwards_when_head_is_pre_merge()
+    {
+        (IManualBlockFinalizationManager manual, IAuRaBlockFinalizationManager aura, IPoSSwitcher posSwitcher, IBlockTree blockTree) = CreateMocks();
+        Block head = Build.A.Block.WithNumber(1_000).TestObject;
+        blockTree.Head.Returns(head);
+        posSwitcher.IsPostMerge(head.Header).Returns(false);
+        using AuRaMergeFinalizationManager wrapper = new(manual, aura, posSwitcher, blockTree);
+
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        wrapper.SetMainBlockBranchProcessor(branchProcessor);
+
+        aura.Received(1).SetMainBlockBranchProcessor(branchProcessor);
+    }
+
+    [Test]
+    public void SetMainBlockBranchProcessor_skips_when_head_is_post_merge()
+    {
+        (IManualBlockFinalizationManager manual, IAuRaBlockFinalizationManager aura, IPoSSwitcher posSwitcher, IBlockTree blockTree) = CreateMocks();
+        Block head = Build.A.Block.WithNumber(30_000_000).TestObject;
+        blockTree.Head.Returns(head);
+        posSwitcher.IsPostMerge(head.Header).Returns(true);
+        using AuRaMergeFinalizationManager wrapper = new(manual, aura, posSwitcher, blockTree);
+
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        wrapper.SetMainBlockBranchProcessor(branchProcessor);
+
+        aura.DidNotReceive().SetMainBlockBranchProcessor(Arg.Any<IBranchProcessor>());
+    }
+
+    [Test]
+    public void SetMainBlockBranchProcessor_forwards_when_HasEverReachedTerminalBlock_but_head_is_genesis()
+    {
+        // Regression for fresh Gnosis archive sync: PoSSwitcher.HasEverReachedTerminalBlock() is
+        // true on startup as soon as Merge.FinalTotalDifficulty is set in config (gnosis_archive.json),
+        // but the head is still at genesis and pre-merge AuRa finalization must still run so the
+        // validator-set transition at block 1300 is applied.
+        (IManualBlockFinalizationManager manual, IAuRaBlockFinalizationManager aura, IPoSSwitcher posSwitcher, IBlockTree blockTree) = CreateMocks();
+        Block genesis = Build.A.Block.Genesis.TestObject;
+        blockTree.Head.Returns(genesis);
+        posSwitcher.HasEverReachedTerminalBlock().Returns(true);
+        posSwitcher.IsPostMerge(genesis.Header).Returns(false);
+        using AuRaMergeFinalizationManager wrapper = new(manual, aura, posSwitcher, blockTree);
+
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        wrapper.SetMainBlockBranchProcessor(branchProcessor);
+
+        aura.Received(1).SetMainBlockBranchProcessor(branchProcessor);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeFinalizationManagerTests.cs
@@ -67,10 +67,8 @@ public class AuRaMergeFinalizationManagerTests
     [Test]
     public void SetMainBlockBranchProcessor_forwards_when_HasEverReachedTerminalBlock_but_head_is_genesis()
     {
-        // Regression for fresh Gnosis archive sync: PoSSwitcher.HasEverReachedTerminalBlock() is
-        // true on startup as soon as Merge.FinalTotalDifficulty is set in config (gnosis_archive.json),
-        // but the head is still at genesis and pre-merge AuRa finalization must still run so the
-        // validator-set transition at block 1300 is applied.
+        // Regression: HasEverReachedTerminalBlock() is true on fresh archive DB with FTD in config,
+        // but head is still genesis — must not skip forwarding in that case.
         (IManualBlockFinalizationManager manual, IAuRaBlockFinalizationManager aura, IPoSSwitcher posSwitcher, IBlockTree blockTree) = CreateMocks();
         Block genesis = Build.A.Block.Genesis.TestObject;
         blockTree.Head.Returns(genesis);

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -5,6 +5,7 @@ using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.Processing;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Merge.Plugin;
@@ -13,12 +14,14 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 {
     private readonly IAuRaBlockFinalizationManager _auRaBlockFinalizationManager;
     private readonly IPoSSwitcher _poSSwitcher;
+    private readonly IBlockTree _blockTree;
 
-    public AuRaMergeFinalizationManager(IManualBlockFinalizationManager manualBlockFinalizationManager, IAuRaBlockFinalizationManager blockFinalizationManager, IPoSSwitcher poSSwitcher)
+    public AuRaMergeFinalizationManager(IManualBlockFinalizationManager manualBlockFinalizationManager, IAuRaBlockFinalizationManager blockFinalizationManager, IPoSSwitcher poSSwitcher, IBlockTree blockTree)
         : base(manualBlockFinalizationManager, blockFinalizationManager, poSSwitcher)
     {
         _auRaBlockFinalizationManager = blockFinalizationManager;
         _poSSwitcher = poSSwitcher;
+        _blockTree = blockTree;
         _auRaBlockFinalizationManager.BlocksFinalized += OnBlockFinalized;
     }
 
@@ -34,9 +37,13 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 
     public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
     {
-        // Skip forwarding post-merge so the inner manager never subscribes to block events
-        // nor runs the startup catch-up walk — AuRa finalization is not active post-merge.
-        if (_poSSwitcher.HasEverReachedTerminalBlock()) return;
+        // Skip forwarding only when the current head is already post-merge. We can't rely on
+        // IPoSSwitcher.HasEverReachedTerminalBlock() because it is true on a fresh archive DB as
+        // soon as Merge.FinalTotalDifficulty is set in config, even with head at genesis — skipping
+        // then would leave pre-merge AuRa finalization completely inert and break validator-set
+        // transitions (e.g. Gnosis block 1300).
+        BlockHeader? head = _blockTree.Head?.Header;
+        if (head is not null && _poSSwitcher.IsPostMerge(head)) return;
         _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
     }
 

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeFinalizationManager.cs
@@ -5,8 +5,8 @@ using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.Processing;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Merge.AuRa;
 
 namespace Nethermind.Merge.Plugin;
 
@@ -37,13 +37,7 @@ public class AuRaMergeFinalizationManager : MergeFinalizationManager, IAuRaBlock
 
     public void SetMainBlockBranchProcessor(IBranchProcessor branchProcessor)
     {
-        // Skip forwarding only when the current head is already post-merge. We can't rely on
-        // IPoSSwitcher.HasEverReachedTerminalBlock() because it is true on a fresh archive DB as
-        // soon as Merge.FinalTotalDifficulty is set in config, even with head at genesis — skipping
-        // then would leave pre-merge AuRa finalization completely inert and break validator-set
-        // transitions (e.g. Gnosis block 1300).
-        BlockHeader? head = _blockTree.Head?.Header;
-        if (head is not null && _poSSwitcher.IsPostMerge(head)) return;
+        if (_poSSwitcher.IsHeadPostMerge(_blockTree)) return;
         _auRaBlockFinalizationManager.SetMainBlockBranchProcessor(branchProcessor);
     }
 

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -70,7 +70,8 @@ namespace Nethermind.Merge.AuRa
                 _auraApi!.FinalizationManager ??
                 throw new ArgumentNullException(nameof(_auraApi.FinalizationManager),
                     "Cannot instantiate AuRaMergeFinalizationManager when AuRaFinalizationManager is null!"),
-                _poSSwitcher);
+                _poSSwitcher,
+                _api.BlockTree!);
         }
 
         public override IModule Module => new AuRaMergeModule();

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
@@ -2,35 +2,25 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac;
-using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa.InitializationSteps;
 using Nethermind.Consensus.Transactions;
-using Nethermind.Core;
+using Nethermind.Merge.AuRa;
 using Nethermind.TxPool;
 
 namespace Nethermind.Merge.Plugin;
 
 /// <summary>
-/// Merge-aware variant of <see cref="InitializeBlockchainAuRa"/>. Skips wiring the branch processor
-/// into the AuRa finalization manager only when the current chain head is already post-merge.
-/// In that state AuRa finalization is no longer active, and the startup catch-up walk in
-/// <c>AuRaBlockFinalizationManager.Initialize</c> would allocate millions of BlockHeaders on long
-/// post-merge chains like Gnosis. For pre-merge heads (fresh archive sync from genesis, or a
-/// restart mid-sync before the merge) the wiring must still run so AuRa finalization events fire
-/// and validator-set transitions (e.g. Gnosis block 1300) are applied.
+/// Skips wiring the branch processor on post-merge heads to avoid the multi-million-header
+/// startup walk in <see cref="Nethermind.Consensus.AuRa.AuRaBlockFinalizationManager"/>. Pre-merge
+/// heads (archive sync from genesis) still wire so validator-set transitions fire.
 /// </summary>
 public class InitializeBlockchainAuRaMerge(AuRaNethermindApi api, IChainHeadInfoProvider chainHeadInfoProvider, ITxGossipPolicy txGossipPolicy)
     : InitializeBlockchainAuRa(api, chainHeadInfoProvider, txGossipPolicy)
 {
     protected override void WireFinalizationBranchProcessor()
     {
-        // IPoSSwitcher.HasEverReachedTerminalBlock() is not a safe guard here: on a fresh archive
-        // DB it already returns true as soon as Merge.FinalTotalDifficulty is set in config (see
-        // PoSSwitcher.Initialize), even though the head is still at genesis. Inspect the actual
-        // head instead so pre-merge archive sync still wires AuRa finalization correctly.
-        BlockHeader? head = Api.BlockTree?.Head?.Header;
-        if (head is null || !Api.Context.Resolve<IPoSSwitcher>().IsPostMerge(head))
+        if (!Api.Context.Resolve<IPoSSwitcher>().IsHeadPostMerge(Api.BlockTree!))
             base.WireFinalizationBranchProcessor();
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializeBlockchainAuRaMerge.cs
@@ -6,22 +6,31 @@ using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa.InitializationSteps;
 using Nethermind.Consensus.Transactions;
+using Nethermind.Core;
 using Nethermind.TxPool;
 
 namespace Nethermind.Merge.Plugin;
 
 /// <summary>
 /// Merge-aware variant of <see cref="InitializeBlockchainAuRa"/>. Skips wiring the branch processor
-/// into the AuRa finalization manager on post-merge chains — AuRa finalization is no longer active
-/// there, and otherwise the startup catch-up walk in <c>AuRaBlockFinalizationManager.Initialize</c>
-/// allocates millions of BlockHeaders on long post-merge chains like Gnosis.
+/// into the AuRa finalization manager only when the current chain head is already post-merge.
+/// In that state AuRa finalization is no longer active, and the startup catch-up walk in
+/// <c>AuRaBlockFinalizationManager.Initialize</c> would allocate millions of BlockHeaders on long
+/// post-merge chains like Gnosis. For pre-merge heads (fresh archive sync from genesis, or a
+/// restart mid-sync before the merge) the wiring must still run so AuRa finalization events fire
+/// and validator-set transitions (e.g. Gnosis block 1300) are applied.
 /// </summary>
 public class InitializeBlockchainAuRaMerge(AuRaNethermindApi api, IChainHeadInfoProvider chainHeadInfoProvider, ITxGossipPolicy txGossipPolicy)
     : InitializeBlockchainAuRa(api, chainHeadInfoProvider, txGossipPolicy)
 {
     protected override void WireFinalizationBranchProcessor()
     {
-        if (!Api.Context.Resolve<IPoSSwitcher>().HasEverReachedTerminalBlock())
+        // IPoSSwitcher.HasEverReachedTerminalBlock() is not a safe guard here: on a fresh archive
+        // DB it already returns true as soon as Merge.FinalTotalDifficulty is set in config (see
+        // PoSSwitcher.Initialize), even though the head is still at genesis. Inspect the actual
+        // head instead so pre-merge archive sync still wires AuRa finalization correctly.
+        BlockHeader? head = Api.BlockTree?.Head?.Header;
+        if (head is null || !Api.Context.Resolve<IPoSSwitcher>().IsPostMerge(head))
             base.WireFinalizationBranchProcessor();
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/PoSSwitcherExtensions.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/PoSSwitcherExtensions.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Core;
+
+namespace Nethermind.Merge.AuRa;
+
+internal static class PoSSwitcherExtensions
+{
+    // Not HasEverReachedTerminalBlock(): that flag is true on a fresh archive DB with
+    // Merge.FinalTotalDifficulty in config, even at genesis.
+    public static bool IsHeadPostMerge(this IPoSSwitcher poSSwitcher, IBlockTree blockTree)
+    {
+        BlockHeader? head = blockTree.Head?.Header;
+        return head is not null && poSSwitcher.IsPostMerge(head);
+    }
+}


### PR DESCRIPTION
baf6fc1591 skipped AuRa finalization wiring whenever IPoSSwitcher.HasEverReachedTerminalBlock() returned true. That flag is true on a completely fresh archive DB as soon as Merge.FinalTotalDifficulty is set in config (gnosis_archive.json), even with head at genesis — see PoSSwitcher.Initialize lines 82-83. On Gnosis archive that caused SetMainBlockBranchProcessor to never be called, so the inner AuRaBlockFinalizationManager never subscribed to BlockProcessed / BlocksProcessing and never fired BlocksFinalized. The MultiValidator switch to the safeContract validator at block 1300 never happened, ContractBasedValidator.FinalizeChange was not invoked for block 1301, and the node rejected block 1301 with InvalidStateRoot.

Use the current head's post-merge status instead. Pre-merge heads (fresh archive from genesis, or a restart mid-sync before the merge) now wire AuRa finalization correctly. The original optimization — skipping the expensive startup walk when resuming on a post-merge head — is preserved.

Also inject IBlockTree into AuRaMergeFinalizationManager so its (currently unreachable in production, but covered by tests) SetMainBlockBranchProcessor guard uses the same head-based check.

Regression tests:
- AuRaMergeFinalizationManagerTests: covers null head, pre-merge head, post-merge head, and the archive case where HasEverReachedTerminalBlock is true but head is still genesis.
- AuRaBlockFinalizationManagerTests: idempotency + different-processor guard, mirroring the master-branch coverage missing from 1.37.0-rc2.

Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
