### PR TITLE
perf(bal): zero-alloc dict-lookup ValidateBlockAccessList

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -300,7 +300,6 @@ public class BlockAccessListManager(
         }
     }
 
-    // todo: optimize early validation
     public void ValidateBlockAccessList(Block block, ushort index, bool validateStorageReads = true)
     {
         if (block.BlockAccessList is null)
@@ -310,85 +309,60 @@ public class BlockAccessListManager(
 
         CheckInitialized();
 
-        IEnumerator<ChangeAtIndex> generatedChanges = GeneratedBlockAccessList.GetChangesAtIndex(index).GetEnumerator();
-        IEnumerator<ChangeAtIndex> suggestedChanges = block.BlockAccessList.GetChangesAtIndex(index).GetEnumerator();
-
-        ChangeAtIndex? generatedHead;
-        ChangeAtIndex? suggestedHead;
+        GeneratedBlockAccessList generated = GeneratedBlockAccessList;
+        ReadOnlyBlockAccessList suggested = block.BlockAccessList;
 
         int generatedReads = 0;
         int suggestedReads = 0;
 
-        void AdvanceGenerated()
+        // Pass 1: walk generated; for each account, look up the matching entry in suggested
+        // via the dictionary (O(1)) instead of a sorted merge-walk. Catches "missing-from-
+        // suggested" and "incorrect changes at this index".
+        foreach (GeneratedAccountChanges gen in generated.AccountChanges)
         {
-            generatedHead = generatedChanges.MoveNext() ? generatedChanges.Current : null;
-            if (generatedHead is not null) generatedReads += generatedHead.Value.Reads;
+            int genReads = IsSystemContract(gen.Address) ? 0 : gen.StorageReads.Count;
+            generatedReads += genReads;
+
+            ReadOnlyAccountChanges? sug = suggested.GetAccountChanges(gen.Address);
+            if (sug is not null)
+            {
+                if (!gen.ChangesAtIndexEqual(sug, index))
+                {
+                    throw new InvalidBlockLevelAccessListException(block.Header,
+                        $"Suggested block-level access list contained incorrect changes for {gen.Address} at index {index}.");
+                }
+                continue;
+            }
+
+            // Generated has the account, suggested doesn't. Tolerated only when there are no
+            // changes at this index AND the entry is either a system-user read at index 0 or
+            // a generic storage-read-only entry.
+            if (gen.HasNoChangesAtIndex(index) &&
+                ((index == 0 && gen.Address == Address.SystemUser && genReads == 0) || genReads > 0))
+            {
+                continue;
+            }
+
+            throw new InvalidBlockLevelAccessListException(block.Header,
+                $"Suggested block-level access list missing account changes for {gen.Address} at index {index}.");
         }
 
-        void AdvanceSuggested()
+        // Pass 2: walk suggested; only accounts NOT present in generated need attention.
+        // Tally suggested reads here for the storage-read gas-budget check below.
+        foreach (ReadOnlyAccountChanges sug in suggested.AccountChanges)
         {
-            suggestedHead = suggestedChanges.MoveNext() ? suggestedChanges.Current : null;
-            if (suggestedHead is not null) suggestedReads += suggestedHead.Value.Reads;
-        }
+            suggestedReads += IsSystemContract(sug.Address) ? 0 : sug.StorageReads.Length;
 
-        AdvanceGenerated();
-        AdvanceSuggested();
-
-        while (generatedHead is not null || suggestedHead is not null)
-        {
-            if (suggestedHead is null)
+            if (generated.HasAccount(sug.Address))
             {
-                if (IsSystemAccountRead(generatedHead.Value, index) || HasOptionalStorageReads(generatedHead.Value))
-                {
-                    AdvanceGenerated();
-                    continue;
-                }
-                throw new InvalidBlockLevelAccessListException(block.Header, $"Suggested block-level access list missing account changes for {generatedHead.Value.Address} at index {index}.");
-            }
-            else if (generatedHead is null)
-            {
-                if (HasNoChanges(suggestedHead.Value))
-                {
-                    AdvanceSuggested();
-                    continue;
-                }
-                throw new InvalidBlockLevelAccessListException(block.Header, $"Suggested block-level access list contained surplus changes for {suggestedHead.Value.Address} at index {index}.");
+                continue;
             }
 
-            int cmp = generatedHead.Value.Address.CompareTo(suggestedHead.Value.Address);
-
-            if (cmp == 0)
+            if (!sug.HasNoChangesAtIndex(index))
             {
-                if (generatedHead.Value.BalanceChange != suggestedHead.Value.BalanceChange ||
-                    generatedHead.Value.NonceChange != suggestedHead.Value.NonceChange ||
-                    generatedHead.Value.CodeChange.HasValue != suggestedHead.Value.CodeChange.HasValue ||
-                    generatedHead.Value.CodeChange is not null && !generatedHead.Value.CodeChange.Value.Equals(suggestedHead.Value.CodeChange.Value) ||
-                    !Enumerable.SequenceEqual(generatedHead.Value.SlotChanges, suggestedHead.Value.SlotChanges))
-                {
-                    throw new InvalidBlockLevelAccessListException(block.Header, $"Suggested block-level access list contained incorrect changes for {suggestedHead.Value.Address} at index {index}.");
-                }
+                throw new InvalidBlockLevelAccessListException(block.Header,
+                    $"Suggested block-level access list contained surplus changes for {sug.Address} at index {index}.");
             }
-            else if (cmp > 0)
-            {
-                if (HasNoChanges(suggestedHead.Value))
-                {
-                    AdvanceSuggested();
-                    continue;
-                }
-                throw new InvalidBlockLevelAccessListException(block.Header, $"Suggested block-level access list contained surplus changes for {suggestedHead.Value.Address} at index {index}.");
-            }
-            else
-            {
-                if (IsSystemAccountRead(generatedHead.Value, index) || HasOptionalStorageReads(generatedHead.Value))
-                {
-                    AdvanceGenerated();
-                    continue;
-                }
-                throw new InvalidBlockLevelAccessListException(block.Header, $"Suggested block-level access list missing account changes for {generatedHead.Value.Address} at index {index}.");
-            }
-
-            AdvanceGenerated();
-            AdvanceSuggested();
         }
 
         int surplusSuggestedReads = suggestedReads - generatedReads;
@@ -397,6 +371,10 @@ public class BlockAccessListManager(
             throw new InvalidBlockLevelAccessListException(block.Header, "Suggested block-level access list contained invalid storage reads.");
         }
     }
+
+    private static bool IsSystemContract(Address address)
+        => address == Eip7002Constants.WithdrawalRequestPredeployAddress
+        || address == Eip7251Constants.ConsolidationRequestPredeployAddress;
 
     public void StoreBeaconRoot(Block block, IReleaseSpec spec)
     {
@@ -459,18 +437,6 @@ public class BlockAccessListManager(
             }
         }
     }
-
-    private static bool HasNoChanges(in ChangeAtIndex c)
-        => c.BalanceChange is null &&
-            c.NonceChange is null &&
-            c.CodeChange is null &&
-            !c.HasSlotChanges;
-
-    private static bool HasOptionalStorageReads(in ChangeAtIndex c)
-        => HasNoChanges(c) && c.Reads > 0;
-
-    private static bool IsSystemAccountRead(in ChangeAtIndex c, ushort index)
-        => index == 0 && c.Address == Address.SystemUser && HasNoChanges(c) && c.Reads == 0;
 
     private void CheckInitialized()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Linq;
 using Nethermind.Blockchain;
 using System.Collections.Concurrent;
 using Nethermind.Core.Caching;

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChanges.cs
@@ -94,8 +94,10 @@ public class GeneratedAccountChanges(Address address)
         //   - other: ReadOnlySlotChanges[] (decoder produces sorted)
         // Walk in lockstep, skipping slots that have no change at this index on either side.
         // Concrete struct enumerator type avoids the boxing the IEnumerable/IEnumerator
-        // interface would force.
-        using SortedDictionary<UInt256, GeneratedSlotChanges>.ValueCollection.Enumerator a
+        // interface would force; Dispose chain bottoms out at empty TreeSet.Enumerator.Dispose
+        // so we skip the `using` for clarity — the manual MoveNext/Current control here is
+        // intentional, and there's no resource to release.
+        SortedDictionary<UInt256, GeneratedSlotChanges>.ValueCollection.Enumerator a
             = _storageChanges.Values.GetEnumerator();
         ReadOnlySlotChanges[] b = other.StorageChanges;
         int j = 0;

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChanges.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json.Serialization;
 using Nethermind.Int256;
