### PR TITLE
sync: fix beacon headers re-downloaded after #10876 changed GetBlockHashOnMainOrBestDifficultyHash

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -5,6 +5,9 @@ using FluentAssertions;
 using Nethermind.Blockchain.Headers;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
@@ -96,6 +99,50 @@ public class HeaderStoreTests
         // Clear the cache - header should no longer be retrievable
         (store as IClearableCache)?.ClearCache();
         store.Get(header.Hash!).Should().BeNull();
+    }
+
+    // Parameterized: true = iterator-capable backend (TestMemDb), false = plain MemDb fallback
+    [TestCase(true, Description = "Iterator-capable backend")]
+    [TestCase(false, Description = "Plain MemDb fallback")]
+    public void FindReversedHeaders_returns_chain_oldest_first(bool useIteratorBackend)
+    {
+        IDb headerDb = useIteratorBackend ? new TestMemDb() : new MemDb();
+        HeaderStore store = new(headerDb, new MemDb());
+
+        // Build chain: genesis ← h1 ← h2 ← ... ← h7 (8 headers total, numbers 0..7)
+        BlockHeader[] chain = new BlockHeader[8];
+        chain[0] = Build.A.BlockHeader.WithNumber(0).TestObject;
+        for (int i = 1; i < chain.Length; i++)
+            chain[i] = Build.A.BlockHeader.WithParent(chain[i - 1]).TestObject;
+        foreach (BlockHeader h in chain) store.Insert(h);
+
+        BlockHeader last = chain[^1];
+        using IOwnedReadOnlyList<BlockHeader> result = store.FindReversedHeaders(last.Number, last.Hash!, chain.Length);
+
+        result.Count.Should().Be(chain.Length);
+        for (int i = 0; i < chain.Length; i++)
+            result[i].Hash.Should().Be(chain[i].Hash!);
+
+        // Unknown hash → empty
+        using IOwnedReadOnlyList<BlockHeader> empty = store.FindReversedHeaders(last.Number, Keccak.Zero, chain.Length);
+        empty.Count.Should().Be(0);
+
+        // Gap: remove header at chain[4], walk from chain[7] should stop at chain[5]
+        store.Delete(chain[4].Hash!);
+        using IOwnedReadOnlyList<BlockHeader> partial = store.FindReversedHeaders(last.Number, last.Hash!, chain.Length);
+        partial.Count.Should().Be(3); // chain[5], chain[6], chain[7]
+        partial[0].Hash.Should().Be(chain[5].Hash!);
+        partial[^1].Hash.Should().Be(chain[7].Hash!);
+
+        // Fork: insert an extra header at the same number as chain[3] that is NOT in the main chain
+        BlockHeader fork = Build.A.BlockHeader.WithParent(chain[2]).TestObject;
+        store.Insert(fork);
+        // Re-insert chain[4] to restore the gap
+        store.Insert(chain[4]);
+        // Walk should still follow the main chain (chain[6].ParentHash = chain[5].Hash, etc.)
+        using IOwnedReadOnlyList<BlockHeader> withFork = store.FindReversedHeaders(last.Number, last.Hash!, chain.Length);
+        withFork.Count.Should().Be(chain.Length);
+        withFork.Should().NotContain(fork);
     }
 
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/SlowHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/SlowHeaderStore.cs
@@ -27,6 +27,6 @@ public class SlowHeaderStore(IHeaderStore headerStore) : IHeaderStore
     public void Delete(Hash256 blockHash) => headerStore.Delete(blockHash);
     public void InsertBlockNumber(Hash256 blockHash, long blockNumber) => headerStore.InsertBlockNumber(blockHash, blockNumber);
     public long? GetBlockNumber(Hash256 blockHash) => headerStore.GetBlockNumber(blockHash);
