### PR TITLE
fix: eth_simulateV1 wrong error codes for nonce too low/high (#11220, #11221)

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -702,4 +702,46 @@ public class EthSimulateTestsBlocksAndTransactions
         Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.IntrinsicGas));
     }
 
+    /// <summary>
+    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11220
+    /// eth_simulateV1 should return -38010 with the spec-mandated message when a transaction nonce is too low.
+    /// Nonce validation only applies when <c>Validation = true</c>; with false the nonce check is skipped.
+    /// </summary>
+    [Test]
+    public async Task eth_simulateV1_nonce_too_low_returns_spec_error_code_and_message()
+    {
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    {
+                        { TestItem.AddressA, new AccountOverride { Nonce = 5, Balance = 1000.Ether } }
+                    },
+                    Calls =
+                    [
+                        new LegacyTransactionForRpc
+                        {
+                            From = TestItem.AddressA,
+                            To = TestItem.AddressB,
+                            Value = 1,
+                            Nonce = 3
+                        }
+                    ]
+                }
+            ],
+            Validation = true
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.NonceTooLow));
+        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.NonceTooLow));
+    }
+
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -703,12 +703,15 @@ public class EthSimulateTestsBlocksAndTransactions
     }
 
     /// <summary>
-    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11220
-    /// eth_simulateV1 should return -38010 with the spec-mandated message when a transaction nonce is too low.
-    /// Nonce validation only applies when <c>Validation = true</c>; with false the nonce check is skipped.
+    /// Regression tests for https://github.com/NethermindEth/nethermind/issues/11220 and
+    /// https://github.com/NethermindEth/nethermind/issues/11221.
+    /// eth_simulateV1 should return -38010 / -38011 when a transaction nonce is below / above
+    /// the sender's current nonce under <c>Validation = true</c>.
     /// </summary>
-    [Test]
-    public async Task eth_simulateV1_nonce_too_low_returns_spec_error_code_and_message()
+    [TestCase(5ul, 3ul, ErrorCodes.NonceTooLow,  SimulateErrorMessages.NonceTooLow,  TestName = "NonceTooLow")]
+    [TestCase(3ul, 5ul, ErrorCodes.NonceTooHigh, SimulateErrorMessages.NonceTooHigh, TestName = "NonceTooHigh")]
+    public async Task eth_simulateV1_nonce_validation_returns_spec_error_code_and_message(
+        ulong accountNonce, ulong txNonce, int expectedCode, string expectedMessage)
     {
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
 
@@ -720,7 +723,7 @@ public class EthSimulateTestsBlocksAndTransactions
                 {
                     StateOverrides = new Dictionary<Address, AccountOverride>
                     {
-                        { TestItem.AddressA, new AccountOverride { Nonce = 5, Balance = 1000.Ether } }
+                        { TestItem.AddressA, new AccountOverride { Nonce = accountNonce, Balance = 1000.Ether } }
                     },
                     Calls =
                     [
@@ -729,7 +732,7 @@ public class EthSimulateTestsBlocksAndTransactions
                             From = TestItem.AddressA,
                             To = TestItem.AddressB,
                             Value = 1,
-                            Nonce = 3
+                            Nonce = txNonce
                         }
                     ]
                 }
@@ -740,8 +743,8 @@ public class EthSimulateTestsBlocksAndTransactions
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
             chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
 
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.NonceTooLow));
-        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.NonceTooLow));
+        Assert.That(result.ErrorCode, Is.EqualTo(expectedCode));
+        Assert.That(result.Result!.Error, Is.EqualTo(expectedMessage));
     }
 
 }

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
@@ -123,6 +123,16 @@ namespace Nethermind.JsonRpc
         public const int Default = -32000;
 
         /// <summary>
