### PR TITLE
feat(init): auto-detect active state backend at startup

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Blockchain.Find;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -12,7 +11,10 @@ namespace Nethermind.Blockchain
     /// <summary>
     /// Watches state persistence in <see cref="IWorldStateManager"/> with <see cref="IWorldStateManager.ReorgBoundaryReached"/> and saves it in <see cref="IBlockFinder.BestPersistedState"/>.
     /// </summary>
-    public class PersistedStateWatcher : IDisposable
+    // No IDisposable: the subscription is safe to leave open because both this watcher and IWorldStateManager
+    // share the same container lifetime. Explicit unsubscription would fire before the trie store disposes,
+    // causing the final PersistOnShutdown ReorgBoundaryReached event to be missed.
+    public class PersistedStateWatcher
     {
         private readonly IWorldStateManager _worldStateManager;
         private readonly IBlockTree _blockTree;
@@ -31,7 +33,5 @@ namespace Nethermind.Blockchain
             if (_logger.IsDebug) _logger.Debug($"Saving reorg boundary {e.BlockNumber}");
             _blockTree.BestPersistedState = e.BlockNumber;
         }
-
-        public void Dispose() => _worldStateManager.ReorgBoundaryReached -= OnReorgBoundaryReached;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
@@ -14,16 +14,16 @@ namespace Nethermind.Blockchain
     /// </summary>
     public class PersistedStateWatcher : IDisposable
     {
-        private readonly IWorldStateManager _trieStore;
+        private readonly IWorldStateManager _worldStateManager;
         private readonly IBlockTree _blockTree;
         private readonly ILogger _logger;
 
-        public PersistedStateWatcher(IWorldStateManager trieStore, IBlockTree blockTree, ILogManager logManager)
+        public PersistedStateWatcher(IWorldStateManager worldStateManager, IBlockTree blockTree, ILogManager logManager)
         {
-            _trieStore = trieStore;
+            _worldStateManager = worldStateManager;
             _blockTree = blockTree;
             _logger = logManager.GetClassLogger<PersistedStateWatcher>();
-            _trieStore.ReorgBoundaryReached += OnReorgBoundaryReached;
+            _worldStateManager.ReorgBoundaryReached += OnReorgBoundaryReached;
         }
 
         private void OnReorgBoundaryReached(object? sender, ReorgBoundaryReached e)
@@ -32,6 +32,6 @@ namespace Nethermind.Blockchain
             _blockTree.BestPersistedState = e.BlockNumber;
         }
 
-        public void Dispose() => _trieStore.ReorgBoundaryReached -= OnReorgBoundaryReached;
+        public void Dispose() => _worldStateManager.ReorgBoundaryReached -= OnReorgBoundaryReached;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PersistedStateWatcher.cs
@@ -12,17 +12,17 @@ namespace Nethermind.Blockchain
     /// <summary>
     /// Watches state persistence in <see cref="IWorldStateManager"/> with <see cref="IWorldStateManager.ReorgBoundaryReached"/> and saves it in <see cref="IBlockFinder.BestPersistedState"/>.
     /// </summary>
-    public class TrieStoreBoundaryWatcher : IDisposable
+    public class PersistedStateWatcher : IDisposable
     {
         private readonly IWorldStateManager _trieStore;
         private readonly IBlockTree _blockTree;
         private readonly ILogger _logger;
 
-        public TrieStoreBoundaryWatcher(IWorldStateManager trieStore, IBlockTree blockTree, ILogManager logManager)
+        public PersistedStateWatcher(IWorldStateManager trieStore, IBlockTree blockTree, ILogManager logManager)
         {
             _trieStore = trieStore;
             _blockTree = blockTree;
-            _logger = logManager.GetClassLogger<TrieStoreBoundaryWatcher>();
+            _logger = logManager.GetClassLogger<PersistedStateWatcher>();
             _trieStore.ReorgBoundaryReached += OnReorgBoundaryReached;
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -87,7 +87,7 @@ public class StandardDbInitializerTests
             {
                 DownloadReceiptsInFastSync = useReceipts
             }))
-            .AddModule(new WorldStateModule(initConfig)) // For the full pruning db
+            .AddModule(new PruningTrieStoreModule(initConfig)) // For the full pruning db
             .AddSingleton<IPruningConfig>(new PruningConfig())
             .AddSingleton<IDbConfig>(new DbConfig())
             .AddSingleton<IInitConfig>(initConfig)

