### PR TITLE
revert: do not skip balance validation in eth_simulateV1

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/DisposableScopeOverridableEnvTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/DisposableScopeOverridableEnvTests.cs
@@ -131,9 +131,6 @@ public class DisposableScopeOverridableEnvTests
         public TransactionResult Trace(Transaction transaction, ITxTracer txTracer) =>
             throw new NotImplementedException();
 
-        public TransactionResult Simulate(Transaction transaction, ITxTracer txTracer) =>
-            throw new NotImplementedException();
-
         public TransactionResult Warmup(Transaction transaction, ITxTracer txTracer) =>
             throw new NotImplementedException();
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
@@ -31,12 +31,6 @@ public interface ITransactionProcessor
     TransactionResult Trace(Transaction transaction, ITxTracer txTracer);
 
     /// <summary>
-    /// Execute transaction skipping all validations including gas and balance checks.
-    /// Used by eth_simulateV1 with validation:false to allow zero-balance senders.
-    /// </summary>
-    TransactionResult Simulate(Transaction transaction, ITxTracer txTracer);
-
-    /// <summary>
     /// Call transaction, no validations, don't commit state
     /// Will NOT charge gas from sender account
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -96,20 +96,9 @@ namespace Nethermind.Evm.TransactionProcessing
             Warmup = 8,
 
             /// <summary>
-            /// Skip all gas and balance validation regardless of transaction type.
-            /// Used by eth_simulateV1 with validation:false to allow zero-balance senders.
-            /// </summary>
-            SkipBalanceValidation = 16,
-
-            /// <summary>
             /// Skip potential fail checks and commit state after execution
             /// </summary>
             SkipValidationAndCommit = Commit | SkipValidation,
-
-            /// <summary>
-            /// Skip all validations including gas/balance checks, commit state. Used by eth_simulateV1 validate:false.
-            /// </summary>
-            SimulateAndCommit = Commit | SkipValidation | SkipBalanceValidation,
 
             /// <summary>
             /// Commit and later restore state also skip validation, use for CallAndRestore
@@ -173,9 +162,6 @@ namespace Nethermind.Evm.TransactionProcessing
 
         public TransactionResult Trace(Transaction transaction, ITxTracer txTracer) =>
             ExecuteCore(transaction, txTracer, ExecutionOptions.SkipValidationAndCommit);
-
-        public TransactionResult Simulate(Transaction transaction, ITxTracer txTracer) =>
-            ExecuteCore(transaction, txTracer, ExecutionOptions.SimulateAndCommit);
 
         public virtual TransactionResult Warmup(Transaction transaction, ITxTracer txTracer) =>
             ExecuteCore(transaction, txTracer, ExecutionOptions.Warmup | ExecutionOptions.SkipValidation);
@@ -624,12 +610,8 @@ namespace Nethermind.Evm.TransactionProcessing
             UInt256 senderBalance = WorldState.GetBalance(tx.SenderAddress!);
             if (UInt256.SubtractUnderflow(in senderBalance, in tx.ValueRef, out UInt256 balanceLeft))
             {
-                if (!opts.HasFlag(ExecutionOptions.SkipBalanceValidation))
-                {
-                    TraceLogInvalidTx(tx, $"INSUFFICIENT_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}");
-                    return TransactionResult.InsufficientSenderBalance;
-                }
-                balanceLeft = UInt256.Zero;
+                TraceLogInvalidTx(tx, $"INSUFFICIENT_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}");
+                return TransactionResult.InsufficientSenderBalance;
             }
 
             bool overflows;
@@ -940,12 +922,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return true;
         }
 
-        protected virtual void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
-        {
-            if (opts.HasFlag(ExecutionOptions.SkipBalanceValidation) && WorldState.GetBalance(tx.SenderAddress!) < tx.ValueRef)
-                return;
-            WorldState.SubtractFromBalance(tx.SenderAddress!, in tx.ValueRef, spec);
-        }
+        protected virtual void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts) => WorldState.SubtractFromBalance(tx.SenderAddress!, in tx.ValueRef, spec);
 
         protected virtual void PayFees(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, in TransactionSubstate substate, long spentGas, in UInt256 premiumPerGas, in UInt256 blobBaseFee, int statusCode)
         {

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -26,7 +26,7 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
         }
         transaction.Hash = transaction.CalculateHash();
 
-        TransactionResult result = simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Simulate(transaction, txTracer);
+        TransactionResult result = simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Trace(transaction, txTracer);
 
         // Keep track of gas left
         long blockGasUsed = transaction.BlockGasUsed;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -517,4 +517,24 @@ public class EthSimulateTestsBlocksAndTransactions
         Assert.That((ulong)returnedTimestamp, Is.EqualTo(futureTimestamp),
             $"Expected block.timestamp = {futureTimestamp} (overridden), got {returnedTimestamp}");
     }
+
+    [Test]
+    public async Task Test_eth_simulate_no_validation_still_returns_insufficient_balance()
+    {
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new() { Calls = [ new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 1_000_000.Ether } ] }
+            ],
+            Validation = false
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.Result!.Error!.Contains("insufficient sender balance"), Is.True);
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.InsufficientFunds));
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -446,44 +446,6 @@ public class EthSimulateTestsBlocksAndTransactions
         Assert.That(tx1Logs[0].LogIndex, Is.EqualTo(2ul));
     }
 
-    [Test]
-    public async Task Test_eth_simulate_no_validation_skips_balance_check()
-    {
-        // Regression: eth_simulateV1 with validation:false must not return -38014 (InsufficientFunds)
-        // for a value transfer from a zero-balance address.
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
-
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
-                {
-                    Calls =
-                    [
-                        new EIP1559TransactionForRpc
-                        {
-                            From = TestItem.AddressA,
-                            To = TestItem.AddressB,
-                            Value = 1_000_000.Ether,
-                        }
-                    ]
-                }
-            ],
-            Validation = false
-        };
-
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result = executor.Execute(payload, BlockParameter.Latest);
-
-        Assert.That((bool)result.Result, Is.True, result.Result.ToString());
-        Assert.That(result.Data, Has.Count.EqualTo(1));
-        Assert.That(result.Data[0].Calls, Has.Count.EqualTo(1));
-        SimulateCallResult call = result.Data[0].Calls.First();
-        Assert.That(call.Error, Is.Null);
-        Assert.That(call.Status, Is.EqualTo(1ul));
-    }
-
     [TestCase(
         """{"blockStateCalls":[{"stateOverrides":{"0x0000000000000000000000000000000000000001":{"MovePrecompileToAddress":"0x0000000000000000000000000000000000000001"}}}]}""",
         ErrorCodes.MovePrecompileSelfReference,


### PR DESCRIPTION
 Reverts #11332

## Changes

- The original PR incorrectly removed balance validation for eth_simulateV1 with validation:false.
- go-ethereum returns InsufficientFunds when validate:false too (see ethereum/go-ethereum api_test.go L1568, L2463)
- Fixes broken hive tests:
  - ethSimulate-gas-fees-and-value-error-38014
  - ethSimulate-simple-no-funds
  - ethSimulate-simple-no-funds-with-balance-querying
  - ethSimulate-simple-send-from-contract-no-balance
  - ethSimulate-override-address-twice

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks