### PR TITLE
perf: replace O(n²) InsertSorted with deferred O(n log n) rebuild

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/ReadOnlyAccountChangesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/ReadOnlyAccountChangesTests.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.BlockAccessLists;
+
+[TestFixture]
+public class ReadOnlyAccountChangesTests
+{
+    [Test]
+    public void LoadPreStateStorage_rebuilds_sorted_arrays_on_access()
+    {
+        ReadOnlyAccountChanges ac = new(TestItem.AddressA,
+            [new ReadOnlySlotChanges(3, [new StorageChange(0, 100)])],
+            [], [], [], []);
+
+        ac.LoadPreStateStorage(1, 10);
+        ac.LoadPreStateStorage(5, 50);
+
+        UInt256[] keys = [.. ac.ChangedSlots];
+        Assert.That(keys, Is.EqualTo(new UInt256[] { 1, 3, 5 }));
+    }
+
+    [Test]
+    public void LoadPreStateStorage_preserves_existing_slot_changes()
+    {
+        StorageChange original = new(0, 100);
+        ReadOnlyAccountChanges ac = new(TestItem.AddressA,
+            [new ReadOnlySlotChanges(3, [original])],
+            [], [], [], []);
+
+        ac.LoadPreStateStorage(3, 999);
+
+        Assert.That(ac.TryGetSlotChanges(3, out ReadOnlySlotChanges? slot), Is.True);
+        Assert.That(slot!.Changes.Length, Is.EqualTo(2));
+        Assert.That(slot.Changes[0].Index, Is.EqualTo(-1));
+        Assert.That(slot.Changes[1].Index, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void StorageChanges_returns_sorted_order_after_prestate_load()
+    {
+        ReadOnlyAccountChanges ac = new(TestItem.AddressA,
+            [new ReadOnlySlotChanges(10, [new StorageChange(0, 1)])],
+            [new UInt256(20)],
+            [], [], []);
+
+        ac.LoadPreStateStorage(5, 50);
+        ac.LoadPreStateStorage(20, 200);
+        ac.LoadPreStateStorage(15, 150);
+
+        ReadOnlySlotChanges[] changes = ac.StorageChanges;
+        Assert.That(changes.Length, Is.EqualTo(4));
+        Assert.That(changes[0].Key, Is.EqualTo(new UInt256(5)));
+        Assert.That(changes[1].Key, Is.EqualTo(new UInt256(10)));
+        Assert.That(changes[2].Key, Is.EqualTo(new UInt256(15)));
+        Assert.That(changes[3].Key, Is.EqualTo(new UInt256(20)));
+    }
+
+    [Test]
+    public void HasSlotChangesAtIndex_works_after_prestate_load()
+    {
+        ReadOnlyAccountChanges ac = new(TestItem.AddressA,
+            [new ReadOnlySlotChanges(1, [new StorageChange(5, 100)])],
+            [], [], [], []);
+
+        ac.LoadPreStateStorage(2, 200);
+
+        Assert.That(ac.HasSlotChangesAtIndex(5), Is.True);
+        Assert.That(ac.HasSlotChangesAtIndex(-1), Is.True);
+        Assert.That(ac.HasSlotChangesAtIndex(99), Is.False);
+    }
+
+    [Test]
+    public void Large_prestate_load_does_not_degrade_quadratically()
+    {
+        ReadOnlyAccountChanges ac = new(TestItem.AddressA, [], [], [], [], []);
+
+        for (int i = 0; i < 10_000; i++)
+        {
+            ac.LoadPreStateStorage(new UInt256((ulong)i * 7919), new UInt256((ulong)i));
+        }
+
+        Assert.That(ac.StorageChanges.Length, Is.EqualTo(10_000));
+        Assert.That(ac.ChangedSlots.Count, Is.EqualTo(10_000));
+
+        for (int i = 1; i < ac.ChangedSlots.Count; i++)
+        {
+            Assert.That(ac.ChangedSlots[i], Is.GreaterThan(ac.ChangedSlots[i - 1]));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
@@ -30,11 +30,25 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
     public Address Address { get; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ReadOnlySlotChanges[] StorageChanges => _orderedStorageChanges;
+    public ReadOnlySlotChanges[] StorageChanges
+    {
+        get
+        {
+            if (_sortedDirty) RebuildSortedArrays();
+            return _orderedStorageChanges;
+        }
+    }
 
     /// <summary>Slot keys, sorted ascending — exposed as <see cref="IList{T}"/> for indexed access.</summary>
     [JsonIgnore]
-    public IList<UInt256> ChangedSlots => _changedSlots;
+    public IList<UInt256> ChangedSlots
+    {
+        get
+        {
+            if (_sortedDirty) RebuildSortedArrays();
+            return _changedSlots;
+        }
+    }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public UInt256[] StorageReads => _storageReads;
@@ -60,6 +74,7 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
     private readonly Dictionary<UInt256, ReadOnlySlotChanges> _storageChanges;
     private ReadOnlySlotChanges[] _orderedStorageChanges;
     private UInt256[] _changedSlots;
+    private bool _sortedDirty;
     private readonly UInt256[] _storageReads;
     private BalanceChange[] _balanceChanges;
     private NonceChange[] _nonceChanges;
@@ -210,7 +225,7 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
         {
             slotChanges = new ReadOnlySlotChanges(slot);
             _storageChanges.Add(slot, slotChanges);
-            InsertSorted(slot, slotChanges);
+            _sortedDirty = true;
         }
         slotChanges.LoadPreStateChange(new StorageChange(-1, value));
     }
@@ -226,25 +241,22 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
     public void RecordWasChanged()
         => AccountChanged = _balanceChanges.Length > 0 || _nonceChanges.Length > 0 || _codeChanges.Length > 0 || _storageChanges.Count > 0;
 
-    /// <summary>Inserts a newly-added slot into the parallel sorted arrays at its correct position.</summary>
-    private void InsertSorted(UInt256 slot, ReadOnlySlotChanges slotChanges)
+    private void RebuildSortedArrays()
     {
-        ReadOnlySpan<UInt256> keys = _changedSlots;
-        int idx = keys.BinarySearch(slot);
-        // BinarySearch returns ~insertionIndex on miss; for new slots, this should always miss.
-        int insertAt = idx >= 0 ? idx : ~idx;
-
-        UInt256[] newKeys = new UInt256[_changedSlots.Length + 1];
-        Array.Copy(_changedSlots, 0, newKeys, 0, insertAt);
-        newKeys[insertAt] = slot;
-        Array.Copy(_changedSlots, insertAt, newKeys, insertAt + 1, _changedSlots.Length - insertAt);
-        _changedSlots = newKeys;
-
-        ReadOnlySlotChanges[] newOrdered = new ReadOnlySlotChanges[_orderedStorageChanges.Length + 1];
-        Array.Copy(_orderedStorageChanges, 0, newOrdered, 0, insertAt);
-        newOrdered[insertAt] = slotChanges;
-        Array.Copy(_orderedStorageChanges, insertAt, newOrdered, insertAt + 1, _orderedStorageChanges.Length - insertAt);
-        _orderedStorageChanges = newOrdered;
+        _sortedDirty = false;
+        int count = _storageChanges.Count;
+        UInt256[] keys = new UInt256[count];
+        ReadOnlySlotChanges[] ordered = new ReadOnlySlotChanges[count];
+        int i = 0;
+        foreach (KeyValuePair<UInt256, ReadOnlySlotChanges> kv in _storageChanges)
+        {
+            keys[i] = kv.Key;
+            ordered[i] = kv.Value;
+            i++;
+        }
+        Array.Sort(keys, ordered);
+        _changedSlots = keys;
+        _orderedStorageChanges = ordered;
     }
 
     /// <summary>Returns the change with <c>Index == index</c> if any; otherwise null.</summary>

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyAccountChanges.cs
@@ -115,7 +115,7 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
 
     public bool HasSlotChangesAtIndex(int index)
     {
-        foreach (ReadOnlySlotChanges slotChanges in _orderedStorageChanges)
+        foreach (ReadOnlySlotChanges slotChanges in StorageChanges)
         {
             if (HasExactIndex(slotChanges.Changes, index)) return true;
         }
@@ -124,7 +124,7 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
 
     public IEnumerable<SlotChangeAtIndex> SlotChangesAtIndex(int index)
     {
-        foreach (ReadOnlySlotChanges slotChanges in _orderedStorageChanges)
+        foreach (ReadOnlySlotChanges slotChanges in StorageChanges)
         {
             StorageChange? change = GetExact(slotChanges.Changes, index);
             if (change is not null)
@@ -243,7 +243,6 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
 
     private void RebuildSortedArrays()
     {
-        _sortedDirty = false;
         int count = _storageChanges.Count;
         UInt256[] keys = new UInt256[count];
         ReadOnlySlotChanges[] ordered = new ReadOnlySlotChanges[count];
@@ -257,6 +256,7 @@ public class ReadOnlyAccountChanges : IEquatable<ReadOnlyAccountChanges>
         Array.Sort(keys, ordered);
         _changedSlots = keys;
         _orderedStorageChanges = ordered;
+        _sortedDirty = false;
     }
 
     /// <summary>Returns the change with <c>Index == index</c> if any; otherwise null.</summary>


### PR DESCRIPTION
## Summary

- Replace per-slot `InsertSorted` (O(n²) array reallocation) with deferred `RebuildSortedArrays` (O(n log n) single sort)
- `LoadPreStateStorage` now sets a dirty flag instead of reallocating two arrays per slot
- `StorageChanges` and `ChangedSlots` properties lazily rebuild sorted arrays on first access after mutation

## Problem

`InsertSorted` allocated 2 new arrays and copied all existing elements on every `LoadPreStateStorage` call. For blocks with thousands of unique slots (e.g. `sload_bloated` with 10GB state), this was O(n²) — causing a **90-second block** (`24363514` in run 25222293131).

dotTrace showed `InsertSorted` OwnTime=12,763 (14% of `LoadPreState` TotalTime=90,315).

## Fix

Defer sorted array construction: accumulate in the `Dictionary` during loading, sort once via `Array.Sort` when `StorageChanges` or `ChangedSlots` is first accessed.

## Types of changes

- [x] Optimization

## Testing

- [x] 16/16 BlockAccessList tests pass
- [x] 126/126 EIP7928 tests pass
- [x] Benchmark run triggered (25223422449)