### PR TITLE
fix(statecomp): serialize empty histograms and run bootstrap on first new head

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -162,13 +162,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
     [CancelAfter(10_000)]
     public async Task OnNewHeadBlock_NoBaseline_FiresDeferredBootstrapScan()
     {
-        // Regression test for the fresh-chain scenario: plugin started with
-        // blockTree.Head==null (no CL forkchoice driving the head past genesis,
-        // e.g. testing_commitBlockV1-driven chains), so StateCompositionPlugin's
-        // ScheduleBootstrapScan bailed. OnNewHeadBlock must absorb that and
-        // dispatch AnalyzeAsync the first time a header arrives without a
-        // baseline; otherwise _incrementalBlock stays at 0 forever and
-        // statecomp_get reports stale zeros after every block.
         long scansBefore = Metrics.StateCompScansCompleted;
 
         IStateReader stateReader = Substitute.For<IStateReader>();
@@ -176,8 +169,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         StateCompositionStateHolder stateHolder = new();
 
-        // No baseline seeded — LastProcessedStateRoot stays Hash256.Zero,
-        // matching the production "fresh chain, no persisted snapshot" state.
         Assert.That(stateHolder.LastProcessedStateRoot, Is.EqualTo(Hash256.Zero));
 
         Block headBlock = Build.A.Block.WithNumber(1).WithStateRoot(NewRoot).TestObject;
@@ -188,10 +179,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
             CreateSnapshotStore(), CreateConfig(), LimboLogs.Instance);
         Assert.That(service, Is.Not.Null, "service must be constructed to subscribe NewHeadBlock");
 
-        // Fire the event the same way IBlockTree would on a real new head.
-        // The service's OnNewHeadBlock subscriber sees lastRoot==Zero, which
-        // before this fix returned silently; now it should dispatch
-        // AnalyzeAsync against the supplied header.
         blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(headBlock));
 
         await WaitForConditionAsync(

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -158,6 +158,56 @@ public class StateCompositionServiceIncrementalRecoveryTests
         }
     }
 
+    [Test]
+    [CancelAfter(10_000)]
+    public async Task OnNewHeadBlock_NoBaseline_FiresDeferredBootstrapScan()
+    {
+        // Regression test for the fresh-chain scenario: plugin started with
+        // blockTree.Head==null (no CL forkchoice driving the head past genesis,
+        // e.g. testing_commitBlockV1-driven chains), so StateCompositionPlugin's
+        // ScheduleBootstrapScan bailed. OnNewHeadBlock must absorb that and
+        // dispatch AnalyzeAsync the first time a header arrives without a
+        // baseline; otherwise _incrementalBlock stays at 0 forever and
+        // statecomp_get reports stale zeros after every block.
+        long scansBefore = Metrics.StateCompScansCompleted;
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        StateCompositionStateHolder stateHolder = new();
+
+        // No baseline seeded — LastProcessedStateRoot stays Hash256.Zero,
+        // matching the production "fresh chain, no persisted snapshot" state.
+        Assert.That(stateHolder.LastProcessedStateRoot, Is.EqualTo(Hash256.Zero));
+
+        Block headBlock = Build.A.Block.WithNumber(1).WithStateRoot(NewRoot).TestObject;
+        blockTree.Head.Returns(headBlock);
+
+        using StateCompositionService service = new(
+            stateReader, worldStateManager, blockTree, stateHolder,
+            CreateSnapshotStore(), CreateConfig(), LimboLogs.Instance);
+        Assert.That(service, Is.Not.Null, "service must be constructed to subscribe NewHeadBlock");
+
+        // Fire the event the same way IBlockTree would on a real new head.
+        // The service's OnNewHeadBlock subscriber sees lastRoot==Zero, which
+        // before this fix returned silently; now it should dispatch
+        // AnalyzeAsync against the supplied header.
+        blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(headBlock));
+
+        await WaitForConditionAsync(
+            () => stateHolder.HasScanBaseline,
+            TimeSpan.FromSeconds(5),
+            "Deferred bootstrap did not set HasScanBaseline=true within 5s").ConfigureAwait(false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Metrics.StateCompScansCompleted, Is.EqualTo(scansBefore + 1),
+                "OnNewHeadBlock with lastRoot==Zero must dispatch AnalyzeAsync, which bumps scans_completed.");
+            Assert.That(stateHolder.LastProcessedStateRoot, Is.Not.EqualTo(Hash256.Zero),
+                "After the deferred bootstrap, the baseline must be seeded from the header root.");
+        }
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string message)
     {
         using CancellationTokenSource cts = new(timeout);

--- a/src/Nethermind/Nethermind.StateComposition/FireAndForget.cs
+++ b/src/Nethermind/Nethermind.StateComposition/FireAndForget.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Nethermind.Logging;
+
+namespace Nethermind.StateComposition;
+
+internal static class FireAndForget
+{
+    /// <summary>
+    /// Run an async work item on the thread pool and log any exception it throws.
+    /// The IsError check stays inside the catch (not a `when` filter) so the
+    /// catch always swallows — otherwise an exception would leak to the
+    /// unobserved-task pipeline whenever Error logging is off.
+    /// </summary>
+    public static void Run(Func<Task> work, ILogger logger, string failureMessage) =>
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await work().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (logger.IsError)
+                    logger.Error(failureMessage, ex);
+            }
+        });
+}

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -23,18 +23,10 @@ internal sealed partial class StateCompositionService
             // Plugin's startup bootstrap couldn't run (head was null at init); fire it now.
             BlockHeader? header = e.Block.Header;
             if (header?.StateRoot is null) return;
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await AnalyzeAsync(header, CancellationToken.None).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    if (_logger.IsError)
-                        _logger.Error("StateComposition: deferred bootstrap scan failed", ex);
-                }
-            });
+            FireAndForget.Run(
+                () => AnalyzeAsync(header, CancellationToken.None),
+                _logger,
+                "StateComposition: deferred bootstrap scan failed");
             return;
         }
 
