### PR TITLE
Avoid pooled RLP aliasing in read-only trie clones

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -835,15 +835,17 @@ namespace Nethermind.Trie.Test.Pruning
         [TestCase(false)]
         public void ReadOnly_store_returns_copies(bool pruning)
         {
-            TrieNode node = new(NodeType.Leaf);
-            Account account = new(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
-            node.Value = _accountDecoder.Encode(account).Bytes;
-            node.Key = Nibbles.BytesToNibbleBytes(TestItem.KeccakA.BytesToArray());
+            TrieNode node = new(NodeType.Branch);
+            for (int i = 0; i < 16; i++)
+            {
+                node.SetChild(i, new TrieNode(NodeType.Unknown, TestItem.Keccaks[i]));
+            }
+
             TreePath emptyPath = TreePath.Empty;
-            node.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath);
 
             using TrieStore fullTrieStore = CreateTrieStore(pruningStrategy: new TestPruningStrategy(pruning));
             IScopedTrieStore trieStore = fullTrieStore.GetTrieStore(null);
+            node.ResolveKey(trieStore, ref emptyPath);
 
             using (ICommitter? committer = fullTrieStore.BeginStateBlockCommit(0, node))
             {
@@ -862,7 +864,14 @@ namespace Nethermind.Trie.Test.Pruning
 
             CappedArray<byte> origRlp = originalNode.FullRlp;
             CappedArray<byte> readOnlyRlp = readOnlyNode.FullRlp;
-            readOnlyRlp.Should().BeEquivalentTo(origRlp);
+            readOnlyRlp.AsSpan().ToArray().Should().Equal(origRlp.AsSpan().ToArray());
+            readOnlyRlp.UnderlyingArray.Should().NotBeSameAs(origRlp.UnderlyingArray);
+
+            byte firstReadOnlyByte = readOnlyRlp[0];
+            origRlp[0] ^= 1;
+
+            readOnlyNode.GetChildHash(0).Should().Be(TestItem.Keccaks[0]);
+            readOnlyNode.FullRlp[0].Should().Be(firstReadOnlyByte);
 
             readOnlyNode.Key?.ToString().Should().Be(originalNode.Key?.ToString());
         }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -872,8 +872,6 @@ namespace Nethermind.Trie.Test.Pruning
 
             readOnlyNode.GetChildHash(0).Should().Be(TestItem.Keccaks[0]);
             readOnlyNode.FullRlp[0].Should().Be(firstReadOnlyByte);
-
-            readOnlyNode.Key?.ToString().Should().Be(originalNode.Key?.ToString());
         }
 
         private long ExpectedPerNodeKeyMemorySize => (scheme == INodeStorage.KeyScheme.Hash ? 0 : TrieStoreDirtyNodesCache.Key.MemoryUsage) + MemorySizes.ObjectHeaderMethodTable + MemorySizes.RefSize + 4 + MemorySizes.RefSize;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -1724,7 +1724,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             return new TrieNode(NodeType.Unknown, key.Keccak);
         }
 
-        // we returning a copy to avoid multithreaded access
+        // AsSpan forces an owned copy via the ReadOnlySpan ctor overload: node.FullRlp may be
+        // pool-backed and returned to the pool while this read-only clone is still in use.
         TrieNode trieNode = new(NodeType.Unknown, key.Keccak, fullRlp.AsSpan());
         trieNode.ResolveNode(GetTrieStore(key.Address), key.Path);
         trieNode.Keccak = key.Keccak;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
@@ -1715,7 +1716,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
     internal TrieNode CloneForReadOnly(in TrieStoreDirtyNodesCache.Key key, TrieNode node)
     {
-        if (node!.FullRlp.IsNull)
+        CappedArray<byte> fullRlp = node!.FullRlp;
+        if (fullRlp.IsNull)
         {
             // // this happens in SyncProgressResolver
             // throw new InvalidAsynchronousStateException("Read only trie store is trying to read a transient node.");
@@ -1723,7 +1725,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
 
         // we returning a copy to avoid multithreaded access
-        TrieNode trieNode = new(NodeType.Unknown, key.Keccak, node.FullRlp);
+        TrieNode trieNode = new(NodeType.Unknown, key.Keccak, fullRlp.AsSpan());
         trieNode.ResolveNode(GetTrieStore(key.Address), key.Path);
         trieNode.Keccak = key.Keccak;
         return trieNode;


### PR DESCRIPTION
## Changes

- Read-only trie clones were intended to isolate concurrent readers, but CloneForReadOnly still reused the original node’s pooled FullRlp backing array. That left the read-only path exposed to buffer reuse while the clone was still decoding or traversing children.

- This change makes read-only clones take ownership of their RLP bytes by copying the serialized node data before resolving it. It also strengthens the trie regression test to assert that read-only clones do not share the original backing array and still decode correctly after the original buffer is mutated.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes