### PR TITLE
Fix: `/health` endpoint reports `ClUnavailable` after 5 minutes (1.37.x regression)

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -66,9 +66,8 @@ public class MergePluginTests
     }
 
     private IContainer BuildContainer(IConfigProvider? configProvider = null) =>
-        // HealthCheckPluginModule is added first to mirror PluginConfig.PluginOrder
-        // (HealthChecks loads before Merge in production). MergePlugin must register its
-        // fallback IEngineRequestsTracker without overriding the real ClHealthRequestsTracker.
+        // HealthCheckPluginModule first: mirrors PluginConfig.PluginOrder (HealthChecks < Merge).
+        // BaseMergePluginModule must not override the real ClHealthRequestsTracker binding.
         new ContainerBuilder()
             .AddModule(new HealthCheckPluginModule())
             .AddModule(new NethermindRunnerModule(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -66,7 +66,11 @@ public class MergePluginTests
     }
 
     private IContainer BuildContainer(IConfigProvider? configProvider = null) =>
+        // HealthCheckPluginModule is added first to mirror PluginConfig.PluginOrder
+        // (HealthChecks loads before Merge in production). MergePlugin must register its
+        // fallback IEngineRequestsTracker without overriding the real ClHealthRequestsTracker.
         new ContainerBuilder()
+            .AddModule(new HealthCheckPluginModule())
             .AddModule(new NethermindRunnerModule(
                 new EthereumJsonSerializer(),
                 _chainSpec,
@@ -75,7 +79,6 @@ public class MergePluginTests
                 [_consensusPlugin!, _plugin],
                 LimboLogs.Instance))
             .AddSingleton(Substitute.For<IRpcModuleProvider>())
-            .AddModule(new HealthCheckPluginModule()) // The merge RPC require it.
             .AddSingleton(Substitute.For<IBlockProcessingQueue>())
             .OnBuild(ctx =>
             {
@@ -85,6 +88,14 @@ public class MergePluginTests
                 api.BlockProcessingQueue.IsEmpty.Returns(true);
             })
             .Build();
+
+    [Test]
+    public void EngineRequestsTracker_resolves_to_ClHealthRequestsTracker_when_HealthChecks_loaded_first()
+    {
+        using IContainer container = BuildContainer();
+
+        container.Resolve<IEngineRequestsTracker>().Should().BeOfType<ClHealthRequestsTracker>();
+    }
 
     [Test]
     public void SlotPerSeconds_has_different_value_in_mergeConfig_and_blocksConfig()

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -325,7 +325,6 @@ public class BaseMergePluginModule : Module
                 .AddSingleton<IAsyncHandler<GetBlobsHandlerV2Request, IEnumerable<BlobAndProofV2?>?>, GetBlobsHandlerV2>()
                 .AddSingleton<IHandler<IReadOnlyList<Hash256>, IEnumerable<ExecutionPayloadBodyV2Result?>>, GetPayloadBodiesByHashV2Handler>()
                 .AddSingleton<IGetPayloadBodiesByRangeV2Handler, GetPayloadBodiesByRangeV2Handler>()
-                .AddSingleton<IEngineRequestsTracker, NoEngineRequestsTracker>()
 
                 .AddSingleton<NoSyncGcRegionStrategy>()
                 .AddSingleton<GCKeeper>((ctx) =>


### PR DESCRIPTION
Fixes Closes Resolves https://github.com/NethermindEth/nethermind/issues/11473

## Changes

### Root cause
PR https://github.com/NethermindEth/nethermind/pull/10357 added `AddSingleton<IEngineRequestsTracker, NoEngineRequestsTracker>()` to `BaseMergePluginModule`. Since `MergePlugin` loads after `HealthChecksPlugin` (per `PluginConfig.PluginOrder`), the no-op tracker overrode `HealthChecksPlugin`'s `Bind<IEngineRequestsTracker, ClHealthRequestsTracker>()`. Engine API calls then updated the no-op while `NodeHealthService` kept reading the never-updated `ClHealthRequestsTracker`, so after `MaxIntervalClRequestTime` (default 300s) the endpoint flipped to `Unhealthy` despite the CL working normally.

### Fix
Removed the redundant registration. `HealthChecksPlugin` is always-enabled and provides the real tracker; `TestMergeModule` registers its own no-op for tests.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

Added regression test `EngineRequestsTracker_resolves_to_ClHealthRequestsTracker_when_HealthChecks_loaded_first` and reordered `BuildContainer` to mirror production plugin order. Verified the test fails on the previous behavior and passes after the fix.