### PR TITLE
fix(eth_simulateV1): return spec-compliant message for out-of-order block number (-38020)

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -702,4 +702,32 @@ public class EthSimulateTestsBlocksAndTransactions
         Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.IntrinsicGas));
     }
 
+    /// <summary>
+    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11219.
+    /// eth_simulateV1 must return -38020 with the spec-mandated fixed message when block
+    /// numbers in the simulation sequence do not increase.
+    /// </summary>
+    [Test]
+    public async Task eth_simulateV1_blocks_out_of_order_returns_spec_error_code_and_message()
+    {
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+
+        // Second block has a lower number than the first — violates the ordering requirement.
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new() { BlockOverrides = new BlockOverride { Number = 100 }, Calls = [] },
+                new() { BlockOverrides = new BlockOverride { Number = 50 }, Calls = [] }
+            ],
+            Validation = false
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.InvalidInputBlocksOutOfOrder));
+        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.BlocksOutOfOrder));
+    }
+
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -134,7 +134,7 @@ public class SimulateTxExecutor<TTrace>(
                     return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail($"Block number too big {givenNumber}!", ErrorCodes.InvalidParams);
 
                 if (givenNumber <= (ulong)lastBlockNumber)
-                    return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail($"Block number out of order {givenNumber} is <= than previous block number of {header.Number}!", ErrorCodes.InvalidInputBlocksOutOfOrder);
+                    return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail(SimulateErrorMessages.BlocksOutOfOrder, ErrorCodes.InvalidInputBlocksOutOfOrder);
 
                 // if the no. of filler blocks are greater than maximum simulate blocks cap
                 if (givenNumber - (ulong)lastBlockNumber > (ulong)_blocksLimit)
@@ -297,6 +297,12 @@ public class SimulateTxExecutor<TTrace>(
 /// </summary>
 internal static class SimulateErrorMessages
 {
+    /// <summary>
+    /// Returned when block numbers in the simulation sequence did not increase
+    /// (error code <see cref="ErrorCodes.InvalidInputBlocksOutOfOrder"/>).
+    /// </summary>
+    public const string BlocksOutOfOrder = "Block number in sequence did not increase";
+
     /// <summary>
     /// Returned when the transaction gas limit is below the intrinsic gas cost
     /// (error code <see cref="ErrorCodes.IntrinsicGas"/>).


### PR DESCRIPTION
Fixes #11219

## Changes

- `eth_simulateV1` now returns the spec-mandated fixed message `"Block number in sequence did not increase"` for error code `-38020` instead of the verbose internal message `"Block number out of order {n} is <= than previous block number of {m}!"`
- Added `SimulateErrorMessages.BlocksOutOfOrder` constant to keep the spec string as a single-point definition shared between the executor and tests
- Added regression test `eth_simulateV1_blocks_out_of_order_returns_spec_error_code_and_message` asserting the correct code and message when block numbers in the simulation sequence do not increase

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added `eth_simulateV1_blocks_out_of_order_returns_spec_error_code_and_message` in `EthSimulateTestsBlocksAndTransactions.cs` — sends two blocks where the second has a lower number than the first and asserts error code `-38020` and message `"Block number in sequence did not increase"`
- All 92 existing simulate tests continue to pass

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No