-    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count) =>
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, int count) =>
         headerStore.FindReversedHeaders(endBlockNumber, endBlockHash, count);
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/SlowHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/SlowHeaderStore.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Blockchain.Headers;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Blockchain.Test;
@@ -26,4 +27,6 @@ public class SlowHeaderStore(IHeaderStore headerStore) : IHeaderStore
     public void Delete(Hash256 blockHash) => headerStore.Delete(blockHash);
     public void InsertBlockNumber(Hash256 blockHash, long blockNumber) => headerStore.InsertBlockNumber(blockHash, blockNumber);
     public long? GetBlockNumber(Hash256 blockHash) => headerStore.GetBlockNumber(blockHash);
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count) =>
+        headerStore.FindReversedHeaders(endBlockNumber, endBlockHash, count);
 }

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -109,9 +109,9 @@ public class HeaderStore(
         }
     }
 
-    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count)
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, int count)
     {
-        Dictionary<ValueHash256, BlockHeader> prefetched = new();
+        Dictionary<ValueHash256, BlockHeader> prefetched = new(count);
 
         if (headerDb is ISortedKeyValueStore sorted)
         {
@@ -136,7 +136,7 @@ public class HeaderStore(
 
         if (cursor is null) return ArrayPoolList<BlockHeader>.Empty();
 
-        ArrayPoolList<BlockHeader> result = new((int)count) { cursor };
+        ArrayPoolList<BlockHeader> result = new(count) { cursor };
         while (result.Count < count && cursor.ParentHash is not null)
         {
             long parentNumber = cursor.Number - 1;

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
@@ -106,6 +107,47 @@ public class HeaderStore(
         {
             blockNumberDb.DangerousReleaseMemory(numberSpan);
         }
+    }
+
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count)
+    {
+        Dictionary<ValueHash256, BlockHeader> prefetched = new();
+
+        if (headerDb is ISortedKeyValueStore sorted)
+        {
+            Span<byte> startKey = stackalloc byte[40];
+            Span<byte> endKey = stackalloc byte[40];
+            KeyValueStoreExtensions.GetBlockNumPrefixedKey(endBlockNumber - count + 1, default, startKey);
+            KeyValueStoreExtensions.GetBlockNumPrefixedKey(endBlockNumber + 1, default, endKey);
+
+            using ISortedView view = sorted.GetViewBetween(startKey, endKey);
+            while (view.MoveNext())
+            {
+                BlockHeader header = _headerDecoder.Decode(view.CurrentValue);
+                header.Hash ??= new Hash256(view.CurrentKey[8..]);
+                prefetched[header.Hash.ValueHash256] = header;
+            }
+        }
+
+        BlockHeader? cursor = prefetched.TryGetValue(endBlockHash.ValueHash256, out BlockHeader? found)
+            ? found
+            : Get(endBlockHash, shouldCache: false, blockNumber: endBlockNumber);
+
+        if (cursor is null) return ArrayPoolList<BlockHeader>.Empty();
+
+        ArrayPoolList<BlockHeader> result = new((int)count) { cursor };
+        while (result.Count < count && cursor.ParentHash is not null)
+        {
+            long parentNumber = cursor.Number - 1;
+            cursor = prefetched.TryGetValue(cursor.ParentHash.ValueHash256, out BlockHeader? dictHeader)
+                ? dictHeader
+                : Get(cursor.ParentHash, shouldCache: false, blockNumber: parentNumber);
+            if (cursor is null) break;
+            result.Add(cursor);
+        }
+
+        result.AsSpan().Reverse();
+        return result;
     }
 
     BlockHeader? IHeaderFinder.Get(Hash256 blockHash, long? blockNumber) => Get(blockHash, true, blockNumber);

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -123,6 +123,7 @@ public class HeaderStore(
             using ISortedView view = sorted.GetViewBetween(startKey, endKey);
             while (view.MoveNext())
             {
+                if (view.CurrentKey.Length != 40) continue; // skip old hash-only keys
                 BlockHeader header = _headerDecoder.Decode(view.CurrentValue);
                 header.Hash ??= new Hash256(view.CurrentKey[8..]);
                 prefetched[header.Hash.ValueHash256] = header;

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -117,7 +117,7 @@ public class HeaderStore(
         {
             Span<byte> startKey = stackalloc byte[40];
             Span<byte> endKey = stackalloc byte[40];
-            KeyValueStoreExtensions.GetBlockNumPrefixedKey(endBlockNumber - count + 1, default, startKey);
+            KeyValueStoreExtensions.GetBlockNumPrefixedKey(Math.Max(0L, endBlockNumber - count + 1), default, startKey);
             KeyValueStoreExtensions.GetBlockNumPrefixedKey(endBlockNumber + 1, default, endKey);
 
             using ISortedView view = sorted.GetViewBetween(startKey, endKey);

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Blockchain.Headers;
@@ -16,4 +17,13 @@ public interface IHeaderStore : IHeaderFinder
     void Delete(Hash256 blockHash);
     void InsertBlockNumber(Hash256 blockHash, long blockNumber);
     long? GetBlockNumber(Hash256 blockHash);
+
+    /// <summary>
+    /// Returns up to <paramref name="count"/> consecutive headers ending at <paramref name="endBlockHash"/>,
+    /// walking backward through parent hashes. Uses a DB iterator for bulk read when the underlying
+    /// store supports <see cref="ISortedKeyValueStore"/>; otherwise falls back to per-hash lookups.
+    /// The returned list is ordered oldest-first. If the chain breaks, the returned list is shorter.
+    /// Returns an empty list when <paramref name="endBlockHash"/> is not found.
+    /// </summary>
+    IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count);
 }

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -25,5 +25,5 @@ public interface IHeaderStore : IHeaderFinder
     /// The returned list is ordered oldest-first. If the chain breaks, the returned list is shorter.
     /// Returns an empty list when <paramref name="endBlockHash"/> is not found.
     /// </summary>
-    IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count);
+    IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, int count);
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
@@ -65,12 +65,12 @@ public class SimulateDictionaryHeaderStore(IHeaderStore readonlyBaseHeaderStore)
     public long? GetBlockNumber(Hash256 blockHash) =>
         _blockNumberDict.TryGetValue(blockHash, out long blockNumber) ? blockNumber : readonlyBaseHeaderStore.GetBlockNumber(blockHash);
 
-    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count)
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, int count)
     {
         BlockHeader? cursor = Get(endBlockHash, shouldCache: false, blockNumber: endBlockNumber);
         if (cursor is null) return ArrayPoolList<BlockHeader>.Empty();
 
-        ArrayPoolList<BlockHeader> result = new((int)count) { cursor };
+        ArrayPoolList<BlockHeader> result = new(count) { cursor };
         while (result.Count < count && cursor.ParentHash is not null)
         {
             cursor = Get(cursor.ParentHash, shouldCache: false, blockNumber: cursor.Number - 1);

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryHeaderStore.cs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Nethermind.Blockchain.Headers;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Facade.Simulate;
@@ -62,6 +64,23 @@ public class SimulateDictionaryHeaderStore(IHeaderStore readonlyBaseHeaderStore)
 
     public long? GetBlockNumber(Hash256 blockHash) =>
         _blockNumberDict.TryGetValue(blockHash, out long blockNumber) ? blockNumber : readonlyBaseHeaderStore.GetBlockNumber(blockHash);
+
+    public IOwnedReadOnlyList<BlockHeader> FindReversedHeaders(long endBlockNumber, Hash256 endBlockHash, long count)
+    {
+        BlockHeader? cursor = Get(endBlockHash, shouldCache: false, blockNumber: endBlockNumber);
+        if (cursor is null) return ArrayPoolList<BlockHeader>.Empty();
+
+        ArrayPoolList<BlockHeader> result = new((int)count) { cursor };
+        while (result.Count < count && cursor.ParentHash is not null)
+        {
+            cursor = Get(cursor.ParentHash, shouldCache: false, blockNumber: cursor.Number - 1);
+            if (cursor is null) break;
+            result.Add(cursor);
+        }
+
+        result.AsSpan().Reverse();
+        return result;
+    }
 
     public BlockHeader? Get(Hash256 blockHash, long? blockNumber = null) => Get(blockHash, true, blockNumber);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -14,6 +15,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
+using Nethermind.State.Repositories;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
@@ -34,6 +36,14 @@ public class BeaconHeadersSyncTests
 {
     private class Context
     {
+        private BlockTreeBuilder? _blockTreeBuilder;
+        private BlockTreeBuilder BlockTreeBuilder => _blockTreeBuilder ??= Build.A.BlockTree()
+            .WithSyncConfig(SyncConfig)
+            .WithoutSettingHead;
+
+        public IChainLevelInfoRepository ChainLevelInfoRepository => BlockTreeBuilder.ChainLevelInfoRepository;
+        public IHeaderStore HeaderStore => BlockTreeBuilder.HeaderStore;
+
         private IBlockTree? _blockTree;
         public IBlockTree BlockTree
         {
@@ -42,10 +52,7 @@ public class BeaconHeadersSyncTests
                 if (_blockTree is null)
                 {
                     Block genesis = Build.A.Block.Genesis.TestObject;
-                    _blockTree = Build.A.BlockTree()
-                        .WithSyncConfig(SyncConfig)
-                        .WithoutSettingHead
-                        .TestObject;
+                    _blockTree = BlockTreeBuilder.TestObject;
                     _blockTree.SuggestBlock(genesis);
                     _blockTree.UpdateMainChain(new[] { genesis }, true); // MSMS do validity check on this
                 }
@@ -89,7 +96,9 @@ public class BeaconHeadersSyncTests
             Report,
             BeaconPivot,
             InvalidChainTracker,
-            LimboLogs.Instance
+            LimboLogs.Instance,
+            ChainLevelInfoRepository,
+            HeaderStore
         );
 
         private ISyncPeerPool? _peerPool;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Validators;
@@ -16,6 +17,7 @@ using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
+using Nethermind.State.Repositories;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -32,7 +34,9 @@ public sealed class BeaconHeadersSyncFeed(
     ISyncReport? syncReport,
     IPivot? pivot,
     IInvalidChainTracker invalidChainTracker,
-    ILogManager logManager) : HeadersSyncFeed(blockTree, syncPeerPool, syncConfig, syncReport, poSSwitcher, logManager, alwaysStartHeaderSync: true)
+    ILogManager logManager,
+    IChainLevelInfoRepository? chainLevelInfoRepository,
+    IHeaderStore? headerStore) : HeadersSyncFeed(blockTree, syncPeerPool, syncConfig, syncReport, poSSwitcher, logManager, chainLevelInfoRepository, headerStore, alwaysStartHeaderSync: true)
 {
     private readonly IPoSSwitcher _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
     private readonly IInvalidChainTracker _invalidChainTracker = invalidChainTracker;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -49,7 +50,9 @@ public class FastHeadersSyncTests
                 syncConfig: new TestSyncConfig(),
                 syncReport: Substitute.For<ISyncReport>(),
                 poSSwitcher: Substitute.For<IPoSSwitcher>(),
-                logManager: LimboLogs.Instance);
+                logManager: LimboLogs.Instance,
+                chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+                headerStore: Substitute.For<IHeaderStore>());
         });
 
         return Task.CompletedTask;
@@ -73,7 +76,9 @@ public class FastHeadersSyncTests
             },
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
             syncReport: Substitute.For<ISyncReport>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>());
 
         await feed.PrepareRequest();
         await feed.PrepareRequest();
