### PR TITLE
perf(state): drive storage trie warm-up from writes via HintSet

### DIFF
--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -81,8 +81,6 @@ public interface IWorldStateScopeProvider
 
         byte[] Get(in UInt256 index);
 
-        void HintGet(in UInt256 index, byte[]? value);
-
         /// <summary>
         /// Hint that a slot is being written. Backends may use this to start asynchronous
         /// trie warm-up for the slot path.

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -84,6 +84,12 @@ public interface IWorldStateScopeProvider
         void HintGet(in UInt256 index, byte[]? value);
 
         /// <summary>
+        /// Hint that a slot is being written. Backends may use this to start asynchronous
+        /// trie warm-up for the slot path.
+        /// </summary>
+        void HintSet(in UInt256 index, byte[]? value);
+
+        /// <summary>
         /// Used by JS tracer. May not work on some database layout.
         /// </summary>
         /// <param name="hash"></param>

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -86,10 +86,6 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
     // (~30-40% of accesses per @weiihann's analysis) never need their trie path warmed because
     // they don't trigger commit-time tree updates. Warm-up is driven from HintSet on the write
     // path instead.
-    public void HintGet(in UInt256 index, byte[]? value)
-    {
-    }
-
     public void HintSet(in UInt256 index, byte[]? value) => WarmUpSlot(index);
 
     private void WarmUpSlot(UInt256 index)

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -79,17 +79,18 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
             }
         }
 
-        HintGet(index, value);
-
         return value!;
     }
 
-    // Note: VERY hot code.
-    // 90% of the read goes through prewarmer, not actually go through this class, meaning this method is called
-    // a lot. Setting the set slot have a measurable net negative impact on performance.
-    // Trying to set this value async through trie warmer proved to be hard to pull of and result in random invalid
-    // block.
-    public void HintGet(in UInt256 index, byte[]? value) => WarmUpSlot(index);
+    // Reads do not warm the trie: most reads come through the prewarmer, and read-only slots
+    // (~30-40% of accesses per @weiihann's analysis) never need their trie path warmed because
+    // they don't trigger commit-time tree updates. Warm-up is driven from HintSet on the write
+    // path instead.
+    public void HintGet(in UInt256 index, byte[]? value)
+    {
+    }
+
+    public void HintSet(in UInt256 index, byte[]? value) => WarmUpSlot(index);
 
     private void WarmUpSlot(UInt256 index)
     {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -453,6 +453,12 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             {
                 valueChanges = new StorageChangeTrace(valueChanges.Before, value);
             }
+
+            if (!storageCell.IsHash)
+            {
+                EnsureStorageTree();
+                _backend.HintSet(storageCell.Index, value);
+            }
         }
 
         public ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -205,8 +205,6 @@ public class PrewarmerScopeProvider(
             }
         }
 
