### PR TITLE
ci(hive): split engine-cancun and engine-api into separate runners

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -63,13 +63,20 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" || "${{ github.event.inputs.test-suite }}" == "all" ]]; then
             # engine-withdrawals at parallelism 2: the 128-block primary build takes
             # ~5 min on shared CI runners at parallelism 4, consuming the entire 300 s
-            # test timeout before the syncing client starts. engine-[^w] covers all
-            # other engine suites automatically.
+            # test timeout before the syncing client starts.
+            # engine-cancun and engine-api split into two runners each (I* vs non-I*)
+            # to reduce memory pressure that causes segfaults/OOM kills.
+            # engine-[^acw] catches exchange-capabilities and any future engine suites.
             {
               echo 'matrix<<MATRIX_END'
               echo '[
+                {"suite":"ethereum/engine", "limit":"engine-cancun/^I", "parallelism":3, "name":"engine-cancun-i"},
+                {"suite":"ethereum/engine", "limit":"engine-cancun/^[^I]", "parallelism":3, "name":"engine-cancun-other"},
+                {"suite":"ethereum/engine", "limit":"engine-api/^I", "parallelism":3, "name":"engine-api-i"},
+                {"suite":"ethereum/engine", "limit":"engine-api/^[^I]", "parallelism":3, "name":"engine-api-other"},
                 {"suite":"ethereum/engine", "limit":"engine-withdrawals", "parallelism":2, "name":"engine-withdrawals"},
-                {"suite":"ethereum/engine", "limit":"engine-[^w]", "name":"engine-other"},
+                {"suite":"ethereum/engine", "limit":"engine-auth", "parallelism":2, "name":"engine-auth"},
+                {"suite":"ethereum/engine", "limit":"engine-[^acw]", "parallelism":2, "name":"engine-other"},
                 {"suite":"ethereum/graphql"},
                 {"suite":"ethereum/rpc-compat"},
                 {"suite":"ethereum/sync"}

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -65,7 +65,7 @@ jobs:
             # ~5 min on shared CI runners at parallelism 4, consuming the entire 300 s
             # test timeout before the syncing client starts.
             # engine-cancun and engine-api split into two runners each (I* vs non-I*)
-            # to reduce memory pressure that causes segfaults/OOM kills.
+            # to reduce contention.
             # engine-[^acw] catches exchange-capabilities and any future engine suites.
             {
               echo 'matrix<<MATRIX_END'


### PR DESCRIPTION
## Changes

- Split `engine-cancun` and `engine-api` hive test suites into two runners each (`^I` vs `^[^I]`) to reduce contention
- Split `engine-auth` into its own runner (was previously bundled in `engine-[^w]`)
- Updated catch-all regex from `engine-[^w]` to `engine-[^acw]` to exclude the now-dedicated `engine-api`, `engine-auth`, and `engine-cancun` suites
- Reduced parallelism from 4 to 2–3 per runner to further lower resource contention

Validated against master run: engine test sets are identical (same test names), total wall-clock time drops from ~42-45m to ~22-25m.

Test workflow run: https://github.com/NethermindEth/nethermind/actions/runs/24967976009

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

CI-only change. Verified by comparing hive test artifacts between branch and master runs — engine test sets are identical (405 vs 403 total; +2 is from hive test loader entries running once per `--sim.limit` invocation).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No