### PR TITLE
Fix Claude review wip-label-removed trigger

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -120,7 +120,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
+          track_progress: ${{ github.event.action != 'unlabeled' }} # not supported for unlabeled events
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
Fix for #11150

## Changes

- Fixed `track_progress` causing the Claude review workflow to fail when the `wip` label is removed from a PR (`unlabeled` event). The input is now disabled for that action type, which is not supported by `claude-code-action@v1`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