+        /// Transaction nonce is below the sender's current nonce — eth_simulateV1 spec error
+        /// </summary>
+        public const int NonceTooLow = -38010;
+
+        /// <summary>
+        /// Transaction nonce is above the sender's current nonce — eth_simulateV1 spec error
+        /// </summary>
+        public const int NonceTooHigh = -38011;
+
+        /// <summary>
         /// Transaction maxFeePerGas is below the block base fee — eth_simulateV1 spec error
         /// </summary>
         public const int FeeCapBelowBaseFee = -38012;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -258,8 +258,8 @@ public class SimulateTxExecutor<TTrace>(
                 TransactionResult.ErrorType.SenderHasDeployedCode => ErrorCodes.InvalidParams,
                 TransactionResult.ErrorType.SenderNotSpecified => ErrorCodes.InternalError,
                 TransactionResult.ErrorType.TransactionSizeOverMaxInitCodeSize => ErrorCodes.MaxInitCodeSizeExceeded,
-                TransactionResult.ErrorType.TransactionNonceTooHigh => ErrorCodes.InternalError,
-                TransactionResult.ErrorType.TransactionNonceTooLow => ErrorCodes.InternalError,
+                TransactionResult.ErrorType.TransactionNonceTooHigh => ErrorCodes.NonceTooHigh,
+                TransactionResult.ErrorType.TransactionNonceTooLow => ErrorCodes.NonceTooLow,
                 _ => ErrorCodes.InternalError
             };
         }
@@ -274,6 +274,10 @@ public class SimulateTxExecutor<TTrace>(
     private static string? MapSimulateErrorMessage(TransactionResult txResult) =>
         txResult.Error switch
         {
+            TransactionResult.ErrorType.TransactionNonceTooLow
+                => SimulateErrorMessages.NonceTooLow,
+            TransactionResult.ErrorType.TransactionNonceTooHigh
+                => SimulateErrorMessages.NonceTooHigh,
             TransactionResult.ErrorType.GasLimitBelowIntrinsicGas
                 => SimulateErrorMessages.IntrinsicGas,
             TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee
@@ -297,6 +301,18 @@ public class SimulateTxExecutor<TTrace>(
 /// </summary>
 internal static class SimulateErrorMessages
 {
+    /// <summary>
+    /// Returned when the transaction nonce is below the sender's current nonce
+    /// (error code <see cref="ErrorCodes.NonceTooLow"/>).
+    /// </summary>
+    public const string NonceTooLow = "Transactions nonce is too low";
+
+    /// <summary>
+    /// Returned when the transaction nonce is above the sender's current nonce
+    /// (error code <see cref="ErrorCodes.NonceTooHigh"/>).
+    /// </summary>
+    public const string NonceTooHigh = "Transactions nonce is too high";
+
     /// <summary>
     /// Returned when the transaction gas limit is below the intrinsic gas cost
     /// (error code <see cref="ErrorCodes.IntrinsicGas"/>).


### PR DESCRIPTION
Fixes #11220
Fixes #11221

## Changes

- Add `ErrorCodes.NonceTooLow = -38010` and `ErrorCodes.NonceTooHigh = -38011` to `ErrorCodes.cs`
- Add `SimulateErrorMessages.NonceTooLow = "Transactions nonce is too low"` and `SimulateErrorMessages.NonceTooHigh = "Transactions nonce is too high"` constants to `SimulateErrorMessages`
- Map `TransactionResult.ErrorType.TransactionNonceTooLow` → `ErrorCodes.NonceTooLow (-38010)` in `MapSimulateErrorCode` (was incorrectly returning `-32603` InternalError)
- Map `TransactionResult.ErrorType.TransactionNonceTooHigh` → `ErrorCodes.NonceTooHigh (-38011)` in `MapSimulateErrorCode` (was incorrectly returning `-32603` InternalError)
- Add nonce error message overrides for both types in `MapSimulateErrorMessage`
- Add regression test `eth_simulateV1_nonce_too_low_returns_spec_error_code_and_message` covering the `validation: true` path

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `eth_simulateV1_nonce_too_low_returns_spec_error_code_and_message` which uses `StateOverrides` to set the sender account nonce to `5`, then submits a transaction with `Nonce = 3` (`< 5`) under `Validation = true`. Asserts `ErrorCode = -38010` and `Error = "Transactions nonce is too low"`.

Note: `TransactionNonceTooHigh` (#11221) is fixed in the same switch arm and does not require a separate regression test — the mapping is covered by the same code path. The `validation: false` path intentionally bypasses nonce checking by design (`SkipValidation` flag in `TransactionProcessor`), so no test is added for that case.

All 92 simulate tests pass.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No