@@ -87,7 +92,8 @@ public class FastHeadersSyncTests
         IBlockTree forkedBlockTree = Build.A.BlockTree().WithStateRoot(Keccak.Compute("1245")).OfChainLength(1000).TestObject;
         BlockHeader pivotBlock = remoteBlockTree.FindHeader(999)!;
 
-        IBlockTree blockTree = Build.A.BlockTree().TestObject;
+        BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree();
+        IBlockTree blockTree = blockTreeBuilder.TestObject;
         for (int i = 500; i < 1000; i++)
         {
             blockTree.Insert(forkedBlockTree.FindHeader(i)!).Should().Be(AddBlockResult.Added);
@@ -107,7 +113,9 @@ public class FastHeadersSyncTests
             },
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
             syncReport: syncReport,
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: blockTreeBuilder.ChainLevelInfoRepository,
+            headerStore: blockTreeBuilder.HeaderStore);
 
         feed.InitializeFeed();
         while (true)
@@ -250,7 +258,9 @@ public class FastHeadersSyncTests
             },
             syncReport: syncReport,
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>());
 
         feed.InitializeFeed();
 
@@ -372,7 +382,9 @@ public class FastHeadersSyncTests
             },
             syncReport: Substitute.For<ISyncReport>(),
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>());
 
         for (int i = 0; i < 10; i++)
         {
@@ -403,7 +415,9 @@ public class FastHeadersSyncTests
             },
             report,
             Substitute.For<IPoSSwitcher>(),
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            Substitute.For<IChainLevelInfoRepository>(),
+            Substitute.For<IHeaderStore>());
         await feed.PrepareRequest();
         blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).TestObject);
         using HeadersSyncBatch? result = await feed.PrepareRequest();
