### PR TITLE
perf: Embed Address bytes inline to remove secondary allocation

### DIFF
--- a/src/Nethermind/Nethermind.Abi/AbiAddress.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiAddress.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Abi
                 {
                     case Address input:
                         {
-                            byte[] bytes = input.Bytes;
+                            byte[] bytes = input.Bytes.ToArray();
                             return packed ? bytes : bytes.PadLeft(UInt256.LengthInBytes);
                         }
                     case string stringInput:

--- a/src/Nethermind/Nethermind.Abi/AbiAddress.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiAddress.cs
@@ -27,8 +27,8 @@ namespace Nethermind.Abi
                 {
                     case Address input:
                         {
-                            byte[] bytes = input.Bytes.ToArray();
-                            return packed ? bytes : bytes.PadLeft(UInt256.LengthInBytes);
+                            ReadOnlySpan<byte> bytes = input.Bytes;
+                            return packed ? bytes.ToArray() : bytes.PadLeft(UInt256.LengthInBytes);
                         }
                     case string stringInput:
                         {

--- a/src/Nethermind/Nethermind.AuRa.Test/Reward/AuRaRewardCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Reward/AuRaRewardCalculatorTests.cs
@@ -215,7 +215,7 @@ namespace Nethermind.AuRa.Test.Reward
 
         private byte[] SetupAbiAddresses(params BlockReward[] rewards)
         {
-            byte[] data = rewards.Select(static r => r.Address).SelectMany(static a => a.Bytes).ToArray();
+            byte[] data = rewards.Select(static r => r.Address).SelectMany(static a => a.Bytes.ToArray()).ToArray();
 
             _abiEncoder.Decode(
                 AbiEncodingStyle.None,

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractBasedValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractBasedValidatorTests.cs
@@ -642,7 +642,7 @@ public class ContractBasedValidatorTests
 
     private byte[] SetupAbiAddresses(Address[] addresses)
     {
-        byte[] data = addresses.SelectMany(static a => a.Bytes).ToArray();
+        byte[] data = addresses.SelectMany(static a => a.Bytes.ToArray()).ToArray();
 
         _abiEncoder.Decode(
             AbiEncodingStyle.None,

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesCompareBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesCompareBenchmarks.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Benchmarks.Core
             (Keccak.EmptyTreeHash.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
             (Keccak.OfAnEmptyString.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
             (Keccak.OfAnEmptyString.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
-            (TestItem.AddressA.Bytes, TestItem.AddressB.Bytes),
+            (TestItem.AddressA.Bytes.ToArray(), TestItem.AddressB.Bytes.ToArray()),
         };
 
         [Params(0, 1, 2, 3, 4, 5)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesIsZeroBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesIsZeroBenchmarks.cs
@@ -18,8 +18,8 @@ namespace Nethermind.Benchmarks.Core
             Keccak.Zero.BytesToArray(),
             Keccak.EmptyTreeHash.BytesToArray(),
             Keccak.OfAnEmptyString.BytesToArray(),
-            TestItem.AddressA.Bytes,
-            Address.Zero.Bytes,
+            TestItem.AddressA.Bytes.ToArray(),
+            Address.Zero.Bytes.ToArray(),
         };
 
         [Params(0, 1, 2, 3, 4)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesPadBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesPadBenchmarks.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Benchmarks.Core
             new byte[]{0},
             new byte[]{1},
             Keccak.Zero.BytesToArray(),
-            TestItem.AddressA.Bytes
+            TestItem.AddressA.Bytes.ToArray()
         };
 
         [Params(0, 1, 2, 3)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesReverseBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesReverseBenchmarks.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Benchmarks.Core
         {
             Keccak.Zero.BytesToArray(),
             Keccak.EmptyTreeHash.BytesToArray(),
-            TestItem.AddressA.Bytes
+            TestItem.AddressA.Bytes.ToArray()
         };
 
         [Params(0, 1, 2)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Benchmarks.Core
             Array.Empty<byte>(),
             new byte[]{1},
             new byte[100000],
-            TestItem.AddressA.Bytes
+            TestItem.AddressA.Bytes.ToArray()
         };
 
         [Params(1)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/Keccak512Benchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/Keccak512Benchmarks.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Benchmarks.Core
             Array.Empty<byte>(),
             new byte[]{1},
             new byte[100000],
-            TestItem.AddressA.Bytes
+            TestItem.AddressA.Bytes.ToArray()
         };
 
         [Params(0, 1, 2, 3)]

--- a/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Benchmarks.Store
         {
             Keccak.EmptyTreeHash.BytesToArray(),
             Keccak.Zero.BytesToArray(),
-            TestItem.AddressA.Bytes,
+            TestItem.AddressA.Bytes.ToArray(),
         };
 
         [Params(0, 1, 2)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsIteratorTests.cs
@@ -37,15 +37,15 @@ public class ReceiptsIteratorTests
 
         iterator.TryGetNext(out TxReceiptStructRef receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes.ToArray());
         receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[0].Hash!.BytesToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes.ToArray());
         receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash!.BytesToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes.ToArray());
         receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash!.BytesToArray());
     }
 
@@ -66,14 +66,14 @@ public class ReceiptsIteratorTests
         ReceiptsIterator iterator = CreateIterator(receipts, block);
 
         iterator.TryGetNext(out TxReceiptStructRef receipt).Should().BeTrue();
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes.ToArray());
         receipt.TxHash.Bytes.Length.Should().Be(0);
         iterator.TryGetNext(out receipt).Should().BeTrue();
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes.ToArray());
         receipt.TxHash.Bytes.Length.Should().Be(0);
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes.ToArray());
         receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash!.BytesToArray());
     }
 
@@ -94,11 +94,11 @@ public class ReceiptsIteratorTests
         ReceiptsIterator iterator = CreateIterator(receipts, block);
 
         iterator.TryGetNext(out TxReceiptStructRef receipt).Should().BeTrue();
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes.ToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes.ToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
-        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes);
+        receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes.ToArray());
     }
 
     private ReceiptsIterator CreateIterator(TxReceipt[] receipts, Block block)

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -162,7 +162,7 @@ internal class TransactionProcessorEip7702Tests
 
         ReadOnlySpan<byte> cellValue = _stateProvider.Get(new StorageCell(signer.Address, 0));
 
