### PR TITLE
fix(build): copy Directory.Build.targets into release image

### DIFF
--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -11,7 +11,8 @@ ENV CI=true
 WORKDIR /nethermind
 
 COPY src/Nethermind src/Nethermind
-COPY Directory.*.props Directory.Build.targets ./
+COPY Directory.*.props .
+COPY Directory.Build.targets .
 COPY global.json .
 COPY nuget.config .
 COPY --chmod=0755 scripts/build/build.sh .

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -11,7 +11,7 @@ ENV CI=true
 WORKDIR /nethermind
 
 COPY src/Nethermind src/Nethermind
-COPY Directory.*.props .
+COPY Directory.*.props Directory.Build.targets ./
 COPY global.json .
 COPY nuget.config .
 COPY --chmod=0755 scripts/build/build.sh .


### PR DESCRIPTION
## Changes

- `scripts/build/Dockerfile`: add `Directory.Build.targets` to the COPY line so it lands next to `Directory.*.props` inside the image.

## Why

Since #10848 (Re-enable ReadyToRun AOT compilation), `src/Nethermind/Directory.Build.targets` imports `../../Directory.Build.targets` — a new repo-root file holding the PGO `PublishReadyToRunMibcPaths` settings.

That PR updated the four root Dockerfiles (`Dockerfile`, `Dockerfile.chiseled`, `Dockerfile.diag`, `Dockerfile.pgo`) to copy the new file, but missed `scripts/build/Dockerfile`, which is the one invoked by the **Release** workflow. Result:

```
/nethermind/src/Nethermind/Directory.Build.targets(3,3): error MSB4019:
The imported project "/nethermind/Directory.Build.targets" was not found.
```

`dotnet restore` doesn't evaluate `Directory.Build.targets` (only `.props`), so the bug stayed latent — it only surfaces during `dotnet publish`, which is what the Release build runs after restore. Local `dotnet build` always worked because the root `Directory.Build.targets` exists on disk.

Repro in CI: https://github.com/NethermindEth/nethermind/actions/runs/24860301345/job/72783875467 (on `release/1.37.0` post-merge of #11331).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Single-line Dockerfile change; matches the exact COPY pattern already used in `Dockerfile`, `Dockerfile.chiseled`, `Dockerfile.diag`, and `Dockerfile.pgo`. Will be exercised by the Release workflow on merge.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No