--- a/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
+++ b/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Linq;
+using Autofac.Features.AttributeFilters;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+
+namespace Nethermind.Init;
+
+internal sealed class FlatStateActivationPolicy(
+    IFlatDbConfig flatDbConfig,
+    IPersistence flatPersistence,
+    [KeyFilter(DbNames.State)] IDb patriciaStateDb,
+    ILogManager logManager)
+{
+    private readonly bool _result = Compute(flatDbConfig, flatPersistence, patriciaStateDb, logManager.GetClassLogger<FlatStateActivationPolicy>());
+
+    public bool ShouldTurnOnFlatDb() => _result;
+
+    private static bool Compute(IFlatDbConfig flatDbConfig, IPersistence flatPersistence, IDb patriciaStateDb, ILogger logger)
+    {
+        if (!flatDbConfig.Enabled)
+        {
+            if (logger.IsInfo) logger.Info("State backend: patricia (flat DB disabled).");
+            return false;
+        }
+        using IPersistence.IPersistenceReader reader = flatPersistence.CreateReader();
+        if (reader.CurrentState != StateId.PreGenesis)
+        {
+            if (logger.IsInfo) logger.Info("State backend: flat (existing flat DB detected).");
+            return true;
+        }
+        if (flatDbConfig.ImportFromPruningTrieState)
+        {
+            if (logger.IsInfo) logger.Info("State backend: flat (importing from patricia trie state).");
+            return true;
+        }
+        if (patriciaStateDb.GetAllKeys().Any())
+        {
+            if (logger.IsInfo) logger.Info("State backend: patricia (existing patricia state detected).");
+            return false;
+        }
+        if (logger.IsInfo) logger.Info("State backend: flat (fresh node, flat DB enabled).");
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
+++ b/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Linq;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Db;
@@ -12,22 +13,22 @@ namespace Nethermind.Init;
 
 internal sealed class FlatStateActivationPolicy(
     IFlatDbConfig flatDbConfig,
-    IPersistence flatPersistence,
-    [KeyFilter(DbNames.State)] IDb patriciaStateDb,
+    Lazy<IPersistence> flatPersistence,
+    [KeyFilter(DbNames.State)] Lazy<IDb> patriciaStateDb,
     ILogManager logManager)
 {
     private readonly bool _result = Compute(flatDbConfig, flatPersistence, patriciaStateDb, logManager.GetClassLogger<FlatStateActivationPolicy>());
 
     public bool ShouldTurnOnFlatDb() => _result;
 
-    private static bool Compute(IFlatDbConfig flatDbConfig, IPersistence flatPersistence, IDb patriciaStateDb, ILogger logger)
+    private static bool Compute(IFlatDbConfig flatDbConfig, Lazy<IPersistence> flatPersistence, Lazy<IDb> patriciaStateDb, ILogger logger)
     {
         if (!flatDbConfig.Enabled)
         {
             if (logger.IsInfo) logger.Info("State backend: patricia (flat DB disabled).");
             return false;
         }
-        using IPersistence.IPersistenceReader reader = flatPersistence.CreateReader();
+        using IPersistence.IPersistenceReader reader = flatPersistence.Value.CreateReader();
         if (reader.CurrentState != StateId.PreGenesis)
         {
             if (logger.IsInfo) logger.Info("State backend: flat (existing flat DB detected).");
@@ -38,7 +39,7 @@ internal sealed class FlatStateActivationPolicy(
             if (logger.IsInfo) logger.Info("State backend: flat (importing from patricia trie state).");
             return true;
         }
-        if (patriciaStateDb.GetAllKeys().Any())
+        if (patriciaStateDb.Value.GetAllKeys().Any())
         {
             if (logger.IsInfo) logger.Info("State backend: patricia (existing patricia state detected).");
             return false;

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -39,10 +39,6 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
             // Implementation of nethermind interfaces
             .AddSingleton<FlatStateReader>()
             .AddSingleton<IWorldStateManager, FlatWorldStateManager>()
-            .OnActivate<IWorldStateManager>((worldStateManager, ctx) =>
-            {
-                new TrieStoreBoundaryWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
-            })
             .AddSingleton<ISnapServer, IWorldStateManager>(wsm => wsm.SnapServer)
 
             // Stub out the pruning trie store admin RPC with a disabled response.

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -110,6 +110,6 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
     {
         public ResultWrapper<PruningStatus> admin_prune() => ResultWrapper<PruningStatus>.Success(PruningStatus.Disabled);
 
-        public ResultWrapper<string> admin_verifyTrie(BlockParameter block) => ResultWrapper<string>.Success("disable");
+        public ResultWrapper<string> admin_verifyTrie(BlockParameter block) => ResultWrapper<string>.Success("disabled");
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -17,7 +17,6 @@ using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
 using Nethermind.Monitoring.Config;
-using Nethermind.State;
 using Nethermind.State.Flat;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.ScopeProvider;

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -37,20 +37,16 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
         builder
 
             // Implementation of nethermind interfaces
+            .AddSingleton<FlatStateReader>()
             .AddSingleton<IWorldStateManager, FlatWorldStateManager>()
             .OnActivate<IWorldStateManager>((worldStateManager, ctx) =>
             {
                 new TrieStoreBoundaryWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
             })
-            .AddSingleton<IStateReader, FlatStateReader>()
             .AddSingleton<ISnapServer, IWorldStateManager>(wsm => wsm.SnapServer)
 
-            // Disable some pruning trie store specific  components
+            // Stub out the pruning trie store admin RPC with a disabled response.
             .AddSingleton<IPruningTrieStateAdminRpcModule, PruningTrieStateAdminRpcModuleStub>()
-            .AddSingleton<MainPruningTrieStoreFactory>(_ => throw new NotSupportedException($"{nameof(MainPruningTrieStoreFactory)} disabled."))
-            .AddSingleton<PruningTrieStateFactory>(_ => throw new NotSupportedException($"{nameof(PruningTrieStateFactory)} disabled."))
-            .AddSingleton<CompositePruningTrigger>(_ => throw new NotSupportedException($"{nameof(CompositePruningTrigger)} disabled."))
-            .AddSingleton<IFullPrunerFactory>(_ => throw new NotSupportedException($"{nameof(IFullPrunerFactory)} disabled."))
 
             // The actual flatDb components
             .AddSingleton<IFlatDbManager>((ctx) => new FlatDbManager(
@@ -124,9 +120,6 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
         }
     }
 
-    /// <summary>
-    /// Need to stub out, or it will register trie store specific module
-    /// </summary>
     private class PruningTrieStateAdminRpcModuleStub : IPruningTrieStateAdminRpcModule
     {
         public ResultWrapper<PruningStatus> admin_prune() => ResultWrapper<PruningStatus>.Success(PruningStatus.Disabled);

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -19,7 +19,6 @@ using Nethermind.Logging;
 using Nethermind.Monitoring.Config;
 using Nethermind.State;
 using Nethermind.State.Flat;
-using Nethermind.State.SnapServer;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.ScopeProvider;
 using Nethermind.State.Flat.Sync;
@@ -39,7 +38,6 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
             // Implementation of nethermind interfaces
             .AddSingleton<FlatStateReader>()
             .AddSingleton<IWorldStateManager, FlatWorldStateManager>()
-            .AddSingleton<ISnapServer, IWorldStateManager>(wsm => wsm.SnapServer)
 
             // Stub out the pruning trie store admin RPC with a disabled response.
             .AddSingleton<IPruningTrieStateAdminRpcModule, PruningTrieStateAdminRpcModuleStub>()

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -23,9 +23,6 @@ using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.ScopeProvider;
 using Nethermind.State.Flat.Sync;
 using Nethermind.State.Flat.Sync.Snap;
-using Nethermind.Synchronization.FastSync;
-using Nethermind.Synchronization.ParallelSync;
-using Nethermind.Synchronization.SnapSync;
 
 namespace Nethermind.Init.Modules;
 
@@ -37,10 +34,10 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
 
             // Implementation of nethermind interfaces
             .AddSingleton<FlatStateReader>()
-            .AddSingleton<IWorldStateManager, FlatWorldStateManager>()
+            .AddSingleton<FlatWorldStateManager>()
 
             // Stub out the pruning trie store admin RPC with a disabled response.
-            .AddSingleton<IPruningTrieStateAdminRpcModule, PruningTrieStateAdminRpcModuleStub>()
+            .AddSingleton<PruningTrieStateAdminRpcModuleStub>()
 
             // The actual flatDb components
             .AddSingleton<IFlatDbManager>((ctx) => new FlatDbManager(
@@ -66,16 +63,12 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
             .Add<FlatOverridableWorldScope>()
 
             // Sync components
-            .AddSingleton<ISnapTrieFactory, FlatSnapTrieFactory>()
+            .AddSingleton<FlatSnapTrieFactory>()
             .AddSingleton<IFlatStateRootIndex>((ctx) => new FlatStateRootIndex(
                 ctx.Resolve<IBlockTree>(),
                 ctx.Resolve<ISyncConfig>().SnapServingMaxDepth))
-            .AddSingleton<ITreeSyncStore, FlatTreeSyncStore>()
-            .Intercept<ISyncConfig>((syncConfig) =>
-            {
-                syncConfig.SnapServingEnabled ??= true;
-            })
-            .AddSingleton<IFullStateFinder, FlatFullStateFinder>()
+            .AddSingleton<FlatTreeSyncStore>()
+            .AddSingleton<FlatFullStateFinder>()
 
             // Persistences
             .AddColumnDatabase<FlatDbColumns>(DbNames.Flat)
@@ -114,7 +107,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
         }
     }
 
-    private class PruningTrieStateAdminRpcModuleStub : IPruningTrieStateAdminRpcModule
+    internal class PruningTrieStateAdminRpcModuleStub : IPruningTrieStateAdminRpcModule
     {
         public ResultWrapper<PruningStatus> admin_prune() => ResultWrapper<PruningStatus>.Success(PruningStatus.Disabled);
 

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -51,7 +51,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
                 configProvider.GetConfig<ISyncConfig>()
             ))
             .AddModule(new DbMonitoringModule())
-            .AddModule(new WorldStateModule(configProvider.GetConfig<IInitConfig>()))
+            .AddModule(new WorldStateModule())
             .AddModule(new PrewarmerModule(configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BuiltInStepsModule())
             .AddModule(new DatabaseMigrationsModule())
@@ -97,6 +97,8 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
 
         if (configProvider.GetConfig<IFlatDbConfig>().Enabled)
             builder.AddModule(new FlatWorldStateModule(configProvider.GetConfig<IFlatDbConfig>()));
+        else
+            builder.AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>()));
     }
 
     // Just a wrapper to make it clear, these three are expected to be available at the time of configurations.

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -52,6 +52,9 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             ))
             .AddModule(new DbMonitoringModule())
             .AddModule(new WorldStateModule())
+            .AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>()))
+            .AddModule(new FlatWorldStateModule(configProvider.GetConfig<IFlatDbConfig>()))
+            .AddModule(new WorldStateDbDeciderModule())
             .AddModule(new PrewarmerModule(configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BuiltInStepsModule())
             .AddModule(new DatabaseMigrationsModule())
@@ -95,10 +98,6 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             builder.AddSingleton<IBlobTxStorage>(NullBlobTxStorage.Instance);
         }
 
-        if (configProvider.GetConfig<IFlatDbConfig>().Enabled)
-            builder.AddModule(new FlatWorldStateModule(configProvider.GetConfig<IFlatDbConfig>()));
-        else
-            builder.AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>()));
     }
 
     // Just a wrapper to make it clear, these three are expected to be available at the time of configurations.

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Autofac;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
-using Nethermind.Blockchain;
 using Nethermind.Blockchain.FullPruning;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
