### PR TITLE
fix: bump Microsoft.AspNetCore.DataProtection to 10.0.7 (GHSA-9mv3-2cwr-p262)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,8 +26,8 @@
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.201" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.0" />


### PR DESCRIPTION
## Changes

- Bump `Microsoft.AspNetCore.DataProtection` and `Microsoft.AspNetCore.DataProtection.Extensions` from `10.0.6` → `10.0.7` in `Directory.Packages.props`.

## Why

`10.0.6` is flagged by the GitHub Advisory Database ([GHSA-9mv3-2cwr-p262](https://github.com/advisories/GHSA-9mv3-2cwr-p262)) as a high-severity vulnerability. NuGet Audit raises `NU1903` at restore time, and with `TreatWarningsAsErrors=true` (see `Directory.Build.props`) this breaks restore for every project in the `Nethermind.Crypto` transitive closure (~40 projects).

The advisory was published after some recent CI runs had already restored, which is why earlier runs succeeded and later ones started failing on the same code (e.g. [run 24855957519](https://github.com/NethermindEth/nethermind/actions/runs/24855957519) passed, [run 24858175566](https://github.com/NethermindEth/nethermind/actions/runs/24858175566/job/72776553652) failed). `10.0.7` is the first patched version per the advisory.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Verified locally: `dotnet restore src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj` now completes cleanly with no `NU1903`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No