### PR TITLE
XDC Downgrade base protocol

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
@@ -23,7 +23,6 @@ using Nethermind.Xdc.Types;
 using NSubstitute;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 
@@ -302,8 +301,8 @@ public class XdcProtocolHandlerTests
     [Test]
     public void SendNewTransactions_UsesTransactionsMessage_NotNewPooledTransactionHashes()
     {
-        // XdcProtocolHandler extends Eth63, so tx gossip must go via TransactionsMessage (0x02),
-        // never via NewPooledTransactionHashesMessage (0x08 from Eth65).
+        // In XdcProtocolHandler tx gossip must go via TransactionsMessage (0x02),
+        // never via NewPooledTransactionHashesMessage (0x08 from Eth65) which conflicts with XDC OrderTxMsg.
         (XdcProtocolHandler handler, _, ISession session, _, _, _) = CreateAll();
         using (handler)
         {

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
@@ -9,8 +9,10 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
+using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -21,6 +23,7 @@ using Nethermind.Xdc.Types;
 using NSubstitute;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 
@@ -62,7 +65,6 @@ public class XdcProtocolHandlerTests
             Substitute.For<IBackgroundTaskScheduler>(),
             Substitute.For<ITxPool>(),
             Substitute.For<IGossipPolicy>(),
-            Substitute.For<IForkInfo>(),
             LimboLogs.Instance,
             Substitute.For<ITxGossipPolicy>());
 
@@ -294,6 +296,23 @@ public class XdcProtocolHandlerTests
             handler.SendSyncInfo(syncInfo);
 
             session.Received(2).DeliverMessage(Arg.Any<SyncInfoMsg>());
+        }
+    }
+
+    [Test]
+    public void SendNewTransactions_UsesTransactionsMessage_NotNewPooledTransactionHashes()
+    {
+        // XdcProtocolHandler extends Eth63, so tx gossip must go via TransactionsMessage (0x02),
+        // never via NewPooledTransactionHashesMessage (0x08 from Eth65).
+        (XdcProtocolHandler handler, _, ISession session, _, _, _) = CreateAll();
+        using (handler)
+        {
+            Transaction tx = Build.A.Transaction.SignedAndResolved().TestObject;
+
+            handler.SendNewTransactions([tx], sendFullTx: true);
+
+            session.Received(1).DeliverMessage(Arg.Is<P2PMessage>(m => m.PacketType == Eth62MessageCode.Transactions));
+            session.DidNotReceive().DeliverMessage(Arg.Is<P2PMessage>(m => m.PacketType == Eth65MessageCode.NewPooledTransactionHashes));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
@@ -298,8 +298,9 @@ public class XdcProtocolHandlerTests
         }
     }
 
