### PR TITLE
fix: misleading "100% Old Headers" and "Unable to find beacon header" logs at fresh sync start

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -32,11 +32,25 @@ public class ChainLevelHelper(
     {
         if (_beaconPivot.ProcessDestination?.Number > blockNumber)
         {
-            // For some reason, this block number is missing when it should not.
-            // anyway, lets just restart the whole sync.
             if (_beaconPivot.ShouldForceStartNewSync) return;
 
-            if (_logger.IsWarn) _logger.Warn($"Unable to find beacon header at height {blockNumber}. This is unexpected, forcing a new beacon sync.");
+            // A gap is expected when forward sync hasn't reached `blockNumber` yet (best beacon header
+            // still below it) or when backward beacon sync hasn't reached it yet (lowest beacon header
+            // still above it). Trigger a new beacon sync to close the gap, but skip the misleading
+            // "this is unexpected" warning when it's just a normal mid-sync state.
+            bool aboveBeaconCoverage = (_blockTree.BestSuggestedBeaconHeader?.Number ?? -1) < blockNumber;
+            bool belowBeaconCoverage = (_blockTree.LowestInsertedBeaconHeader?.Number ?? long.MaxValue) > blockNumber;
+            bool expectedDuringSync = aboveBeaconCoverage || belowBeaconCoverage;
+
+            if (!expectedDuringSync)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Unable to find beacon header at height {blockNumber}. This is unexpected, forcing a new beacon sync.");
+            }
+            else if (_logger.IsDebug)
+            {
+                _logger.Debug($"Beacon header at height {blockNumber} not yet downloaded, requesting a new beacon sync.");
+            }
+
             _beaconPivot.ShouldForceStartNewSync = true;
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -76,7 +76,7 @@ public class FastHeadersSyncTests
             {
                 FastSync = true,
                 PivotNumber = pivotNumber,
-                PivotHash = Keccak.Zero.ToString(),
+                PivotHash = TestItem.KeccakA.ToString(),
                 PivotTotalDifficulty = "1000"
             },
             poSSwitcher: Substitute.For<IPoSSwitcher>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -59,6 +59,39 @@ public class FastHeadersSyncTests
     }
 
     [Test]
+    public void When_initialized_with_no_inserted_headers_progress_starts_at_zero()
+    {
+        // Regression test for issue #11447: Reset() with a null LowestInsertedBlockHeader used to fall
+        // back to 0, producing a current value of (_pivotNumber + 1) — visible as "Old Headers
+        // 24,998,904 / 24,998,903 (100.00 %)" right after a fresh FlatDB sync started.
+        const long pivotNumber = 1000;
+        BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
+        blockTree.SyncPivot = (pivotNumber, TestItem.KeccakA);
+
+        ISyncReport syncReport = new NullSyncReport();
+        using HeadersSyncFeed feed = new(
+            blockTree: blockTree,
+            syncPeerPool: Substitute.For<ISyncPeerPool>(),
+            syncConfig: new TestSyncConfig
+            {
+                FastSync = true,
+                PivotNumber = pivotNumber,
+                PivotHash = Keccak.Zero.ToString(),
+                PivotTotalDifficulty = "1000"
+            },
+            poSSwitcher: Substitute.For<IPoSSwitcher>(),
+            syncReport: syncReport,
+            logManager: LimboLogs.Instance,
+            chainLevelInfoRepository: Substitute.For<IChainLevelInfoRepository>(),
+            headerStore: Substitute.For<IHeaderStore>());
+
+        feed.InitializeFeed();
+
+        syncReport.FastBlocksHeaders.CurrentValue.Should().Be(0);
+        syncReport.FastBlocksHeaders.TargetValue.Should().Be(pivotNumber);
+    }
+
+    [Test]
     public async Task Can_prepare_3_requests_in_a_row()
     {
         BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -195,7 +195,9 @@ namespace Nethermind.Synchronization.FastBlocks
             }
 
             base.InitializeFeed();
-            HeadersSyncProgressLoggerReport.Reset(_pivotNumber - (LowestInsertedBlockHeader?.Number ?? 0) + 1, TotalBlocks);
+            // null lowest header means nothing inserted yet — without this guard the bar would briefly read 100%.
+            long currentValue = LowestInsertedBlockHeader is null ? 0 : _pivotNumber - LowestInsertedBlockHeader.Number + 1;
+            HeadersSyncProgressLoggerReport.Reset(currentValue, TotalBlocks);
         }
 
         protected virtual void ResetPivot()


### PR DESCRIPTION
Fixes #11447

## Changes

- `HeadersSyncFeed.InitializeFeed` starts the headers progress counter at 0 when no headers are inserted. The previous formula fell back to `_pivotNumber + 1`, briefly displaying `Old Headers 24,998,904 / 24,998,903 (100.00 %)` right after a fresh FlatDB sync started.
- `ChainLevelHelper.OnMissingBeaconHeader` no longer logs the alarming `Unable to find beacon header at height X. This is unexpected, forcing a new beacon sync.` warning when the gap is just an expected mid-sync state — forward beacon coverage hasn't reached `X` yet, or backward beacon sync hasn't reached it yet. The new beacon sync is still triggered to close the gap; only the misleading warning is suppressed (logged at Debug instead).
- Added regression test `When_initialized_with_no_inserted_headers_progress_starts_at_zero` in `FastHeadersSyncTests`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `dotnet test --project Nethermind.Synchronization.Test` — 37/37 `FastHeadersSyncTests` pass.
- `dotnet test --project Nethermind.Merge.Plugin.Test --filter Synchronization|BlockTreeTests|BeaconHeader` — all pass.
- Recommend a manual fresh FlatDB mainnet sync to confirm both log lines no longer appear at startup.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No