### PR TITLE
debug_traceCallMany: materialize simple call traces

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -22,6 +22,7 @@ using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Facade;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Int256;
+using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Logging;
@@ -43,15 +44,58 @@ public class DebugModuleTests
     private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
-    private DebugRpcModule CreateDebugRpcModule(IDebugBridge customDebugBridge) => new(
+    private DebugRpcModule CreateDebugRpcModule(
+        IDebugBridge customDebugBridge,
+        IBlockchainBridge? blockchainBridge = null,
+        IBlockFinder? blockFinder = null) => new(
             LimboLogs.Instance,
             customDebugBridge,
             _jsonRpcConfig,
             _specProvider,
-            _blockchainBridge,
+            blockchainBridge ?? _blockchainBridge,
             new BlocksConfig(),
-            _blockFinder
+            blockFinder ?? _blockFinder
         );
+
+    [Test]
+    public void Debug_traceCallMany_materializes_simple_path_before_timeout_source_is_disposed()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
+        blockFinder.SearchForHeader(Arg.Any<BlockParameter>()).Returns(new SearchResult<BlockHeader>(header));
+        blockchainBridge.HasStateForBlock(header).Returns(true);
+        localDebugBridge
+            .GetBundleTraces(
+                Arg.Any<TransactionBundle[]>(),
+                Arg.Any<BlockParameter>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<GethTraceOptions>())
+            .Returns(static callInfo => GetBundleTracesUsingCancellationToken(callInfo.ArgAt<CancellationToken>(2)));
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(localDebugBridge, blockchainBridge, blockFinder);
+        TransactionBundle bundle = new()
+        {
+            Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }]
+        };
+
+        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
+            rpcModule.debug_traceCallMany([bundle], BlockParameter.Latest);
+
+        result.Data.First().Should().HaveCount(1);
+    }
+
+    private static IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTracesUsingCancellationToken(CancellationToken cancellationToken)
+    {
+        yield return GetTraceUsingCancellationToken(cancellationToken);
+    }
+
+    private static IEnumerable<GethLikeTxTrace> GetTraceUsingCancellationToken(CancellationToken cancellationToken)
+    {
+        using CancellationTokenRegistration registration = cancellationToken.Register(static () => { });
+        yield return new GethLikeTxTrace();
+    }
 
     [Test]
     public async Task Get_from_db()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -468,8 +468,17 @@ public class DebugRpcModule(
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
 
-        IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces = debugBridge
-            .GetBundleTraces(bundles, blockParameter, cancellationToken, options);
+        List<IEnumerable<GethLikeTxTrace>> bundleTraces = new(bundles.Length);
+        foreach (IEnumerable<GethLikeTxTrace> bundleTrace in debugBridge.GetBundleTraces(bundles, blockParameter, cancellationToken, options))
+        {
+            List<GethLikeTxTrace> traces = new();
+            foreach (GethLikeTxTrace trace in bundleTrace)
+            {
+                traces.Add(trace);
+            }
+
+            bundleTraces.Add(traces.ToArray());
+        }
 
         if (_logger.IsTrace)
         {


### PR DESCRIPTION
## Changes

- Materialize simple-path `debug_traceCallMany` bundle traces before the request timeout source is disposed.
- Add regression coverage for enumerating traces while the cancellation token is still usable.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added `Debug_traceCallMany_materializes_simple_path_before_timeout_source_is_disposed`.
- Ran `git diff --check`.
- `.NET build/test` intentionally skipped by user request.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No