### PR TITLE
perf(flat-state): avoid LOH allocation from ConcurrentDictionary.Keys in Snapshot

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -37,9 +37,11 @@ public class Snapshot(
     public IEnumerable<KeyValuePair<HashedKey<Address>, bool>> SelfDestructedStorageAddresses => content.SelfDestructedStorageAddresses;
     public IEnumerable<KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?>> Storages => content.Storages;
     public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodes => content.StorageNodes;
-    public IEnumerable<(Hash256, TreePath)> StorageTrieNodeKeys => content.StorageNodes.Keys.Select(k => k.Key);
+    // Enumerate KeyValuePairs instead of `.Keys`: ConcurrentDictionary.Keys snapshots into a fresh
+    // List<TKey> sized to Count, which lands on the LOH for 100k+ node snapshots.
+    public IEnumerable<(Hash256, TreePath)> StorageTrieNodeKeys => content.StorageNodes.Select(kv => kv.Key.Key);
     public IEnumerable<KeyValuePair<HashedKey<TreePath>, TrieNode>> StateNodes => content.StateNodes;
-    public IEnumerable<TreePath> StateNodeKeys => content.StateNodes.Keys.Select(k => k.Key);
+    public IEnumerable<TreePath> StateNodeKeys => content.StateNodes.Select(kv => kv.Key.Key);
     public int AccountsCount => content.Accounts.Count;
     public int StoragesCount => content.Storages.Count;
     public int StateNodesCount => content.StateNodes.Count;


### PR DESCRIPTION
## Summary

- `Snapshot.StorageTrieNodeKeys` / `StateNodeKeys` were using `ConcurrentDictionary.Keys`, which snapshots into a fresh `List<TKey>` sized to `Count` on every call.
- For 100k+ node snapshots the backing array is multi-MB and lands on the LOH each persistence cycle.
- Enumerate KeyValuePairs directly (struct enumerator, no allocation) and project to the key.

## Test plan

- [ ] Existing flat-state tests pass
- [ ] Allocation profile during snapshot persistence shows no `List<HashedKey<...>>` LOH spikes from these properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)