### PR TITLE
ci(expb): wire multi-image analyze step outputs

### DIFF
--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -1947,6 +1947,12 @@ jobs:
           echo "========================================="
           echo ""
 
+          # Populate GITHUB_OUTPUT for downstream quality gate
+          {
+            echo "exception_found=${exception_found}"
+            echo "invalid_block_found=${invalid_block_found}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Upload metrics artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -1971,10 +1971,12 @@ jobs:
             echo "Continuing multi-image run (fail-fast is disabled)."
           fi
           if [[ "${{ steps.analyze.outputs.exception_found }}" == "true" ]]; then
-            echo "Exceptions were detected for ${{ matrix.tag }} run ${{ matrix.run }}."
+            echo "Exceptions were detected for ${{ matrix.tag }} run ${{ matrix.run }}. Failing workflow."
+            exit 1
           fi
           if [[ "${{ steps.analyze.outputs.invalid_block_found }}" == "true" ]]; then
-            echo "Invalid block lines were detected for ${{ matrix.tag }} run ${{ matrix.run }}."
+            echo "Invalid block lines were detected for ${{ matrix.tag }} run ${{ matrix.run }}. Failing workflow."
+            exit 1
           fi
 
       - name: Collect and upload dotTrace snapshots

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -1967,8 +1967,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${{ steps.run-expb.outcome }}" != "success" ]]; then
-            echo "expb execute-scenarios did not finish successfully for ${{ matrix.tag }} run ${{ matrix.run }}."
-            echo "Continuing multi-image run (fail-fast is disabled)."
+            echo "expb execute-scenarios did not finish successfully for ${{ matrix.tag }} run ${{ matrix.run }}. Failing workflow."
+            echo "Sibling matrix jobs still run to completion (fail-fast is disabled)."
+            exit 1
           fi
           if [[ "${{ steps.analyze.outputs.exception_found }}" == "true" ]]; then
             echo "Exceptions were detected for ${{ matrix.tag }} run ${{ matrix.run }}. Failing workflow."


### PR DESCRIPTION
Multi-path `analyze` wrote `exception_found` / `invalid_block_found` only into `metrics.env`, not to `$GITHUB_OUTPUT`. **Effect?** The `Enforce run quality gates` step read `steps.analyze.outputs.*` and always got empty strings, so the exception and invalid-block checks never fired. **Fix?** Append both values to `$GITHUB_OUTPUT` at the end of the multi analyze step, matching the single-path equivalent.

## Enforcement

The multi-image `Enforce run quality gates` step previously only *logged* when a flag was set, so with the outputs wired it would have reported problems and still passed. Both branches now `exit 1`, and so does the `run-expb` outcome check, matching the single-image gate and AGENTS.md's "any detected `Exception` in run output must fail the workflow after reporting matching lines".

`fail-fast: false` on the matrix means sibling jobs still run to completion, and every step after the gate (`Upload metrics artifact`, `Collect and upload dotTrace snapshots`, `Upload dotTrace artifact`, `Cleanup rendered config`) carries `if: always()`, so failing the job does not cost any artifacts.