@@ -131,23 +123,16 @@ internal sealed partial class StateCompositionService
         BlockHeader? header = head?.Header ?? _blockTree.Head?.Header;
         if (header is null) return;
 
-        _ = Task.Run(async () =>
-        {
-            try
+        FireAndForget.Run(
+            async () =>
             {
                 Result<StateCompositionStats> result =
                     await AnalyzeAsync(header, CancellationToken.None).ConfigureAwait(false);
-
                 if (!result.IsSuccess && _logger.IsWarn)
                     _logger.Warn($"StateComposition: auto-rescan skipped: {result.Error}");
-            }
-            catch (Exception ex)
-            {
-                // Don't lift the IsError check into a `when` filter — it would leak the exception when logging is off.
-                if (_logger.IsError)
-                    _logger.Error("StateComposition: auto-rescan failed", ex);
-            }
-        });
+            },
+            _logger,
+            "StateComposition: auto-rescan failed");
     }
 
 }

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -28,8 +28,18 @@ internal sealed partial class StateCompositionService
             if (header?.StateRoot is null) return;
             _ = Task.Run(async () =>
             {
-                try { await AnalyzeAsync(header, CancellationToken.None).ConfigureAwait(false); }
-                catch (Exception ex) when (_logger.IsError) { _logger.Error("StateComposition: deferred bootstrap scan failed", ex); }
+                try
+                {
+                    await AnalyzeAsync(header, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Guard the log call itself, not the catch: a `when (IsError)`
+                    // filter would let the exception escape into the unobserved-task
+                    // pipeline whenever Error logging is off.
+                    if (_logger.IsError)
+                        _logger.Error("StateComposition: deferred bootstrap scan failed", ex);
+                }
             });
             return;
         }

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -20,10 +20,7 @@ internal sealed partial class StateCompositionService
         Hash256 lastRoot = _stateHolder.LastProcessedStateRoot;
         if (lastRoot == Hash256.Zero)
         {
-            // No baseline yet — bootstrap-on-startup couldn't run because the head
-            // was null at init. Trigger a scan now that a head exists. AnalyzeAsync
-            // is serialized by its own scan semaphore, so a duplicate dispatch is
-            // a no-op rather than a race.
+            // Plugin's startup bootstrap couldn't run (head was null at init); fire it now.
             BlockHeader? header = e.Block.Header;
             if (header?.StateRoot is null) return;
             _ = Task.Run(async () =>
@@ -34,9 +31,6 @@ internal sealed partial class StateCompositionService
                 }
                 catch (Exception ex)
                 {
-                    // Guard the log call itself, not the catch: a `when (IsError)`
-                    // filter would let the exception escape into the unobserved-task
-                    // pipeline whenever Error logging is off.
                     if (_logger.IsError)
                         _logger.Error("StateComposition: deferred bootstrap scan failed", ex);
                 }
@@ -149,9 +143,7 @@ internal sealed partial class StateCompositionService
             }
             catch (Exception ex)
             {
-                // Guard the log call itself, not the catch: a `when (IsError)`
-                // filter would let the exception escape into the unobserved-task
-                // pipeline whenever Error logging is off.
+                // Don't lift the IsError check into a `when` filter — it would leak the exception when logging is off.
                 if (_logger.IsError)
                     _logger.Error("StateComposition: auto-rescan failed", ex);
             }

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -18,7 +18,21 @@ internal sealed partial class StateCompositionService
     private void OnNewHeadBlock(object? sender, BlockEventArgs e)
     {
         Hash256 lastRoot = _stateHolder.LastProcessedStateRoot;
-        if (lastRoot == Hash256.Zero) return;
+        if (lastRoot == Hash256.Zero)
+        {
+            // No baseline yet — bootstrap-on-startup couldn't run because the head
+            // was null at init. Trigger a scan now that a head exists. AnalyzeAsync
+            // is serialized by its own scan semaphore, so a duplicate dispatch is
+            // a no-op rather than a race.
+            BlockHeader? header = e.Block.Header;
+            if (header?.StateRoot is null) return;
+            _ = Task.Run(async () =>
+            {
+                try { await AnalyzeAsync(header, CancellationToken.None).ConfigureAwait(false); }
+                catch (Exception ex) when (_logger.IsError) { _logger.Error("StateComposition: deferred bootstrap scan failed", ex); }
+            });
+            return;
+        }
 
         Hash256? newRoot = e.Block.Header.StateRoot;
         if (newRoot is null || newRoot == lastRoot) return;

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
@@ -75,15 +75,20 @@ internal sealed partial class StateCompositionService : IStoppableService, IDisp
     }
 
     /// <summary>
