### PR TITLE
`eth_feeHistory` fixes

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using FluentAssertions;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
@@ -12,10 +13,10 @@ namespace Nethermind.Core.Test.Json;
 [TestFixture]
 public class DoubleArrayConverterTests : ConverterTestBase<double[]>
 {
-    static readonly DoubleArrayConverter converter = new();
+    static readonly DoubleArrayConverter _converter = new();
 
     [TestCaseSource(nameof(RoundtripTestCases))]
-    public void Test_roundtrip(double[] value) => TestConverter(value, static (a, b) => a.AsSpan().SequenceEqual(b), converter);
+    public void Test_roundtrip(double[] value) => TestConverter(value, static (a, b) => a.AsSpan().SequenceEqual(b), _converter);
 
     static IEnumerable<TestCaseData> RoundtripTestCases()
     {
@@ -32,8 +33,8 @@ public class DoubleArrayConverterTests : ConverterTestBase<double[]>
     [TestCase(0.3333333333333333, "[0.3333333333333333]")]
     public void Write_PreservesFullIeee754Precision(double value, string expectedJson)
     {
-        JsonSerializerOptions options = new() { Converters = { converter } };
-        string json = System.Text.Json.JsonSerializer.Serialize(new[] { value }, options);
-        Assert.That(json, Is.EqualTo(expectedJson));
+        JsonSerializerOptions options = new() { Converters = { _converter } };
+        string json = JsonSerializer.Serialize(new[] { value }, options);
+        json.Should().Be(expectedJson, "double array serialization must preserve full IEEE 754 round-trip precision");
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Nethermind.Serialization.Json;
-
 using NUnit.Framework;
 
 namespace Nethermind.Core.Test.Json;
@@ -23,5 +23,17 @@ public class DoubleArrayConverterTests : ConverterTestBase<double[]>
         yield return new TestCaseData(new double[] { 1, 1, 1, 1 }).SetName("All ones");
         yield return new TestCaseData(new double[] { 0, 0, 0, 0 }).SetName("All zeros");
         yield return new TestCaseData(Array.Empty<double>()).SetName("Empty array");
+        yield return new TestCaseData(new double[] { 1.0 / 3.0, 1.0 / 6.0, 0.678584082336891, 0.9985787551520126 }).SetName("Full precision values");
+    }
+
+    [TestCase(0.678584082336891, "[0.678584082336891]")]
+    [TestCase(0.9985787551520126, "[0.9985787551520126]")]
+    [TestCase(0.16666666666666666, "[0.16666666666666666]")]
+    [TestCase(0.3333333333333333, "[0.3333333333333333]")]
+    public void Write_PreservesFullIeee754Precision(double value, string expectedJson)
+    {
+        JsonSerializerOptions options = new() { Converters = { converter } };
+        string json = System.Text.Json.JsonSerializer.Serialize(new[] { value }, options);
+        Assert.That(json, Is.EqualTo(expectedJson));
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Core.Test.Json;
 [TestFixture]
 public class DoubleArrayConverterTests : ConverterTestBase<double[]>
 {
-    static readonly DoubleArrayConverter _converter = new();
+    private static readonly DoubleArrayConverter _converter = new();
 
     [TestCaseSource(nameof(RoundtripTestCases))]
     public void Test_roundtrip(double[] value) => TestConverter(value, static (a, b) => a.AsSpan().SequenceEqual(b), _converter);

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Text.Json;
+using FluentAssertions;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
@@ -24,7 +25,7 @@ public class DoubleConverterTests
     public void Write_PreservesFullIeee754Precision(double value, string expected)
     {
         string json = JsonSerializer.Serialize(value, Options);
-        Assert.That(json, Is.EqualTo(expected));
+        json.Should().Be(expected, "double serialization must preserve full IEEE 754 round-trip precision");
     }
 
     [TestCase(0.678584082336891)]
@@ -35,6 +36,6 @@ public class DoubleConverterTests
     {
         string json = JsonSerializer.Serialize(value, Options);
         double deserialized = JsonSerializer.Deserialize<double>(json, Options);
-        Assert.That(deserialized, Is.EqualTo(value));
+        deserialized.Should().Be(value, "deserialization must recover the original double value exactly");
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
@@ -11,9 +11,9 @@ namespace Nethermind.Core.Test.Json;
 [TestFixture]
 public class DoubleConverterTests
 {
-    static readonly DoubleConverter _converter = new();
+    private static readonly DoubleConverter _converter = new();
 
-    static readonly JsonSerializerOptions Options = new() { Converters = { _converter } };
+    private static readonly JsonSerializerOptions Options = new() { Converters = { _converter } };
 
     [TestCase(0.678584082336891, "0.678584082336891")]
     [TestCase(0.9985787551520126, "0.9985787551520126")]

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
@@ -13,7 +13,7 @@ public class DoubleConverterTests
 {
     static readonly DoubleConverter _converter = new();
 
-    static JsonSerializerOptions Options => new() { Converters = { _converter } };
+    static readonly JsonSerializerOptions Options = new() { Converters = { _converter } };
 
     [TestCase(0.678584082336891, "0.678584082336891")]
     [TestCase(0.9985787551520126, "0.9985787551520126")]

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleConverterTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.Json;
+using Nethermind.Serialization.Json;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Json;
+
+[TestFixture]
+public class DoubleConverterTests
+{
+    static readonly DoubleConverter _converter = new();
+
+    static JsonSerializerOptions Options => new() { Converters = { _converter } };
+
+    [TestCase(0.678584082336891, "0.678584082336891")]
+    [TestCase(0.9985787551520126, "0.9985787551520126")]
+    [TestCase(0.16666666666666666, "0.16666666666666666")]
+    [TestCase(0.3333333333333333, "0.3333333333333333")]
+    [TestCase(0.0105, "0.0105")]
+    [TestCase(0.0, "0")]
+    [TestCase(1.0, "1")]
+    public void Write_PreservesFullIeee754Precision(double value, string expected)
+    {
+        string json = JsonSerializer.Serialize(value, Options);
+        Assert.That(json, Is.EqualTo(expected));
+    }
+
+    [TestCase(0.678584082336891)]
+    [TestCase(0.9985787551520126)]
+    [TestCase(0.16666666666666666)]
+    [TestCase(0.3333333333333333)]
+    public void Roundtrip_PreservesValue(double value)
+    {
+        string json = JsonSerializer.Serialize(value, Options);
+        double deserialized = JsonSerializer.Deserialize<double>(json, Options);
+        Assert.That(deserialized, Is.EqualTo(value));
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -216,6 +216,17 @@ public class JsonRpcServiceTests
         Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.InvalidParams));
     }
 
+    [TestCase("eth_getBlockByNumber", new object?[] { }, "missing value for required argument 0", TestName = "FirstArgOmitted")]
+    [TestCase("eth_feeHistory", new object?[] { "0x1", "latest" }, "missing value for required argument 2", TestName = "LaterArgOmitted")]
+    public void MissingRequiredArgument_ReturnsGethStyleError(string method, object?[] parameters, string expectedMessage)
+    {
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        JsonRpcErrorResponse? response = TestRequest(ethRpcModule, method, parameters) as JsonRpcErrorResponse;
+        Assert.That(response?.Error?.Code, Is.EqualTo(ErrorCodes.InvalidParams));
+        Assert.That(response?.Error?.Message, Is.EqualTo(expectedMessage));
+        Assert.That(response?.Error?.Data, Is.Null);
+    }
+
     [Test]
     public void IncorrectMethodNameTest()
     {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -396,7 +396,7 @@ public class AdminModuleTests
     public async Task No_subscription_name_admin()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe");
-        string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params\",\"data\":\"Incorrect parameters count, expected: 2, actual: 0\"},\"id\":67}";
+        string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"missing value for required argument 0\"},\"id\":67}";
         expectedResult.Should().Be(serialized);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -107,7 +107,7 @@ public partial class EthRpcModuleTests
     {
         using Context ctx = await Context.Create();
         string serialized = await ctx.Test.TestEthRpc("eth_feeHistory", "0x1", "latest");
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params\"},\"id\":67}"));
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"missing value for required argument 2\"},\"id\":67}"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -103,6 +103,14 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task EthFeeHistory_WhenRewardPercentilesIsMissing_ReturnsInvalidParams()
+    {
+        using Context ctx = await Context.Create();
+        string serialized = await ctx.Test.TestEthRpc("eth_feeHistory", "0x1", "latest");
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params\"},\"id\":67}"));
+    }
+
+    [Test]
     public async Task Eth_get_transaction_by_block_hash_and_index()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
@@ -102,8 +102,8 @@ namespace Nethermind.JsonRpc.Test.Modules
             resultWrapper.Result.ResultType.Should().Be(ResultType.Failure);
         }
 
-        [TestCase(new double[] { -1, 1, 2 })]
-        [TestCase(new[] { 1, 2.2, 101, 102 })]
+        [TestCase(new double[] { -1, 1, 2 }, TestName = "NegativePercentile")]
+        [TestCase(new[] { 1, 2.2, 101, 102 }, TestName = "PercentileOver100")]
         public void GetFeeHistory_IfRewardPercentilesContainInvalidNumber_ResultsInFailure(double[] rewardPercentiles)
         {
             int blockCount = 10;
@@ -217,7 +217,6 @@ namespace Nethermind.JsonRpc.Test.Modules
         [TestCase(5, 3, 0)]
         public void GetFeeHistory_GivenValidInputs_FirstBlockNumberCalculatedCorrectly(int blockCount, long newestBlockNumber, long expectedOldestBlockNumber)
         {
-            // BlockParameter lastBlockNumber = new(newestBlockNumber);
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             const BlockTreeLookupOptions options = BlockTreeLookupOptions.ExcludeTxHashes |
                                                    BlockTreeLookupOptions.TotalDifficultyNotNeeded |

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
+using Nethermind.Evm;
 using Nethermind.Specs.Forks;
 using NSubstitute;
 using NUnit.Framework;
@@ -451,6 +452,50 @@ namespace Nethermind.JsonRpc.Test.Modules
                     GetSubstitutedFeeHistoryOracle(blockTree: blockTree, receiptStorage: receiptStorage, spec: spec);
                 return feeHistoryOracle1;
             }
+        }
+
+        [Test]
+        public void GetFeeHistory_BaseFeePerBlobGasNewestPlusOne_UsesNextBlockEstimate()
+        {
+            // The last entry of baseFeePerBlobGas (index = blockCount) is the NEXT block's
+            // estimated fee — derived from CalculateExcessBlobGas(newestBlock.Header), not the current fee.
+            // Use large excess so the fake-exponential produces a fee well above MinBlobGasPrice,
+            // ensuring current and next are numerically distinct after BlobGasUsed=0 reduces excess.
+            const BlockTreeLookupOptions options = BlockTreeLookupOptions.ExcludeTxHashes |
+                                                   BlockTreeLookupOptions.TotalDifficultyNotNeeded |
+                                                   BlockTreeLookupOptions.DoNotCreateLevelIfMissing;
+
+            IReleaseSpec spec = Cancun.Instance;
+            ulong excessBlobGas = spec.GasCosts.MaxBlobGasPerBlock * 16;
+            Block block = Build.A.Block.Genesis
+                .WithBaseFeePerGas(1)
+                .WithGasUsed(1).WithGasLimit(10)
+                .WithBlobGasUsed(0)
+                .WithExcessBlobGas(excessBlobGas)
+                .TestObject;
+
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            blockTree.FindBlock(Arg.Any<BlockParameter>()).Returns(block);
+            blockTree.Head.Returns(block);
+            blockTree.FindBlock(block.Hash!, options, block.Number).Returns(block);
+
+            ISpecProvider specProvider = SpecProviderSubstitute.Create();
+            specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+            specProvider.GetSpec(Arg.Any<ForkActivation>()).BaseFeeCalculator.Returns(new DefaultBaseFeeCalculator());
+
+            FeeHistoryOracle oracle = new(blockTree, Substitute.For<IReceiptStorage>(), specProvider);
+            using ResultWrapper<FeeHistoryResults> result = oracle.GetFeeHistory(1, new BlockParameter(0L), []);
+
+            ArrayPoolList<UInt256> fees = result.Data.BaseFeePerBlobGas;
+            fees.Count.Should().Be(2, "blockCount + 1 entries");
+
+            BlobGasCalculator.TryCalculateFeePerBlobGas(excessBlobGas, spec.BlobBaseFeeUpdateFraction, out UInt256 expectedCurrentFee);
+            fees[0].Should().Be(expectedCurrentFee, "index 0 is the current block's blob base fee");
+
+            ulong nextExcess = BlobGasCalculator.CalculateExcessBlobGas(block.Header, spec) ?? 0;
+            BlobGasCalculator.TryCalculateFeePerBlobGas(nextExcess, spec.BlobBaseFeeUpdateFraction, out UInt256 expectedNextFee);
+            fees[1].Should().Be(expectedNextFee, "index 1 is the next block's estimated blob base fee");
+            fees[1].Should().BeLessThan(fees[0], "next fee must be lower since BlobGasUsed=0 reduces excess blob gas");
         }
 
         private static FeeHistoryOracle GetSubstitutedFeeHistoryOracle(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             blockTree.FindBlock(Arg.Any<long>()).Returns((Block?)null);
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
-            ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Block is not available", ErrorCodes.ResourceUnavailable);
+            ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("upstream does not have the requested block yet", ErrorCodes.InternalError);
 
             using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter((long)0), []);
             resultWrapper.Should().BeEquivalentTo(expected);
@@ -66,7 +66,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             blockTree.FindPendingBlock().Returns(Build.A.Block.WithNumber(pendingBlockNumber).TestObject);
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
-            ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Block is not available", ErrorCodes.ResourceUnavailable);
+            ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("upstream does not have the requested block yet", ErrorCodes.InternalError);
 
             using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter(lastBlockNumber), []);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/FeeHistoryOracleTests.cs
@@ -30,7 +30,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle();
             ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("blockCount: Value 0 is less than 1", ErrorCodes.InvalidParams);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(0, BlockParameter.Latest);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(0, BlockParameter.Latest, []);
             resultWrapper.Should().BeEquivalentTo(expected);
         }
 
@@ -40,7 +40,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle();
             ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Is not correct block number", ErrorCodes.InvalidParams);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(0, new BlockParameter(TestItem.KeccakA));
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(0, new BlockParameter(TestItem.KeccakA), []);
             resultWrapper.Should().BeEquivalentTo(expected);
         }
 
