### PR TITLE
fix(snap-sync): drive FlatSnapTrieFactory init/finalize from SnapSyncRunner.Run

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -14,18 +14,23 @@ namespace Nethermind.State.Flat.Sync.Snap;
 /// <summary>
 /// ISnapTrieFactory implementation for flat state storage.
 /// Uses IPersistence to create reader/writeBatch per tree for proper resource management.
+/// EnsureInitialize/FinalizeSync are driven by the snap-sync runner at start/end of the run,
+/// so they don't need internal locking — they're never called concurrently with CreateXxxTree.
 /// </summary>
 public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfig, ILogManager logManager) : ISnapTrieFactory
 {
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapTrieFactory>();
-    private readonly Lock _lock = new();
 
-    private bool _initialized = false;
+    public void EnsureInitialize()
+    {
+        if (_logger.IsInfo) _logger.Info("Clearing database");
+        persistence.Clear();
+    }
+
+    public void FinalizeSync() => persistence.Flush();
 
     public ISnapTree<PathWithAccount> CreateStateTree()
     {
-        EnsureDatabaseCleared();
-
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
         return new FlatSnapStateTree(reader, writeBatch, syncConfig.EnableSnapDoubleWriteCheck, logManager);
@@ -33,24 +38,8 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
     public ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath)
     {
-        EnsureDatabaseCleared();
-
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);
         IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(StateId.Sync, StateId.Sync, WriteFlags.DisableWAL);
         return new FlatSnapStorageTree(reader, writeBatch, accountPath.ToCommitment(), syncConfig.EnableSnapDoubleWriteCheck, logManager);
-    }
-
-    private void EnsureDatabaseCleared()
-    {
-        if (_initialized) return;
-
-        using (_lock.EnterScope())
-        {
-            if (_initialized) return;
-            _initialized = true;
-
-            _logger.Info("Clearing database");
-            persistence.Clear();
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -403,33 +403,10 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         if (dbMode == DbMode.Hash) Assert.Ignore("Hash db does not support snap sync");
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-
-        PrivateKey clientKey = TestItem.PrivateKeyD;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
-        {
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
-            syncConfig.SnapSync = true;
-
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
-
-            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
-            networkConfig.P2PPort = AllocatePort();
-            // Disable IP filtering for E2E tests as all nodes run on localhost
-            networkConfig.FilterPeersByRecentIp = false;
-            networkConfig.FilterDiscoveryNodesByRecentIp = false;
-        });
-
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+        await RunSnapSyncOnce(cancellationTokenSource.Token);
     }
 
-    // Stress reproducer for the Windows-only SnapSync flake observed in CI:
-    //   - run #25139586200 / job #73686059011 (PR #11422)
-    // Re-runs the same logic as SnapSync() many times, each iteration as its own NUnit case
-    // so a single flake doesn't terminate the rest. Intentionally NO [Retry] — we want every
-    // failure to surface. Marked [Explicit] so it doesn't run in normal CI; invoke with:
-    //   dotnet test --filter "FullyQualifiedName~SnapSync_StressRepro"
-    // Runs only on Flat dbMode (where the flake has been observed).
+    // Stress reproducer for SnapSync Windows flake — run manually; see PR #11443 for context.
     [Test, Explicit("Stress reproducer for SnapSync Windows flake — run manually")]
     [TestCaseSource(nameof(StressIterations))]
     public async Task SnapSync_StressRepro(int iteration)
@@ -438,7 +415,11 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         _ = iteration; // index is purely to give NUnit a unique case per attempt
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
+        await RunSnapSyncOnce(cancellationTokenSource.Token);
+    }
 
+    private async Task RunSnapSyncOnce(CancellationToken cancellationToken)
+    {
         PrivateKey clientKey = TestItem.PrivateKeyD;
         await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
         {
@@ -446,15 +427,16 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             syncConfig.FastSync = true;
             syncConfig.SnapSync = true;
 
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
+            await SetPivot(syncConfig, cancellationToken);
 
             INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
             networkConfig.P2PPort = AllocatePort();
+            // Disable IP filtering for E2E tests as all nodes run on localhost
             networkConfig.FilterPeersByRecentIp = false;
             networkConfig.FilterDiscoveryNodesByRecentIp = false;
         });
 
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationToken);
     }
 
     private const int StressIterationCount = 30;

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -423,6 +423,43 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
     }
 
