### PR TITLE
debug_traceCallMany: extend timeout CTS lifetime to enumerator disposal

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -43,15 +43,107 @@ public class DebugModuleTests
     private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
-    private DebugRpcModule CreateDebugRpcModule(IDebugBridge customDebugBridge) => new(
+    private DebugRpcModule CreateDebugRpcModule(
+        IDebugBridge customDebugBridge,
+        IBlockchainBridge? blockchainBridge = null,
+        IBlockFinder? blockFinder = null) => new(
             LimboLogs.Instance,
             customDebugBridge,
             _jsonRpcConfig,
             _specProvider,
-            _blockchainBridge,
+            blockchainBridge ?? _blockchainBridge,
             new BlocksConfig(),
-            _blockFinder
+            blockFinder ?? _blockFinder
         );
+
+    [Test]
+    public void Debug_traceCallMany_does_not_dispose_timeout_cts_before_consumer_enumerates()
+    {
+        (DebugRpcModule rpcModule, IDebugBridge localDebugBridge) = BuildTraceCallManyModule();
+        localDebugBridge
+            .GetBundleTraces(
+                Arg.Any<TransactionBundle[]>(),
+                Arg.Any<BlockParameter>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<GethTraceOptions>())
+            .Returns(static callInfo => YieldTraceUsing(callInfo.ArgAt<CancellationToken>(2)));
+
+        TransactionBundle bundle = new()
+        {
+            Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }]
+        };
+
+        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
+            rpcModule.debug_traceCallMany([bundle], BlockParameter.Latest);
+
+        // Iterate the way the JSON-RPC serializer does: drain each inner sequence inline.
+        // The inner iterator touches CancellationToken.WaitHandle, which throws
+        // ObjectDisposedException if the timeout CTS has been disposed prematurely.
+        List<int> innerCounts = [];
+        foreach (IEnumerable<GethLikeTxTrace> traces in result.Data)
+        {
+            innerCounts.Add(traces.Count());
+        }
+        innerCounts.Should().BeEquivalentTo([1]);
+    }
+
+    [Test]
+    public void Debug_traceCallMany_does_not_eagerly_materialize_bundles()
+    {
+        (DebugRpcModule rpcModule, IDebugBridge localDebugBridge) = BuildTraceCallManyModule();
+        localDebugBridge
+            .GetBundleTraces(
+                Arg.Any<TransactionBundle[]>(),
+                Arg.Any<BlockParameter>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<GethTraceOptions>())
+            .Returns(_ => YieldOneThenThrow());
+
+        TransactionBundle bundle = new()
+        {
+            Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }]
+        };
+
+        // Result should be a deferred sequence: traceCallMany must not enumerate the second
+        // bundle (which throws) before returning. Eager materialization would surface the
+        // exception from this call.
+        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
+            rpcModule.debug_traceCallMany([bundle, bundle], BlockParameter.Latest);
+
+        result.Data.Should().NotBeNull();
+    }
+
+    private (DebugRpcModule Module, IDebugBridge DebugBridge) BuildTraceCallManyModule()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+        Block headBlock = Build.A.Block.WithHeader(header).TestObject;
+        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
+        blockFinder.Head.Returns(headBlock);
+        blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(header);
+        blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+        return (CreateDebugRpcModule(localDebugBridge, blockchainBridge, blockFinder), localDebugBridge);
+    }
+
+    private static IEnumerable<IEnumerable<GethLikeTxTrace>> YieldTraceUsing(CancellationToken cancellationToken)
+    {
+        yield return YieldOne(cancellationToken);
+    }
+
+    private static IEnumerable<GethLikeTxTrace> YieldOne(CancellationToken cancellationToken)
+    {
+        // Touching WaitHandle throws ObjectDisposedException if the source CTS has been disposed,
+        // so this enumerator only completes successfully while the timeout CTS is still alive.
+        _ = cancellationToken.WaitHandle;
+        yield return new GethLikeTxTrace();
+    }
+
+    private static IEnumerable<IEnumerable<GethLikeTxTrace>> YieldOneThenThrow()
+    {
+        yield return [new GethLikeTxTrace()];
+        throw new InvalidOperationException("bundles enumerated past first element — streaming was lost");
+    }
 
     [Test]
     public async Task Get_from_db()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -43,106 +43,51 @@ public class DebugModuleTests
     private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
     private readonly MemDb _blocksDb = new();
 