@@ -52,7 +52,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
             ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Block is not available", ErrorCodes.ResourceUnavailable);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter((long)0));
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter((long)0), []);
             resultWrapper.Should().BeEquivalentTo(expected);
         }
 
@@ -67,7 +67,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
             ResultWrapper<FeeHistoryResults> expected = ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Block is not available", ErrorCodes.ResourceUnavailable);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter(lastBlockNumber));
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, new BlockParameter(lastBlockNumber), []);
 
             resultWrapper.Should().BeEquivalentTo(expected);
         }
@@ -134,7 +134,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree, specProvider: specProvider);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(blockCount, newestBlock);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(blockCount, newestBlock, []);
 
             UInt256 resultNextBaseFee = resultWrapper.Data.BaseFeePerGas[1];
             UInt256 resultBaseFee = resultWrapper.Data.BaseFeePerGas[0];
@@ -160,7 +160,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             ISpecProvider specProvider = GetSpecProviderWithEip1559EnabledAs(true);
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree, specProvider: specProvider);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, newestBlock);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, newestBlock, []);
 
             resultWrapper.Data.GasUsedRatio![0].Should().Be(expectedGasUsedRatio);
         }
@@ -177,23 +177,22 @@ namespace Nethermind.JsonRpc.Test.Modules
             blockTree.FindBlock(newestBlock).Returns(headBlock);
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree, specProvider: specProvider);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, newestBlock);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, newestBlock, []);
 
             resultWrapper.Data.BaseFeePerGas![1].Should().Be((UInt256)expectedNextBaseFee);
             resultWrapper.Data.BaseFeePerGas![0].Should().Be((UInt256)baseFee);
         }
 
-        [TestCase(null)]
-        [TestCase(new double[] { })]
-        public void GetFeeHistory_IfRewardPercentilesIsNullOrEmpty_RewardsIsNull(double[]? rewardPercentiles)
+        [Test]
+        public void GetFeeHistory_IfRewardPercentilesIsEmpty_RewardsIsNull()
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             blockTree.FindBlock(BlockParameter.Latest).Returns(Build.A.Block.TestObject);
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, BlockParameter.Latest, rewardPercentiles);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(1, BlockParameter.Latest, []);
 
-            resultWrapper.Data.Reward.Should().BeNull();
+            resultWrapper.Data.Reward.Should().BeNull("an empty rewardPercentiles array means no reward computation was requested");
         }
 
         [TestCase(5, new ulong[] { 0, 0, 0, 0, 0 })]
@@ -245,7 +244,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
 
-            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(blockCount, newestBlockParameter);
+            using ResultWrapper<FeeHistoryResults> resultWrapper = feeHistoryOracle.GetFeeHistory(blockCount, newestBlockParameter, []);
 
             resultWrapper.Data.OldestBlock.Should().Be(expectedOldestBlockNumber);
         }
@@ -261,7 +260,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
 
             using ResultWrapper<FeeHistoryResults> resultWrapper =
-                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Pending);
+                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Pending, []);
 
             resultWrapper.Data.OldestBlock.Should().Be(lastBlockNumberExpected);
         }
@@ -277,7 +276,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
 
             using ResultWrapper<FeeHistoryResults> resultWrapper =
-                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Latest);
+                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Latest, []);
 
             resultWrapper.Data.OldestBlock.Should().Be(lastBlockNumberExpected);
         }
@@ -290,7 +289,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             FeeHistoryOracle feeHistoryOracle = GetSubstitutedFeeHistoryOracle(blockTree: blockTree);
 
             using ResultWrapper<FeeHistoryResults> resultWrapper =
