### PR TITLE
style: enable nullable for Nethermind.Serialization.Json and Nethermind.Serialization.Rlp

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -20,8 +20,8 @@ namespace Nethermind.Blockchain.Test.Proofs;
 [Parallelizable(ParallelScope.All)]
 public class ReceiptTrieTests
 {
-    private static readonly IRlpStreamEncoder<TxReceipt> _decoder = Rlp.GetStreamEncoder<TxReceipt>()!;
-    private static readonly IRlpValueDecoder<TxReceipt> _valueDecoder = Rlp.GetValueDecoder<TxReceipt>()!;
+    private static readonly IRlpStreamEncoder<TxReceipt?> _decoder = Rlp.GetStreamEncoder<TxReceipt?>()!;
+    private static readonly IRlpValueDecoder<TxReceipt?> _valueDecoder = Rlp.GetValueDecoder<TxReceipt?>()!;
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Can_calculate_root_no_eip_658()

--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -86,7 +86,7 @@ public class ReceiptTrieTests
         TrieNode node = new(NodeType.Unknown, proof.Last());
         node.ResolveNode(Substitute.For<ITrieNodeResolver>(), TreePath.Empty);
         Rlp.ValueDecoderContext ctx = node.Value.ToArray().AsRlpValueContext();
-        TxReceipt receipt = _valueDecoder.Decode(ref ctx);
+        TxReceipt receipt = _valueDecoder.Decode(ref ctx)!;
         Assert.That(receipt.Bloom, Is.Not.Null);
 
         for (int i = proof.Length; i > 0; i--)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidatorsDecoder.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidatorsDecoder.cs
@@ -8,9 +8,9 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Consensus.AuRa.Validators
 {
-    internal sealed class PendingValidatorsDecoder : RlpValueDecoder<PendingValidators>, IRlpObjectDecoder<PendingValidators>
+    internal sealed class PendingValidatorsDecoder : RlpValueDecoder<PendingValidators?>, IRlpObjectDecoder<PendingValidators?>
     {
-        protected override PendingValidators DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        protected override PendingValidators? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             if (decoderContext.IsNextItemEmptyList())
             {
@@ -43,7 +43,7 @@ namespace Nethermind.Consensus.AuRa.Validators
             return result;
         }
 
-        public Rlp Encode(PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public Rlp Encode(PendingValidators? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             if (item is null)
             {
@@ -55,7 +55,7 @@ namespace Nethermind.Consensus.AuRa.Validators
             return new Rlp(rlpStream.Data.ToArray());
         }
 
-        public override void Encode(RlpStream rlpStream, PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public override void Encode(RlpStream rlpStream, PendingValidators? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             (int contentLength, int addressesLength) = GetContentLength(item, rlpBehaviors);
             rlpStream.StartSequence(contentLength);
@@ -69,7 +69,7 @@ namespace Nethermind.Consensus.AuRa.Validators
             rlpStream.Encode(item.AreFinalized);
         }
 
-        public override int GetLength(PendingValidators item, RlpBehaviors rlpBehaviors) =>
+        public override int GetLength(PendingValidators? item, RlpBehaviors rlpBehaviors) =>
             item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors).Total);
 
         private static (int Total, int Addresses) GetContentLength(PendingValidators item, RlpBehaviors rlpBehaviors)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfoDecoder.cs
@@ -6,7 +6,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Consensus.AuRa.Validators
 {
-    internal sealed class ValidatorInfoDecoder : RlpValueDecoder<ValidatorInfo>, IRlpObjectDecoder<ValidatorInfo>
+    internal sealed class ValidatorInfoDecoder : RlpValueDecoder<ValidatorInfo?>, IRlpObjectDecoder<ValidatorInfo?>
     {
         protected override ValidatorInfo? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {

--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -31,8 +31,8 @@ public class Witness : IDisposable
 
 public static class WitnessExtensions
 {
-    private static readonly IRlpValueDecoder<BlockHeader> _decoder =
-        Rlp.GetValueDecoder<BlockHeader>() ?? new HeaderDecoder();
+    private static readonly IRlpValueDecoder<BlockHeader?> _decoder =
+        Rlp.GetValueDecoder<BlockHeader?>() ?? new HeaderDecoder();
 
     extension(Witness witness)
     {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptArrayDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptArrayDecoderTests.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Core.Test.Encoding
 
             ReceiptArrayStorageDecoder decoder = new();
             Rlp.ValueDecoderContext ctx = new(rlp.AsSpan());
-            TxReceipt[] deserialized = decoder.Decode(ref ctx, RlpBehaviors.Storage);
+            TxReceipt[] deserialized = decoder.Decode(ref ctx, RlpBehaviors.Storage)!;
 
             deserialized.Should().BeEquivalentTo(GetExpectedArray());
         }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
@@ -190,7 +190,7 @@ namespace Nethermind.Core.Test.Encoding
 
             byte[] rlpStreamResult = decoder.EncodeNew(txReceipt, RlpBehaviors.None);
             Rlp.ValueDecoderContext ctx = new(rlpStreamResult);
-            TxReceipt deserialized = decoder.Decode(ref ctx);
+            TxReceipt deserialized = decoder.Decode(ref ctx)!;
 
             AssertMessageReceipt(txReceipt, deserialized);
         }
@@ -271,7 +271,7 @@ namespace Nethermind.Core.Test.Encoding
 
             byte[] rlpStreamResult = decoder.EncodeNew(txReceipt);
             Rlp.ValueDecoderContext ctx = new(rlpStreamResult);
-            TxReceipt deserialized = decoder.Decode(ref ctx);
+            TxReceipt deserialized = decoder.Decode(ref ctx)!;
 
             AssertMessageReceipt(txReceipt, deserialized);
         }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
@@ -52,7 +52,7 @@ public partial class ShardBlobTxDecoderTests
         Func<Transaction> tryDecode = () =>
         {
             Rlp.ValueDecoderContext ctx = new(bytes);
-            return _txDecoder.Decode(ref ctx);
+            return _txDecoder.Decode(ref ctx)!;
         };
         tryDecode.Should().Throw<RlpException>();
     }
@@ -111,7 +111,7 @@ public partial class ShardBlobTxDecoderTests
         Func<Transaction> tryDecode = () =>
         {
             Rlp.ValueDecoderContext ctx = new(stream.Data);
-            return _txDecoder.Decode(ref ctx);
+            return _txDecoder.Decode(ref ctx)!;
         };
         tryDecode.Should().Throw<RlpException>();
     }

--- a/src/Nethermind/Nethermind.Core.Test/Json/Base64ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/Base64ConverterTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Nethermind.Core.Test.Json;
 
 [TestFixture]
-public class Base64ConverterTests : ConverterTestBase<byte[]?>
+public class Base64ConverterTests : ConverterTestBase<byte[]>
 {
     [TestCase(null)]
     [TestCase(new byte[0])]

--- a/src/Nethermind/Nethermind.Era1/EraReader.cs
+++ b/src/Nethermind/Nethermind.Era1/EraReader.cs
@@ -194,7 +194,7 @@ public class EraReader(E2StoreReader e2) : IAsyncEnumerable<(Block, TxReceipt[])
     private TxReceipt[] DecodeReceipts(Memory<byte> buffer)
     {
         Rlp.ValueDecoderContext ctx = new(buffer.Span);
-        return RlpDecoderExtensions.DecodeArray(_receiptDecoder, ref ctx, RlpBehaviors.None);
+        return RlpDecoderExtensions.DecodeArray(_receiptDecoder, ref ctx, RlpBehaviors.None)!;
     }
 
     public ValueHash256 CalculateChecksum() => _fileReader.CalculateChecksum();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/IdConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/IdConverterTests.cs
@@ -25,7 +25,7 @@ namespace Nethermind.JsonRpc.Test.Data
         public void Can_handle_int()
         {
             IdConverter converter = new();
-            converter.Write(new Utf8JsonWriter(new MemoryStream()), 1, null);
+            converter.Write(new Utf8JsonWriter(new MemoryStream()), 1, null!);
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace Nethermind.JsonRpc.Test.Data
         {
             IdConverter converter = new();
             Assert.Throws<NotSupportedException>(
-                () => converter.Write(new Utf8JsonWriter(new MemoryStream()), 1.1, null));
+                () => converter.Write(new Utf8JsonWriter(new MemoryStream()), 1.1, null!));
         }
 
         [TestCase(typeof(int))]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -165,7 +165,7 @@ public partial class EthRpcModuleTests
         byte[]? txBytes = new EthereumJsonSerializer().Deserialize<JsonRpcResponse<byte[]>>(serialized).Result;
 
         Transaction tx = null!;
-        Assert.DoesNotThrow(() => tx = TxDecoder.Instance.Decode(txBytes, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm));
+        Assert.DoesNotThrow(() => tx = TxDecoder.Instance.Decode(txBytes, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm)!);
         Assert.That(tx.IsInMempoolForm());
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -214,7 +214,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
             for (i = 0; i < transactions.Length; i++)
             {
                 Rlp.ValueDecoderContext ctx = new(txData[i]);
-                transactions[i] = rlpDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                transactions[i] = rlpDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping)!;
             }
 
             return new TransactionDecodingResult(_transactions = transactions);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -17,13 +17,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         private static readonly RlpLimit ReceiptsRlpLimit = RlpLimit.For<ReceiptsMessage>(NethermindSyncLimits.MaxHashesFetch, nameof(ReceiptsMessage.TxReceipts));
         private static readonly RlpLimit BlockReceiptsRlpLimit = RlpLimit.For<TxReceipt[]>(NethermindSyncLimits.MaxHashesFetch, nameof(ReceiptsMessage.TxReceipts));
         private readonly ISpecProvider _specProvider;
-        private readonly IRlpStreamEncoder<TxReceipt> _encoder;
-        private readonly IRlpValueDecoder<TxReceipt> _decoder;
+        private readonly IRlpStreamEncoder<TxReceipt?> _encoder;
+        private readonly IRlpValueDecoder<TxReceipt?> _decoder;
         private readonly DecodeRlpValue<TxReceipt[]> _decodeArrayFunc;
 
-        public ReceiptsMessageSerializer(ISpecProvider specProvider) : this(specProvider, (RlpValueDecoder<TxReceipt>)Rlp.GetValueDecoder<TxReceipt>()!) { }
+        public ReceiptsMessageSerializer(ISpecProvider specProvider) : this(specProvider, (RlpValueDecoder<TxReceipt?>)Rlp.GetValueDecoder<TxReceipt?>()!) { }
 
-        protected ReceiptsMessageSerializer(ISpecProvider specProvider, RlpValueDecoder<TxReceipt> decoder)
+        protected ReceiptsMessageSerializer(ISpecProvider specProvider, RlpValueDecoder<TxReceipt?> decoder)
         {
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _encoder = decoder;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
@@ -11,7 +11,7 @@ using Nethermind.Serialization.Rlp;
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V69.Messages;
 
 [Rlp.SkipGlobalRegistration] // Created explicitly
-public sealed class ReceiptMessageDecoder69(bool skipStateAndStatus = false) : RlpValueDecoder<TxReceipt>
+public sealed class ReceiptMessageDecoder69(bool skipStateAndStatus = false) : RlpValueDecoder<TxReceipt?>
 {
     // A 100M gas ceiling still allows roughly 266k LOG0 emissions after intrinsic gas.
     private static readonly RlpLimit LogsRlpLimit = RlpLimit.For<TxReceipt>(270_000, nameof(TxReceipt.Logs));
@@ -117,7 +117,7 @@ public sealed class ReceiptMessageDecoder69(bool skipStateAndStatus = false) : R
         return logsLength;
     }
 
-    public override int GetLength(TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override int GetLength(TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         (int total, _) = GetContentLength(item, rlpBehaviors);
         return Rlp.LengthOfSequence(total);

--- a/src/Nethermind/Nethermind.Optimism.Test/ReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/ReceiptDecoderTests.cs
@@ -17,7 +17,7 @@ public class ReceiptDecoderTests
         {
             OptimismReceiptMessageDecoder decoder = new();
             Rlp.ValueDecoderContext ctx = new(rlp);
-            OptimismTxReceipt decodedReceipt = (OptimismTxReceipt)decoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+            OptimismTxReceipt decodedReceipt = (OptimismTxReceipt)decoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping)!;
 
             RlpStream encodedRlp = new(decoder.GetLength(decodedReceipt, RlpBehaviors.SkipTypedWrapping));
             decoder.Encode(encodedRlp, decodedReceipt, RlpBehaviors.SkipTypedWrapping);
@@ -40,7 +40,7 @@ public class ReceiptDecoderTests
             decoder.Encode(encodedRlp, decodedReceipt, RlpBehaviors.SkipTypedWrapping);
 
             Rlp.ValueDecoderContext valueDecoderCtx = new(encodedRlp.Data);
-            OptimismTxReceipt decodedStorageReceipt = decoder.Decode(ref valueDecoderCtx, RlpBehaviors.SkipTypedWrapping);
+            OptimismTxReceipt decodedStorageReceipt = decoder.Decode(ref valueDecoderCtx, RlpBehaviors.SkipTypedWrapping)!;
 
             Assert.Multiple(() =>
             {
@@ -59,7 +59,7 @@ public class ReceiptDecoderTests
             trieDecoder.Encode(encodedTrieRlp, decodedReceipt, RlpBehaviors.SkipTypedWrapping);
 
             Rlp.ValueDecoderContext trieCtx = new(encodedTrieRlp.Data);
-            OptimismTxReceipt decodedTrieReceipt = (OptimismTxReceipt)trieDecoder.Decode(ref trieCtx, RlpBehaviors.SkipTypedWrapping);
+            OptimismTxReceipt decodedTrieReceipt = (OptimismTxReceipt)trieDecoder.Decode(ref trieCtx, RlpBehaviors.SkipTypedWrapping)!;
 
             Assert.Multiple(() =>
             {

--- a/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
@@ -63,7 +63,7 @@ public class RlpDecoderTests
         byte[] bytes = Bytes.FromHexString(hexBytes);
         Rlp.ValueDecoderContext context = bytes.AsRlpValueContext();
 
-        Transaction transaction = _decoder.Decode(ref context);
+        Transaction transaction = _decoder.Decode(ref context)!;
 
         transaction.Should().NotBeNull();
     }

--- a/src/Nethermind/Nethermind.Serialization.Json/Base64Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/Base64Converter.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Serialization.Json;
 
 public class Base64Converter : JsonConverter<byte[]>
 {
-    public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override byte[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         JsonTokenType tokenType = reader.TokenType;
 

--- a/src/Nethermind/Nethermind.Serialization.Json/BigIntegerConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/BigIntegerConverter.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Serialization.Json
         public override BigInteger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.TokenType switch
         {
             JsonTokenType.Number => new BigInteger(reader.GetInt64()),
-            JsonTokenType.String => BigInteger.Parse(reader.GetString()),
+            JsonTokenType.String => BigInteger.Parse(reader.GetString()!),
             _ => throw new JsonException($"Cannot convert {reader.TokenType} to {nameof(BigInteger)}")
         };
 

--- a/src/Nethermind/Nethermind.Serialization.Json/BufferSegment.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/BufferSegment.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 
 namespace Nethermind.Serialization.Json;
 
-#nullable enable
-
 internal sealed class BufferSegment : ReadOnlySequenceSegment<byte>
 {
     private IMemoryOwner<byte>? _memoryOwner;

--- a/src/Nethermind/Nethermind.Serialization.Json/BufferSegmentStack.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/BufferSegmentStack.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 
 namespace Nethermind.Serialization.Json;
 
-#nullable enable
-
 internal struct BufferSegmentStack(int size)
 {
     private SegmentAsValueType[] _array = new SegmentAsValueType[size];

--- a/src/Nethermind/Nethermind.Serialization.Json/DictionaryAddressKeyConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DictionaryAddressKeyConverter.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Nethermind.Serialization.Json
 {
     using System.Collections.Generic;

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleArrayConverter.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Serialization.Json
         {
             if (reader.TokenType == JsonTokenType.String)
             {
-                string s = reader.GetString();
+                string? s = reader.GetString();
                 if (s is null) ThrowExpectedArrayString();
                 return JsonSerializer.Deserialize<double[]>(s)
                     ?? throw new JsonException($"Could not deserialize double array from string: {s}");

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -48,17 +48,17 @@ namespace Nethermind.Serialization.Json
             RefreshInstanceOptions();
         }
 
-        public object Deserialize(string json, Type type) => JsonSerializer.Deserialize(json, type, GetSerializerOptions(indented: false));
+        public object Deserialize(string json, Type type) => JsonSerializer.Deserialize(json, type, GetSerializerOptions(indented: false))!;
 
-        public T Deserialize<T>(Stream stream) => JsonSerializer.Deserialize<T>(stream, GetSerializerOptions(indented: false));
+        public T Deserialize<T>(Stream stream) => JsonSerializer.Deserialize<T>(stream, GetSerializerOptions(indented: false))!;
 
-        public T Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, GetSerializerOptions(indented: false));
+        public T Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, GetSerializerOptions(indented: false))!;
 
-        public T Deserialize<T>(ref Utf8JsonReader json) => JsonSerializer.Deserialize<T>(ref json, GetSerializerOptions(indented: false));
+        public T Deserialize<T>(ref Utf8JsonReader json) => JsonSerializer.Deserialize<T>(ref json, GetSerializerOptions(indented: false))!;
 
         public string Serialize<T>(T value, bool indented = false) => JsonSerializer.Serialize<T>(value, GetSerializerOptions(indented));
 
-        private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter> instanceConverters = null, int maxDepth = DefaultMaxDepth)
+        private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter>? instanceConverters = null, int maxDepth = DefaultMaxDepth)
         {
             SnapshotGlobalOptions(out bool strictHexFormat, out JsonConverter[] additionalConverters, out IJsonTypeInfoResolver[] additionalResolvers);
 

--- a/src/Nethermind/Nethermind.Serialization.Json/Hash256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/Hash256Converter.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#nullable enable
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Serialization.Json
                 throw new NotSupportedException();
             }
 
-            return reader.GetString();
+            return reader.GetString()!;
         }
 
         public override void Write(

--- a/src/Nethermind/Nethermind.Serialization.Json/JavaScriptObjectConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/JavaScriptObjectConverter.cs
@@ -11,8 +11,6 @@ using Microsoft.ClearScript;
 using Microsoft.ClearScript.JavaScript;
 using Nethermind.Core.Buffers;
 
-#nullable enable
-
 namespace Nethermind.Serialization.Json;
 
 public class JavaScriptObjectConverter : JsonConverter<IJavaScriptObject>

--- a/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Serialization.Json/StorageCellIndexConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StorageCellIndexConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using Nethermind.Int256;
 
-#nullable enable
-
 namespace Nethermind.Serialization.Json
 {
     using System.Collections.Generic;

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -14,8 +14,6 @@ using Nethermind.Core.Collections;
 
 namespace Nethermind.Serialization.Json;
 
-#nullable enable
-
 public abstract class CountingWriter : PipeWriter
 {
     public long WrittenCount { get; protected set; }

--- a/src/Nethermind/Nethermind.Serialization.Json/ValueHash256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ValueHash256Converter.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#nullable enable
 using System;
 using System.Runtime.CompilerServices;
 using System.Text.Json;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Serialization.Rlp
 
             Encode(item, rlpStream, contentLength);
 
-            return new Rlp(rlpStream.Data.ToArray());
+            return new Rlp(rlpStream.Data.ToArray()!);
         }
 
         public void Encode(Account account, RlpStream rlpStream, int? contentLength = null)
@@ -183,7 +183,7 @@ namespace Nethermind.Serialization.Rlp
             }
             else
             {
-                storageRoot = rlpStream.DecodeKeccak();
+                storageRoot = rlpStream.DecodeKeccak()!;
             }
 
             return storageRoot;
@@ -199,7 +199,7 @@ namespace Nethermind.Serialization.Rlp
             }
             else
             {
-                codeHash = rlpStream.DecodeKeccak();
+                codeHash = rlpStream.DecodeKeccak()!;
             }
 
             return codeHash;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp;
 
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockBodyDecoder))]
-public sealed class BlockBodyDecoder(IHeaderDecoder headerDecoder = null) : RlpValueDecoder<BlockBody>
+public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpValueDecoder<BlockBody>
 {
     private readonly TxDecoder _txDecoder = TxDecoder.Instance;
     private readonly IHeaderDecoder _headerDecoder = headerDecoder ?? new HeaderDecoder();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp;
 
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockBodyDecoder))]
-public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpValueDecoder<BlockBody>
+public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpValueDecoder<BlockBody?>
 {
     private readonly TxDecoder _txDecoder = TxDecoder.Instance;
     private readonly IHeaderDecoder _headerDecoder = headerDecoder ?? new HeaderDecoder();
@@ -16,7 +16,7 @@ public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : Rlp
     private static BlockBodyDecoder? _instance = null;
     public static BlockBodyDecoder Instance => _instance ??= new BlockBodyDecoder();
 
-    public override int GetLength(BlockBody item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetBodyLength(item));
+    public override int GetLength(BlockBody? item, RlpBehaviors rlpBehaviors) => item is null ? 1 : Rlp.LengthOfSequence(GetBodyLength(item));
 
     public int GetBodyLength(BlockBody b)
     {
@@ -87,19 +87,24 @@ public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : Rlp
     public BlockBody? DecodeUnwrapped(ref Rlp.ValueDecoderContext ctx, int lastPosition)
     {
         Transaction[] transactions = ctx.DecodeArray(_txDecoder);
-        BlockHeader[] uncles = ctx.DecodeArray(_headerDecoder);
+        BlockHeader[] uncles = ctx.DecodeArray(_headerDecoder)!;
         Withdrawal[]? withdrawals = null;
 
         if (ctx.PeekNumberOfItemsRemaining(lastPosition, 1) > 0)
         {
-            withdrawals = ctx.DecodeArray(_withdrawalDecoderDecoder);
+            withdrawals = ctx.DecodeArray(_withdrawalDecoderDecoder)!;
         }
 
         return new BlockBody(transactions, uncles, withdrawals);
     }
 
-    public override void Encode(RlpStream stream, BlockBody body, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, BlockBody? body, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
+        if (body is null)
+        {
+            stream.EncodeNullObject();
+            return;
+        }
         stream.StartSequence(GetBodyLength(body));
         stream.StartSequence(GetTxLength(body.Transactions));
         foreach (Transaction? txn in body.Transactions)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public sealed class BlockDecoder(IHeaderDecoder headerDecoder) : RlpValueDecoder<Block>
+    public sealed class BlockDecoder(IHeaderDecoder headerDecoder) : RlpValueDecoder<Block?>
     {
         private readonly IHeaderDecoder _headerDecoder = headerDecoder ?? throw new ArgumentNullException(nameof(headerDecoder));
         private readonly BlockBodyDecoder _blockBodyDecoder = new(headerDecoder);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -67,8 +67,8 @@ namespace Nethermind.Serialization.Rlp
             int sequenceLength = decoderContext.ReadSequenceLength();
             int blockCheck = decoderContext.Position + sequenceLength;
 
-            BlockHeader header = _headerDecoder.Decode(ref decoderContext);
-            BlockBody body = _blockBodyDecoder.DecodeUnwrapped(ref decoderContext, blockCheck);
+            BlockHeader header = _headerDecoder.Decode(ref decoderContext)!;
+            BlockBody body = _blockBodyDecoder.DecodeUnwrapped(ref decoderContext, blockCheck)!;
 
             Block block = new(header, body)
             {
@@ -87,7 +87,7 @@ namespace Nethermind.Serialization.Rlp
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new(rlpStream.Data.ToArray());
+            return new(rlpStream.Data.ToArray()!);
         }
 
         public override void Encode(RlpStream stream, Block? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -129,7 +129,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 stream.StartSequence(withdrawalsLength.Value);
 
-                for (int i = 0; i < item.Withdrawals.Length; i++)
+                for (int i = 0; i < item.Withdrawals!.Length; i++)
                 {
                     stream.Encode(item.Withdrawals[i]);
                 }
@@ -149,7 +149,7 @@ namespace Nethermind.Serialization.Rlp
             int sequenceLength = decoderContext.ReadSequenceLength();
             int blockCheck = decoderContext.Position + sequenceLength;
 
-            BlockHeader header = _headerDecoder.Decode(ref decoderContext);
+            BlockHeader header = _headerDecoder.Decode(ref decoderContext)!;
 
             int contentLength = decoderContext.ReadSequenceLength();
             int transactionCount = decoderContext.PeekNumberOfItemsRemaining(decoderContext.Position + contentLength);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp
 {
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockInfoDecoder))]
-    public sealed class BlockInfoDecoder() : RlpValueDecoder<BlockInfo>
+    public sealed class BlockInfoDecoder() : RlpValueDecoder<BlockInfo?>
     {
         public static BlockInfoDecoder Instance { get; } = new();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
@@ -10,7 +10,7 @@ using Nethermind.Core;
 namespace Nethermind.Serialization.Rlp
 {
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ChainLevelDecoder))]
-    public sealed class ChainLevelDecoder() : RlpValueDecoder<ChainLevelInfo>
+    public sealed class ChainLevelDecoder() : RlpValueDecoder<ChainLevelInfo?>
     {
         public override void Encode(RlpStream stream, ChainLevelInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Serialization.Rlp
                 return;
             }
 
-            if (item.BlockInfos.AsSpan().Contains(null))
+            if (Array.Exists(item.BlockInfos, static bi => bi is null))
             {
                 ThrowHasNull();
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
@@ -34,14 +34,14 @@ namespace Nethermind.Serialization.Rlp
             using ArrayPoolListRef<Hash256> topics = new(topicCount);
             while (decoderContext.Position < untilPosition)
             {
-                topics.Add(decoderContext.DecodeZeroPrefixKeccak());
+                topics.Add(decoderContext.DecodeZeroPrefixKeccak()!);
             }
             decoderContext.Check(untilPosition);
 
             byte[] data = DecodeCompactData(ref decoderContext);
             decoderContext.Check(logEntryCheck);
 
-            return new LogEntry(address, data, topics.ToArray());
+            return new LogEntry(address!, data, topics.ToArray());
         }
 
         public static void DecodeLogEntryStructRef(scoped ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors behaviors, out LogEntryStructRef item)
@@ -75,7 +75,7 @@ namespace Nethermind.Serialization.Rlp
             using ArrayPoolListRef<Hash256> topics = new(sequenceLength * 2 / Rlp.LengthOfKeccakRlp);
             while (valueDecoderContext.Position < untilPosition)
             {
-                topics.Add(valueDecoderContext.DecodeZeroPrefixKeccak());
+                topics.Add(valueDecoderContext.DecodeZeroPrefixKeccak()!);
             }
             valueDecoderContext.Check(untilPosition);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Serialization.Rlp
 {
     [Decoder(RlpDecoderKey.Storage)]
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CompactReceiptStorageDecoder))]
-    public sealed class CompactReceiptStorageDecoder() : RlpValueDecoder<TxReceipt>, IRlpObjectDecoder<TxReceipt>, IReceiptRefDecoder
+    public sealed class CompactReceiptStorageDecoder() : RlpValueDecoder<TxReceipt?>, IRlpObjectDecoder<TxReceipt?>, IReceiptRefDecoder
     {
         public static readonly CompactReceiptStorageDecoder Instance = new();
 
@@ -206,7 +206,7 @@ namespace Nethermind.Serialization.Rlp
             return logsLength;
         }
 
-        public override int GetLength(TxReceipt item, RlpBehaviors rlpBehaviors)
+        public override int GetLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
         {
             (int Total, _) = GetContentLength(item, rlpBehaviors);
             return Rlp.LengthOfSequence(Total);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Serialization.Rlp
             using ArrayPoolListRef<LogEntry> logEntries = new(sequenceLength * 2 / Rlp.LengthOfAddressRlp);
             while (decoderContext.Position < lastCheck)
             {
-                logEntries.Add(CompactLogEntryDecoder.Decode(ref decoderContext, RlpBehaviors.AllowExtraBytes));
+                logEntries.Add(CompactLogEntryDecoder.Decode(ref decoderContext, RlpBehaviors.AllowExtraBytes)!);
             }
 
             txReceipt.Logs = logEntries.ToArray();
@@ -124,11 +124,12 @@ namespace Nethermind.Serialization.Rlp
         // Refstruct decode does not generate bloom
         public bool CanDecodeBloom => false;
 
-        public Rlp Encode(TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public Rlp Encode(TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
+            if (item is null) return Rlp.OfEmptyList;
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data.ToArray());
+            return new Rlp(rlpStream.Data.ToArray()!);
         }
 
         public override void Encode(RlpStream rlpStream, TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Eip7928/AccountChangesDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Eip7928/AccountChangesDecoder.cs
@@ -23,7 +23,7 @@ public class AccountChangesDecoder : IRlpValueDecoder<AccountChanges>, IRlpStrea
         int length = ctx.ReadSequenceLength();
         int check = length + ctx.Position;
 
-        Address address = ctx.DecodeAddress();
+        Address address = ctx.DecodeAddress()!;
 
         SlotChanges[] slotChanges = ctx.DecodeArray(SlotChangesDecoder.Instance, true, default, _slotsLimit);
         UInt256? lastSlot = null;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -30,9 +30,9 @@ namespace Nethermind.Serialization.Rlp
             int headerSequenceLength = decoderContext.ReadSequenceLength();
             int headerCheck = decoderContext.Position + headerSequenceLength;
 
-            Hash256? parentHash = decoderContext.DecodeKeccak();
-            Hash256? unclesHash = decoderContext.DecodeKeccak();
-            Address? beneficiary = decoderContext.DecodeAddress();
+            Hash256 parentHash = decoderContext.DecodeKeccak()!;
+            Hash256 unclesHash = decoderContext.DecodeKeccak()!;
+            Address beneficiary = decoderContext.DecodeAddress()!;
             Hash256? stateRoot = decoderContext.DecodeKeccak();
             Hash256? transactionsRoot = decoderContext.DecodeKeccak();
             Hash256? receiptsRoot = decoderContext.DecodeKeccak();
@@ -120,7 +120,7 @@ namespace Nethermind.Serialization.Rlp
                 if (isAuRa)
                 {
                     rlpStream.Encode(header.AuRaStep!.Value);
-                    rlpStream.Encode(header.AuRaSignature);
+                    rlpStream.Encode(header.AuRaSignature!);
                 }
                 else
                 {
@@ -164,7 +164,7 @@ namespace Nethermind.Serialization.Rlp
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
 
-            return new Rlp(rlpStream.Data.ToArray());
+            return new Rlp(rlpStream.Data.ToArray()!);
         }
 
         private static int GetContentLength(BlockHeader? item, RlpBehaviors rlpBehaviors)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -9,11 +9,11 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public interface IHeaderDecoder : IBlockHeaderDecoder<BlockHeader> { }
-    public interface IBlockHeaderDecoder<T> : IRlpValueDecoder<T>, IRlpStreamEncoder<T> where T : BlockHeader { }
+    public interface IHeaderDecoder : IBlockHeaderDecoder<BlockHeader?> { }
+    public interface IBlockHeaderDecoder<T> : IRlpValueDecoder<T>, IRlpStreamEncoder<T> where T : BlockHeader? { }
 
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(HeaderDecoder))]
-    public sealed class HeaderDecoder() : RlpValueDecoder<BlockHeader>, IHeaderDecoder
+    public sealed class HeaderDecoder() : RlpValueDecoder<BlockHeader?>, IHeaderDecoder
     {
         public const int NonceLength = 8;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -28,12 +28,12 @@ namespace Nethermind.Serialization.Rlp
 
     public interface IRlpValueDecoder<T> : IRlpDecoder<T>
     {
-        T? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+        T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 
     public static class RlpValueDecoderExtensions
     {
-        public static T? Decode<T>(this IRlpValueDecoder<T> decoder, ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public static T Decode<T>(this IRlpValueDecoder<T> decoder, ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             Rlp.ValueDecoderContext context = new(bytes);
             return decoder.Decode(ref context, rlpBehaviors);
@@ -54,7 +54,7 @@ namespace Nethermind.Serialization.Rlp
 
     public abstract class RlpValueDecoder<T> : RlpStreamEncoder<T>, IRlpValueDecoder<T>
     {
-        public T? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             try
             {
@@ -63,10 +63,10 @@ namespace Nethermind.Serialization.Rlp
             catch (Exception e) when (e is IndexOutOfRangeException or ArgumentOutOfRangeException)
             {
                 ThrowRlpException(e);
-                return default;
+                return default!;
             }
         }
 
-        protected abstract T? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+        protected abstract T DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -28,12 +28,12 @@ namespace Nethermind.Serialization.Rlp
 
     public interface IRlpValueDecoder<T> : IRlpDecoder<T>
     {
-        T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+        T? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 
     public static class RlpValueDecoderExtensions
     {
-        public static T Decode<T>(this IRlpValueDecoder<T> decoder, ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public static T? Decode<T>(this IRlpValueDecoder<T> decoder, ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             Rlp.ValueDecoderContext context = new(bytes);
             return decoder.Decode(ref context, rlpBehaviors);
@@ -54,7 +54,7 @@ namespace Nethermind.Serialization.Rlp
 
     public abstract class RlpValueDecoder<T> : RlpStreamEncoder<T>, IRlpValueDecoder<T>
     {
-        public T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public T? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             try
             {
@@ -67,6 +67,6 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
-        protected abstract T DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+        protected abstract T? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Serialization.Rlp
     {
         public static readonly KeccakDecoder Instance = new();
 
-        protected override Hash256? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => decoderContext.DecodeKeccak();
+        protected override Hash256 DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => decoderContext.DecodeKeccak()!;
 
         public override int GetLength(Hash256 item, RlpBehaviors rlpBehaviors) => Rlp.LengthOf(item);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
@@ -7,14 +7,14 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp
 {
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(KeccakDecoder))]
-    public sealed class KeccakDecoder() : RlpValueDecoder<Hash256>
+    public sealed class KeccakDecoder() : RlpValueDecoder<Hash256?>
     {
         public static readonly KeccakDecoder Instance = new();
 
-        protected override Hash256 DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => decoderContext.DecodeKeccak()!;
+        protected override Hash256? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => decoderContext.DecodeKeccak();
 
-        public override int GetLength(Hash256 item, RlpBehaviors rlpBehaviors) => Rlp.LengthOf(item);
+        public override int GetLength(Hash256? item, RlpBehaviors rlpBehaviors) => Rlp.LengthOf(item);
 
-        public override void Encode(RlpStream stream, Hash256 item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => stream.Encode(item);
+        public override void Encode(RlpStream stream, Hash256? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => stream.Encode(item);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeccakDecoder.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Serialization.Rlp
     public sealed class KeccakDecoder() : RlpValueDecoder<Hash256?>
     {
         public static readonly KeccakDecoder Instance = new();
+        public static readonly IRlpValueDecoder<Hash256> NonNullableInstance = new NonNullDecoderWrapper<Hash256>(Instance);
 
         protected override Hash256? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => decoderContext.DecodeKeccak();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -15,20 +15,20 @@ public static class KeyValueStoreRlpExtensions
 {
     [SkipLocalsInit]
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, ValueHash256 hash, IRlpValueDecoder<TItem> decoder,
-        ClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+        ClockCache<ValueHash256, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpValueDecoder<TItem> decoder, ClockCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class =>
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpValueDecoder<TItem> decoder, ClockCache<ValueHash256, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class =>
         Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
 
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long key, IRlpValueDecoder<TItem>? decoder, ClockCache<long, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         ReadOnlySpan<byte> keyDb = key.ToBigEndianSpanWithoutLeadingZeros(out _);
-        return Get(db, key, keyDb, decoder, cache, rlpBehaviors, shouldCache);
+        return Get(db, key, keyDb, decoder!, cache, rlpBehaviors, shouldCache);
     }
 
     public static TItem? Get<TCacheKey, TItem>(
@@ -36,13 +36,13 @@ public static class KeyValueStoreRlpExtensions
         TCacheKey cacheKey,
         ReadOnlySpan<byte> key,
         IRlpValueDecoder<TItem> decoder,
-        ClockCache<TCacheKey, TItem> cache = null,
+        ClockCache<TCacheKey, TItem>? cache = null,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None,
         bool shouldCache = true
     ) where TItem : class
       where TCacheKey : struct, IEquatable<TCacheKey>
     {
-        TItem item = cache?.Get(cacheKey);
+        TItem? item = cache?.Get(cacheKey);
         item ??= db is IReadOnlyNativeKeyValueStore native
             ? Get(native, key, decoder, rlpBehaviors)
             : Get(db, key, decoder, rlpBehaviors);
@@ -57,14 +57,14 @@ public static class KeyValueStoreRlpExtensions
 
     [SkipLocalsInit]
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, ValueHash256 hash, IRlpValueDecoder<TItem> decoder,
-        AssociativeCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
+        AssociativeCache<ValueHash256, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
         return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpValueDecoder<TItem> decoder, AssociativeCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class =>
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpValueDecoder<TItem> decoder, AssociativeCache<ValueHash256, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class =>
         Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
 
     public static TItem? Get<TCacheKey, TItem>(
@@ -72,13 +72,13 @@ public static class KeyValueStoreRlpExtensions
         TCacheKey cacheKey,
         ReadOnlySpan<byte> key,
         IRlpValueDecoder<TItem> decoder,
-        AssociativeCache<TCacheKey, TItem> cache = null,
+        AssociativeCache<TCacheKey, TItem>? cache = null,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None,
         bool shouldCache = true
     ) where TItem : class
       where TCacheKey : struct, IHash64bit<TCacheKey>
     {
-        TItem item = cache?.Get(in cacheKey);
+        TItem? item = cache?.Get(in cacheKey);
         item ??= db is IReadOnlyNativeKeyValueStore native
             ? Get(native, key, decoder, rlpBehaviors)
             : Get(db, key, decoder, rlpBehaviors);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
@@ -10,7 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp
 {
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(LogEntryDecoder))]
-    public sealed class LogEntryDecoder() : RlpValueDecoder<LogEntry>
+    public sealed class LogEntryDecoder() : RlpValueDecoder<LogEntry?>
     {
         private static readonly RlpLimit RlpLimit = RlpLimit.For<LogEntry>((int)16.MB, nameof(LogEntry));
         public static LogEntryDecoder Instance { get; } = new();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
@@ -30,6 +30,7 @@ namespace Nethermind.Serialization.Rlp
             int topicsLength = decoderContext.ReadSequenceLength();
             int topicsCheck = decoderContext.Position + topicsLength;
             int topicCount = topicsLength / Rlp.LengthOfKeccakRlp;
+            decoderContext.GuardLimit(topicCount, RlpLimit.L4);
             Hash256[] topics = new Hash256[topicCount];
             for (int i = 0; i < topics.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
@@ -30,18 +30,17 @@ namespace Nethermind.Serialization.Rlp
             int topicsLength = decoderContext.ReadSequenceLength();
             int topicsCheck = decoderContext.Position + topicsLength;
             int topicCount = topicsLength / Rlp.LengthOfKeccakRlp;
-            decoderContext.GuardLimit(topicCount, RlpLimit.L4);
             Hash256[] topics = new Hash256[topicCount];
             for (int i = 0; i < topics.Length; i++)
             {
-                topics[i] = decoderContext.DecodeKeccak();
+                topics[i] = decoderContext.DecodeKeccak()!;
             }
             decoderContext.Check(topicsCheck);
 
             byte[] data = decoderContext.DecodeByteArray();
             decoderContext.Check(logEntryCheck);
 
-            return new LogEntry(address, data, topics);
+            return new LogEntry(address!, data, topics);
         }
 
         public Rlp Encode(LogEntry? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -53,7 +52,7 @@ namespace Nethermind.Serialization.Rlp
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data.ToArray());
+            return new Rlp(rlpStream.Data.ToArray()!);
         }
 
         public override void Encode(RlpStream rlpStream, LogEntry? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NonNullDecoderWrapper.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NonNullDecoderWrapper.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Serialization.Rlp
+{
+    public sealed class NonNullDecoderWrapper<T>(IRlpValueDecoder<T?> inner) : IRlpValueDecoder<T> where T : class
+    {
+        public T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
+            inner.Decode(ref decoderContext, rlpBehaviors) ?? throw new RlpException($"Decoded {typeof(T).Name} is null");
+
+        public int GetLength(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => inner.GetLength(item, rlpBehaviors);
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/OwnedBlockBodies.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/OwnedBlockBodies.cs
@@ -30,7 +30,7 @@ public class OwnedBlockBodies(BlockBody?[]? bodies, IMemoryOwner<byte>? memoryOw
     {
         if (_memoryOwner is null) return;
 
-        foreach (BlockBody? blockBody in Bodies)
+        foreach (BlockBody? blockBody in Bodies!)
         {
             if (blockBody is null) continue;
             foreach (Transaction tx in blockBody.Transactions)
@@ -49,7 +49,7 @@ public class OwnedBlockBodies(BlockBody?[]? bodies, IMemoryOwner<byte>? memoryOw
     {
         if (_memoryOwner is null) return;
 
-        foreach (BlockBody? blockBody in Bodies)
+        foreach (BlockBody? blockBody in Bodies!)
         {
             if (blockBody is null) continue;
             foreach (Transaction tx in blockBody.Transactions)
@@ -64,15 +64,15 @@ public class OwnedBlockBodies(BlockBody?[]? bodies, IMemoryOwner<byte>? memoryOw
 
     public IEnumerator<BlockBody?> GetEnumerator()
     {
-        foreach (BlockBody blockBody in _rawBodies)
+        foreach (BlockBody? blockBody in _rawBodies!)
         {
             yield return blockBody;
         }
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => _rawBodies.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _rawBodies!.GetEnumerator();
 
-    public int Count => _rawBodies.Length;
+    public int Count => _rawBodies!.Length;
 
-    public BlockBody? this[int index] => _rawBodies[index];
+    public BlockBody? this[int index] => _rawBodies![index];
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
@@ -16,11 +16,11 @@ public sealed class ReceiptArrayStorageDecoder(bool compactEncoding = true) : Rl
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ReceiptArrayStorageDecoder))]
     public ReceiptArrayStorageDecoder() : this(true) { }
 
-    private static readonly IRlpStreamEncoder<TxReceipt> Decoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.LegacyStorage)!;
-    private static readonly IRlpValueDecoder<TxReceipt> ValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.LegacyStorage)!;
+    private static readonly IRlpStreamEncoder<TxReceipt?> Decoder = Rlp.GetStreamEncoder<TxReceipt?>(RlpDecoderKey.LegacyStorage)!;
+    private static readonly IRlpValueDecoder<TxReceipt?> ValueDecoder = Rlp.GetValueDecoder<TxReceipt?>(RlpDecoderKey.LegacyStorage)!;
 
-    private static readonly IRlpStreamEncoder<TxReceipt> CompactDecoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.Storage)!;
-    private static readonly IRlpValueDecoder<TxReceipt> CompactValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.Storage)!;
+    private static readonly IRlpStreamEncoder<TxReceipt?> CompactDecoder = Rlp.GetStreamEncoder<TxReceipt?>(RlpDecoderKey.Storage)!;
+    private static readonly IRlpValueDecoder<TxReceipt?> CompactValueDecoder = Rlp.GetValueDecoder<TxReceipt?>(RlpDecoderKey.Storage)!;
 
     public const int CompactEncoding = 127;
 
@@ -68,19 +68,19 @@ public sealed class ReceiptArrayStorageDecoder(bool compactEncoding = true) : Rl
         if (decoderContext.PeekByte() == CompactEncoding)
         {
             decoderContext.ReadByte();
-            return CompactValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
+            return (TxReceipt[])(Array)CompactValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
         }
         else
         {
             int startPosition = decoderContext.Position;
             try
             {
-                return ValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage);
+                return (TxReceipt[])(Array)ValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage);
             }
             catch (RlpException)
             {
                 decoderContext.Position = startPosition;
-                return ValueDecoder.DecodeArray(ref decoderContext);
+                return (TxReceipt[])(Array)ValueDecoder.DecodeArray(ref decoderContext);
             }
         }
     }
@@ -126,19 +126,19 @@ public sealed class ReceiptArrayStorageDecoder(bool compactEncoding = true) : Rl
         if (receiptsData.Length > 0 && receiptsData[0] == CompactEncoding)
         {
             Rlp.ValueDecoderContext decoderContext = new(receiptsData[1..]);
-            return CompactValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
+            return (TxReceipt[])(Array)CompactValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
         }
         else
         {
             Rlp.ValueDecoderContext decoderContext = new(receiptsData);
             try
             {
-                return ValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage);
+                return (TxReceipt[])(Array)ValueDecoder.DecodeArray(ref decoderContext, RlpBehaviors.Storage);
             }
             catch (RlpException)
             {
                 decoderContext.Position = 0;
-                return ValueDecoder.DecodeArray(ref decoderContext);
+                return (TxReceipt[])(Array)ValueDecoder.DecodeArray(ref decoderContext);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
@@ -16,11 +16,11 @@ public sealed class ReceiptArrayStorageDecoder(bool compactEncoding = true) : Rl
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ReceiptArrayStorageDecoder))]
     public ReceiptArrayStorageDecoder() : this(true) { }
 
-    private static readonly IRlpStreamEncoder<TxReceipt> Decoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.LegacyStorage);
-    private static readonly IRlpValueDecoder<TxReceipt> ValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.LegacyStorage);
+    private static readonly IRlpStreamEncoder<TxReceipt> Decoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.LegacyStorage)!;
+    private static readonly IRlpValueDecoder<TxReceipt> ValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.LegacyStorage)!;
 
-    private static readonly IRlpStreamEncoder<TxReceipt> CompactDecoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.Storage);
-    private static readonly IRlpValueDecoder<TxReceipt> CompactValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.Storage);
+    private static readonly IRlpStreamEncoder<TxReceipt> CompactDecoder = Rlp.GetStreamEncoder<TxReceipt>(RlpDecoderKey.Storage)!;
+    private static readonly IRlpValueDecoder<TxReceipt> CompactValueDecoder = Rlp.GetValueDecoder<TxReceipt>(RlpDecoderKey.Storage)!;
 
     public const int CompactEncoding = 127;
 
@@ -148,14 +148,14 @@ public sealed class ReceiptArrayStorageDecoder(bool compactEncoding = true) : Rl
         Rlp.ValueDecoderContext context = new(receiptData);
         try
         {
-            TxReceipt receipt = ValueDecoder.Decode(ref context, RlpBehaviors.Storage);
+            TxReceipt receipt = ValueDecoder.Decode(ref context, RlpBehaviors.Storage)!;
             receipt.TxHash = hash;
             return receipt;
         }
         catch (RlpException)
         {
             context.Position = 0;
-            TxReceipt receipt = ValueDecoder.Decode(ref context);
+            TxReceipt receipt = ValueDecoder.Decode(ref context)!;
             receipt.TxHash = hash;
             return receipt;
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Serialization.Rlp
         // A 100M gas ceiling still allows roughly 266k LOG0 emissions after intrinsic gas.
         private static readonly RlpLimit LogsRlpLimit = RlpLimit.For<TxReceipt>(270_000, nameof(TxReceipt.Logs));
 
-        protected override TxReceipt DecodeInternal(ref Rlp.ValueDecoderContext ctx, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        protected override TxReceipt? DecodeInternal(ref Rlp.ValueDecoderContext ctx, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             if (ctx.IsNextItemEmptyList())
             {
@@ -116,9 +116,10 @@ namespace Nethermind.Serialization.Rlp
         private static int GetLogsLength(TxReceipt item)
         {
             int logsLength = 0;
-            for (int i = 0; i < item.Logs.Length; i++)
+            LogEntry[] logs = item.Logs ?? [];
+            for (int i = 0; i < logs.Length; i++)
             {
-                logsLength += Rlp.LengthOf(item.Logs[i]);
+                logsLength += Rlp.LengthOf(logs[i]);
             }
 
             return logsLength;
@@ -151,7 +152,7 @@ namespace Nethermind.Serialization.Rlp
             int length = GetLength(item, rlpBehaviors);
             RlpStream stream = new(length);
             Encode(stream, item, rlpBehaviors);
-            return stream.Data.ToArray();
+            return stream.Data.ToArray()!;
         }
 
         public override void Encode(RlpStream rlpStream, TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -195,7 +196,7 @@ namespace Nethermind.Serialization.Rlp
                 rlpStream.Encode(item.Bloom);
 
             rlpStream.StartSequence(logsLength);
-            LogEntry[] logs = item.Logs;
+            LogEntry[] logs = item.Logs ?? [];
             for (int i = 0; i < logs.Length; i++)
             {
                 rlpStream.Encode(logs[i]);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Serialization.Rlp
     [Rlp.Decoder(RlpDecoderKey.Default)]
     [Rlp.Decoder(RlpDecoderKey.Trie)]
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ReceiptMessageDecoder))]
-    public sealed class ReceiptMessageDecoder(bool skipStateAndStatus = false, bool skipBloom = false) : RlpValueDecoder<TxReceipt>
+    public sealed class ReceiptMessageDecoder(bool skipStateAndStatus = false, bool skipBloom = false) : RlpValueDecoder<TxReceipt?>
     {
         // A 100M gas ceiling still allows roughly 266k LOG0 emissions after intrinsic gas.
         private static readonly RlpLimit LogsRlpLimit = RlpLimit.For<TxReceipt>(270_000, nameof(TxReceipt.Logs));
@@ -86,7 +86,7 @@ namespace Nethermind.Serialization.Rlp
                 => throw new RlpException("Unexpected receipt field");
         }
 
-        private (int Total, int Logs) GetContentLength(TxReceipt item, RlpBehaviors rlpBehaviors)
+        private (int Total, int Logs) GetContentLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
         {
             if (item is null)
             {
@@ -128,13 +128,13 @@ namespace Nethermind.Serialization.Rlp
         /// <summary>
         /// https://eips.ethereum.org/EIPS/eip-2718
         /// </summary>
-        public override int GetLength(TxReceipt item, RlpBehaviors rlpBehaviors)
+        public override int GetLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
         {
             (int Total, _) = GetContentLength(item, rlpBehaviors);
             int receiptPayloadLength = Rlp.LengthOfSequence(Total);
 
             bool isForTxRoot = (rlpBehaviors & RlpBehaviors.SkipTypedWrapping) == RlpBehaviors.SkipTypedWrapping;
-            int result = item.TxType != TxType.Legacy
+            int result = item?.TxType != TxType.Legacy
                 ? isForTxRoot
                     ? (1 + receiptPayloadLength)
                     : Rlp.LengthOfSequence(1 + receiptPayloadLength) // Rlp(TransactionType || TransactionPayload)
@@ -155,7 +155,7 @@ namespace Nethermind.Serialization.Rlp
             return stream.Data.ToArray()!;
         }
 
-        public override void Encode(RlpStream rlpStream, TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public override void Encode(RlpStream rlpStream, TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             if (item is null)
             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptRecoveryBlock.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptRecoveryBlock.cs
@@ -56,7 +56,7 @@ public struct ReceiptRecoveryBlock
             Position = _currentTransactionPosition
         };
         TxDecoder.Instance.Decode(ref decoderContext, ref _txBuffer, RlpBehaviors.AllowUnsigned);
-        Hash256 _ = _txBuffer.Hash; // Force Hash evaluation
+        Hash256? _ = _txBuffer!.Hash; // Force Hash evaluation
         _currentTransactionPosition = decoderContext.Position;
 
         return _txBuffer;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Serialization.Rlp
 {
     [Rlp.Decoder(RlpDecoderKey.LegacyStorage)]
     [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ReceiptStorageDecoder))]
-    public sealed class ReceiptStorageDecoder(bool supportTxHash = true) : RlpValueDecoder<TxReceipt>, IRlpObjectDecoder<TxReceipt>, IReceiptRefDecoder
+    public sealed class ReceiptStorageDecoder(bool supportTxHash = true) : RlpValueDecoder<TxReceipt?>, IRlpObjectDecoder<TxReceipt?>, IReceiptRefDecoder
     {
         private readonly bool _supportTxHash = supportTxHash;
         private const byte MarkTxHashByte = 255;
@@ -244,13 +244,13 @@ namespace Nethermind.Serialization.Rlp
         /// <summary>
         /// https://eips.ethereum.org/EIPS/eip-2718
         /// </summary>
-        public override int GetLength(TxReceipt item, RlpBehaviors rlpBehaviors)
+        public override int GetLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
         {
             (int Total, _) = GetContentLength(item, rlpBehaviors);
             int receiptPayloadLength = Rlp.LengthOfSequence(Total);
 
             bool isForTxRoot = (rlpBehaviors & RlpBehaviors.SkipTypedWrapping) == RlpBehaviors.SkipTypedWrapping;
-            int result = item.TxType != TxType.Legacy
+            int result = item?.TxType != TxType.Legacy
                 ? isForTxRoot
                     ? (1 + receiptPayloadLength)
                     : Rlp.LengthOfSequence(1 + receiptPayloadLength) // Rlp(TransactionType || ReceiptPayload)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -333,17 +333,7 @@ namespace Nethermind.Serialization.Rlp
         public void DecodeLogEntryStructRef(scoped ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors behaviour,
             out LogEntryStructRef current) => LogEntryDecoder.DecodeStructRef(ref decoderContext, behaviour, out current);
 
-        public Hash256[] DecodeTopics(Rlp.ValueDecoderContext valueDecoderContext)
-        {
-            int sequenceLength = valueDecoderContext.ReadSequenceLength();
-            int topicsCheck = valueDecoderContext.Position + sequenceLength;
-            int topicCount = sequenceLength / Rlp.LengthOfKeccakRlp;
-            Hash256[] topics = new Hash256[topicCount];
-            for (int i = 0; i < topics.Length; i++)
-                topics[i] = valueDecoderContext.DecodeKeccak()!;
-            valueDecoderContext.Check(topicsCheck);
-            return topics;
-        }
+        public Hash256[] DecodeTopics(Rlp.ValueDecoderContext valueDecoderContext) => KeccakDecoder.NonNullableInstance.DecodeArray(ref valueDecoderContext);
 
         public bool CanDecodeBloom => true;
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -333,7 +333,17 @@ namespace Nethermind.Serialization.Rlp
         public void DecodeLogEntryStructRef(scoped ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors behaviour,
             out LogEntryStructRef current) => LogEntryDecoder.DecodeStructRef(ref decoderContext, behaviour, out current);
 
-        public Hash256[] DecodeTopics(Rlp.ValueDecoderContext valueDecoderContext) => KeccakDecoder.Instance.DecodeArray(ref valueDecoderContext);
+        public Hash256[] DecodeTopics(Rlp.ValueDecoderContext valueDecoderContext)
+        {
+            int sequenceLength = valueDecoderContext.ReadSequenceLength();
+            int topicsCheck = valueDecoderContext.Position + sequenceLength;
+            int topicCount = sequenceLength / Rlp.LengthOfKeccakRlp;
+            Hash256[] topics = new Hash256[topicCount];
+            for (int i = 0; i < topics.Length; i++)
+                topics[i] = valueDecoderContext.DecodeKeccak()!;
+            valueDecoderContext.Check(topicsCheck);
+            return topics;
+        }
 
         public bool CanDecodeBloom => true;
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -98,11 +98,12 @@ namespace Nethermind.Serialization.Rlp
             return txReceipt;
         }
 
-        public Rlp Encode(TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        public Rlp Encode(TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
+            if (item is null) return Rlp.OfEmptyList;
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data.ToArray());
+            return new Rlp(rlpStream.Data.ToArray()!);
         }
 
         public override void Encode(RlpStream rlpStream, TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -153,7 +154,7 @@ namespace Nethermind.Serialization.Rlp
 
                 rlpStream.StartSequence(logsLength);
 
-                LogEntry[] logs = item.Logs;
+                LogEntry[] logs = item.Logs ?? [];
                 for (int i = 0; i < logs.Length; i++)
                 {
                     rlpStream.Encode(logs[i]);
@@ -174,7 +175,7 @@ namespace Nethermind.Serialization.Rlp
 
                 rlpStream.StartSequence(logsLength);
 
-                LogEntry[] logs = item.Logs;
+                LogEntry[] logs = item.Logs ?? [];
                 for (int i = 0; i < logs.Length; i++)
                 {
                     rlpStream.Encode(logs[i]);
@@ -223,17 +224,18 @@ namespace Nethermind.Serialization.Rlp
                 contentLength += Rlp.LengthOf(item.PostTransactionState);
             }
 
-            contentLength += Rlp.LengthOf(item.Error);
+            contentLength += Rlp.LengthOf(item.Error ?? string.Empty);
 
             return (contentLength, logsLength);
         }
 
         private static int GetLogsLength(TxReceipt item)
         {
+            LogEntry[] logs = item.Logs ?? [];
             int logsLength = 0;
-            for (int i = 0; i < item.Logs.Length; i++)
+            for (int i = 0; i < logs.Length; i++)
             {
-                logsLength += Rlp.LengthOf(item.Logs[i]);
+                logsLength += Rlp.LengthOf(logs[i]);
             }
 
             return logsLength;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Serialization.Rlp
         internal static readonly Rlp OfEmptyStringHash = Encode(Keccak.OfAnEmptyString.Bytes); // use bytes to avoid stack overflow
 
         internal static readonly Rlp EmptyBloom = Encode(Bloom.Empty.Bytes);
-        static Rlp() => RegisterDecoders(Assembly.GetAssembly(typeof(Rlp)));
+        static Rlp() => RegisterDecoders(Assembly.GetAssembly(typeof(Rlp))!);
 
         /// <summary>
         /// This is not encoding - just a creation of an RLP object, e.g. passing 192 would mean an RLP of an empty sequence.
@@ -79,7 +79,7 @@ namespace Nethermind.Serialization.Rlp
             using Lock.Scope _ = _decoderLock.EnterScope();
             _decoderBuilder.Clear();
             _decodersSnapshot = null;
-            RegisterDecoders(Assembly.GetAssembly(typeof(Rlp)));
+            RegisterDecoders(Assembly.GetAssembly(typeof(Rlp))!);
             RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
         }
 
@@ -144,8 +144,8 @@ namespace Nethermind.Serialization.Rlp
             return span.ToPooledList();
         }
 
-        public static IRlpValueDecoder<T>? GetValueDecoder<T>(string key = RlpDecoderKey.Default) => Decoders.TryGetValue(new(typeof(T), key), out IRlpDecoder value) ? value as IRlpValueDecoder<T> : null;
-        public static IRlpStreamEncoder<T>? GetStreamEncoder<T>(string key = RlpDecoderKey.Default) => Decoders.TryGetValue(new(typeof(T), key), out IRlpDecoder value) ? value as IRlpStreamEncoder<T> : null;
+        public static IRlpValueDecoder<T>? GetValueDecoder<T>(string key = RlpDecoderKey.Default) => Decoders.TryGetValue(new(typeof(T), key), out IRlpDecoder? value) ? value as IRlpValueDecoder<T> : null;
+        public static IRlpStreamEncoder<T>? GetStreamEncoder<T>(string key = RlpDecoderKey.Default) => Decoders.TryGetValue(new(typeof(T), key), out IRlpDecoder? value) ? value as IRlpStreamEncoder<T> : null;
         public static IRlpObjectDecoder<T> GetObjectDecoder<T>(string key = RlpDecoderKey.Default) => Decoders.GetValueOrDefault(new(typeof(T), key)) as IRlpObjectDecoder<T> ?? throw new RlpException($"{nameof(Rlp)} does not support encoding {typeof(T).Name}");
 
         public static ArrayPoolList<T> DecodeArrayPool<T>(ref ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None, RlpLimit? limit = null)
@@ -164,7 +164,7 @@ namespace Nethermind.Serialization.Rlp
             ArrayPoolList<T> result = new(length);
             for (int i = 0; i < length; i++)
             {
-                result.Add(rlpDecoder.Decode(ref decoderContext, rlpBehaviors));
+                result.Add(rlpDecoder.Decode(ref decoderContext, rlpBehaviors)!);
             }
 
             if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
@@ -180,7 +180,7 @@ namespace Nethermind.Serialization.Rlp
             IRlpValueDecoder<T>? rlpDecoder = GetValueDecoder<T>();
             bool shouldCheckStream = decoderContext.Position == 0 && (rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes;
             int length = decoderContext.Length;
-            T? result = rlpDecoder is not null ? rlpDecoder.Decode(ref decoderContext, rlpBehaviors) : throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
+            T result = rlpDecoder is not null ? rlpDecoder.Decode(ref decoderContext, rlpBehaviors)! : throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
             if (shouldCheckStream)
                 decoderContext.Check(length);
             return result;
@@ -205,7 +205,7 @@ namespace Nethermind.Serialization.Rlp
                 int totalLength = rlpStreamEncoder.GetLength(item, behaviors);
                 RlpStream stream = new(totalLength);
                 rlpStreamEncoder.Encode(stream, item, behaviors);
-                return new Rlp(stream.Data.ToArray());
+                return new Rlp(stream.Data.ToArray()!);
             }
 
             return GetObjectDecoder<T>().Encode(item, behaviors);
@@ -224,7 +224,7 @@ namespace Nethermind.Serialization.Rlp
                 int totalLength = rlpStreamEncoder.GetLength(items, behaviors);
                 RlpStream stream = new(totalLength);
                 rlpStreamEncoder.Encode(stream, items, behaviors);
-                return new Rlp(stream.Data.ToArray());
+                return new Rlp(stream.Data.ToArray()!);
             }
 
             return GetObjectDecoder<T>().Encode(items, behaviors);
@@ -665,7 +665,7 @@ namespace Nethermind.Serialization.Rlp
 
             private Memory<byte> ReadSlicedMemory(int length)
             {
-                Memory<byte> data = Memory.Value.Slice(Position, length);
+                Memory<byte> data = Memory.GetValueOrDefault().Slice(Position, length);
                 Position += length;
                 return data;
             }
@@ -1377,7 +1377,7 @@ namespace Nethermind.Serialization.Rlp
                 return default;
             }
 
-            public T[] DecodeArray<T>(IRlpValueDecoder<T>? decoder = null, bool checkPositions = true, T defaultElement = default, RlpLimit? limit = null)
+            public T[] DecodeArray<T>(IRlpValueDecoder<T>? decoder = null, bool checkPositions = true, T? defaultElement = default, RlpLimit? limit = null)
             {
                 if (decoder is null)
                 {
@@ -1395,12 +1395,12 @@ namespace Nethermind.Serialization.Rlp
                 {
                     if (PeekByte() == OfEmptyList[0])
                     {
-                        result[i] = defaultElement;
+                        result[i] = defaultElement!;
                         Position++;
                     }
                     else
                     {
-                        result[i] = decoder.Decode(ref this);
+                        result[i] = decoder.Decode(ref this)!;
                     }
                 }
 
@@ -1412,7 +1412,7 @@ namespace Nethermind.Serialization.Rlp
                 return result;
             }
 
-            public T[] DecodeArray<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T defaultElement = default, RlpLimit? limit = null)
+            public T[] DecodeArray<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T? defaultElement = default, RlpLimit? limit = null)
             {
                 int positionCheck = ReadSequenceLength() + Position;
                 int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null);
@@ -1422,7 +1422,7 @@ namespace Nethermind.Serialization.Rlp
                 {
                     if (PeekByte() == OfEmptyList[0])
                     {
-                        result[i] = defaultElement;
+                        result[i] = defaultElement!;
                         Position++;
                     }
                     else
@@ -1439,7 +1439,7 @@ namespace Nethermind.Serialization.Rlp
                 return result;
             }
 
-            public ArrayPoolList<T> DecodeArrayPoolList<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T defaultElement = default, RlpLimit? limit = null)
+            public ArrayPoolList<T> DecodeArrayPoolList<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T? defaultElement = default, RlpLimit? limit = null)
             {
                 int positionCheck = ReadSequenceLength() + Position;
                 int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null);
@@ -1452,7 +1452,7 @@ namespace Nethermind.Serialization.Rlp
                     {
                         if (PeekByte() == OfEmptyList[0])
                         {
-                            result[i] = defaultElement;
+                            result[i] = defaultElement!;
                             Position++;
                         }
                         else
@@ -1796,7 +1796,7 @@ namespace Nethermind.Serialization.Rlp
 
         public bool Equals(RlpDecoderKey other) => _type == other._type && _key.Equals(other._key);
 
-        public override bool Equals(object obj) => obj is RlpDecoderKey key && Equals(key);
+        public override bool Equals(object? obj) => obj is RlpDecoderKey key && Equals(key);
 
         public static bool operator ==(RlpDecoderKey left, RlpDecoderKey right) => left.Equals(right);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.std.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.std.cs
@@ -78,8 +78,8 @@ public partial class Rlp
                             try
                             {
                                 _decoderBuilder[key] = instance ??= (IRlpDecoder)(type.GetConstructor(Type.EmptyTypes) is not null ?
-                                    Activator.CreateInstance(type) :
-                                    Activator.CreateInstance(type, BindingFlags.CreateInstance | BindingFlags.OptionalParamBinding, null, [Type.Missing], null));
+                                    Activator.CreateInstance(type)! :
+                                    Activator.CreateInstance(type, BindingFlags.CreateInstance | BindingFlags.OptionalParamBinding, null, [Type.Missing], null)!);
                             }
                             catch (Exception)
                             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Serialization.Rlp
             T[] result = new T[length];
             for (int i = 0; i < result.Length; i++)
             {
-                result[i] = decoder.Decode(ref decoderContext, rlpBehaviors);
+                result[i] = decoder.Decode(ref decoderContext, rlpBehaviors)!;
             }
 
             if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
@@ -40,7 +40,7 @@ namespace Nethermind.Serialization.Rlp
             Rlp[] rlpSequence = new Rlp[items.Length];
             for (int i = 0; i < items.Length; i++)
             {
-                rlpSequence[i] = items[i] is null ? Rlp.OfEmptyList : decoder.Encode(items[i], behaviors);
+                rlpSequence[i] = items[i] is null ? Rlp.OfEmptyList : decoder.Encode(items[i]!, behaviors);
             }
 
             return Rlp.Encode(rlpSequence);
@@ -74,7 +74,7 @@ namespace Nethermind.Serialization.Rlp
             int totalLength = 0;
             for (int i = 0; i < items.Length; i++)
             {
-                totalLength += decoder.GetLength(items[i], behaviors);
+                totalLength += decoder.GetLength(items[i]!, behaviors);
             }
 
             int bufferLength = Rlp.LengthOfSequence(totalLength);
@@ -84,7 +84,7 @@ namespace Nethermind.Serialization.Rlp
 
             for (int i = 0; i < items.Length; i++)
             {
-                decoder.Encode(rlpStream, items[i], behaviors);
+                decoder.Encode(rlpStream, items[i]!, behaviors);
             }
 
             return rlpStream;
@@ -103,7 +103,7 @@ namespace Nethermind.Serialization.Rlp
             int totalLength = 0;
             for (int i = 0; i < items.Count; i++)
             {
-                totalLength += decoder.GetLength(items[i], behaviors);
+                totalLength += decoder.GetLength(items[i]!, behaviors);
             }
 
             int bufferLength = Rlp.LengthOfSequence(totalLength);
@@ -113,7 +113,7 @@ namespace Nethermind.Serialization.Rlp
 
             for (int i = 0; i < items.Count; i++)
             {
-                decoder.Encode(rlpStream, items[i], behaviors);
+                decoder.Encode(rlpStream, items[i]!, behaviors);
             }
 
             return rlpStream;
@@ -124,7 +124,7 @@ namespace Nethermind.Serialization.Rlp
             int totalLength = 0;
             for (int i = 0; i < items.Count; i++)
             {
-                totalLength += decoder.GetLength(items[i], behaviors);
+                totalLength += decoder.GetLength(items[i]!, behaviors);
             }
 
             int bufferLength = Rlp.LengthOfSequence(totalLength);
@@ -134,7 +134,7 @@ namespace Nethermind.Serialization.Rlp
 
             for (int i = 0; i < items.Count; i++)
             {
-                decoder.Encode(rlpStream, items[i], behaviors);
+                decoder.Encode(rlpStream, items[i]!, behaviors);
             }
 
             return rlpStream;
@@ -143,9 +143,9 @@ namespace Nethermind.Serialization.Rlp
         public static CappedArray<byte> EncodeToCappedArray<T>(this IRlpStreamEncoder<T> decoder, T? item,
             RlpBehaviors rlpBehaviors = RlpBehaviors.None, ICappedArrayPool? bufferPool = null)
         {
-            int size = decoder.GetLength(item, rlpBehaviors);
+            int size = decoder.GetLength(item!, rlpBehaviors);
             CappedArray<byte> buffer = bufferPool.SafeRent(size);
-            decoder.Encode(buffer.AsRlpStream(), item, rlpBehaviors);
+            decoder.Encode(buffer.AsRlpStream(), item!, rlpBehaviors);
             return buffer;
         }
 
@@ -184,12 +184,13 @@ namespace Nethermind.Serialization.Rlp
             if (items is null)
             {
                 stream.Encode(Rlp.OfEmptyList);
+                return;
             }
 
             stream.StartSequence(decoder.GetContentLength(items, behaviors));
             for (int index = 0; index < items.Length; index++)
             {
-                T t = items[index];
+                T? t = items[index];
                 if (t is null)
                 {
                     stream.Encode(Rlp.OfEmptyList);
@@ -212,7 +213,7 @@ namespace Nethermind.Serialization.Rlp
             int contentLength = 0;
             for (int i = 0; i < items.Length; i++)
             {
-                contentLength += decoder.GetLength(items[i], behaviors);
+                contentLength += decoder.GetLength(items[i]!, behaviors);
             }
 
             return contentLength;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpLimit.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpLimit.cs
@@ -18,7 +18,7 @@ public record struct RlpLimit(int Limit, string TypeName = "", ReadOnlyMemory<ch
     public static readonly RlpLimit L32 = new(32);
     public static readonly RlpLimit L64 = new(64);
     public static readonly RlpLimit L65 = new(65);
-    private string _collectionExpression;
+    private string? _collectionExpression;
 
     public RlpLimit() : this((int)4.MiB) { }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -56,14 +56,14 @@ namespace Nethermind.Serialization.Rlp
                 WriteByte(Rlp.EmptyListByte);
                 return;
             }
-            IRlpStreamEncoder<T> decoder = Rlp.GetStreamEncoder<T>();
+            IRlpStreamEncoder<T> decoder = Rlp.GetStreamEncoder<T>()!;
             int contentLength = decoder.GetContentLength(items);
 
             StartSequence(contentLength);
 
             foreach (T? item in items)
             {
-                decoder.Encode(this, item, rlpBehaviors);
+                decoder.Encode(this, item!, rlpBehaviors);
             }
         }
         public void Encode(Block value) => _blockDecoder.Encode(this, value);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -67,13 +67,13 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
     public void RegisterDecoder(TxType type, ITxDecoder decoder) => _decoders[(int)type] = decoder;
 
     private ITxDecoder GetDecoder(TxType txType) =>
-        _decoders.TryGetByTxType(txType, out ITxDecoder decoder)
+        _decoders.TryGetByTxType(txType, out ITxDecoder? decoder)
             ? decoder
             : throw new RlpException($"Unknown transaction type {txType}") { Data = { { "txType", txType } } };
 
     protected override T? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        T transaction = null;
+        T? transaction = null;
         Decode(ref decoderContext, ref transaction, rlpBehaviors);
         return transaction;
     }
@@ -111,7 +111,7 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
             }
         }
 
-        GetDecoder(txType).Decode(ref Unsafe.As<T, Transaction>(ref transaction), txSequenceStart, transactionSequence, ref decoderContext, rlpBehaviors);
+        GetDecoder(txType).Decode(ref Unsafe.As<T?, Transaction?>(ref transaction), txSequenceStart, transactionSequence, ref decoderContext, rlpBehaviors);
     }
 
     public override void Encode(RlpStream stream, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => EncodeTx(stream, item, rlpBehaviors, forSigning: false, isEip155Enabled: false, chainId: 0);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -71,11 +71,11 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
             ? decoder
             : throw new RlpException($"Unknown transaction type {txType}") { Data = { { "txType", txType } } };
 
-    protected override T? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override T DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         T? transaction = null;
         Decode(ref decoderContext, ref transaction, rlpBehaviors);
-        return transaction;
+        return transaction!;
     }
 
     public void Decode(ref Rlp.ValueDecoderContext decoderContext, ref T? transaction, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -146,5 +146,5 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     protected override int GetPayloadLength(Transaction transaction) =>
         base.GetPayloadLength(transaction)
         + Rlp.LengthOf(transaction.MaxFeePerBlobGas)
-        + Rlp.LengthOf(transaction.BlobVersionedHashes);
+        + Rlp.LengthOf(transaction.BlobVersionedHashes!);
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/SignatureBuilder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/SignatureBuilder.cs
@@ -13,7 +13,7 @@ public static class SignatureBuilder
     {
         bool allowUnsigned = rlpBehaviors.HasFlag(RlpBehaviors.AllowUnsigned);
         bool isSignatureOk = true;
-        string signatureError = null;
+        string? signatureError = null;
         if (rBytes.Length == 0 || sBytes.Length == 0)
         {
             isSignatureOk = false;
@@ -39,6 +39,6 @@ public static class SignatureBuilder
             ? new Signature(rBytes, sBytes, v)
             : allowUnsigned
                 ? null
-                : throw new RlpException(signatureError);
+                : throw new RlpException(signatureError!);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
@@ -23,7 +23,7 @@ public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal>
         {
             Index = decoderContext.DecodeULong(),
             ValidatorIndex = decoderContext.DecodeULong(),
-            Address = decoderContext.DecodeAddress(),
+            Address = decoderContext.DecodeAddress()!,
             AmountInGwei = decoderContext.DecodeULong()
         };
     }
@@ -47,11 +47,11 @@ public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal>
 
     public Rlp Encode(Withdrawal? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        RlpStream stream = new(GetLength(item, rlpBehaviors));
+        RlpStream stream = new(GetLength(item!, rlpBehaviors));
 
         Encode(stream, item, rlpBehaviors);
 
-        return new(stream.Data.ToArray());
+        return new(stream.Data.ToArray()!);
     }
 
     private static int GetContentLength(Withdrawal item) =>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Serialization.Rlp;
 
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(WithdrawalDecoder))]
-public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal>
+public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal?>
 {
     protected override Withdrawal? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
@@ -60,5 +60,5 @@ public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal>
         Rlp.LengthOfAddressRlp +
         Rlp.LengthOf(item.AmountInGwei);
 
-    public override int GetLength(Withdrawal item, RlpBehaviors _) => Rlp.LengthOfSequence(GetContentLength(item));
+    public override int GetLength(Withdrawal? item, RlpBehaviors _) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item));
 }

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -190,7 +190,7 @@ public class ShutterTxLoader(
 
     private Transaction DecodeTransaction(ReadOnlySpan<byte> encoded)
     {
-        Transaction tx = TxDecoder.Instance.Decode(encoded, RlpBehaviors.SkipTypedWrapping);
+        Transaction tx = TxDecoder.Instance.Decode(encoded, RlpBehaviors.SkipTypedWrapping)!;
         tx.SenderAddress = ecdsa.RecoverAddress(tx, true);
         return tx;
     }

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -20,7 +20,7 @@ namespace Nethermind.State.Repositories
 
         private readonly object _writeLock = new();
         private readonly ClockCache<long, ChainLevelInfo> _blockInfoCache = new(CacheSize);
-        private readonly IRlpValueDecoder<ChainLevelInfo> _decoder = Rlp.GetValueDecoder<ChainLevelInfo>();
+        private readonly IRlpValueDecoder<ChainLevelInfo?> _decoder = Rlp.GetValueDecoder<ChainLevelInfo?>();
 
         private readonly IDb _blockInfoDb = blockInfoDb ?? throw new ArgumentNullException(nameof(blockInfoDb));
 
@@ -72,7 +72,7 @@ namespace Nethermind.State.Repositories
 
         public BatchWrite StartBatch() => new(_writeLock, _blockInfoDb.StartWriteBatch());
 
-        public ChainLevelInfo? LoadLevel(long number) => _blockInfoDb.Get(number, Rlp.GetValueDecoder<ChainLevelInfo>(), _blockInfoCache);
+        public ChainLevelInfo? LoadLevel(long number) => _blockInfoDb.Get(number, Rlp.GetValueDecoder<ChainLevelInfo?>(), _blockInfoCache);
 
         public IOwnedReadOnlyList<ChainLevelInfo?> MultiLoadLevel(in ArrayPoolListRef<long> blockNumbers)
         {

--- a/src/Nethermind/Nethermind.Stateless.Executor/InputSerializer.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/InputSerializer.cs
@@ -65,9 +65,9 @@ public static class InputSerializer
         ulong chainId = ReadUInt64(input, ref offset);
         int blockLength = ReadInt32(input, ref offset);
 
-        IRlpValueDecoder<Block> blockDecoder = Rlp.GetValueDecoder<Block>()!; // cannot be null
+        IRlpValueDecoder<Block?> blockDecoder = Rlp.GetValueDecoder<Block?>()!; // cannot be null
         Rlp.ValueDecoderContext blockContext = new(input.Slice(offset, blockLength));
-        Block block = blockDecoder.Decode(ref blockContext, RlpBehaviors.None);
+        Block? block = blockDecoder.Decode(ref blockContext, RlpBehaviors.None) ?? throw new RlpException("Block is null");
         blockContext.Check(blockLength);
         offset += blockLength;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/ExtraConsensusDataDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ExtraConsensusDataDecoderTests.cs
@@ -21,11 +21,11 @@ internal class ExtraConsensusDataDecoderTests
     {
         ExtraConsensusDataDecoder decoder = new();
         Rlp.ValueDecoderContext context = new(Bytes.FromHexString(extraDataRlp));
-        ExtraFieldsV2 decodedExtraData = decoder.Decode(ref context);
+        ExtraFieldsV2 decodedExtraData = decoder.Decode(ref context)!;
 
         Rlp encodedExtraData = decoder.Encode(decodedExtraData);
 
-        ExtraFieldsV2 unencoded = decoder.Decode((ReadOnlySpan<byte>)encodedExtraData.Bytes);
+        ExtraFieldsV2 unencoded = decoder.Decode((ReadOnlySpan<byte>)encodedExtraData.Bytes)!;
 
         unencoded.Should().BeEquivalentTo(decodedExtraData);
     }
@@ -43,12 +43,12 @@ internal class ExtraConsensusDataDecoderTests
         if (useRlpStream)
         {
             Rlp.ValueDecoderContext context = new(stream.Data);
-            decodedExtraData = decoder.Decode(ref context);
+            decodedExtraData = decoder.Decode(ref context)!;
         }
         else
         {
             Rlp.ValueDecoderContext context = new(stream.Data);
-            decodedExtraData = decoder.Decode(ref context);
+            decodedExtraData = decoder.Decode(ref context)!;
         }
 
         decodedExtraData.Should().BeEquivalentTo(extraFields);
@@ -62,7 +62,7 @@ internal class ExtraConsensusDataDecoderTests
 
         Rlp encodedExtraData = decoder.Encode(extraFieldsV2);
 
-        ExtraFieldsV2 unencoded = decoder.Decode((ReadOnlySpan<byte>)encodedExtraData.Bytes);
+        ExtraFieldsV2 unencoded = decoder.Decode((ReadOnlySpan<byte>)encodedExtraData.Bytes)!;
 
         unencoded.Should().BeEquivalentTo(extraFieldsV2);
     }

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/SyncInfoDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/SyncInfoDecoderTests.cs
@@ -72,12 +72,12 @@ public class SyncInfoDecoderTests
         if (useRlpStream)
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
         else
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
 
         decoded.Should().BeEquivalentTo(syncInfo);
@@ -106,11 +106,11 @@ public class SyncInfoDecoderTests
 
         // Decode with ValueDecoderContext
         Rlp.ValueDecoderContext streamCtx = new(stream.Data.AsSpan());
-        SyncInfo decodedStream = decoder.Decode(ref streamCtx);
+        SyncInfo decodedStream = decoder.Decode(ref streamCtx)!;
 
         // Decode with ValueDecoderContext
         Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-        SyncInfo decodedContext = decoder.Decode(ref decoderContext);
+        SyncInfo decodedContext = decoder.Decode(ref decoderContext)!;
 
         // Both should be equivalent to original
         decodedStream.Should().BeEquivalentTo(syncInfo);
@@ -156,7 +156,7 @@ public class SyncInfoDecoderTests
     public void Decode_Null_ReturnsNull()
     {
         SyncInfoDecoder decoder = new();
-        SyncInfo decoded = decoder.Decode((ReadOnlySpan<byte>)Rlp.OfEmptyList.Bytes);
+        SyncInfo decoded = decoder.Decode((ReadOnlySpan<byte>)Rlp.OfEmptyList.Bytes)!;
 
         Assert.That(decoded, Is.Null);
     }
@@ -167,7 +167,7 @@ public class SyncInfoDecoderTests
         SyncInfoDecoder decoder = new();
         Rlp.ValueDecoderContext decoderContext = new(Rlp.OfEmptyList.Bytes);
 
-        SyncInfo decoded = decoder.Decode(ref decoderContext);
+        SyncInfo decoded = decoder.Decode(ref decoderContext)!;
 
         Assert.That(decoded, Is.Null);
     }

--- a/src/Nethermind/Nethermind.Xdc.Test/QuorumCertificateDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/QuorumCertificateDecoderTests.cs
@@ -30,7 +30,7 @@ internal class QuorumCertificateDecoderTests
         RlpStream stream = new(decoder.GetLength(quorumCert));
         decoder.Encode(stream, quorumCert);
         Rlp.ValueDecoderContext ctx = new(stream.Data.AsSpan());
-        QuorumCertificate decoded = decoder.Decode(ref ctx);
+        QuorumCertificate decoded = decoder.Decode(ref ctx)!;
 
         decoded.Should().BeEquivalentTo(quorumCert);
     }
@@ -47,12 +47,12 @@ internal class QuorumCertificateDecoderTests
         if (useRlpStream)
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
         else
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
 
         decoded.Should().BeEquivalentTo(quorumCert);

--- a/src/Nethermind/Nethermind.Xdc.Test/SnapshotDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SnapshotDecoderTests.cs
@@ -48,7 +48,7 @@ public class SnapshotDecoderTests
         encoder.Encode(stream, original);
 
         SnapshotDecoder decoder = new();
-        Snapshot decoded = decoder.Decode(stream.Data.AsSpan());
+        Snapshot decoded = decoder.Decode(stream.Data.AsSpan())!;
         decoded.Should().BeEquivalentTo(original);
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/SubnetSnapshotDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SubnetSnapshotDecoderTests.cs
@@ -48,7 +48,7 @@ public class SubnetSnapshotDecoderTests
         encoder.Encode(stream, original);
 
         SubnetSnapshotDecoder decoder = new();
-        SubnetSnapshot decoded = decoder.Decode(stream.Data.AsSpan());
+        SubnetSnapshot decoded = decoder.Decode(stream.Data.AsSpan())!;
         decoded.Should().BeEquivalentTo(original);
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateDecoderTests.cs
@@ -35,12 +35,12 @@ public class TimeoutCertificateDecoderTests
         if (useRlpStream)
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
         else
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
 
         decoded.Should().BeEquivalentTo(tc);

--- a/src/Nethermind/Nethermind.Xdc.Test/VoteDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/VoteDecoderTests.cs
@@ -59,12 +59,12 @@ public class VoteDecoderTests
         if (useRlpStream)
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
         else
         {
             Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-            decoded = decoder.Decode(ref decoderContext);
+            decoded = decoder.Decode(ref decoderContext)!;
         }
 
         decoded.Should().BeEquivalentTo(vote, options => options.Excluding(v => v.Signer));
@@ -85,10 +85,10 @@ public class VoteDecoderTests
         stream.Position = 0;
 
         Rlp.ValueDecoderContext streamCtx = new(stream.Data.AsSpan());
-        Vote decodedStream = decoder.Decode(ref streamCtx);
+        Vote decodedStream = decoder.Decode(ref streamCtx)!;
 
         Rlp.ValueDecoderContext decoderContext = new(stream.Data.AsSpan());
-        Vote decodedContext = decoder.Decode(ref decoderContext);
+        Vote decodedContext = decoder.Decode(ref decoderContext)!;
 
         decodedStream.Should().BeEquivalentTo(vote, options => options.Excluding(v => v.Signer));
         decodedContext.Should().BeEquivalentTo(vote, options => options.Excluding(v => v.Signer));
@@ -130,7 +130,7 @@ public class VoteDecoderTests
         Assert.That(sealingEncoded.Bytes.Length, Is.LessThan(normalEncoded.Bytes.Length),
             "ForSealing encoding should be shorter as it omits the signature.");
 
-        Vote decoded = decoder.Decode((ReadOnlySpan<byte>)sealingEncoded.Bytes, RlpBehaviors.ForSealing);
+        Vote decoded = decoder.Decode((ReadOnlySpan<byte>)sealingEncoded.Bytes, RlpBehaviors.ForSealing)!;
 
         Assert.That(decoded.Signature, Is.Null,
             "ForSealing decoding should not contain Signature field.");
@@ -152,7 +152,7 @@ public class VoteDecoderTests
     public void Decode_Null_ReturnsNull()
     {
         VoteDecoder decoder = new();
-        Vote decoded = decoder.Decode((ReadOnlySpan<byte>)Rlp.OfEmptyList.Bytes);
+        Vote? decoded = decoder.Decode((ReadOnlySpan<byte>)Rlp.OfEmptyList.Bytes);
 
         Assert.That(decoded, Is.Null);
     }
@@ -163,7 +163,7 @@ public class VoteDecoderTests
         VoteDecoder decoder = new();
         Rlp.ValueDecoderContext decoderContext = new(Rlp.OfEmptyList.Bytes);
 
-        Vote decoded = decoder.Decode(ref decoderContext);
+        Vote? decoded = decoder.Decode(ref decoderContext);
 
         Assert.That(decoded, Is.Null);
     }

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseSnapshotDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseSnapshotDecoder.cs
@@ -9,9 +9,9 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc.RLP;
 
-internal abstract class BaseSnapshotDecoder<T> : RlpValueDecoder<T> where T : Snapshot
+internal abstract class BaseSnapshotDecoder<T> : RlpValueDecoder<T?> where T : Snapshot
 {
-    protected TResult DecodeBase<TResult>(ref Rlp.ValueDecoderContext decoderContext, Func<long, Hash256, Address[], TResult> createSnapshot, RlpBehaviors rlpBehaviors = RlpBehaviors.None) where TResult : Snapshot
+    protected TResult? DecodeBase<TResult>(ref Rlp.ValueDecoderContext decoderContext, Func<long, Hash256, Address[], TResult> createSnapshot, RlpBehaviors rlpBehaviors = RlpBehaviors.None) where TResult : Snapshot
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -47,7 +47,7 @@ internal abstract class BaseSnapshotDecoder<T> : RlpValueDecoder<T> where T : Sn
         return addresses;
     }
 
-    public Rlp Encode(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
             return Rlp.OfEmptyList;
@@ -57,7 +57,7 @@ internal abstract class BaseSnapshotDecoder<T> : RlpValueDecoder<T> where T : Sn
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -90,7 +90,7 @@ internal abstract class BaseSnapshotDecoder<T> : RlpValueDecoder<T> where T : Sn
         }
     }
 
-    public override int GetLength(T item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(T? item, RlpBehaviors rlpBehaviors) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
     protected virtual int GetContentLength(T item, RlpBehaviors rlpBehaviors)
     {
         if (item is null)

--- a/src/Nethermind/Nethermind.Xdc/RLP/ExtraConsensusDataDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/ExtraConsensusDataDecoder.cs
@@ -6,10 +6,10 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc.RLP;
 
-internal sealed class ExtraConsensusDataDecoder : RlpValueDecoder<ExtraFieldsV2>
+internal sealed class ExtraConsensusDataDecoder : RlpValueDecoder<ExtraFieldsV2?>
 {
     private readonly QuorumCertificateDecoder _quorumCertificateDecoder = new();
-    protected override ExtraFieldsV2 DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override ExtraFieldsV2? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -28,7 +28,7 @@ internal sealed class ExtraConsensusDataDecoder : RlpValueDecoder<ExtraFieldsV2>
         return new ExtraFieldsV2(round, quorumCert);
     }
 
-    public Rlp Encode(ExtraFieldsV2 item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(ExtraFieldsV2? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
             return Rlp.OfEmptyList;
@@ -38,7 +38,7 @@ internal sealed class ExtraConsensusDataDecoder : RlpValueDecoder<ExtraFieldsV2>
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, ExtraFieldsV2 item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, ExtraFieldsV2? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -51,7 +51,7 @@ internal sealed class ExtraConsensusDataDecoder : RlpValueDecoder<ExtraFieldsV2>
         _quorumCertificateDecoder.Encode(stream, item.QuorumCert, rlpBehaviors);
     }
 
-    public override int GetLength(ExtraFieldsV2 item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(ExtraFieldsV2? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
     private int GetContentLength(ExtraFieldsV2? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)

--- a/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
@@ -11,10 +11,10 @@ using BlockRoundInfo = Nethermind.Xdc.Types.BlockRoundInfo;
 
 namespace Nethermind.Xdc;
 
-internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertificate>
+internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertificate?>
 {
     private readonly XdcBlockInfoDecoder _blockInfoDecoder = new();
-    protected override QuorumCertificate DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override QuorumCertificate? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         int sequenceLength = decoderContext.ReadSequenceLength();
         if (sequenceLength == 0)
@@ -44,7 +44,7 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
         return new QuorumCertificate(blockInfo, signatures, gap);
     }
 
-    public Rlp Encode(QuorumCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(QuorumCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
             return Rlp.OfEmptyList;
@@ -55,7 +55,7 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, QuorumCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, QuorumCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -86,7 +86,7 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
         stream.Encode(item.GapNumber);
     }
 
-    public override int GetLength(QuorumCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(QuorumCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
     private int GetContentLength(QuorumCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)

--- a/src/Nethermind/Nethermind.Xdc/RLP/SnapshotDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/SnapshotDecoder.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Xdc.RLP;
 
 internal sealed class SnapshotDecoder : BaseSnapshotDecoder<Snapshot>
 {
-    protected override Snapshot DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override Snapshot? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     => DecodeBase<Snapshot>(ref decoderContext, (number, hash, candidates) => new Snapshot(number, hash, candidates), rlpBehaviors);
 
 }

--- a/src/Nethermind/Nethermind.Xdc/RLP/SubnetSnapshotDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/SubnetSnapshotDecoder.cs
@@ -10,9 +10,9 @@ namespace Nethermind.Xdc.RLP;
 internal sealed class SubnetSnapshotDecoder : BaseSnapshotDecoder<SubnetSnapshot>
 {
 
-    protected override SubnetSnapshot DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override SubnetSnapshot? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        SubnetSnapshot subnetSnapshot = DecodeBase<SubnetSnapshot>(ref decoderContext, (number, hash, candidates) => new SubnetSnapshot(number, hash, candidates), rlpBehaviors);
+        SubnetSnapshot? subnetSnapshot = DecodeBase<SubnetSnapshot>(ref decoderContext, (number, hash, candidates) => new SubnetSnapshot(number, hash, candidates), rlpBehaviors);
         if (subnetSnapshot is null)
             return null;
 

--- a/src/Nethermind/Nethermind.Xdc/RLP/SyncInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/SyncInfoDecoder.cs
@@ -7,12 +7,12 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc;
 
-internal class SyncInfoDecoder : RlpValueDecoder<SyncInfo>
+internal class SyncInfoDecoder : RlpValueDecoder<SyncInfo?>
 {
     private readonly QuorumCertificateDecoder _quorumCertificateDecoder = new();
     private readonly TimeoutCertificateDecoder _timeoutCertificateDecoder = new();
 
-    protected override SyncInfo DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override SyncInfo? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -45,7 +45,7 @@ internal class SyncInfoDecoder : RlpValueDecoder<SyncInfo>
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, SyncInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, SyncInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -58,7 +58,7 @@ internal class SyncInfoDecoder : RlpValueDecoder<SyncInfo>
         _timeoutCertificateDecoder.Encode(stream, item.HighestTimeoutCert, rlpBehaviors);
     }
 
-    public override int GetLength(SyncInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(SyncInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
 
     public int GetContentLength(SyncInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
@@ -9,9 +9,9 @@ using System.Linq;
 
 namespace Nethermind.Xdc.RLP;
 
-public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertificate>
+public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertificate?>
 {
-    protected override TimeoutCertificate DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override TimeoutCertificate? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -46,7 +46,7 @@ public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertifica
         return new TimeoutCertificate(round, signatures, gapNumber);
     }
 
-    public Rlp Encode(TimeoutCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(TimeoutCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
             return Rlp.OfEmptyList;
@@ -57,7 +57,7 @@ public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertifica
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, TimeoutCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, TimeoutCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -85,7 +85,7 @@ public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertifica
         stream.Encode(item.GapNumber);
     }
 
-    public override int GetLength(TimeoutCertificate item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(TimeoutCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
     private int GetContentLength(TimeoutCertificate? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutDecoder.cs
@@ -8,9 +8,9 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc.RLP;
 
-public sealed class TimeoutDecoder : RlpValueDecoder<Timeout>
+public sealed class TimeoutDecoder : RlpValueDecoder<Timeout?>
 {
-    protected override Timeout DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override Timeout? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -49,7 +49,7 @@ public sealed class TimeoutDecoder : RlpValueDecoder<Timeout>
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override void Encode(RlpStream stream, Timeout item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, Timeout? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -77,7 +77,7 @@ public sealed class TimeoutDecoder : RlpValueDecoder<Timeout>
         stream.Encode(item.GapNumber);
     }
 
-    public override int GetLength(Timeout item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(Timeout? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
     public int GetContentLength(Timeout? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)

--- a/src/Nethermind/Nethermind.Xdc/RLP/VoteDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/VoteDecoder.cs
@@ -9,11 +9,11 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc;
 
-public sealed class VoteDecoder : RlpValueDecoder<Vote>
+public sealed class VoteDecoder : RlpValueDecoder<Vote?>
 {
     private static readonly XdcBlockInfoDecoder _xdcBlockInfoDecoder = new();
 
-    protected override Vote DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override Vote? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -39,7 +39,7 @@ public sealed class VoteDecoder : RlpValueDecoder<Vote>
         return new Vote(proposedBlockInfo, gapNumber, signature);
     }
 
-    public override void Encode(RlpStream stream, Vote item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, Vote? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -57,7 +57,7 @@ public sealed class VoteDecoder : RlpValueDecoder<Vote>
         stream.Encode(item.GapNumber);
     }
 
-    public Rlp Encode(Vote item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public Rlp Encode(Vote? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
             return Rlp.OfEmptyList;
@@ -68,7 +68,7 @@ public sealed class VoteDecoder : RlpValueDecoder<Vote>
         return new Rlp(rlpStream.Data.ToArray());
     }
 
-    public override int GetLength(Vote item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(Vote? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item!, rlpBehaviors));
 
     public int GetContentLength(Vote item, RlpBehaviors rlpBehaviors) => ((rlpBehaviors & RlpBehaviors.ForSealing) != RlpBehaviors.ForSealing ? Rlp.LengthOfSequence(Signature.Size) : 0)
             + Rlp.LengthOf(item.GapNumber)

--- a/src/Nethermind/Nethermind.Xdc/RLP/XdcBlockInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/XdcBlockInfoDecoder.cs
@@ -7,9 +7,9 @@ using Nethermind.Xdc.Types;
 
 namespace Nethermind.Xdc.RLP;
 
-internal sealed class XdcBlockInfoDecoder : RlpValueDecoder<BlockRoundInfo>
+internal sealed class XdcBlockInfoDecoder : RlpValueDecoder<BlockRoundInfo?>
 {
-    protected override BlockRoundInfo DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override BlockRoundInfo? DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (decoderContext.IsNextItemEmptyList())
         {
@@ -28,7 +28,7 @@ internal sealed class XdcBlockInfoDecoder : RlpValueDecoder<BlockRoundInfo>
         return new BlockRoundInfo(new Hash256(hashBytes), round, number);
     }
 
-    public override void Encode(RlpStream stream, BlockRoundInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    public override void Encode(RlpStream stream, BlockRoundInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         if (item is null)
         {
@@ -41,7 +41,7 @@ internal sealed class XdcBlockInfoDecoder : RlpValueDecoder<BlockRoundInfo>
         stream.Encode(item.BlockNumber);
     }
 
-    public override int GetLength(BlockRoundInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+    public override int GetLength(BlockRoundInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => item is null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
 
     private static int GetContentLength(BlockRoundInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {

--- a/tools/StatelessInputGen/InputGenerator.cs
+++ b/tools/StatelessInputGen/InputGenerator.cs
@@ -82,10 +82,16 @@ internal static class InputGenerator
 
                 byte[] rlp = Convert.FromHexString(rlpHex![2..]);
 
-                IRlpValueDecoder<Block> blockDecoder = Rlp.GetValueDecoder<Block>()!;
+                IRlpValueDecoder<Block?> blockDecoder = Rlp.GetValueDecoder<Block?>()!;
                 Rlp.ValueDecoderContext blockContext = new(rlp);
                 block = blockDecoder.Decode(ref blockContext, RlpBehaviors.None);
                 blockContext.Check(rlp.Length);
+
+                if (block is null)
+                {
+                    AnsiConsole.MarkupLine($"[red]Block RLP decoded as null[/]");
+                    return;
+                }
 
                 string blockNumber = EnsureBlockParamIsNumber(blockParam, block);
 

--- a/tools/StatelessInputGen/InputGenerator.cs
+++ b/tools/StatelessInputGen/InputGenerator.cs
@@ -84,14 +84,9 @@ internal static class InputGenerator
 
                 IRlpValueDecoder<Block?> blockDecoder = Rlp.GetValueDecoder<Block?>()!;
                 Rlp.ValueDecoderContext blockContext = new(rlp);
-                block = blockDecoder.Decode(ref blockContext, RlpBehaviors.None);
+                block = blockDecoder.Decode(ref blockContext, RlpBehaviors.None)
+                    ?? throw new RlpException("Block RLP decoded as null");
                 blockContext.Check(rlp.Length);
-
-                if (block is null)
-                {
-                    AnsiConsole.MarkupLine($"[red]Block RLP decoded as null[/]");
-                    return;
-                }
 
                 string blockNumber = EnsureBlockParamIsNumber(blockParam, block);
 


### PR DESCRIPTION
## Summary

- Enable `<Nullable>enable</Nullable>` for packages that previously had `none` or `annotations`
- Fix all nullable warnings to compile cleanly with `TreatWarningsAsErrors`
- Packages enabled: **Nethermind.Serialization.Json**, **Nethermind.Serialization.Rlp**
- Downstream fixes in Merge.Plugin, Shutter to match updated interface nullability

## Nullable Status (Topological Order)

Legend:
- [x] = `<Nullable>enable</Nullable>` (full nullable warnings)
- [~] = `<Nullable>annotations</Nullable>` (metadata only, no warnings)
- [ ] = no `<Nullable>` setting (effectively disabled)

### Leaf packages (no internal deps)

- [x] Nethermind.Analyzers
- [x] Nethermind.Logging
- [x] Nethermind.Logging.Microsoft
- [x] Nethermind.Serialization.SszGenerator
- [x] Nethermind.UI

### Core layer

- [x] Nethermind.Core  <- Logging
- [x] Nethermind.Logging.NLog  <- Logging
- [x] Nethermind.Abi  <- Core
- [x] Nethermind.Config  <- Core
- [x] Nethermind.Serialization.Json  <- Core ✅ **this PR**
- [x] Nethermind.Serialization.Rlp  <- Core ✅ **this PR**
- [x] Nethermind.Serialization.Ssz  <- Core

### Infrastructure layer

- [ ] Nethermind.Monitoring  <- Config, Logging
- [x] Nethermind.Network.Contract  <- Config
- [x] Nethermind.Seq  <- Config
- [ ] Nethermind.Grpc  <- Config, Core, Serialization.Json
- [x] Nethermind.Sockets  <- Core, Logging, Serialization.Json
- [~] Nethermind.Specs  <- Config, Core, Serialization.Json
- [~] Nethermind.Crypto  <- Core, Serialization.Rlp
- [~] Nethermind.Db  <- Config, Serialization.Rlp
- [x] Nethermind.Merkleization  <- Core, Serialization.Ssz
- [ ] Nethermind.Network.Stats  <- Config, Core, Logging, Network.Contract
- [ ] Nethermind.KeyStore  <- Config, Core, Crypto, Serialization.Json

### Data layer

- [~] Nethermind.Trie  <- Core, Db, Serialization.Rlp
- [~] Nethermind.Evm  <- Core, Crypto, Serialization.Rlp, Specs, Trie
- [x] Nethermind.Evm.Precompiles  <- Core, Crypto, Evm, Serialization.Rlp, Specs
- [~] Nethermind.State  <- Core, Db, Evm, Serialization.Rlp, Trie
- [x] Nethermind.TxPool  <- Config, Core, Crypto, Db, Evm, Network.Contract, State

### Blockchain layer

- [~] Nethermind.Blockchain  <- Abi, Core, Db, Evm, Evm.Precompiles, Network.Stats, Specs, State, TxPool
- [ ] Nethermind.Wallet  <- Core, KeyStore, Serialization.Rlp, TxPool
- [~] Nethermind.Consensus  <- Blockchain, Config, Core, Crypto, Evm, TxPool
- [x] Nethermind.History  <- Consensus
- [x] Nethermind.Stateless.Executor  <- Consensus
- [~] Nethermind.Synchronization  <- Consensus, History, Logging, Network.Contract, Trie
- [x] Nethermind.Stateless.ZiskGuest  <- Stateless.Executor

### Network / Facade layer

- [~] Nethermind.Facade  <- Consensus, Core, Crypto, Synchronization
- [~] Nethermind.Network  <- Blockchain, Config, Core, Crypto, Network.Contract, Network.Stats, Synchronization
- [x] Nethermind.State.Flat  <- Blockchain, Core, Db, Evm, Serialization.Rlp, State, Synchronization, Trie
- [x] Nethermind.Network.Enr  <- Crypto, Network
- [x] Nethermind.Network.Dns  <- Network, Network.Enr

### RPC layer

- [~] Nethermind.JsonRpc  <- Abi, Blockchain, Config, Consensus, Core, Crypto, Evm, Facade, Network, Network.Dns, Sockets, Synchronization, Wallet

### API / Init layer

- [x] Nethermind.Api  <- Blockchain, Facade, Grpc, History, JsonRpc, Monitoring, Network, Sockets
- [ ] Nethermind.Db.Rpc  <- Db, JsonRpc, Serialization.Json, State
- [~] Nethermind.Consensus.Clique  <- Api, Blockchain, Consensus, JsonRpc
- [~] Nethermind.Consensus.Ethash  <- Api, Blockchain, Consensus, Core, Crypto, Serialization.Rlp, Specs
- [x] Nethermind.Db.Rocks  <- Api, Db
- [x] Nethermind.Era1  <- Api, Blockchain, Consensus, Core, JsonRpc, Merkleization, Serialization.Rlp, Serialization.Ssz, State
- [x] Nethermind.ExternalSigner.Plugin  <- Api, JsonRpc
- [x] Nethermind.Merge.Plugin  <- Api
- [x] Nethermind.Network.Discovery  <- Api, Crypto, Facade, Network, Network.Enr
- [x] Nethermind.UPnP.Plugin  <- Api

### Plugin layer

- [x] Nethermind.Flashbots  <- Merge.Plugin
- [ ] Nethermind.HealthChecks  <- Api, Merge.Plugin
- [x] Nethermind.Init  <- Api, Db.Rocks, Db.Rpc, Era1, Network.Discovery, Network.Dns, Network.Enr, Specs, State.Flat
- [~] Nethermind.Consensus.AuRa  <- Abi, Api, Blockchain, Facade, Init, Specs, Synchronization
- [x] Nethermind.EthStats  <- Api, Blockchain, Core, Init, JsonRpc, Logging, Network
- [x] Nethermind.Hive  <- Api, Init
- [x] Nethermind.Init.Snapshot  <- Api, Init
- [x] Nethermind.JsonRpc.TraceStore  <- Api, Init
- [x] Nethermind.Optimism  <- Api, Blockchain, Consensus, Core, Init, JsonRpc, Merge.Plugin
- [x] Nethermind.Shutter  <- Blockchain, Consensus, Core, Crypto, Init, Merge.Plugin, Merkleization, Network.Discovery, Serialization.Ssz, Specs
- [x] Nethermind.Taiko  <- Api, Blockchain, Consensus, Core, Evm, Evm.Precompiles, Init, JsonRpc, Logging, Merge.Plugin, Serialization.Json
- [~] Nethermind.Xdc  <- Api, Consensus, Core, Init
- [x] Nethermind.Merge.AuRa  <- Blockchain, Consensus, Consensus.AuRa, Core, Db, Evm, Merge.Plugin, Specs, State

## Changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Both `Nethermind.slnx` and `Benchmarks.slnx` build with 0 errors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-sonnet-4-6)