### PR TITLE
perf(db): account native rocksdb memory via GC.AddMemoryPressure

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -98,6 +98,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private int _maxWriteBufferNumber;
     private readonly RocksDbReader _reader;
     private bool _isUsingSharedBlockCache;
+    private ulong _ownBlockCacheSize;
+    private long _addedMemoryPressure;
 
     public DbOnTheRocks(
         string basePath,
@@ -121,6 +123,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         _iteratorManager = new IteratorManager(_db, null, _readAheadReadOptions);
 
         _reader = new RocksDbReader(this, CreateReadOptions, _iteratorManager, null);
+
+        _addedMemoryPressure = (long)_writeBufferSize + (long)_ownBlockCacheSize;
+        if (_addedMemoryPressure > 0) GC.AddMemoryPressure(_addedMemoryPressure);
     }
 
     protected virtual RocksDb DoOpen(string path, (DbOptions Options, ColumnFamilies? Families) db)
@@ -505,11 +510,16 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         if (dbConfig.BlockCache is not null)
         {
             tableOptions.SetBlockCache(dbConfig.BlockCache.Value);
+            _ownBlockCacheSize = blockCacheSize > 0 ? blockCacheSize : 32_000_000;
         }
         else if (sharedCache is not null && blockCacheSize == 0)
         {
             tableOptions.SetBlockCache(sharedCache.Value);
             _isUsingSharedBlockCache = true;
+        }
+        else
+        {
+            _ownBlockCacheSize = blockCacheSize > 0 ? blockCacheSize : 32_000_000;
         }
 
         // Note: the ordering is important.
@@ -1487,6 +1497,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         ReleaseUnmanagedResources();
 
         _dbsByPath.Remove(_fullPath!, out _);
+
+        if (_addedMemoryPressure > 0) GC.RemoveMemoryPressure(_addedMemoryPressure);
 
         _isDisposed = true;
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -98,7 +98,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private int _maxWriteBufferNumber;
     private readonly RocksDbReader _reader;
     private bool _isUsingSharedBlockCache;
-    private ulong _ownBlockCacheSize;
     private long _addedMemoryPressure;
 
     public DbOnTheRocks(
@@ -124,7 +123,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         _reader = new RocksDbReader(this, CreateReadOptions, _iteratorManager, null);
 
-        _addedMemoryPressure = (long)_writeBufferSize + (long)_ownBlockCacheSize;
         if (_addedMemoryPressure > 0) GC.AddMemoryPressure(_addedMemoryPressure);
     }
 
@@ -507,10 +505,13 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
 
         BlockBasedTableOptions? tableOptions = new();
+        // Per-call cache pressure to add to the GC. Cache memory owned by a HyperClockCacheWrapper
+        // (whether passed via dbConfig.BlockCache or as the shared cache) is already reported by
+        // that wrapper, so don't double-count here.
+        ulong perCallCachePressure = 0;
         if (dbConfig.BlockCache is not null)
         {
             tableOptions.SetBlockCache(dbConfig.BlockCache.Value);
-            _ownBlockCacheSize = blockCacheSize > 0 ? blockCacheSize : 32_000_000;
         }
         else if (sharedCache is not null && blockCacheSize == 0)
         {
@@ -519,7 +520,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
         else
         {
-            _ownBlockCacheSize = blockCacheSize > 0 ? blockCacheSize : 32_000_000;
+            // RocksDB allocates a 32MB block cache by default if `block_based_table_factory.block_cache`
+            // is not specified in the options string.
+            perCallCachePressure = blockCacheSize > 0 ? blockCacheSize : 32_000_000;
         }
 
         // Note: the ordering is important.
@@ -563,6 +566,10 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             if (_logger.IsDebug) _logger.Debug($"Expected max memory footprint of {Name} DB is {_maxThisDbSize / 1000 / 1000} MB ({writeBufferNumber} * {writeBufferSize / 1000 / 1000} MB + {blockCacheSize / 1000 / 1000} MB)");
             if (_logger.IsDebug) _logger.Debug($"Total max DB footprint so far is {_maxRocksSize / 1000 / 1000} MB");
         }
+
+        // Accumulate one full write buffer plus this column's own block cache (if any).
+        // BuildOptions is called once per column family for ColumnsDb, so accumulate to capture all columns.
+        _addedMemoryPressure += (long)_writeBufferSize + (long)perCallCachePressure;
 
         #endregion
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -505,9 +505,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
 
         BlockBasedTableOptions? tableOptions = new();