-        Assert.That(cellValue.ToArray(), Is.EqualTo(sender.Address.Bytes));
+        Assert.That(cellValue.ToArray(), Is.EqualTo(sender.Address.Bytes.ToArray()));
     }
 
     public static IEnumerable<TestCaseData> DifferentAuthorityTupleValues()

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/CallFrame.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/CallFrame.cs
@@ -66,8 +66,8 @@ public record CallFrame
 
     // ReSharper disable InconsistentNaming
     public string? getType() => Type;
-    public ITypedArray<byte> getFrom() => _fromConverted ??= From.Bytes.ToTypedScriptArray();
-    public ITypedArray<byte> getTo() => _toConverted ??= To.Bytes.ToTypedScriptArray();
+    public ITypedArray<byte> getFrom() => _fromConverted ??= From.Bytes.ToArray().ToTypedScriptArray();
+    public ITypedArray<byte> getTo() => _toConverted ??= To.Bytes.ToArray().ToTypedScriptArray();
     public ITypedArray<byte> getInput() => _inputConverted ??= Input.ToTypedScriptArray();
     public long getGas() => Gas;
     public dynamic getValue() => (_valueConverted ??= Value?.ToBigInteger()) ?? Undefined.Value;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Context.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Context.cs
@@ -110,8 +110,8 @@ public class Context
     }
 
     public string type { get; set; } = null!;