-    private DebugRpcModule CreateDebugRpcModule(
-        IDebugBridge customDebugBridge,
-        IBlockchainBridge? blockchainBridge = null,
-        IBlockFinder? blockFinder = null) => new(
+    private DebugRpcModule CreateDebugRpcModule(IDebugBridge customDebugBridge) => new(
             LimboLogs.Instance,
             customDebugBridge,
             _jsonRpcConfig,
             _specProvider,
-            blockchainBridge ?? _blockchainBridge,
+            _blockchainBridge,
             new BlocksConfig(),
-            blockFinder ?? _blockFinder
+            _blockFinder
         );
 
     [Test]
-    public void Debug_traceCallMany_does_not_dispose_timeout_cts_before_consumer_enumerates()
+    public void Debug_traceCallMany_streams_under_live_cancellation_token()
     {
-        (DebugRpcModule rpcModule, IDebugBridge localDebugBridge) = BuildTraceCallManyModule();
-        localDebugBridge
-            .GetBundleTraces(
-                Arg.Any<TransactionBundle[]>(),
-                Arg.Any<BlockParameter>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<GethTraceOptions>())
-            .Returns(static callInfo => YieldTraceUsing(callInfo.ArgAt<CancellationToken>(2)));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+        _blockFinder.Head.Returns(Build.A.Block.WithHeader(header).TestObject);
+        _blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(header);
+        _blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
+        _debugBridge
+            .GetBundleTraces(Arg.Any<TransactionBundle[]>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+            .Returns(static c => StreamBundles(c.ArgAt<CancellationToken>(2)));
 
-        TransactionBundle bundle = new()
-        {
-            Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }]
-        };
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        TransactionBundle bundle = new() { Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }] };
 
-        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
-            rpcModule.debug_traceCallMany([bundle], BlockParameter.Latest);
-
-        // Iterate the way the JSON-RPC serializer does: drain each inner sequence inline.
-        // The inner iterator touches CancellationToken.WaitHandle, which throws
-        // ObjectDisposedException if the timeout CTS has been disposed prematurely.
-        List<int> innerCounts = [];
-        foreach (IEnumerable<GethLikeTxTrace> traces in result.Data)
-        {
-            innerCounts.Add(traces.Count());
-        }
-        innerCounts.Should().BeEquivalentTo([1]);
-    }
-
-    [Test]
-    public void Debug_traceCallMany_does_not_eagerly_materialize_bundles()
-    {
-        (DebugRpcModule rpcModule, IDebugBridge localDebugBridge) = BuildTraceCallManyModule();
-        localDebugBridge
-            .GetBundleTraces(
-                Arg.Any<TransactionBundle[]>(),
-                Arg.Any<BlockParameter>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<GethTraceOptions>())
-            .Returns(_ => YieldOneThenThrow());
-
-        TransactionBundle bundle = new()
-        {
-            Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }]
-        };
-
-        // Result should be a deferred sequence: traceCallMany must not enumerate the second
-        // bundle (which throws) before returning. Eager materialization would surface the
-        // exception from this call.
         ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
             rpcModule.debug_traceCallMany([bundle, bundle], BlockParameter.Latest);
 
-        result.Data.Should().NotBeNull();
+        // The first inner sequence touches WaitHandle (throws ObjectDisposedException if the
+        // timeout CTS has been disposed). The second bundle throws unconditionally, so the
+        // call only succeeds if the result is a deferred sequence and we stop after the first.
+        using IEnumerator<IEnumerable<GethLikeTxTrace>> outer = result.Data.GetEnumerator();
+        outer.MoveNext().Should().BeTrue();
+        outer.Current.Count().Should().Be(1);
     }
 
-    private (DebugRpcModule Module, IDebugBridge DebugBridge) BuildTraceCallManyModule()
+    private static IEnumerable<IEnumerable<GethLikeTxTrace>> StreamBundles(CancellationToken token)
     {
-        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
-        Block headBlock = Build.A.Block.WithHeader(header).TestObject;
-        IDebugBridge localDebugBridge = Substitute.For<IDebugBridge>();
-        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-        IBlockchainBridge blockchainBridge = Substitute.For<IBlockchainBridge>();
-        blockFinder.Head.Returns(headBlock);
-        blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(header);
-        blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
-        return (CreateDebugRpcModule(localDebugBridge, blockchainBridge, blockFinder), localDebugBridge);
+        yield return YieldTrace(token);
+        throw new InvalidOperationException("second bundle should not be enumerated — streaming was lost");
     }
 
