### PR TITLE
fix: mark top-level CREATE account for selfdestruct state gas refund

### DIFF
--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -87,6 +87,9 @@ public struct StackAccessTracker() : IDisposable
     public readonly void RecordAccountCreated(Address address)
         => _trackingState.StateGas.RecordAccountCreated(address);
 
+    public readonly void MarkAccountCreatedForRefund(Address address)
+        => _trackingState.StateGas.MarkAccountCreatedForRefund(address);
+
     public readonly void RecordCodeDeposit(Address address, int codeLength)
         => _trackingState.StateGas.RecordCodeDeposit(address, codeLength);
 

--- a/src/Nethermind/Nethermind.Evm/StateGasTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StateGasTracker.cs
@@ -69,6 +69,9 @@ internal sealed class StateGasTracker
     public void RecordAccountCreated(Address address)
         => _changes.Add(new StateChange { Kind = StateChangeKind.AccountCreated, Address = address });
 
+    public void MarkAccountCreatedForRefund(Address address)
+        => _createdAccounts.Add(address);
+
     public void RecordCodeDeposit(Address address, int codeLength)
     {
         if (codeLength <= 0) return;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1134,9 +1134,19 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
             //     For the FastCall path that's done at EvmInstructions.Call.cs by recording on
             //     vm.VmState.AccessTracker (the caller). For full-frame CALL we'd need to fire
             //     on the parent before the inner snapshot is taken; deferring that for now.
-            if (spec.IsEip8037Enabled && wasCreated && !vmState.IsTopLevel && vmState.ExecutionType.IsAnyCreate())
+            if (spec.IsEip8037Enabled && wasCreated && vmState.ExecutionType.IsAnyCreate())
             {
-                vmState.AccessTracker.RecordAccountCreated(env.ExecutingAccount);
+                if (vmState.IsTopLevel)
+                {
+                    // Top-level CREATE pays via intrinsic createStateCost — don't record a
+                    // state change (would double-charge), but DO mark the account as created
+                    // so GetSelfDestructStateRefund can refund it if the initcode selfdestructs.
+                    vmState.AccessTracker.MarkAccountCreatedForRefund(env.ExecutingAccount);
+                }
+                else
+                {
+                    vmState.AccessTracker.RecordAccountCreated(env.ExecutingAccount);
+                }
             }
 
             // For contract creation calls, increment the nonce if the specification requires it.


### PR DESCRIPTION
Top-level CREATE transactions pay account creation state gas via intrinsic createStateCost, so RecordAccountCreated was skipped to avoid double-charging. But GetSelfDestructStateRefund checks _createdAccounts — when the initcode selfdestructs, the refund was zero because the account wasn't tracked.

Add MarkAccountCreatedForRefund that registers the account in _createdAccounts without recording a state change, so the selfdestruct refund path works correctly.

Fixes: test_selfdestruct_in_create_tx_initcode

Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