-    [Test]
-    public void SendNewTransactions_UsesTransactionsMessage_NotNewPooledTransactionHashes()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void SendNewTransactions_UsesTransactionsMessage_NotNewPooledTransactionHashes(bool sendFullTx)
     {
         // In XdcProtocolHandler tx gossip must go via TransactionsMessage (0x02),
         // never via NewPooledTransactionHashesMessage (0x08 from Eth65) which conflicts with XDC OrderTxMsg.
@@ -308,7 +309,7 @@ public class XdcProtocolHandlerTests
         {
             Transaction tx = Build.A.Transaction.SignedAndResolved().TestObject;
 
-            handler.SendNewTransactions([tx], sendFullTx: true);
+            handler.SendNewTransactions([tx], sendFullTx: sendFullTx);
 
             session.Received(1).DeliverMessage(Arg.Is<P2PMessage>(m => m.PacketType == Eth62MessageCode.Transactions));
             session.DidNotReceive().DeliverMessage(Arg.Is<P2PMessage>(m => m.PacketType == Eth65MessageCode.NewPooledTransactionHashes));

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
@@ -8,4 +8,6 @@ public static class XdcMessageCode
     public const int VoteMsg = 0xe0;
     public const int TimeoutMsg = 0xe1;
     public const int SyncInfoMsg = 0xe2;
+
+    public static bool IsXdcMessage(int packetType) => packetType is >= VoteMsg and <= SyncInfoMsg;
 }

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 namespace Nethermind.Xdc.P2P;

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
@@ -10,8 +10,7 @@ using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.ProtocolHandlers;
-using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
-using Nethermind.Network.P2P.Subprotocols.Eth.V65;
+using Nethermind.Network.P2P.Subprotocols.Eth.V63;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
@@ -33,13 +32,9 @@ internal class XdcProtocolHandler(
     IBackgroundTaskScheduler backgroundTaskScheduler,
     ITxPool txPool,
     IGossipPolicy gossipPolicy,
-    IForkInfo forkInfo,
     ILogManager logManager,
-    ITxGossipPolicy? transactionsGossipPolicy = null) : Eth65ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy), IStaticProtocolInfo
+    ITxGossipPolicy? transactionsGossipPolicy = null) : Eth63ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, logManager, transactionsGossipPolicy), IStaticProtocolInfo
 {
-    private readonly ITimeoutCertificateManager _timeoutCertificateManager = timeoutCertificateManager;
-    private readonly IVotesManager _votesManager = votesManager;
-    private readonly IBlockTree _blockTree = blockTree;
     private AssociativeKeyCache<ValueHash256> _notifiedVotes = new(MemoryAllowance.MemPoolSize / 2);
     private AssociativeKeyCache<ValueHash256> _notifiedTimeouts = new(MemoryAllowance.MemPoolSize / 2);
 
@@ -58,10 +53,11 @@ internal class XdcProtocolHandler(
 
         int packetType = message.PacketType;
 
-        (bool isSyncing, _, _) = _blockTree.IsSyncing();
-        if (isSyncing) // ignore XDC updates while syncing
+        (bool isSyncing, _, _) = blockTree.IsSyncing();
+        if (isSyncing && XdcMessageCode.IsXdcMessage(packetType))
         {
-            base.HandleMessageCore(message);
+            const string ignored = $"XDC message ignored, syncing";
+            ReportIn(ignored, size);
             return;
         }
 
@@ -96,13 +92,8 @@ internal class XdcProtocolHandler(
         }
     }
 
-    protected override void EnrichStatusMessage(StatusMessage statusMessage)
-    {
-        // We do not want to add ForkId to status message in XDPoS
-    }
-
-    private void Handle(VoteMsg voteMsg) => _ = _votesManager.OnReceiveVote(voteMsg.Vote);
-    private void Handle(TimeoutMsg timeoutMsg) => _timeoutCertificateManager.OnReceiveTimeout(timeoutMsg.Timeout);
+    private void Handle(VoteMsg voteMsg) => votesManager.OnReceiveVote(voteMsg.Vote);
+    private void Handle(TimeoutMsg timeoutMsg) => timeoutCertificateManager.OnReceiveTimeout(timeoutMsg.Timeout);
     private void Handle(SyncInfoMsg syncInfoMsg)
     {
         if (!syncInfoManager.VerifySyncInfo(syncInfoMsg.SyncInfo, out string error))

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Blockchain;
@@ -92,8 +92,8 @@ internal class XdcProtocolHandler(
         }
     }
 
-    private void Handle(VoteMsg voteMsg) => votesManager.OnReceiveVote(voteMsg.Vote);
-    private void Handle(TimeoutMsg timeoutMsg) => timeoutCertificateManager.OnReceiveTimeout(timeoutMsg.Timeout);
+    private void Handle(VoteMsg voteMsg) => _ = votesManager.OnReceiveVote(voteMsg.Vote);
+    private void Handle(TimeoutMsg timeoutMsg) => _ = timeoutCertificateManager.OnReceiveTimeout(timeoutMsg.Timeout);
     private void Handle(SyncInfoMsg syncInfoMsg)
     {
         if (!syncInfoManager.VerifySyncInfo(syncInfoMsg.SyncInfo, out string error))


### PR DESCRIPTION
XDC runs on `eth/100`, reusing Ethereum's `eth` protocol name. This led to the assumption that it supports `eth/65`, but the XDC Go client only supports up to `eth/63`. Message codes `0x08/0x09` also conflict with XDC's deprecated
  `OrderTxMsg/LendingTxMsg`, causing the Go client to disconnect with wrong message format or unknown code.  

**Fix:** downgrade base protocol to `eth/63`.