-                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Earliest);
+                feeHistoryOracle.GetFeeHistory(1, BlockParameter.Earliest, []);
 
             resultWrapper.Data.OldestBlock.Should().Be(0);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -265,7 +265,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public async Task No_subscription_name()
         {
             string serialized = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe");
-            string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params\",\"data\":\"Incorrect parameters count, expected: 2, actual: 0\"},\"id\":67}";
+            string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"missing value for required argument 0\"},\"id\":67}";
             expectedResult.Should().Be(serialized);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -199,6 +199,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         if (missingParamsCount != 0)
         {
             bool hasIncorrectParameters = true;
+            int firstMissingRequiredIndex = -1;
             if (missingParamsCount > 0)
             {
                 hasIncorrectParameters = false;
@@ -215,9 +216,10 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                     {
                         explicitNullableParamsCount += 1;
                     }
-                    if (!method.ExpectedParameters[method.ExpectedParameters.Length - missingParamsCount + i].IsOptional && !nullable)
+                    if (!method.ExpectedParameters[parameterIndex].IsOptional && !nullable)
                     {
                         hasIncorrectParameters = true;
+                        firstMissingRequiredIndex = parameterIndex;
                         break;
                     }
                 }
@@ -225,7 +227,10 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
             if (hasIncorrectParameters)
             {
-                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", $"Incorrect parameters count, expected: {method.ExpectedParameters.Length}, actual: {method.ExpectedParameters.Length - missingParamsCount}", request.Id);
+                string message = firstMissingRequiredIndex >= 0
+                    ? $"missing value for required argument {firstMissingRequiredIndex}"
+                    : "Invalid params";
+                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, request.Id);
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -127,7 +127,7 @@ public partial class EthRpcModule(
         return ResultWrapper<UInt256?>.Success(gasPriceWithBaseFee);
     }
 
-    public ResultWrapper<FeeHistoryResults> eth_feeHistory(int blockCount, BlockParameter newestBlock, double[]? rewardPercentiles = null) => _feeHistoryOracle.GetFeeHistory(blockCount, newestBlock, rewardPercentiles);
+    public ResultWrapper<FeeHistoryResults> eth_feeHistory(int blockCount, BlockParameter newestBlock, double[] rewardPercentiles) => _feeHistoryOracle.GetFeeHistory(blockCount, newestBlock, rewardPercentiles);
 
     public ResultWrapper<IEnumerable<Address>> eth_accounts()
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -293,7 +293,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
             foreach (double percentile in rewardPercentiles)
             {
                 double thresholdGasUsed = (ulong)(blockInfo.GasUsed * percentile / 100);
-                while (txIndex < rewardsInBlock.Count && sumGasUsed < thresholdGasUsed)
+                while (txIndex + 1 < rewardsInBlock.Count && sumGasUsed < thresholdGasUsed)
                 {
                     txIndex++;
                     sumGasUsed += rewardsInBlock[txIndex].GasUsed;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -169,8 +169,8 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 
             if (historyInfo is null)
             {
-                return ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Block is not available",
-                    ErrorCodes.ResourceUnavailable);
+                return ResultWrapper<FeeHistoryResults>.Fail("upstream does not have the requested block yet",
+                    ErrorCodes.InternalError);
             }
 
             BlockFeeHistorySearchInfo info = historyInfo.Value;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -63,6 +63,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
             UInt256 BlockBaseFeePerGas,
             UInt256 BaseFeePerGasEst,
             UInt256 BaseFeePerBlobGas,
+            UInt256 BaseFeePerBlobGasEst,
             double GasUsedRatio,
             double BlobGasUsedRatio,
             Hash256? ParentHash,
@@ -105,24 +106,28 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
         // As time passes and the head progresses only older least used blocks are auto removed from the cache
         private BlockFeeHistorySearchInfo? SaveHistorySearchInfo(Block block)
         {
-            double CalculateBlobGasUsedRatio(Block b, out UInt256 feePerBlobGas)
-            {
-                IReleaseSpec spec = _specProvider.GetSpec(b.Header);
-                BlobGasCalculator.TryCalculateFeePerBlobGas(b.Header, spec.BlobBaseFeeUpdateFraction, out feePerBlobGas);
-
-                ulong maxBlobGasPerBlock = spec.GasCosts.MaxBlobGasPerBlock;
-                return maxBlobGasPerBlock == 0 ? 0 : (b.BlobGasUsed ?? 0) / (double)maxBlobGasPerBlock;
-            }
-
             BlockFeeHistorySearchInfo BlockFeeHistorySearchInfoFromBlock(Block b)
             {
-                double blobGasUsedRatio = CalculateBlobGasUsedRatio(b, out UInt256 feePerBlobGas);
+                IReleaseSpec spec = _specProvider.GetSpec(b.Header);
+                BlobGasCalculator.TryCalculateFeePerBlobGas(b.Header, spec.BlobBaseFeeUpdateFraction, out UInt256 feePerBlobGas);
+                ulong maxBlobGasPerBlock = spec.GasCosts.MaxBlobGasPerBlock;
+                double blobGasUsedRatio = maxBlobGasPerBlock == 0 ? 0 : (b.BlobGasUsed ?? 0) / (double)maxBlobGasPerBlock;
+
+                UInt256 nextFeePerBlobGas = UInt256.Zero;
+                if (b.Header.ExcessBlobGas.HasValue)
+                {
+                    ulong nextExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(b.Header, spec) ?? 0;
+                    BlobGasCalculator.TryCalculateFeePerBlobGas(nextExcessBlobGas, spec.BlobBaseFeeUpdateFraction, out nextFeePerBlobGas);
+                    if (nextFeePerBlobGas == UInt256.MaxValue)
+                        nextFeePerBlobGas = UInt256.Zero;
+                }
 
                 return new(
                     b.Number,
                     b.BaseFeePerGas,
                     BaseFeeCalculator.Calculate(b.Header, _specProvider.GetSpecFor1559(b.Number + 1)),
                     feePerBlobGas == UInt256.MaxValue ? UInt256.Zero : feePerBlobGas,
+                    nextFeePerBlobGas,
                     b.GasUsed / (double)b.GasLimit,
                     blobGasUsedRatio,
                     b.ParentHash,
@@ -182,7 +187,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 
             long oldestBlockNumber = info.BlockNumber;
             baseFeePerGas[effectiveBlockCount] = info.BaseFeePerGasEst;
-            baseFeePerBlobGas[effectiveBlockCount] = info.BaseFeePerBlobGas;
+            baseFeePerBlobGas[effectiveBlockCount] = info.BaseFeePerBlobGasEst;
 
             while (historyInfo is not null && effectiveBlockCount-- > 0)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -147,9 +147,15 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
         public ResultWrapper<FeeHistoryResults> GetFeeHistory(
             int blockCount,
             BlockParameter newestBlock,
-            double[]? rewardPercentiles = null)
+            double[]? rewardPercentiles)
         {
-            ResultWrapper<FeeHistoryResults> initialCheckResult = Validate(ref blockCount, newestBlock, rewardPercentiles);
+            if (rewardPercentiles is null)
+                return ResultWrapper<FeeHistoryResults>.Fail("missing value for required argument 2", ErrorCodes.InvalidParams);
+
+            if (blockCount > MaxBlockCount)
+                blockCount = MaxBlockCount;
+
+            ResultWrapper<FeeHistoryResults> initialCheckResult = Validate(blockCount, newestBlock, rewardPercentiles);
             if (initialCheckResult.Result.ResultType == ResultType.Failure)
             {
                 return initialCheckResult;
@@ -172,7 +178,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
             ArrayPoolList<UInt256> baseFeePerBlobGas = new(tempBlockCount, tempBlockCount);
             ArrayPoolList<double> gasUsedRatio = new(effectiveBlockCount, effectiveBlockCount);
             ArrayPoolList<double> blobGasUsedRatio = new(effectiveBlockCount, effectiveBlockCount);
-            ArrayPoolList<ArrayPoolList<UInt256>>? rewards = rewardPercentiles?.Length > 0
+            ArrayPoolList<ArrayPoolList<UInt256>>? rewards = rewardPercentiles.Length > 0
                 ? new ArrayPoolList<ArrayPoolList<UInt256>>(effectiveBlockCount, effectiveBlockCount)
                 : null;
 
@@ -232,9 +238,16 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 
         private static ArrayPoolList<UInt256>? CalculateRewardsPercentiles(
             BlockFeeHistorySearchInfo blockInfo,
-            double[] rewardPercentiles) => blockInfo.BlockTransactionsLength == 0
-                ? new ArrayPoolList<UInt256>(rewardPercentiles.Length, Enumerable.Repeat(UInt256.Zero, rewardPercentiles.Length))
-                : CalculatePercentileValues(blockInfo, rewardPercentiles, blockInfo.RewardsInBlocks);
+            double[] rewardPercentiles)
+        {
+            if (blockInfo.BlockTransactionsLength != 0)
+                return CalculatePercentileValues(blockInfo, rewardPercentiles, blockInfo.RewardsInBlocks);
+
+            ArrayPoolList<UInt256> zeros = new(rewardPercentiles.Length);
+            for (int i = 0; i < rewardPercentiles.Length; i++)
+                zeros.Add(UInt256.Zero);
+            return zeros;
+        }
 
         private List<RewardInfo> GetRewardsInBlock(Block block)
         {
@@ -294,51 +307,44 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
             return percentileValues;
         }
 
-        private static ResultWrapper<FeeHistoryResults> Validate(ref int blockCount, BlockParameter newestBlock, double[]? rewardPercentiles)
+        private static ResultWrapper<FeeHistoryResults> Validate(int blockCount, BlockParameter newestBlock, double[] rewardPercentiles)
         {
             if (newestBlock.Type == BlockParameterType.BlockHash)
             {
                 return ResultWrapper<FeeHistoryResults>.Fail("newestBlock: Is not correct block number", ErrorCodes.InvalidParams);
             }
 
-            switch (blockCount)
+            if (blockCount < 1)
             {
-                case < 1:
-                    return ResultWrapper<FeeHistoryResults>.Fail($"blockCount: Value {blockCount} is less than 1", ErrorCodes.InvalidParams);
-                case > MaxBlockCount:
-                    blockCount = MaxBlockCount;
-                    break;
+                return ResultWrapper<FeeHistoryResults>.Fail($"blockCount: Value {blockCount} is less than 1", ErrorCodes.InvalidParams);
             }
 
-            if (rewardPercentiles is not null)
+            if (rewardPercentiles.Length > RewardPercentilesLengthLimit)
             {
-                if (rewardPercentiles.Length > RewardPercentilesLengthLimit)
+                return ResultWrapper<FeeHistoryResults>.Fail(
+                    $"rewardPercentiles: {rewardPercentiles.Length} is over the query limit {RewardPercentilesLengthLimit}.",
+                    ErrorCodes.InvalidParams);
+            }
+
+            double previousPercentile = -1;
+            for (int i = 0; i < rewardPercentiles.Length; i++)
+            {
+                double currentPercentile = rewardPercentiles[i];
+                if (currentPercentile is > 100 or < 0)
                 {
                     return ResultWrapper<FeeHistoryResults>.Fail(
-                        $"rewardPercentiles: {rewardPercentiles.Length} is over the query limit {RewardPercentilesLengthLimit}.",
+                        "rewardPercentiles: Some values are below 0 or greater than 100.",
                         ErrorCodes.InvalidParams);
                 }
 
-                double previousPercentile = -1;
-                for (int i = 0; i < rewardPercentiles.Length; i++)
+                if (currentPercentile <= previousPercentile)
                 {
-                    double currentPercentile = rewardPercentiles[i];
-                    if (currentPercentile is > 100 or < 0)
-                    {
-                        return ResultWrapper<FeeHistoryResults>.Fail(
-                            "rewardPercentiles: Some values are below 0 or greater than 100.",
-                            ErrorCodes.InvalidParams);
-                    }
-
-                    if (currentPercentile <= previousPercentile)
-                    {
-                        return ResultWrapper<FeeHistoryResults>.Fail(
-                            $"rewardPercentiles: Value at index {i}: {currentPercentile} is less than or equal to the value at previous index {i - 1}: {rewardPercentiles[i - 1]}.",
-                            ErrorCodes.InvalidParams);
-                    }
-
-                    previousPercentile = currentPercentile;
+                    return ResultWrapper<FeeHistoryResults>.Fail(
+                        $"rewardPercentiles: Value at index {i}: {currentPercentile} is less than or equal to the value at previous index {i - 1}: {rewardPercentiles[i - 1]}.",
+                        ErrorCodes.InvalidParams);
                 }
+
+                previousPercentile = currentPercentile;
             }
 
             return _success;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -149,6 +149,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
             BlockParameter newestBlock,
             double[] rewardPercentiles)
         {
+            ArgumentNullException.ThrowIfNull(rewardPercentiles);
             if (blockCount > MaxBlockCount)
                 blockCount = MaxBlockCount;
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -116,9 +116,10 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 UInt256 nextFeePerBlobGas = UInt256.Zero;
                 if (b.Header.ExcessBlobGas.HasValue)
                 {
+                    // Uses parent-block spec for BlobBaseFeeUpdateFraction, matching Geth's feehistory.go.
+                    // At hard-fork boundaries this is one block off, but it is intentional for compatibility.
                     ulong nextExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(b.Header, spec) ?? 0;
-                    BlobGasCalculator.TryCalculateFeePerBlobGas(nextExcessBlobGas, spec.BlobBaseFeeUpdateFraction, out nextFeePerBlobGas);
-                    if (nextFeePerBlobGas == UInt256.MaxValue)
+                    if (!BlobGasCalculator.TryCalculateFeePerBlobGas(nextExcessBlobGas, spec.BlobBaseFeeUpdateFraction, out nextFeePerBlobGas))
                         nextFeePerBlobGas = UInt256.Zero;
                 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -22,7 +22,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 {
     public class FeeHistoryOracle : IFeeHistoryOracle, IDisposable
     {
-        private static readonly ResultWrapper<FeeHistoryResults> _success = ResultWrapper<FeeHistoryResults>.Success(null);
+        private static readonly ResultWrapper<FeeHistoryResults> _validationPassed = ResultWrapper<FeeHistoryResults>.Success(null);
         private const int MaxBlockCount = 1024;
         private const int RewardPercentilesLengthLimit = 100;
         private readonly int _oldestBlockDistanceFromHeadAllowedInCache;
@@ -147,11 +147,8 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
         public ResultWrapper<FeeHistoryResults> GetFeeHistory(
             int blockCount,
             BlockParameter newestBlock,
-            double[]? rewardPercentiles)
+            double[] rewardPercentiles)
         {
-            if (rewardPercentiles is null)
-                return ResultWrapper<FeeHistoryResults>.Fail("missing value for required argument 2", ErrorCodes.InvalidParams);
-
             if (blockCount > MaxBlockCount)
                 blockCount = MaxBlockCount;
 
@@ -347,7 +344,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 previousPercentile = currentPercentile;
             }
 
-            return _success;
+            return _validationPassed;
         }
 
         public void Dispose() => _blockTree.BlockAddedToMain -= OnBlockAddedToMain;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -113,15 +113,13 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 ulong maxBlobGasPerBlock = spec.GasCosts.MaxBlobGasPerBlock;
                 double blobGasUsedRatio = maxBlobGasPerBlock == 0 ? 0 : (b.BlobGasUsed ?? 0) / (double)maxBlobGasPerBlock;
 
-                UInt256 nextFeePerBlobGas = UInt256.Zero;
-                if (b.Header.ExcessBlobGas.HasValue)
-                {
-                    // Uses parent-block spec for BlobBaseFeeUpdateFraction, matching Geth's feehistory.go.
-                    // At hard-fork boundaries this is one block off, but it is intentional for compatibility.
-                    ulong nextExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(b.Header, spec) ?? 0;
-                    if (!BlobGasCalculator.TryCalculateFeePerBlobGas(nextExcessBlobGas, spec.BlobBaseFeeUpdateFraction, out nextFeePerBlobGas))
-                        nextFeePerBlobGas = UInt256.Zero;
-                }
+                // Uses parent-block spec for BlobBaseFeeUpdateFraction, matching Geth's feehistory.go.
+                // At hard-fork boundaries this is one block off, but it is intentional for compatibility.
+                UInt256 nextFeePerBlobGas =
+                    b.Header.ExcessBlobGas.HasValue &&
+                    BlobGasCalculator.TryCalculateFeePerBlobGas(BlobGasCalculator.CalculateExcessBlobGas(b.Header, spec) ?? 0, spec.BlobBaseFeeUpdateFraction, out UInt256 fee)
+                    ? fee
+                    : UInt256.Zero;
 
                 return new(
                     b.Number,
@@ -242,16 +240,9 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 
         private static ArrayPoolList<UInt256>? CalculateRewardsPercentiles(
             BlockFeeHistorySearchInfo blockInfo,
-            double[] rewardPercentiles)
-        {
-            if (blockInfo.BlockTransactionsLength != 0)
-                return CalculatePercentileValues(blockInfo, rewardPercentiles, blockInfo.RewardsInBlocks);
-
-            ArrayPoolList<UInt256> zeros = new(rewardPercentiles.Length);
-            for (int i = 0; i < rewardPercentiles.Length; i++)
-                zeros.Add(UInt256.Zero);
-            return zeros;
-        }
+            double[] rewardPercentiles) => blockInfo.BlockTransactionsLength == 0
+                ? new ArrayPoolList<UInt256>(rewardPercentiles.Length, rewardPercentiles.Length)
+                : CalculatePercentileValues(blockInfo, rewardPercentiles, blockInfo.RewardsInBlocks);
 
         private List<RewardInfo> GetRewardsInBlock(Block block)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/IFeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/IFeeHistoryOracle.cs
@@ -7,6 +7,6 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
 {
     public interface IFeeHistoryOracle
     {
-        ResultWrapper<FeeHistoryResults> GetFeeHistory(int blockCount, BlockParameter newestBlock, double[]? rewardPercentiles);
+        ResultWrapper<FeeHistoryResults> GetFeeHistory(int blockCount, BlockParameter newestBlock, double[] rewardPercentiles);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/IFeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/IFeeHistoryOracle.cs
@@ -8,6 +8,5 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
     public interface IFeeHistoryOracle
     {
         ResultWrapper<FeeHistoryResults> GetFeeHistory(int blockCount, BlockParameter newestBlock, double[]? rewardPercentiles);
-
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -50,7 +50,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             Description = "Returns block fee history.",
             IsSharable = true,
             ExampleResponse = "{\"baseFeePerGas\": [\"0x116c1cbb03\", \"0x10c3714c06\"], \"gasUsedRatio\": [0.3487305666666667, 0.3], \"oldestBlock\": \"0xc7e5ff\", \"reward\": [[\"0x3b9aca00\",\"0x3b9aca00\"], [\"0x0\",\"0x3bb24dfa\"]]}")]
-        ResultWrapper<FeeHistoryResults> eth_feeHistory(int blockCount, BlockParameter newestBlock, double[]? rewardPercentiles = null);
+        ResultWrapper<FeeHistoryResults> eth_feeHistory(int blockCount, BlockParameter newestBlock, double[] rewardPercentiles);
 
         [JsonRpcMethod(IsImplemented = false, Description = "Returns full state snapshot", IsSharable = true)]
         ResultWrapper<byte[]> eth_snapshot();

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Nethermind.Core.Collections;
+
+namespace Nethermind.Serialization.Json
+{
+    public class DoubleArrayConverter : JsonConverter<double[]>
+    {
+        public override double[] Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                string? s = reader.GetString();
+                if (s is null) throw new JsonException("Expected a JSON array string, got null.");
+                return JsonSerializer.Deserialize<double[]>(s, options)
+                    ?? throw new JsonException($"Could not deserialize double array from string: {s}");
+            }
+
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException();
+            }
+            using ArrayPoolListRef<double> values = new(16);
+            while (reader.Read() && reader.TokenType == JsonTokenType.Number)
+            {
+                values.Add(reader.GetDouble());
+            }
+            if (reader.TokenType != JsonTokenType.EndArray)
+            {
+                throw new JsonException();
+            }
+
+            if (values.Count == 0) return [];
+
+            double[] result = new double[values.Count];
+            values.CopyTo(result, 0);
+            return result;
+        }
+
+        [SkipLocalsInit]
+        public override void Write(
+            Utf8JsonWriter writer,
+            double[] values,
+            JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (double value in values)
+            {
+                writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
+            }
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Serialization.Json
             {
                 string s = reader.GetString();
                 if (s is null) throw new JsonException("Expected a JSON array string, got null.");
-                return JsonSerializer.Deserialize<double[]>(s, options)
+                return JsonSerializer.Deserialize<double[]>(s)
                     ?? throw new JsonException($"Could not deserialize double array from string: {s}");
             }
 
@@ -55,6 +55,8 @@ namespace Nethermind.Serialization.Json
             writer.WriteStartArray();
             foreach (double value in values)
             {
+                if (double.IsNaN(value) || double.IsInfinity(value))
+                    throw new JsonException($"The value '{value}' is not a valid JSON number.");
                 writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
             }
             writer.WriteEndArray();

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -20,24 +21,21 @@ namespace Nethermind.Serialization.Json
             if (reader.TokenType == JsonTokenType.String)
             {
                 string s = reader.GetString();
-                if (s is null) throw new JsonException("Expected a JSON array string, got null.");
+                if (s is null) ThrowExpectedArrayString();
                 return JsonSerializer.Deserialize<double[]>(s)
                     ?? throw new JsonException($"Could not deserialize double array from string: {s}");
             }
 
             if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                throw new JsonException();
-            }
+                ThrowExpectedStartArray();
+
             using ArrayPoolListRef<double> values = new(16);
             while (reader.Read() && reader.TokenType == JsonTokenType.Number)
             {
                 values.Add(reader.GetDouble());
             }
             if (reader.TokenType != JsonTokenType.EndArray)
-            {
-                throw new JsonException();
-            }
+                ThrowExpectedEndArray();
 
             if (values.Count == 0) return [];
 
@@ -56,10 +54,26 @@ namespace Nethermind.Serialization.Json
             foreach (double value in values)
             {
                 if (double.IsNaN(value) || double.IsInfinity(value))
-                    throw new JsonException($"The value '{value}' is not a valid JSON number.");
+                    ThrowNotFiniteJsonException(value);
                 writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
             }
             writer.WriteEndArray();
         }
+
+        [DoesNotReturn]
+        private static void ThrowExpectedArrayString() =>
+            throw new JsonException("Expected a JSON array string, got null.");
+
+        [DoesNotReturn]
+        private static void ThrowExpectedStartArray() =>
+            throw new JsonException("Expected start of JSON array.");
+
+        [DoesNotReturn]
+        private static void ThrowExpectedEndArray() =>
+            throw new JsonException("Expected end of JSON array.");
+
+        [DoesNotReturn]
+        private static void ThrowNotFiniteJsonException(double value) =>
+            throw new JsonException($"The value '{value}' is not a valid JSON number.");
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Serialization.Json
         {
             if (reader.TokenType == JsonTokenType.String)
             {
-                string? s = reader.GetString();
+                string s = reader.GetString();
                 if (s is null) throw new JsonException("Expected a JSON array string, got null.");
                 return JsonSerializer.Deserialize<double[]>(s, options)
                     ?? throw new JsonException($"Could not deserialize double array from string: {s}");

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Nethermind.Serialization.Json
 {
-    using Nethermind.Core.Collections;
-    using System.Globalization;
-    using System.Runtime.CompilerServices;
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
-
     public class DoubleConverter : JsonConverter<double>
     {
         public override double Read(
@@ -23,54 +21,5 @@ namespace Nethermind.Serialization.Json
             Utf8JsonWriter writer,
             double value,
             JsonSerializerOptions options) => writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
-    }
-
-    public class DoubleArrayConverter : JsonConverter<double[]>
-    {
-        public override double[] Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
-        {
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                string s = reader.GetString();
-                return JsonSerializer.Deserialize<double[]>(s);
-            }
-
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                throw new JsonException();
-            }
-            using ArrayPoolListRef<double> values = new(16);
-            while (reader.Read() && reader.TokenType == JsonTokenType.Number)
-            {
-                values.Add(reader.GetDouble());
-            }
-            if (reader.TokenType != JsonTokenType.EndArray)
-            {
-                throw new JsonException();
-            }
-
-            if (values.Count == 0) return [];
-
-            double[] result = new double[values.Count];
-            values.CopyTo(result, 0);
-            return result;
-        }
-
-        [SkipLocalsInit]
-        public override void Write(
-            Utf8JsonWriter writer,
-            double[] values,
-            JsonSerializerOptions options)
-        {
-            writer.WriteStartArray();
-            foreach (double value in values)
-            {
-                writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
-            }
-            writer.WriteEndArray();
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -20,6 +20,11 @@ namespace Nethermind.Serialization.Json
         public override void Write(
             Utf8JsonWriter writer,
             double value,
-            JsonSerializerOptions options) => writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
+            JsonSerializerOptions options)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                throw new JsonException($"The value '{value}' is not a valid JSON number.");
+            writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -23,8 +24,12 @@ namespace Nethermind.Serialization.Json
             JsonSerializerOptions options)
         {
             if (double.IsNaN(value) || double.IsInfinity(value))
-                throw new JsonException($"The value '{value}' is not a valid JSON number.");
+                ThrowNotFiniteJsonException(value);
             writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
         }
+
+        [DoesNotReturn]
+        private static void ThrowNotFiniteJsonException(double value) =>
+            throw new JsonException($"The value '{value}' is not a valid JSON number.");
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Serialization.Json
         public override void Write(
             Utf8JsonWriter writer,
             double value,
-            JsonSerializerOptions options) => writer.WriteRawValue(value.ToString("0.##########", CultureInfo.InvariantCulture), skipInputValidation: true);
+            JsonSerializerOptions options) => writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
     }
 
     public class DoubleArrayConverter : JsonConverter<double[]>
@@ -68,7 +68,7 @@ namespace Nethermind.Serialization.Json
             writer.WriteStartArray();
             foreach (double value in values)
             {
-                writer.WriteRawValue(value.ToString("0.0#########", CultureInfo.InvariantCulture), skipInputValidation: true);
+                writer.WriteRawValue(value.ToString("R", CultureInfo.InvariantCulture), skipInputValidation: true);
             }
             writer.WriteEndArray();
         }


### PR DESCRIPTION
Fixes Closes Resolves https://github.com/NethermindEth/nethermind/issues/11204 & https://github.com/NethermindEth/nethermind/issues/11201 & https://github.com/NethermindEth/nethermind/issues/11202 & https://github.com/NethermindEth/nethermind/issues/11203

## Changes

# eth_feeHistory: Geth Compatibility Fixes

Fixes a lot of the test failures in the `eth_feeHistory` test suite by aligning Nethermind's behaviour with Geth and the Ethereum JSON-RPC spec.

---

## Fix 1 — `rewardPercentiles` is a required parameter (test_22)

The spec marks `rewardPercentiles` as required. Nethermind previously accepted calls with only 2 arguments and returned a successful result. Geth returns `-32602`.

`rewardPercentiles` is now required at the RPC method signature level (`double[]`, no default). An explicit null-guard in `FeeHistoryOracle.GetFeeHistory` returns a clean error if the framework passes null for an absent argument, making the contract visible in code rather than relying on framework behaviour.

---

## Fix 2 — Full IEEE 754 precision for `gasUsedRatio` / `blobGasUsedRatio` (test_01, test_03–test_20, 17 tests)

`DoubleConverter` was serialising double values with the `"0.##########"` format, capping output at 10 decimal digits and rounding the last. Geth returns the full double precision value.

Changed both `DoubleConverter` and `DoubleArrayConverter` to use the `"R"` (round-trip) format specifier, which emits the minimum number of digits required to uniquely represent the IEEE 754 value — identical to what Geth produces.

---

## Fix 3 — Geth-compatible missing-argument error message (all endpoints)

https://github.com/ethereum/go-ethereum/blob/8e2107dc39dc9dab132150ec915e7ac299f9eb48/rpc/json.go#L331
https://github.com/ethereum/go-ethereum/blob/8e2107dc39dc9dab132150ec915e7ac299f9eb48/rpc/json.go#L349

When a required argument is omitted, Nethermind returned:

```json
{"code": -32602, "message": "Invalid params", "data": "Incorrect parameters count, expected: 3, actual: 2"}
```

## Fix 4 — `baseFeePerBlobGas[blockCount]` reports next-block estimate, not current-block fee

**Root cause:**  
`GetFeeHistory` fills `baseFeePerBlobGas` with `blockCount + 1` entries — indices `[0..blockCount-1]` are the actual per-block fees, and index `[blockCount]` is the next block's estimated blob base fee (matching the same pattern as `baseFeePerGas[blockCount]`).

The bug was that the pre-loop "next" slot was populated with `info.BaseFeePerBlobGas` (the newest block's *current* fee) instead of the projected next fee.

**Fix:**  
Added `BaseFeePerBlobGasEst` to `BlockFeeHistorySearchInfo`, computed using the same pattern Geth uses:  
https://github.com/ethereum/go-ethereum/blob/master/eth/gasprice/feehistory.go

1. `nextExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(block.Header, spec)`  
2. `BaseFeePerBlobGasEst = TryCalculateFeePerBlobGas(nextExcessBlobGas, spec.BlobBaseFeeUpdateFraction)`

Pre-4844 blocks (`ExcessBlobGas == null`) correctly produce `0` for both the current and next slot, mirroring Geth's `if excessBlobGas != nil` guard.

**Affected:**  
`eth_feeHistory` calls that span or land near the EIP-4844 activation boundary, where the newest block's current blob fee differs from its projected next-block fee.

## Fix 5 — `eth_feeHistory` returns wrong error code for non-existent block

**Root cause:**  
When `newestBlock` does not exist, `FeeHistoryOracle.GetFeeHistory` returned `-32002` (`ResourceUnavailable`) with message `"newestBlock: Block is not available"`.

Geth returns `-32603` (`InternalError`) with message `"upstream does not have the requested block yet"`.

**Fix:**  
Single-line change in `FeeHistoryOracle.cs` — replace `ErrorCodes.ResourceUnavailable` with `ErrorCodes.InternalError` and align the message to Geth's.

**Affected:**  
`eth_feeHistory` calls where `newestBlock` refers to a block that does not exist on the node (e.g. a far-future block number).

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No