-    public ITypedArray<byte>? from => _fromConverted ??= From?.Bytes.ToTypedScriptArray();
-    public ITypedArray<byte>? to => _toConverted ??= To?.Bytes.ToTypedScriptArray();
+    public ITypedArray<byte>? from => _fromConverted ??= From?.Bytes.ToArray().ToTypedScriptArray();
+    public ITypedArray<byte>? to => _toConverted ??= To?.Bytes.ToArray().ToTypedScriptArray();
     public ITypedArray<byte>? input => _inputConverted ??= Input.ToArray().ToTypedScriptArray();
     public long gas { get; set; }
     public long gasUsed { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Engine.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Engine.cs
@@ -121,7 +121,7 @@ public class Engine : IDisposable
     /// <summary>
     /// Converts input to 20 byte Address byte representation
     /// </summary>
-    private ITypedArray<byte> ToAddress(object address) => address.ToAddress().Bytes.ToTypedScriptArray();
+    private ITypedArray<byte> ToAddress(object address) => address.ToAddress().Bytes.ToArray().ToTypedScriptArray();
 
     /// <summary>
     /// Checks if contract at given address is a precompile
@@ -144,13 +144,13 @@ public class Engine : IDisposable
     /// <summary>
     /// Creates a contract address from sender and nonce (used for CREATE instruction)
     /// </summary>
-    private ITypedArray<byte> ToContract(object from, ulong nonce) => ContractAddress.From(from.ToAddress(), nonce).Bytes.ToTypedScriptArray();
+    private ITypedArray<byte> ToContract(object from, ulong nonce) => ContractAddress.From(from.ToAddress(), nonce).Bytes.ToArray().ToTypedScriptArray();
 
     /// <summary>
     /// Creates a contract address from sender, salt and initcode (used for CREATE2 instruction)
     /// </summary>
     private ITypedArray<byte> ToContract2(object from, string salt, object initcode) =>
-        ContractAddress.From(from.ToAddress(), Bytes.FromHexString(salt, EvmStack.WordSize), initcode.ToBytes()).Bytes.ToTypedScriptArray();
+        ContractAddress.From(from.ToAddress(), Bytes.FromHexString(salt, EvmStack.WordSize), initcode.ToBytes()).Bytes.ToArray().ToTypedScriptArray();
 
     public void Interrupt() => V8Engine.Interrupt();
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Log.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Log.cs
@@ -85,8 +85,8 @@ namespace Nethermind.Blockchain.Tracing.GethStyle.Custom.JavaScript
             private IJavaScriptObject? _valueConverted;
             public Address Caller { get; } = caller;
 
-            public ITypedArray<byte> getAddress() => _addressConverted ??= _address.Bytes.ToTypedScriptArray();
-            public ITypedArray<byte> getCaller() => _callerConverted ??= Caller.Bytes.ToTypedScriptArray();
+            public ITypedArray<byte> getAddress() => _addressConverted ??= _address.Bytes.ToArray().ToTypedScriptArray();
+            public ITypedArray<byte> getCaller() => _callerConverted ??= Caller.Bytes.ToArray().ToTypedScriptArray();
             public object getInput() => (_inputConverted ??= _input?.ToArray().ToTypedScriptArray()) ?? (object)Undefined.Value;
 
             public IJavaScriptObject getValue() => _valueConverted ??= _value.ToBigInteger();

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -476,7 +476,7 @@ public class CliqueBlockProducer : IBlockProducer
             {
                 Address signer = snapshot.Signers.Keys[i];
                 int index = Clique.ExtraVanityLength + 20 * i;
-                Array.Copy(signer.Bytes, 0, header.ExtraData, index, signer.Bytes.Length);
+                signer.Bytes.CopyTo(header.ExtraData.AsSpan(index, signer.Bytes.Length));
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealValidator.cs
@@ -147,7 +147,7 @@ namespace Nethermind.Consensus.Clique
             {
                 byte[] signersBytes = new byte[snapshot.Signers.Count * Address.Size];
                 int signerIndex = 0;
-                foreach (Address signer in snapshot.Signers.Keys) Array.Copy(signer.Bytes, 0, signersBytes, signerIndex++ * Address.Size, Address.Size);
+                foreach (Address signer in snapshot.Signers.Keys) signer.Bytes.CopyTo(signersBytes.AsSpan(signerIndex++ * Address.Size, Address.Size));
 
                 int extraSuffix = header.ExtraData.Length - Clique.ExtraSealLength - Clique.ExtraVanityLength;
                 if (!header.ExtraData.AsSpan(Clique.ExtraVanityLength, extraSuffix).SequenceEqual(signersBytes))

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
@@ -92,7 +92,7 @@ public class WitnessGeneratingWorldState(IWorldState inner, IStateReader stateRe
         // Keys should be ordered like: <address1><address2><slot1-address2><slot2-address2><address3><slot1-address3>
         foreach (KeyValuePair<Address, HashSet<UInt256>> kvp in _storageSlots)
         {
-            keys.Add(kvp.Key.Bytes);
+            keys.Add(kvp.Key.Bytes.ToArray());
             foreach (UInt256 slot in kvp.Value)
                 keys.Add(slot.ToBigEndian());
         }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
@@ -114,12 +114,12 @@ namespace Nethermind.Core.Test.Builders
         public static TestExecutionRequest ExecutionRequestA = new() { RequestType = 0, RequestDataParts = [PublicKeyA.Bytes.Slice(0, 48), KeccakA.Bytes.ToArray(), BitConverter.GetBytes((ulong)1_000_000_000), SignatureBytes, BitConverter.GetBytes((ulong)1)] };
         public static TestExecutionRequest ExecutionRequestB = new() { RequestType = 0, RequestDataParts = [PublicKeyB.Bytes.Slice(0, 48), KeccakB.Bytes.ToArray(), BitConverter.GetBytes((ulong)2_000_000_000), SignatureBytes, BitConverter.GetBytes((ulong)2)] };
         public static TestExecutionRequest ExecutionRequestC = new() { RequestType = 0, RequestDataParts = [PublicKeyC.Bytes.Slice(0, 48), KeccakC.Bytes.ToArray(), BitConverter.GetBytes((ulong)3_000_000_000), SignatureBytes, BitConverter.GetBytes((ulong)3)] };
-        public static TestExecutionRequest ExecutionRequestD = new() { RequestType = 1, RequestDataParts = [AddressA.Bytes, PublicKeyA.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)1_000_000_000)] };
-        public static TestExecutionRequest ExecutionRequestE = new() { RequestType = 1, RequestDataParts = [AddressB.Bytes, PublicKeyB.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)2_000_000_000)] };
-        public static TestExecutionRequest ExecutionRequestF = new() { RequestType = 1, RequestDataParts = [AddressC.Bytes, PublicKeyC.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)3_000_000_000)] };
-        public static TestExecutionRequest ExecutionRequestG = new() { RequestType = 2, RequestDataParts = [AddressA.Bytes, PublicKeyA.Bytes.Slice(0, 48), PublicKeyB.Bytes.Slice(0, 48)] };
-        public static TestExecutionRequest ExecutionRequestH = new() { RequestType = 2, RequestDataParts = [AddressB.Bytes, PublicKeyB.Bytes.Slice(0, 48), PublicKeyC.Bytes.Slice(0, 48)] };
-        public static TestExecutionRequest ExecutionRequestI = new() { RequestType = 2, RequestDataParts = [AddressC.Bytes, PublicKeyC.Bytes.Slice(0, 48), PublicKeyA.Bytes.Slice(0, 48)] };
+        public static TestExecutionRequest ExecutionRequestD = new() { RequestType = 1, RequestDataParts = [AddressA.Bytes.ToArray(), PublicKeyA.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)1_000_000_000)] };
+        public static TestExecutionRequest ExecutionRequestE = new() { RequestType = 1, RequestDataParts = [AddressB.Bytes.ToArray(), PublicKeyB.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)2_000_000_000)] };
+        public static TestExecutionRequest ExecutionRequestF = new() { RequestType = 1, RequestDataParts = [AddressC.Bytes.ToArray(), PublicKeyC.Bytes.Slice(0, 48), BitConverter.GetBytes((ulong)3_000_000_000)] };
+        public static TestExecutionRequest ExecutionRequestG = new() { RequestType = 2, RequestDataParts = [AddressA.Bytes.ToArray(), PublicKeyA.Bytes.Slice(0, 48), PublicKeyB.Bytes.Slice(0, 48)] };
+        public static TestExecutionRequest ExecutionRequestH = new() { RequestType = 2, RequestDataParts = [AddressB.Bytes.ToArray(), PublicKeyB.Bytes.Slice(0, 48), PublicKeyC.Bytes.Slice(0, 48)] };
+        public static TestExecutionRequest ExecutionRequestI = new() { RequestType = 2, RequestDataParts = [AddressC.Bytes.ToArray(), PublicKeyC.Bytes.Slice(0, 48), PublicKeyA.Bytes.Slice(0, 48)] };
 
         public static IPEndPoint IPEndPointA = IPEndPoint.Parse("10.0.0.1");
         public static IPEndPoint IPEndPointB = IPEndPoint.Parse("10.0.0.2");

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AuthorizationTupleDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AuthorizationTupleDecoderTests.cs
@@ -54,7 +54,7 @@ public class AuthorizationTupleDecoderTests
         yield return TupleRlpStream(
             //Wrong chain size
             Enumerable.Range(0, 33).Select(static i => (byte)0xFF).ToArray(),
-            Address.Zero.Bytes,
+            Address.Zero.Bytes.ToArray(),
             Enumerable.Range(0, 8).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 1).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
