### PR TITLE
fix(fastsync): clean flat storage when account is null in `VerifyStorageUpdated`

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -225,8 +225,9 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
     public void EnsureStorageEmpty(Hash256 address)
     {
         // Only need to clean flat storage entries. Orphaned storage trie nodes are not a problem
-        // because the trie is always traversed from the account's storage root hash — if the root
-        // is EmptyTreeHash, no storage trie nodes will ever be reached.
+        // because the trie is always traversed from the account's storage root hash — when the
+        // account has EmptyTreeHash or the account no longer exists, no storage trie nodes will
+        // ever be reached.
         using IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
         ValueHash256 addressHash = address.ValueHash256;
         writeBatch.DeleteStorageRange(addressHash, ValueKeccak.Zero, ValueKeccak.MaxValue);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -488,6 +488,42 @@ namespace Nethermind.Synchronization.Test.FastSync
             clearedAddresses.Should().Contain(TestItem.KeccakA, "EnsureStorageEmpty should be called for account with empty storage root in UpdatedStorages");
         }
 
+        [Test]
+        [Repeat(TestRepeatCount)]
+        public async Task RepairDeletedAccount_calls_EnsureStorageEmpty()
+        {
+            RemoteDbContext remote = new(_logManager);
+
+            // Final state has no record of KeccakA — account was removed (e.g. SELFDESTRUCT).
+            // KeccakB exists so the state tree is not entirely empty.
+            StateTree state = remote.StateTree;
+            state.Set(TestItem.KeccakB, Build.An.Account.WithNonce(2).TestObject);
+            state.Commit();
+
+            List<Hash256> clearedAddresses = new();
+
+            await using IContainer container = PrepareDownloader(remote, configureBuilder: builder =>
+            {
+                builder.AddDecorator<ITreeSyncStore>((ctx, inner) =>
+                    new TrackingTreeSyncStore(inner, clearedAddresses));
+            });
+            IStateSyncTestOperation local = container.Resolve<IStateSyncTestOperation>();
+
+            local.SetAccountsAndCommit(
+                (TestItem.KeccakB, Build.An.Account.WithNonce(2).TestObject));
+
+            local.DeleteStateRoot();
+
+            // Earlier sync wrote storage for KeccakA before the account was deleted upstream.
+            container.Resolve<StateSyncPivot>().UpdatedStorages.Add(TestItem.KeccakA);
+
+            SafeContext ctx = container.Resolve<SafeContext>();
+            await ActivateAndWait(ctx);
+
+            local.CompareTrees(remote, _logger, "END");
+            clearedAddresses.Should().Contain(TestItem.KeccakA, "EnsureStorageEmpty should be called when the account no longer exists in final state");
+        }
+
         private class TrackingTreeSyncStore(ITreeSyncStore inner, List<Hash256> clearedAddresses) : ITreeSyncStore
         {
             public bool NodeExists(Hash256? address, in TreePath path, in ValueHash256 hash) => inner.NodeExists(address, path, hash);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -746,14 +746,16 @@ namespace Nethermind.Synchronization.FastSync
             {
                 Account? account = verificationContext.GetAccount(updatedAddress);
 
-                if (account?.StorageRoot == Keccak.EmptyTreeHash)
+                // Account may be null if it was deleted in the final state. In both the deleted
+                // and empty-storage-root cases, any flat storage entries written earlier in sync
+                // must be cleared to avoid stale slots.
+                if (account is null || account.StorageRoot == Keccak.EmptyTreeHash)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} is empty, ensuring flat storage cleared");
+                    if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} is empty or account deleted, ensuring flat storage cleared");
                     _store.EnsureStorageEmpty(updatedAddress);
                     dependentItem.Counter--;
                 }
-                else if (account?.StorageRoot is not null
-                    && AddNodeToPending(new StateSyncItem(account.StorageRoot, updatedAddress, TreePath.Empty, NodeDataType.Storage), dependentItem, "incomplete storage") == AddNodeResult.Added)
+                else if (AddNodeToPending(new StateSyncItem(account.StorageRoot, updatedAddress, TreePath.Empty, NodeDataType.Storage), dependentItem, "incomplete storage") == AddNodeResult.Added)
                 {
                     if (_logger.IsDebug) _logger.Debug($"Storage {updatedAddress} missing correct storage root {account.StorageRoot}");
                 }


### PR DESCRIPTION
`VerifyStorageUpdated` skip flat storage cleanup when an address in `UpdatedStorages` no longer has an account It only branches on `account?.StorageRoot == EmptyTreeHash`; a deleted account (`account is null`) falls through to the "Storage is ok" path and leaves stale flat slots from earlier sync downloads. Treat `account is null` the same as an empty storage root and call `EnsureStorageEmpty`. Adds `RepairDeletedAccount_calls_EnsureStorageEmpty` regression test and broadens the `EnsureStorageEmpty` comment to cover both cases.