-        // Per-call cache pressure to add to the GC. Cache memory owned by a HyperClockCacheWrapper
-        // (whether passed via dbConfig.BlockCache or as the shared cache) is already reported by
-        // that wrapper, so don't double-count here.
         ulong perCallCachePressure = 0;
         if (dbConfig.BlockCache is not null)
         {
@@ -567,8 +564,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             if (_logger.IsDebug) _logger.Debug($"Total max DB footprint so far is {_maxRocksSize / 1000 / 1000} MB");
         }
 
-        // Accumulate one full write buffer plus this column's own block cache (if any).
-        // BuildOptions is called once per column family for ColumnsDb, so accumulate to capture all columns.
         _addedMemoryPressure += (long)_writeBufferSize + (long)perCallCachePressure;
 
         #endregion

--- a/src/Nethermind/Nethermind.Db.Rocks/HyperClockCacheWrapper.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/HyperClockCacheWrapper.cs
@@ -12,12 +12,16 @@ public class HyperClockCacheWrapper : SafeHandleZeroOrMinusOneIsInvalid
 {
     private static readonly Lock _nativeCacheLock = new();
 
+    private readonly long _capacity;
+
     public HyperClockCacheWrapper(ulong capacity = 32_000_000) : base(ownsHandle: true)
     {
         lock (_nativeCacheLock)
         {
             SetHandle(Native.Instance.rocksdb_cache_create_hyper_clock(new UIntPtr(capacity), 0));
         }
+        _capacity = (long)capacity;
+        GC.AddMemoryPressure(_capacity);
     }
 
     public IntPtr Handle => DangerousGetHandle();
@@ -28,6 +32,7 @@ public class HyperClockCacheWrapper : SafeHandleZeroOrMinusOneIsInvalid
         {
             Native.Instance.rocksdb_cache_destroy(handle);
         }
+        GC.RemoveMemoryPressure(_capacity);
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/HyperClockCacheWrapper.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/HyperClockCacheWrapper.cs
@@ -20,8 +20,10 @@ public class HyperClockCacheWrapper : SafeHandleZeroOrMinusOneIsInvalid
         {
             SetHandle(Native.Instance.rocksdb_cache_create_hyper_clock(new UIntPtr(capacity), 0));
         }
-        _capacity = (long)capacity;
-        GC.AddMemoryPressure(_capacity);
+        // If the native call returned a zero/null handle, SafeHandle won't call ReleaseHandle,
+        // so don't add pressure either — keep add/remove balanced.
+        _capacity = IsInvalid ? 0 : (long)capacity;
+        if (_capacity > 0) GC.AddMemoryPressure(_capacity);
     }
 
     public IntPtr Handle => DangerousGetHandle();
@@ -32,7 +34,7 @@ public class HyperClockCacheWrapper : SafeHandleZeroOrMinusOneIsInvalid
         {
             Native.Instance.rocksdb_cache_destroy(handle);
         }
-        GC.RemoveMemoryPressure(_capacity);
+        if (_capacity > 0) GC.RemoveMemoryPressure(_capacity);
         return true;
     }
 


### PR DESCRIPTION
## Summary
- `HyperClockCacheWrapper` reports its cache capacity to the GC via `GC.AddMemoryPressure` on construct and `GC.RemoveMemoryPressure` on release.
- `DbOnTheRocks` reports, per instance, one full write buffer plus the per-DB block cache size when the DB is not using the shared cache (configured value, else the rocksdb 32MB default). Shared-cache DBs add no extra pressure since the shared wrapper already accounts for it.

This gives the GC a more accurate view of process memory so heuristics for collection / heap sizing reflect the native buffers RocksDB holds.

## Test plan
- [ ] `dotnet build -c release src/Nethermind/Nethermind.slnx` (passes locally for `Nethermind.Db.Rocks`)
- [ ] `dotnet test --project src/Nethermind/Nethermind.Db.Rocks.Test/Nethermind.Db.Rocks.Test.csproj -c release` — existing dispose/lifecycle tests would surface any unbalanced add/remove (would throw `ArgumentOutOfRangeException`)
- [ ] Sanity: open + dispose a `DbOnTheRocks` and confirm `GC.GetGCMemoryInfo()` reflects the added pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)