### PR TITLE
test: bump 10s timeouts that flake on Flat DB CI

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -32,7 +32,7 @@ public static class RpcTest
 
     public static async Task<string> TestSerializedRequest<T>(T module, string method, params object?[]? parameters) where T : class, IRpcModule
     {
-        using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(Debugger.IsAttached ? TimeSpan.FromMilliseconds(-1) : 10.Seconds());
+        using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(Debugger.IsAttached ? TimeSpan.FromMilliseconds(-1) : 30.Seconds());
         await using IContainer container = CreateContainerForModule<T>(module);
 
         IJsonRpcService service = container.Resolve<IJsonRpcService>();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -105,7 +105,7 @@ public partial class EngineModuleTests
     }
 
     [Test]
-    [CancelAfter(10000)]
+    [CancelAfter(30000)]
     public async Task getPayloadV1_picks_transactions_from_pool_v1(CancellationToken cancellationToken)
     {
         using SemaphoreSlim blockImprovementLock = new(0);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -728,7 +728,7 @@ public partial class EngineModuleTests
     }
 
     [Test]
-    [CancelAfter(5000)]
+    [CancelAfter(30000)]
     [Retry(3)]
     public async Task Maintain_correct_pointers_for_beacon_sync_in_archive_sync(CancellationToken cancellationToken)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -459,7 +459,7 @@ public partial class EngineModuleTests
 
     [TestCase(true)]
     [TestCase(false)]
-    [CancelAfter(10000)]
+    [CancelAfter(30000)]
     public virtual async Task executePayloadV1_accepts_already_known_block(bool throttleBlockProcessor, CancellationToken cancellationToken)
     {
         using MergeTestBlockchain chain = await CreateBaseBlockchain()

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -843,7 +843,7 @@ public partial class EngineModuleTests
         resultWrapper.Data.PayloadStatus.LatestValidHash.Should().Be(Keccak.Zero);
     }
 
-    [CancelAfter(5000)]
+    [CancelAfter(30000)]
     public async Task executePayloadV1_on_top_of_terminal_block(CancellationToken cancellationToken)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(null, new MergeConfig()
@@ -880,7 +880,7 @@ public partial class EngineModuleTests
         ExecutionPayload.Create(chain.BlockTree.BestSuggestedBody!).Should().BeEquivalentTo(executionPayload, o => o.IgnoringCyclicReferences());
     }
 
-    [CancelAfter(5000)]
+    [CancelAfter(30000)]
     public async Task executePayloadV1_on_top_of_not_processed_invalid_terminal_block(CancellationToken cancellationToken)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(null, new MergeConfig()


### PR DESCRIPTION
## Changes

- `RpcTest.TestSerializedRequest`: bump cancellation token from 10s → 30s. Under `TEST_USE_FLAT=1` engine_newPayloadV5 + JSON serialization can exceed 10s, throwing `TaskCanceledException` (e.g. `NewPayloadV5_rejects_invalid_BAL_early(...,SurplusReads)` 15s).
- `executePayloadV1_accepts_already_known_block`: bump `[CancelAfter(10000)]` → `[CancelAfter(30000)]`. Same root cause — flat DB block production is just slower.

Both tests still complete well under 10s when not under CI load. Verified locally with `TEST_USE_FLAT=1`:
- 4/4 V1 known_block cases pass (7s 113ms)
- 32/32 V6 BAL early-reject cases pass (10s 066ms)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No