### PR TITLE
Optimise parallel execution: reduce worldstate, txprocessor allocations

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Linq;
 using Nethermind.Blockchain;
@@ -477,15 +478,14 @@ public class BlockAccessListManager(
 
     private void CheckInitialized()
     {
-        if (_txProcessorWithWorldStateManager is null)
-            throw new InvalidOperationException($"{nameof(_txProcessorWithWorldStateManager)} was not initialized.");
-
-        if (_gasRemaining is null)
-            throw new InvalidOperationException($"{nameof(_gasRemaining)} was not initialized.");
-
-        if (_blockExecutionContext is null)
-            throw new InvalidOperationException($"{nameof(_blockExecutionContext)} was not initialized.");
+        if (_txProcessorWithWorldStateManager is null) ThrowNotInitialized(nameof(_txProcessorWithWorldStateManager));
+        if (_gasRemaining is null) ThrowNotInitialized(nameof(_gasRemaining));
+        if (_blockExecutionContext is null) ThrowNotInitialized(nameof(_blockExecutionContext));
     }
+
+    [DoesNotReturn]
+    private static void ThrowNotInitialized(string fieldName)
+        => throw new InvalidOperationException($"{fieldName} was not initialized.");
 
     private interface ITxProcessorWithWorldStateManager
     {
@@ -554,21 +554,29 @@ public class BlockAccessListManager(
         {
             _currentBlock = block;
             _currentCtx = blockExecutionContext;
-            int previousSize = _lastBalIndex + 1;
-            _lastBalIndex = block.Transactions.Length + 1;
 
-            ReclaimAndResize(_lastBalIndex + 1, previousSize);
+            int previousSize = _lastBalIndex + 1;
+            int newLastBalIndex = block.Transactions.Length + 1;
+            ReclaimAndResize(newLastBalIndex + 1, previousSize);
+            _lastBalIndex = newLastBalIndex;
         }
 
+        // Thread-safety note for _inUse / _perTxBal:
+        //   Each balIndex slot has at most one writer at a time. Pre/post (idx 0 and
+        //   _lastBalIndex) are written only by the main thread; tx slots (1..len) are
+        //   each owned by a single parallel-loop iteration, so no two workers ever
+        //   touch the same slot. Cross-thread reads (validator → worker's slot) happen
+        //   strictly after the worker's gasResults[i-1].SetResult, whose pairing with
+        //   GetResult() establishes the publication barrier. Plain reads/writes are
+        //   therefore sufficient — Volatile/Interlocked would be redundant fencing.
         public TxProcessorWithWorldState Get(int? balIndex = null)
         {
-            if (_currentBlock is null)
-                throw new InvalidOperationException($"{nameof(_currentBlock)} was not initialized.");
+            if (_currentBlock is null) ThrowNotInitialized(nameof(_currentBlock));
 
             balIndex = ClampBalIndex(balIndex ?? 0);
 
             // Re-entrant Get for the same balIndex returns the already-acquired processor
-            // (lets pre/post callers share state across calls).
+            // (lets pre/post callers share state across calls — main thread only).
             TxProcessorWithWorldState? existing = _inUse[balIndex.Value];
             if (existing is not null) return existing;
 
@@ -649,14 +657,18 @@ public class BlockAccessListManager(
                 if (_inUse[i] is not null) Return(i);
 
             for (int i = 0; i < previousSize; i++)
-                if (_perTxBal[i] is { } bal) StaticPool<BlockAccessList>.Return(bal);
+            {
+                if (_perTxBal[i] is { } bal)
+                {
+                    StaticPool<BlockAccessList>.Return(bal);
+                    _perTxBal[i] = null;
+                }
+            }
 
             if (_inUse.Length < size)
                 Array.Resize(ref _inUse, Math.Max(2 * _inUse.Length, size));
             if (_perTxBal.Length < size)
                 Array.Resize(ref _perTxBal, Math.Max(2 * _perTxBal.Length, size));
-            Array.Clear(_inUse);
-            Array.Clear(_perTxBal);
         }
 
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
 using Nethermind.Blockchain;
+using System.Collections.Concurrent;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Cpu;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Tracing;
@@ -144,12 +147,27 @@ public class BlockAccessListManager(
         }
     }
 
+    public void ReturnTxProcessor(int balIndex)
+    {
+        if (Enabled && ParallelExecutionEnabled)
+        {
+            // Eagerly detach the worker's generated BAL into a per-tx slot and recycle the
+            // pool slot. Workers therefore never block on the validator — but the validator
+            // still merges per-tx slots into the target in order, preserving incremental
+            // validation semantics.
+            _parallelTxProcessorWithWorldStateManager.Return(balIndex);
+        }
+    }
+
     public void IncrementalValidation(Block block, TaskCompletionSource<(long BlockGasUsed, long BlockStateGasUsed, InvalidBlockException? Exception)>[] gasResults, BlockReceiptsTracer[] receiptsTracers, BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler, CancellationToken token)
     {
         CheckInitialized();
 
         int len = block.Transactions.Length;
-        _txProcessorWithWorldStateManager.GetPreExecution().WorldState.MergeGeneratingBal(GeneratedBlockAccessList);
+
+        // Pre is held by main-thread system contract handlers — never went through Return,
+        // so MergeAndReturnBal will detach it before merging.
+        _parallelTxProcessorWithWorldStateManager.MergeAndReturnBal(0, GeneratedBlockAccessList);
         ValidateBlockAccessList(block, 0);
 
         long totalRegularGas = 0;
@@ -176,8 +194,12 @@ public class BlockAccessListManager(
 
                 transactionProcessedEventHandler?.OnTransactionProcessed(new TxProcessedEventArgs(j, block.Transactions[j], block.Header, receiptsTracers[j].TxReceipts[0]));
 
+                // Worker for tx (j+1) has stashed its BAL into _perTxBal[j+1] via Return as
+                // soon as the tx finished — no contention with the validator. Merge it into
+                // the target now, in order, so incremental validation sees only data from
+                // txs 0..(j+1).
                 bool validateStorageReads = j == chunkEnd - 1;
-                _txProcessorWithWorldStateManager.Get(j + 1).WorldState.MergeGeneratingBal(GeneratedBlockAccessList);
+                _parallelTxProcessorWithWorldStateManager.MergeAndReturnBal(j + 1, GeneratedBlockAccessList);
                 ValidateBlockAccessList(block, (ushort)(j + 1), validateStorageReads);
             }
         }
@@ -271,7 +293,7 @@ public class BlockAccessListManager(
         {
             CheckInitialized();
 
-            _txProcessorWithWorldStateManager.GetPostExecution().WorldState.MergeGeneratingBal(GeneratedBlockAccessList);
+            _txProcessorWithWorldStateManager.MergeAndReturnBal(int.MaxValue, GeneratedBlockAccessList);
             block.GeneratedBlockAccessList = GeneratedBlockAccessList;
             block.EncodedBlockAccessList = Rlp.Encode(GeneratedBlockAccessList).Bytes;
             block.Header.BlockAccessListHash = new(ValueKeccak.Compute(block.EncodedBlockAccessList).Bytes);
@@ -473,48 +495,188 @@ public class BlockAccessListManager(
         TxProcessorWithWorldState GetPostExecution() => Get(int.MaxValue);
         void NextTransaction();
         void Rollback();
+        void MergeAndReturnBal(int balIndex, BlockAccessList target);
     }
 
-    private class ParallelTxProcessorWithWorldStateManager(
-        IBlockhashProvider blockHashProvider,
-        ISpecProvider specProvider,
-        IWorldState stateProvider,
-        ILogManager logManager) : ITxProcessorWithWorldStateManager
+    private class ParallelTxProcessorWithWorldStateManager : ITxProcessorWithWorldStateManager
     {
-        private TxProcessorWithWorldState[] _txProcessorsWithWorldStates;
-        private int _len;
+        private const int DefaultTxCount = 10000;
+        private static readonly int ProcessorPoolSize = RuntimeInformation.ProcessorCount;
 
-        public void Setup(Block block, BlockExecutionContext blockExecutionContext)
+        // BAL pool is larger since extra BALs are retained so they can be merged in order
+        private static readonly int BalPoolSize = RuntimeInformation.ProcessorCount * 2;
+
+        static ParallelTxProcessorWithWorldStateManager()
         {
-            _len = block.Transactions.Length + 2;
-            _txProcessorsWithWorldStates = new TxProcessorWithWorldState[_len];
-            for (int i = 0; i < _len; i++)
+            StaticPool<BlockAccessList>.SetMaxPooledCount(BalPoolSize);
+            for (int i = 0; i < BalPoolSize; i++)
             {
-                // todo: could be a lot of allocations here
-                // will optimize to allocate ~16 worldstates upfront, and reuse them as they are ready
-                _txProcessorsWithWorldStates[i] = new(i, true, blockHashProvider, specProvider, stateProvider, logManager);
-                _txProcessorsWithWorldStates[i].Setup(block, blockExecutionContext);
+                StaticPool<BlockAccessList>.Return(new());
             }
         }
 
-        public TxProcessorWithWorldState Get(int? balIndex)
-            => _txProcessorsWithWorldStates[int.Min(balIndex ?? 0, _len - 1)];
+        private Block? _currentBlock;
+        private BlockExecutionContext _currentCtx;
+        private int _lastBalIndex;
+
+        // _inUse[i] is the processor currently bound to balIndex i.
+        private TxProcessorWithWorldState?[] _inUse = new TxProcessorWithWorldState?[DefaultTxCount];
+
+        // _perTxBal[i] holds its detached BAL until the validator merges it in order.
+        private BlockAccessList?[] _perTxBal = new BlockAccessList?[DefaultTxCount];
+
+        // processors are not shared statically between BAL managers
+        private readonly ConcurrentQueue<TxProcessorWithWorldState> _processors = [];
+        private readonly IBlockhashProvider _blockHashProvider;
+        private readonly ISpecProvider _specProvider;
+        private readonly IWorldState _stateProvider;
+        private readonly ILogManager _logManager;
+        private int _processorCount;
+
+        public ParallelTxProcessorWithWorldStateManager(
+            IBlockhashProvider blockHashProvider,
+            ISpecProvider specProvider,
+            IWorldState stateProvider,
+            ILogManager logManager)
+        {
+            _blockHashProvider = blockHashProvider;
+            _specProvider = specProvider;
+            _stateProvider = stateProvider;
+            _logManager = logManager;
+            for (int i = 0; i < ProcessorPoolSize; i++)
+            {
+                _processors.Enqueue(NewProcessor());
+                _processorCount++;
+            }
+        }
+
+        public void Setup(Block block, BlockExecutionContext blockExecutionContext)
+        {
+            _currentBlock = block;
+            _currentCtx = blockExecutionContext;
+            int previousSize = _lastBalIndex + 1;
+            _lastBalIndex = block.Transactions.Length + 1;
+
+            ReclaimAndResize(_lastBalIndex + 1, previousSize);
+        }
+
+        public TxProcessorWithWorldState Get(int? balIndex = null)
+        {
+            if (_currentBlock is null)
+                throw new InvalidOperationException($"{nameof(_currentBlock)} was not initialized.");
+
+            balIndex = ClampBalIndex(balIndex ?? 0);
+
+            // Re-entrant Get for the same balIndex returns the already-acquired processor
+            // (lets pre/post callers share state across calls).
+            TxProcessorWithWorldState? existing = _inUse[balIndex.Value];
+            if (existing is not null) return existing;
+
+            TxProcessorWithWorldState processor = RentProcessor();
+
+            // Install a fresh BAL before Setup so the worker has somewhere to record changes.
+            processor.WorldState.SetGeneratingBlockAccessList(StaticPool<BlockAccessList>.Rent());
+            processor.Setup(_currentBlock, _currentCtx, balIndex.Value);
+            _inUse[balIndex.Value] = processor;
+            return processor;
+        }
+
+        /// <summary>Detaches the worker's populated BAL into the per-tx slot and recycles
+        /// the processor immediately, so workers never block on the validator.</summary>
+        public void Return(int balIndex)
+        {
+            balIndex = ClampBalIndex(balIndex);
+
+            TxProcessorWithWorldState? processor = _inUse[balIndex];
+            if (processor is null) return;
+
+            _perTxBal[balIndex] = processor.WorldState.GetGeneratingBlockAccessList();
+            processor.WorldState.SetGeneratingBlockAccessList(null);
+            _inUse[balIndex] = null;
+            ReturnProcessor(processor);
+        }
+
+        /// <summary>Merges the per-tx BAL into <paramref name="target"/> in caller-controlled
+        /// order, then returns it to the pool. Idempotent w.r.t. <see cref="Return"/>: also
+        /// detaches the BAL for pre/post callers that never went through Return.</summary>
+        public void MergeAndReturnBal(int balIndex, BlockAccessList target)
+        {
+            balIndex = ClampBalIndex(balIndex);
+
+            Return(balIndex);
+
+            BlockAccessList? source = _perTxBal[balIndex];
+            if (source is null) return;
+
+            target.Merge(source);
+            _perTxBal[balIndex] = null;
+            StaticPool<BlockAccessList>.Return(source);
+        }
 
         public void NextTransaction() { }
 
         public void Rollback() { }
+
+        private int ClampBalIndex(int balIndex)
+            => int.Min(int.Max(balIndex, 0), _lastBalIndex);
+
+        private TxProcessorWithWorldState NewProcessor()
+            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager);
+
+        private TxProcessorWithWorldState RentProcessor()
+        {
+            if (Volatile.Read(ref _processorCount) > 0 && _processors.TryDequeue(out TxProcessorWithWorldState? p))
+            {
+                Interlocked.Decrement(ref _processorCount);
+                return p;
+            }
+            return NewProcessor();
+        }
+
+        private void ReturnProcessor(TxProcessorWithWorldState p)
+        {
+            if (Interlocked.Increment(ref _processorCount) > ProcessorPoolSize)
+            {
+                Interlocked.Decrement(ref _processorCount);
+                return;
+            }
+            _processors.Enqueue(p);
+        }
+
+        private void ReclaimAndResize(int size, int previousSize)
+        {
+            for (int i = 0; i < previousSize; i++)
+                if (_inUse[i] is not null) Return(i);
+
+            for (int i = 0; i < previousSize; i++)
+                if (_perTxBal[i] is { } bal) StaticPool<BlockAccessList>.Return(bal);
+
+            if (_inUse.Length < size)
+                Array.Resize(ref _inUse, Math.Max(2 * _inUse.Length, size));
+            if (_perTxBal.Length < size)
+                Array.Resize(ref _perTxBal, Math.Max(2 * _perTxBal.Length, size));
+            Array.Clear(_inUse);
+            Array.Clear(_perTxBal);
+        }
+
     }
 
-    private class SequentialTxProcessorWithWorldStateManager(
-        IBlockhashProvider blockHashProvider,
-        ISpecProvider specProvider,
-        IWorldState stateProvider,
-        ILogManager logManager) : ITxProcessorWithWorldStateManager
+    private class SequentialTxProcessorWithWorldStateManager : ITxProcessorWithWorldStateManager
     {
-        private readonly TxProcessorWithWorldState _txProcessorWithWorldState = new(0, false, blockHashProvider, specProvider, stateProvider, logManager);
+        private readonly TxProcessorWithWorldState _txProcessorWithWorldState;
+
+        public SequentialTxProcessorWithWorldStateManager(
+            IBlockhashProvider blockHashProvider,
+            ISpecProvider specProvider,
+            IWorldState stateProvider,
+            ILogManager logManager)
+        {
+            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager);
+            _txProcessorWithWorldState.WorldState.SetGeneratingBlockAccessList(new());
+        }
 
         public void Setup(Block block, BlockExecutionContext blockExecutionContext)
-            => _txProcessorWithWorldState.Setup(block, blockExecutionContext);
+            => _txProcessorWithWorldState.Setup(block, blockExecutionContext, 0);
 
         public TxProcessorWithWorldState Get(int? _)
             => _txProcessorWithWorldState;
@@ -526,6 +688,9 @@ public class BlockAccessListManager(
         }
 
         public void Rollback() => _txProcessorWithWorldState.WorldState.Clear();
+
+        public void MergeAndReturnBal(int _, BlockAccessList target)
+            => _txProcessorWithWorldState.WorldState.MergeGeneratingBal(target);
     }
 
     private class TxProcessorWithWorldState
@@ -534,10 +699,8 @@ public class BlockAccessListManager(
         public readonly TransactionProcessor<EthereumGasPolicy> TxProcessor;
         public readonly ExecuteTransactionProcessorAdapter TxProcessorAdapter;
         private readonly BlockAccessListBasedWorldState? _balWorldState;
-        private readonly int _balIndex;
 
         public TxProcessorWithWorldState(
-            int balIndex,
             bool parallel,
             IBlockhashProvider blockHashProvider,
             ISpecProvider specProvider,
@@ -549,21 +712,20 @@ public class BlockAccessListManager(
             IWorldState worldState = stateProvider;
             if (parallel)
             {
-                _balWorldState = new BlockAccessListBasedWorldState(stateProvider, balIndex, logManager);
+                _balWorldState = new BlockAccessListBasedWorldState(stateProvider, logManager);
                 worldState = _balWorldState;
             }
             WorldState = new TracedAccessWorldState(worldState, parallel);
-            WorldState.SetIndex(balIndex);
             EthereumCodeInfoRepository codeInfoRepository = new(WorldState);
             TxProcessor = new(BlobBaseFeeCalculator.Instance, specProvider, WorldState, virtualMachine, codeInfoRepository, logManager, parallel);
             TxProcessorAdapter = new(TxProcessor);
-            _balIndex = balIndex;
         }
 
-        public void Setup(Block block, BlockExecutionContext blockExecutionContext)
+        public void Setup(Block block, BlockExecutionContext blockExecutionContext, int balIndex)
         {
             WorldState.Clear();
-            WorldState.SetIndex(_balIndex);
+            WorldState.SetIndex(balIndex);
+            _balWorldState?.SetBlockAccessIndex(balIndex);
             TxProcessorAdapter.SetBlockExecutionContext(blockExecutionContext);
             _balWorldState?.Setup(block);
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -102,22 +102,29 @@ public partial class BlockProcessor
                         }
 
                         int txIndex = i - 1;
+                        Transaction tx = state.txs[txIndex];
                         try
                         {
-                            Transaction tx = state.txs[txIndex];
-                            ProcessTransaction(
-                                state.balManager.GetTxProcessor(i),
-                                state.stateProvider,
-                                state.block,
-                                tx,
-                                txIndex,
-                                state.receiptsTracers[txIndex],
-                                state.processingOptions);
+                            // The using block detaches the worker's BAL into _perTxBal[i] and
+                            // recycles the pool slot via Dispose BEFORE we signal the gas result,
+                            // so the validator finds _perTxBal[i] populated when it awaits
+                            // gasResults[i-1] — even if ProcessTransaction throws.
+                            using (TxProcessorLease lease = state.balManager.RentTxProcessor(i))
+                            {
+                                ProcessTransaction(
+                                    lease.Adapter,
+                                    state.stateProvider,
+                                    state.block,
+                                    tx,
+                                    txIndex,
+                                    state.receiptsTracers[txIndex],
+                                    state.processingOptions);
+                            }
                             state.gasResults[txIndex].SetResult((tx.BlockGasUsed, state.receiptsTracers[txIndex].BlockStateGasUsed, null));
                         }
                         catch (InvalidBlockException ex)
                         {
-                            state.gasResults[txIndex].SetResult((state.txs[txIndex].GasLimit, 0, ex));
+                            state.gasResults[txIndex].SetResult((tx.GasLimit, 0, ex));
                         }
                         catch
                         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
@@ -26,6 +26,17 @@ public interface IBlockAccessListManager
     ITransactionProcessorAdapter GetTxProcessor(int? balIndex = null);
     void NextTransaction();
     void Rollback();
+    void ReturnTxProcessor(int balIndex);
+
+    /// <summary>
+    /// Acquires a tx processor for <paramref name="balIndex"/> and returns a stack-only lease
+    /// whose <c>Dispose</c> calls <see cref="ReturnTxProcessor"/>. Use with a <c>using</c>
+    /// block so the pool slot is recycled (and the worker's BAL captured into <c>_perTxBal</c>)
+    /// even on exception, without an explicit try/finally.
+    /// </summary>
+    TxProcessorLease RentTxProcessor(int balIndex)
+        => new(GetTxProcessor(balIndex), this, balIndex);
+
     void IncrementalValidation(Block block, TaskCompletionSource<(long BlockGasUsed, long BlockStateGasUsed, InvalidBlockException? Exception)>[] gasResults, BlockReceiptsTracer[] receiptsTracers, BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler, CancellationToken token);
     void SetBlockAccessList(Block block);
     void ValidateBlockAccessList(Block block, ushort index, bool validateStorageReads = true);
@@ -34,4 +45,25 @@ public interface IBlockAccessListManager
     void ProcessWithdrawals(Block block, IReleaseSpec spec);
     void ProcessExecutionRequests(Block block, TxReceipt[] txReceipts, IReleaseSpec spec);
     void ApplyAuRaPreprocessingChanges(IReleaseSpec spec, Address withdrawalContractAddress);
+}
+
+/// <summary>
+/// Stack-only handle representing a borrowed tx processor from the pool. Dispose returns
+/// the slot via <see cref="IBlockAccessListManager.ReturnTxProcessor"/>. <c>readonly ref
+/// struct</c> so it never heap-allocates and can't escape the worker's stack frame.
+/// </summary>
+public readonly ref struct TxProcessorLease
+{
+    public readonly ITransactionProcessorAdapter Adapter;
+    private readonly IBlockAccessListManager _manager;
+    private readonly int _balIndex;
+
+    internal TxProcessorLease(ITransactionProcessorAdapter adapter, IBlockAccessListManager manager, int balIndex)
+    {
+        Adapter = adapter;
+        _manager = manager;
+        _balIndex = balIndex;
+    }
+
+    public void Dispose() => _manager.ReturnTxProcessor(_balIndex);
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/NullBlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/NullBlockAccessListManager.cs
@@ -30,6 +30,7 @@ public class NullBlockAccessListManager : IBlockAccessListManager
     public ITransactionProcessorAdapter GetTxProcessor(int? balIndex = null) => throw new InvalidOperationException("NullBlockAccessListManager does not provide transaction processors.");
     public void NextTransaction() { }
     public void Rollback() { }
+    public void ReturnTxProcessor(int balIndex) { }
     public void IncrementalValidation(Block block, TaskCompletionSource<(long BlockGasUsed, long BlockStateGasUsed, InvalidBlockException? Exception)>[] gasResults, BlockReceiptsTracer[] receiptsTracers, BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler, CancellationToken token) { }
     public void SetBlockAccessList(Block block) { }
     public void ValidateBlockAccessList(Block block, ushort index, bool validateStorageReads = true) { }

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessList.cs
@@ -8,13 +8,14 @@ using System.Text;
 using System.Text.Json.Serialization;
 using Nethermind.Int256;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Resettables;
 
 [assembly: InternalsVisibleTo("Nethermind.Core.Test")]
 [assembly: InternalsVisibleTo("Nethermind.State.Test")]
 
 namespace Nethermind.Core.BlockAccessLists;
 
-public class BlockAccessList : IEquatable<BlockAccessList>, IJournal<int>
+public class BlockAccessList : IEquatable<BlockAccessList>, IJournal<int>, IResettable
 {
     [JsonIgnore]
     public int Index = 0;

--- a/src/Nethermind/Nethermind.Core/Caching/StaticPool.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/StaticPool.cs
@@ -16,11 +16,21 @@ namespace Nethermind.Core.Caching;
 /// </typeparam>
 public static class StaticPool<T> where T : class, IResettable, new()
 {
+    private const int DefaultMaxPooledCount = 4096;
+
     /// <summary>
     /// Hard cap for the total number of items that can be stored in the shared pool.
-    /// Prevents unbounded growth under bursty workloads while still allowing reuse.
+    /// Defaults to <see cref="DefaultMaxPooledCount"/>; override per-T at startup via
+    /// <see cref="SetMaxPooledCount"/>.
     /// </summary>
-    private const int MaxPooledCount = 4096;
+    private static int _maxPooledCount = DefaultMaxPooledCount;
+
+    /// <summary>
+    /// Override the pool's hard cap for this <typeparamref name="T"/>. Intended to be called
+    /// once at startup before any Rent/Return; there is no synchronization against in-flight
+    /// callers, so reservations may briefly exceed a smaller new cap.
+    /// </summary>
+    public static void SetMaxPooledCount(int maxPooledCount) => _maxPooledCount = maxPooledCount;
 
     /// <summary>
     /// Global pool shared between threads.
@@ -78,7 +88,7 @@ public static class StaticPool<T> where T : class, IResettable, new()
     {
         // We use Interlocked.Increment to reserve a slot up front.
         // This guarantees a bounded queue length without relying on slow Count().
-        if (Interlocked.Increment(ref _poolCount) > MaxPooledCount)
+        if (Interlocked.Increment(ref _poolCount) > _maxPooledCount)
         {
             // Roll back reservation if we'd exceed the cap.
             Interlocked.Decrement(ref _poolCount);

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -62,6 +62,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     {
         bool useParallel = parallelOverride ?? parallel;
         TracedAccessWorldState tracedState = new(TestState, parallel: useParallel);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessList());
         ILogManager logManager = LimboLogs.Instance;
         IBlockhashProvider blockhashProvider = new TestBlockhashProvider(SpecProvider);
         EthereumCodeInfoRepository codeInfoRepo = new(tracedState);
@@ -979,6 +980,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     public void CodeInfoRepository_getcachedcodeinfo_records_account_read_in_bal(string address)
     {
         TracedAccessWorldState tracedState = new(TestState, parallel: parallel);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessList());
 
         CodeInfoRepository repo = new(tracedState, new EthereumPrecompileProvider());
 
@@ -1037,6 +1039,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         TestState.CommitTree(0);
 
         TracedAccessWorldState tracedState = new(TestState, parallel: parallel);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessList());
 
         CodeInfoRepository repo = new(tracedState, new EthereumPrecompileProvider());
         CodeInfo result = repo.GetCachedCodeInfo(delegatedAccount, true, Amsterdam.Instance, out Address? delegationAddress);
@@ -1065,6 +1068,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         TestState.CommitTree(0);
 
         TracedAccessWorldState tracedState = new(TestState, parallel: parallel);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessList());
 
         CacheCodeInfoRepository repo = new(tracedState, new EthereumPrecompileProvider());
         CodeInfo result = repo.GetCachedCodeInfo(TestItem.AddressB, false, Amsterdam.Instance, out Address? delegationAddress);

--- a/src/Nethermind/Nethermind.State.Test/BlockAccessListBasedWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/BlockAccessListBasedWorldStateTests.cs
@@ -60,7 +60,8 @@ public class BlockAccessListBasedWorldStateTests
         BlockAccessList suggestedBal = new();
         balSetup(suggestedBal);
 
-        BlockAccessListBasedWorldState bws = new(inner, blockAccessIndex, Logger);
+        BlockAccessListBasedWorldState bws = new(inner, Logger);
+        bws.SetBlockAccessIndex(blockAccessIndex);
         Block block = Build.A.Block.WithHeader(baseBlock).WithBlockAccessList(suggestedBal).TestObject;
         bws.Setup(block);
         IDisposable scope = bws.BeginScope(baseBlock);

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -51,6 +51,7 @@ public class TracedAccessWorldStateTests(bool parallel)
 
         BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
         TracedAccessWorldState tws = new(inner, parallel: parallel);
+        tws.SetGeneratingBlockAccessList(new());
         IDisposable scope = tws.BeginScope(baseBlock);
         tws.SetIndex(0);
         return (tws, scope);
@@ -74,7 +75,7 @@ public class TracedAccessWorldStateTests(bool parallel)
                 tws.SubtractFromBalance(TestItem.AddressA, delta, Spec, out _);
             }
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -102,7 +103,7 @@ public class TracedAccessWorldStateTests(bool parallel)
                 tws.SetNonce(TestItem.AddressA, value);
             }
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -123,7 +124,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             ValueHash256 codeHash = ValueKeccak.Compute(code);
             tws.InsertCode(TestItem.AddressA, codeHash, code, Spec);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -143,7 +144,7 @@ public class TracedAccessWorldStateTests(bool parallel)
         {
             tws.Set(cell, [0x01]);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -168,7 +169,7 @@ public class TracedAccessWorldStateTests(bool parallel)
                 _ = tws.GetOriginal(cell);
             }
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             Assert.That(ac, Is.Not.Null);
             Assert.That(ac!.StorageReads, Has.Count.EqualTo(1));
             Assert.That(ac.StorageReads.First(), Is.EqualTo((UInt256)2));
@@ -259,7 +260,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             using (Assert.EnterMultipleScope())
             {
                 readAndAssert(tws);
-                Assert.That(tws.GetGeneratingBlockAccessList().HasAccount(TestItem.AddressA), Is.True);
+                Assert.That(tws.GetGeneratingBlockAccessList()!.HasAccount(TestItem.AddressA), Is.True);
             }
         }
     }
@@ -274,7 +275,7 @@ public class TracedAccessWorldStateTests(bool parallel)
         {
             tws.CreateAccount(TestItem.AddressA, balance, nonce);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -302,7 +303,7 @@ public class TracedAccessWorldStateTests(bool parallel)
         {
             tws.DeleteAccount(TestItem.AddressA);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             Assert.That(ac, Is.Not.Null);
             using (Assert.EnterMultipleScope())
             {
@@ -321,8 +322,8 @@ public class TracedAccessWorldStateTests(bool parallel)
         {
             tws.AddAccountRead(TestItem.AddressA);
 
-            Assert.That(tws.GetGeneratingBlockAccessList().HasAccount(TestItem.AddressA), Is.True);
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            Assert.That(tws.GetGeneratingBlockAccessList()!.HasAccount(TestItem.AddressA), Is.True);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac!.BalanceChanges, Is.Empty);
@@ -341,13 +342,13 @@ public class TracedAccessWorldStateTests(bool parallel)
             Snapshot snap = tws.TakeSnapshot();
             tws.AddToBalance(TestItem.AddressA, 50, Spec, out _);
 
-            Assert.That(tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA)!
+            Assert.That(tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA)!
                 .BalanceChanges, Has.Count.EqualTo(1));
 
             tws.Restore(snap);
 
             // Balance change must be rolled back by the snapshot restore.
-            Assert.That(tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA)!
+            Assert.That(tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA)!
                 .BalanceChanges, Is.Empty);
         }
     }
@@ -360,7 +361,7 @@ public class TracedAccessWorldStateTests(bool parallel)
         {
             tws.SubtractFromBalance(Address.SystemUser, 0u, Spec, out _);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(Address.SystemUser);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(Address.SystemUser);
             Assert.That(ac, Is.Null);
         }
     }
@@ -381,7 +382,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             tws.AddToBalance(TestItem.AddressA, 100, Spec, out UInt256 oldBalance1);
             tws.AddToBalance(TestItem.AddressA, 100, Spec, out UInt256 oldBalance2);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(oldBalance1, Is.EqualTo((UInt256)1000), "first old balance from inner state");
@@ -404,7 +405,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             tws.IncrementNonce(TestItem.AddressA, 1, out UInt256 oldNonce1);
             tws.IncrementNonce(TestItem.AddressA, 1, out UInt256 oldNonce2);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(oldNonce1, Is.EqualTo((UInt256)0), "first old nonce from inner");
@@ -429,7 +430,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             // Second InsertCode should see code1 as old code (from BAL), not empty (from inner)
             tws.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code2), code2, Spec);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);
@@ -453,7 +454,7 @@ public class TracedAccessWorldStateTests(bool parallel)
             tws.Set(cell, [0x01]);
             tws.Set(cell, [0x02]);
 
-            AccountChanges? ac = tws.GetGeneratingBlockAccessList().GetAccountChanges(TestItem.AddressA);
+            AccountChanges? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(ac, Is.Not.Null);

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -18,15 +18,15 @@ using Nethermind.Logging;
 
 namespace Nethermind.State;
 
-public class BlockAccessListBasedWorldState(
-    IWorldState innerWorldState,
-    int blockAccessIndex,
-    ILogManager logManager) : IWorldState
+public class BlockAccessListBasedWorldState(IWorldState innerWorldState, ILogManager logManager) : IWorldState
 {
     protected IWorldState _innerWorldState = innerWorldState;
     private BlockAccessList? _suggestedBlockAccessList;
     private BlockHeader? _suggestedBlockHeader;
+    private int _blockAccessIndex = 0;
     private readonly TransientStorageProvider _transientStorageProvider = new(logManager);
+
+    public void SetBlockAccessIndex(int index) => _blockAccessIndex = index;
 
     public bool IsInScope => _innerWorldState.IsInScope;
     public IWorldStateScopeProvider ScopeProvider => _innerWorldState.ScopeProvider;
@@ -72,11 +72,11 @@ public class BlockAccessListBasedWorldState(
 
             if (slotChanges is not null)
             {
-                return slotChanges.Get(blockAccessIndex);
+                return slotChanges.Get(_blockAccessIndex);
             }
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Storage access for {storageCell.Address} not in block access list at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Storage access for {storageCell.Address} not in block access list at index {_blockAccessIndex}.");
     }
 
     public byte[] GetOriginal(in StorageCell storageCell)
@@ -90,11 +90,11 @@ public class BlockAccessListBasedWorldState(
 
             if (slotChanges is not null)
             {
-                return slotChanges.Get(blockAccessIndex);
+                return slotChanges.Get(_blockAccessIndex);
             }
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Storage access for {storageCell.Address} not in block access list at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Storage access for {storageCell.Address} not in block access list at index {_blockAccessIndex}.");
     }
 
     public void IncrementNonce(Address address, UInt256 delta, out UInt256 oldNonce) => oldNonce = GetNonce(address);
@@ -114,12 +114,12 @@ public class BlockAccessListBasedWorldState(
 
         if (accountChanges is not null)
         {
-            return accountChanges.GetBalance(blockAccessIndex)
+            return accountChanges.GetBalance(_blockAccessIndex)
                 ?? throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader,
-                    $"Suggested block-level access list missing balance for {address} at index {blockAccessIndex}.");
+                    $"Suggested block-level access list missing balance for {address} at index {_blockAccessIndex}.");
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public UInt256 GetNonce(Address address)
@@ -130,12 +130,12 @@ public class BlockAccessListBasedWorldState(
 
         if (accountChanges is not null)
         {
-            return accountChanges.GetNonce(blockAccessIndex)
+            return accountChanges.GetNonce(_blockAccessIndex)
                 ?? throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader,
-                    $"Suggested block-level access list missing nonce for {address} at index {blockAccessIndex}.");
+                    $"Suggested block-level access list missing nonce for {address} at index {_blockAccessIndex}.");
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public ValueHash256 GetCodeHash(Address address)
@@ -146,10 +146,10 @@ public class BlockAccessListBasedWorldState(
 
         if (accountChanges is not null)
         {
-            return accountChanges.GetCodeHash(blockAccessIndex);
+            return accountChanges.GetCodeHash(_blockAccessIndex);
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public byte[]? GetCode(Address address)
@@ -160,10 +160,10 @@ public class BlockAccessListBasedWorldState(
 
         if (accountChanges is not null)
         {
-            return accountChanges.GetCode(blockAccessIndex);
+            return accountChanges.GetCode(_blockAccessIndex);
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public byte[]? GetCode(in ValueHash256 _)
@@ -206,10 +206,10 @@ public class BlockAccessListBasedWorldState(
         if (accountChanges is not null)
         {
             // check if existed before current tx
-            return accountChanges.AccountExists(blockAccessIndex);
+            return accountChanges.AccountExists(_blockAccessIndex);
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public bool IsContract(Address address)
@@ -227,7 +227,7 @@ public class BlockAccessListBasedWorldState(
             return accountChanges.EmptyBeforeBlock;
         }
 
-        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {blockAccessIndex}.");
+        throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
     }
 
     public bool IsDeadAccount(Address address)

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -25,9 +25,10 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     public IWorldStateScopeProvider ScopeProvider => _innerWorldState.ScopeProvider;
     public Hash256 StateRoot => _innerWorldState.StateRoot;
     protected IWorldState _innerWorldState = innerWorldState;
-    private readonly BlockAccessList _generatingBlockAccessList = new();
+    private BlockAccessList? _generatingBlockAccessList;
     private int _systemAccountReadSuppressionDepth;
-    internal BlockAccessList GetGeneratingBlockAccessList() => _generatingBlockAccessList;
+    public BlockAccessList? GetGeneratingBlockAccessList() => _generatingBlockAccessList;
+    public void SetGeneratingBlockAccessList(BlockAccessList? bal) => _generatingBlockAccessList = bal;
 
     public bool HasStateForBlock(BlockHeader? baseBlock)
         => _innerWorldState.HasStateForBlock(baseBlock);
@@ -192,7 +193,10 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         => _generatingBlockAccessList.Index++;
 
     public void Clear()
-        => _generatingBlockAccessList.Clear();
+    {
+        _generatingBlockAccessList.Clear();
+        _systemAccountReadSuppressionDepth = 0;
+    }
 
     public void MergeGeneratingBal(BlockAccessList other)
         => other.Merge(_generatingBlockAccessList);


### PR DESCRIPTION
## Changes

- Reduce allocations by reusing `TracedAccessWorldState`, `BlockAccessListBasedWorldState`, `TransactionProcessor`, `BlockAccessList` instance

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Covered by engine module tests.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
