### PR TITLE
ci: bump NuGet cache key to evict corrupt Windows entries

### DIFF
--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -105,8 +105,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.project }}
         id: test
@@ -164,8 +164,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -89,8 +89,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.project }}
         id: test

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -106,8 +106,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.project }}
         id: test
@@ -187,8 +187,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -267,8 +267,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+          key: nuget-v2-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-v2-${{ runner.os }}-
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test


### PR DESCRIPTION
## Changes

- Bumps the `actions/cache@v5` key prefix from `nuget-` to `nuget-v2-` (both `key` and `restore-keys`) in `nethermind-tests.yml`, `nethermind-tests-flat.yml`, and `nethermind-tests-checked.yml`.

## Why

Windows shards have been failing on the `Cache NuGet packages` step with a "Cache hit" log followed by a 2-second silent failure and every downstream test step skipped — e.g. [run 25106465684, job 73568875126](https://github.com/NethermindEth/nethermind/actions/runs/25106465684/job/73568875126?pr=11401). Root cause is [actions/cache#1729](https://github.com/actions/cache/issues/1729): an earlier run that got cancelled mid-save wrote a corrupt TAR under the cached key, and on Windows the TAR extraction fails silently for every subsequent restore against that key.

Re-running the workflow doesn't help — the same poisoned key gets restored every time. Bumping the prefix routes future runs to a fresh storage slot. The first job per OS misses and seeds a clean entry; subsequent jobs hit the new healthy cache. Old `nuget-` entries become unreachable and GitHub will evict them via the 7-day no-access policy.

`restore-keys` is bumped together with `key` so that an exact-key miss can't fall back into the poisoned `nuget-` entry.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

CI itself exercises this — the first PR run will miss and reseed; subsequent runs will validate the new cache.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No