@@ -84,7 +84,7 @@ public class AuthorizationTupleDecoderTests
         yield return TupleRlpStream(
             //Wrong nonce size
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
-            Address.Zero.Bytes,
+            Address.Zero.Bytes.ToArray(),
             Enumerable.Range(0, 9).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 1).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
@@ -94,7 +94,7 @@ public class AuthorizationTupleDecoderTests
         yield return TupleRlpStream(
             //Wrong yParity size
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
-            Address.Zero.Bytes,
+            Address.Zero.Bytes.ToArray(),
             Enumerable.Range(0, 8).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 2).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
@@ -104,7 +104,7 @@ public class AuthorizationTupleDecoderTests
         yield return TupleRlpStream(
             //Wrong R size
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
-            Address.Zero.Bytes,
+            Address.Zero.Bytes.ToArray(),
             Enumerable.Range(0, 8).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 1).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 33).Select(static i => (byte)0xFF).ToArray(),
@@ -114,7 +114,7 @@ public class AuthorizationTupleDecoderTests
         yield return TupleRlpStream(
             //Wrong S size
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),
-            Address.Zero.Bytes,
+            Address.Zero.Bytes.ToArray(),
             Enumerable.Range(0, 8).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 1).Select(static i => (byte)0xFF).ToArray(),
             Enumerable.Range(0, 32).Select(static i => (byte)0xFF).ToArray(),

--- a/src/Nethermind/Nethermind.Core.Test/Json/ByteArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/ByteArrayConverterTests.cs
@@ -225,7 +225,7 @@ public class ByteArrayConverterTests : ConverterTestBase<byte[]>
         {
             { Bytes.FromHexString("0x0"), null },
             { Bytes.FromHexString("0x1"), random.NextInt(int.MaxValue) },
-            { Build.An.Address.TestObject.Bytes, random.NextInt(int.MaxValue) },
+            { Build.An.Address.TestObject.Bytes.ToArray(), random.NextInt(int.MaxValue) },
             { random.GenerateRandomBytes(10), random.NextInt(int.MaxValue) },
             { random.GenerateRandomBytes(32), random.NextInt(int.MaxValue) },
         };

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -27,17 +27,35 @@ namespace Nethermind.Core
         private const int HexCharsCount = 2 * Size; // 5a4eab120fb44eb6684e5e32785702ff45ea344d
         private const int PrefixedHexCharsCount = 2 + HexCharsCount; // 0x5a4eab120fb44eb6684e5e32785702ff45ea344d
 
-        public static Address Zero { get; } = new(new byte[Size]);
+        public static Address Zero { get; } = new(default(AddressBytes));
         public static Address MaxValue { get; } = new("0xffffffffffffffffffffffffffffffffffffffff");
 
         public const string SystemUserHex = "0xfffffffffffffffffffffffffffffffffffffffe";
         public static Address SystemUser { get; } = new(SystemUserHex);
 
-        public byte[] Bytes { get; }
+        private AddressBytes _bytes;
 
-        public Address(Hash256 hash) : this(hash.Bytes.Slice(12, Size).ToArray()) { }
+        public ReadOnlySpan<byte> Bytes
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in FirstByte), Size);
+        }
 
-        public Address(in ValueHash256 hash) : this(hash.BytesAsSpan.Slice(12, Size).ToArray()) { }
+        [InlineArray(Size)]
+        internal struct AddressBytes
+        {
+            private byte _element0;
+        }
+
+        private ref readonly byte FirstByte
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ref Unsafe.As<AddressBytes, byte>(ref Unsafe.AsRef(in _bytes));
+        }
+
+        public Address(Hash256 hash) : this(hash.Bytes.Slice(12, Size)) { }
+
+        public Address(in ValueHash256 hash) : this(hash.BytesAsSpan.Slice(12, Size)) { }
 
         public byte this[int index] => Bytes[index];
 
@@ -124,20 +142,6 @@ namespace Nethermind.Core
             return false;
         }
 
-        public Address(byte[] bytes)
-        {
-            ArgumentNullException.ThrowIfNull(bytes);
-
-            if (bytes.Length != Size)
-            {
-                throw new ArgumentException(
-                    $"{nameof(Address)} should be {Size} bytes long and is {bytes.Length} bytes long",
-                    nameof(bytes));
-            }
-
-            Bytes = bytes;
-        }
-
         public Address(ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length != Size)
@@ -147,8 +151,10 @@ namespace Nethermind.Core
                     nameof(bytes));
             }
 
-            Bytes = bytes.ToArray();
+            bytes.CopyTo(MemoryMarshal.CreateSpan(ref Unsafe.As<AddressBytes, byte>(ref _bytes), Size));
         }
+
+        internal Address(AddressBytes bytes) => _bytes = bytes;
 
         public bool Equals(Address? other)
         {
@@ -163,8 +169,8 @@ namespace Nethermind.Core
             }
 
             // Address must be 20 bytes long Vector128 + uint
-            ref byte bytes0 = ref MemoryMarshal.GetArrayDataReference(Bytes);
-            ref byte bytes1 = ref MemoryMarshal.GetArrayDataReference(other.Bytes);
+            ref byte bytes0 = ref Unsafe.AsRef(in FirstByte);
+            ref byte bytes1 = ref Unsafe.AsRef(in other.FirstByte);
             // Compare first 16 bytes with Vector128 and last 4 bytes with uint
             return
                 Unsafe.As<byte, Vector128<byte>>(ref bytes0) ==
@@ -215,7 +221,7 @@ namespace Nethermind.Core
             return obj.GetType() == GetType() && Equals((Address)obj);
         }
 