-    /// Run a full trie scan. The plugin has exactly two legal callers — any third
-    /// caller collapses the single-operating-mode invariant, so a reviewer adding
-    /// one must delete this comment as a tripwire:
+    /// Run a full trie scan. The plugin has exactly three legal callers — any
+    /// fourth caller collapses the single-operating-mode invariant, so a reviewer
+    /// adding one must delete this comment as a tripwire:
     /// <list type="bullet">
     /// <item><description>Plugin bootstrap: <see cref="StateCompositionPlugin.Init"/>
     /// schedules a background scan when no persisted snapshot is available.</description></item>
     /// <item><description>Incremental recovery: <see cref="ScheduleBaselineRescan"/>
     /// from the <see cref="MissingTrieNodeException"/> handler in
     /// <see cref="RunIncrementalDiff"/>.</description></item>
+    /// <item><description>Deferred bootstrap: <see cref="OnNewHeadBlock"/> dispatches a
+    /// scan when no baseline exists yet (the plugin's startup bootstrap couldn't run
+    /// because <c>blockTree.Head</c> was null at <see cref="StateCompositionPlugin.Init"/>
+    /// time, e.g. a fresh chain whose head is driven by <c>testing_commitBlockV1</c>
+    /// or any non-CL forkchoice mechanism).</description></item>
     /// </list>
     /// Fail-fast / queued via <see cref="_scanLock"/> so back-to-back triggers collapse into one scan.
     /// </summary>

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
@@ -85,10 +85,8 @@ internal sealed partial class StateCompositionService : IStoppableService, IDisp
     /// from the <see cref="MissingTrieNodeException"/> handler in
     /// <see cref="RunIncrementalDiff"/>.</description></item>
     /// <item><description>Deferred bootstrap: <see cref="OnNewHeadBlock"/> dispatches a
-    /// scan when no baseline exists yet (the plugin's startup bootstrap couldn't run
-    /// because <c>blockTree.Head</c> was null at <see cref="StateCompositionPlugin.Init"/>
-    /// time, e.g. a fresh chain whose head is driven by <c>testing_commitBlockV1</c>
-    /// or any non-CL forkchoice mechanism).</description></item>
+    /// scan when no baseline exists (covers fresh chains where <c>blockTree.Head</c> was
+    /// null at <see cref="StateCompositionPlugin.Init"/> time).</description></item>
     /// </list>
     /// Fail-fast / queued via <see cref="_scanLock"/> so back-to-back triggers collapse into one scan.
     /// </summary>

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionStateHolder.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionStateHolder.cs
@@ -19,11 +19,21 @@ internal sealed class StateCompositionStateHolder
     private readonly Lock _lock = new();
 
     private StateCompositionStats _currentStats;
