### PR TITLE
fix: Revise dependency caching

### DIFF
--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -100,6 +100,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test
@@ -152,6 +156,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test
@@ -159,7 +159,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -84,6 +84,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test
@@ -182,7 +182,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -259,7 +259,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: |
-            **/packages.lock.json
+            src/Nethermind/**/packages.lock.json
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -101,6 +101,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.project }}
         id: test
@@ -175,6 +179,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -248,6 +256,10 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test


### PR DESCRIPTION
## Changes

Replaced the manual buggy NuGet package caching with one of `actions/setup-dotnet`. It's based on the lock file of `Nethermind.Runner`; hence, it doesn't cover the packages referenced by test projects. Nevertheless, the vast majority of packages are cached, greatly reducing the burden.
 
## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: CI caching optimization

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Requires manual testing