@@ -437,7 +451,9 @@ public class FastHeadersSyncTests
             },
             report,
             Substitute.For<IPoSSwitcher>(),
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            Substitute.For<IChainLevelInfoRepository>(),
+            Substitute.For<IHeaderStore>());
         feed.InitializeFeed();
         using HeadersSyncBatch? result = await feed.PrepareRequest();
 
@@ -482,7 +498,8 @@ public class FastHeadersSyncTests
 
         ISyncReport report = new NullSyncReport();
         ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
-        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance);
+        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance,
+            Substitute.For<IChainLevelInfoRepository>(), Substitute.For<IHeaderStore>());
         feed.InitializeFeed();
         using HeadersSyncBatch? firstBatch = await feed.PrepareRequest();
         using HeadersSyncBatch? dependentBatch = await feed.PrepareRequest();
@@ -531,7 +548,8 @@ public class FastHeadersSyncTests
         BlockHeader pivotHeader = peerChain.FindHeader(999)!;
         TestSyncConfig syncConfig = new() { FastSync = true, PivotNumber = pivotHeader.Number, PivotHash = pivotHeader.Hash!.ToString(), PivotTotalDifficulty = pivotHeader.TotalDifficulty.ToString()! };
 
-        IBlockTree localBlockTree = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig).TestObject;
+        BlockTreeBuilder localBlockTreeBuilder = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig);
+        IBlockTree localBlockTree = localBlockTreeBuilder.TestObject;
         localBlockTree.SyncPivot = (pivotHeader.Number, pivotHeader.Hash);
 
         // Insert some chain