@@ -22,7 +21,6 @@ using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Synchronization.Trie;
 using Nethermind.Trie;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Init.Modules;
 

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -15,6 +15,12 @@ using Nethermind.Db.FullPruning;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
 using Nethermind.State;
+using Nethermind.State.Healing;
+using Nethermind.Synchronization.FastSync;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.SnapSync;
+using Nethermind.Synchronization.Trie;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 
@@ -82,6 +88,16 @@ public class PruningTrieStoreModule(IInitConfig initConfig) : Module
 
             // Some admin rpc to trigger verify trie and pruning
             .Map<IPruningTrieStateAdminRpcModule, PruningTrieStateFactoryOutput>((m) => m.AdminRpcModule)
+
+            // Sync components backed by the patricia trie store
+            .AddSingleton<IFullStateFinder, FullStateFinder>()
+            .AddSingleton<ISnapTrieFactory, PatriciaSnapTrieFactory>()
+            .AddSingleton<ITreeSyncStore, PatriciaTreeSyncStore>()
+            .AddSingleton<IPathRecovery, ISyncPeerPool, INodeStorage, ILogManager>((peerPool, nodeStorage, logManager) => new PathNodeRecovery(
+                new NodeDataRecovery(peerPool!, nodeStorage, logManager),
+                new SnapRangeRecovery(peerPool!, logManager),
+                logManager
+            ))
             ;
 
         if (initConfig.DiagnosticMode == DiagnosticMode.VerifyTrie)

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.IO.Abstractions;
+using System.Threading;
+using Autofac;
+using Nethermind.Api;
+using Nethermind.Api.Steps;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.FullPruning;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Db;
+using Nethermind.Db.FullPruning;
+using Nethermind.JsonRpc.Modules.Admin;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Init.Modules;
+
+public class PruningTrieStoreModule(IInitConfig initConfig) : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        builder
+
+            // Special case for state db with pruning trie state.
+            .AddKeyedSingleton<IDb>(DbNames.State, (ctx) =>
+            {
+                DbSettings stateDbSettings = new(GetTitleDbName(DbNames.State), DbNames.State);
+                IFileSystem fileSystem = ctx.Resolve<IFileSystem>();
+                IDbFactory dbFactory = ctx.Resolve<IDbFactory>();
+                return new FullPruningDb(
+                    stateDbSettings,
+                    dbFactory is not MemDbFactory
+                        ? new FullPruningInnerDbFactory(dbFactory, fileSystem, stateDbSettings.DbPath)
+                        : dbFactory,
+                    () => Interlocked.Increment(ref Nethermind.Db.Metrics.StateDbInPruningWrites));
+            })
+
+            .AddSingleton<INodeStorageFactory>(ctx =>
+            {
+                IInitConfig initConfig = ctx.Resolve<IInitConfig>();
+                ISyncConfig syncConfig = ctx.Resolve<ISyncConfig>();
+                IDb stateDb = ctx.ResolveKeyed<IDb>(DbNames.State);
+                ILogManager logManager = ctx.Resolve<ILogManager>();
+                INodeStorageFactory nodeStorageFactory = new NodeStorageFactory(initConfig.StateDbKeyScheme, logManager);
+                nodeStorageFactory.DetectCurrentKeySchemeFrom(stateDb);
+
+                syncConfig.SnapServingEnabled |= syncConfig.SnapServingEnabled is null
+                                                 && nodeStorageFactory.CurrentKeyScheme is INodeStorage.KeyScheme.HalfPath or null
+                                                 && initConfig.StateDbKeyScheme != INodeStorage.KeyScheme.Hash;
+
+                if (nodeStorageFactory.CurrentKeyScheme is INodeStorage.KeyScheme.Hash
+                    || initConfig.StateDbKeyScheme == INodeStorage.KeyScheme.Hash)
+                {
+                    // Special case in case its using hashdb, use a slightly different database configuration.
+                    if (stateDb is ITunableDb tunableDb) tunableDb.Tune(ITunableDb.TuneType.HashDb);
+                }
+
+                return nodeStorageFactory;
+            })
+
+            // Used by sync code and trie store
+            .AddSingleton<INodeStorage>(ctx =>
+            {
+                IDb stateDb = ctx.ResolveKeyed<IDb>(DbNames.State);
+                INodeStorageFactory nodeStorageFactory = ctx.Resolve<INodeStorageFactory>();
+                return nodeStorageFactory.WrapKeyValueStore(stateDb);
+            })
+
+            // Most config actually done in factory. We just call `Build` and then get back components from its output.
+            .AddSingleton<MainPruningTrieStoreFactory>() // This part is done separately so that triestore can be obtained in test.
+            .AddSingleton<CompositePruningTrigger>()
+            .AddSingleton<IFullPrunerFactory, FullPrunerFactory>()
+            .AddSingleton<PruningTrieStateFactory>()
+            .AddSingleton<PruningTrieStateFactoryOutput>()
+
+            .Map<IWorldStateManager, PruningTrieStateFactoryOutput>((o) => o.WorldStateManager)
+
+            // Some admin rpc to trigger verify trie and pruning
+            .Map<IPruningTrieStateAdminRpcModule, PruningTrieStateFactoryOutput>((m) => m.AdminRpcModule)
+            ;
+
+        if (initConfig.DiagnosticMode == DiagnosticMode.VerifyTrie)
+        {
+            builder.AddStep(typeof(RunVerifyTrie));
+        }
+    }
+
+    private static string GetTitleDbName(string dbName) => char.ToUpper(dbName[0]) + dbName[1..];
+
+    // Just a wrapper to easily extract the output of `PruningTrieStateFactory` which do the actual initializations.
+    private class PruningTrieStateFactoryOutput
+    {
+        public IWorldStateManager WorldStateManager { get; }
+        public IPruningTrieStateAdminRpcModule AdminRpcModule { get; }
+
+        public PruningTrieStateFactoryOutput(PruningTrieStateFactory factory)
+        {
+            (IWorldStateManager worldStateManager, IPruningTrieStateAdminRpcModule adminRpc) = factory.Build();
+            WorldStateManager = worldStateManager;
+            AdminRpcModule = adminRpc;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -84,15 +84,10 @@ public class PruningTrieStoreModule(IInitConfig initConfig) : Module
             .AddSingleton<PruningTrieStateFactory>()
             .AddSingleton<PruningTrieStateFactoryOutput>()
 
-            .Map<IWorldStateManager, PruningTrieStateFactoryOutput>((o) => o.WorldStateManager)
-
-            // Some admin rpc to trigger verify trie and pruning
-            .Map<IPruningTrieStateAdminRpcModule, PruningTrieStateFactoryOutput>((m) => m.AdminRpcModule)
-
             // Sync components backed by the patricia trie store
-            .AddSingleton<IFullStateFinder, FullStateFinder>()
-            .AddSingleton<ISnapTrieFactory, PatriciaSnapTrieFactory>()
-            .AddSingleton<ITreeSyncStore, PatriciaTreeSyncStore>()
+            .AddSingleton<FullStateFinder>()
+            .AddSingleton<PatriciaSnapTrieFactory>()
+            .AddSingleton<PatriciaTreeSyncStore>()
             .AddSingleton<IPathRecovery, ISyncPeerPool, INodeStorage, ILogManager>((peerPool, nodeStorage, logManager) => new PathNodeRecovery(
                 new NodeDataRecovery(peerPool!, nodeStorage, logManager),
                 new SnapRangeRecovery(peerPool!, logManager),
@@ -109,7 +104,7 @@ public class PruningTrieStoreModule(IInitConfig initConfig) : Module
     private static string GetTitleDbName(string dbName) => char.ToUpper(dbName[0]) + dbName[1..];
 
     // Just a wrapper to easily extract the output of `PruningTrieStateFactory` which do the actual initializations.
-    private class PruningTrieStateFactoryOutput
+    internal class PruningTrieStateFactoryOutput
     {
         public IWorldStateManager WorldStateManager { get; }
         public IPruningTrieStateAdminRpcModule AdminRpcModule { get; }

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Autofac;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.State;
@@ -50,11 +49,5 @@ internal class WorldStateDbDeciderModule : Module
                 (policy, flatFactory, patriciaFactory) =>
                     policy.ShouldTurnOnFlatDb()
                         ? flatFactory()
-                        : (IFullStateFinder)patriciaFactory())
-
-            .Intercept<ISyncConfig>((syncConfig, ctx) =>
-            {
-                if (ctx.Resolve<FlatStateActivationPolicy>().ShouldTurnOnFlatDb())
-                    syncConfig.SnapServingEnabled ??= true;
-            });
+                        : (IFullStateFinder)patriciaFactory());
 }

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.JsonRpc.Modules.Admin;
+using Nethermind.State;
+using Nethermind.State.Flat.ScopeProvider;
+using Nethermind.State.Flat.Sync;
+using Nethermind.State.Flat.Sync.Snap;
+using Nethermind.Synchronization.FastSync;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.SnapSync;
+
+namespace Nethermind.Init.Modules;
+
+internal class WorldStateDbDeciderModule : Module
+{
+    protected override void Load(ContainerBuilder builder) =>
+        builder
+            .AddSingleton<FlatStateActivationPolicy>()
+
+            .AddSingleton<IWorldStateManager, FlatStateActivationPolicy, Func<FlatWorldStateManager>, Func<PruningTrieStoreModule.PruningTrieStateFactoryOutput>>(
+                (policy, flatFactory, patriciaFactory) =>
+                    policy.ShouldTurnOnFlatDb()
+                        ? flatFactory()
+                        : patriciaFactory().WorldStateManager)
+
+            .AddSingleton<IPruningTrieStateAdminRpcModule, FlatStateActivationPolicy, Func<FlatWorldStateModule.PruningTrieStateAdminRpcModuleStub>, Func<PruningTrieStoreModule.PruningTrieStateFactoryOutput>>(
+                (policy, flatFactory, patriciaFactory) =>
+                    policy.ShouldTurnOnFlatDb()
+                        ? flatFactory()
+                        : patriciaFactory().AdminRpcModule)
+
+            .AddSingleton<ISnapTrieFactory, FlatStateActivationPolicy, Func<FlatSnapTrieFactory>, Func<PatriciaSnapTrieFactory>>(
+                (policy, flatFactory, patriciaFactory) =>
+                    policy.ShouldTurnOnFlatDb()
+                        ? flatFactory()
+                        : (ISnapTrieFactory)patriciaFactory())
+
+            .AddSingleton<ITreeSyncStore, FlatStateActivationPolicy, Func<FlatTreeSyncStore>, Func<PatriciaTreeSyncStore>>(
+                (policy, flatFactory, patriciaFactory) =>
+                    policy.ShouldTurnOnFlatDb()
+                        ? flatFactory()
+                        : (ITreeSyncStore)patriciaFactory())
+
+            .AddSingleton<IFullStateFinder, FlatStateActivationPolicy, Func<FlatFullStateFinder>, Func<FullStateFinder>>(
+                (policy, flatFactory, patriciaFactory) =>
+                    policy.ShouldTurnOnFlatDb()
+                        ? flatFactory()
+                        : (IFullStateFinder)patriciaFactory())
+
+            .Intercept<ISyncConfig>((syncConfig, ctx) =>
+            {
+                if (ctx.Resolve<FlatStateActivationPolicy>().ShouldTurnOnFlatDb())
+                    syncConfig.SnapServingEnabled ??= true;
+            });
+}

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Autofac;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.State;
@@ -21,11 +22,14 @@ internal class WorldStateDbDeciderModule : Module
         builder
             .AddSingleton<FlatStateActivationPolicy>()
 
-            .AddSingleton<IWorldStateManager, FlatStateActivationPolicy, Func<FlatWorldStateManager>, Func<PruningTrieStoreModule.PruningTrieStateFactoryOutput>>(
-                (policy, flatFactory, patriciaFactory) =>
-                    policy.ShouldTurnOnFlatDb()
-                        ? flatFactory()
-                        : patriciaFactory().WorldStateManager)
+            .AddSingleton<IWorldStateManager, FlatStateActivationPolicy, ISyncConfig, Func<FlatWorldStateManager>, Func<PruningTrieStoreModule.PruningTrieStateFactoryOutput>>(
+                (policy, syncConfig, flatFactory, patriciaFactory) =>
+                {
+                    if (!policy.ShouldTurnOnFlatDb()) return patriciaFactory().WorldStateManager;
+                    // Flat state can always serve snap requests; set before InitializeNetwork registers capabilities.
+                    syncConfig.SnapServingEnabled ??= true;
+                    return flatFactory();
+                })
 
             .AddSingleton<IPruningTrieStateAdminRpcModule, FlatStateActivationPolicy, Func<FlatWorldStateModule.PruningTrieStateAdminRpcModuleStub>, Func<PruningTrieStoreModule.PruningTrieStateFactoryOutput>>(
                 (policy, flatFactory, patriciaFactory) =>

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -17,9 +17,9 @@ public class WorldStateModule : Module
 {
     protected override void Load(ContainerBuilder builder) =>
         builder
-            // Stub: a backend module must override this. Load PruningTrieStoreModule or FlatWorldStateModule.
+            // Stub: overridden by WorldStateDbDeciderModule which selects patricia or flat at runtime.
             .AddSingleton<IWorldStateManager>(_ => throw new InvalidOperationException(
-                $"No world state backend registered. Load {nameof(PruningTrieStoreModule)} or {nameof(FlatWorldStateModule)}."))
+                $"No world state backend registered. Load {nameof(WorldStateDbDeciderModule)}."))
 
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
 

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -7,7 +7,6 @@ using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
-using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 
@@ -23,10 +22,8 @@ public class WorldStateModule : Module
 
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
 
-            .OnActivate<IWorldStateManager>((worldStateManager, ctx) =>
-            {
-                new PersistedStateWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
-            })
+            .AddSingleton<PersistedStateWatcher>()
+            .ResolveOnServiceActivation<PersistedStateWatcher, IWorldStateManager>()
 
             // Prevent multiple concurrent verify trie.
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -1,118 +1,33 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.IO.Abstractions;
-using System.Threading;
+using System;
 using Autofac;
-using Nethermind.Api;
-using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.FullPruning;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
-using Nethermind.Db;
-using Nethermind.Db.FullPruning;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
-using Nethermind.Logging;
 using Nethermind.State;
-using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Init.Modules;
 
-public class WorldStateModule(IInitConfig initConfig) : Module
+public class WorldStateModule : Module
 {
-    protected override void Load(ContainerBuilder builder)
-    {
+    protected override void Load(ContainerBuilder builder) =>
         builder
+            // Stub: a backend module must override this. Load PruningTrieStoreModule or FlatWorldStateModule.
+            .AddSingleton<IWorldStateManager>(_ => throw new InvalidOperationException(
+                $"No world state backend registered. Load {nameof(PruningTrieStoreModule)} or {nameof(FlatWorldStateModule)}."))
 
-            // Special case for state db with pruning trie state.
-            .AddKeyedSingleton<IDb>(DbNames.State, (ctx) =>
-            {
-                DbSettings stateDbSettings = new(GetTitleDbName(DbNames.State), DbNames.State);
-                IFileSystem fileSystem = ctx.Resolve<IFileSystem>();
-                IDbFactory dbFactory = ctx.Resolve<IDbFactory>();
-                return new FullPruningDb(
-                    stateDbSettings,
-                    dbFactory is not MemDbFactory
-                        ? new FullPruningInnerDbFactory(dbFactory, fileSystem, stateDbSettings.DbPath)
-                        : dbFactory,
-                    () => Interlocked.Increment(ref Nethermind.Db.Metrics.StateDbInPruningWrites));
-            })
-
-            .AddSingleton<INodeStorageFactory>(ctx =>
-            {
-                IInitConfig initConfig = ctx.Resolve<IInitConfig>();
-                ISyncConfig syncConfig = ctx.Resolve<ISyncConfig>();
-                IDb stateDb = ctx.ResolveKeyed<IDb>(DbNames.State);
-                ILogManager logManager = ctx.Resolve<ILogManager>();
-                INodeStorageFactory nodeStorageFactory = new NodeStorageFactory(initConfig.StateDbKeyScheme, logManager);
-                nodeStorageFactory.DetectCurrentKeySchemeFrom(stateDb);
-
-                syncConfig.SnapServingEnabled |= syncConfig.SnapServingEnabled is null
-                                                 && nodeStorageFactory.CurrentKeyScheme is INodeStorage.KeyScheme.HalfPath or null
-                                                 && initConfig.StateDbKeyScheme != INodeStorage.KeyScheme.Hash;
-
-                if (nodeStorageFactory.CurrentKeyScheme is INodeStorage.KeyScheme.Hash
-                    || initConfig.StateDbKeyScheme == INodeStorage.KeyScheme.Hash)
-                {
-                    // Special case in case its using hashdb, use a slightly different database configuration.
-                    if (stateDb is ITunableDb tunableDb) tunableDb.Tune(ITunableDb.TuneType.HashDb);
-                }
-
-                return nodeStorageFactory;
-            })
-
-            // Used by sync code and trie store
-            .AddSingleton<INodeStorage>(ctx =>
-            {
-                IDb stateDb = ctx.ResolveKeyed<IDb>(DbNames.State);
-                INodeStorageFactory nodeStorageFactory = ctx.Resolve<INodeStorageFactory>();
-                return nodeStorageFactory.WrapKeyValueStore(stateDb);
-            })
-
-            // Most config actually done in factory. We just call `Build` and then get back components from its output.
-            .AddSingleton<MainPruningTrieStoreFactory>() // This part is done separately so that triestore can be obtained in test.
-            .AddSingleton<IReadOnlyTrieStore>(ctx =>
-                ctx.Resolve<MainPruningTrieStoreFactory>().PruningTrieStore.AsReadOnly())
-            .AddSingleton<CompositePruningTrigger>()
-            .AddSingleton<IFullPrunerFactory, FullPrunerFactory>()
-            .AddSingleton<PruningTrieStateFactory>()
-            .AddSingleton<PruningTrieStateFactoryOutput>()
-
-            .Map<IWorldStateManager, PruningTrieStateFactoryOutput>((o) => o.WorldStateManager)
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
-
-            // Some admin rpc to trigger verify trie and pruning
-            .Map<IPruningTrieStateAdminRpcModule, PruningTrieStateFactoryOutput>((m) => m.AdminRpcModule)
-            .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpcModule>()
 
             // Prevent multiple concurrent verify trie.
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()
 
             .AddSingleton<IFinalizedStateProvider, ReorgDepthFinalizedStateProvider>()
-            ;
 
-        if (initConfig.DiagnosticMode == DiagnosticMode.VerifyTrie)
-        {
-            builder.AddStep(typeof(RunVerifyTrie));
-        }
-    }
-
-    // Just a wrapper to easily extract the output of `PruningTrieStateFactory` which do the actual initializations.
-    private class PruningTrieStateFactoryOutput
-    {
-        public IWorldStateManager WorldStateManager { get; }
-        public IPruningTrieStateAdminRpcModule AdminRpcModule { get; }
-
-        public PruningTrieStateFactoryOutput(PruningTrieStateFactory factory)
-        {
-            (IWorldStateManager worldStateManager, IPruningTrieStateAdminRpcModule adminRpc) = factory.Build();
-            WorldStateManager = worldStateManager;
-            AdminRpcModule = adminRpc;
-        }
-    }
-
-    private static string GetTitleDbName(string dbName) => char.ToUpper(dbName[0]) + dbName[1..];
+            // Admin RPC surface is common to all backends; each backend registers its implementation.
+            .RegisterSingletonJsonRpcModule<IPruningTrieStateAdminRpcModule>()
+        ;
 }

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -19,13 +19,13 @@ public class WorldStateModule : Module
         builder
             // Stub: overridden by WorldStateDbDeciderModule which selects patricia or flat at runtime.
             .AddSingleton<IWorldStateManager>(_ => throw new InvalidOperationException(
-                $"No world state backend registered. Load {nameof(WorldStateDbDeciderModule)}."))
+                $"No world state backend registered. Load {nameof(WorldStateDbDeciderModule)} together with {nameof(PruningTrieStoreModule)} and {nameof(FlatWorldStateModule)}."))
 
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
 
             .OnActivate<IWorldStateManager>((worldStateManager, ctx) =>
             {
-                new TrieStoreBoundaryWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
+                new PersistedStateWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
             })
 
             // Prevent multiple concurrent verify trie.

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateModule.cs
@@ -7,6 +7,7 @@ using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
+using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 
@@ -21,6 +22,11 @@ public class WorldStateModule : Module
                 $"No world state backend registered. Load {nameof(PruningTrieStoreModule)} or {nameof(FlatWorldStateModule)}."))
 
             .Map<IStateReader, IWorldStateManager>((m) => m.GlobalStateReader)