-        public override int GetHashCode() => new ReadOnlySpan<byte>(Bytes).FastHash();
+        public override int GetHashCode() => Bytes.FastHash();
 
         public static bool operator ==(Address? a, Address? b)
         {
@@ -231,7 +237,7 @@ namespace Nethermind.Core
 
         public AddressStructRef ToStructRef() => new(Bytes);
 
-        public int CompareTo(Address? other) => Bytes.AsSpan().SequenceCompareTo(other?.Bytes);
+        public int CompareTo(Address? other) => other is null ? 1 : Bytes.SequenceCompareTo(other.Bytes);
 
         private class AddressTypeConverter : TypeConverter
         {
@@ -255,7 +261,7 @@ namespace Nethermind.Core
         [SkipLocalsInit]
         public ValueHash256 ToHash()
         {
-            ref byte value = ref MemoryMarshal.GetArrayDataReference(Bytes);
+            ref byte value = ref Unsafe.AsRef(in FirstByte);
             // build the 4×8-byte lanes:
             // - lane0 = 0UL
             // - lane1 = first 4 bytes of 'value', shifted up into the high half
@@ -272,7 +278,7 @@ namespace Nethermind.Core
             return result;
         }
 
-        internal long GetHashCode64() => SpanExtensions.FastHash64For20Bytes(ref MemoryMarshal.GetArrayDataReference(Bytes));
+        internal long GetHashCode64() => SpanExtensions.FastHash64For20Bytes(ref Unsafe.AsRef(in FirstByte));
     }
 
     public readonly struct AddressAsKey(Address key) : IEquatable<AddressAsKey>, IHash64bit<AddressAsKey>

--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -119,7 +119,7 @@ public class Bloom : IEquatable<Bloom>
         for (int entryIndex = 0; entryIndex < logEntries.Length; entryIndex++)
         {
             LogEntry logEntry = logEntries[entryIndex];
-            byte[] addressBytes = logEntry.Address.Bytes;
+            ReadOnlySpan<byte> addressBytes = logEntry.Address.Bytes;
             Set(addressBytes);
             Hash256[] topics = logEntry.Topics;
             for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
@@ -135,7 +135,7 @@ public class Bloom : IEquatable<Bloom>
         for (int entryIndex = 0; entryIndex < logEntries.Length; entryIndex++)
         {
             LogEntry logEntry = logEntries[entryIndex];
-            byte[] addressBytes = logEntry.Address.Bytes;
+            ReadOnlySpan<byte> addressBytes = logEntry.Address.Bytes;
             Set(addressBytes, blockBloom);
             Hash256[] topics = logEntry.Topics;
             for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)

--- a/src/Nethermind/Nethermind.Core/JsonConverters/AddressConverter.cs
+++ b/src/Nethermind/Nethermind.Core/JsonConverters/AddressConverter.cs
@@ -38,7 +38,7 @@ public class AddressConverter : JsonConverter<Address>
         addressBytes[0] = (byte)'0';
         addressBytes[1] = (byte)'x';
         Span<byte> hex = addressBytes[2..];
-        value.Bytes.AsSpan().OutputBytesToByteHex(hex, false);
+        value.Bytes.OutputBytesToByteHex(hex, false);
         writer.WritePropertyName(addressBytes);
     }
 }

--- a/src/Nethermind/Nethermind.Core/StorageCell.cs
+++ b/src/Nethermind/Nethermind.Core/StorageCell.cs
@@ -65,8 +65,8 @@ namespace Nethermind.Core
             if (ReferenceEquals(a, b))
                 return true;
 
-            ref byte ab = ref MemoryMarshal.GetArrayDataReference(a.Bytes);
-            ref byte bb = ref MemoryMarshal.GetArrayDataReference(b.Bytes);
+            ref byte ab = ref MemoryMarshal.GetReference(a.Bytes);
+            ref byte bb = ref MemoryMarshal.GetReference(b.Bytes);
             return Unsafe.As<byte, Vector128<byte>>(ref ab) == Unsafe.As<byte, Vector128<byte>>(ref bb)
                 && Unsafe.As<byte, uint>(ref Unsafe.Add(ref ab, 16)) == Unsafe.As<byte, uint>(ref Unsafe.Add(ref bb, 16));
         }

--- a/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
+++ b/src/Nethermind/Nethermind.Db/LogIndex/LogIndexStorage.cs
@@ -524,7 +524,7 @@ namespace Nethermind.Db.LogIndex
         public string GetDbSize() => _rootDb.GatherMetric().Size.SizeToString(useSi: true, addSpace: true);
 
         public IEnumerator<int> GetEnumerator(Address address, int from, int to) =>
