### PR TITLE
fix(prewarm): run speculative prewarming when BAL EIP is not active

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -247,13 +247,14 @@ public class BlockCachePreWarmerTests
     }
 
     /// <summary>
-    /// Verifies the prewarmer gate logic: ParallelExecution ON disables prewarming unless
-    /// ParallelExecutionBatchRead is ON and BALs are available.
+    /// Verifies the prewarmer gate logic: ParallelExecution ON skips speculative prewarming
+    /// only when BAL is active for the spec (so parallel execution can actually run); when
+    /// BAL is not active, speculative prewarming runs regardless of ParallelExecution.
     /// </summary>
     [TestCase(true, true, true, true, TestName = "ParallelExec ON, BALs ON, BatchRead ON => BAL warming")]
     [TestCase(true, true, false, false, TestName = "ParallelExec ON, BALs ON, BatchRead OFF => skipped")]
-    [TestCase(true, false, true, false, TestName = "ParallelExec ON, BALs OFF, BatchRead ON => skipped")]
-    [TestCase(true, false, false, false, TestName = "ParallelExec ON, BALs OFF, BatchRead OFF => skipped")]
+    [TestCase(true, false, true, true, TestName = "ParallelExec ON, BALs OFF, BatchRead ON => speculative")]
+    [TestCase(true, false, false, true, TestName = "ParallelExec ON, BALs OFF, BatchRead OFF => speculative")]
     [TestCase(false, true, true, true, TestName = "ParallelExec OFF, BALs ON, BatchRead ON => BAL warming")]
     [TestCase(false, false, false, true, TestName = "ParallelExec OFF, BALs OFF, BatchRead OFF => speculative")]
     public async Task PreWarmCaches_GateLogic(bool parallelExecution, bool hasBal, bool batchRead, bool expectWarmed)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -101,13 +101,16 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
     // Pre-warming runs in two distinct modes:
     //  - Speculative tx execution (default): runs txs against a snapshot to seed caches.
-    //    Skipped when parallel execution is on, because parallel execution keeps its results
-    //    rather than throwing them away after warmup.
+    //    Skipped when parallel execution will actually run, because parallel execution keeps
+    //    its results rather than throwing them away after warmup. Parallel execution requires
+    //    BAL, so when BAL isn't active for this spec we still need speculative prewarming.
     //  - BAL-based read warming: when parallel execution is on AND batch read is enabled,
     //    we still warm — but only by reading state/storage referenced by the block's
     //    access list (no tx execution).
     private bool ShouldPreWarm(IReleaseSpec spec)
-        => !_parallelExecutionEnabled || IsBalReadWarmingEnabled(spec);
+        => !_parallelExecutionEnabled
+        || !spec.BlockLevelAccessListsEnabled
+        || IsBalReadWarmingEnabled(spec);
 
     public bool IsBalReadWarmingEnabled(IReleaseSpec spec)
         => _parallelExecutionBatchRead && spec.BlockLevelAccessListsEnabled;


### PR DESCRIPTION
Fixes #11427

## Summary

- `BlockCachePreWarmer.ShouldPreWarm` skipped speculative prewarming whenever `ParallelExecution=true` (the default), but `BlockAccessListManager` only runs parallel execution when the block actually has a `BlockAccessList`. On pre-BAL forks neither path ran, silently regressing block-processing performance from pre-BAL releases.
- Treat specs without `BlockLevelAccessListsEnabled` the same as `ParallelExecution=off` so speculative prewarming runs on those blocks. BAL-active specs are unchanged.
- Updated `PreWarmCaches_GateLogic` test cases for the two ``ParallelExec ON, BALs OFF`` rows that previously expected ``skipped``.

| ParallelExec | BAL spec | BatchRead | Behavior |
|---|---|---|---|
| ON | ON | ON | BAL read warming |
| ON | ON | OFF | skipped (parallel exec runs) |
| ON | OFF | * | **speculative (was: skipped)** |
| OFF | * | * | speculative / BAL warming |

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

- [x] ``dotnet test --project src/Nethermind/Nethermind.Consensus.Test/... --filter ~BlockCachePreWarmerTests`` — 12/12 pass.

## Documentation

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)