+
+            .OnActivate<IWorldStateManager>((worldStateManager, ctx) =>
+            {
+                new TrieStoreBoundaryWatcher(worldStateManager, ctx.Resolve<IBlockTree>(), ctx.Resolve<ILogManager>());
+            })
 
             // Prevent multiple concurrent verify trie.
             .AddSingleton<IVerifyTrieStarter, VerifyTrieStarter>()

--- a/src/Nethermind/Nethermind.Init/Nethermind.Init.csproj
+++ b/src/Nethermind/Nethermind.Init/Nethermind.Init.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Nethermind.Network.Enr\Nethermind.Network.Enr.csproj" />
     <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat\Nethermind.State.Flat.csproj" />
+    <ProjectReference Include="..\Nethermind.Synchronization\Nethermind.Synchronization.csproj" />
 
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Nethermind.Runner.Test</_Parameter1>

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -73,11 +73,6 @@ public class PruningTrieStateFactory(
             logManager,
             new LastNStateRootTracker(blockTree, syncConfig.SnapServingMaxDepth));
 
-        // NOTE: Don't forget this! Very important!
-        TrieStoreBoundaryWatcher trieStoreBoundaryWatcher = new(stateManager, blockTree!, logManager);
-        // Must be disposed after main trie store or the final persist on dispose will not set persisted state on blocktree.
-        disposeStack.Push(trieStoreBoundaryWatcher);
-
         disposeStack.Push(mainWorldTrieStore);
 
         FullPruner? fullPruner = fullPrunerFactory.Create(stateManager.GlobalStateReader, trieStore);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.ExecutionWitness.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.ExecutionWitness.cs
