### PR TITLE
fix(flat-db): skip ImportFlatDb when pruning trie state lacks head root

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
@@ -8,10 +8,12 @@ using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State.Flat;
 using Nethermind.State.Flat.Persistence;
+using Nethermind.Trie;
 
 namespace Nethermind.Init.Steps;
 
@@ -22,6 +24,7 @@ namespace Nethermind.Init.Steps;
 public class ImportFlatDb(
     IBlockTree blockTree,
     IPersistence persistence,
+    INodeStorage nodeStorage,
     Importer importer,
     IProcessExitSource exitSource,
     IFlatDbConfig flatDbConfig,
@@ -52,6 +55,14 @@ public class ImportFlatDb(
                 if (_logger.IsInfo) _logger.Info("Flat db already exist");
                 return;
             }
+        }
+
+        if (head.StateRoot is null ||
+            !nodeStorage.KeyExists(null, TreePath.Empty, new ValueHash256(head.StateRoot.Bytes)))
+        {
+            if (_logger.IsInfo) _logger.Info(
+                $"Pruning trie state does not contain head state root {head.StateRoot}; skipping flat DB import.");
+            return;
         }
 
         if (_logger.IsInfo) _logger.Info($"Copying state {head.ToString(BlockHeader.Format.Short)} with state root {head.StateRoot}");


### PR DESCRIPTION
Fixes #11418

## Changes

- `ImportFlatDb.Execute` now also guards on the **source** pruning trie node storage. If `INodeStorage` does not contain `head.StateRoot`, the step logs and returns instead of calling `Importer.Copy`.

## Why

When a user starts Nethermind with `--FlatDb.Enabled=true --FlatDb.Layout=FlatInTrie --FlatDb.ImportFromPruningTrieState=true` on a fresh DB and is interrupted before the first sync completes, the next start enters a Docker restart loop:

```
Step StepWrapper failed: Nethermind.Trie.TrieException: Missing node is not expected
  at Importer.Visitor.VisitMissingNode(...)
  at PatriciaTree.Accept(...)
  at ImportFlatDb.Execute(...)
```

The previous logic only checked the destination flat DB (`reader.CurrentState.BlockNumber > 0`). On the **first** start the step short-circuited because `blockTree.Head` was null (genesis hadn't been written yet), so the bug was hidden. On a partial-sync restart, `blockTree.Head` reloads as genesis from the persisted block tree, the destination check passes (flat DB still empty), and the importer attempts to read the genesis state root from the pruning trie node storage — which never received it, because FlatDb has been the primary state store from day one. `VisitMissingNode` throws and the runner exits.

Removing the flag breaks the loop today (the import step is no longer registered). With this fix, the flag becomes a safe no-op when there is nothing to migrate, while still functioning correctly for its intended use case (migrating an already-synced pruning trie state DB to FlatDb).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

There is no existing test project for `Nethermind.Init` steps; adding one would be out of scope for this fix. Manual reproduction of the original issue:

1. Start a fresh node with `--FlatDb.Enabled=true --FlatDb.Layout=FlatInTrie --FlatDb.ImportFromPruningTrieState=true`.
2. Stop before sync completes.
3. Restart with the same flags. With the fix, the log shows `Pruning trie state does not contain head state root … skipping flat DB import.` and sync resumes normally; without the fix, the runner crashes with `TrieException: Missing node is not expected`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

`--FlatDb.ImportFromPruningTrieState=true` no longer crashes a node that has FlatDb as the primary state store and is restarted mid-sync; the option is now a no-op when the pruning trie state DB has nothing to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)