+    // Stress reproducer for the Windows-only SnapSync flake observed in CI:
+    //   - run #25139586200 / job #73686059011 (PR #11422)
+    // Re-runs the same logic as SnapSync() many times, each iteration as its own NUnit case
+    // so a single flake doesn't terminate the rest. Intentionally NO [Retry] — we want every
+    // failure to surface. Marked [Explicit] so it doesn't run in normal CI; invoke with:
+    //   dotnet test --filter "FullyQualifiedName~SnapSync_StressRepro"
+    // Runs only on Flat dbMode (where the flake has been observed).
+    [Test, Explicit("Stress reproducer for SnapSync Windows flake — run manually")]
+    [TestCaseSource(nameof(StressIterations))]
+    public async Task SnapSync_StressRepro(int iteration)
+    {
+        if (dbMode != DbMode.Flat) Assert.Ignore("Stress repro only targets the Flat dbMode where the flake was observed");
+        _ = iteration; // index is purely to give NUnit a unique case per attempt
+
+        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
+
+        PrivateKey clientKey = TestItem.PrivateKeyD;
+        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+        {
+            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+            syncConfig.FastSync = true;
+            syncConfig.SnapSync = true;
+
+            await SetPivot(syncConfig, cancellationTokenSource.Token);
+
+            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
+            networkConfig.P2PPort = AllocatePort();
+            networkConfig.FilterPeersByRecentIp = false;
+            networkConfig.FilterDiscoveryNodesByRecentIp = false;
+        });
+
+        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+    }
+
+    private const int StressIterationCount = 30;
+    private static IEnumerable<int> StressIterations() => Enumerable.Range(0, StressIterationCount);
+
     [Test]
     [Retry(5)]
     public async Task SnapSync_HalfPathServer_HashClient()

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Nethermind.Core.Crypto;
-using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -17,67 +15,35 @@ namespace Nethermind.Synchronization.Test.SnapSync;
 [TestFixture]
 public class SnapSyncRunnerTests
 {
-    [Test]
-    public async Task Run_calls_EnsureInitialize_then_dispatcher_then_FinalizeSync_in_order()
+    public enum DispatcherOutcome { Completes, Throws, Cancels }
+
+    [TestCase(DispatcherOutcome.Completes, null)]
+    [TestCase(DispatcherOutcome.Throws, typeof(InvalidOperationException))]
+    [TestCase(DispatcherOutcome.Cancels, typeof(OperationCanceledException))]
+    public async Task Run_invokes_lifecycle_in_order(DispatcherOutcome outcome, Type? expectedException)
     {
         List<string> calls = new();
-        ISnapTrieFactory factory = MakeRecordingFactory(calls);
-
-        SnapSyncRunner runner = new(token =>
-        {
-            calls.Add("dispatcher");
-            return Task.CompletedTask;
-        }, factory);
-
-        await runner.Run(CancellationToken.None);
-
-        calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
-    }
-
-    [Test]
-    public async Task Run_calls_FinalizeSync_when_dispatcher_throws()
-    {
-        List<string> calls = new();
-        ISnapTrieFactory factory = MakeRecordingFactory(calls);
-
-        SnapSyncRunner runner = new(_ =>
-        {
-            calls.Add("dispatcher");
-            throw new InvalidOperationException("boom");
-        }, factory);
-
-        Func<Task> act = () => runner.Run(CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
-
-        calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
-    }
-
-    [Test]
-    public async Task Run_calls_FinalizeSync_when_dispatcher_cancelled()
-    {
-        List<string> calls = new();
-        ISnapTrieFactory factory = MakeRecordingFactory(calls);
+        ISnapTrieFactory factory = Substitute.For<ISnapTrieFactory>();
+        factory.When(f => f.EnsureInitialize()).Do(_ => calls.Add("EnsureInitialize"));
+        factory.When(f => f.FinalizeSync()).Do(_ => calls.Add("FinalizeSync"));
 
         using CancellationTokenSource cts = new();
-        cts.Cancel();
+        if (outcome == DispatcherOutcome.Cancels) cts.Cancel();
+
         SnapSyncRunner runner = new(token =>
         {
             calls.Add("dispatcher");
-            token.ThrowIfCancellationRequested();
+            if (outcome == DispatcherOutcome.Throws) throw new InvalidOperationException("boom");
+            if (outcome == DispatcherOutcome.Cancels) token.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }, factory);
 
         Func<Task> act = () => runner.Run(cts.Token);
-        await act.Should().ThrowAsync<OperationCanceledException>();
+        if (expectedException is null)
+            await act.Should().NotThrowAsync();
+        else
+            await act.Should().ThrowAsync<Exception>().Where(e => expectedException.IsInstanceOfType(e));
 
         calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
-    }
-
-    private static ISnapTrieFactory MakeRecordingFactory(List<string> calls)
-    {
-        ISnapTrieFactory factory = Substitute.For<ISnapTrieFactory>();
-        factory.When(f => f.EnsureInitialize()).Do(_ => calls.Add("EnsureInitialize"));
-        factory.When(f => f.FinalizeSync()).Do(_ => calls.Add("FinalizeSync"));
-        return factory;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
@@ -33,9 +33,12 @@ public class SnapSyncRunnerTests
         SnapSyncRunner runner = new(token =>
         {
             calls.Add("dispatcher");
-            if (outcome == DispatcherOutcome.Throws) throw new InvalidOperationException("boom");
-            if (outcome == DispatcherOutcome.Cancels) token.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
+            return outcome switch
+            {
+                DispatcherOutcome.Throws => throw new InvalidOperationException("boom"),
+                DispatcherOutcome.Cancels => throw new OperationCanceledException(token),
+                _ => Task.CompletedTask,
+            };
         }, factory);
 
         Func<Task> act = () => runner.Run(cts.Token);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using Nethermind.State.Snap;
+using Nethermind.Synchronization.SnapSync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.SnapSync;
+
+[TestFixture]
+public class SnapSyncRunnerTests
+{
+    [Test]
+    public async Task Run_calls_EnsureInitialize_then_dispatcher_then_FinalizeSync_in_order()
+    {
+        List<string> calls = new();
+        ISnapTrieFactory factory = MakeRecordingFactory(calls);
+
+        SnapSyncRunner runner = new(token =>
+        {
+            calls.Add("dispatcher");
+            return Task.CompletedTask;
+        }, factory);
+
+        await runner.Run(CancellationToken.None);
+
+        calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
+    }
+
+    [Test]
+    public async Task Run_calls_FinalizeSync_when_dispatcher_throws()
+    {
+        List<string> calls = new();
+        ISnapTrieFactory factory = MakeRecordingFactory(calls);
+
+        SnapSyncRunner runner = new(_ =>
+        {
+            calls.Add("dispatcher");
+            throw new InvalidOperationException("boom");
+        }, factory);
+
+        Func<Task> act = () => runner.Run(CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
+    }
+
+    [Test]
+    public async Task Run_calls_FinalizeSync_when_dispatcher_cancelled()
+    {
+        List<string> calls = new();
+        ISnapTrieFactory factory = MakeRecordingFactory(calls);
+
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+        SnapSyncRunner runner = new(token =>
+        {
+            calls.Add("dispatcher");
+            token.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }, factory);
+
+        Func<Task> act = () => runner.Run(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        calls.Should().Equal("EnsureInitialize", "dispatcher", "FinalizeSync");
+    }
+
+    private static ISnapTrieFactory MakeRecordingFactory(List<string> calls)
+    {
+        ISnapTrieFactory factory = Substitute.For<ISnapTrieFactory>();
+        factory.When(f => f.EnsureInitialize()).Do(_ => calls.Add("EnsureInitialize"));
+        factory.When(f => f.FinalizeSync()).Do(_ => calls.Add("FinalizeSync"));
+        return factory;
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
@@ -8,6 +8,21 @@ namespace Nethermind.Synchronization.SnapSync;
 
 public interface ISnapTrieFactory
 {
+    /// <summary>
+    /// Called once at the start of a snap-sync run, before any tree is created. Implementations
+    /// that need a clean slate (e.g. flat-state, which can't merge two snap-sync runs in place)
+    /// perform their reset here. Called from a single sequential entry point — implementations
+    /// must not assume concurrent invocations.
+    /// </summary>
+    void EnsureInitialize() { }
+
+    /// <summary>
+    /// Called once at the end of a snap-sync run, after all created trees have been disposed.
+    /// Implementations that buffer writes can flush here. Called from a single sequential exit
+    /// point — implementations must not assume concurrent invocations.
+    /// </summary>
+    void FinalizeSync() { }
+
     ISnapTree<PathWithAccount> CreateStateTree();
     ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath);
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
@@ -8,19 +8,8 @@ namespace Nethermind.Synchronization.SnapSync;
 
 public interface ISnapTrieFactory
 {
-    /// <summary>
-    /// Called once at the start of a snap-sync run, before any tree is created. Implementations
-    /// that need a clean slate (e.g. flat-state, which can't merge two snap-sync runs in place)
-    /// perform their reset here. Called from a single sequential entry point — implementations
-    /// must not assume concurrent invocations.
-    /// </summary>
+    // Called once at the start/end of a snap-sync run from SnapSyncRunner.Run — sequential, no concurrent invocations.
     void EnsureInitialize() { }
-
-    /// <summary>
-    /// Called once at the end of a snap-sync run, after all created trees have been disposed.
-    /// Implementations that buffer writes can flush here. Called from a single sequential exit
-    /// point — implementations must not assume concurrent invocations.
-    /// </summary>
     void FinalizeSync() { }
 
     ISnapTree<PathWithAccount> CreateStateTree();

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
@@ -2,40 +2,28 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Synchronization.ParallelSync;
 
-[assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
-
 namespace Nethermind.Synchronization.SnapSync;
 
-public class SnapSyncRunner : ISnapSyncRunner
+public class SnapSyncRunner(Func<CancellationToken, Task> runDispatcher, ISnapTrieFactory snapTrieFactory) : ISnapSyncRunner
 {
-    private readonly Func<CancellationToken, Task> _runDispatcher;
-    private readonly ISnapTrieFactory _snapTrieFactory;
-
     public SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory)
         : this(dispatcher.Run, snapTrieFactory) { }
 
-    internal SnapSyncRunner(Func<CancellationToken, Task> runDispatcher, ISnapTrieFactory snapTrieFactory)
-    {
-        _runDispatcher = runDispatcher;
-        _snapTrieFactory = snapTrieFactory;
-    }
-
     public async Task Run(CancellationToken token)
     {
-        _snapTrieFactory.EnsureInitialize();
+        snapTrieFactory.EnsureInitialize();
         try
         {
-            await _runDispatcher(token);
+            await runDispatcher(token);
         }
         finally
         {
             // Always finalize — FinalizeSync is idempotent and we want partial writes flushed on cancel/throw.
-            _snapTrieFactory.FinalizeSync();
+            snapTrieFactory.FinalizeSync();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
@@ -1,27 +1,41 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Synchronization.ParallelSync;
 
+[assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
+
 namespace Nethermind.Synchronization.SnapSync;
 
-public class SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory) : ISnapSyncRunner
+public class SnapSyncRunner : ISnapSyncRunner
 {
+    private readonly Func<CancellationToken, Task> _runDispatcher;
+    private readonly ISnapTrieFactory _snapTrieFactory;
+
+    public SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory)
+        : this(dispatcher.Run, snapTrieFactory) { }
+
+    internal SnapSyncRunner(Func<CancellationToken, Task> runDispatcher, ISnapTrieFactory snapTrieFactory)
+    {
+        _runDispatcher = runDispatcher;
+        _snapTrieFactory = snapTrieFactory;
+    }
+
     public async Task Run(CancellationToken token)
     {
-        // Sequential lifecycle: init before any batch can create a tree, finalize after all
-        // batches have completed and their trees disposed. The new dispatcher.Run guarantees
-        // both ordering halves, so the factory doesn't need internal locking for these hooks.
-        snapTrieFactory.EnsureInitialize();
+        _snapTrieFactory.EnsureInitialize();
         try
         {
-            await dispatcher.Run(token);
+            await _runDispatcher(token);
         }
         finally
         {
-            snapTrieFactory.FinalizeSync();
+            // Always finalize — FinalizeSync is idempotent and we want partial writes flushed on cancel/throw.
+            _snapTrieFactory.FinalizeSync();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
@@ -7,7 +7,21 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization.SnapSync;
 
-public class SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher) : ISnapSyncRunner
+public class SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory) : ISnapSyncRunner
 {
-    public Task Run(CancellationToken token) => dispatcher.Run(token);
+    public async Task Run(CancellationToken token)
+    {
+        // Sequential lifecycle: init before any batch can create a tree, finalize after all
+        // batches have completed and their trees disposed. The new dispatcher.Run guarantees
+        // both ordering halves, so the factory doesn't need internal locking for these hooks.
+        snapTrieFactory.EnsureInitialize();
+        try
+        {
+            await dispatcher.Run(token);
+        }
+        finally
+        {
+            snapTrieFactory.FinalizeSync();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Ports the snap-sync flake fix from #11443 onto @asdacap's snap+state dispatcher refactor (#11102), in the cleaner shape he suggested: drive `FlatSnapTrieFactory.Clear()` from `SnapSyncRunner.Run` boundaries instead of a lazy `EnsureDatabaseCleared` lock.

This PR is **stacked on top of `amirul/simple-sync-dispatcher`** so it can land alongside #11102.

## Background

#11443 root-caused a Windows-only `E2ESyncTests.SnapSync` flake to a race in `FlatSnapTrieFactory.EnsureDatabaseCleared`:

```csharp
if (_initialized) return;          // unlocked fast path
using (_lock.EnterScope())
{
    if (_initialized) return;
    _initialized = true;            // ← published BEFORE Clear() ran
    persistence.Clear();             // ← still iterating GetAllKeys / queueing Removes
}
```

Thread T2 could read `_initialized = true` via the unlocked fast path while T1 was still inside `Clear()`. T2 would then call `CreateStateTree` and start writing accounts. When T1's `Clear` batch finally disposed, every queued `Remove` (including the keys T2 had just committed) would land on the live DB, and the flat DB ended up missing entries the trie still referenced — surfacing as "Account in trie not found in flat" in the verifier.

#11443 fixed it by publishing `_initialized` _after_ `Clear()` and marking the field `volatile`. Validated as 0/300 stress runs vs. 8–15/60 before.

## What this PR does

@asdacap pointed out that on top of #11102's runner refactor, the lazy-init pattern can go away entirely — the snap-sync run has a single sequential entry/exit point in `SnapSyncRunner.Run`, so init/cleanup can be hooked there:

- Add two default-no-op methods to `ISnapTrieFactory`:
  - `EnsureInitialize()` — called once before any tree is created.
  - `FinalizeSync()` — called once after the dispatcher has drained.
- `FlatSnapTrieFactory` implements them with `persistence.Clear()` and `persistence.Flush()` respectively. The lock and the `_initialized` flag are deleted.
- `SnapSyncRunner.Run` brackets `dispatcher.Run(token)` with `EnsureInitialize` (before) and `FinalizeSync` (in `finally`).
- `PatriciaSnapTrieFactory`, `TestSnapTrieFactory`, and the other test factories pick up the empty default implementations and don't need changes.

Because `SimpleDispatcher.Run` (introduced by #11102) only returns once every batch handler — and therefore every `ISnapTree.Dispose` — has completed, neither hook needs internal locking. This also obviates the in-flight tree drain that #11443 needed on master (commit `12a66f1e1b`).

## Stress reproducer

The same `SnapSync_StressRepro` test from #11443 (cherry-picked here) runs 30 iterations × 2 Flat fixtures = 60 cases, no `[Retry]`, `[Explicit]`. Local Windows results on this branch:

| Run | `Verification failed` | Test failures |
|---|---:|---:|
| Run 1 | 0 | 0 |
| Run 2 | 0 | 0 |
| Run 3 | 0 | 0 |
| **Total** | **0/180** | **0/180** |

Plus full Flat test suite (292 tests, 4 skipped) and `RecreateState*` (20 tests) and `StateSyncFeed*` (834 tests) all pass.

## Test plan

- [x] Solution builds clean (0 warnings, 0 errors).
- [x] `Nethermind.State.Flat.Test` passes (292 tests).
- [x] `RecreateStateFromAccountRanges` / `RecreateStateFromStorageRanges` pass (20 tests).
- [x] `StateSyncFeed*` passes (834 tests).
- [x] `SnapSync_StressRepro`: 0 failures across 3 stress runs (180 invocations).