### PR TITLE
Reorg up to lastFinalized block

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgDepthFinalizedStateProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgDepthFinalizedStateProviderTests.cs
@@ -26,17 +26,70 @@ public class ReorgDepthFinalizedStateProviderTests
     }
 
     [Test]
-    public void FinalizedBlockNumber_ReturnsCorrectValue()
+    public void FinalizedBlockNumber_FallsBackToBestKnownMinusMaxDepth_WhenFinalizedHashIsNull()
     {
-        // Arrange
         long bestKnownNumber = 1000;
         _blockTree.BestKnownNumber.Returns(bestKnownNumber);
+        _blockTree.FinalizedHash.Returns((Hash256?)null);
 
-        // Act
         long result = _provider.FinalizedBlockNumber;
 
-        // Assert
         result.Should().Be(bestKnownNumber - Reorganization.MaxDepth);
+    }
+
+    [Test]
+    public void FinalizedBlockNumber_ReturnsHeaderNumber_WhenFinalizedHashAndHeaderAreKnown()
+    {
+        const long finalizedNumber = 950;
+        Hash256 finalizedHash = TestItem.KeccakA;
+        BlockHeader finalizedHeader = Build.A.BlockHeader.WithNumber(finalizedNumber).TestObject;
+
+        _blockTree.FinalizedHash.Returns(finalizedHash);
+        _blockTree.FindHeader(finalizedHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(finalizedHeader);
+
+        long result = _provider.FinalizedBlockNumber;
+
+        result.Should().Be(finalizedNumber);
+    }
+
+    [Test]
+    public void FinalizedBlockNumber_FallsBack_WhenFinalizedHeaderCannotBeFound()
+    {
+        const long bestKnownNumber = 1000;
+        Hash256 finalizedHash = TestItem.KeccakA;
+
+        _blockTree.BestKnownNumber.Returns(bestKnownNumber);
+        _blockTree.FinalizedHash.Returns(finalizedHash);
+        _blockTree.FindHeader(finalizedHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns((BlockHeader?)null);
+
+        long result = _provider.FinalizedBlockNumber;
+
+        result.Should().Be(bestKnownNumber - Reorganization.MaxDepth);
+    }
+
+    [Test]
+    public void FinalizedBlockNumber_FallsBack_WhenFinalizedHashIsZero()
+    {
+        const long bestKnownNumber = 1000;
+
+        _blockTree.BestKnownNumber.Returns(bestKnownNumber);
+        _blockTree.FinalizedHash.Returns(Keccak.Zero);
+
+        long result = _provider.FinalizedBlockNumber;
+
+        result.Should().Be(bestKnownNumber - Reorganization.MaxDepth);
+        _blockTree.DidNotReceive().FindHeader(Arg.Any<Hash256>(), Arg.Any<BlockTreeLookupOptions>());
+    }
+
+    [Test]
+    public void FinalizedBlockNumber_FallsBack_DoesNotGoNegative()
+    {
+        // Below Reorganization.MaxDepth (=64) the formula bestKnownNumber - 64 would be negative;
+        // FinalizedBlockNumber must clamp to 0.
+        _blockTree.BestKnownNumber.Returns(10);
+        _blockTree.FinalizedHash.Returns((Hash256?)null);
+
+        _provider.FinalizedBlockNumber.Should().Be(0);
     }
 
     [Test]
@@ -55,42 +108,19 @@ public class ReorgDepthFinalizedStateProviderTests
         _blockTree.DidNotReceive().FindHeader(Arg.Any<long>(), Arg.Any<BlockTreeLookupOptions>());
     }
 
-    [Test]
-    public void GetFinalizedStateRootAt_ReturnsStateRoot_WhenBlockNumberIsFinalized()
+    [TestCase(900, TestName = "Inside the finalized window")]
+    [TestCase(1000 - 64, TestName = "Exactly at the boundary (bestKnown - MaxDepth)")]
+    public void GetFinalizedStateRootAt_ReturnsStateRoot_WhenBlockIsAtOrBelowFinalizedBoundary(long blockNumber)
     {
-        // Arrange
-        long bestKnownNumber = 1000;
-        long blockNumber = 900;
+        const long bestKnownNumber = 1000;
         Hash256 expectedStateRoot = TestItem.KeccakA;
         BlockHeader header = Build.A.BlockHeader.WithStateRoot(expectedStateRoot).TestObject;
 
         _blockTree.BestKnownNumber.Returns(bestKnownNumber);
         _blockTree.FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical).Returns(header);
 
-        // Act
         Hash256? result = _provider.GetFinalizedStateRootAt(blockNumber);
 
-        // Assert
-        result.Should().Be(expectedStateRoot);
-        _blockTree.Received(1).FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
-    }
-
-    [Test]
-    public void GetFinalizedStateRootAt_AtBoundary_ReturnsStateRoot()
-    {
-        // Arrange
-        long bestKnownNumber = 1000;
-        long blockNumber = bestKnownNumber - Reorganization.MaxDepth; // Exactly at the boundary
-        Hash256 expectedStateRoot = TestItem.KeccakD;
-        BlockHeader header = Build.A.BlockHeader.WithStateRoot(expectedStateRoot).TestObject;
-
-        _blockTree.BestKnownNumber.Returns(bestKnownNumber);
-        _blockTree.FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical).Returns(header);
-
-        // Act
-        Hash256? result = _provider.GetFinalizedStateRootAt(blockNumber);
-
-        // Assert
         result.Should().Be(expectedStateRoot);
         _blockTree.Received(1).FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
     }