@@ -96,7 +96,7 @@ public partial class DebugRpcModuleTests
         BlockHeader parent = blockchain.BlockTree.Head!.Header;
 
         // Construct witness-generating infrastructure manually to demonstrate the tree visitor pattern.
-        IReadOnlyTrieStore readOnlyTrieStore = blockchain.Container.Resolve<IReadOnlyTrieStore>();
+        IReadOnlyTrieStore readOnlyTrieStore = blockchain.Container.Resolve<IWorldStateManager>().CreateReadOnlyTrieStore();
         IReadOnlyDbProvider readOnlyDbProvider = new ReadOnlyDbProvider(blockchain.DbProvider, true);
         WitnessCapturingTrieStore capturingTrieStore = new(readOnlyTrieStore);
         StateReader stateReader = new(capturingTrieStore, readOnlyDbProvider.CodeDb, blockchain.LogManager);

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
@@ -17,30 +17,39 @@ namespace Nethermind.Runner.Test.Module;
 [Parallelizable(ParallelScope.All)]
 public class FlatStateActivationPolicyTests
 {
+    [Flags]
+    public enum Flags
+    {
+        None = 0,
+        Enabled = 1,
+        FlatHasData = 2,
+        ImportFromPruningTrieState = 4,
+        PatriciaHasData = 8
+    }
+
     // Branch 1: Enabled=false → false, regardless of db content
     // Branch 2: Enabled=true, flat persistence has committed state → true
     // Branch 3: Enabled=true, no committed state, ImportFromPruningTrieState=true → true
     // Branch 4: Enabled=true, no committed state, ImportFromPruningTrieState=false, patricia has data → false
     // Branch 5: Enabled=true, no committed state, ImportFromPruningTrieState=false, no patricia data → true
-    [TestCase(false, false, false, false, false, Description = "Disabled → always false")]
-    [TestCase(true, true, false, false, true, Description = "Flat has committed state → true")]
-    [TestCase(true, false, true, false, true, Description = "ImportFromPruningTrieState=true → true")]
-    [TestCase(true, false, false, true, false, Description = "Patricia has data → false")]
-    [TestCase(true, false, false, false, true, Description = "Fresh node, flat enabled → true")]
-    public void ShouldTurnOnFlatDb_ReturnsExpected(
-        bool enabled, bool flatHasData, bool importFromPruningTrieState, bool patriciaHasData, bool expected)
+    [TestCase(Flags.None, false, Description = "Disabled → always false")]
+    [TestCase(Flags.Enabled | Flags.FlatHasData, true, Description = "Flat has committed state → true")]
+    [TestCase(Flags.Enabled | Flags.ImportFromPruningTrieState, true, Description = "ImportFromPruningTrieState=true → true")]
+    [TestCase(Flags.Enabled | Flags.PatriciaHasData, false, Description = "Patricia has data → false")]
+    [TestCase(Flags.Enabled, true, Description = "Fresh node, flat enabled → true")]
+    public void ShouldTurnOnFlatDb_ReturnsExpected(Flags flags, bool expected)
     {
         IFlatDbConfig flatDbConfig = Substitute.For<IFlatDbConfig>();
-        flatDbConfig.Enabled.Returns(enabled);
-        flatDbConfig.ImportFromPruningTrieState.Returns(importFromPruningTrieState);
+        flatDbConfig.Enabled.Returns(flags.HasFlag(Flags.Enabled));
+        flatDbConfig.ImportFromPruningTrieState.Returns(flags.HasFlag(Flags.ImportFromPruningTrieState));
 
         IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
-        reader.CurrentState.Returns(flatHasData ? new StateId(1, Nethermind.Core.Crypto.Keccak.Zero) : StateId.PreGenesis);
+        reader.CurrentState.Returns(flags.HasFlag(Flags.FlatHasData) ? new StateId(1, Nethermind.Core.Crypto.Keccak.Zero) : StateId.PreGenesis);
         IPersistence flatPersistence = Substitute.For<IPersistence>();
         flatPersistence.CreateReader().Returns(reader);
 
         MemDb patriciaDb = new();
-        if (patriciaHasData)
+        if (flags.HasFlag(Flags.PatriciaHasData))
             patriciaDb.Set([1], [1]);
 
         FlatStateActivationPolicy policy = new(flatDbConfig, new Lazy<IPersistence>(() => flatPersistence), new Lazy<IDb>(() => patriciaDb), LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using FluentAssertions;
 using Nethermind.Db;
 using Nethermind.Init;
@@ -42,7 +43,7 @@ public class FlatStateActivationPolicyTests
         if (patriciaHasData)
             patriciaDb.Set([1], [1]);
 
-        FlatStateActivationPolicy policy = new(flatDbConfig, flatPersistence, patriciaDb, LimboLogs.Instance);
+        FlatStateActivationPolicy policy = new(flatDbConfig, new Lazy<IPersistence>(() => flatPersistence), new Lazy<IDb>(() => patriciaDb), LimboLogs.Instance);
         policy.ShouldTurnOnFlatDb().Should().Be(expected);
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Db;
+using Nethermind.Init;
+using Nethermind.Logging;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test.Module;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class FlatStateActivationPolicyTests
+{
+    // Branch 1: Enabled=false → false, regardless of db content
+    // Branch 2: Enabled=true, flat persistence has committed state → true
+    // Branch 3: Enabled=true, no committed state, ImportFromPruningTrieState=true → true
+    // Branch 4: Enabled=true, no committed state, ImportFromPruningTrieState=false, patricia has data → false
+    // Branch 5: Enabled=true, no committed state, ImportFromPruningTrieState=false, no patricia data → true
+    [TestCase(false, false, false, false, false, Description = "Disabled → always false")]
+    [TestCase(true, true, false, false, true, Description = "Flat has committed state → true")]
+    [TestCase(true, false, true, false, true, Description = "ImportFromPruningTrieState=true → true")]
+    [TestCase(true, false, false, true, false, Description = "Patricia has data → false")]
+    [TestCase(true, false, false, false, true, Description = "Fresh node, flat enabled → true")]
+    public void ShouldTurnOnFlatDb_ReturnsExpected(
+        bool enabled, bool flatHasData, bool importFromPruningTrieState, bool patriciaHasData, bool expected)
+    {
+        IFlatDbConfig flatDbConfig = Substitute.For<IFlatDbConfig>();
+        flatDbConfig.Enabled.Returns(enabled);
+        flatDbConfig.ImportFromPruningTrieState.Returns(importFromPruningTrieState);
+
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.CurrentState.Returns(flatHasData ? new StateId(1, Nethermind.Core.Crypto.Keccak.Zero) : StateId.PreGenesis);
+        IPersistence flatPersistence = Substitute.For<IPersistence>();
+        flatPersistence.CreateReader().Returns(reader);
+
+        MemDb patriciaDb = new();
+        if (patriciaHasData)
+            patriciaDb.Set([1], [1]);
+
+        FlatStateActivationPolicy policy = new(flatDbConfig, flatPersistence, patriciaDb, LimboLogs.Instance);
+        policy.ShouldTurnOnFlatDb().Should().Be(expected);
+    }
+}

--- a/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Db;
+using Nethermind.State;
+using Nethermind.State.Flat.ScopeProvider;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test.Module;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class WorldStateDbDeciderModuleTests
+{
+    [TestCase(false, Description = "Flat disabled → patricia backend selected")]
+    [TestCase(true, Description = "Flat enabled, fresh DB → flat backend selected")]
+    public void IWorldStateManager_ResolvesToCorrectBackend(bool flatEnabled)
+    {
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule())
+            .Intercept<IFlatDbConfig>((cfg) => { cfg.Enabled = flatEnabled; })
+            .Build();
+
+        IWorldStateManager worldStateManager = container.Resolve<IWorldStateManager>();
+
+        if (flatEnabled)
+            worldStateManager.Should().BeOfType<FlatWorldStateManager>();
+        else
+            worldStateManager.Should().NotBeOfType<FlatWorldStateManager>();
+    }
+}

--- a/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Buffers.Binary;
 using Autofac;
 using FluentAssertions;
@@ -20,27 +21,36 @@ namespace Nethermind.Runner.Test.Module;
 [Parallelizable(ParallelScope.All)]
 public class WorldStateDbDeciderModuleTests
 {
+    [Flags]
+    public enum Flags
+    {
+        None = 0,
+        Enabled = 1,
+        FlatHasData = 2,
+        ImportFromPruningTrieState = 4,
+        PatriciaHasData = 8
+    }
+
     // Mirrors the 5 branches in FlatStateActivationPolicy at the full DI container level.
-    [TestCase(false, false, false, false, false, Description = "Flat disabled → patricia")]
-    [TestCase(true, true, false, false, true, Description = "Flat has committed state → flat")]
-    [TestCase(true, false, true, false, true, Description = "ImportFromPruningTrieState → flat")]
-    [TestCase(true, false, false, true, false, Description = "Patricia has data → patricia")]
-    [TestCase(true, false, false, false, true, Description = "Fresh node, flat enabled → flat")]
-    public void IWorldStateManager_ResolvesToCorrectBackend(
-        bool enabled, bool flatHasData, bool importFromPruningTrieState, bool patriciaHasData, bool expectFlat)
+    [TestCase(Flags.None, false, Description = "Flat disabled → patricia")]
+    [TestCase(Flags.Enabled | Flags.FlatHasData, true, Description = "Flat has committed state → flat")]
+    [TestCase(Flags.Enabled | Flags.ImportFromPruningTrieState, true, Description = "ImportFromPruningTrieState → flat")]
+    [TestCase(Flags.Enabled | Flags.PatriciaHasData, false, Description = "Patricia has data → patricia")]
+    [TestCase(Flags.Enabled, true, Description = "Fresh node, flat enabled → flat")]
+    public void IWorldStateManager_ResolvesToCorrectBackend(Flags flags, bool expectFlat)
     {
         using IContainer container = new ContainerBuilder()
             .AddModule(new TestNethermindModule())
             .Intercept<IFlatDbConfig>((cfg) =>
             {
-                cfg.Enabled = enabled;
-                cfg.ImportFromPruningTrieState = importFromPruningTrieState;
+                cfg.Enabled = flags.HasFlag(Flags.Enabled);
+                cfg.ImportFromPruningTrieState = flags.HasFlag(Flags.ImportFromPruningTrieState);
             })
             .Build();
 
         // Populate DBs before FlatStateActivationPolicy is evaluated.
         // The policy is a lazy singleton — it's only constructed when IWorldStateManager is first resolved.
-        if (flatHasData)
+        if (flags.HasFlag(Flags.FlatHasData))
         {
             // Write a non-PreGenesis current state into the flat DB metadata column.
             // Format: 8-byte big-endian block number + 32-byte state root (matches BasePersistence encoding).
@@ -51,7 +61,7 @@ public class WorldStateDbDeciderModuleTests
             metadataDb.Set(key, value);
         }
 
-        if (patriciaHasData)
+        if (flags.HasFlag(Flags.PatriciaHasData))
             container.ResolveKeyed<IDb>(DbNames.State).Set(Bytes.FromHexString("0000000000000001"), [1]);
 
         IWorldStateManager worldStateManager = container.Resolve<IWorldStateManager>();

--- a/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/WorldStateDbDeciderModuleTests.cs
@@ -1,12 +1,16 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers.Binary;
 using Autofac;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.State;
+using Nethermind.State.Flat;
 using Nethermind.State.Flat.ScopeProvider;
 using NUnit.Framework;
 
@@ -16,18 +20,43 @@ namespace Nethermind.Runner.Test.Module;
 [Parallelizable(ParallelScope.All)]
 public class WorldStateDbDeciderModuleTests
 {
-    [TestCase(false, Description = "Flat disabled → patricia backend selected")]
-    [TestCase(true, Description = "Flat enabled, fresh DB → flat backend selected")]
-    public void IWorldStateManager_ResolvesToCorrectBackend(bool flatEnabled)
+    // Mirrors the 5 branches in FlatStateActivationPolicy at the full DI container level.
+    [TestCase(false, false, false, false, false, Description = "Flat disabled → patricia")]
+    [TestCase(true, true, false, false, true, Description = "Flat has committed state → flat")]
+    [TestCase(true, false, true, false, true, Description = "ImportFromPruningTrieState → flat")]
+    [TestCase(true, false, false, true, false, Description = "Patricia has data → patricia")]
+    [TestCase(true, false, false, false, true, Description = "Fresh node, flat enabled → flat")]
+    public void IWorldStateManager_ResolvesToCorrectBackend(
+        bool enabled, bool flatHasData, bool importFromPruningTrieState, bool patriciaHasData, bool expectFlat)
     {
         using IContainer container = new ContainerBuilder()
             .AddModule(new TestNethermindModule())
-            .Intercept<IFlatDbConfig>((cfg) => { cfg.Enabled = flatEnabled; })
+            .Intercept<IFlatDbConfig>((cfg) =>
+            {
+                cfg.Enabled = enabled;
+                cfg.ImportFromPruningTrieState = importFromPruningTrieState;
+            })
             .Build();
+
+        // Populate DBs before FlatStateActivationPolicy is evaluated.
+        // The policy is a lazy singleton — it's only constructed when IWorldStateManager is first resolved.
+        if (flatHasData)
+        {
+            // Write a non-PreGenesis current state into the flat DB metadata column.
+            // Format: 8-byte big-endian block number + 32-byte state root (matches BasePersistence encoding).
+            IDb metadataDb = container.Resolve<IColumnsDb<FlatDbColumns>>().GetColumnDb(FlatDbColumns.Metadata);
+            byte[] key = Keccak.Compute("CurrentState").BytesToArray();
+            byte[] value = new byte[8 + 32];
+            BinaryPrimitives.WriteInt64BigEndian(value, 1);
+            metadataDb.Set(key, value);
+        }
+
+        if (patriciaHasData)
+            container.ResolveKeyed<IDb>(DbNames.State).Set(Bytes.FromHexString("0000000000000001"), [1]);
 
         IWorldStateManager worldStateManager = container.Resolve<IWorldStateManager>();
 
-        if (flatEnabled)
+        if (expectFlat)
             worldStateManager.Should().BeOfType<FlatWorldStateManager>();
         else
             worldStateManager.Should().NotBeOfType<FlatWorldStateManager>();

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -908,7 +908,8 @@
           "Nethermind.Network.Dns": "[1.39.0-unstable, )",
           "Nethermind.Network.Enr": "[1.39.0-unstable, )",
           "Nethermind.Specs": "[1.39.0-unstable, )",
-          "Nethermind.State.Flat": "[1.39.0-unstable, )"
+          "Nethermind.State.Flat": "[1.39.0-unstable, )",
+          "Nethermind.Synchronization": "[1.39.0-unstable, )"
         }
       },
       "nethermind.init.snapshot": {

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -19,7 +19,6 @@ namespace Nethermind.State.Flat.Sync.Snap;
 /// </summary>
 public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfig, ILogManager logManager) : ISnapTrieFactory
 {
-    // Flat state can always serve snap requests. Enable it by default unless the user explicitly disabled it.
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapTrieFactory>();
 
     public void EnsureInitialize()

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -19,6 +19,7 @@ namespace Nethermind.State.Flat.Sync.Snap;
 /// </summary>
 public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfig, ILogManager logManager) : ISnapTrieFactory
 {
+    // Flat state can always serve snap requests. Enable it by default unless the user explicitly disabled it.
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapTrieFactory>();
 
     public void EnsureInitialize()

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -13,7 +13,6 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Specs.ChainSpecStyle;
-using Nethermind.State.Healing;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -26,7 +25,6 @@ using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Synchronization.StateSync;
-using Nethermind.Synchronization.Trie;
 
 namespace Nethermind.Synchronization
 {
@@ -409,6 +407,7 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         serviceCollection
             .AddSingleton<ProgressTracker>()
+            .AddSingleton<ISnapTrieFactory, PatriciaSnapTrieFactory>()
             .AddSingleton<ISnapProvider, SnapProvider>()
             .AddSingleton<ISimpleSyncFeed<SnapSyncBatch>, SnapSyncFeed>()
             .AddSingleton<ISyncDownloader<SnapSyncBatch>, SnapSyncDownloader>()
@@ -466,6 +465,7 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         serviceCollection
             .AddSingleton<IStateSyncPivot, StateSyncPivot>()
+            .AddSingleton<ITreeSyncStore, PatriciaTreeSyncStore>()
             .AddSingleton<TreeSync>()
             .AddSingleton<ISimpleSyncFeed<StateSyncBatch>, StateSyncFeed>()
             .AddSingleton<ISyncDownloader<StateSyncBatch>, StateSyncDownloader>()

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -304,7 +304,6 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .AddSingleton<ISyncModeSelector, MultiSyncModeSelector>()
             .AddSingleton<ISyncProgressResolver, SyncProgressResolver>()
             .AddSingleton<ISyncReport, SyncReport>()
-            .AddSingleton<IFullStateFinder, FullStateFinder>()
             .AddSingleton<SyncDbTuner>()
             .AddSingleton<MallocTrimmer>()
             .AddSingleton<ISyncPointers, SyncPointers>()
@@ -356,12 +355,6 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .AddSingleton<SyncPeerPool>()
                 .Bind<ISyncPeerPool, SyncPeerPool>()
                 .Bind<IPeerDifficultyRefreshPool, SyncPeerPool>()
-
-            .AddSingleton<IPathRecovery, ISyncPeerPool, INodeStorage, ILogManager>((peerPool, nodeStorage, logManager) => new PathNodeRecovery(
-                new NodeDataRecovery(peerPool!, nodeStorage, logManager),
-                new SnapRangeRecovery(peerPool!, logManager),
-                logManager
-            ))
 
             .AddSingleton<ISyncServer, SyncServer>();
 
@@ -416,7 +409,6 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         serviceCollection
             .AddSingleton<ProgressTracker>()
-            .AddSingleton<ISnapTrieFactory, PatriciaSnapTrieFactory>()
             .AddSingleton<ISnapProvider, SnapProvider>()
             .AddSingleton<ISimpleSyncFeed<SnapSyncBatch>, SnapSyncFeed>()
             .AddSingleton<ISyncDownloader<SnapSyncBatch>, SnapSyncDownloader>()
@@ -474,7 +466,6 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
     {
         serviceCollection
             .AddSingleton<IStateSyncPivot, StateSyncPivot>()
-            .AddSingleton<ITreeSyncStore, PatriciaTreeSyncStore>()
             .AddSingleton<TreeSync>()
             .AddSingleton<ISimpleSyncFeed<StateSyncBatch>, StateSyncFeed>()
             .AddSingleton<ISyncDownloader<StateSyncBatch>, StateSyncDownloader>()


### PR DESCRIPTION
## Summary

- Introduce `FlatStateActivationPolicy` that decides at startup which state backend to activate using five ordered checks: flat disabled → patricia; flat DB has committed state → flat; `ImportFromPruningTrieState` configured → flat; patricia DB has data → patricia; fresh node → flat. Logs the selected backend and reason at startup.
- Add `WorldStateDbDeciderModule` that loads both backend modules unconditionally and dispatches all five overlapping world-state interfaces (`IWorldStateManager`, `IPruningTrieStateAdminRpcModule`, `ISnapTrieFactory`, `ITreeSyncStore`, `IFullStateFinder`) to the winner using `Func<T>` lazy factories — the unused backend's heavy components never instantiate.
- Remove the `if (flatDbConfig.Enabled) … else …` branch in `NethermindModule`, making it safe to flip `IFlatDbConfig.Enabled = true` by default in a follow-up PR without silently breaking existing patricia-synced nodes.

## Type of change

- [x] Refactoring (no functional changes, no API changes)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- New parameterized unit test `FlatStateActivationPolicyTests` covers all five decision branches.
- Existing `FullPruningDiskTest`, `EthRpcModuleTests`, and `Nethermind.State.Flat.Test` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)