@@ -42,6 +44,125 @@ public class GeneratedAccountChanges(Address address)
 
     public bool TryGetSlotChanges(UInt256 key, [NotNullWhen(true)] out GeneratedSlotChanges? slotChanges)
         => _storageChanges.TryGetValue(key, out slotChanges);
+
+    /// <summary>Per-family change lists are appended in monotonically increasing <c>Index</c>
+    /// order during <see cref="Merge"/>, so we binary-search via <see cref="IndexKey{T}"/>
+    /// rather than scanning. Mirrors <see cref="ReadOnlyAccountChanges"/>.</summary>
+    public BalanceChange? BalanceChangeAtIndex(int index) => GetExact(BalanceChanges, index);
+    public NonceChange? NonceChangeAtIndex(int index) => GetExact(NonceChanges, index);
+    public CodeChange? CodeChangeAtIndex(int index) => GetExact(CodeChanges, index);
+
+    public bool HasSlotChangesAtIndex(int index)
+    {
+        foreach (GeneratedSlotChanges slot in _storageChanges.Values)
+        {
+            if (TryGetSlotChangeAtIndex(slot, index, out _)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>True iff this account has no balance/nonce/code/slot change at <paramref name="index"/>.
+    /// Storage reads are not changes; this only inspects mutating entries.</summary>
+    public bool HasNoChangesAtIndex(ushort index)
+        => BalanceChangeAtIndex(index) is null
+        && NonceChangeAtIndex(index) is null
+        && CodeChangeAtIndex(index) is null
+        && !HasSlotChangesAtIndex(index);
+
+    /// <summary>Structural equality of the per-index slice of this account against the suggested
+    /// (decoded) account. Address is not compared (callers ensure they're matched). Walks both
+    /// sides without allocating: per-slot lookup is an O(log n) binary search via
+    /// <see cref="IndexKey{T}"/>; both storage maps iterate in sorted-by-slot-key order so
+    /// account-level slot pairing is a single linear merge-walk.</summary>
+    public bool ChangesAtIndexEqual(ReadOnlyAccountChanges other, ushort index)
+    {
+        if (BalanceChangeAtIndex(index) != other.BalanceChangeAtIndex(index)) return false;
+        if (NonceChangeAtIndex(index) != other.NonceChangeAtIndex(index)) return false;
+
+        CodeChange? thisCode = CodeChangeAtIndex(index);
+        CodeChange? otherCode = other.CodeChangeAtIndex(index);
+        if (thisCode.HasValue != otherCode.HasValue) return false;
+        if (thisCode.HasValue && !thisCode.Value.Equals(otherCode!.Value)) return false;
+
+        return SlotChangesAtIndexEqual(other, index);
+    }
+
+    private bool SlotChangesAtIndexEqual(ReadOnlyAccountChanges other, ushort index)
+    {
+        // Both sides iterate slots in sorted-by-key order:
+        //   - this:  SortedDictionary<UInt256, GeneratedSlotChanges>.Values
+        //   - other: ReadOnlySlotChanges[] (decoder produces sorted)
+        // Walk in lockstep, skipping slots that have no change at this index on either side.
+        // Concrete struct enumerator type avoids the boxing the IEnumerable/IEnumerator
+        // interface would force.
+        using SortedDictionary<UInt256, GeneratedSlotChanges>.ValueCollection.Enumerator a
+            = _storageChanges.Values.GetEnumerator();
+        ReadOnlySlotChanges[] b = other.StorageChanges;
+        int j = 0;
+        bool aHas = a.MoveNext();
+        StorageChange aChange = default, bChange = default;
+
+        while (true)
+        {
+            // Advance each side to the next slot that has a change at `index`, capturing the
+            // change in the same binary search rather than re-searching after presence is known.
+            bool aMatched = false;
+            while (aHas)
+            {
+                if (TryGetSlotChangeAtIndex(a.Current, index, out aChange)) { aMatched = true; break; }
+                aHas = a.MoveNext();
+            }
+            bool bMatched = false;
+            while (j < b.Length)
+            {
+                if (TryGetSlotChangeAtIndex(b[j], index, out bChange)) { bMatched = true; break; }
+                j++;
+            }
+
+            if (!aMatched && !bMatched) return true;
+            if (aMatched != bMatched) return false;
+            if (a.Current.Key != b[j].Key) return false;
+            if (!aChange.Equals(bChange)) return false;
+
+            aHas = a.MoveNext();
+            j++;
+        }
+    }
+
+    private static bool TryGetSlotChangeAtIndex(GeneratedSlotChanges slot, int index, out StorageChange change)
+    {
+        ReadOnlySpan<StorageChange> span = CollectionsMarshal.AsSpan(slot.Changes);
+        int idx = span.BinarySearch(new IndexKey<StorageChange>(index));
+        if (idx >= 0)
+        {
+            change = span[idx];
+            return true;
+        }
+        change = default;
+        return false;
+    }
+
+    private static bool TryGetSlotChangeAtIndex(ReadOnlySlotChanges slot, int index, out StorageChange change)
+    {
+        ReadOnlySpan<StorageChange> span = slot.Changes;
+        int idx = span.BinarySearch(new IndexKey<StorageChange>(index));
+        if (idx >= 0)
+        {
+            change = span[idx];
+            return true;
+        }
+        change = default;
+        return false;
+    }
+
+    /// <summary>O(log n) lookup of the entry with <c>Index == index</c> over a list kept sorted
+    /// by index (the merge contract on <see cref="GeneratedAccountChanges"/> guarantees that).</summary>
+    private static T? GetExact<T>(List<T> changes, int index) where T : struct, IIndexedChange
+    {
+        ReadOnlySpan<T> span = CollectionsMarshal.AsSpan(changes);
+        int idx = span.BinarySearch(new IndexKey<T>(index));
+        return idx >= 0 ? span[idx] : null;
+    }
 
     public GeneratedSlotChanges GetOrAddSlotChanges(UInt256 key)
     {

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
@@ -54,25 +54,6 @@ public class GeneratedBlockAccessList
     public void Clear() => _accountChanges.Clear();
     public void Reset() => Clear();
 
-    public IEnumerable<ChangeAtIndex> GetChangesAtIndex(ushort index)
-    {
-        foreach (GeneratedAccountChanges acc in _accountChanges.Values)
-        {
-            bool isSystemContract =
-                acc.Address == Eip7002Constants.WithdrawalRequestPredeployAddress ||
-                acc.Address == Eip7251Constants.ConsolidationRequestPredeployAddress;
-
-            yield return new ChangeAtIndex(
-                acc.Address,
-                BalanceAtIndex(acc, index),
-                NonceAtIndex(acc, index),
-                CodeAtIndex(acc, index),
-                SlotChangesAtIndex(acc, index),
-                HasSlotChangesAtIndex(acc, index),
-                isSystemContract ? 0 : acc.StorageReads.Count);
-        }
-    }
-
     /// <summary>For tests only — builds the accountChanges dictionary directly.</summary>
     internal static GeneratedBlockAccessList FromAccounts(IEnumerable<GeneratedAccountChanges> accounts)
     {
@@ -93,85 +74,5 @@ public class GeneratedBlockAccessList
             sb.Append("  ").AppendLine(ac.ToString());
         }
         return sb.ToString();
-    }
-
-    private static BalanceChange? BalanceAtIndex(GeneratedAccountChanges acc, int index)
-    {
-        // Linear scan — most accounts have very few entries; lists are sorted by index.
-        foreach (BalanceChange b in acc.BalanceChanges)
-        {
-            if (b.Index == index) return b;
-            if (b.Index > index) break;
-        }
-        return null;
-    }
-
-    private static NonceChange? NonceAtIndex(GeneratedAccountChanges acc, int index)
-    {
-        foreach (NonceChange n in acc.NonceChanges)
-        {
-            if (n.Index == index) return n;
-            if (n.Index > index) break;
-        }
-        return null;
-    }
-
-    private static CodeChange? CodeAtIndex(GeneratedAccountChanges acc, int index)
-    {
-        foreach (CodeChange c in acc.CodeChanges)
-        {
-            if (c.Index == index) return c;
-            if (c.Index > index) break;
-        }
-        return null;
-    }
-
-    private static IEnumerable<SlotChangeAtIndex> SlotChangesAtIndex(GeneratedAccountChanges acc, int index)
-    {
-        foreach (GeneratedSlotChanges slot in acc.StorageChanges)
-        {
-            foreach (StorageChange c in slot.Changes)
-            {
-                if (c.Index == index)
-                {
-                    yield return new SlotChangeAtIndex(slot.Key, c);
-                    break;
-                }
-                if (c.Index > index) break;
-            }
-        }
-    }
-
-    private static bool HasSlotChangesAtIndex(GeneratedAccountChanges acc, int index)
-    {
-        foreach (GeneratedSlotChanges slot in acc.StorageChanges)
-        {
-            foreach (StorageChange c in slot.Changes)
-            {
-                if (c.Index == index) return true;
-                if (c.Index > index) break;
-            }
-        }
-        return false;
-    }
-}
-
-public record struct ChangeAtIndex(
-    Address Address,
-    BalanceChange? BalanceChange,
-    NonceChange? NonceChange,
-    CodeChange? CodeChange,
-    IEnumerable<SlotChangeAtIndex> SlotChanges,
-    bool HasSlotChanges,
-    int Reads)
-{
-    public override string ToString()
-    {
-        int slotChangeCount = 0;
-        foreach (SlotChangeAtIndex _ in SlotChanges)
-        {
-            slotChangeCount++;
-        }
-        return $"{nameof(ChangeAtIndex)}({Address}, Balance={BalanceChange?.Value}, Nonce={NonceChange?.Value}, Code={CodeChange is not null}, Slots={slotChangeCount}, Reads={Reads})";
     }
 }

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
@@ -119,6 +119,14 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
         }
     }
 