--- a/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
@@ -10,6 +10,9 @@ namespace Nethermind.Blockchain;
 
 public class ReorgDepthFinalizedStateProvider(IBlockTree blockTree) : IFinalizedStateProvider
 {
+    private sealed record FinalizedCache(Hash256 Hash, long Number);
+    private FinalizedCache? _cache;
+
     public long FinalizedBlockNumber
     {
         get
@@ -17,8 +20,15 @@ public class ReorgDepthFinalizedStateProvider(IBlockTree blockTree) : IFinalized
             Hash256? finalizedHash = blockTree.FinalizedHash;
             if (finalizedHash is not null && finalizedHash != Keccak.Zero)
             {
+                FinalizedCache? cache = _cache;
+                if (cache is not null && cache.Hash == finalizedHash) return cache.Number;
+
                 BlockHeader? finalizedHeader = blockTree.FindHeader(finalizedHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
-                if (finalizedHeader is not null) return finalizedHeader.Number;
+                if (finalizedHeader is not null)
+                {
+                    _cache = new FinalizedCache(finalizedHash, finalizedHeader.Number);
+                    return finalizedHeader.Number;
+                }
             }
             return Math.Max(0, blockTree.BestKnownNumber - Reorganization.MaxDepth);
         }

--- a/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
@@ -10,7 +10,19 @@ namespace Nethermind.Blockchain;
 
 public class ReorgDepthFinalizedStateProvider(IBlockTree blockTree) : IFinalizedStateProvider
 {
-    public long FinalizedBlockNumber => Math.Max(0, blockTree.BestKnownNumber - Reorganization.MaxDepth);
+    public long FinalizedBlockNumber
+    {
+        get
+        {
+            Hash256? finalizedHash = blockTree.FinalizedHash;
+            if (finalizedHash is not null && finalizedHash != Keccak.Zero)
+            {
+                BlockHeader? finalizedHeader = blockTree.FindHeader(finalizedHash, BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
+                if (finalizedHeader is not null) return finalizedHeader.Number;
+            }
+            return Math.Max(0, blockTree.BestKnownNumber - Reorganization.MaxDepth);
+        }
+    }
 
     public Hash256? GetFinalizedStateRootAt(long blockNumber)
     {

--- a/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Blockchain;
 public class ReorgDepthFinalizedStateProvider(IBlockTree blockTree) : IFinalizedStateProvider
 {
     private sealed record FinalizedCache(Hash256 Hash, long Number);
-    private FinalizedCache? _cache;
+    private volatile FinalizedCache? _cache;
 
     public long FinalizedBlockNumber
     {

--- a/src/Nethermind/Nethermind.Db.Test/LogIndex/LogIndexStorageIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/LogIndex/LogIndexStorageIntegrationTests.cs
@@ -70,7 +70,7 @@ namespace Nethermind.Db.Test.LogIndex
             };
 
             ILogIndexStorage storage = failOnBlock is null && failOnCallN is null
-                ? new LogIndexStorage(dbFactory ?? _dbFactory, LimboLogs.Instance, config)
+                ? new LogIndexStorage(dbFactory ?? _dbFactory, LimboLogs.Instance, config, NullFinalizedBlockProvider.Instance)
                 : new SaveFailingLogIndexStorage(dbFactory ?? _dbFactory, LimboLogs.Instance, config)
                 {
                     FailOnBlock = failOnBlock ?? 0,
@@ -1071,8 +1071,14 @@ namespace Nethermind.Db.Test.LogIndex
                 $"{_batchCount} * {_blocksPerBatch} blocks (ex-ranges: {ExtendedGetRanges}, compression: {Compression})";
         }
 
+        private sealed class NullFinalizedBlockProvider : IFinalizedBlockProvider
+        {
+            public static readonly NullFinalizedBlockProvider Instance = new();
+            public long? FinalizedBlockNumber => null;
+        }
+
         private class SaveFailingLogIndexStorage(IDbFactory dbFactory, ILogManager logManager, ILogIndexConfig config)
-            : LogIndexStorage(dbFactory, logManager, config)
+            : LogIndexStorage(dbFactory, logManager, config, NullFinalizedBlockProvider.Instance)
         {
             public const string FailMessage = "Test exception.";
 

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -80,7 +80,10 @@ public interface IPruningConfig : IConfig
     [ConfigItem(Description = "Enable tracking of past key to reduce database and pruning cache growth", DefaultValue = "true")]
     bool TrackPastKeys { get; set; }
 
-    [ConfigItem(Description = "The number of past states before the state gets pruned. Used to determine how old of a state to keep from the head.", DefaultValue = "64")]
+    [ConfigItem(Description = "Controls in-memory dirty-state retention and snap-serving depth. " +
+                             "On post-Merge networks the reorg window is determined dynamically from the finalized block " +
+                             "rather than this value; PruningBoundary is used only as the fallback floor before the first " +
+                             "finalized block is established, and as the minimum dirty-node cache depth for memory pressure management.", DefaultValue = "64")]
     int PruningBoundary { get; set; }
 
     [ConfigItem(Description = "Dirty node shard count", DefaultValue = "8")]

--- a/src/Nethermind/Nethermind.Db/LogIndex/IFinalizedBlockProvider.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/IFinalizedBlockProvider.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.LogIndex;
+
+/// <summary>
+/// Provides the current finalized block number so that subsystems can determine their reorg-safe window dynamically.
+/// </summary>
+public interface IFinalizedBlockProvider
+{
+    /// <summary>Returns the current finalized block number, or null if finalization has not yet been established.</summary>
+    long? FinalizedBlockNumber { get; }
+}

--- a/src/Nethermind/Nethermind.Db/LogIndex/ILogIndexConfig.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/ILogIndexConfig.cs
@@ -21,7 +21,8 @@ public interface ILogIndexConfig : IConfig
     public bool Reset { get; set; }
 
     [ConfigItem(
-        Description = "Max allowed reorg depth for the index.",
+        Description = "Fallback reorg depth used before the first finalized block is established. " +
+                      "On post-Merge networks the reorg window tracks the finalized block dynamically and this value is not the effective limit.",
         DefaultValue = "64",
         HiddenFromDocs = true
     )]

--- a/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
@@ -518,7 +518,7 @@ namespace Nethermind.Db.LogIndex
         {
             if (_maxBlock is null) return null;
             if (_finalizedBlockProvider.FinalizedBlockNumber is { } finalized)
-                return checked((int)finalized);
+                return finalized > int.MaxValue ? _maxBlock : (int)finalized;
             return _maxBlock - _maxReorgDepth;
         }
 

--- a/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
@@ -185,6 +185,7 @@ namespace Nethermind.Db.LogIndex
         private readonly ILogger _logger;
 
         private readonly int _maxReorgDepth;
+        private readonly IFinalizedBlockProvider _finalizedBlockProvider;
 
         private readonly AllMergeOperators _mergeOperators;
         private readonly ICompressor _compressor;
@@ -222,13 +223,14 @@ namespace Nethermind.Db.LogIndex
         private bool _stopped;
         private bool _disposed;
 
-        public LogIndexStorage(IDbFactory dbFactory, ILogManager logManager, ILogIndexConfig config)
+        public LogIndexStorage(IDbFactory dbFactory, ILogManager logManager, ILogIndexConfig config, IFinalizedBlockProvider finalizedBlockProvider)
         {
             try
             {
                 Enabled = config.Enabled;
 
                 _maxReorgDepth = config.MaxReorgDepth!.Value;
+                _finalizedBlockProvider = finalizedBlockProvider;
 
                 _logger = logManager.GetClassLogger<LogIndexStorage>();
 
@@ -512,7 +514,13 @@ namespace Nethermind.Db.LogIndex
             return (min, max);
         }
 
-        private int? GetLastReorgableBlockNumber() => _maxBlock - _maxReorgDepth;
+        private int? GetCompressionBoundary()
+        {
+            if (_maxBlock is null) return null;
+            if (_finalizedBlockProvider.FinalizedBlockNumber is { } finalized)
+                return checked((int)finalized);
+            return _maxBlock - _maxReorgDepth;
+        }
 
         private static bool IsBlockNewer(int next, int? lastMin, int? lastMax, bool isBackwardSync) => isBackwardSync
             ? lastMin is null || next < lastMin
@@ -935,7 +943,7 @@ namespace Nethermind.Db.LogIndex
 
         private Span<byte> RemoveReorgableBlocks(Span<byte> data)
         {
-            if (GetLastReorgableBlockNumber() is not { } lastCompressBlock)
+            if (GetCompressionBoundary() is not { } lastCompressBlock)
                 return Span<byte>.Empty;
 
             int lastCompressIndex = LastBlockSearch(data, lastCompressBlock, false);

--- a/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
@@ -514,13 +514,14 @@ namespace Nethermind.Db.LogIndex
             return (min, max);
         }
 
-        private int? GetCompressionBoundary()
-        {
-            if (_maxBlock is null) return null;
-            if (_finalizedBlockProvider.FinalizedBlockNumber is { } finalized)
-                return finalized > int.MaxValue ? _maxBlock : (int)finalized;
-            return _maxBlock - _maxReorgDepth;
-        }
+        private int? GetCompressionBoundary() => _maxBlock is null
+            ? null
+            : _finalizedBlockProvider.FinalizedBlockNumber switch
+            {
+                null => _maxBlock - _maxReorgDepth,
+                > int.MaxValue => _maxBlock,
+                var finalized => (int)finalized
+            };
 
         private static bool IsBlockNewer(int next, int? lastMin, int? lastMax, bool isBackwardSync) => isBackwardSync
             ? lastMin is null || next < lastMin

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -12,6 +12,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Db.FullPruning;
+using Nethermind.Db.LogIndex;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
@@ -92,11 +93,25 @@ public class WorldStateModule(IInitConfig initConfig) : Module
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()
 
             .AddSingleton<IFinalizedStateProvider, ReorgDepthFinalizedStateProvider>()
+            .AddSingleton<IFinalizedBlockProvider, IFinalizedStateProvider>(
+                provider => new FinalizedBlockProviderAdapter(provider))
             ;
 
         if (initConfig.DiagnosticMode == DiagnosticMode.VerifyTrie)
         {
             builder.AddStep(typeof(RunVerifyTrie));
+        }
+    }
+
+    private sealed class FinalizedBlockProviderAdapter(IFinalizedStateProvider inner) : IFinalizedBlockProvider
+    {
+        public long? FinalizedBlockNumber
+        {
+            get
+            {
+                long number = inner.FinalizedBlockNumber;
+                return number > 0 ? number : null;
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -805,42 +805,6 @@ public partial class EngineModuleTests
         chain.BlockTree.HeadHash.Should().Be(headHash);
     }
 
-    [TestCase(false, TestName = "ApplyForkchoiceUpdate path (no payload attributes)")]
-    [TestCase(true, TestName = "StartBuildingPayload path (with payload attributes)")]
-    public async Task forkchoiceUpdatedV1_WhenZeroFinalizedHash_PreservesKnownFinalizedHash(bool withPayloadAttributes)
-    {
-        using MergeTestBlockchain chain = await CreateBlockchain();
-        IEngineRpcModule rpc = chain.EngineRpcModule;
-
-        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 2, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
-        Hash256 b1Hash = branch[0].BlockHash;
-        Hash256 b2Hash = branch[1].BlockHash;
-
-        // First FCU: set head to b2 and finalize b1
-        await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b2Hash, b1Hash, b1Hash));
-        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "precondition: b1 is finalized after first FCU");
-
-        // Second FCU: zero finalizedBlockHash — must preserve b1 as finalized regardless of path
-        PayloadAttributes? payloadAttributes = withPayloadAttributes
-            ? new PayloadAttributes
-            {
-                Timestamp = branch[1].Timestamp + 1,
-                PrevRandao = Keccak.Zero,
-                SuggestedFeeRecipient = Address.Zero,
-            }
-            : null;
-        ForkchoiceStateV1 fcuWithZeroFinalized = new(b2Hash, Keccak.Zero, Keccak.Zero);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithZeroFinalized, payloadAttributes);
-
-        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-        if (withPayloadAttributes)
-        {
-            result.Data.PayloadId.Should().NotBeNull("payload build must be started when attributes are provided");
-        }
-        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "zero finalizedBlockHash must preserve the previously known finalized hash");
-        chain.BlockTree.SafeHash.Should().Be(b1Hash, "zero safeBlockHash must preserve the previously known safe hash");
-    }
-
     [Test]
     public async Task forkchoiceUpdatedV1_WhenNonZeroUnknownFinalizedHash_ReturnsInvalidForkchoiceState()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -805,6 +805,42 @@ public partial class EngineModuleTests
         chain.BlockTree.HeadHash.Should().Be(headHash);
     }
 
+    [TestCase(false, TestName = "ApplyForkchoiceUpdate path (no payload attributes)")]
+    [TestCase(true, TestName = "StartBuildingPayload path (with payload attributes)")]
+    public async Task forkchoiceUpdatedV1_WhenZeroFinalizedHash_PreservesKnownFinalizedHash(bool withPayloadAttributes)
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 2, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b1Hash = branch[0].BlockHash;
+        Hash256 b2Hash = branch[1].BlockHash;
+
+        // First FCU: set head to b2 and finalize b1
+        await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b2Hash, b1Hash, b1Hash));
+        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "precondition: b1 is finalized after first FCU");
+
+        // Second FCU: zero finalizedBlockHash — must preserve b1 as finalized regardless of path
+        PayloadAttributes? payloadAttributes = withPayloadAttributes
+            ? new PayloadAttributes
+            {
+                Timestamp = branch[1].Timestamp + 1,
+                PrevRandao = Keccak.Zero,
+                SuggestedFeeRecipient = Address.Zero,
+            }
+            : null;
+        ForkchoiceStateV1 fcuWithZeroFinalized = new(b2Hash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithZeroFinalized, payloadAttributes);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        if (withPayloadAttributes)
+        {
+            result.Data.PayloadId.Should().NotBeNull("payload build must be started when attributes are provided");
+        }
+        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "zero finalizedBlockHash must preserve the previously known finalized hash");
+        chain.BlockTree.SafeHash.Should().Be(b1Hash, "zero safeBlockHash must preserve the previously known safe hash");
+    }
+
     [Test]
     public async Task forkchoiceUpdatedV1_WhenNonZeroUnknownFinalizedHash_ReturnsInvalidForkchoiceState()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -10,10 +10,10 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
