### PR TITLE
Fix EIP-8037 cross-frame state gas restoration accounting

### DIFF
--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -277,6 +277,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void CreditStateGasRefund(ref EthereumGasPolicy gas, long amount) =>
+        gas.StateReservoir += amount;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void DiscardStateGas(ref EthereumGasPolicy gas, long amount, long stateGasFloor)
     {
         long discardableStateGas = Math.Max(0, gas.StateGasUsed - stateGasFloor);

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -324,6 +324,13 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual void RefundStateGas(ref TSelf gas, long amount, long stateGasFloor) => TSelf.UpdateGasUp(ref gas, amount);
 
     /// <summary>
+    /// Credits state gas back to the usable budget without reducing committed state gas usage.
+    /// </summary>
+    /// <param name="gas">The gas state to update.</param>
+    /// <param name="amount">Credited state gas amount.</param>
+    static virtual void CreditStateGasRefund(ref TSelf gas, long amount) => TSelf.UpdateGasUp(ref gas, amount);
+
+    /// <summary>
     /// Discards state gas from block-state accounting without refunding it back into the
     /// usable gas budget. This is used for reverted state charges that should remain paid
     /// by the transaction but must not contribute to committed state gas.

--- a/src/Nethermind/Nethermind.Evm/StateGasTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StateGasTracker.cs
@@ -15,6 +15,7 @@ internal sealed class StateGasTracker
     private readonly Stack<AccountingEvent> _accountingEvents = new();
     private readonly HashSet<StorageCell> _createdStorageSlots = new(StorageCell.EqualityComparer);
     private readonly Dictionary<AddressAsKey, int> _createdStorageSlotsByAddress = new(AddressAsKey.EqualityComparer);
+    private readonly Dictionary<StorageCell, int> _pendingStorageRefunds = new(StorageCell.EqualityComparer);
     private readonly HashSet<AddressAsKey> _createdAccounts = new(AddressAsKey.EqualityComparer);
     private readonly Dictionary<AddressAsKey, int> _createdCodeLengths = new(AddressAsKey.EqualityComparer);
 
@@ -41,6 +42,7 @@ internal sealed class StateGasTracker
         _accountingEvents.Clear();
         _createdStorageSlots.Clear();
         _createdStorageSlotsByAddress.Clear();
+        _pendingStorageRefunds.Clear();
         _createdAccounts.Clear();
         _createdCodeLengths.Clear();
     }
@@ -102,8 +104,11 @@ internal sealed class StateGasTracker
         for (int i = snapshot; i < changesSpan.Length; i++)
         {
             ref StateChange change = ref changesSpan[i];
-            if (change.Accounted) continue;
-            (accountedIndices ??= []).Add(i);
+            bool accounted = change.Accounted;
+            if (!accounted)
+            {
+                (accountedIndices ??= []).Add(i);
+            }
 
             switch (change.Kind)
             {
@@ -128,9 +133,11 @@ internal sealed class StateGasTracker
                     }
                     break;
                 case StateChangeKind.AccountCreated:
+                    if (accounted) continue;
                     (accountAgg ??= new(AddressAsKey.EqualityComparer)).Add(change.Address!);
                     break;
                 case StateChangeKind.CodeDeposit:
+                    if (accounted) continue;
                     (codeAgg ??= new(AddressAsKey.EqualityComparer))[change.Address!] = change.CodeLength;
                     break;
             }
@@ -140,6 +147,7 @@ internal sealed class StateGasTracker
 
         long stateGasCharge = 0;
         long stateGasRefund = 0;
+        long stateGasCredit = 0;
         List<AccountingAction> actions = [];
 
         if (storageAgg is not null)
@@ -148,19 +156,40 @@ internal sealed class StateGasTracker
             {
                 bool entryIsZero = (slot & FrameStorageFlags.EntryIsZero) != 0;
                 bool exitIsZero = (slot & FrameStorageFlags.ExitIsZero) != 0;
-                if (entryIsZero == exitIsZero) continue;
-
                 bool txEntryIsZero = (slot & FrameStorageFlags.TxEntryIsZero) != 0;
                 bool isCreated = _createdStorageSlots.Contains(cell);
+                bool hasPendingRefund = HasPendingStorageRefund(cell);
+                long storageSetStateCost = TGasPolicy.GetStorageSetStateCost(in gas);
+                if (entryIsZero == exitIsZero)
+                {
+                    if (entryIsZero && txEntryIsZero && hasPendingRefund)
+                    {
+                        stateGasCredit = checked(stateGasCredit + storageSetStateCost);
+                        actions.Add(AccountingAction.ConsumePendingStorageRefund(cell));
+                    }
+
+                    continue;
+                }
+
                 if (!exitIsZero && txEntryIsZero && !isCreated)
                 {
-                    stateGasCharge = checked(stateGasCharge + TGasPolicy.GetStorageSetStateCost(in gas));
+                    if (hasPendingRefund)
+                    {
+                        stateGasCredit = checked(stateGasCredit + storageSetStateCost);
+                        actions.Add(AccountingAction.ConsumePendingStorageRefund(cell));
+                    }
+
+                    stateGasCharge = checked(stateGasCharge + storageSetStateCost);
                     actions.Add(AccountingAction.ChargeStorage(cell));
                 }
                 else if (exitIsZero && !entryIsZero && txEntryIsZero && isCreated)
                 {
-                    stateGasRefund = checked(stateGasRefund + TGasPolicy.GetStorageSetStateCost(in gas));
+                    stateGasRefund = checked(stateGasRefund + storageSetStateCost);
                     actions.Add(AccountingAction.RefundStorage(cell));
+                }
+                else if (exitIsZero && !entryIsZero && txEntryIsZero)
+                {
+                    actions.Add(AccountingAction.AddPendingStorageRefund(cell));
                 }
             }
         }