-    private TrieDepthDistribution _currentDistribution;
+    // Initialize ImmutableArray fields to Empty so BuildReport() serializes before
+    // the first scan publishes a real distribution.
+    private TrieDepthDistribution _currentDistribution = new()
+    {
+        AccountTrieLevels = ImmutableArray<TrieLevelStat>.Empty,
+        StorageTrieLevels = ImmutableArray<TrieLevelStat>.Empty,
+        StorageMaxDepthHistogram = ImmutableArray<long>.Empty,
+        BranchOccupancyDistribution = ImmutableArray<long>.Empty,
+    };
     private ScanMetadata _lastScanMetadata;
     private bool _hasScanBaseline;
 
-    private CumulativeTrieStats _incrementalStats;
+    // Initialize SlotCountHistogram to Empty (not default) so BuildReport() can be
+    // serialized before the first scan completes. STJ throws on default(ImmutableArray<T>).
+    private CumulativeTrieStats _incrementalStats = new() { SlotCountHistogram = ImmutableArray<long>.Empty };
     private bool _hasIncrementalBaseline;
     private readonly CumulativeDepthStats _currentDepthStats = new();
     private long _incrementalBlock;

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionStateHolder.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionStateHolder.cs
@@ -19,8 +19,8 @@ internal sealed class StateCompositionStateHolder
     private readonly Lock _lock = new();
 
     private StateCompositionStats _currentStats;
-    // Initialize ImmutableArray fields to Empty so BuildReport() serializes before
-    // the first scan publishes a real distribution.
+    // ImmutableArray fields seeded to Empty: STJ throws on default(ImmutableArray<T>) when
+    // BuildReport() serializes before the first scan completes.
     private TrieDepthDistribution _currentDistribution = new()
     {
         AccountTrieLevels = ImmutableArray<TrieLevelStat>.Empty,
@@ -31,8 +31,6 @@ internal sealed class StateCompositionStateHolder
     private ScanMetadata _lastScanMetadata;
     private bool _hasScanBaseline;
 
-    // Initialize SlotCountHistogram to Empty (not default) so BuildReport() can be
-    // serialized before the first scan completes. STJ throws on default(ImmutableArray<T>).
     private CumulativeTrieStats _incrementalStats = new() { SlotCountHistogram = ImmutableArray<long>.Empty };
     private bool _hasIncrementalBaseline;
     private readonly CumulativeDepthStats _currentDepthStats = new();

--- a/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
+++ b/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
@@ -115,22 +115,15 @@ public class StateCompositionPlugin(IStateCompositionConfig config) : INethermin
             return;
         }
 
-        _ = Task.Run(async () =>
-        {
-            try
+        FireAndForget.Run(
+            async () =>
             {
                 Result<StateCompositionStats> result =
                     await service.AnalyzeAsync(head, CancellationToken.None).ConfigureAwait(false);
-
                 if (!result.IsSuccess && logger.IsWarn)
                     logger.Warn($"StateComposition: bootstrap scan skipped: {result.Error}");
-            }
-            catch (Exception ex)
-            {
-                // Don't lift the IsError check into a `when` filter — it would leak the exception when logging is off.
-                if (logger.IsError)
-                    logger.Error("StateComposition: bootstrap scan failed", ex);
-            }
-        });
+            },
+            logger,
+            "StateComposition: bootstrap scan failed");
     }
 }

--- a/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
+++ b/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;

--- a/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
+++ b/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
@@ -98,19 +98,9 @@ public class StateCompositionPlugin(IStateCompositionConfig config) : INethermin
     public Task InitRpcModules() => Task.CompletedTask;
 
     /// <summary>
-    /// Fire-and-forget the bootstrap scan against the current chain head. This
-    /// is the plugin's startup-time call site for
-    /// <see cref="StateCompositionService.AnalyzeAsync"/>; the two other legal
-    /// callers live inside the service itself
-    /// (<see cref="StateCompositionService.OnNewHeadBlock"/> as the deferred
-    /// bootstrap when this site couldn't run because the head was null at
-    /// init, and the <c>MissingTrieNodeException</c> recovery path in
-    /// <c>RunIncrementalDiff</c>). If the block tree has no head yet (very
-    /// early init) we log a warning here and rely on the deferred bootstrap
-    /// to fire on the first head block instead — operators no longer need to
-    /// restart the node. <see cref="StateCompositionService.AnalyzeAsync"/>
-    /// already serialises via its scan semaphore, so the dispatched task is
-    /// safe regardless of which call site triggered it.
+    /// Fire-and-forget the startup bootstrap scan against the current chain head.
+    /// If the block tree has no head yet, fall through to the deferred bootstrap
+    /// in <see cref="StateCompositionService.OnNewHeadBlock"/> on the first new head.
     /// </summary>
     private static void ScheduleBootstrapScan(
         StateCompositionService service,
@@ -137,9 +127,7 @@ public class StateCompositionPlugin(IStateCompositionConfig config) : INethermin
             }
             catch (Exception ex)
             {
-                // Guard the log call itself, not the catch: a `when (IsError)`
-                // filter would let the exception escape into the unobserved-task
-                // pipeline whenever Error logging is off.
+                // Don't lift the IsError check into a `when` filter — it would leak the exception when logging is off.
                 if (logger.IsError)
                     logger.Error("StateComposition: bootstrap scan failed", ex);
             }