@@ -31,13 +31,17 @@ using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Test;
 using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Merge.Plugin.InvalidChainTracker;
+using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
+using Nethermind.Synchronization.Peers;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -564,6 +568,296 @@ public partial class EngineModuleTests
     }
 
 
+    [TestCase(3, TestName = "2 blocks behind head")]
+    [TestCase(33, TestName = "32 blocks behind head")]
+    public async Task forkchoiceUpdatedV1_WhenHeadIsCanonicalAncestorWithRetainedState_ReorgsToAncestor(int chainLength)
+    {
+        // Spec PR #786: MUST reorg to a canonical ancestor whose state is retained by the trie store.
+        // No finalized block is set — the MAY-skip (spec point 2) never fires; the reorg proceeds
+        // because IStateReader.HasStateForBlock returns true for all recently processed blocks in
+        // the test's MemDb-backed trie store.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, chainLength, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b1Hash = branch[0].BlockHash;
+        Hash256 headHash = branch[chainLength - 1].BlockHash;
+
+        // Advance head to the last block without setting finalized
+        (await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(headHash, Keccak.Zero, Keccak.Zero))).Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(headHash, $"precondition: head is at H={chainLength}");
+
+        ForkchoiceStateV1 fcuToAncestor = new(b1Hash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuToAncestor);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(b1Hash, $"head must reorg to b1 — state for b1 is retained");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenHeadIsAncestorOfFinalizedBlock_SkipsUpdate()
+    {
+        // Spec PR #786 point 2: client MAY skip the update when headBlockHash is a valid ancestor of the
+        // latest known finalized block. Build 34 blocks, explicitly finalize b34, then FCU to b1
+        // (H=1 <= H=34, canonical) — the MAY-skip fires, not any depth limit.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 34, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b1Hash = branch[0].BlockHash;
+        Hash256 b34Hash = branch[33].BlockHash;
+
+        // Set head to b34 and explicitly finalize it
+        (await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b34Hash, b34Hash, b34Hash))).Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(b34Hash, "precondition: head is at H=34");
+        chain.BlockTree.FinalizedHash.Should().Be(b34Hash, "precondition: b34 is finalized");
+
+        ForkchoiceStateV1 fcuToAncestorOfFinalized = new(b1Hash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuToAncestorOfFinalized);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        result.Data.PayloadStatus.LatestValidHash.Should().Be(b1Hash, "spec mandates latestValidHash == forkchoiceState.headBlockHash when skipping");
+        result.Data.PayloadId.Should().BeNull("spec mandates payloadId: null when skipping");
+        chain.BlockTree.HeadHash.Should().Be(b34Hash, "Nethermind skips the update — b1 is a canonical ancestor of the finalized block, skip is permitted by spec");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenHeadIsOnDifferentBranch_ReorgsRegardlessOfDepth()
+    {
+        // Spec PR #786: the MAY-skip (spec point 2) only fires when headBlockHash is a canonical ancestor
+        // of the finalized block. A non-canonical (fork) block is NOT eligible for the skip. The reorg
+        // proceeds because the side block was just processed and its state is retained — IStateReader
+        // .HasStateForBlock returns true. Builds a canonical chain of 34 blocks, then a side block off
+        // genesis.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        // Capture genesis as parent before building canonical chain
+        ExecutionPayload genesisAsParent = CreateParentBlockRequestOnHead(chain.BlockTree);
+
+        // Build canonical chain: genesis → b1 → b2 → ... → b34 (head at H=34)
+        IReadOnlyList<ExecutionPayload> canonical = await ProduceBranchV1(rpc, chain, 34, genesisAsParent, setHead: true);
+        Hash256 b34Hash = canonical[33].BlockHash;
+        chain.BlockTree.HeadHash.Should().Be(b34Hash, "precondition: canonical head is at H=34");
+
+        // Build a side block off genesis (H=1, different branch)
+        ExecutionPayload sideBlock = CreateBlockRequest(chain, genesisAsParent, TestItem.AddressA);
+        await rpc.engine_newPayloadV1(sideBlock);
+        Hash256 sideHash = sideBlock.BlockHash;
+        chain.BlockTree.IsMainChain(chain.BlockTree.FindHeader(sideHash, BlockTreeLookupOptions.None)!).Should().BeFalse("precondition: side block is not on canonical chain");
+
+        // FCU to the side block — it's on a different branch, so it must reorg regardless of depth
+        ForkchoiceStateV1 fcuToSide = new(sideHash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuToSide);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(sideHash, "different-branch FCU must always reorg — MAY-skip only applies to canonical ancestors of the finalized block");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenStateForNewHeadIsUnavailable_ReturnsTooDeepReorg()
+    {
+        // Spec PR #786 point 6: -38006 when the state backend cannot serve the FCU target.
+        // Mock-based because MemDb-backed integration tests cannot evict state on demand —
+        // HasStateForBlock always returns true there. This test wires HasStateForBlock to
+        // return false and asserts the gate fires.
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        Block headBlock = Build.A.Block.WithNumber(100).TestObject;
+        Block deepAncestor = Build.A.Block.WithNumber(33).TestObject;
+        // TryGetBranch walks parents via FindBlock(parentHash, …) — provide one parent so the loop
+        // breaks on IsMainChain(parent) instead of returning false (which would short-circuit to
+        // InvalidParams before ShouldProceedWithReorg runs).
+        Block ancestorParent = Build.A.Block.WithNumber(32).TestObject;
+
+        blockTree.FindBlock(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor);
+        blockTree.FindBlock(deepAncestor.Header.ParentHash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing, blockNumber: 32).Returns(ancestorParent);
+        blockTree.GetInfo(deepAncestor.Number, deepAncestor.Hash!).Returns(
+            (new BlockInfo(deepAncestor.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
+        blockTree.Head.Returns(headBlock);
+        blockTree.HeadHash.Returns(headBlock.Hash!);
+        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
+        blockTree.IsMainChain(Arg.Any<Hash256>()).Returns(true);
+        blockTree.FindHeader(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor.Header);
+
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager.CanReorgOn(deepAncestor.Header).Returns(false);
+
+        ForkchoiceUpdatedHandler handler = new(
+            blockTree,
+            Substitute.For<IManualBlockFinalizationManager>(),
+            Substitute.For<IPoSSwitcher>(),
+            Substitute.For<IPayloadPreparationService>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            Substitute.For<IBlockCacheService>(),
+            Substitute.For<IInvalidChainTracker>(),
+            Substitute.For<IMergeSyncController>(),
+            Substitute.For<IBeaconPivot>(),
+            Substitute.For<IPeerRefresher>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<ISyncPeerPool>(),
+            new MergeConfig(),
+            worldStateManager,
+            Substitute.For<ILogManager>());
+
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
+            new ForkchoiceStateV1(deepAncestor.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
+
+        result.ErrorCode.Should().Be(MergeErrorCodes.TooDeepReorg,
+            "state for the FCU target is not retained — gate must reject with -38006");
+        blockTree.DidNotReceive().UpdateMainChain(Arg.Any<IReadOnlyList<Block>>(), Arg.Any<bool>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenReorgWithinRetainedState_Reorgs()
+    {
+        // Spec PR #786 point 6: a reorg to a canonical ancestor whose state is still retained by
+        // the trie store must succeed. With finalized=b50, the trie store keeps state for blocks
+        // in [50, 100], so a reorg to b80 (depth 20) is served from the dirty cache.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 100, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b50Hash = branch[49].BlockHash;
+        Hash256 b80Hash = branch[79].BlockHash;
+        Hash256 b100Hash = branch[99].BlockHash;
+
+        (await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b100Hash, b50Hash, b50Hash))).Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(b100Hash, "precondition: head is at H=100");
+        chain.BlockTree.FinalizedHash.Should().Be(b50Hash, "precondition: b50 is finalized");
+
+        ForkchoiceStateV1 fcuToCanonicalAfterFinalized = new(b80Hash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuToCanonicalAfterFinalized);
+
+        result.ErrorCode.Should().Be(0, "reorg whose target state is retained must not return -38006");
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(b80Hash, "head must reorg to b80");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenHeadEqualsFinalized_DoesNotSkip()
+    {
+        // Spec PR #786 point 2: MAY-skip uses strict `<`, so newHead.Number == finalized.Number
+        // does NOT trigger the skip — the FCU falls through to the normal update path and
+        // returns Valid (with payloadId == null since no attributes were provided).
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 10, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b10Hash = branch[9].BlockHash;
+
+        (await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b10Hash, b10Hash, b10Hash))).Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(b10Hash, "precondition: head is at H=10 and finalized");
+        chain.BlockTree.FinalizedHash.Should().Be(b10Hash, "precondition: b10 is finalized");
+
+        // Re-issue FCU with newHead == finalized — strict `<` means MAY-skip does not fire.
+        ForkchoiceStateV1 fcuHeadEqualsFinalized = new(b10Hash, b10Hash, b10Hash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuHeadEqualsFinalized);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        result.Data.PayloadStatus.LatestValidHash.Should().Be(b10Hash);
+        chain.BlockTree.HeadHash.Should().Be(b10Hash, "head stays at b10 (no actual reorg, but path was the normal-update path, not MAY-skip)");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenInconsistent_ReturnsInvalidForkchoiceStateBeforeProceedingToReorgCheck()
+    {
+        // Spec ordering: RejectIfInconsistent (-38002) runs BEFORE ShouldProceedWithReorg (-38006).
+        // Locks in the validate-before-mutate ordering introduced with PR #786.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        ExecutionPayload genesisAsParent = CreateParentBlockRequestOnHead(chain.BlockTree);
+
+        IReadOnlyList<ExecutionPayload> canonical = await ProduceBranchV1(rpc, chain, 10, genesisAsParent, setHead: true);
+        Hash256 b5Hash = canonical[4].BlockHash;
+        Hash256 b10Hash = canonical[9].BlockHash;
+        chain.BlockTree.HeadHash.Should().Be(b10Hash, "precondition: canonical head is at H=10");
+
+        // Side block off genesis (H=1) — finalized=b5 is canonical but NOT an ancestor of this side block.
+        ExecutionPayload sideBlock = CreateBlockRequest(chain, genesisAsParent, TestItem.AddressA);
+        await rpc.engine_newPayloadV1(sideBlock);
+
+        // finalized.Number=5 > newHead.Number=1 (and finalized not ancestor of side) → RejectIfInconsistent fires.
+        ForkchoiceStateV1 fcuInconsistent = new(sideBlock.BlockHash, b5Hash, b5Hash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuInconsistent);
+
+        result.ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState,
+            "RejectIfInconsistent must run before ShouldProceedWithReorg");
+        chain.BlockTree.HeadHash.Should().Be(b10Hash, "head must not change when -38002 is returned");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenZeroFinalizedAndSafeHash_ReturnsValidWithoutError()
+    {
+        // Spec: zero safeBlockHash and finalizedBlockHash mean "unknown" — must not return -38002.
+        // Models CL checkpoint-syncing from a non-finalized state where safe/finalized are unknown.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 3, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
+        Hash256 headHash = branch[2].BlockHash;
+
+        ForkchoiceStateV1 fcuWithUnknownFinality = new(headHash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithUnknownFinality);
+
+        result.ErrorCode.Should().Be(0, "zero safe/finalized hashes must not produce an error");
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.HeadHash.Should().Be(headHash);
+    }
+
+    [TestCase(false, TestName = "ApplyForkchoiceUpdate path (no payload attributes)")]
+    [TestCase(true, TestName = "StartBuildingPayload path (with payload attributes)")]
+    public async Task forkchoiceUpdatedV1_WhenZeroFinalizedHash_PreservesKnownFinalizedHash(bool withPayloadAttributes)
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 2, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        Hash256 b1Hash = branch[0].BlockHash;
+        Hash256 b2Hash = branch[1].BlockHash;
+
+        // First FCU: set head to b2 and finalize b1
+        await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(b2Hash, b1Hash, b1Hash));
+        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "precondition: b1 is finalized after first FCU");
+
+        // Second FCU: zero finalizedBlockHash — must preserve b1 as finalized regardless of path
+        PayloadAttributes? payloadAttributes = withPayloadAttributes
+            ? new PayloadAttributes
+            {
+                Timestamp = branch[1].Timestamp + 1,
+                PrevRandao = Keccak.Zero,
+                SuggestedFeeRecipient = Address.Zero,
+            }
+            : null;
+        ForkchoiceStateV1 fcuWithZeroFinalized = new(b2Hash, Keccak.Zero, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithZeroFinalized, payloadAttributes);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        if (withPayloadAttributes)
+        {
+            result.Data.PayloadId.Should().NotBeNull("payload build must be started when attributes are provided");
+        }
+        chain.BlockTree.FinalizedHash.Should().Be(b1Hash, "zero finalizedBlockHash must preserve the previously known finalized hash");
+        chain.BlockTree.SafeHash.Should().Be(b1Hash, "zero safeBlockHash must preserve the previously known safe hash");
+    }
+
+    [Test]
+    public async Task forkchoiceUpdatedV1_WhenNonZeroUnknownFinalizedHash_ReturnsInvalidForkchoiceState()
+    {
+        // Spec: -38002 must only fire for non-zero hashes that are unknown, not for zero hashes.
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
+        Hash256 headHash = branch[0].BlockHash;
+
+        ForkchoiceStateV1 fcuWithUnknownFinalized = new(headHash, TestItem.KeccakA, Keccak.Zero);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithUnknownFinalized);
+
+        result.ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState,
+            "non-zero unknown finalizedBlockHash must return -38002");
+    }
+
     [Test]
     public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_as_safe_block()
     {
@@ -985,7 +1279,7 @@ public partial class EngineModuleTests
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
         {
-            ForkchoiceStateV1 forkchoiceStateV1 = new(block.BlockHash, block.BlockHash, block.BlockHash);
+            ForkchoiceStateV1 forkchoiceStateV1 = new(block.BlockHash, Keccak.Zero, Keccak.Zero);
             ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1, null);
             result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
             result.Data.PayloadId.Should().Be(null);
@@ -1018,7 +1312,7 @@ public partial class EngineModuleTests
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
         {
-            ForkchoiceStateV1 forkchoiceStateV1 = new(block.BlockHash, block.BlockHash, block.BlockHash);
+            ForkchoiceStateV1 forkchoiceStateV1 = new(block.BlockHash, Keccak.Zero, Keccak.Zero);
             ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1, null);
             result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
             result.Data.PayloadId.Should().Be(null);
@@ -1081,7 +1375,7 @@ public partial class EngineModuleTests
             chain.StateReader.GetBalance(payloadBlock, to).Should().Be(toBalanceAfter);
             if (moveHead)
             {
-                ForkchoiceStateV1 forkChoiceUpdatedRequest = new(executePayloadRequest.BlockHash, executePayloadRequest.BlockHash, executePayloadRequest.BlockHash);
+                ForkchoiceStateV1 forkChoiceUpdatedRequest = new(executePayloadRequest.BlockHash, Keccak.Zero, Keccak.Zero);
                 await rpc.engine_forkchoiceUpdatedV1(forkChoiceUpdatedRequest);
                 chain.ReadOnlyState.StateRoot.Should().Be(executePayloadRequest.StateRoot);
                 chain.ReadOnlyState.StateRoot.Should().NotBe(parentHeader.StateRoot!);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -708,6 +708,50 @@ public partial class EngineModuleTests
     }
 
     [Test]
+    public async Task forkchoiceUpdatedV1_WhenBlockIsNotYetProcessed_ReturnsSyncing()
+    {
+        // Spec point 1 + point 6: an unprocessed beacon block has no committed state, so CanReorgOn
+        // is undefined for it. The handler must not return -38006; it must fall through to SYNCING
+        // so beacon header sync can proceed.
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        Block headBlock = Build.A.Block.WithNumber(100).TestObject;
+        Block beaconTarget = Build.A.Block.WithNumber(101).TestObject;
+
+        blockTree.Head.Returns(headBlock);
+        blockTree.HeadHash.Returns(headBlock.Hash!);
+        blockTree.FindHeader(beaconTarget.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(beaconTarget.Header);
+        blockTree.GetInfo(beaconTarget.Number, beaconTarget.Hash!).Returns(
+            (new BlockInfo(beaconTarget.Hash!, 0) { WasProcessed = false }, new ChainLevelInfo(true)));
+
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager.CanReorgOn(Arg.Any<BlockHeader>()).Returns(false); // would force -38006 if the gate ran
+
+        ForkchoiceUpdatedHandler handler = new(
+            blockTree,
+            Substitute.For<IManualBlockFinalizationManager>(),
+            Substitute.For<IPoSSwitcher>(),
+            Substitute.For<IPayloadPreparationService>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            Substitute.For<IBlockCacheService>(),
+            Substitute.For<IInvalidChainTracker>(),
+            Substitute.For<IMergeSyncController>(),
+            Substitute.For<IBeaconPivot>(),
+            Substitute.For<IPeerRefresher>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<ISyncPeerPool>(),
+            new MergeConfig(),
+            worldStateManager,
+            Substitute.For<ILogManager>());
+
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
+            new ForkchoiceStateV1(beaconTarget.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
+
+        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Syncing,
+            "unprocessed block must trigger sync, not -38006 — CanReorgOn is undefined for unvalidated blocks");
+        result.ErrorCode.Should().Be(0);
+    }
+
+    [Test]
     public async Task forkchoiceUpdatedV1_WhenReorgWithinRetainedState_Reorgs()
     {
         // Spec PR #786 point 6: a reorg to a canonical ancestor whose state is still retained by

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -669,35 +669,13 @@ public partial class EngineModuleTests
         // InvalidParams before ShouldProceedWithReorg runs).
         Block ancestorParent = Build.A.Block.WithNumber(32).TestObject;
 
-        blockTree.FindBlock(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor);
+        SetUpDeepAncestorReorgScenario(blockTree, headBlock, deepAncestor);
         blockTree.FindBlock(deepAncestor.Header.ParentHash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing, blockNumber: 32).Returns(ancestorParent);
-        blockTree.GetInfo(deepAncestor.Number, deepAncestor.Hash!).Returns(
-            (new BlockInfo(deepAncestor.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
-        blockTree.Head.Returns(headBlock);
-        blockTree.HeadHash.Returns(headBlock.Hash!);
-        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
-        blockTree.IsMainChain(Arg.Any<Hash256>()).Returns(true);
-        blockTree.FindHeader(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor.Header);
 
         IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
         worldStateManager.CanReorgOn(deepAncestor.Header).Returns(false);
 
-        ForkchoiceUpdatedHandler handler = new(
-            blockTree,
-            Substitute.For<IManualBlockFinalizationManager>(),
-            Substitute.For<IPoSSwitcher>(),
-            Substitute.For<IPayloadPreparationService>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            Substitute.For<IBlockCacheService>(),
-            Substitute.For<IInvalidChainTracker>(),
-            Substitute.For<IMergeSyncController>(),
-            Substitute.For<IBeaconPivot>(),
-            Substitute.For<IPeerRefresher>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<ISyncPeerPool>(),
-            new MergeConfig(),
-            worldStateManager,
-            Substitute.For<ILogManager>());
+        ForkchoiceUpdatedHandler handler = BuildHandler(blockTree, worldStateManager);
 
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
             new ForkchoiceStateV1(deepAncestor.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
@@ -726,22 +704,7 @@ public partial class EngineModuleTests
         IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
         worldStateManager.CanReorgOn(Arg.Any<BlockHeader>()).Returns(false); // would force -38006 if the gate ran
 
-        ForkchoiceUpdatedHandler handler = new(
-            blockTree,
-            Substitute.For<IManualBlockFinalizationManager>(),
-            Substitute.For<IPoSSwitcher>(),
-            Substitute.For<IPayloadPreparationService>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            Substitute.For<IBlockCacheService>(),
-            Substitute.For<IInvalidChainTracker>(),
-            Substitute.For<IMergeSyncController>(),
-            Substitute.For<IBeaconPivot>(),
-            Substitute.For<IPeerRefresher>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<ISyncPeerPool>(),
-            new MergeConfig(),
-            worldStateManager,
-            Substitute.For<ILogManager>());
+        ForkchoiceUpdatedHandler handler = BuildHandler(blockTree, worldStateManager);
 
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
             new ForkchoiceStateV1(beaconTarget.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
@@ -830,40 +793,27 @@ public partial class EngineModuleTests
         chain.BlockTree.HeadHash.Should().Be(b10Hash, "head must not change when -38002 is returned");
     }
 
-    [Test]
-    public async Task forkchoiceUpdatedV1_WhenZeroFinalizedAndSafeHash_ReturnsValidWithoutError()
+    // Spec: -38002 fires only for non-zero unknown safe/finalized hashes; zero means "unknown" and
+    // must not produce an error. Models CL checkpoint-syncing from a non-finalized state.
+    [TestCase(false, 0, TestName = "Zero safe and finalized — Valid, no error")]
+    [TestCase(true, MergeErrorCodes.InvalidForkchoiceState, TestName = "Non-zero unknown safe with zero finalized — returns -38002")]
+    public async Task forkchoiceUpdatedV1_validates_safe_and_finalized_hashes(bool useUnknownSafe, int expectedErrorCode)
     {
-        // Spec: zero safeBlockHash and finalizedBlockHash mean "unknown" — must not return -38002.
-        // Models CL checkpoint-syncing from a non-finalized state where safe/finalized are unknown.
-        using MergeTestBlockchain chain = await CreateBlockchain();
-        IEngineRpcModule rpc = chain.EngineRpcModule;
-
-        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 3, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
-        Hash256 headHash = branch[2].BlockHash;
-
-        ForkchoiceStateV1 fcuWithUnknownFinality = new(headHash, Keccak.Zero, Keccak.Zero);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithUnknownFinality);
-
-        result.ErrorCode.Should().Be(0, "zero safe/finalized hashes must not produce an error");
-        result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-        chain.BlockTree.HeadHash.Should().Be(headHash);
-    }
-
-    [Test]
-    public async Task forkchoiceUpdatedV1_WhenNonZeroUnknownFinalizedHash_ReturnsInvalidForkchoiceState()
-    {
-        // Spec: -38002 must only fire for non-zero hashes that are unknown, not for zero hashes.
         using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = chain.EngineRpcModule;
 
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
         Hash256 headHash = branch[0].BlockHash;
 
-        ForkchoiceStateV1 fcuWithUnknownFinalized = new(headHash, TestItem.KeccakA, Keccak.Zero);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(fcuWithUnknownFinalized);
+        Hash256 safeHash = useUnknownSafe ? TestItem.KeccakA : Keccak.Zero;
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(headHash, safeHash, Keccak.Zero));
 
-        result.ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState,
-            "non-zero unknown finalizedBlockHash must return -38002");
+        result.ErrorCode.Should().Be(expectedErrorCode);
+        if (expectedErrorCode == 0)
+        {
+            result.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+            chain.BlockTree.HeadHash.Should().Be(headHash);
+        }
     }
 
     [Test]
@@ -2219,4 +2169,34 @@ public partial class EngineModuleTests
             .WithDifficulty(900000)
             .WithTotalDifficulty(1900000L)
             .WithStateRoot(new Hash256(correctStateRoot ? "0x1ef7300d8961797263939a3d29bbba4ccf1702fabf02d8ad7a20b454edb6fd2f" : "0x1ef7300d8961797263939a3d29bfba4ccf1702fabf02d8ad7a20b454edb6fd2f"));
+
+    private static void SetUpDeepAncestorReorgScenario(IBlockTree blockTree, Block headBlock, Block deepAncestor)
+    {
+        blockTree.FindBlock(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor);
+        blockTree.FindHeader(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor.Header);
+        blockTree.GetInfo(deepAncestor.Number, deepAncestor.Hash!).Returns(
+            (new BlockInfo(deepAncestor.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
+        blockTree.Head.Returns(headBlock);
+        blockTree.HeadHash.Returns(headBlock.Hash!);
+        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
+        blockTree.IsMainChain(Arg.Any<Hash256>()).Returns(true);
+    }
+
+    private static ForkchoiceUpdatedHandler BuildHandler(IBlockTree blockTree, IWorldStateManager worldStateManager) =>
+        new(
+            blockTree,
+            Substitute.For<IManualBlockFinalizationManager>(),
+            Substitute.For<IPoSSwitcher>(),
+            Substitute.For<IPayloadPreparationService>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            Substitute.For<IBlockCacheService>(),
+            Substitute.For<IInvalidChainTracker>(),
+            Substitute.For<IMergeSyncController>(),
+            Substitute.For<IBeaconPivot>(),
+            Substitute.For<IPeerRefresher>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<ISyncPeerPool>(),
+            new MergeConfig(),
+            worldStateManager,
+            Substitute.For<ILogManager>());
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -170,9 +170,10 @@ public class ForkchoiceUpdatedHandler(
 
         if (!blockInfo.WasProcessed)
         {
-            if (!ShouldProceedWithReorg(newHeadHeader, forkchoiceState, out ResultWrapper<ForkchoiceUpdatedV1Result>? errorResult))
+            if (_blockTree.IsOnMainChainBehindFinalized(newHeadHeader))
             {
-                return errorResult;
+                if (_logger.IsInfo) _logger.Info($"Valid. ForkChoiceUpdated skipped - head is a valid ancestor of the latest known finalized block.");
+                return ForkchoiceUpdatedV1Result.Valid(null, forkchoiceState.HeadBlockHash);
             }
 
             BlockHeader? blockParent = _blockTree.FindHeader(newHeadHeader.ParentHash!, blockNumber: newHeadHeader.Number - 1);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -22,6 +22,7 @@ using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Merge.Plugin.Handlers;
@@ -48,6 +49,7 @@ public class ForkchoiceUpdatedHandler(
     ISpecProvider specProvider,
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
+    IWorldStateManager worldStateManager,
     ILogManager logManager) : IForkchoiceUpdatedHandler
 {
     protected readonly IBlockTree _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -55,6 +57,7 @@ public class ForkchoiceUpdatedHandler(
     private readonly IPoSSwitcher _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
     private readonly ILogger _logger = logManager.GetClassLogger<ForkchoiceUpdatedHandler>();
     private readonly bool _simulateBlockProduction = mergeConfig.SimulateBlockProduction;
+    private readonly IWorldStateManager _worldStateManager = worldStateManager ?? throw new ArgumentNullException(nameof(worldStateManager));
 
     public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Handle(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {
@@ -64,18 +67,25 @@ public class ForkchoiceUpdatedHandler(
             ?? StartBuildingPayload(newHeadHeader!, forkchoiceState, payloadAttributes);
     }
 
-    protected virtual bool IsOnMainChainBehindFinalized(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,
-        [NotNullWhen(true)] out ResultWrapper<ForkchoiceUpdatedV1Result>? result)
+    protected virtual bool ShouldProceedWithReorg(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,
+        [NotNullWhen(false)] out ResultWrapper<ForkchoiceUpdatedV1Result>? errorResult)
     {
         if (_blockTree.IsOnMainChainBehindFinalized(newHeadHeader))
         {
             if (_logger.IsInfo) _logger.Info($"Valid. ForkChoiceUpdated skipped - head is a valid ancestor of the latest known finalized block.");
-            result = ForkchoiceUpdatedV1Result.Valid(null, forkchoiceState.HeadBlockHash);
-            return true;
+            errorResult = ForkchoiceUpdatedV1Result.Valid(null, forkchoiceState.HeadBlockHash);
+            return false;
         }
 
-        result = null;
-        return false;
+        if (!_worldStateManager.CanReorgOn(newHeadHeader))
+        {
+            if (_logger.IsWarn) _logger.Warn($"Too deep reorg. Backend cannot reorg to {newHeadHeader.ToString(BlockHeader.Format.Short)}. Request: {forkchoiceState}.");
+            errorResult = ResultWrapper<ForkchoiceUpdatedV1Result>.Fail("Too deep reorg", MergeErrorCodes.TooDeepReorg);
+            return false;
+        }
+
+        errorResult = null;
+        return true;
     }
 
     // Rejects a finalized/safe entry that fails the request-local numeric bounds
@@ -160,7 +170,7 @@ public class ForkchoiceUpdatedHandler(
 
         if (!blockInfo.WasProcessed)
         {
-            if (IsOnMainChainBehindFinalized(newHeadHeader, forkchoiceState, out ResultWrapper<ForkchoiceUpdatedV1Result>? errorResult))
+            if (!ShouldProceedWithReorg(newHeadHeader, forkchoiceState, out ResultWrapper<ForkchoiceUpdatedV1Result>? errorResult))
             {
                 return errorResult;
             }
@@ -239,7 +249,11 @@ public class ForkchoiceUpdatedHandler(
             return ForkchoiceUpdatedV1Result.Error(setHeadErrorMsg, ErrorCodes.InvalidParams);
         }
 
-        if (IsOnMainChainBehindFinalized(newHeadHeader, forkchoiceState, out ResultWrapper<ForkchoiceUpdatedV1Result>? result))
+        long finalizedNumber = finalizedHeader?.Number ?? 0;
+        if (RejectIfInconsistent(finalizedHeader, 0, "finalized", newHeadHeader, requestStr) is { } finalizedError) return finalizedError;
+        if (RejectIfInconsistent(safeBlockHeader, finalizedNumber, "safe", newHeadHeader, requestStr) is { } safeError) return safeError;
+
+        if (blocks is not null && !ShouldProceedWithReorg(newHeadHeader, forkchoiceState, out ResultWrapper<ForkchoiceUpdatedV1Result>? result))
         {
             return result;
         }
@@ -250,14 +264,6 @@ public class ForkchoiceUpdatedHandler(
         {
             _blockTree.UpdateMainChain(blocks!, true, true);
         }
-
-        // Spec ordering within a single FCU: finalized <= safe <= head. Ancestry must be
-        // re-validated on every FCU - the binding is (head, finalized, safe), so a repeated
-        // finalized/safe hash paired with a new head on a sibling branch is still a spec violation.
-        long finalizedNumber = finalizedHeader?.Number ?? 0;
-
-        if (RejectIfInconsistent(finalizedHeader, 0, "finalized", newHeadHeader, requestStr) is { } finalizedError) return finalizedError;
-        if (RejectIfInconsistent(safeBlockHeader, finalizedNumber, "safe", newHeadHeader, requestStr) is { } safeError) return safeError;
 
         bool nonZeroFinalizedBlockHash = finalizedBlockHash != Keccak.Zero;
         if (nonZeroFinalizedBlockHash)

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeErrorCodes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeErrorCodes.cs
@@ -34,4 +34,9 @@ public static class MergeErrorCodes
     /// Payload attributes are invalid or inconsistent.
     /// </summary>
     public const int UnsupportedFork = -38005;
+
+    /// <summary>
+    /// Reorg depth exceeds the limitation.
+    /// </summary>
+    public const int TooDeepReorg = -38006;
 }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateManager.cs
@@ -72,4 +72,6 @@ public class FlatWorldStateManager(
         _trieVerifier.Verify(stateAtBlock, cancellationToken);
 
     public void FlushCache(CancellationToken cancellationToken) => flatDbManager.FlushCache(cancellationToken);
+
+    public bool CanReorgOn(BlockHeader header) => GlobalStateReader.HasStateForBlock(header);
 }

--- a/src/Nethermind/Nethermind.State/IWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateManager.cs
@@ -47,6 +47,18 @@ public interface IWorldStateManager
     /// Persist and clear cache. Used by some tests.
     /// </summary>
     void FlushCache(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns true when the backend can make <paramref name="header"/> the new head — i.e. it is
+    /// safe to reorg the chain so that subsequent blocks are built on top of this state.
+    /// </summary>
+    /// <remarks>
+    /// This is distinct from <see cref="IStateReader.HasStateForBlock"/>: an archive node has the
+    /// state for every historical block (so <c>HasStateForBlock</c> returns true everywhere), but
+    /// the live trie store may not be willing to rewind to an arbitrary ancient block. This method
+    /// lets each backend apply its own reorg-window policy on top of state availability.
+    /// </remarks>
+    bool CanReorgOn(BlockHeader header);
 }
 
 public interface IOverridableWorldScope : IDisposable

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -70,4 +70,6 @@ public class WorldStateManager : IWorldStateManager
     public bool VerifyTrie(BlockHeader stateAtBlock, CancellationToken cancellationToken) => _blockingVerifyTrie?.VerifyTrie(stateAtBlock, cancellationToken) ?? true;
 
     public void FlushCache(CancellationToken cancellationToken) => _trieStore.PersistCache(cancellationToken);
+
+    public bool CanReorgOn(BlockHeader header) => GlobalStateReader.HasStateForBlock(header);
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
@@ -37,41 +37,19 @@ public class TaikoEngineApiTests
         Block genesisBlock = Build.A.Block.WithNumber(0).TestObject;
         Block futureBlock = Build.A.Block.WithNumber(1).TestObject;
 
-        AddBlock(blockTree, genesisBlock);
+        RegisterBlock(blockTree, genesisBlock);
+        SetHead(blockTree, genesisBlock);
 
-        TaikoForkchoiceUpdatedHandler forkchoiceUpdatedHandler = new(
-            blockTree,
-            Substitute.For<IManualBlockFinalizationManager>(),
-            Substitute.For<IPoSSwitcher>(),
-            Substitute.For<IPayloadPreparationService>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            Substitute.For<IBlockCacheService>(),
-            Substitute.For<IInvalidChainTracker>(),
-            Substitute.For<IMergeSyncController>(),
-            Substitute.For<IBeaconPivot>(),
-            Substitute.For<IPeerRefresher>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<ISyncPeerPool>(),
-            new MergeConfig(),
-            Substitute.For<IWorldStateManager>(),
-            Substitute.For<ILogManager>()
-        );
+        TaikoForkchoiceUpdatedHandler forkchoiceUpdatedHandler = BuildHandler(blockTree);
 
         ResultWrapper<ForkchoiceUpdatedV1Result> beforeNewBlockAdded = await forkchoiceUpdatedHandler.Handle(new ForkchoiceStateV1(genesisBlock.Hash!, futureBlock.Hash!, futureBlock.Hash!), null, 2);
         Assert.That(beforeNewBlockAdded.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
 
-        AddBlock(blockTree, futureBlock);
+        RegisterBlock(blockTree, futureBlock);
+        SetHead(blockTree, futureBlock);
 
         ResultWrapper<ForkchoiceUpdatedV1Result> afterNewBlockAdded = await forkchoiceUpdatedHandler.Handle(new ForkchoiceStateV1(futureBlock.Hash!, futureBlock.Hash!, futureBlock.Hash!), null, 2);
         Assert.That(afterNewBlockAdded.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
-
-        static void AddBlock(IBlockTree blockTree, Block block)
-        {
-            blockTree.FindHeader(block.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(block.Header);
-            blockTree.GetInfo(block.Number, block.Hash!).Returns((new BlockInfo(block.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
-            blockTree.Head.Returns(block);
-            blockTree.HeadHash.Returns(block.Hash!);
-        }
     }
 
     [TestCase(100ul, 100ul, true, TestName = "Equal timestamps allowed for Pacaya")]
@@ -83,29 +61,11 @@ public class TaikoEngineApiTests
 
         Block headBlock = Build.A.Block.WithNumber(1).WithTimestamp(headTimestamp).TestObject;
 
-        blockTree.FindHeader(headBlock.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(headBlock.Header);
-        blockTree.GetInfo(headBlock.Number, headBlock.Hash!).Returns((new BlockInfo(headBlock.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
-        blockTree.Head.Returns(headBlock);
-        blockTree.HeadHash.Returns(headBlock.Hash!);
+        RegisterBlock(blockTree, headBlock);
+        SetHead(blockTree, headBlock);
         blockTree.IsMainChain(headBlock.Header).Returns(true);
 
-        TaikoForkchoiceUpdatedHandler handler = new(
-            blockTree,
-            Substitute.For<IManualBlockFinalizationManager>(),
-            Substitute.For<IPoSSwitcher>(),
-            Substitute.For<IPayloadPreparationService>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            Substitute.For<IBlockCacheService>(),
-            Substitute.For<IInvalidChainTracker>(),
-            Substitute.For<IMergeSyncController>(),
-            Substitute.For<IBeaconPivot>(),
-            Substitute.For<IPeerRefresher>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<ISyncPeerPool>(),
-            new MergeConfig(),
-            Substitute.For<IWorldStateManager>(),
-            Substitute.For<ILogManager>()
-        );
+        TaikoForkchoiceUpdatedHandler handler = BuildHandler(blockTree);
 
         PayloadAttributes payloadAttributes = new()
         {
@@ -134,24 +94,43 @@ public class TaikoEngineApiTests
         // override, an FCU to a block whose state has been evicted (HasStateForBlock == false)
         // would return -38006 Too deep reorg. With the override, it must proceed regardless.
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-
         Block headBlock = Build.A.Block.WithNumber(100).TestObject;
         Block deepAncestor = Build.A.Block.WithNumber(33).TestObject;
 
-        blockTree.FindBlock(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor);
-        blockTree.GetInfo(deepAncestor.Number, deepAncestor.Hash!).Returns(
-            (new BlockInfo(deepAncestor.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
-        blockTree.Head.Returns(headBlock);
-        blockTree.HeadHash.Returns(headBlock.Hash!);
+        RegisterBlock(blockTree, deepAncestor);
+        SetHead(blockTree, headBlock);
         blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
         blockTree.IsMainChain(Arg.Any<Hash256>()).Returns(true);
-        blockTree.FindHeader(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor.Header);
 
         // Simulate state being unavailable for the reorg target — base handler would return -38006.
         IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
         worldStateManager.CanReorgOn(deepAncestor.Header).Returns(false);
 
-        TaikoForkchoiceUpdatedHandler handler = new(
+        TaikoForkchoiceUpdatedHandler handler = BuildHandler(blockTree, worldStateManager);
+
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
+            new ForkchoiceStateV1(deepAncestor.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
+
+        Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
+        blockTree.Received().UpdateMainChain(Arg.Any<IReadOnlyList<Block>>(), true, true);
+    }
+
+    private static void RegisterBlock(IBlockTree blockTree, Block block, bool processed = true)
+    {
+        blockTree.FindHeader(block.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(block.Header);
+        blockTree.FindBlock(block.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(block);
+        blockTree.GetInfo(block.Number, block.Hash!).Returns(
+            (new BlockInfo(block.Hash!, 0) { WasProcessed = processed }, new ChainLevelInfo(true)));
+    }
+
+    private static void SetHead(IBlockTree blockTree, Block block)
+    {
+        blockTree.Head.Returns(block);
+        blockTree.HeadHash.Returns(block.Hash!);
+    }
+
+    private static TaikoForkchoiceUpdatedHandler BuildHandler(IBlockTree blockTree, IWorldStateManager? worldStateManager = null) =>
+        new(
             blockTree,
             Substitute.For<IManualBlockFinalizationManager>(),
             Substitute.For<IPoSSwitcher>(),
@@ -165,14 +144,6 @@ public class TaikoEngineApiTests
             Substitute.For<ISpecProvider>(),
             Substitute.For<ISyncPeerPool>(),
             new MergeConfig(),
-            worldStateManager,
-            Substitute.For<ILogManager>()
-        );
-
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
-            new ForkchoiceStateV1(deepAncestor.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
-
-        Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
-        blockTree.Received().UpdateMainChain(Arg.Any<IReadOnlyList<Block>>(), true, true);
-    }
+            worldStateManager ?? Substitute.For<IWorldStateManager>(),
+            Substitute.For<ILogManager>());
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Synchronization.Peers;
 using NSubstitute;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.State;
 using Nethermind.JsonRpc;
 using Nethermind.Merge.Plugin;
 using Nethermind.Taiko.Rpc;
@@ -51,6 +52,7 @@ public class TaikoEngineApiTests
             Substitute.For<ISpecProvider>(),
             Substitute.For<ISyncPeerPool>(),
             new MergeConfig(),
+            Substitute.For<IWorldStateManager>(),
             Substitute.For<ILogManager>()
         );
 
@@ -100,6 +102,7 @@ public class TaikoEngineApiTests
             Substitute.For<ISpecProvider>(),
             Substitute.For<ISyncPeerPool>(),
             new MergeConfig(),
+            Substitute.For<IWorldStateManager>(),
             Substitute.For<ILogManager>()
         );
 
@@ -121,5 +124,54 @@ public class TaikoEngineApiTests
         {
             Assert.That(result.Result.Error, Does.Contain("Invalid payload timestamp"));
         }
+    }
+
+    [Test]
+    public async Task ShouldProceedWithReorg_Override_BypassesTooDeepReorgError()
+    {
+        // Taiko overrides ShouldProceedWithReorg to always proceed (return true). Without the
+        // override, an FCU to a block whose state has been evicted (HasStateForBlock == false)
+        // would return -38006 Too deep reorg. With the override, it must proceed regardless.
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+
+        Block headBlock = Build.A.Block.WithNumber(100).TestObject;
+        Block deepAncestor = Build.A.Block.WithNumber(33).TestObject;
+
+        blockTree.FindBlock(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor);
+        blockTree.GetInfo(deepAncestor.Number, deepAncestor.Hash!).Returns(
+            (new BlockInfo(deepAncestor.Hash!, 0) { WasProcessed = true }, new ChainLevelInfo(true)));
+        blockTree.Head.Returns(headBlock);
+        blockTree.HeadHash.Returns(headBlock.Hash!);
+        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
+        blockTree.IsMainChain(Arg.Any<Hash256>()).Returns(true);
+        blockTree.FindHeader(deepAncestor.Hash!, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(deepAncestor.Header);
+
+        // Simulate state being unavailable for the reorg target — base handler would return -38006.
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager.CanReorgOn(deepAncestor.Header).Returns(false);
+
+        TaikoForkchoiceUpdatedHandler handler = new(
+            blockTree,
+            Substitute.For<IManualBlockFinalizationManager>(),
+            Substitute.For<IPoSSwitcher>(),
+            Substitute.For<IPayloadPreparationService>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            Substitute.For<IBlockCacheService>(),
+            Substitute.For<IInvalidChainTracker>(),
+            Substitute.For<IMergeSyncController>(),
+            Substitute.For<IBeaconPivot>(),
+            Substitute.For<IPeerRefresher>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<ISyncPeerPool>(),
+            new MergeConfig(),
+            worldStateManager,
+            Substitute.For<ILogManager>()
+        );
+
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await handler.Handle(
+            new ForkchoiceStateV1(deepAncestor.Hash!, Keccak.Zero, Keccak.Zero), null, 1);
+
+        Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
+        blockTree.Received().UpdateMainChain(Arg.Any<IReadOnlyList<Block>>(), true, true);
     }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using Nethermind.Core;
 using Nethermind.Consensus.Producers;

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
@@ -18,6 +18,7 @@ using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Taiko.Rpc;
@@ -36,6 +37,7 @@ internal class TaikoForkchoiceUpdatedHandler(
     ISpecProvider specProvider,
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
+    IWorldStateManager worldStateManager,
     ILogManager logManager) : ForkchoiceUpdatedHandler(
     blockTree,
     manualBlockFinalizationManager,
@@ -50,13 +52,14 @@ internal class TaikoForkchoiceUpdatedHandler(
     specProvider,
     syncPeerPool,
     mergeConfig,
+    worldStateManager,
     logManager)
 {
-    protected override bool IsOnMainChainBehindFinalized(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,
-        [NotNullWhen(true)] out ResultWrapper<ForkchoiceUpdatedV1Result>? result)
+    protected override bool ShouldProceedWithReorg(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,
+        [NotNullWhen(false)] out ResultWrapper<ForkchoiceUpdatedV1Result>? errorResult)
     {
-        result = null;
-        return false;
+        errorResult = null;
+        return true;
     }
 
     // Taiko finality follows L1 and may regress on L1 reorgs, so Ethereum's spec-ordering bounds


### PR DESCRIPTION
Implements **-38006 Too deep reorg** execution-apis: https://github.com/ethereum/execution-apis/pull/786, point 6 on top of **#11388** (point 2).

## Changes

- **`ForkchoiceUpdatedHandler.ShouldProceedWithReorg`**  
  Returns `-38006` when `IWorldStateManager.CanReorgOn(header)` is `false`.  
  All `pruning-trie`, `flat-DB`, `archive` apply their own policy via `HasStateForBlock`.

- **`ReorgDepthFinalizedStateProvider.FinalizedBlockNumber`**  
  Returns `_blockTree.FinalizedHash`'s block number instead of `BestKnownNumber - 64`.  
  Trie dirty-cache eviction now retains the `[finalized, head]` range.

- **`LogIndexStorage.GetCompressionBoundary`**  
  Compression cutoff is now `finalized`, keeping log data above finalized reorg-safe.

- **`MergeErrorCodes.TooDeepReorg`**  
  Added `= -38006`.

- **`TaikoForkchoiceUpdatedHandler`**  
  Overrides `ShouldProceedWithReorg` to always proceed  
  (Taiko finality follows L1).

All three gates now read the same boundary:

`_blockTree.FinalizedHash`

### Bug fix (atomicity)

Reorder `RejectIfInconsistent` to run before `UpdateMainChain` , so an inconsistent FCU returns -38002 without partially mutating the head. Aligns with `paris.md` step 7 ("all updates to the forkchoice state resulting from this call MUST be made atomically"). 

The previous ordering let the head move before the inconsistency check returned the error - unreachable in practice (well-behaved CLs never send inconsistent tuples), but spec-noncompliant.

**Test pinned:**
`forkchoiceUpdatedV1_WhenInconsistent_ReturnsInvalidForkchoiceStateBeforeProceedingToReorgCheck`

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No