### PR TITLE
fix(state): honour SELFDESTRUCT marker in PerContractState.StorageRoot

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/SelfDestructCreate2SameBlockTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/SelfDestructCreate2SameBlockTests.cs
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+using Nethermind.Core.Container;
+
+namespace Nethermind.Blockchain.Test;
+
+/// <summary>
+/// Regression tests for the metamorphic-contract bug observed on Sepolia block 4913057
+/// (Shanghai-era, archive node, prewarming enabled).
+///
+/// In that block, transaction 45 (sender 0x0c27…) called SELFDESTRUCT on contract
+/// X (= 0x140da4…9372). Transaction 57 (sender 0xf93bab…) sent 0.001 ETH to X,
+/// creating an empty account at the destroyed address. Transaction 58 (same sender
+/// 0xf93bab…) called the metamorphic factory at 0x030a571…d25 to redeploy at X
+/// via CREATE2 → transient → CREATE → X.
+///
+/// On Nethermind 1.37.1 the redeploy reverts: CREATE inside the transient sees X
+/// as still having code and returns address(0), so the factory's
+/// `require(deployed != 0)` fails. The same tx executed via debug_traceCall against
+/// the parent state (i.e. without applying the SELFDESTRUCT) reproduces the
+/// identical wrong gas usage (0x17a758) and revert message, which means the
+/// SELFDESTRUCT effect from tx 45 is not visible to tx 58 during real block
+/// processing.
+///
+/// These tests reproduce the scenario at the BlockProcessor level (block production
+/// + validation, prewarming enabled by default) on TestBlockchain.
+/// </summary>
+[Parallelizable(ParallelScope.All)]
+public class SelfDestructCreate2SameBlockTests
+{
+    /// <summary>
+    /// Two-tx variant: SELFDESTRUCT then CREATE2 redeploy, different senders.
+    /// </summary>
+    [Test]
+    public async Task Redeploy_via_CREATE2_succeeds_when_destroy_and_redeploy_have_different_senders()
+    {
+        await RunRedeployScenario(includeIntermediateValueTransfer: false);
+    }
+
+    /// <summary>
+    /// Three-tx variant matching the actual Sepolia 4913057 layout: SELFDESTRUCT,
+    /// then a value-transfer to the destroyed address (creates an empty account),
+    /// then CREATE2-based redeploy.
+    /// </summary>
+    [Test]
+    public async Task Redeploy_via_CREATE2_succeeds_after_value_transfer_recreates_account()
+    {
+        await RunRedeployScenario(includeIntermediateValueTransfer: true);
+    }
+
+    private static async Task RunRedeployScenario(bool includeIntermediateValueTransfer)
+    {
+        // Use Shanghai (pre-Cancun) so SELFDESTRUCT fully wipes the account
+        // — matches the failing real-world block (Sepolia 4913057, Dec 2023).
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Shanghai.Instance);
+
+        using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder =>
+        {
+            builder.AddSingleton(specProvider);
+        });
+
+        // Code that, when called by anyone, immediately self-destructs to msg.sender.
+        // 0x33 = CALLER, 0xff = SELFDESTRUCT.
+        byte[] selfDestructCode = [0x33, 0xff];
+        byte[] selfDestructInit = Prepare.EvmCode.ForInitOf(selfDestructCode).Done;
+
+        // Factory bytecode: when called, runs CREATE2(value=msg.value, offset=0, len, salt=0)
+        // over a copy of `selfDestructInit` placed in memory. ForCreate2Of pushes salt=0.
+        byte[] factoryRuntime = Prepare.EvmCode.ForCreate2Of(selfDestructInit).Done;
+        byte[] factoryInit = Prepare.EvmCode.ForInitOf(factoryRuntime).Done;
+
+        EthereumEcdsa ecdsa = new(specProvider.ChainId);
+        long gasLimit = 1_000_000;
+
+        // ---- Block 1: A deploys factory ------------------------------------------------
+        Transaction deployFactoryTx = Build.A.Transaction
+            .WithCode(factoryInit)
+            .WithGasLimit(gasLimit)
+            .WithNonce(0)
+            .WithGasPrice(20)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyA, isEip155Enabled: true).TestObject;
+
+        Address factoryAddr = ContractAddress.From(TestItem.AddressA, 0);
+        Address selfDestructAddr = ContractAddress.From(factoryAddr, new byte[32], selfDestructInit);
+
+        await chain.AddBlock(deployFactoryTx);
+
+        // ---- Block 2: A calls factory → first metamorphic deploy at selfDestructAddr ----
+        Transaction firstDeployTx = Build.A.Transaction
+            .To(factoryAddr)
+            .WithGasLimit(gasLimit)
+            .WithNonce(1)
+            .WithGasPrice(20)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyA, isEip155Enabled: true).TestObject;
+
+        await chain.AddBlock(firstDeployTx);
+
+        // Sanity: contract exists at selfDestructAddr with the expected code.
+        chain.StateReader.TryGetAccount(chain.BlockTree.Head!.Header, selfDestructAddr, out var preAcct)
+            .Should().BeTrue("setup must place the metamorphic contract at the expected address");
+        chain.StateReader.GetCode(preAcct.CodeHash).Should().Equal(selfDestructCode,
+            "setup must have deployed the 0x33ff self-destruct stub");
+
+        // ---- Test block: destroy + (optional value-transfer) + redeploy --------------
+        // tx0 (A → X): triggers SELFDESTRUCT.
+        // tx1 (C → X) optional: sends 1 wei to recreate an empty account at X (mirrors
+        //                       user's tx 0x39 which transferred 0.001 ETH to the
+        //                       destroyed contract before redeployment).
+        // txLast (B → factory):  CREATE2-redeploy at X. Different sender from destroy.
+        Transaction destroyTx = Build.A.Transaction
+            .To(selfDestructAddr)
+            .WithGasLimit(gasLimit)
+            .WithNonce(2)
+            .WithGasPrice(100)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyA, isEip155Enabled: true).TestObject;
+
+        Transaction redeployTx = Build.A.Transaction
+            .To(factoryAddr)
+            .WithGasLimit(gasLimit)
+            .WithNonce(0)
+            .WithGasPrice(50)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyB, isEip155Enabled: true).TestObject;
+
+        Block testBlock;
+        TxReceipt[] receipts;
+
+        if (includeIntermediateValueTransfer)
+        {
+            // Same sender (B) for the value-transfer AND the redeploy, matching the
+            // real Sepolia tx pattern where 0xf93bab… did both tx 0x39 and tx 0x3a.
+            // This places both into the same prewarmer sender-group so the cache
+            // populates from parent state with selfDestructAddr still having code,
+            // and the redeploy's prewarming pre-execution sees the OLD account.
+            Transaction valueTx = Build.A.Transaction
+                .To(selfDestructAddr)
+                .WithGasLimit(GasCostOf.Transaction)
+                .WithValue(1)
+                .WithNonce(0)
+                .WithGasPrice(75)
+                .SignedAndResolved(ecdsa, TestItem.PrivateKeyB, isEip155Enabled: true).TestObject;
+
+            Transaction redeployTxAfterValueTransfer = Build.A.Transaction
+                .To(factoryAddr)
+                .WithGasLimit(gasLimit)
+                .WithNonce(1)
+                .WithGasPrice(50)
+                .SignedAndResolved(ecdsa, TestItem.PrivateKeyB, isEip155Enabled: true).TestObject;
+
+            testBlock = await chain.AddBlock(destroyTx, valueTx, redeployTxAfterValueTransfer);
+
+            testBlock.Transactions.Length.Should().Be(3, "test block must contain all three txs");
+            testBlock.Transactions[0].Hash!.Should().Be(destroyTx.Hash!, "destroy tx must be first");
+            testBlock.Transactions[1].Hash!.Should().Be(valueTx.Hash!, "value-transfer tx must be second");
+            testBlock.Transactions[2].Hash!.Should().Be(redeployTxAfterValueTransfer.Hash!, "redeploy tx must be last");
+
+            receipts = chain.ReceiptStorage.Get(testBlock);
+            receipts[0].StatusCode.Should().Be(StatusCode.Success, "destroy tx must succeed");
+            receipts[1].StatusCode.Should().Be(StatusCode.Success, "value-transfer tx must succeed");
+            receipts[2].StatusCode.Should().Be(StatusCode.Success,
+                "redeploy tx must succeed — if it reverts, the SELFDESTRUCT effect from the destroy tx is not visible to the redeploy");
+        }
+        else
+        {
+            testBlock = await chain.AddBlock(destroyTx, redeployTx);
+
+            testBlock.Transactions.Length.Should().Be(2, "test block must contain both txs");
+            testBlock.Transactions[0].Hash!.Should().Be(destroyTx.Hash!, "destroy tx must be first");
+            testBlock.Transactions[1].Hash!.Should().Be(redeployTx.Hash!, "redeploy tx must be second");
+
+            receipts = chain.ReceiptStorage.Get(testBlock);
+            receipts[0].StatusCode.Should().Be(StatusCode.Success, "destroy tx must succeed");
+            receipts[1].StatusCode.Should().Be(StatusCode.Success,
+                "redeploy tx must succeed — if it reverts, the SELFDESTRUCT effect from the destroy tx is not visible to the redeploy");
+        }
+
+        // Final state: contract redeployed at the same address with the same code.
+        chain.StateReader.TryGetAccount(chain.BlockTree.Head!.Header, selfDestructAddr, out var postAcct)
+            .Should().BeTrue("contract must exist at the metamorphic address after redeploy");
+        chain.StateReader.GetCode(postAcct.CodeHash).Should().Equal(selfDestructCode,
+            "redeployed code must equal the metamorphic stub");
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/SelfDestructPrewarmerStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SelfDestructPrewarmerStateTests.cs
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Db;
+using Nethermind.Db;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing.State;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs.Forks;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NUnit.Framework;
+
+namespace Nethermind.State.Test;
+
+/// <summary>
+/// Direct state-level probes for the same-block SELFDESTRUCT + recreate pattern that
+/// failed on Sepolia block 4913057. These tests bypass block production entirely and
+/// exercise <see cref="WorldState"/> with <see cref="PrewarmerScopeProvider"/> wired
+/// the same way the main processing path wires it (cache-populating prewarmer scope
+/// + cache-consuming "main" scope sharing one <see cref="PreBlockCaches"/>).
+///
+/// They probe:
+///  1. After the prewarmer warms <c>preBlockCaches.StateCache[X] = parentAccount</c>,
+///     does the main scope's <c>IsContract(X)</c>/<c>IsNonZeroAccount(X)</c> return
+///     the post-destroy state (false) rather than the cached parent state?
+///  2. Same after a value transfer recreates the account between destroy and read,
+///     mirroring tx 0x39 → tx 0x3a in the failing block.
+/// </summary>
+[Parallelizable(ParallelScope.None)]
+public class SelfDestructPrewarmerStateTests
+{
+    private static readonly Address X = TestItem.AddressA;
+    private static readonly byte[] ContractCode = [0x33, 0xff];
+
+    private static (WorldState mainState, WorldState prewarmerState, PreBlockCaches caches, BlockHeader genesis)
+        BuildSharedCacheWorldStates()
+    {
+        // One backing TrieStore + one in-memory state DB shared by both the main and
+        // prewarmer scopes (they each take their own resettable scope on top of it).
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        PruningConfig pruningConfig = new();
+        TestFinalizedStateProvider finalized = new(pruningConfig.PruningBoundary);
+        TrieStore trieStore = new(
+            new NodeStorage(dbProvider.StateDb),
+            No.Pruning,
+            Persist.EveryBlock,
+            finalized,
+            pruningConfig,
+            LimboLogs.Instance);
+        finalized.TrieStore = trieStore;
+
+        TrieStoreScopeProvider baseProvider = new(trieStore, dbProvider.CodeDb, LimboLogs.Instance);
+        PreBlockCaches caches = new();
+
+        // Pre-genesis: place the contract X with code and seed slot 7 = 7 (so we can
+        // observe storage clearing too).
+        WorldState seedState = new(baseProvider, LimboLogs.Instance);
+        Hash256 seedStateRoot;
+        using (seedState.BeginScope(IWorldState.PreGenesis))
+        {
+            seedState.CreateAccount(X, Unit.Ether);
+            seedState.InsertCode(X, ContractCode, Shanghai.Instance);
+            seedState.Set(new StorageCell(X, 7), new byte[] { 7 });
+            seedState.Commit(Shanghai.Instance);
+            seedState.CommitTree(0);
+            seedStateRoot = seedState.StateRoot;
+        }
+
+        BlockHeader genesis = Build.A.BlockHeader.WithStateRoot(seedStateRoot).WithNumber(0).TestObject;
+
+        WorldState mainState = new(
+            new PrewarmerScopeProvider(baseProvider, caches, populatePreBlockCache: false),
+            LimboLogs.Instance);
+
+        WorldState prewarmerState = new(
+            new PrewarmerScopeProvider(baseProvider, caches, populatePreBlockCache: true),
+            LimboLogs.Instance);
+
+        return (mainState, prewarmerState, caches, genesis);
+    }
+
+    [Test]
+    public void Main_scope_sees_destroyed_account_even_with_prewarmed_cache()
+    {
+        (WorldState mainState, WorldState prewarmerState, PreBlockCaches caches, BlockHeader genesis) = BuildSharedCacheWorldStates();
+
+        // Step 1: prewarmer reads X — populates caches.StateCache with parentAccount (with code).
+        using (prewarmerState.BeginScope(genesis))
+        {
+            prewarmerState.IsContract(X).Should().BeTrue("contract has code at parent state");
+            prewarmerState.GetCode(X).Should().Equal(ContractCode);
+        }
+        caches.StateCache.TryGetValue((AddressAsKey)X, out Account? cached).Should().BeTrue("prewarmer should have populated state cache");
+        cached!.HasCode.Should().BeTrue("cached parent account must have code");
+
+        // Step 2: main scope simulates tx0 (destroy) and then reads.
+        using (mainState.BeginScope(genesis))
+        {
+            // tx0: destroy
+            mainState.ClearStorage(X);
+            mainState.DeleteAccount(X);
+            mainState.Commit(Shanghai.Instance, NullStateTracer.Instance, isGenesis: false, commitRoots: false);
+
+            // tx1 begins: collision-relevant probes.
+            mainState.AccountExists(X).Should().BeFalse("X must not exist after destroy + commit");
+            mainState.IsContract(X).Should().BeFalse("X must not be a contract after destroy + commit");
+
+            // EIP-684/7610 collision check uses IsNonZeroAccount (in WorldState):
+            bool nonZero = mainState.IsNonZeroAccount(X, out bool exists);
+            exists.Should().BeFalse("AccountExists must be false");
+            nonZero.Should().BeFalse("IsNonZeroAccount must be false → CREATE may proceed");
+        }
+    }
+
+    /// <summary>
+    /// Regression for the actual Sepolia 4913057 fault. <see cref="IWorldState.IsNonZeroAccount"/>
+    /// is a default interface method that, on a class that does not provide its own
+    /// <c>IAccountStateProvider.IsStorageEmpty</c>/<c>TryGetAccount</c> (e.g. <c>ParallelWorldState</c>
+    /// wrapping <c>WorldState</c>), routes through the default <c>IAccountStateProvider.IsStorageEmpty</c>
+    /// which calls <c>TryGetAccount</c>. <see cref="WorldState.IAccountStateProvider.TryGetAccount"/>
+    /// builds the <see cref="AccountStruct"/> by calling <c>_persistentStorageProvider.GetStorageRoot</c>,
+    /// and that method does NOT honour the same-block SELFDESTRUCT marker
+    /// (<c>PerContractState.BlockChange.HasClear</c>), unlike <c>PerContractState.IsEmpty</c>.
+    /// As a result, after a same-block destroy + recreate via value transfer the AccountStruct
+    /// carries the destroyed contract's parent <c>StorageRoot</c>, <c>IsStorageEmpty</c> returns
+    /// false, and a CREATE collides where it should not.
+    /// </summary>
+    [Test]
+    public void IsNonZeroAccount_via_IWorldState_default_returns_false_after_destroy_and_value_transfer()
+    {
+        // Use ParallelWorldState (production decorator over WorldState) so we exercise the
+        // default-interface-method dispatch path that the EVM actually hits in production.
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        PruningConfig pruningConfig = new();
+        TestFinalizedStateProvider finalized = new(pruningConfig.PruningBoundary);
+        TrieStore trieStore = new(
+            new NodeStorage(dbProvider.StateDb),
+            No.Pruning,
+            Persist.EveryBlock,
+            finalized,
+            pruningConfig,
+            LimboLogs.Instance);
+        finalized.TrieStore = trieStore;
+
+        TrieStoreScopeProvider baseProvider = new(trieStore, dbProvider.CodeDb, LimboLogs.Instance);
+        WorldState inner = new(baseProvider, LimboLogs.Instance);
+        ParallelWorldState worldState = new(inner);
+
+        // Pre-genesis: contract X with code AND non-empty storage (so its StorageRoot is non-empty).
+        Hash256 seedRoot;
+        using (worldState.BeginScope(IWorldState.PreGenesis))
+        {
+            worldState.CreateAccount(X, Unit.Ether);
+            worldState.InsertCode(X, ContractCode, Shanghai.Instance);
+            worldState.Set(new StorageCell(X, 7), new byte[] { 7 });
+            worldState.Commit(Shanghai.Instance);
+            worldState.CommitTree(0);
+            seedRoot = worldState.StateRoot;
+        }
+
+        BlockHeader genesis = Build.A.BlockHeader.WithStateRoot(seedRoot).WithNumber(0).TestObject;
+
+        using (worldState.BeginScope(genesis))
+        {
+            // Force the read that primes TrieStoreWorldStateBackendScope._loadedAccounts with
+            // the parent (with non-empty StorageRoot). The EVM's first interaction with X in
+            // tx 0x2d (the SELFDESTRUCT call) does this implicitly when it loads X's code.
+            worldState.GetCodeHash(X);
+
+            // tx 0x2d: SELFDESTRUCT.
+            worldState.ClearStorage(X);
+            worldState.DeleteAccount(X);
+            worldState.Commit(Shanghai.Instance, NullStateTracer.Instance, isGenesis: false, commitRoots: false);
+
+            // tx 0x39: value transfer recreates the empty account at X.
+            worldState.AddToBalanceAndCreateIfNotExists(X, UInt256.One, Shanghai.Instance);
+            worldState.Commit(Shanghai.Instance, NullStateTracer.Instance, isGenesis: false, commitRoots: false);
+
+            // tx 0x3a's CREATE collision check, exactly as the EVM performs it
+            // (IWorldState reference, default interface method).
+            IWorldState asInterface = worldState;
+            bool isNonZero = asInterface.IsNonZeroAccount(X, out bool exists);
+
+            exists.Should().BeTrue("X exists after value transfer");
+            isNonZero.Should().BeFalse(
+                "the new account at X has no code, zero nonce and an empty storage tree (HasClear marker); " +
+                "CREATE inside the metamorphic transient must therefore not collide");
+        }
+    }
+
+    [Test]
+    public void Main_scope_sees_recreated_account_as_collision_free_after_value_transfer()
+    {
+        (WorldState mainState, WorldState prewarmerState, PreBlockCaches caches, BlockHeader genesis) = BuildSharedCacheWorldStates();
+
+        // Step 1: prewarmer pre-populates state cache with parentAccount (has code).
+        using (prewarmerState.BeginScope(genesis))
+        {
+            prewarmerState.GetAccount(X);
+            ((IAccountStateProvider)prewarmerState).IsStorageEmpty(X).Should().BeFalse("seed has slot 7 set");
+        }
+
+        // Step 2: main scope simulates tx 0x2d (destroy), tx 0x39 (value transfer),
+        // then probes collision before tx 0x3a's CREATE.
+        using (mainState.BeginScope(genesis))
+        {
+            // tx 0x2d: SELFDESTRUCT effect at end of tx.
+            mainState.ClearStorage(X);
+            mainState.DeleteAccount(X);
+            mainState.Commit(Shanghai.Instance, NullStateTracer.Instance, isGenesis: false, commitRoots: false);
+
+            // tx 0x39: send 1 wei to X — recreates an empty account.
+            mainState.AddToBalanceAndCreateIfNotExists(X, UInt256.One, Shanghai.Instance);
+            mainState.Commit(Shanghai.Instance, NullStateTracer.Instance, isGenesis: false, commitRoots: false);
+
+            // tx 0x3a's collision check on X. The new account is a fresh
+            // empty-with-balance account: no code, no nonce, empty storage.
+            mainState.AccountExists(X).Should().BeTrue("X must exist after value transfer");
+            mainState.IsContract(X).Should().BeFalse("X must NOT have code after value transfer; cache must not pollute");
+            mainState.GetNonce(X).Should().Be((UInt256)0);
+            ((IAccountStateProvider)mainState).IsStorageEmpty(X).Should().BeTrue("storage must be empty after destroy + value transfer");
+
+            bool nonZero = mainState.IsNonZeroAccount(X, out bool exists);
+            exists.Should().BeTrue();
+            nonZero.Should().BeFalse(
+                "this is the CREATE collision check that fails on the user's node — recreate must not look like a contract");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -473,6 +473,16 @@ internal sealed class PersistentStorageProvider : PartialStorageProviderBase
         {
             get
             {
+                // Honour the same-block SELFDESTRUCT marker. Without this short-circuit, callers
+                // that build an Account/AccountStruct for the destroyed address pull the parent
+                // StorageRoot out of the trie store's _loadedAccounts cache, the resulting
+                // AccountStruct.IsStorageEmpty returns false, and the default
+                // IAccountStateProvider.IsStorageEmpty / IWorldState.IsNonZeroAccount routes
+                // (used by ParallelWorldState because it does not provide its own override) flag
+                // a phantom EIP-684/7610 collision when a metamorphic factory does
+                // CREATE-inside-CREATE2 at the destroyed address in the same block.
+                if (BlockChange.HasClear) return Keccak.EmptyTreeHash;
+
                 EnsureStorageTree();
                 return _backend.RootHash;
             }


### PR DESCRIPTION
## Changes

- `PerContractState.StorageRoot` now short-circuits to `Keccak.EmptyTreeHash` when the same-block SELFDESTRUCT marker (`BlockChange.HasClear`) is set — mirroring the existing short-circuit in `PerContractState.IsEmpty`. One added line in `Nethermind.State/PersistentStorageProvider.cs`.
- New unit test `SelfDestructPrewarmerStateTests.IsNonZeroAccount_via_IWorldState_default_returns_false_after_destroy_and_value_transfer` reproduces the bug at the state layer (fails on parent, passes with this fix).
- Two supporting tests in `SelfDestructPrewarmerStateTests` and two block-level integration tests in `SelfDestructCreate2SameBlockTests` lock in correctness for the same-block SELFDESTRUCT-then-redeploy pattern with both two-tx and three-tx (with intermediate value transfer) variants.

### Symptom

Sepolia archive node running 1.37.1 deterministically rejects block **4913057** with `HeaderGasUsedMismatch: Expected 9922769, got 9916180` (Δ = 6589 gas, exactly one EIP-684 collision revert with refund), and stops processing further blocks. The failing transaction is the metamorphic-contract redeploy at index 0x3a in the block:

```
to:    0x030a5714a5cb1ea7d98b4b978e1379c2b8805d25  (0age metamorphic factory)
data:  deployMetamorphicContractWithConstructor(salt, initCode)
```

`debug_traceCall` reproduces the failure when run against parent state (i.e. without applying tx 0x2d's SELFDESTRUCT first), proving the EVM is correct in isolation and that block-level state propagation between the destroy and the redeploy is broken.

### Root cause

The EVM CREATE collision check is `state.IsNonZeroAccount(X)`. `ParallelWorldState` (the production decorator over `WorldState`, registered at `BlockProcessingModule.cs:56-57`) does not override `IsNonZeroAccount`, so the **default interface method on `IWorldState`** runs. That default calls `IsStorageEmpty(X)`, also unoverridden in `ParallelWorldState`, so it routes to the **default in `IAccountStateProvider`**:

```csharp
TryGetAccount(address, out AccountStruct account);
return account.IsStorageEmpty;
```

`TryGetAccount` lands on `WorldState.IAccountStateProvider.TryGetAccount`, which builds the `AccountStruct` via:

```csharp
account = _stateProvider.GetAccount(address)
    .WithChangedStorageRoot(_persistentStorageProvider.GetStorageRoot(address))
    .ToStruct();
```

`PerContractState.StorageRoot` calls `EnsureStorageTree` → `CreateStorageTree` → `_provider._currentScope.CreateStorageTree(_address)` → `LookupStorageTree` → `Get(X)?.StorageRoot`. `Get(X)` is `TrieStoreWorldStateBackendScope.Get`, which serves from `_loadedAccounts`. That cache was populated when the EVM first read X earlier in the block (e.g. to load X's code for tx 0x2d's SELFDESTRUCT call), and it holds the parent (pre-destroy) account with a **non-empty** `StorageRoot`.

Result: `GetStorageRoot` returns the parent's non-empty `StorageRoot`, `WithChangedStorageRoot` stuffs it into the `AccountStruct`, `account.IsStorageEmpty` is `_storageRoot == EmptyTreeHash` so returns false, `IsNonZeroAccount` short-circuits to true, the inner CREATE inside the metamorphic transient hits a phantom EIP-684/EIP-7610 collision, the factory's `require(deployed != 0)` reverts, and the block ends with `HeaderGasUsedMismatch`.

`PerContractState.IsEmpty` already short-circuits on `BlockChange.HasClear`. `PerContractState.StorageRoot` did not. This PR adds the same short-circuit, so any consumer (including the `IAccountStateProvider.TryGetAccount` path) sees `EmptyTreeHash` while the SELFDESTRUCT marker is in effect.

The fix is a one-line short-circuit at the boundary that matches the existing `IsEmpty` invariant; no behavioural change for code paths that don't go through `TryGetAccount`/`StorageRoot`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New regression test: `SelfDestructPrewarmerStateTests.IsNonZeroAccount_via_IWorldState_default_returns_false_after_destroy_and_value_transfer` — exercises `ParallelWorldState` wrapping `WorldState`, primes `_loadedAccounts` the way the EVM does, then performs the collision check via the `IWorldState` default interface method. **Fails on the parent commit and passes with this fix.**
- Supporting tests: `Main_scope_sees_destroyed_account_even_with_prewarmed_cache` and `Main_scope_sees_recreated_account_as_collision_free_after_value_transfer` pin cache-layer correctness.
- Block-level: `SelfDestructCreate2SameBlockTests` (two test cases) drives the full `BlockProcessor` + `BranchProcessor` + prewarming flow through `BasicTestBlockchain` for both two-tx and three-tx (with intermediate value transfer) variants.

Existing suites still pass with the fix:

| Suite | Total | Failed |
|---|---|---|
| `Nethermind.State.Test` | 707 | 0 |
| `Nethermind.Blockchain.Test` | 1426 | 0 |
| `Nethermind.Evm.Test` (SELFDESTRUCT/CREATE/Eip7708 selectors) | 32 | 0 |

#### Verification on an affected node

Confirmed on a live Sepolia archive node running 1.37.1 + this fix: block 4913057 validates and sync resumes from there.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

> Fixes a determinism bug that caused Sepolia archive nodes to reject block 4913057 with `HeaderGasUsedMismatch` when a contract was SELFDESTRUCTed and then redeployed at the same address (via the 0age metamorphic-contract pattern) within the same block. `PerContractState.StorageRoot` now correctly returns `EmptyTreeHash` while a same-block SELFDESTRUCT marker is in effect, so the EIP-684/EIP-7610 CREATE collision check sees the destroyed account as empty and lets the redeploy proceed.

## Remarks

The same defect class is likely worth checking on `master`, although `Nethermind.State` has been substantially restructured there (cross-block caches, sharded `NodeStorageCache`, etc.) — the symbol and call path may be different. Worth a quick verification but out of scope for this 1.37.1 backport.