-        public void HintGet(in UInt256 index, byte[]? value) => baseStorageTree.HintGet(in index, value);
-
         public void HintSet(in UInt256 index, byte[]? value) => baseStorageTree.HintSet(in index, value);
 
         private byte[] LoadFromTreeStorage(in StorageCell storageCell)

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -194,7 +194,6 @@ public class PrewarmerScopeProvider(
                 if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
                 {
                     if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    baseStorageTree.HintGet(in index, value);
                     Db.Metrics.IncrementStorageTreeCache();
                 }
                 else
@@ -207,6 +206,8 @@ public class PrewarmerScopeProvider(
         }
 
         public void HintGet(in UInt256 index, byte[]? value) => baseStorageTree.HintGet(in index, value);
+
+        public void HintSet(in UInt256 index, byte[]? value) => baseStorageTree.HintSet(in index, value);
 
         private byte[] LoadFromTreeStorage(in StorageCell storageCell)
         {

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -142,6 +142,10 @@ namespace Nethermind.State
         {
         }
 
+        public void HintSet(in UInt256 index, byte[]? value)
+        {
+        }
+
         public byte[] Get(in ValueHash256 hash) => GetArray(in hash, null);
 
         [SkipLocalsInit]

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -138,10 +138,6 @@ namespace Nethermind.State
 
         public byte[] Get(in UInt256 index) => Get(index, null);
 
-        public void HintGet(in UInt256 index, byte[]? value)
-        {
-        }
-
         public void HintSet(in UInt256 index, byte[]? value)
         {
         }

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -75,6 +75,8 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
 
         public void HintGet(in UInt256 index, byte[]? value) => storageTree.HintGet(in index, value);
 
+        public void HintSet(in UInt256 index, byte[]? value) => storageTree.HintSet(in index, value);
+
         public byte[] Get(in ValueHash256 hash)
         {
             byte[]? bytes = storageTree.Get(in hash);

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -73,8 +73,6 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
             return bytes;
         }
 
-        public void HintGet(in UInt256 index, byte[]? value) => storageTree.HintGet(in index, value);
-
         public void HintSet(in UInt256 index, byte[]? value) => storageTree.HintSet(in index, value);
 
         public byte[] Get(in ValueHash256 hash)


### PR DESCRIPTION
## Changes

Follow-up to #11317. Move flat-DB storage trie warm-up from the read path to the write path:

- Add `IStorageTree.HintSet(in UInt256, byte[]?)` alongside the existing `HintGet`.
- `FlatStorageTree.HintGet` becomes a no-op; `HintSet` runs the existing `WarmUpSlot` logic.
- `PersistentStorageProvider.PerContractState.SaveChange` calls `HintSet` so only slots that are actually written schedule trie warm-up jobs.
- Drop the now-useless `baseStorageTree.HintGet` call from the storage cache-hit path in `PrewarmerScopeProvider`.
- Forward `HintSet` through `PrewarmerScopeProvider` and `WorldStateScopeOperationLogger`.
- Add a no-op `HintSet` on the non-flat `StorageTree`.

Account-level `HintGet` (`IScope.HintGet(Address, Account?)`) is unchanged — it stays on the read path.

### Why

Per @weiihann's analysis, ~30–40% of storage slot accesses are read-only and don't trigger commit-time tree updates, so warming the trie for them is wasted CPU. Driving warm-up from writes preserves the savings for read-write slots (the dominant 60–70%) while skipping the read-only tail.

A previous attempt to do this (commit `5365f74f42`) was reverted (`69a5d95d7c`) after isolated benchmarks were neutral-to-regressive: write-side hints arrive *later* than read-side hints, leaving the `TrieWarmer` less lead time before commit and making commit time more variable. Recent runs by @kamil show a marginal improvement, and this is expected to scale into a clearer win as state grows.

### Result

<img width="2632" height="1620" alt="image" src="https://github.com/user-attachments/assets/f59103a7-fb88-4b4a-83d0-86b4100ffada" />

- Graph is Before,After,Before,After,
- Storage rlp read op cut in half and at rocksdb level its 20% (many recent rlp read).
- CPU per block reduced slightly and mgas/sec increased slightly.
- Doing the same with account effectively disable state trie warming and causes regression, albeit also small.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Existing focused suites pass locally:

- `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj -c release --no-build` — 313 passed, 4 skipped
- `dotnet test --project src/Nethermind/Nethermind.State.Test/Nethermind.State.Test.csproj -c release --no-build` — 777 passed, 3 skipped
- `dotnet test --project src/Nethermind/Nethermind.Consensus.Test/Nethermind.Consensus.Test.csproj -c release --no-build -- --filter FullyQualifiedName~BlockCachePreWarmerTests` — 12 passed
- `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj -c release --no-build -- --filter FullyQualifiedName~TrieWarmerTests` — 3 passed

EXPB reproducible-benchmark validation pending — comparing against master mean and the PR #11317 baseline (run `24829908301`, mean `35.86 ms`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Draft because EXPB results are still needed to confirm this is a net improvement on this branch. If the move is again neutral-to-regressive on its own, the change may still be desirable as the state subsystem grows (bigger tries → more CPU per warm-up → larger absolute savings from skipping read-only warm-ups), but that should be an explicit call rather than implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)