### PR TITLE
test: stabilize CI flakes (timeout bumps + log noise)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Timeout.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Timeout.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Blockchain.Test;
 
 internal class Timeout
 {
-    public const int LongTestTime = 60_000;
+    public const int LongTestTime = 120_000;
     public const int MaxTestTime = 15_000;
     public const int MaxWaitTime = 1_000;
 }

--- a/src/Nethermind/Nethermind.Core/ProgressLogger.cs
+++ b/src/Nethermind/Nethermind.Core/ProgressLogger.cs
@@ -8,7 +8,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.Core
 {
-    public class ProgressLogger(string prefix, ILogManager logManager, ITimestamper? timestamper = null)
+    public class ProgressLogger
     {
         public const int QueuePaddingLength = 8;
         public const int SkippedPaddingLength = 7;
@@ -16,11 +16,30 @@ namespace Nethermind.Core
         public const int BlockPaddingLength = 10;
         public const int PrefixAlignment = -13;
 
-        private readonly ITimestamper _timestamper = timestamper ?? Timestamper.Default;
-        private readonly ILogger _logger = logManager.GetClassLogger<ProgressLogger>();
-        private string _prefix = prefix;
+        private readonly ITimestamper _timestamper;
+        private readonly ILogger _logger;
+        private readonly Action<string>? _logAction;
+        private string _prefix;
         private (long, long, long, long) _lastReportState = (0, 0, 0, 0);
         private Func<ProgressLogger, string>? _formatter;
+
+        public ProgressLogger(string prefix, ILogManager logManager, ITimestamper? timestamper = null, LogLevel logLevel = LogLevel.Info)
+        {
+            _prefix = prefix;
+            _timestamper = timestamper ?? Timestamper.Default;
+            _logger = logManager.GetClassLogger<ProgressLogger>();
+            ILogger logger = _logger;
+            InterfaceLogger underlying = logger.UnderlyingLogger;
+            _logAction = logLevel switch
+            {
+                LogLevel.Info when logger.IsInfo => underlying.Info,
+                LogLevel.Debug when logger.IsDebug => underlying.Debug,
+                LogLevel.Warn when logger.IsWarn => underlying.Warn,
+                LogLevel.Error when logger.IsError => s => underlying.Error(s),
+                LogLevel.Trace when logger.IsTrace => underlying.Trace,
+                _ => null,
+            };
+        }
 
         public void Update(long value)
         {
@@ -152,9 +171,8 @@ namespace Nethermind.Core
             (long, long, long, long) reportState = (CurrentValue, TargetValue, CurrentQueued, _skipped);
             if (reportState != _lastReportState)
             {
-                string reportString = _formatter is not null ? _formatter(this) : DefaultFormatter();
                 _lastReportState = reportState;
-                _logger.Info(reportString);
+                _logAction?.Invoke(_formatter is not null ? _formatter(this) : DefaultFormatter());
             }
             SetMeasuringPoint(resetCompletion: false);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -32,7 +32,7 @@ public static class RpcTest
 
     public static async Task<string> TestSerializedRequest<T>(T module, string method, params object?[]? parameters) where T : class, IRpcModule
     {
-        using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(Debugger.IsAttached ? TimeSpan.FromMilliseconds(-1) : 30.Seconds());
+        using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(Debugger.IsAttached ? TimeSpan.FromMilliseconds(-1) : 60.Seconds());
         await using IContainer container = CreateContainerForModule<T>(module);
 
         IJsonRpcService service = container.Resolve<IJsonRpcService>();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -197,11 +197,11 @@ public abstract partial class BaseEngineModuleTests
             MergeConfig.TerminalTotalDifficulty ??= "0";
             // Production default (7s) is too tight under Flat DB CI load — validation
             // races the timeout and the handler returns SYNCING, breaking tests that
-            // assert VALID/INVALID. Only bump when still at the production default;
-            // callers that exercise timeout→SYNCING behavior pass an explicit value.
+            // assert VALID/INVALID. Tests that exercise timeout→SYNCING behavior pass
+            // an explicit shorter value.
             if (MergeConfig.NewPayloadBlockProcessingTimeout == DefaultNewPayloadBlockProcessingTimeout)
             {
-                MergeConfig.NewPayloadBlockProcessingTimeout = 30_000;
+                MergeConfig.NewPayloadBlockProcessingTimeout = 60_000;
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/VisitorProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitorProgressTracker.cs
@@ -39,7 +39,7 @@ public class VisitorProgressTracker
 
         _operationName = operationName;
         _printNodes = printNodes;
-        _logger = new ProgressLogger(operationName, logManager);
+        _logger = new ProgressLogger(operationName, logManager, logLevel: LogLevel.Debug);
         _logger.Reset(0, 10000); // Use 10000 for 0.01% precision
         _logger.SetFormat(FormatProgress);
         _reportingInterval = reportingInterval;


### PR DESCRIPTION
## Summary
Four small fixes to address recurring CI flakes and log-noise in the test suite.

### 1. `RpcTest.TestSerializedRequest`: 30s → 60s
Covers `IJsonRpcService.SendRequestAsync` (its own 20s internal cap) plus `EthereumJsonSerializer.SerializeAsync` calls. On slow CI runners, large `NewPayloadV5_*` BAL responses can blow this budget, surfacing as:
```
System.Threading.Tasks.TaskCanceledException : A task was canceled.
   at Nethermind.Serialization.Json.CountingStreamPipeWriter.FlushAsyncInternal
   at Nethermind.Serialization.Json.EthereumJsonSerializer.SerializeAsync
   at Nethermind.JsonRpc.Test.RpcTest.TestSerializedRequest
```

### 2. Engine test `NewPayloadBlockProcessingTimeout`: 30s → 60s
`BaseEngineModuleTests` already bumps this from the 7s production default to 30s for tests, but 30s has been seen to race on heavily contended runners — e.g. `can_progress_chain_one_by_one_v4_with_requests(30)` fails at ~36s with `NewPayloadHandler` returning `SYNCING` because block validation hasn't finished by the time the next iteration's `engine_newPayloadV4` checks.

Bump to 60s. Tests that *intentionally* exercise the timeout→SYNCING path (e.g. `NewPayloadHandlerRaceConditionTests`) already pass explicit shorter values, so they're unaffected.

### 3. Trie Verification progress: Info → Debug
`worldStateManager.VerifyTrie` (used by E2E sync tests) was emitting ~26k progress lines per run because `VisitorProgressTracker` logs on every level-3 node and shallow leaf. Demote the progress lines to Debug; production users investigating verification can opt in via Debug logging. Other `ProgressLogger` callers (BloomMigration, ReceiptMigration) continue at Info as before.

`ProgressLogger` was also restructured to resolve the level→method binding once at construction (cached `Action<string>?` bound to the underlying `InterfaceLogger`), so `LogProgress` becomes `_logAction?.Invoke(...)` — no per-call switch and no redundant `IsXxx` re-check.

### 4. `Timeout.LongTestTime`: 60s → 120s
`prune_on_disk_multiple_times` has `[MaxTime(LongTestTime)]` and runs 3 sequential pruning iterations. On Windows CI it takes ~75s, blowing the 60s cap and crashing the test process with exit code 2.

## Motivation
Recent master CI shows `Run Nethermind.Merge.Plugin.Test`, `Run Nethermind.Blockchain.Test (windows-latest)` and `Run Nethermind.JsonRpc.Test (checked)` failing intermittently across many commits. The fixes above address the bulk of observed failures.