### PR TITLE
fix(build): enable R2R platform packs on the locked restore

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -11,7 +11,11 @@ cd src/Nethermind/Nethermind.Runner
 
 echo "Building Nethermind"
 
-dotnet restore --locked-mode
+# Pass PublishReadyToRun so the SDK fetches R2R platform packs (crossgen2,
+# runtime packs) for every RID listed in the csproj's <RuntimeIdentifiers>.
+# Staying in --locked-mode preserves reproducibility — platform packs are
+# determined by the pinned SDK image, not the lock file.
+dotnet restore --locked-mode -p:PublishReadyToRun=true
 
 for rid in "linux-arm64" "linux-x64" "osx-arm64" "osx-x64" "win-x64"; do
   echo "  Publishing for $rid"


### PR DESCRIPTION
## Changes

- `scripts/build/build.sh`: pass `-p:PublishReadyToRun=true` to the single upfront `dotnet restore --locked-mode` so the SDK fetches the R2R platform packs (crossgen2 + runtime packs) for every RID declared in `Nethermind.Runner.csproj`'s `<RuntimeIdentifiers>`.

## Why

Since #10848 (Re-enable ReadyToRun AOT compilation), `Nethermind.Runner.csproj` sets `<PublishReadyToRun>true</PublishReadyToRun>` whenever a `RuntimeIdentifier` is set. crossgen2 then needs the target RID's runtime pack, but our Release build's restore step did not tell the SDK we'd need R2R, so no platform packs were pulled. `dotnet publish --no-restore` then died with:

```
error NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found.
```

Repro in CI: https://github.com/NethermindEth/nethermind/actions/runs/24861786258/job/72788780775

## Reproducibility (addressing review feedback)

This version intentionally preserves `--locked-mode` on a **single** upfront restore. Reproducibility is not affected:

- `--locked-mode` remains in force for every user-level NuGet package — `packages.lock.json` stays authoritative.
- The R2R platform packs (`Microsoft.NETCore.App.Crossgen2.<rid>`, `Microsoft.NETCore.App.Runtime.<rid>`) are not user packages and have never been in `packages.lock.json` (verified: `grep -c 'crossgen2\|ReadyToRun' packages.lock.json` → 0). They are resolved from the SDK's platform-pack index.
- The SDK image is digest-pinned in `scripts/build/Dockerfile:4`, so platform-pack versions are bit-identical across runs.
- Each RID publish still runs with `--no-restore`, so the per-RID loop adds no further restore steps and no further opportunity for non-deterministic resolution.

An earlier iteration of this PR added a per-RID unlocked restore inside the publish loop; that approach would have broken reproducibility and was replaced by this single-flag change after Ruben's review.

## Local verification

Ran the exact `scripts/build/Dockerfile` end-to-end (fresh `--no-cache` build from the branch HEAD):

- Single `dotnet restore --locked-mode -p:PublishReadyToRun=true` completes with no NU1004 (lock file mismatch) and no NU1903 warnings.
- All five RID publishes (`linux-arm64`, `linux-x64`, `osx-arm64`, `osx-x64`, `win-x64`) run crossgen2 through to completion with no NETSDK1094.
- Resulting image contains the expected `/output/{linux-arm64, linux-x64, osx-arm64, osx-x64, win-x64, ref}/` tree with `nethermind` binary + plugins per RID.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Will be exercised by the Release workflow on merge.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No