-            GetEnumerator(null, address.Bytes, from, to);
+            GetEnumerator(null, address.Bytes.ToArray(), from, to);
 
         public IEnumerator<int> GetEnumerator(int topicIndex, Hash256 topic, int from, int to) =>
             GetEnumerator(topicIndex, topic.BytesToArray(), from, to);

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
@@ -65,7 +65,7 @@ public class ProofTxTracerTests(bool treatSystemAccountDifferently) : VirtualMac
     {
         byte[] code = Prepare.EvmCode
             .PushData(SampleHexData1)
-            .PushData(TestItem.AddressC.Bytes)
+            .PushData(TestItem.AddressC)
             .Op(Instruction.BALANCE)
             .Done;
 
@@ -82,7 +82,7 @@ public class ProofTxTracerTests(bool treatSystemAccountDifferently) : VirtualMac
 
         byte[] code = Prepare.EvmCode
             .PushData(SampleHexData1)
-            .PushData(TestItem.AddressC.Bytes)
+            .PushData(TestItem.AddressC)
             .Op(Instruction.BALANCE)
             .Done;
 
@@ -96,7 +96,7 @@ public class ProofTxTracerTests(bool treatSystemAccountDifferently) : VirtualMac
     {
         byte[] code = Prepare.EvmCode
             .PushData(SampleHexData1)
-            .PushData(SenderRecipientAndMiner.Default.Miner.Bytes)
+            .PushData(SenderRecipientAndMiner.Default.Miner)
             .Op(Instruction.BALANCE)
             .Done;
 

--- a/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Evm.Test
             Assert.That(receipt.GasSpent, Is.EqualTo(83199), "with refund");
 
             byte[] returnData = TestState.Get(new StorageCell(TestItem.AddressC, 0)).ToArray();
-            Assert.That(returnData, Is.EqualTo(deployed.Bytes), "address returned");
+            Assert.That(returnData, Is.EqualTo(deployed.Bytes.ToArray()), "address returned");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -108,7 +108,7 @@ public class CodeInfoRepository : ICodeInfoRepository
         {
             authorizedBuffer = new byte[Eip7702Constants.DelegationHeader.Length + Address.Size];
             Eip7702Constants.DelegationHeader.CopyTo(authorizedBuffer);
-            codeSource.Bytes.CopyTo(authorizedBuffer, Eip7702Constants.DelegationHeader.Length);
+            codeSource.Bytes.CopyTo(authorizedBuffer.AsSpan(Eip7702Constants.DelegationHeader.Length));
             codeHash = ValueKeccak.Compute(authorizedBuffer);
         }
         else

--- a/src/Nethermind/Nethermind.Evm/Prepare.cs
+++ b/src/Nethermind/Nethermind.Evm/Prepare.cs
@@ -245,7 +245,7 @@ namespace Nethermind.Evm
 
         public Prepare PushData(Address address)
         {
-            PushData(address.Bytes);
+            PushData(address.Bytes.ToArray());
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Evm/Prepare.cs
+++ b/src/Nethermind/Nethermind.Evm/Prepare.cs
@@ -245,7 +245,9 @@ namespace Nethermind.Evm
 
         public Prepare PushData(Address address)
         {
-            PushData(address.Bytes.ToArray());
+            ReadOnlySpan<byte> bytes = address.Bytes;
+            _byteCode.Add((byte)(Instruction.PUSH1 + (byte)bytes.Length - 1));
+            _byteCode.AddRange(bytes);
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -318,7 +318,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
     protected void PrepareCreateData(VmState<TGasPolicy> previousState, ref ZeroPaddedSpan previousCallOutput)
     {
-        _previousCallResult = previousState.Env.ExecutingAccount.Bytes;
+        _previousCallResult = previousState.Env.ExecutingAccount.Bytes.ToArray();
         _previousCallOutputDestination = UInt256.Zero;
         ReturnDataBuffer = Array.Empty<byte>();
         previousCallOutput = ZeroPaddedSpan.Empty;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthSimulateTestsPrecompilesWithRedirection.cs
@@ -107,7 +107,7 @@ public class EthSimulateTestsPrecompilesWithRedirection
             .JUMPDEST()
             .PushData(Bytes.ZeroByte)
             .Op(Instruction.DUP1)
-            .PushData(TestItem.AddressB.Bytes)
+            .PushData(TestItem.AddressB)
             .Op(Instruction.SWAP1)
             .Op(Instruction.POP)
             .Op(Instruction.CALLDATASIZE)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/StorageValuesResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/StorageValuesResult.cs
@@ -45,7 +45,7 @@ internal sealed class StorageValuesResultConverter : JsonConverter<StorageValues
         keyBytes[1] = (byte)'x';
         foreach (KeyValuePair<Address, Memory<byte>[]> entry in value.Slots)
         {
-            entry.Key.Bytes.AsSpan().OutputBytesToByteHex(keyBytes[2..], false);
+            entry.Key.Bytes.OutputBytesToByteHex(keyBytes[2..], false);
             writer.WritePropertyName(keyBytes);
             writer.WriteStartArray();
             foreach (Memory<byte> slot in entry.Value)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromReplay.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromReplay.cs
@@ -140,7 +140,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
                 foreach ((Address address, ParityAccountStateChange stateChange) in value.StateChanges.OrderBy(static sc => sc.Key, GenericComparer.GetOptimized<Address>()))
                 {
-                    address.Bytes.AsSpan().OutputBytesToByteHex(hex, false);
+                    address.Bytes.OutputBytesToByteHex(hex, false);
                     writer.WritePropertyName(addressBytes);
                     JsonSerializer.Serialize(writer, stateChange, options);
                 }

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
@@ -46,7 +46,7 @@ public class DepositTransactionBuilder(ulong chainId, CLChainSpecEngineParameter
         blockInfo.BaseFee.ToBigEndian().CopyTo(data, 36);
         blockInfo.BlobBaseFee.ToBigEndian().CopyTo(data, 68);
         blockInfo.BlockHash.Bytes.CopyTo(data.AsSpan(100));
-        blockInfo.BatcherAddress.Bytes.CopyTo(data, 144);
+        blockInfo.BatcherAddress.Bytes.CopyTo(data.AsSpan(144));
 
         Span<byte> source = stackalloc byte[64];
         blockInfo.BlockHash.Bytes.CopyTo(source);

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
@@ -79,10 +79,10 @@ public class PreimageRecordingPersistenceTests
 
         // Verify address preimages
         ValueHash256 addressAPath = addressA.ToAccountPath;
-        _preimageDb.Get(addressAPath.BytesAsSpan[..PreimageLookupSize]).Should().BeEquivalentTo(addressA.Bytes);
+        _preimageDb.Get(addressAPath.BytesAsSpan[..PreimageLookupSize]).Should().BeEquivalentTo(addressA.Bytes.ToArray());
 
         ValueHash256 addressBPath = addressB.ToAccountPath;
-        _preimageDb.Get(addressBPath.BytesAsSpan[..PreimageLookupSize]).Should().BeEquivalentTo(addressB.Bytes);
+        _preimageDb.Get(addressBPath.BytesAsSpan[..PreimageLookupSize]).Should().BeEquivalentTo(addressB.Bytes.ToArray());
 
         // Verify slot preimage
         ValueHash256 slotHash = ValueKeccak.Zero;
@@ -135,7 +135,7 @@ public class PreimageRecordingPersistenceTests
 
         // Pre-populate preimage database with address and slot preimages
         ValueHash256 addrHash = address.ToAccountPath;
-        _preimageDb.Set(addrHash.BytesAsSpan[..PreimageLookupSize], address.Bytes);
+        _preimageDb.Set(addrHash.BytesAsSpan[..PreimageLookupSize], address.Bytes.ToArray());
 
         ValueHash256 slotHash = ValueKeccak.Zero;
         StorageTree.ComputeKeyWithLookup(slot, ref slotHash);
@@ -170,7 +170,7 @@ public class PreimageRecordingPersistenceTests
 
         // Pre-populate only address preimage (missing slot preimage)
         ValueHash256 addrHash = address.ToAccountPath;
-        _preimageDb.Set(addrHash.BytesAsSpan[..PreimageLookupSize], address.Bytes);
+        _preimageDb.Set(addrHash.BytesAsSpan[..PreimageLookupSize], address.Bytes.ToArray());
 
         ValueHash256 slotHash = ValueKeccak.Zero;
         StorageTree.ComputeKeyWithLookup(slot, ref slotHash);

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -113,7 +113,7 @@ namespace Nethermind.State.Proofs
         }
 
         public AccountProofCollector(Address? address, params byte[][] storageKeys)
-            : this(Keccak.Compute(address?.Bytes ?? Address.Zero.Bytes).Bytes, storageKeys) => _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
+            : this(Keccak.Compute((address ?? Address.Zero).Bytes).Bytes, storageKeys) => _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
 
         public AccountProofCollector(Address? address, IEnumerable<UInt256> storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray())

--- a/src/Nethermind/Nethermind.Xdc.Test/EpochSwitchManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/EpochSwitchManagerTests.cs
@@ -719,7 +719,7 @@ internal class EpochSwitchManagerTests
 
         for (int i = 0; i < nextEpochCandidates!.Length; i++)
         {
-            Array.Copy(nextEpochCandidates[i].Bytes, 0, extraData, XdcConstants.ExtraVanity + i * Address.Size, Address.Size);
+            nextEpochCandidates[i].Bytes.CopyTo(extraData.AsSpan(XdcConstants.ExtraVanity + i * Address.Size, Address.Size));
         }
 
         return extraData;

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcBlockHeaderBuilder.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcBlockHeaderBuilder.cs
@@ -117,7 +117,7 @@ public class XdcBlockHeaderBuilder : BlockHeaderBuilder
     }
     public XdcBlockHeaderBuilder WithValidators(Address[] validators)
     {
-        XdcTestObjectInternal.Validators = validators.SelectMany(a => a.Bytes).ToArray();
+        XdcTestObjectInternal.Validators = validators.SelectMany(a => a.Bytes.ToArray()).ToArray();
         return this;
     }
     public XdcBlockHeaderBuilder WithValidators(byte[] validators)
@@ -127,7 +127,7 @@ public class XdcBlockHeaderBuilder : BlockHeaderBuilder
     }
     public XdcBlockHeaderBuilder WithPenalties(Address[] penalties)
     {
-        XdcTestObjectInternal.Penalties = penalties.SelectMany(a => a.Bytes).ToArray();
+        XdcTestObjectInternal.Penalties = penalties.SelectMany(a => a.Bytes.ToArray()).ToArray();
         return this;
     }
     public XdcBlockHeaderBuilder WithPenalties(byte[] penalties)

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcSubnetBlockHeaderBuilder.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcSubnetBlockHeaderBuilder.cs
@@ -74,7 +74,7 @@ public class XdcSubnetBlockHeaderBuilder : XdcBlockHeaderBuilder
     }
     public XdcSubnetBlockHeaderBuilder WithNextValidators(Address[] nextValidators)
     {
-        XdcTestObjectInternal.NextValidators = nextValidators.SelectMany(a => a.Bytes).ToArray();
+        XdcTestObjectInternal.NextValidators = nextValidators.SelectMany(a => a.Bytes.ToArray()).ToArray();
         return this;
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestHelper.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestHelper.cs
@@ -98,7 +98,7 @@ internal static class XdcTestHelper
     {
         byte[] extraData = new byte[XdcConstants.ExtraVanity + addresses.Length * Address.Size + XdcConstants.ExtraSeal];
         for (int i = 0; i < addresses.Length; i++)
-            Array.Copy(addresses[i].Bytes, 0, extraData, XdcConstants.ExtraVanity + i * Address.Size, Address.Size);
+            addresses[i].Bytes.CopyTo(extraData.AsSpan(XdcConstants.ExtraVanity + i * Address.Size, Address.Size));
         return extraData;
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/HeaderVerificationTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/HeaderVerificationTests.cs
@@ -176,7 +176,7 @@ internal class HeaderVerificationTests
     public void NonEpochBlock_With_Penalties_Fails()
     {
         XdcBlockHeader invalidPenaltiesExistBlock = GetLastHeader(false);
-        invalidPenaltiesExistBlock.Penalties = TestItem.AddressF.Bytes;
+        invalidPenaltiesExistBlock.Penalties = TestItem.AddressF.Bytes.ToArray();
         BlockHeader? invalidPenaltiesExistBlockParent = xdcTestBlockchain.BlockTree.FindHeader(invalidPenaltiesExistBlock.ParentHash!);
         bool result = xdcHeaderValidator.Validate(invalidPenaltiesExistBlock, invalidPenaltiesExistBlockParent!);
         Assert.That(result, Is.False);
@@ -226,7 +226,7 @@ internal class HeaderVerificationTests
     public void NonEpochSwitch_Block_With_ValidatorsSet()
     {
         XdcBlockHeader nonEpochSwitchWithValidators = GetLastHeader(false);
-        nonEpochSwitchWithValidators.Validators = xdcTestBlockchain.MasterNodeCandidates.SelectMany(addr => addr.Address.Bytes).ToArray(); // implement helper to return acc1 addr bytes
+        nonEpochSwitchWithValidators.Validators = xdcTestBlockchain.MasterNodeCandidates.SelectMany(addr => addr.Address.Bytes.ToArray()).ToArray(); // implement helper to return acc1 addr bytes
         BlockHeader? nonEpochSwitchWithValidatorsParent = xdcTestBlockchain.BlockTree.FindHeader(nonEpochSwitchWithValidators.ParentHash!);
         bool result = xdcHeaderValidator.Validate(nonEpochSwitchWithValidators, nonEpochSwitchWithValidatorsParent);
         Assert.That(result, Is.False);

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/SubnetPenaltyTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/SubnetPenaltyTests.cs
@@ -80,7 +80,7 @@ internal class SubnetPenaltyTests
         Address[] injectedPenalties = [TestItem.AddressA, TestItem.AddressB];
         byte[] penaltyBytes = new byte[injectedPenalties.Length * Address.Size];
         for (int i = 0; i < injectedPenalties.Length; i++)
-            injectedPenalties[i].Bytes.CopyTo(penaltyBytes, i * Address.Size);
+            injectedPenalties[i].Bytes.CopyTo(penaltyBytes.AsSpan(i * Address.Size));
         ctx.Headers[target - EpochLength + 1].Penalties = penaltyBytes;
 
         Address[] penalties = ctx.Handler.HandlePenalties(
@@ -179,7 +179,7 @@ internal class SubnetPenaltyTests
         Address[] injectedPenalties = [eip55Second, eip55First];
         byte[] penaltyBytes = new byte[injectedPenalties.Length * Address.Size];
         for (int i = 0; i < injectedPenalties.Length; i++)
-            injectedPenalties[i].Bytes.CopyTo(penaltyBytes, i * Address.Size);
+            injectedPenalties[i].Bytes.CopyTo(penaltyBytes.AsSpan(i * Address.Size));
         ctx.Headers[target - EpochLength + 1].Penalties = penaltyBytes;
 
         Address[] penalties = ctx.Handler.HandlePenalties(

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockProducer.cs
@@ -85,14 +85,14 @@ internal class XdcBlockProducer(
 
             for (int i = 0; i < masternodes.Length; i++)
             {
-                Array.Copy(masternodes[i].Bytes, 0, xdcBlockHeader.Validators, i * Address.Size, Address.Size);
+                masternodes[i].Bytes.CopyTo(xdcBlockHeader.Validators.AsSpan(i * Address.Size, Address.Size));
             }
 
             xdcBlockHeader.Penalties = new byte[penalties.Length * Address.Size];
 
             for (int i = 0; i < penalties.Length; i++)
             {
-                Array.Copy(penalties[i].Bytes, 0, xdcBlockHeader.Penalties, i * Address.Size, Address.Size);
+                penalties[i].Bytes.CopyTo(xdcBlockHeader.Penalties.AsSpan(i * Address.Size, Address.Size));
             }
         }
         return xdcBlockHeader;

--- a/src/Nethermind/Nethermind.Xdc/XdcSubnetBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcSubnetBlockProducer.cs
@@ -48,13 +48,13 @@ internal class XdcSubnetBlockProducer(
             headerCandidate.NextValidators = new byte[nextEpochCandidates.Length * Address.Size];
             for (int i = 0; i < nextEpochCandidates.Length; i++)
             {
-                Array.Copy(nextEpochCandidates[i].Bytes, 0, headerCandidate.NextValidators, i * Address.Size, Address.Size);
+                nextEpochCandidates[i].Bytes.CopyTo(headerCandidate.NextValidators.AsSpan(i * Address.Size, Address.Size));
             }
 
             headerCandidate.Penalties = new byte[nextPenalties.Length * Address.Size];
             for (int i = 0; i < nextPenalties.Length; i++)
             {
-                Array.Copy(nextPenalties[i].Bytes, 0, headerCandidate.Penalties, i * Address.Size, Address.Size);
+                nextPenalties[i].Bytes.CopyTo(headerCandidate.Penalties.AsSpan(i * Address.Size, Address.Size));
             }
         }
 


### PR DESCRIPTION
## Changes

- Replaced `byte[] Bytes` on `Address` with an `[InlineArray(20)]` struct field (mirrors the existing `Bloom.BloomData` and `HexBuffer256` patterns). Each `Address` is now one heap allocation instead of two; the 20 bytes live directly in the object payload.
- Public `Bytes` property is now `ReadOnlySpan<byte>` (was `byte[]`). Internal hot paths (`Equals`, `ToHash`, `GetHashCode64`, `StorageCell.Equals`) take the ref straight into the inline array.
- Updated downstream callers — most consumers fed the bytes into `ReadOnlySpan<byte>` overloads already and were untouched. The few that genuinely needed `byte[]` (long-term storage in `_previousCallResult`, `LogIndexEnumerator` keys, `ArrayPoolList<byte[]>`, JS-tracing typed arrays) now call `.ToArray()` explicitly. `AbiAddress.Encode` and `Prepare.PushData(Address)` were rewritten to skip the intermediate array entirely.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### Notes on testing

`Nethermind.Core.Test`, `Nethermind.Abi.Test`, `Nethermind.State.Test`, `Nethermind.Evm.Test` all pass locally. `Nethermind.Trie.Test` had 3 known timing-flaky failures under parallel load (`Will_Persist_ReCommittedPersistedNode_FromCommitBuffer`, `Can_ContinueEvenWhenPruningIsBlocked` ×2) that pass in isolation — pre-existing, unrelated.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

`Address.Bytes` changes signature from `byte[]` to `ReadOnlySpan<byte>` — that's a public API surface change. Most internal call sites flow into span-accepting overloads transparently; sites needing `byte[]` were updated explicitly in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)