### PR TITLE
fix(parallel): capture and rethrow worker exceptions in ParallelUnbalancedWork

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core.Threading;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Threading;
+
+public class ParallelUnbalancedWorkTests
+{
+    private static readonly ParallelOptions FourThreads = new() { MaxDegreeOfParallelism = 4 };
+
+    [Test]
+    public void For_HappyPath_RunsAllIterations()
+    {
+        int sum = 0;
+        ParallelUnbalancedWork.For(0, 1000, i => Interlocked.Add(ref sum, i));
+
+        sum.Should().Be(Enumerable.Range(0, 1000).Sum());
+    }
+
+    [Test]
+    public void For_WhenWorkerThrows_RethrowsOnCallingThread()
+    {
+        InvalidOperationException expected = new("boom");
+
+        Action act = () => ParallelUnbalancedWork.For(0, 1000, FourThreads, i =>
+        {
+            if (i == 500) throw expected;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Should().BeSameAs(expected);
+    }
+
+    [Test]
+    public void For_WhenWorkerThrows_PreservesOriginalStackTrace()
+    {
+        Action act = () => ParallelUnbalancedWork.For(0, 1000, FourThreads, i =>
+        {
+            if (i == 100) ThrowFromHelper();
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.StackTrace.Should().Contain(nameof(ThrowFromHelper));
+    }
+
+    [Test]
+    public void For_WhenManyWorkersThrow_RethrowsExactlyOneException()
+    {
+        // Every iteration throws — only the first captured exception should surface.
+        Action act = () => ParallelUnbalancedWork.For(0, 10_000, FourThreads,
+            i => throw new InvalidOperationException($"boom-{i}"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void For_WhenWorkerThrows_WaitsForAllThreadsBeforeRethrow()
+    {
+        // If the throwing worker raced ahead of the others, MarkThreadCompleted would not yet have been
+        // called for them and the calling thread would either rethrow with workers still in flight or
+        // hang on the semaphore. Use init/finally to count actual thread arrivals — with the new
+        // capture/rethrow path, every thread that ran init must run finally before For returns.
+        int initCount = 0;
+        int finallyCount = 0;
+
+        Action act = () => ParallelUnbalancedWork.For<int>(
+            0, 5_000, FourThreads,
+            init: () => { Interlocked.Increment(ref initCount); return 0; },
+            action: (i, _) =>
+            {
+                if (i == 17) throw new InvalidOperationException();
+                return 0;
+            },
+            @finally: _ => Interlocked.Increment(ref finallyCount));
+
+        act.Should().Throw<InvalidOperationException>();
+        finallyCount.Should().Be(initCount);
+        initCount.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public void For_WithThreadLocal_WhenInitThrows_RethrowsOnCallingThread()
+    {
+        Action act = () => ParallelUnbalancedWork.For<int>(
+            0, 100, FourThreads,
+            init: () => throw new InvalidOperationException("init failed"),
+            action: (_, l) => l,
+            @finally: _ => { });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("init failed");
+    }
+
+    [Test]
+    public void For_WithThreadLocal_WhenFinallyThrows_RethrowsOnCallingThread()
+    {
+        Action act = () => ParallelUnbalancedWork.For<int>(
+            0, 100, FourThreads,
+            init: () => 0,
+            action: (_, l) => l,
+            @finally: _ => throw new InvalidOperationException("finally failed"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("finally failed");
+    }
+
+    [Test]
+    public void For_WithThreadLocal_HappyPath_RunsAllIterations()
+    {
+        int total = 0;
+
+        ParallelUnbalancedWork.For<int>(
+            0, 1000, FourThreads,
+            init: () => 0,
+            action: (i, local) => local + i,
+            @finally: local => Interlocked.Add(ref total, local));
+
+        total.Should().Be(Enumerable.Range(0, 1000).Sum());
+    }
+
+    [Test]
+    public void For_DoesNotLeakWorkerExceptionToThreadPool()
+    {
+        // If a worker exception escaped onto a thread-pool thread it would surface via
+        // AppDomain.UnhandledException (and crash the process under default settings). Subscribe and
+        // assert nothing fires while the calling thread observes the rethrow.
+        int unhandled = 0;
+        UnhandledExceptionEventHandler handler = (_, _) => Interlocked.Increment(ref unhandled);
+        AppDomain.CurrentDomain.UnhandledException += handler;
+        try
+        {
+            Action act = () => ParallelUnbalancedWork.For(0, 1000, FourThreads, i =>
+            {
+                if (i % 11 == 0) throw new InvalidOperationException();
+            });
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.UnhandledException -= handler;
+        }
+
+        unhandled.Should().Be(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowFromHelper() => throw new InvalidOperationException("from helper");
+}

--- a/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
@@ -100,6 +100,42 @@ public class ParallelUnbalancedWorkTests
     }
 
     [Test]
+    public void For_WithThreadLocal_WhenInitThrows_FinallyIsNotCalled()
+    {
+        // Matches BCL Parallel.For<TLocal>: localFinally must not run if localInit threw — otherwise
+        // a reference-typed TLocal with non-trivial cleanup would NPE on default(TLocal).
+        int finallyCalls = 0;
+
+        Action act = () => ParallelUnbalancedWork.For<object>(
+            0, 100, FourThreads,
+            init: () => throw new InvalidOperationException("init failed"),
+            action: (_, l) => l,
+            @finally: _ => Interlocked.Increment(ref finallyCalls));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("init failed");
+        finallyCalls.Should().Be(0);
+    }
+
+    [Test]
+    public void For_WhenWorkerFaults_OtherWorkersStopFetchingWork()
+    {
+        // Once one worker captures an exception, others must stop pulling new indices — otherwise
+        // we burn CPU and run side effects after the operation is already faulted.
+        int actionCalls = 0;
+        const int range = 100_000;
+
+        Action act = () => ParallelUnbalancedWork.For(0, range, FourThreads, i =>
+        {
+            Interlocked.Increment(ref actionCalls);
+            if (i == 0) throw new InvalidOperationException();
+        });
+
+        act.Should().Throw<InvalidOperationException>();
+        // Some racing iterations are unavoidable, but we should be nowhere near the full range.
+        actionCalls.Should().BeLessThan(range / 2);
+    }
+
+    [Test]
     public void For_WithThreadLocal_WhenFinallyThrows_RethrowsOnCallingThread()
     {
         Action act = () => ParallelUnbalancedWork.For<int>(

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,6 +51,9 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         {
             data.Event.Wait();
         }
+
+        // Rethrow the first captured worker exception, if any, on the calling thread
+        data.ThrowIfFaulted();
 
         parallelOptions.CancellationToken.ThrowIfCancellationRequested();
     }
@@ -133,13 +137,21 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     {
         try
         {
-            int i = _data.Index.GetNext();
-            while (i < _data.ToExclusive)
+            try
             {
-                if (_data.CancellationToken.IsCancellationRequested) return;
-                _data.Action(i);
-                // Get the next index
-                i = _data.Index.GetNext();
+                int i = _data.Index.GetNext();
+                while (i < _data.ToExclusive)
+                {
+                    if (_data.CancellationToken.IsCancellationRequested) return;
+                    _data.Action(i);
+                    i = _data.Index.GetNext();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Capture so the exception is rethrown on the calling thread instead of escaping
+                // a thread-pool worker (which would otherwise be unobserved/fatal).
+                _data.CaptureException(ex);
             }
         }
         finally
@@ -181,6 +193,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         public SharedCounter Index { get; } = new SharedCounter(fromInclusive);
         public SemaphoreSlim Event { get; } = new(initialCount: 0);
         private int _activeThreads = threads;
+        private ExceptionDispatchInfo? _exception;
         public CancellationToken CancellationToken { get; } = token;
 
         /// <summary>
@@ -192,6 +205,24 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// Gets the number of active threads.
         /// </summary>
         public int ActiveThreads => Volatile.Read(ref _activeThreads);
+
+        /// <summary>
+        /// Captures the first exception observed by any worker so it can be rethrown on the
+        /// calling thread. Subsequent exceptions are dropped.
+        /// </summary>
+        public void CaptureException(Exception exception)
+        {
+            // Skip the (non-trivial) ExceptionDispatchInfo.Capture call once we already have one.
+            if (Volatile.Read(ref _exception) is not null) return;
+
+            // Only the first exception wins; any later ones are discarded.
+            Interlocked.CompareExchange(ref _exception, ExceptionDispatchInfo.Capture(exception), null);
+        }
+
+        /// <summary>
+        /// Rethrows the first captured exception (preserving its original stack trace), if any.
+        /// </summary>
+        public void ThrowIfFaulted() => _exception?.Throw();
 
         /// <summary>
         /// Marks a thread as completed.
@@ -272,6 +303,9 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
                 data.Event.Wait();
             }
 
+            // Rethrow the first captured worker exception, if any, on the calling thread
+            data.ThrowIfFaulted();
+
             parallelOptions.CancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -286,9 +320,10 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// </summary>
         public void Execute()
         {
-            TLocal? value = _data.Init();
+            TLocal? value = default;
             try
             {
+                value = _data.Init();
                 int i = _data.Index.GetNext();
                 while (i < _data.ToExclusive)
                 {
@@ -297,9 +332,24 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
                     i = _data.Index.GetNext();
                 }
             }
+            catch (Exception ex)
+            {
+                // Capture so the exception is rethrown on the calling thread instead of escaping
+                // a thread-pool worker (which would otherwise be unobserved/fatal).
+                _data.CaptureException(ex);
+            }
             finally
             {
-                _data.Finally(value);
+                // A throwing Finally must not skip MarkThreadCompleted, or the calling thread hangs
+                // on the semaphore. Capture and continue.
+                try
+                {
+                    _data.Finally(value!);
+                }
+                catch (Exception ex)
+                {
+                    _data.CaptureException(ex);
+                }
                 _data.MarkThreadCompleted();
             }
         }

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -142,7 +142,8 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
                 int i = _data.Index.GetNext();
                 while (i < _data.ToExclusive)
                 {
-                    if (_data.CancellationToken.IsCancellationRequested) return;
+                    // Stop pulling work once cancelled or another worker has faulted.
+                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
                     _data.Action(i);
                     i = _data.Index.GetNext();
                 }
@@ -207,13 +208,19 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         public int ActiveThreads => Volatile.Read(ref _activeThreads);
 
         /// <summary>
+        /// Whether any worker has captured an exception. Used by workers to short-circuit
+        /// fetching new indices once the operation is already faulted.
+        /// </summary>
+        public bool IsFaulted => Volatile.Read(ref _exception) is not null;
+
+        /// <summary>
         /// Captures the first exception observed by any worker so it can be rethrown on the
         /// calling thread. Subsequent exceptions are dropped.
         /// </summary>
         public void CaptureException(Exception exception)
         {
             // Skip the (non-trivial) ExceptionDispatchInfo.Capture call once we already have one.
-            if (Volatile.Read(ref _exception) is not null) return;
+            if (IsFaulted) return;
 
             // Only the first exception wins; any later ones are discarded.
             Interlocked.CompareExchange(ref _exception, ExceptionDispatchInfo.Capture(exception), null);
@@ -222,7 +229,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         /// <summary>
         /// Rethrows the first captured exception (preserving its original stack trace), if any.
         /// </summary>
-        public void ThrowIfFaulted() => _exception?.Throw();
+        public void ThrowIfFaulted() => Volatile.Read(ref _exception)?.Throw();
 
         /// <summary>
         /// Marks a thread as completed.
@@ -321,13 +328,18 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         public void Execute()
         {
             TLocal? value = default;
+            // Track Init success so a throwing Init does not leak into Finally with default(TLocal)
+            // — matches BCL Parallel.For<TLocal>, which only invokes localFinally when localInit ran.
+            bool initSucceeded = false;
             try
             {
                 value = _data.Init();
+                initSucceeded = true;
                 int i = _data.Index.GetNext();
                 while (i < _data.ToExclusive)
                 {
-                    if (_data.CancellationToken.IsCancellationRequested) return;
+                    // Stop pulling work once cancelled or another worker has faulted.
+                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
                     value = _data.Action(i, value);
                     i = _data.Index.GetNext();
                 }
@@ -340,15 +352,18 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             }
             finally
             {
-                // A throwing Finally must not skip MarkThreadCompleted, or the calling thread hangs
-                // on the semaphore. Capture and continue.
-                try
+                if (initSucceeded)
                 {
-                    _data.Finally(value!);
-                }
-                catch (Exception ex)
-                {
-                    _data.CaptureException(ex);
+                    // A throwing Finally must not skip MarkThreadCompleted, or the calling thread
+                    // hangs on the semaphore. Capture and continue.
+                    try
+                    {
+                        _data.Finally(value!);
+                    }
+                    catch (Exception ex)
+                    {
+                        _data.CaptureException(ex);
+                    }
                 }
                 _data.MarkThreadCompleted();
             }


### PR DESCRIPTION
## Changes

- Worker exceptions were escaping onto thread-pool threads (unobserved/fatal under default settings) and could leave the calling thread waiting on the semaphore.

- Capture the first exception via ExceptionDispatchInfo, let remaining workersdrain, then rethrow on the caller with the original stack trace preserved.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes