### PR TITLE
fix(snap-sync): three Windows-flake fixes for E2ESyncTests.SnapSync

### DIFF
--- a/src/Nethermind/Nethermind.Db/SnapshotableMemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/SnapshotableMemColumnsDb.cs
@@ -17,14 +17,7 @@ namespace Nethermind.Db
         private readonly Dictionary<TKey, SnapshotableMemDb> _columnDbs = new();
         private readonly bool _neverPrune;
 
-        // Cross-column atomicity guard. Each per-column SnapshotableMemDb has its own version
-        // counter and lock, so per-column reads/writes are individually consistent. But a
-        // multi-column writeBatch dispose applies columns one-by-one, and CreateSnapshot
-        // captures column snapshots one-by-one. Without this lock a snapshot taken concurrently
-        // with an in-flight writeBatch dispose can capture some columns AFTER the new writes
-        // and others BEFORE, producing a cross-column-inconsistent reader view. RocksDB does
-        // not have this problem (its snapshots are atomic across CFs); this lock makes the
-        // in-memory test backend match.
+        // Cross-column atomicity guard so CreateSnapshot can't observe a half-applied multi-column writeBatch dispose. RocksDB has this for free; this matches it.
         private readonly Lock _atomicityLock = new();
 
         private SnapshotableMemColumnsDb(TKey[] keys, bool neverPrune)

--- a/src/Nethermind/Nethermind.Db/SnapshotableMemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/SnapshotableMemColumnsDb.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Core;
 
 namespace Nethermind.Db
@@ -15,6 +16,16 @@ namespace Nethermind.Db
     {
         private readonly Dictionary<TKey, SnapshotableMemDb> _columnDbs = new();
         private readonly bool _neverPrune;
+
+        // Cross-column atomicity guard. Each per-column SnapshotableMemDb has its own version
+        // counter and lock, so per-column reads/writes are individually consistent. But a
+        // multi-column writeBatch dispose applies columns one-by-one, and CreateSnapshot
+        // captures column snapshots one-by-one. Without this lock a snapshot taken concurrently
+        // with an in-flight writeBatch dispose can capture some columns AFTER the new writes
+        // and others BEFORE, producing a cross-column-inconsistent reader view. RocksDB does
+        // not have this problem (its snapshots are atomic across CFs); this lock makes the
+        // in-memory test backend match.
+        private readonly Lock _atomicityLock = new();
 
         private SnapshotableMemColumnsDb(TKey[] keys, bool neverPrune)
         {
@@ -55,16 +66,37 @@ namespace Nethermind.Db
 
         public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
 
-        public IColumnsWriteBatch<TKey> StartWriteBatch() => new InMemoryColumnWriteBatch<TKey>(this);
+        public IColumnsWriteBatch<TKey> StartWriteBatch() => new AtomicColumnsWriteBatch(this);
 
         public IColumnDbSnapshot<TKey> CreateSnapshot()
         {
+            using Lock.Scope _ = _atomicityLock.EnterScope();
             Dictionary<TKey, IKeyValueStoreSnapshot> snapshots = new();
             foreach (KeyValuePair<TKey, SnapshotableMemDb> kvp in _columnDbs)
             {
                 snapshots[kvp.Key] = kvp.Value.CreateSnapshot();
             }
             return new ColumnSnapshot(snapshots);
+        }
+
+        /// <summary>
+        /// Wraps <see cref="InMemoryColumnWriteBatch{TKey}"/> so the per-column commit phase
+        /// happens under the columns DB's write lock, making the multi-column commit atomic
+        /// w.r.t. <see cref="CreateSnapshot"/>.
+        /// </summary>
+        private sealed class AtomicColumnsWriteBatch(SnapshotableMemColumnsDb<TKey> db) : IColumnsWriteBatch<TKey>
+        {
+            private readonly InMemoryColumnWriteBatch<TKey> _inner = new(db);
+
+            public IWriteBatch GetColumnBatch(TKey key) => _inner.GetColumnBatch(key);
+
+            public void Clear() => _inner.Clear();
+
+            public void Dispose()
+            {
+                using Lock.Scope _ = db._atomicityLock.EnterScope();
+                _inner.Dispose();
+            }
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -7,10 +7,12 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.Sync;
+using Nethermind.State.Flat.Sync.Snap;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -72,7 +74,8 @@ public class FlatTreeSyncStoreTests
 
         Assert.That(HasStorageEntries(address), Is.True, "Storage entries should exist before cleanup");
 
-        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), LimboLogs.Instance);
+        FlatSnapTrieFactory snapTrieFactory = new(_persistence, Substitute.For<ISyncConfig>(), LimboLogs.Instance);
+        FlatTreeSyncStore store = new(_persistence, Substitute.For<IPersistenceManager>(), snapTrieFactory, LimboLogs.Instance);
         store.EnsureStorageEmpty(Keccak.Compute(address.Bytes));
 
         Assert.That(HasStorageEntries(address), Is.False, "Storage entries should be deleted after EnsureStorageEmpty");

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -9,13 +10,14 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.ScopeProvider;
+using Nethermind.State.Flat.Sync.Snap;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Flat.Sync;
 
-public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager persistenceManager, ILogManager logManager) : ITreeSyncStore
+public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager persistenceManager, FlatSnapTrieFactory snapTrieFactory, ILogManager logManager) : ITreeSyncStore
 {
     // For flat, one cannot continue syncing after finalization as it will corrupt existing state.
     private bool _wasFinalized = false;
@@ -235,6 +237,13 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
     public void FinalizeSync(BlockHeader pivotHeader)
     {
         if (Interlocked.CompareExchange(ref _wasFinalized, true, false)) throw new InvalidOperationException("Db was finalized");
+
+        // Wait for any in-flight ISnapTree disposals to complete. Phase-1 / phase-2 trees
+        // hold per-tree IWriteBatch instances; until each tree's Dispose returns, its writes
+        // aren't yet committed to the underlying persistence. Without this drain a caller that
+        // observes "sync finished" can read state that's missing accounts from late-disposed
+        // trees (manifests as E2ESyncTests.SnapSync "Verification failed: N missing in flat").
+        snapTrieFactory.WaitForInFlightTreesDrained(TimeSpan.FromSeconds(30));
 
         using IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         StateId from = reader.CurrentState;

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -18,8 +18,6 @@ namespace Nethermind.State.Flat.Sync;
 
 public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager persistenceManager, FlatSnapTrieFactory snapTrieFactory, ILogManager logManager) : ITreeSyncStore
 {
-    private readonly ILogger _logger = logManager.GetClassLogger<FlatTreeSyncStore>();
-
     // For flat, one cannot continue syncing after finalization as it will corrupt existing state.
     private bool _wasFinalized = false;
 
@@ -244,8 +242,9 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         // aren't yet committed to the underlying persistence. Without this drain a caller that
         // observes "sync finished" can read state that's missing accounts from late-disposed
         // trees (manifests as E2ESyncTests.SnapSync "Verification failed: N missing in flat").
-        if (!snapTrieFactory.WaitForInFlightTreesDrained(TimeSpan.FromSeconds(30)))
-            if (_logger.IsWarn) _logger.Warn("FlatTreeSyncStore.FinalizeSync proceeding despite in-flight ISnapTrees not draining within 30s — committed state may be incomplete.");
+        // WaitForInFlightTreesDrained logs its own warning on timeout; we still proceed so a
+        // stuck tree doesn't permanently block FinalizeSync.
+        snapTrieFactory.WaitForInFlightTreesDrained(TimeSpan.FromSeconds(30));
 
         using IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         StateId from = reader.CurrentState;

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -19,6 +18,8 @@ namespace Nethermind.State.Flat.Sync;
 
 public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager persistenceManager, FlatSnapTrieFactory snapTrieFactory, ILogManager logManager) : ITreeSyncStore
 {
+    private readonly ILogger _logger = logManager.GetClassLogger<FlatTreeSyncStore>();
+
     // For flat, one cannot continue syncing after finalization as it will corrupt existing state.
     private bool _wasFinalized = false;
 
@@ -243,7 +244,8 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         // aren't yet committed to the underlying persistence. Without this drain a caller that
         // observes "sync finished" can read state that's missing accounts from late-disposed
         // trees (manifests as E2ESyncTests.SnapSync "Verification failed: N missing in flat").
-        snapTrieFactory.WaitForInFlightTreesDrained(TimeSpan.FromSeconds(30));
+        if (!snapTrieFactory.WaitForInFlightTreesDrained(TimeSpan.FromSeconds(30)))
+            if (_logger.IsWarn) _logger.Warn("FlatTreeSyncStore.FinalizeSync proceeding despite in-flight ISnapTrees not draining within 30s — committed state may be incomplete.");
 
         using IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         StateId from = reader.CurrentState;

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
@@ -24,13 +24,15 @@ public class FlatSnapStateTree : ISnapTree<PathWithAccount>
     private readonly bool _enableDoubleWriteCheck;
     private readonly SnapUpperBoundAdapter _adapter;
     private readonly StateTree _tree;
+    private readonly FlatSnapTrieFactory? _ownerFactory;
     private IReadOnlyList<PathWithAccount>? _pendingEntries;
 
-    public FlatSnapStateTree(IPersistence.IPersistenceReader reader, IPersistence.IWriteBatch writeBatch, bool enableDoubleWriteCheck, ILogManager logManager)
+    public FlatSnapStateTree(IPersistence.IPersistenceReader reader, IPersistence.IWriteBatch writeBatch, bool enableDoubleWriteCheck, ILogManager logManager, FlatSnapTrieFactory? ownerFactory = null)
     {
         _reader = reader;
         _writeBatch = writeBatch;
         _enableDoubleWriteCheck = enableDoubleWriteCheck;
+        _ownerFactory = ownerFactory;
         _adapter = new SnapUpperBoundAdapter(new PersistenceTrieStoreAdapter(reader, writeBatch, enableDoubleWriteCheck));
         _tree = new StateTree(_adapter, logManager);
     }
@@ -74,8 +76,15 @@ public class FlatSnapStateTree : ISnapTree<PathWithAccount>
 
     public void Dispose()
     {
-        _writeBatch.Dispose();
-        _reader.Dispose();
+        try
+        {
+            _writeBatch.Dispose();
+            _reader.Dispose();
+        }
+        finally
+        {
+            _ownerFactory?.OnTreeDisposed();
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStorageTree.cs
@@ -26,14 +26,16 @@ public class FlatSnapStorageTree : ISnapTree<PathWithStorageSlot>
     private readonly StorageTree _tree;
     private readonly Hash256 _addressHash;
     private readonly SnapUpperBoundAdapter _adapter;
+    private readonly FlatSnapTrieFactory? _ownerFactory;
     private IReadOnlyList<PathWithStorageSlot>? _pendingEntries;
 
-    public FlatSnapStorageTree(IPersistence.IPersistenceReader reader, IPersistence.IWriteBatch writeBatch, Hash256 addressHash, bool enableDoubleWriteCheck, ILogManager logManager)
+    public FlatSnapStorageTree(IPersistence.IPersistenceReader reader, IPersistence.IWriteBatch writeBatch, Hash256 addressHash, bool enableDoubleWriteCheck, ILogManager logManager, FlatSnapTrieFactory? ownerFactory = null)
     {
         _reader = reader;
         _writeBatch = writeBatch;
         _enableDoubleWriteCheck = enableDoubleWriteCheck;
         _addressHash = addressHash;
+        _ownerFactory = ownerFactory;
         _adapter = new SnapUpperBoundAdapter(new PersistenceStorageTrieStoreAdapter(reader, writeBatch, addressHash, enableDoubleWriteCheck));
         _tree = new StorageTree(_adapter, logManager);
     }
@@ -82,8 +84,15 @@ public class FlatSnapStorageTree : ISnapTree<PathWithStorageSlot>
 
     public void Dispose()
     {
-        _writeBatch.Dispose();
-        _reader.Dispose();
+        try
+        {
+            _writeBatch.Dispose();
+            _reader.Dispose();
+        }
+        finally
+        {
+            _ownerFactory?.OnTreeDisposed();
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics;
+using System.Threading;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -14,6 +16,8 @@ namespace Nethermind.State.Flat.Sync.Snap;
 /// <summary>
 /// ISnapTrieFactory implementation for flat state storage.
 /// Uses IPersistence to create reader/writeBatch per tree for proper resource management.
+/// Tracks in-flight trees so callers can wait for all writeBatches to drain before relying
+/// on the persisted state being complete.
 /// </summary>
 public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfig, ILogManager logManager) : ISnapTrieFactory
 {
@@ -22,13 +26,45 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
     private bool _initialized = false;
 
+    // Tracks ISnapTree instances created via this factory that haven't been disposed yet.
+    // The dispose path commits the per-tree IWriteBatch; until that completes, the tree's
+    // accumulated writes aren't yet visible to subsequent IPersistence readers. Callers
+    // that need a consistent post-sync view (e.g. FlatTreeSyncStore.FinalizeSync) drain via
+    // <see cref="WaitForInFlightTreesDrained"/>.
+    private long _inFlightTrees;
+
+    internal void OnTreeCreated() => Interlocked.Increment(ref _inFlightTrees);
+
+    internal void OnTreeDisposed() => Interlocked.Decrement(ref _inFlightTrees);
+
+    /// <summary>
+    /// Spin-wait until all trees handed out by this factory have been disposed. Returns true
+    /// if drained within <paramref name="timeout"/>, false on timeout.
+    /// </summary>
+    public bool WaitForInFlightTreesDrained(System.TimeSpan timeout)
+    {
+        long deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+        SpinWait spin = new();
+        while (Interlocked.Read(ref _inFlightTrees) > 0)
+        {
+            if (Stopwatch.GetTimestamp() > deadline)
+            {
+                if (_logger.IsWarn) _logger.Warn($"FlatSnapTrieFactory: {Interlocked.Read(ref _inFlightTrees)} trees still in flight after {timeout}");
+                return false;
+            }
+            spin.SpinOnce();
+        }
+        return true;
+    }
+
     public ISnapTree<PathWithAccount> CreateStateTree()
     {
         EnsureDatabaseCleared();
 
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
-        return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager);
+        OnTreeCreated();
+        return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
     }
 
     public ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath)
@@ -37,7 +73,8 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
-        return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager);
+        OnTreeCreated();
+        return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
     }
 
     private void EnsureDatabaseCleared()

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Diagnostics;
-using System.Threading;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -62,9 +61,30 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
         EnsureDatabaseCleared();
 
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
-        IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
+        IPersistence.IWriteBatch writeBatch;
+        try
+        {
+            writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
+        }
+        catch
+        {
+            reader.Dispose();
+            throw;
+        }
         OnTreeCreated();
-        return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
+        try
+        {
+            return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
+        }
+        catch
+        {
+            // Constructor failed: pair the OnTreeCreated above with OnTreeDisposed and release
+            // the per-tree resources ourselves, since no FlatSnapStateTree.Dispose will run.
+            OnTreeDisposed();
+            writeBatch.Dispose();
+            reader.Dispose();
+            throw;
+        }
     }
 
     public ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath)
@@ -72,9 +92,28 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
         EnsureDatabaseCleared();
 
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
-        IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
+        IPersistence.IWriteBatch writeBatch;
+        try
+        {
+            writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
+        }
+        catch
+        {
+            reader.Dispose();
+            throw;
+        }
         OnTreeCreated();
-        return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
+        try
+        {
+            return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
+        }
+        catch
+        {
+            OnTreeDisposed();
+            writeBatch.Dispose();
+            reader.Dispose();
+            throw;
+        }
     }
 
     private void EnsureDatabaseCleared()

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Diagnostics;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
@@ -40,7 +41,7 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
     /// Spin-wait until all trees handed out by this factory have been disposed. Returns true
     /// if drained within <paramref name="timeout"/>, false on timeout.
     /// </summary>
-    public bool WaitForInFlightTreesDrained(System.TimeSpan timeout)
+    public bool WaitForInFlightTreesDrained(TimeSpan timeout)
     {
         long deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
         SpinWait spin = new();
@@ -60,29 +61,22 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
     {
         EnsureDatabaseCleared();
 
-        IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
-        IPersistence.IWriteBatch writeBatch;
+        IPersistence.IPersistenceReader? reader = null;
+        IPersistence.IWriteBatch? writeBatch = null;
+        bool treeTracked = false;
         try
         {
+            reader = persistence.CreateReader(ReaderFlags.Sync);
             writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
-        }
-        catch
-        {
-            reader.Dispose();
-            throw;
-        }
-        OnTreeCreated();
-        try
-        {
+            OnTreeCreated();
+            treeTracked = true;
             return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
         }
         catch
         {
-            // Constructor failed: pair the OnTreeCreated above with OnTreeDisposed and release
-            // the per-tree resources ourselves, since no FlatSnapStateTree.Dispose will run.
-            OnTreeDisposed();
-            writeBatch.Dispose();
-            reader.Dispose();
+            if (treeTracked) OnTreeDisposed();
+            writeBatch?.Dispose();
+            reader?.Dispose();
             throw;
         }
     }
@@ -91,27 +85,22 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
     {
         EnsureDatabaseCleared();
 
-        IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
-        IPersistence.IWriteBatch writeBatch;
+        IPersistence.IPersistenceReader? reader = null;
+        IPersistence.IWriteBatch? writeBatch = null;
+        bool treeTracked = false;
         try
         {
+            reader = persistence.CreateReader(ReaderFlags.Sync);
             writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
-        }
-        catch
-        {
-            reader.Dispose();
-            throw;
-        }
-        OnTreeCreated();
-        try
-        {
+            OnTreeCreated();
+            treeTracked = true;
             return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager, this);
         }
         catch
         {
-            OnTreeDisposed();
-            writeBatch.Dispose();
-            reader.Dispose();
+            if (treeTracked) OnTreeDisposed();
+            writeBatch?.Dispose();
+            reader?.Dispose();
             throw;
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -24,7 +24,7 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapTrieFactory>();
     private readonly Lock _lock = new();
 
-    private bool _initialized = false;
+    private volatile bool _initialized;
 
     // Tracks ISnapTree instances created via this factory that haven't been disposed yet.
     // The dispose path commits the per-tree IWriteBatch; until that completes, the tree's
@@ -84,10 +84,15 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
         using (_lock.EnterScope())
         {
             if (_initialized) return;
-            _initialized = true;
 
             _logger.Info("Clearing database");
             persistence.Clear();
+
+            // Set _initialized AFTER Clear completes so a concurrent caller can't see _initialized=true
+            // and proceed to write accounts while Clear is still iterating GetAllKeys / queueing
+            // Removes in its write batch — that race deletes freshly-written accounts when Clear's
+            // batch finally disposes. Volatile (via the field declaration) gives the publish ordering.
+            _initialized = true;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -408,33 +408,10 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         if (dbMode == DbMode.Hash) Assert.Ignore("Hash db does not support snap sync");
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-
-        PrivateKey clientKey = TestItem.PrivateKeyD;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
-        {
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
-            syncConfig.SnapSync = true;
-
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
-
-            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
-            networkConfig.P2PPort = AllocatePort();
-            // Disable IP filtering for E2E tests as all nodes run on localhost
-            networkConfig.FilterPeersByRecentIp = false;
-            networkConfig.FilterDiscoveryNodesByRecentIp = false;
-        });
-
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+        await RunSnapSyncOnce(cancellationTokenSource.Token);
     }
 
-    // Stress reproducer for the Windows-only SnapSync flake observed in CI:
-    //   - run #25139586200 / job #73686059011 (PR #11422)
-    // Re-runs the same logic as SnapSync() many times, each iteration as its own NUnit case
-    // so a single flake doesn't terminate the rest. Intentionally NO [Retry] — we want every
-    // failure to surface. Marked [Explicit] so it doesn't run in normal CI; invoke with:
-    //   dotnet test --filter "FullyQualifiedName~SnapSync_StressRepro"
-    // Runs only on Flat dbMode (where the flake has been observed).
+    // Stress reproducer for SnapSync Windows flake — run manually; see PR #11443 for context.
     [Test, Explicit("Stress reproducer for SnapSync Windows flake — run manually")]
     [TestCaseSource(nameof(StressIterations))]
     public async Task SnapSync_StressRepro(int iteration)
@@ -443,7 +420,11 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         _ = iteration; // index is purely to give NUnit a unique case per attempt
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
+        await RunSnapSyncOnce(cancellationTokenSource.Token);
+    }
 
+    private async Task RunSnapSyncOnce(CancellationToken cancellationToken)
+    {
         PrivateKey clientKey = TestItem.PrivateKeyD;
         await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
         {
@@ -451,15 +432,16 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             syncConfig.FastSync = true;
             syncConfig.SnapSync = true;
 
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
+            await SetPivot(syncConfig, cancellationToken);
 
             INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
             networkConfig.P2PPort = AllocatePort();
+            // Disable IP filtering for E2E tests as all nodes run on localhost
             networkConfig.FilterPeersByRecentIp = false;
             networkConfig.FilterDiscoveryNodesByRecentIp = false;
         });
 
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationToken);
     }
 
     private const int StressIterationCount = 30;

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -428,6 +428,43 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
     }
 
+    // Stress reproducer for the Windows-only SnapSync flake observed in CI:
+    //   - run #25139586200 / job #73686059011 (PR #11422)
+    // Re-runs the same logic as SnapSync() many times, each iteration as its own NUnit case
+    // so a single flake doesn't terminate the rest. Intentionally NO [Retry] — we want every
+    // failure to surface. Marked [Explicit] so it doesn't run in normal CI; invoke with:
+    //   dotnet test --filter "FullyQualifiedName~SnapSync_StressRepro"
+    // Runs only on Flat dbMode (where the flake has been observed).
+    [Test, Explicit("Stress reproducer for SnapSync Windows flake — run manually")]
+    [TestCaseSource(nameof(StressIterations))]
+    public async Task SnapSync_StressRepro(int iteration)
+    {
+        if (dbMode != DbMode.Flat) Assert.Ignore("Stress repro only targets the Flat dbMode where the flake was observed");
+        _ = iteration; // index is purely to give NUnit a unique case per attempt
+
+        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
+
+        PrivateKey clientKey = TestItem.PrivateKeyD;
+        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+        {
+            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+            syncConfig.FastSync = true;
+            syncConfig.SnapSync = true;
+
+            await SetPivot(syncConfig, cancellationTokenSource.Token);
+
+            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
+            networkConfig.P2PPort = AllocatePort();
+            networkConfig.FilterPeersByRecentIp = false;
+            networkConfig.FilterDiscoveryNodesByRecentIp = false;
+        });
+
+        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+    }
+
+    private const int StressIterationCount = 30;
+    private static IEnumerable<int> StressIterations() => Enumerable.Range(0, StressIterationCount);
+
     [Test]
     [Retry(5)]
     public async Task SnapSync_HalfPathServer_HashClient()