+    /// <summary>True iff this account has no balance/nonce/code/slot change at <paramref name="index"/>.
+    /// Storage reads are not changes; this only inspects mutating entries.</summary>
+    public bool HasNoChangesAtIndex(ushort index)
+        => BalanceChangeAtIndex(index) is null
+        && NonceChangeAtIndex(index) is null
+        && CodeChangeAtIndex(index) is null
+        && !HasSlotChangesAtIndex(index);
+
     /// <summary>Most recent balance strictly before <paramref name="blockAccessIndex"/>; null if none.</summary>
     public UInt256? GetBalance(int blockAccessIndex) => TryGetLastBefore(_balanceChanges, blockAccessIndex, out BalanceChange last) ? last.Value : null;
 

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyBlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyBlockAccessList.cs
@@ -49,25 +49,6 @@ public class ReadOnlyBlockAccessList : IEquatable<ReadOnlyBlockAccessList>
         ItemCount = itemCount;
     }
 
-    public IEnumerable<ChangeAtIndex> GetChangesAtIndex(ushort index)
-    {
-        foreach (ReadOnlyAccountChanges acc in _accountChanges.Values)
-        {
-            bool isSystemContract =
-                acc.Address == Eip7002Constants.WithdrawalRequestPredeployAddress ||
-                acc.Address == Eip7251Constants.ConsolidationRequestPredeployAddress;
-
-            yield return new ChangeAtIndex(
-                acc.Address,
-                acc.BalanceChangeAtIndex(index),
-                acc.NonceChangeAtIndex(index),
-                acc.CodeChangeAtIndex(index),
-                acc.SlotChangesAtIndex(index),
-                acc.HasSlotChangesAtIndex(index),
-                isSystemContract ? 0 : acc.StorageReads.Length);
-        }
-    }
-
     public bool Equals(ReadOnlyBlockAccessList? other)
     {
         if (other is null) return false;


### PR DESCRIPTION
## Changes

Rewrites `BlockAccessListManager.ValidateBlockAccessList` from a sorted merge-walk over yielded `ChangeAtIndex` records into two passes of O(1) dictionary lookups against the new `GeneratedBlockAccessList` / `ReadOnlyBlockAccessList` structures.

The merge-walk pattern only existed because the validator wanted both sides in sorted address order — a stylistic choice, not a requirement. Both BALs already have hash-keyed account dictionaries; there's no reason to sort.

### What this removes per `ValidateBlockAccessList` call

- `Enumerator` allocations from `GetChangesAtIndex` on both sides
- `ChangeAtIndex` record-struct yields (with boxed `IEnumerable<SlotChangeAtIndex>` field)
- The `Enumerable.SequenceEqual` enumerators used for slot comparison
- All sort/list materialization that previously fed the merge-walk

The sequential tail of `IncrementalValidation` (`incrementalValidationTask.GetAwaiter().GetResult()` after parallel `For`) was dominated by these per-call allocations × N+1 indices per block. Zero per-call allocs now.

### What this adds

- `GeneratedAccountChanges.HasNoChangesAtIndex(ushort)` and `ChangesAtIndexEqual(ReadOnlyAccountChanges, ushort)` — cross-type structural compare at one index, no allocation
- `GeneratedAccountChanges.{Balance,Nonce,Code}ChangeAtIndex` — `Span<T>.BinarySearch` via `IndexKey<T>` over the per-family `List<T>` (lists are sorted by Index per the `Merge` contract); mirrors the pattern `ReadOnlyAccountChanges` already uses for its sorted arrays
- `GeneratedAccountChanges.HasSlotChangesAtIndex` and per-slot helpers — binary search inside `GeneratedSlotChanges.Changes` / `ReadOnlySlotChanges.Changes` instead of forward scan
- `ReadOnlyAccountChanges.HasNoChangesAtIndex(ushort)` — single helper covering balance/nonce/code/slot
- `ValidateBlockAccessList` rewritten:
  - Pass 1 walks `generated.AccountChanges`, looks up each in suggested via `GetAccountChanges`; catches "incorrect changes" (paired) and "missing-from-suggested" (gen-only)
  - Pass 2 walks `suggested.AccountChanges`, checks `generated.HasAccount`; catches "surplus" (sug-only with changes at this index) and tallies suggested reads for the gas-budget check

### What this removes from the type surface

- `GeneratedBlockAccessList.GetChangesAtIndex` and its private per-index helpers
- `ReadOnlyBlockAccessList.GetChangesAtIndex`
- The `ChangeAtIndex` record struct (validator was the only consumer)

### Complexity

- Per-call validator: O(2n log n) sorts + per-yield record/list allocations → O(n) dict probes + zero allocations
- Per-account index lookups inside `ChangesAtIndexEqual`: linear scan with early-exit → O(log m) binary search for the families and per-slot index

## Types of changes

- [x] Optimization

## Testing

- [x] Yes (existing tests cover behaviour)

`Nethermind.Core.Test` (BlockAccessList / AccountChanges): 17/17 pass
`Nethermind.Blockchain.Test` (ValidateBlockAccessList / BlockProcessor): 24/24 pass
`Nethermind.State.Test` (BlockAccessList / TracedAccess): 67/67 pass (1 unrelated skip)
Full solution build: 0 warnings, 0 errors