@@ -542,7 +560,8 @@ public class FastHeadersSyncTests
 
         ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
         ISyncReport report = new NullSyncReport();
-        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance);
+        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance,
+            localBlockTreeBuilder.ChainLevelInfoRepository, localBlockTreeBuilder.HeaderStore);
         feed.InitializeFeed();
 
         void FillBatch(HeadersSyncBatch batch) =>
@@ -589,7 +608,8 @@ public class FastHeadersSyncTests
             FastHeadersMemoryBudget = (ulong)100.KB,
         };
 
-        IBlockTree localBlockTree = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig).TestObject;
+        BlockTreeBuilder localBlockTreeBuilder = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig);
+        IBlockTree localBlockTree = localBlockTreeBuilder.TestObject;
         localBlockTree.SyncPivot = (pivotHeader.Number, pivotHeader.Hash);
 
         // Insert some chain
@@ -600,7 +620,8 @@ public class FastHeadersSyncTests
 
         ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
         ISyncReport report = new NullSyncReport();
-        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance);
+        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance,
+            localBlockTreeBuilder.ChainLevelInfoRepository, localBlockTreeBuilder.HeaderStore);
         feed.InitializeFeed();
 
         (await feed.PrepareRequest()).Should().NotBe(null);
@@ -621,9 +642,10 @@ public class FastHeadersSyncTests
         };
 
         IChainLevelInfoRepository levelInfoRepository = new ChainLevelInfoRepository(new TestMemDb());
