### PR TITLE
perf(sync): allow multiple sync allocation slots per peer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -179,4 +179,7 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = "_Technical._ Estimated max size of blocks in block processing queue before stop downloading.", DefaultValue = "200000000", HiddenFromDocs = true)]
     long ForwardSyncBlockProcessingQueueMemoryBudget { get; set; }
+
+    [ConfigItem(Description = "_Technical._ Specify concurrent request per peer for syncing.", DefaultValue = "2", HiddenFromDocs = true)]
+    int AllocationSlots { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -73,6 +73,7 @@ namespace Nethermind.Blockchain.Synchronization
         public int SyncDispatcherAllocateTimeoutMs { get; set; } = 1000;
         public bool NeedToWaitForHeader { get; set; }
         public bool VerifyTrieOnStateSyncFinished { get; set; }
+        public int AllocationSlots { get; set; } = 2;
         public bool TrieHealing { get; set; } = true;
         public int StateMaxDistanceFromHead { get; set; } = 128;
         public int StateMinDistanceFromHead { get; set; } = 32;

--- a/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ContainerBuilderExtensions.cs
@@ -137,6 +137,30 @@ public static class ContainerBuilderExtensions
         return builder;
     }
 
+    public static ContainerBuilder AddSingleton<T, TArg0, TArg1, TArg2, TArg3, TArg4, TArg5>(this ContainerBuilder builder, Func<TArg0, TArg1, TArg2, TArg3, TArg4, TArg5, T> factoryMethod) where T : class where TArg0 : notnull where TArg1 : notnull where TArg2 : notnull where TArg3 : notnull where TArg4 : notnull where TArg5 : notnull
+    {
+        Func<IComponentContext, TArg0> param0 = CreateArgResolver<TArg0>(factoryMethod.Method, 0);
+        Func<IComponentContext, TArg1> param1 = CreateArgResolver<TArg1>(factoryMethod.Method, 1);
+        Func<IComponentContext, TArg2> param2 = CreateArgResolver<TArg2>(factoryMethod.Method, 2);
+        Func<IComponentContext, TArg3> param3 = CreateArgResolver<TArg3>(factoryMethod.Method, 3);
+        Func<IComponentContext, TArg4> param4 = CreateArgResolver<TArg4>(factoryMethod.Method, 4);
+        Func<IComponentContext, TArg5> param5 = CreateArgResolver<TArg5>(factoryMethod.Method, 5);
+
+        builder
+            .Register((ctx) => factoryMethod(
+                param0(ctx),
+                param1(ctx),
+                param2(ctx),
+                param3(ctx),
+                param4(ctx),
+                param5(ctx)
+            ))
+            .As<T>()
+            .SingleInstance();
+
+        return builder;
+    }
+
     public static ContainerBuilder AddSingleton<T>(this ContainerBuilder builder, Func<IComponentContext, T> factory) where T : class
     {
         builder.Register(factory)

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Synchronization.Peers;
@@ -92,9 +95,36 @@ namespace Nethermind.Synchronization.Test
         public void Can_allocate()
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.TryAllocate(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeTrue();
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
+            peerInfo.CanBeAllocated(_contexts).Should().BeFalse();
+        }
+
+        [Test]
+        public void Can_allocate_multiple()
+        {
+            if (!PeerInfo.IsOnlyOneContext(_contexts)) return;
+
+            Dictionary<AllocationContexts, int> newAllowances = PeerInfo.DefaultAllowances.ToDictionary();
+            newAllowances[_contexts] = 5;
+
+            PeerInfo peerInfo = new(Substitute.For<ISyncPeer>(), newAllowances.ToFrozenDictionary());
+
+            for (int i = 0; i < 5; i++)
+            {
+                peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
+                peerInfo.TryAllocate(_contexts);
+            }
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
+            peerInfo.CanBeAllocated(_contexts).Should().BeFalse();
+
+            // Partial free
+            peerInfo.Free(_contexts);
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
+            peerInfo.TryAllocate(_contexts);
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
             peerInfo.CanBeAllocated(_contexts).Should().BeFalse();
         }
 
@@ -102,11 +132,11 @@ namespace Nethermind.Synchronization.Test
         public void Can_free()
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.TryAllocate(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeTrue();
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
             peerInfo.Free(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.CanBeAllocated(_contexts).Should().BeTrue();
         }
 
@@ -115,16 +145,16 @@ namespace Nethermind.Synchronization.Test
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
             peerInfo.TryAllocate(AllocationContexts.Blocks);
-            peerInfo.IsAllocated(AllocationContexts.Bodies).Should().BeTrue();
-            peerInfo.IsAllocated(AllocationContexts.Headers).Should().BeFalse();
-            peerInfo.IsAllocated(AllocationContexts.Receipts).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Bodies).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Headers).Should().BeFalse();
+            peerInfo.IsAllocationFull(AllocationContexts.Receipts).Should().BeTrue();
             peerInfo.CanBeAllocated(AllocationContexts.Bodies).Should().BeFalse();
             peerInfo.CanBeAllocated(AllocationContexts.Headers).Should().BeTrue();
             peerInfo.CanBeAllocated(AllocationContexts.Receipts).Should().BeFalse();
 
             peerInfo.Free(AllocationContexts.Receipts);