--- a/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
+++ b/src/Nethermind/Nethermind.StateComposition/StateCompositionPlugin.cs
@@ -98,14 +98,19 @@ public class StateCompositionPlugin(IStateCompositionConfig config) : INethermin
     public Task InitRpcModules() => Task.CompletedTask;
 
     /// <summary>
-    /// Fire-and-forget the bootstrap scan against the current chain head. This is
-    /// the only call site that originates from the plugin (the other legal caller
-    /// of <see cref="StateCompositionService.AnalyzeAsync"/> is the
-    /// MissingTrieNodeException recovery path inside the service itself). If the
-    /// block tree has no head yet (very early init), log a warning — operators
-    /// must restart the node once the consensus client has driven the head past
-    /// genesis. <see cref="StateCompositionService.AnalyzeAsync"/> already
-    /// serialises via its scan semaphore, so the dispatched task is safe.
+    /// Fire-and-forget the bootstrap scan against the current chain head. This
+    /// is the plugin's startup-time call site for
+    /// <see cref="StateCompositionService.AnalyzeAsync"/>; the two other legal
+    /// callers live inside the service itself
+    /// (<see cref="StateCompositionService.OnNewHeadBlock"/> as the deferred
+    /// bootstrap when this site couldn't run because the head was null at
+    /// init, and the <c>MissingTrieNodeException</c> recovery path in
+    /// <c>RunIncrementalDiff</c>). If the block tree has no head yet (very
+    /// early init) we log a warning here and rely on the deferred bootstrap
+    /// to fire on the first head block instead — operators no longer need to
+    /// restart the node. <see cref="StateCompositionService.AnalyzeAsync"/>
+    /// already serialises via its scan semaphore, so the dispatched task is
+    /// safe regardless of which call site triggered it.
     /// </summary>
     private static void ScheduleBootstrapScan(
         StateCompositionService service,


### PR DESCRIPTION
## Changes

- Initialize \`_currentDistribution\` and \`_incrementalStats\` so their \`ImmutableArray<T>\` fields are \`Empty\` rather than \`default\`. \`System.Text.Json\` throws \`InvalidOperationException\` on the first enumeration of \`default(ImmutableArray<T>)\`, which truncated \`statecomp_get\` JSON mid-stream before any scan had populated the live state.
- In \`OnNewHeadBlock\`, when \`LastProcessedStateRoot == Hash256.Zero\`, dispatch \`AnalyzeAsync(header)\` so the bootstrap fires on the first head block. Without this, a node started before the head advanced past genesis (e.g. a fresh chain driven by \`testing_commitBlockV1\`) stayed pinned at block 0 forever because \`ScheduleBootstrapScan\` bailed on the null head and never retried.
- Add a regression test (\`OnNewHeadBlock_NoBaseline_FiresDeferredBootstrapScan\`) covering the deferred-bootstrap path.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

End-to-end smoke against a fresh \`lab-genesis.json\` (post-merge from genesis, head driven by \`testing_commitBlockV1\`):

- before: \`statecomp_get\` returns truncated JSON; even after blocks land, \`blockNumber\` stays at 0
- after: \`statecomp_get\` returns valid JSON (\`slotCountHistogram: []\` etc.), and the deferred scan fires on the first new head; \`_incrementalBlock\` advances per block

A unit test (\`OnNewHeadBlock_NoBaseline_FiresDeferredBootstrapScan\`) covers the deferred-bootstrap path. The existing \`MissingTrieNodeException\` recovery test still passes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Both fixes are guarded:
- The \`Empty\` initialization only changes default values of unpopulated fields; any path that overwrites them with real scan data (\`PublishScanBaseline\`, \`RestoreFromSnapshot\`, \`ApplyDiff\`) is unaffected.
- The deferred-scan dispatch only runs when no baseline is set AND a head exists; the existing \`_scanLock\` semaphore prevents concurrent or duplicate dispatches.