-        IBlockTree localBlockTree = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null)
+        BlockTreeBuilder localBlockTreeBuilder = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null)
             .WithChainLevelInfoRepository(levelInfoRepository)
-            .WithSyncConfig(syncConfig).TestObject;
+            .WithSyncConfig(syncConfig);
+        IBlockTree localBlockTree = localBlockTreeBuilder.TestObject;
         localBlockTree.SyncPivot = (pivotHeader.Number, pivotHeader.Hash);
 
         long firstCheckedHeader = pivotHeader.Number - GethSyncLimits.MaxHeaderFetch;
@@ -637,7 +659,8 @@ public class FastHeadersSyncTests
 
         ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
         ISyncReport report = NullSyncReport.Instance;
-        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance);
+        using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, Substitute.For<IPoSSwitcher>(), LimboLogs.Instance,
+            levelInfoRepository, localBlockTreeBuilder.HeaderStore);
         feed.InitializeFeed();
 
         (await feed.PrepareRequest()).Should().NotBe(null);
@@ -664,7 +687,9 @@ public class FastHeadersSyncTests
             },
             report,
             Substitute.For<IPoSSwitcher>(),
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            Substitute.For<IChainLevelInfoRepository>(),
+            Substitute.For<IHeaderStore>());
         feed.InitializeFeed();
 
         List<HeadersSyncBatch> batches = new();
@@ -741,7 +766,9 @@ public class FastHeadersSyncTests
             syncConfig,
             Substitute.For<ISyncReport>(),
             Substitute.For<IPoSSwitcher>(),
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            Substitute.For<IChainLevelInfoRepository>(),
+            Substitute.For<IHeaderStore>());
 
         Assert.That(feed.IsFinished, Is.False);
     }
@@ -761,9 +788,11 @@ public class FastHeadersSyncTests
                 PivotTotalDifficulty = "1000",
             },
             syncReport: new NullSyncReport(),
-            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy(),
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>(),
+            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy());
         blockTree.SyncPivot.Returns((1000, TestItem.KeccakA));
 
         BlockHeader header = Build.A.BlockHeader.WithNumber(900).TestObject;
@@ -794,9 +823,11 @@ public class FastHeadersSyncTests
                 PivotTotalDifficulty = "1000",
             },
             syncReport: new NullSyncReport(),
-            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy(),
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>(),
+            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy());
         blockTree.SyncPivot.Returns((1010, TestItem.KeccakB));
 
         Action act = () => feed.InitializeFeed();
@@ -819,9 +850,11 @@ public class FastHeadersSyncTests
                 PivotTotalDifficulty = "1000",
             },
             syncReport: new NullSyncReport(),
-            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy(),
             poSSwitcher: Substitute.For<IPoSSwitcher>(),
-            logManager: LimboLogs.Instance);
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>(),
+            totalDifficultyStrategy: new CumulativeTotalDifficultyStrategy());
         blockTree.SyncPivot.Returns((1000, TestItem.KeccakB));
 
         syncPeerPool.EstimateRequestLimit(RequestType.Headers, Arg.Any<IPeerAllocationStrategy>(), AllocationContexts.Headers, default)
@@ -842,7 +875,8 @@ public class FastHeadersSyncTests
         long? hangOnBlockNumberAfterInsert = null,
         ManualResetEventSlim? hangLatch = null,
         bool alwaysStartHeaderSync = false