-            peerInfo.IsAllocated(AllocationContexts.Receipts).Should().BeFalse();
-            peerInfo.IsAllocated(AllocationContexts.Bodies).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Receipts).Should().BeFalse();
+            peerInfo.IsAllocationFull(AllocationContexts.Bodies).Should().BeTrue();
         }
 
         [Test]
@@ -143,8 +173,8 @@ namespace Nethermind.Synchronization.Test
 
             peerInfo.Free(AllocationContexts.Bodies);
 
-            peerInfo.IsAllocated(AllocationContexts.Headers).Should().BeTrue();
-            peerInfo.IsAllocated(AllocationContexts.Bodies).Should().BeFalse();
+            peerInfo.IsAllocationFull(AllocationContexts.Headers).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Bodies).Should().BeFalse();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
@@ -6,7 +6,7 @@ using System;
 namespace Nethermind.Synchronization.Peers
 {
     [Flags]
-    public enum AllocationContexts
+    public enum AllocationContexts : uint
     {
         None = 0,
         Headers = 1,

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Frozen;
 using NonBlocking;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using FastEnumUtility;
 using Nethermind.Blockchain.Synchronization;
@@ -18,11 +20,27 @@ using Nethermind.Stats.Model;
 
 namespace Nethermind.Synchronization.Peers
 {
-    public class PeerInfo(ISyncPeer syncPeer)
+    public class PeerInfo(ISyncPeer syncPeer, FrozenDictionary<AllocationContexts, int>? allocationAllowances = null)
     {
+        public static readonly FrozenDictionary<AllocationContexts, int> DefaultAllowances = new Dictionary<AllocationContexts, int>()
+        {
+            {AllocationContexts.Headers, 1},
+            {AllocationContexts.Bodies, 1},
+            {AllocationContexts.Receipts, 1},
+            {AllocationContexts.State, 1},
+            {AllocationContexts.Snap, 1},
+            {AllocationContexts.ForwardHeader, 1},
+        }.ToFrozenDictionary();
+
+        private readonly FrozenDictionary<AllocationContexts, int> _allocationAllowances = allocationAllowances ?? DefaultAllowances;
+
         public NodeClientType PeerClientType => SyncPeer?.ClientType ?? NodeClientType.Unknown;
 
-        public AllocationContexts AllocatedContexts { get; private set; }
+        public ConcurrentDictionary<AllocationContexts, int> AllocationSlots { get; } = new(allocationAllowances ?? DefaultAllowances);
+
+        public Dictionary<AllocationContexts, int> AvailableAllocationSlots => AllocationSlots
+            .Select(kv => (kv.Key, _allocationAllowances[kv.Key] - kv.Value))
+            .ToDictionary();
 
         public AllocationContexts SleepingContexts { get; private set; }
 
@@ -40,6 +58,23 @@ namespace Nethermind.Synchronization.Peers
         public long HeadNumber => SyncPeer.HeadNumber;
 
         public Hash256 HeadHash => SyncPeer.HeadHash;
+        public bool HasAnyAllocation => AllocationSlots.Any(kv => kv.Value < _allocationAllowances[kv.Key]);
+
+        public AllocationContexts AllocatedContexts
+        {
+            get
+            {
+                AllocationContexts result = AllocationContexts.None;
+                foreach (KeyValuePair<AllocationContexts, int> kv in AllocationSlots)
+                {
+                    if (kv.Value < _allocationAllowances[kv.Key])
+                    {
+                        result |= kv.Key;
+                    }
+                }
+                return result;
+            }
+        }
 
         private long _lastNotifiedEarliestNumber;
         private long _lastNotifiedLatestNumber;
@@ -57,21 +92,41 @@ namespace Nethermind.Synchronization.Peers
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool CanBeAllocated(AllocationContexts contexts) => !IsAsleep(contexts) &&
-                   !IsAllocated(contexts) &&
+                   !IsAllocationFull(contexts) &&
                    this.SupportsAllocation(contexts);
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool IsAsleep(AllocationContexts contexts) => (contexts & SleepingContexts) != AllocationContexts.None;
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public bool IsAllocated(AllocationContexts contexts) => (contexts & AllocatedContexts) != AllocationContexts.None;
+        public bool IsAllocationFull(AllocationContexts contexts) => SeparateAllocationContexts(contexts).Any(aCtx => AllocationSlots[aCtx] <= 0);
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool TryAllocate(AllocationContexts contexts)
         {
             if (CanBeAllocated(contexts))
             {
-                AllocatedContexts |= contexts;
+                bool failed = false;
+                AllocationContexts updatedCtx = AllocationContexts.None;
+
+                foreach (AllocationContexts aCtx in SeparateAllocationContexts(contexts))
+                {
+                    int current = AllocationSlots[aCtx];
+                    if (current <= 0 || !AllocationSlots.TryUpdate(aCtx, current - 1, current))
+                    {
+                        failed = true;
+                        break;
+                    }
+
+                    updatedCtx |= aCtx;
+                }
+
+                if (failed)
+                {
+                    Free(updatedCtx);
+                    return false;
+                }
+
                 return true;
             }
 
@@ -79,7 +134,13 @@ namespace Nethermind.Synchronization.Peers
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public void Free(AllocationContexts contexts) => AllocatedContexts &= ~contexts;
+        public void Free(AllocationContexts contexts)
+        {
+            foreach (AllocationContexts aCtx in SeparateAllocationContexts(contexts))
+            {
+                AllocationSlots[aCtx]++;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void PutToSleep(AllocationContexts contexts, DateTime dateTime)
@@ -175,6 +236,64 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
-        public override string ToString() => $"[{BuildContextString(AllocatedContexts)} ][{BuildContextString(SleepingContexts)} ]{SyncPeer}";
+        private string BuildSlotContextString()
+        {
+            StringBuilder ctxStringBuilder = new();
+
+            (AllocationContexts, char)[] stringOrders =
+            [
+                (AllocationContexts.Headers, 'h'),
+                (AllocationContexts.Bodies, 'b'),
+                (AllocationContexts.Receipts, 'r'),
+                (AllocationContexts.State, 'n'),
+                (AllocationContexts.Snap, 's'),
+                (AllocationContexts.ForwardHeader, 'f'),
+            ];
+
+            foreach ((AllocationContexts ctx, char chRep) in stringOrders)
+            {
+                int count = AllocationSlots[ctx];
+                int allowances = _allocationAllowances[ctx];
+                if (count == allowances)
+                {
+                    ctxStringBuilder.Append(' ');
+                }
+                else if (count == 0)
+                {
+                    ctxStringBuilder.Append(Char.ToUpper(chRep));
+                }
+                else if (allowances - count == 1)
+                {
+                    ctxStringBuilder.Append(chRep);
+                }
+                else
+                {
+                    ctxStringBuilder.Append(allowances - count);
+                }
+            }
+
+            return ctxStringBuilder.ToString();
+        }
+
+        public override string ToString() => $"[{BuildSlotContextString()} ][{BuildContextString(SleepingContexts)} ]{SyncPeer}";
+
+        private AllocationContexts[] SeparateAllocationContexts(AllocationContexts contexts)
+        {
+            if (SeparatedContextsCache.TryGetValue(contexts, out AllocationContexts[] cachedContext))
+            {
+                return cachedContext;
+            }
+
+            cachedContext = FastEnum.GetValues<AllocationContexts>()
+                .Where(aCtx => IsOnlyOneContext(aCtx) && (contexts & aCtx) != 0)
+                .ToArray();
+
+            SeparatedContextsCache.TryAdd(contexts, cachedContext);
+            return cachedContext;
+        }
+
+        private static readonly ConcurrentDictionary<AllocationContexts, AllocationContexts[]> SeparatedContextsCache = new();
+
+        public static bool IsOnlyOneContext(AllocationContexts x) => (x & (x - 1)) == 0;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -42,6 +43,7 @@ namespace Nethermind.Synchronization.Peers
         private readonly Channel<RefreshTotalDiffTask> _peerRefreshQueue = Channel.CreateUnbounded<RefreshTotalDiffTask>();
 
         private readonly ConcurrentDictionary<PublicKey, PeerInfo> _peers = new();
+        private readonly FrozenDictionary<AllocationContexts, int> _allocationAllowances;
 
         private readonly ConcurrentDictionary<PublicKey, CancellationTokenSource> _refreshCancelTokens = new();
 
@@ -65,8 +67,9 @@ namespace Nethermind.Synchronization.Peers
             INodeStatsManager nodeStatsManager,
             IBetterPeerStrategy betterPeerStrategy,
             INetworkConfig networkConfig,
+            ISyncConfig syncConfig,
             ILogManager logManager)
-        : this(blockTree, nodeStatsManager, betterPeerStrategy, logManager, networkConfig.ActivePeersMaxCount, networkConfig.PriorityPeersMaxCount)
+        : this(blockTree, nodeStatsManager, betterPeerStrategy, logManager, networkConfig.ActivePeersMaxCount, networkConfig.PriorityPeersMaxCount, DefaultUpgradeIntervalInMs, syncConfig.AllocationSlots)
         {
 
         }
@@ -77,7 +80,8 @@ namespace Nethermind.Synchronization.Peers
             ILogManager logManager,
             int peersMaxCount = 100,
             int priorityPeerMaxCount = 0,
-            int allocationsUpgradeIntervalInMsInMs = DefaultUpgradeIntervalInMs)
+            int allocationsUpgradeIntervalInMsInMs = DefaultUpgradeIntervalInMs,
+            int allocationSlots = 1)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _stats = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
@@ -86,6 +90,19 @@ namespace Nethermind.Synchronization.Peers
             PriorityPeerMaxCount = priorityPeerMaxCount;
             _allocationsUpgradeIntervalInMs = allocationsUpgradeIntervalInMsInMs;
             _logger = logManager?.GetClassLogger<SyncPeerPool>() ?? throw new ArgumentNullException(nameof(logManager));
+
+            Dictionary<AllocationContexts, int> allocationAllowances = new();
+            foreach (AllocationContexts ctx in Enum.GetValues<AllocationContexts>())
+            {
+                if (PeerInfo.IsOnlyOneContext(ctx))
+                {
+                    allocationAllowances[ctx] = allocationSlots;
+                }
+            }
+
+            // These is a problem with header where it reliably hangs when setting a high enough allowance. So we disable it for now.
+            allocationAllowances[AllocationContexts.Headers] = 1;
+            _allocationAllowances = allocationAllowances.ToFrozenDictionary();
 
             if (_logger.IsDebug) _logger.Debug($"PeerMaxCount: {PeerMaxCount}, PriorityPeerMaxCount: {PriorityPeerMaxCount}");
         }
@@ -237,7 +254,7 @@ namespace Nethermind.Synchronization.Peers
                 return;
             }
 
-            PeerInfo peerInfo = new(syncPeer);
+            PeerInfo peerInfo = new(syncPeer, _allocationAllowances);
             if (!_peers.TryAdd(syncPeer.Node.Id, peerInfo))
             {
                 return;
@@ -661,11 +678,11 @@ namespace Nethermind.Synchronization.Peers
             if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}, {exception}");
             _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
 
-            if (exception is OperationCanceledException || exception is TimeoutException)
+            if (exception is OperationCanceledException or TimeoutException)
             {
                 // We don't want to disconnect on timeout. It could be that we are downloading from the peer,
                 // or we have some connection issue
-                ReportWeakPeer(new PeerInfo(syncPeer), AllocationContexts.All);
+                ReportWeakPeer(new PeerInfo(syncPeer, _allocationAllowances), AllocationContexts.All);
             }
             else
             {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -75,7 +76,7 @@ namespace Nethermind.Synchronization.Peers
                 if (_logger.IsDebug)
                 {
                     string header = $"Allocated sync peers {_currentInitializedPeerCount}({_peerPool.PeerCount})/{_peerPool.PeerMaxCount}";
-                    _logger.Debug(MakeReportForPeers(OrderedPeers.Where(static p => (p.AllocatedContexts & AllocationContexts.All) != AllocationContexts.None), header));
+                    _logger.Debug(MakeReportForPeers(OrderedPeers.Where(static p => p.HasAnyAllocation), header));
                 }
             }
         }
@@ -108,7 +109,7 @@ namespace Nethermind.Synchronization.Peers
                 PeersContextCounts sleepingContexts = new();
                 foreach (PeerInfo peerInfo in peers)
                 {
-                    CountContexts(peerInfo.AllocatedContexts, ref activeContexts);
+                    CountContextDict(peerInfo.AvailableAllocationSlots, ref activeContexts);
                     CountContexts(peerInfo.SleepingContexts, ref sleepingContexts);
                 }
 
@@ -137,6 +138,24 @@ namespace Nethermind.Synchronization.Peers
                 contextCounts.Blocks += contexts.HasFlag(AllocationContexts.Blocks) ? 1 : 0;
                 contextCounts.State += contexts.HasFlag(AllocationContexts.State) ? 1 : 0;
                 contextCounts.Snap += contexts.HasFlag(AllocationContexts.Snap) ? 1 : 0;
+            }
+
+            static void CountContextDict(Dictionary<AllocationContexts, int> availableSlots, ref PeersContextCounts contextCounts)
+            {
+                contextCounts.Total++;
+
+                if (!availableSlots.Any(kv => kv.Value > 0))
+                {
+                    contextCounts.None++;
+                    return;
+                }
+
+                contextCounts.Headers += availableSlots[AllocationContexts.Headers];
+                contextCounts.Bodies += availableSlots[AllocationContexts.Bodies];
+                contextCounts.Receipts += availableSlots[AllocationContexts.Receipts];
+                contextCounts.Blocks += availableSlots[AllocationContexts.Blocks];
+                contextCounts.State += availableSlots[AllocationContexts.State];
+                contextCounts.Snap += availableSlots[AllocationContexts.Snap];
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -349,9 +349,9 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .RegisterNamedComponentInItsOwnLifetime<SyncFeedComponent<BlocksRequest>>(nameof(FastSyncFeed), ConfigureFastSync)
             .RegisterNamedComponentInItsOwnLifetime<SyncFeedComponent<BlocksRequest>>(nameof(FullSyncFeed), ConfigureFullSync)
 
-            .AddSingleton<SyncPeerPool, IBlockTree, INodeStatsManager, IBetterPeerStrategy, INetworkConfig, ILogManager>(
-                    (blockTree, stats, betterPeerStrategy, networkConfig, logManager) =>
-                        new SyncPeerPool(blockTree, stats, betterPeerStrategy, networkConfig, logManager))
+            .AddSingleton<SyncPeerPool, IBlockTree, INodeStatsManager, IBetterPeerStrategy, INetworkConfig, ISyncConfig, ILogManager>(
+                    (blockTree, stats, betterPeerStrategy, networkConfig, syncConfig, logManager) =>
+                        new SyncPeerPool(blockTree, stats, betterPeerStrategy, networkConfig, syncConfig, logManager))
                 .Bind<ISyncPeerPool, SyncPeerPool>()
                 .Bind<IPeerDifficultyRefreshPool, SyncPeerPool>()
 


### PR DESCRIPTION
Redo of #7174 (which had merge conflicts on master).

## Summary
- New `Sync.AllocationSlots` config (default `2`) lets sync request more than one concurrent request per peer per context, useful when server-side latency/processing is the bottleneck.
- `PeerInfo` switches from a single `AllocatedContexts` flag to a per-context `AllocationSlots` counter (`IsAllocationFull` replaces `IsAllocated`).
- Headers pinned to 1 slot (known hang at higher allowances; carried over from the original PR).
- Wires `ISyncConfig` into the `SyncPeerPool` DI registration; adds a 6-arg `AddSingleton` overload for that.

## Test plan
- [x] `dotnet build -c release Nethermind.slnx` (clean)
- [x] `Nethermind.Synchronization.Test` — 1998/1998 passed, 132 skipped
- [ ] Smoke / sync benchmark on a real peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)