-    private static IEnumerable<IEnumerable<GethLikeTxTrace>> YieldTraceUsing(CancellationToken cancellationToken)
+    private static IEnumerable<GethLikeTxTrace> YieldTrace(CancellationToken token)
     {
-        yield return YieldOne(cancellationToken);
-    }
-
-    private static IEnumerable<GethLikeTxTrace> YieldOne(CancellationToken cancellationToken)
-    {
-        // Touching WaitHandle throws ObjectDisposedException if the source CTS has been disposed,
-        // so this enumerator only completes successfully while the timeout CTS is still alive.
-        _ = cancellationToken.WaitHandle;
+        _ = token.WaitHandle;
         yield return new GethLikeTxTrace();
-    }
-
-    private static IEnumerable<IEnumerable<GethLikeTxTrace>> YieldOneThenThrow()
-    {
-        yield return [new GethLikeTxTrace()];
-        throw new InvalidOperationException("bundles enumerated past first element — streaming was lost");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -465,11 +465,10 @@ public class DebugRpcModule(
     {
         PrepareTransactions(bundles, header);
 
-        using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
-        CancellationToken cancellationToken = timeout.Token;
+        CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
         IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces = debugBridge
-            .GetBundleTraces(bundles, blockParameter, cancellationToken, options);
+            .GetBundleTraces(bundles, blockParameter, timeout.Token, options);
 
         if (_logger.IsTrace)
         {
@@ -477,7 +476,24 @@ public class DebugRpcModule(
             _logger.Trace($"{nameof(debug_traceCallMany)} completed: {bundles.Length} bundles, {totalTransactions} transactions via simple path");
         }
 
-        return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Success(bundleTraces);
+        return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Success(StreamBundleTraces(bundleTraces, timeout));
+    }
+
+    // Bind the timeout CTS lifetime to enumerator disposal so the lazy bundle pipeline
+    // can keep using the cancellation token after this method returns (JSON-RPC serializes
+    // the result lazily). Disposing the CTS earlier breaks downstream token consumers
+    // (e.g. WaitHandle access throws ObjectDisposedException).
+    private static IEnumerable<IEnumerable<GethLikeTxTrace>> StreamBundleTraces(
+        IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        using (cancellationTokenSource)
+        {
+            foreach (IEnumerable<GethLikeTxTrace> traces in bundleTraces)
+            {
+                yield return traces;
+            }
+        }
     }
 
     private ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> TraceCallManyWithOverrides(TransactionBundle[] bundles, GethTraceOptions? options, BlockHeader header)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -466,17 +466,24 @@ public class DebugRpcModule(
         PrepareTransactions(bundles, header);
 
         CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
-
-        IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces = debugBridge
-            .GetBundleTraces(bundles, blockParameter, timeout.Token, options);
-
-        if (_logger.IsTrace)
+        try
         {
-            int totalTransactions = bundles.Sum(b => b.Transactions?.Length ?? 0);
-            _logger.Trace($"{nameof(debug_traceCallMany)} completed: {bundles.Length} bundles, {totalTransactions} transactions via simple path");
-        }
+            IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces = debugBridge
+                .GetBundleTraces(bundles, blockParameter, timeout.Token, options);
 
-        return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Success(StreamBundleTraces(bundleTraces, timeout));
+            if (_logger.IsTrace)
+            {
+                int totalTransactions = bundles.Sum(b => b.Transactions?.Length ?? 0);
+                _logger.Trace($"{nameof(debug_traceCallMany)} completed: {bundles.Length} bundles, {totalTransactions} transactions via simple path");
+            }
+
+            return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Success(StreamBundleTraces(bundleTraces, timeout));
+        }
+        catch
+        {
+            timeout.Dispose();
+            throw;
+        }
     }
 
     // Bind the timeout CTS lifetime to enumerator disposal so the lazy bundle pipeline


### PR DESCRIPTION
Replaces #11425

## Changes

- Bind the timeout `CancellationTokenSource` lifetime to enumerator disposal in `DebugRpcModule.TraceCallMany`'s simple path. The previous `using` scope disposed the CTS before the lazy bundle pipeline was enumerated, leaving the cancellation token unusable to downstream consumers (e.g. `WaitHandle` access throws `ObjectDisposedException`).
- Mirrors the iterator-owns-CTS pattern already used by `EthRpcModule.GetLogs`. Streaming is preserved — no per-bundle or per-trace buffering is introduced.
- Add two regression tests:
  - `Debug_traceCallMany_does_not_dispose_timeout_cts_before_consumer_enumerates` fails on the unfixed code with `ObjectDisposedException` and passes with the fix.
  - `Debug_traceCallMany_does_not_eagerly_materialize_bundles` guards against a regression to eager materialization.

Replaces #11425, which fixed the same bug by materializing every bundle/trace into nested `List<>`/`T[]` and giving up the zero-allocation streaming pipeline that was a deliberate design choice (see https://github.com/NethermindEth/nethermind/pull/11425#issuecomment-4350364618).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- All 22 `DebugModuleTests` pass with the fix.
- Verified the new disposed-CTS regression test fails on master without the production fix (`ObjectDisposedException` from `WaitHandle`) and passes with it.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No