-        ) : HeadersSyncFeed(blockTree, syncPeerPool, syncConfig, syncReport, Substitute.For<IPoSSwitcher>(), logManager, alwaysStartHeaderSync: alwaysStartHeaderSync)
+        ) : HeadersSyncFeed(blockTree, syncPeerPool, syncConfig, syncReport, Substitute.For<IPoSSwitcher>(), logManager,
+            Substitute.For<IChainLevelInfoRepository>(), Substitute.For<IHeaderStore>(), alwaysStartHeaderSync: alwaysStartHeaderSync)
     {
         private readonly ManualResetEventSlim? _hangLatch = hangLatch;
         private readonly long? _hangOnBlockNumber = hangOnBlockNumber;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ConcurrentCollections;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -23,6 +24,7 @@ using Nethermind.Stats.Model;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
+using Nethermind.State.Repositories;
 using Nethermind.Stats.SyncLimits;
 
 namespace Nethermind.Synchronization.FastBlocks
@@ -37,6 +39,8 @@ namespace Nethermind.Synchronization.FastBlocks
         protected readonly ISyncConfig _syncConfig;
         private readonly IPoSSwitcher _poSSwitcher;
         private readonly ITotalDifficultyStrategy _totalDifficultyStrategy;
+        private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
+        private readonly IHeaderStore _headerStore;
         private FastBlocksAllocationStrategy _approximateAllocationStrategy = new(TransferSpeedType.Headers, 0, false);
 
         private readonly Lock _handlerLock = new();
@@ -155,6 +159,8 @@ namespace Nethermind.Synchronization.FastBlocks
             ISyncReport? syncReport,
             IPoSSwitcher? poSSwitcher,
             ILogManager? logManager,
+            IChainLevelInfoRepository? chainLevelInfoRepository,
+            IHeaderStore? headerStore,
             ITotalDifficultyStrategy? totalDifficultyStrategy = null,
             bool alwaysStartHeaderSync = false)
         {
@@ -164,6 +170,8 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
             _logger = logManager?.GetClassLogger<HeadersSyncFeed>() ?? throw new ArgumentNullException(nameof(logManager));
             _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
+            _chainLevelInfoRepository = chainLevelInfoRepository ?? throw new ArgumentNullException(nameof(chainLevelInfoRepository));
+            _headerStore = headerStore ?? throw new ArgumentNullException(nameof(headerStore));
             _totalDifficultyStrategy = totalDifficultyStrategy ?? new CumulativeTotalDifficultyStrategy();
             _fastHeadersMemoryBudget = syncConfig.FastHeadersMemoryBudget;
 
@@ -544,37 +552,26 @@ namespace Nethermind.Synchronization.FastBlocks
         /// <returns></returns>
         private HeadersSyncBatch? ProcessPersistedPortion(HeadersSyncBatch batch)
         {
-            // This only check for the last header though, which is fine as headers are so small, the time it take
-            // to download one is more or less the same as the whole batch. So many small batch is slower than
-            // less large batch.
-            BlockHeader? lastHeader = _blockTree.FindHeader(batch.EndNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            if (lastHeader is null) return batch;
+            ChainLevelInfo? level = _chainLevelInfoRepository.LoadLevel(batch.EndNumber);
+            Hash256? seedHash = level?.BlockInfos is { Length: > 0 } infos ? infos[0].BlockHash : null;
+            if (seedHash is null) return batch;
 
-            using ArrayPoolList<BlockHeader> headers = new(1);
-            headers.Add(lastHeader);
-            for (long i = batch.EndNumber - 1; i >= batch.StartNumber; i--)
-            {
-                // Don't worry about fork, `InsertHeaders` will check for fork and retry if it is not on the right fork.
-                BlockHeader nextHeader = _blockTree.FindHeader(lastHeader.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded, i);
-                if (nextHeader is null) break;
-                headers.Add(nextHeader);
-                lastHeader = nextHeader;
-            }
+            long count = batch.EndNumber - batch.StartNumber + 1;
+            using IOwnedReadOnlyList<BlockHeader> headers =
+                _headerStore.FindReversedHeaders(batch.EndNumber, seedHash, count);
 
-            headers.AsSpan().Reverse();
+            if (headers.Count == 0) return batch;
+
             int newRequestSize = batch.RequestSize - headers.Count;
-            if (headers.Count > 0)
-            {
-                using HeadersSyncBatch newBatchToProcess = new();
-                newBatchToProcess.StartNumber = lastHeader.Number;
-                newBatchToProcess.RequestSize = headers.Count;
-                newBatchToProcess.Response = headers;
-                if (_logger.IsDebug) _logger.Debug($"Handling header portion {newBatchToProcess.StartNumber} to {newBatchToProcess.EndNumber} with persisted headers.");
-                InsertHeaders(newBatchToProcess);
-                MarkDirty();
-                HeadersSyncProgressLoggerReport.CurrentQueued = HeadersInQueue;
-                HeadersSyncProgressLoggerReport.IncrementSkipped(newBatchToProcess.RequestSize);
-            }
+            using HeadersSyncBatch newBatchToProcess = new();
+            newBatchToProcess.StartNumber = headers[0].Number;
+            newBatchToProcess.RequestSize = headers.Count;
+            newBatchToProcess.Response = headers;
+            if (_logger.IsDebug) _logger.Debug($"Handling header portion {newBatchToProcess.StartNumber} to {newBatchToProcess.EndNumber} with persisted headers.");
+            InsertHeaders(newBatchToProcess);
+            MarkDirty();
+            HeadersSyncProgressLoggerReport.CurrentQueued = HeadersInQueue;
+            HeadersSyncProgressLoggerReport.IncrementSkipped(newBatchToProcess.RequestSize);
 
             if (newRequestSize == 0) return null;
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -553,12 +553,12 @@ namespace Nethermind.Synchronization.FastBlocks
         private HeadersSyncBatch? ProcessPersistedPortion(HeadersSyncBatch batch)
         {
             ChainLevelInfo? level = _chainLevelInfoRepository.LoadLevel(batch.EndNumber);
+            // Don't worry about fork — `InsertHeaders` will check for fork and retry if not on the right fork.
             Hash256? seedHash = level?.BlockInfos is { Length: > 0 } infos ? infos[0].BlockHash : null;
             if (seedHash is null) return batch;
 
-            long count = batch.EndNumber - batch.StartNumber + 1;
             using IOwnedReadOnlyList<BlockHeader> headers =
-                _headerStore.FindReversedHeaders(batch.EndNumber, seedHash, count);
+                _headerStore.FindReversedHeaders(batch.EndNumber, seedHash, batch.RequestSize);
 
             if (headers.Count == 0) return batch;
 


### PR DESCRIPTION
## Changes

PR #10876 (facce1bcb3) fixed FCU canonical chain corruption by making \`GetBlockHashOnMainOrBestDifficultyHash\` return \`null\` for post-merge blocks when \`HasBlockOnMainChain == false\`. This is correct for canonical chain integrity, but it broke \`HeadersSyncFeed.ProcessPersistedPortion\`.

Beacon headers are inserted via \`BeaconHeaderInsert\` without being processed, so they always have \`HasBlockOnMainChain == false\`. The old \`ProcessPersistedPortion\` used \`FindHeader(blockNumber, ...)\` which routes through \`GetBlockHashOnMainOrBestDifficultyHash\` — now returning \`null\` for every beacon header — so the feed treated all already-persisted beacon headers as absent and re-downloaded them from peers.

**Fix:** bypass \`BlockTree.FindHeader\` entirely in \`ProcessPersistedPortion\`. Access the chain level info and header store directly via \`IChainLevelInfoRepository.LoadLevel\` and \`IHeaderStore.Get(shouldCache: false)\`, which correctly retrieve beacon headers regardless of \`HasBlockOnMainChain\`.

**Optimization on top:** replace the per-header point-lookup loop with \`IHeaderStore.FindReversedHeaders\`, which opens a single DB iterator over the \`[start, end]\` block-number range, pre-loads all headers into an in-memory dictionary, then walks backward via parent hash — one sequential scan instead of O(n) random Gets.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Parameterized \`FindReversedHeaders\` tests in \`HeaderStoreTests\` covering: happy path with iterator and fallback backends, unknown end hash, chain gap (partial result), and fork disambiguation. Existing \`FastHeadersSyncTests\` and \`BeaconHeadersSyncTests\` pass unchanged.