### PR TITLE
test: raise NewPayloadBlockProcessingTimeout in merge tests

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -192,7 +192,11 @@ public abstract partial class BaseEngineModuleTests
 
         public MergeTestBlockchain(IMergeConfig? mergeConfig = null)
         {
-            MergeConfig = mergeConfig ?? new MergeConfig();
+            // Default 7s is too tight under Flat DB CI load — validation races the
+            // timeout and the handler returns SYNCING, breaking tests that assert
+            // VALID/INVALID. Only bump when caller didn't supply a config (callers
+            // that test timeout→SYNCING behavior pass an explicit short timeout).
+            MergeConfig = mergeConfig ?? new MergeConfig { NewPayloadBlockProcessingTimeout = 30_000 };
             MergeConfig.TerminalTotalDifficulty ??= "0";
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -33,6 +33,7 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Synchronization;
+using static Nethermind.Merge.Plugin.MergeConfig;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
@@ -192,12 +193,16 @@ public abstract partial class BaseEngineModuleTests
 
         public MergeTestBlockchain(IMergeConfig? mergeConfig = null)
         {
-            // Default 7s is too tight under Flat DB CI load — validation races the
-            // timeout and the handler returns SYNCING, breaking tests that assert
-            // VALID/INVALID. Only bump when caller didn't supply a config (callers
-            // that test timeout→SYNCING behavior pass an explicit short timeout).
-            MergeConfig = mergeConfig ?? new MergeConfig { NewPayloadBlockProcessingTimeout = 30_000 };
+            MergeConfig = mergeConfig ?? new MergeConfig();
             MergeConfig.TerminalTotalDifficulty ??= "0";
+            // Production default (7s) is too tight under Flat DB CI load — validation
+            // races the timeout and the handler returns SYNCING, breaking tests that
+            // assert VALID/INVALID. Only bump when still at the production default;
+            // callers that exercise timeout→SYNCING behavior pass an explicit value.
+            if (MergeConfig.NewPayloadBlockProcessingTimeout == DefaultNewPayloadBlockProcessingTimeout)
+            {
+                MergeConfig.NewPayloadBlockProcessingTimeout = 30_000;
+            }
         }
 
         protected override Task AddBlocksOnStart() => Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -65,7 +65,7 @@ public interface IMergeConfig : IConfig
     public int CollectionsPerDecommit { get; set; }
 
     [ConfigItem(Description = "The timeout, in milliseconds, for the `engine_newPayload` method.", DefaultValue = "7000", HiddenFromDocs = true)]
-    public int NewPayloadBlockProcessingTimeout { get; }
+    public int NewPayloadBlockProcessingTimeout { get; set; }
 
     [ConfigItem(Description = "Cache NewPayload valid or invalid results", DefaultValue = "50", HiddenFromDocs = true)]
     public int NewPayloadCacheSize { get; }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -31,7 +31,9 @@ namespace Nethermind.Merge.Plugin
 
         public int CollectionsPerDecommit { get; set; } = 25;
 
-        public int NewPayloadBlockProcessingTimeout { get; set; } = 7000;
+        public const int DefaultNewPayloadBlockProcessingTimeout = 7000;
+
+        public int NewPayloadBlockProcessingTimeout { get; set; } = DefaultNewPayloadBlockProcessingTimeout;
         public int NewPayloadCacheSize { get; set; } = 50;
 
         public bool SimulateBlockProduction { get; set; } = false;


### PR DESCRIPTION
## Changes

`NewPayloadHandler` races block validation against `MergeConfig.NewPayloadBlockProcessingTimeout` (default **7000 ms**) — when the timeout wins, the handler returns `SYNCING` (`NewPayloadHandler.cs:398` → \`result ?? ValidationResult.Syncing\`).

Under `TEST_USE_FLAT=1` CI load, validation routinely takes longer than 7s, so this path fires during normal tests:

- `NewPayloadV5_rejects_invalid_BAL_early(...,True,True,MissingChange)` — typed-RPC path, expected `INVALID`, got `SYNCING`
- `executePayloadV1_processes_passed_transactions(False/True)` — `ProduceBranchV1` loop, expected `VALID`, got `SYNCING` (the test ran 3m 12s before assertion failed because each iteration kept hitting the 7s timeout)

These are the SYNCING failures that were left over after #11380.

Bump the default to 30s in `MergeTestBlockchain`'s default-config path. Tests that *intentionally* exercise the timeout→SYNCING behavior (`NewPayloadHandlerRaceConditionTests`, several V1/V3 cases) pass their own `MergeConfig` with explicit short timeouts (100/1000 ms) — unaffected.

Verified locally with `TEST_USE_FLAT=1` — V6 BAL early-reject (32) + V1 processes_passed_transactions (4) + V1 V3 race-condition tests (3) all pass (39/39, 9s).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No