### PR DESCRIPTION
## Summary

Three commits in this PR fix the Windows-only `E2ESyncTests.SnapSync` flake observed in CI ([run #25139586200, job #73686059011](https://github.com/NethermindEth/nethermind/actions/runs/25139586200/job/73686059011?pr=11422) on PR #11422):

1. **fix(db): cross-column snapshot atomicity in `SnapshotableMemColumnsDb`** (`c14030da4d`) — eliminates the `TrieNodeException` mode.
2. **fix(snap-sync): drain in-flight ISnapTrees in `FlatTreeSyncStore.FinalizeSync`** (`12a66f1e1b`) — closes a separate ordering gap where post-sync readers could see state from not-yet-disposed phase-1 trees.
3. **fix(snap-sync): don't publish `_initialized` until `Clear()` completes** (`73b160f057`) — eliminates the deterministic "missing in flat" mode.

Plus the stress reproducer (`edc0d3dbc9`) used to drive the diagnosis.

**Result:** 5 stress runs × 60 tests = **300 invocations, 0 failures**. Previously 8–15 failures per 60-test run on Windows.

## Failure modes the flake produces

### Mode B: `TrieNodeException` (cross-column tearing)

Block processing leases a fresh `persistenceReader` while the persistence pipeline is committing, gets a snapshot where the Accounts column is updated but the StateNodes column is not, walks the trie at the new state root, and throws `TrieNodeException` for a node that should be there.

### Mode A: `Verification failed: N missing in flat`

Trie-side iteration finds account leaves that the flat-side iterator can't see. The same ~9 hashed addresses missed reliably across runs, all in verifier partitions 0–1 (first byte ≤ 0x3f). Counter-based diagnosis (instrumenting both source-side `SetAccount`/`RemoveAccount`/`DeleteAccountRange` and sink-side `InMemoryWriteBatch.Set` filtered to `Column_Account`) showed source vs. sink Set counts matched perfectly while the sink had ~507K *unaccounted* Removes. Tracing back uncovered `ClearAllColumns` racing against fresh sync writes — the third fix below.

## Fix 1 — `c14030da4d` cross-column snapshot atomicity

`SnapshotableMemColumnsDb.CreateSnapshot()` iterates columns and captures each column's snapshot independently. `InMemoryColumnWriteBatch.Dispose()` iterates per-column batches and disposes each independently. Without a global guard, a `CreateSnapshot` concurrent with an in-flight `writeBatch.Dispose` can capture some columns *after* the new writes and others *before* — a cross-column-inconsistent reader view.

This race only affects the test backend — RocksDB has atomic cross-CF snapshots — but it manifests concretely in `E2ESyncTests.SnapSync`. The fix wraps `CreateSnapshot` and the wrapped `AtomicColumnsWriteBatch.Dispose` in a single `Lock` so per-Dispose multi-column commits are atomic w.r.t. snapshot creation.

## Fix 2 — `12a66f1e1b` drain in-flight ISnapTrees in FinalizeSync

Phase-1 / phase-2 trees produced by `FlatSnapTrieFactory` hold per-tree `IWriteBatch` instances; until each tree's `Dispose` returns, its writes aren't yet committed to the underlying persistence. Without a drain, a caller that observes "sync finished" can read state that's missing accounts from late-disposed trees.

`FlatSnapTrieFactory` now tracks an `_inFlightTrees` counter (incremented in `CreateStateTree`/`CreateStorageTree`, decremented in `FlatSnapStateTree.Dispose`/`FlatSnapStorageTree.Dispose`). `FlatTreeSyncStore.FinalizeSync` calls `WaitForInFlightTreesDrained` (spin-wait, 30s timeout) before bumping the persisted state ID. This is independent of fix 3 — it closes a different ordering window that can otherwise re-emerge as the same symptom.

## Fix 3 — `73b160f057` don't publish `_initialized` until `Clear()` completes

`FlatSnapTrieFactory.EnsureDatabaseCleared` had this ordering:

```csharp
if (_initialized) return;
using (_lock.EnterScope())
{
    if (_initialized) return;
    _initialized = true;          // published BEFORE Clear() ran
    persistence.Clear();           // still iterating + queueing Removes
}
```

Sequence that wipes accounts:

1. Thread T1 enters `EnsureDatabaseCleared`, sets `_initialized = true`, then starts `persistence.Clear()`. `Clear()` opens a single `IColumnsWriteBatch`, then for each column iterates `db.GetColumnDb(column).GetAllKeys()` and queues `columnBatch.Remove(key)` for every key it sees — and only disposes the batch (applying the queued Removes) when *all columns* are done.
2. Thread T2 hits the unlocked fast-path `if (_initialized) return;`, sees `true`, and skips Clear entirely.
3. T2 calls `persistence.CreateWriteBatch(...)` and starts writing accounts via `SetAccount`. These commit normally (their own `IPersistence.IWriteBatch.Dispose`).
4. T1's `Clear()` is still inside its `IColumnsWriteBatch`. As it iterates `GetAllKeys()` for the Account column, it sees the keys T2 just committed and queues `columnBatch.Remove(key)` for them.
5. T1's batch finally disposes. Every queued `Remove` lands on the live DB — including T2's freshly-written accounts. The flat DB ends up missing entries that the trie still references; the verifier reports "Account in trie not found in flat".

The fix: publish `_initialized = true` *after* `persistence.Clear()` returns, and mark the field `volatile`. Concurrent fast-path readers either observe `false` (and wait on the lock) or observe `true` (and Clear is genuinely done, so it's safe to proceed).

### How fix 3 was diagnosed

Surface symptoms (key seen by trie iterator but not by flat iterator) were consistent across runs but didn't point at any obvious caller. Source-side instrumentation in `BaseFlatPersistence.WriteBatch` (`SetAccount` / `RemoveAccount` / `DeleteAccountRange` preview) plus sink-side instrumentation in `InMemoryWriteBatch.Set` (filtered to `_store.Name == "Column_Account"`) showed:

```
setBaseFlat = 1,134,377   setIM = 1,134,377    ← all sets accounted
removeBaseFlat = 1,974    DeleteAccountRangePreview = 552
removeIM = 509,598
clearAllColumnsCalls = 60   clearAccountRemoves = 507,072    ← gap closes here
```

507,072 of the 509,598 sink Removes came from `ClearAllColumns` — i.e. ~8,451 accounts removed *per test*, where the DB was supposed to be empty when Clear ran. ~8,451 ≈ the test fixture's account count, confirming Clear was racing against sync writes. The race is timing-sensitive (any instrumentation in the hot path masks it) which is why Linux/macOS pass and only Windows reproduces.

## Stress reproducer

`SnapSync_StressRepro` runs 30 iterations × 2 Flat fixtures = 60 cases, each as its own NUnit case (so a single failure doesn't terminate the rest), no `[Retry]`, `[Explicit]`. ~1m runtime.

```
dotnet test --project src/Nethermind/Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj \
  -c release -- --filter "FullyQualifiedName~SnapSync_StressRepro"
```

| Configuration | Local Windows results (per 60-test run) |
|---|---|
| Baseline (no fix) | 18/60 fail; ~12 Mode A + ~6 Mode B |
| + cross-column fix (fix 1) | ~18/60 fail; 18 Mode A + 0 Mode B |
| + ISnapTree drain (fix 2) | 8–15/60 fail; all Mode A |
| + `_initialized` race (fix 3) | **0/60** |

Across 5 consecutive runs of the stress reproducer with all three fixes applied: **0/300 failures**.

## Test plan

- [x] `Nethermind.Db` builds (0 warnings, 0 errors)
- [x] `Nethermind.State.Flat` builds (0 warnings, 0 errors)
- [x] `Nethermind.Synchronization.Test` builds (0 warnings, 0 errors)
- [x] Stress reproducer: 0/300 failures across 5 consecutive 60-test runs on Windows