@@ -189,6 +218,11 @@ internal sealed class StateGasTracker
         if (stateGasRefund > 0)
         {
             TGasPolicy.RefundStateGas(ref gasAfterFrameAccounting, stateGasRefund, stateGasFloor);
+        }
+
+        if (stateGasCredit > 0)
+        {
+            TGasPolicy.CreditStateGasRefund(ref gasAfterFrameAccounting, stateGasCredit);
         }
 
         if (stateGasCharge > 0 && !TGasPolicy.ConsumeStateGas(ref gasAfterFrameAccounting, stateGasCharge))
@@ -244,6 +278,12 @@ internal sealed class StateGasTracker
                     _createdStorageSlots.Remove(action.StorageCell);
                     AdjustStorageSlotCount(action.StorageCell.Address, -1);
                     break;
+                case AccountingActionKind.AddPendingStorageRefund:
+                    AdjustPendingStorageRefundCount(action.StorageCell, +1);
+                    break;
+                case AccountingActionKind.ConsumePendingStorageRefund:
+                    AdjustPendingStorageRefundCount(action.StorageCell, -1);
+                    break;
                 case AccountingActionKind.ChargeAccount:
                     _createdAccounts.Add(action.Address);
                     break;
@@ -277,6 +317,12 @@ internal sealed class StateGasTracker
                     _createdStorageSlots.Add(action.StorageCell);
                     AdjustStorageSlotCount(action.StorageCell.Address, +1);
                     break;
+                case AccountingActionKind.AddPendingStorageRefund:
+                    AdjustPendingStorageRefundCount(action.StorageCell, -1);
+                    break;
+                case AccountingActionKind.ConsumePendingStorageRefund:
+                    AdjustPendingStorageRefundCount(action.StorageCell, +1);
+                    break;
                 case AccountingActionKind.ChargeAccount:
                     _createdAccounts.Remove(action.Address);
                     break;
@@ -294,6 +340,19 @@ internal sealed class StateGasTracker
         if (count == 0)
         {
             _createdStorageSlotsByAddress.Remove(address);
+        }
+    }
+
+    private bool HasPendingStorageRefund(StorageCell storageCell) =>
+        _pendingStorageRefunds.TryGetValue(storageCell, out int count) && count > 0;
+
+    private void AdjustPendingStorageRefundCount(StorageCell storageCell, int delta)
+    {
+        ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(_pendingStorageRefunds, storageCell, out _);
+        count += delta;
+        if (count == 0)
+        {
+            _pendingStorageRefunds.Remove(storageCell);
         }
     }
 
@@ -358,6 +417,12 @@ internal sealed class StateGasTracker
         public static AccountingAction RefundStorage(StorageCell storageCell) =>
             new(AccountingActionKind.RefundStorage, storageCell, default, 0);
 
+        public static AccountingAction AddPendingStorageRefund(StorageCell storageCell) =>
+            new(AccountingActionKind.AddPendingStorageRefund, storageCell, default, 0);
+
+        public static AccountingAction ConsumePendingStorageRefund(StorageCell storageCell) =>
+            new(AccountingActionKind.ConsumePendingStorageRefund, storageCell, default, 0);
+
         public static AccountingAction ChargeAccount(AddressAsKey address) =>
             new(AccountingActionKind.ChargeAccount, default, address, 0);
 
@@ -369,6 +434,8 @@ internal sealed class StateGasTracker
     {
         ChargeStorage,
         RefundStorage,
+        AddPendingStorageRefund,
+        ConsumePendingStorageRefund,
         ChargeAccount,
         ChargeCodeDeposit,
     }


### PR DESCRIPTION
## Changes

- Fixes cross-frame EIP-8037 storage state gas netting for restoration paths where child frames already accounted clearing/resetting writes.
- Includes accounted child storage changes when computing the parent frame's net storage transition.
- Tracks pending storage restoration refunds and credits the state gas reservoir without reducing committed state gas usage.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c Release --verbosity quiet`
- `dotnet build src/Nethermind/Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -c Release --verbosity quiet`
- `dotnet run --no-build --no-launch-profile -c Release --project src/Nethermind/Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -- -b -i C:/tmp/eest-snobal-v2/fixtures/blockchain_tests/for_amsterdam/amsterdam/eip8037_state_creation_gas_cost_increase/state_gas_sstore/sstore_restoration_charge_in_ancestor.json -f .*single_hop.* -n`

Focused fixture result on this branch:

- `test_sstore_restoration_charge_in_ancestor[...,CALLCODE,...,single_hop] PASS`
- `test_sstore_restoration_charge_in_ancestor[...,DELEGATECALL,...,single_hop] PASS`

The clean `bal-devnet-5` test runner uses the older `-b/-i/-f/-n` CLI; the newer `--engineTest --jsonout --workers` command is not available on this base branch.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No