### PR TITLE
refactor: serialise FinalizeSync via captured per-round pivot

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -554,12 +554,16 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             async Task<int> RunOneRequest()
             {
-                using StateSyncBatch? request = await ctx.Feed.PrepareRequest(cancellation);
+                // Drive TreeSync directly: the feed wrapper only returns null on cancellation,
+                // round-termination signalling lives in StateSyncRunner. This test wants the
+                // single-shot "is there a batch right now" semantics that TreeSync exposes.
+                if (ctx.TreeFeed.IsSyncRoundFinished()) return 0;
+                using StateSyncBatch? request = await ctx.TreeFeed.PrepareRequest();
                 if (request is null) return 0;
                 PeerInfo peer = new(ctx.SyncPeerMocks[0]);
                 await downloader.Dispatch(peer, request!, cancellation);
                 int requestCount = request.RequestedNodes?.Count ?? 0;
-                ctx.Feed.HandleResponse(request, peer);
+                ctx.TreeFeed.HandleResponse(request, peer);
                 return requestCount;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -404,7 +404,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             await using IContainer container = BuildTestContainerBuilder(remote)
                 .Build();
             SafeContext ctx = container.Resolve<SafeContext>();
-            ctx.TreeFeed.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            ctx.TreeFeed.ResetStateRootToBestSuggested();
 
             using StateSyncBatch? request = await ctx.Feed.PrepareRequest(ctx.CancellationToken);
             request.Should().NotBeNull();
@@ -423,7 +423,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             await using IContainer container = BuildTestContainerBuilder(remote)
                 .Build();
             SafeContext ctx = container.Resolve<SafeContext>();
-            ctx.TreeFeed.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            ctx.TreeFeed.ResetStateRootToBestSuggested();
 
             using StateSyncBatch? request = await ctx.Feed.PrepareRequest(ctx.CancellationToken);
             request.Should().NotBeNull();
@@ -549,7 +549,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             await using IContainer container = PrepareDownloader(remote);
             SafeContext ctx = container.Resolve<SafeContext>();
-            ctx.TreeFeed.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            ctx.TreeFeed.ResetStateRootToBestSuggested();
             ISyncDownloader<StateSyncBatch> downloader = container.Resolve<ISyncDownloader<StateSyncBatch>>();
 
             async Task<int> RunOneRequest()

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -221,8 +221,8 @@ public abstract class StateSyncFeedTestsBase(
 
         public void ResetFeed()
         {
-            treeSync.Value.ResetStateRoot(SyncFeedState.Dormant);
-            treeSync.Value.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            treeSync.Value.ResetStateRoot();
+            treeSync.Value.ResetStateRootToBestSuggested();
         }
 
         public Task RunFeed(CancellationToken cancellationToken) => stateSyncRunner.Value.RunStateSyncRounds(cancellationToken);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
@@ -20,20 +20,22 @@ namespace Nethermind.Synchronization.FastSync
             {
                 try
                 {
-                    if (treeSync.IsSyncRoundFinished())
-                        return null;
+                    if (treeSync.IsSyncRoundFinished()) return null;
 
                     StateSyncBatch? batch = await treeSync.PrepareRequest();
-                    if (batch is not null)
-                        return batch;
+                    if (batch is not null) return batch;
+                }
+                catch (OperationCanceledException)
+                {
+                    return null;
                 }
                 catch (Exception e)
                 {
                     _logger.Error("Error when preparing a state sync batch", e);
                 }
 
-                // Pending queue empty or transient error — wait and retry
-                await Task.Delay(50, token);
+                try { await Task.Delay(50, token); }
+                catch (OperationCanceledException) { return null; }
             }
 
             return null;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
@@ -20,22 +20,20 @@ namespace Nethermind.Synchronization.FastSync
             {
                 try
                 {
-                    if (treeSync.IsSyncRoundFinished()) return null;
+                    if (treeSync.IsSyncRoundFinished())
+                        return null;
 
                     StateSyncBatch? batch = await treeSync.PrepareRequest();
-                    if (batch is not null) return batch;
-                }
-                catch (OperationCanceledException)
-                {
-                    return null;
+                    if (batch is not null)
+                        return batch;
                 }
                 catch (Exception e)
                 {
                     _logger.Error("Error when preparing a state sync batch", e);
                 }
 
-                try { await Task.Delay(50, token); }
-                catch (OperationCanceledException) { return null; }
+                // Pending queue empty or transient error — wait and retry
+                await Task.Delay(50, token);
             }
 
             return null;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -80,7 +80,7 @@ public class StateSyncRunner(
             // in StateNodes mode and close to head.
             await StateSyncPrecursorWait(token);
 
-            BlockHeader? roundPivot = treeSync.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            BlockHeader? roundPivot = treeSync.ResetStateRootToBestSuggested();
             if (roundPivot is null) continue;
 
             await stateSyncDispatcher.Run(token);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -96,15 +96,10 @@ public class StateSyncRunner(
 
         if (finalPivot is null) return;
 
-        if (_logger.IsInfo) _logger.Info("State sync completed.");
+        if (_logger.IsInfo) _logger.Info($"STATE SYNC FINISHED:{Metrics.StateSyncRequests}, {Metrics.SyncedStateTrieNodes}");
 
-        // FinalizeSync used to be invoked inside TreeSync.SaveNode's IsRoot branch, where
-        // GetPivotHeader's mutating side effect could race with concurrent root-saves
-        // (svlachakis #11457/#11458). Calling it here, with the captured per-round pivot,
-        // serialises the pivot read against in-flight handlers and pins the pivot value.
         treeSync.VerifyPostSyncCleanUp();
-        try { treeSync.FinalizeSync(finalPivot); }
-        catch (ObjectDisposedException) { }
+        treeSync.FinalizeSync(finalPivot);
 
         if (syncConfig.VerifyTrieOnStateSyncFinished)
             verifyTrieStarter?.TryStartVerifyTrie(finalPivot);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -57,17 +57,13 @@ public class StateSyncRunner(
             }
             finally
             {
-                TuneStateDb(ITunableDb.TuneType.Default);
+                // Skip on shutdown so we don't touch DBs that may already be disposed.
+                if (!token.IsCancellationRequested) TuneStateDb(ITunableDb.TuneType.Default);
             }
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
             // Clean shutdown — swallow so Synchronizer doesn't log "State sync failed".
-        }
-        catch (ObjectDisposedException)
-        {
-            // DBs / stores can be torn down while sync is in progress on shutdown — same
-            // semantics as cancellation: swallow rather than logging "State sync failed".
         }
     }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -64,6 +64,11 @@ public class StateSyncRunner(
         {
             // Clean shutdown — swallow so Synchronizer doesn't log "State sync failed".
         }
+        catch (ObjectDisposedException)
+        {
+            // DBs / stores can be torn down while sync is in progress on shutdown — same
+            // semantics as cancellation: swallow rather than logging "State sync failed".
+        }
     }
 
     public async Task RunStateSyncRounds(CancellationToken token)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -86,7 +86,13 @@ public class StateSyncRunner(
             await StateSyncPrecursorWait(token);
 
             BlockHeader? roundPivot = treeSync.ResetStateRootToBestSuggested();
-            if (roundPivot is null) continue;
+            if (roundPivot is null)
+            {
+                // Pivot not known yet — wait and retry. StateSyncPrecursorWait can return
+                // immediately, so without this we'd spin tightly.
+                await Task.Delay(1000, token);
+                continue;
+            }
 
             await stateSyncDispatcher.Run(token);
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -18,7 +19,6 @@ namespace Nethermind.Synchronization.FastSync;
 public class StateSyncRunner(
     ISnapSyncRunner snapSyncRunner,
     TreeSync treeSync,
-    IStateSyncPivot stateSyncPivot,
     SimpleDispatcher<StateSyncBatch> stateSyncDispatcher,
     ISyncConfig syncConfig,
     ISyncModeSelector syncModeSelector,
@@ -70,6 +70,8 @@ public class StateSyncRunner(
     {
         if (_logger.IsInfo) _logger.Info("Starting state sync.");
 
+        BlockHeader? finalPivot = null;
+
         while (!token.IsCancellationRequested)
         {
             // Yield between rounds when the mode selector has moved away from StateNodes
@@ -78,18 +80,34 @@ public class StateSyncRunner(
             // in StateNodes mode and close to head.
             await StateSyncPrecursorWait(token);
 
-            treeSync.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            BlockHeader? roundPivot = treeSync.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            if (roundPivot is null) continue;
+
             await stateSyncDispatcher.Run(token);
 
-            if (treeSync.IsRootComplete) break;
+            // If sync completed in this round, the pivot it committed against is roundPivot.
+            // Capturing here avoids re-reading GetPivotHeader() (mutating) for FinalizeSync.
+            if (treeSync.IsRootComplete)
+            {
+                finalPivot = roundPivot;
+                break;
+            }
         }
+
+        if (finalPivot is null) return;
 
         if (_logger.IsInfo) _logger.Info("State sync completed.");
 
-        if (syncConfig.VerifyTrieOnStateSyncFinished && stateSyncPivot.GetPivotHeader() is { } pivot)
-        {
-            verifyTrieStarter?.TryStartVerifyTrie(pivot);
-        }
+        // FinalizeSync used to be invoked inside TreeSync.SaveNode's IsRoot branch, where
+        // GetPivotHeader's mutating side effect could race with concurrent root-saves
+        // (svlachakis #11457/#11458). Calling it here, with the captured per-round pivot,
+        // serialises the pivot read against in-flight handlers and pins the pivot value.
+        treeSync.VerifyPostSyncCleanUp();
+        try { treeSync.FinalizeSync(finalPivot); }
+        catch (ObjectDisposedException) { }
+
+        if (syncConfig.VerifyTrieOnStateSyncFinished)
+            verifyTrieStarter?.TryStartVerifyTrie(finalPivot);
     }
 
     private void TuneStateDb(ITunableDb.TuneType tuneType)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -380,7 +380,6 @@ namespace Nethermind.Synchronization.FastSync
 
             if (rootNodeKeyExists)
             {
-                _logger.Info($"STATE SYNC FINISHED:{Metrics.StateSyncRequests}, {Metrics.SyncedStateTrieNodes}");
                 return true;
             }
 
@@ -388,30 +387,6 @@ namespace Nethermind.Synchronization.FastSync
         }
 
         public void FinalizeSync(BlockHeader pivotHeader) => _store.FinalizeSync(pivotHeader);
-
-        public void VerifyPostSyncCleanUp()
-        {
-            try
-            {
-                lock (_dependencies)
-                {
-                    if (_dependencies.Count != 0)
-                    {
-                        if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
-                    }
-
-                    _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
-                }
-
-                if (_pendingItems.Count != 0)
-                {
-                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
-                }
-
-                CleanupMemory();
-            }
-            catch (ObjectDisposedException) { }
-        }
 
         public void ResetStateRoot(SyncFeedState currentState) => ResetStateRoot(_blockNumber, _rootNode, currentState);
 
@@ -735,9 +710,6 @@ namespace Nethermind.Synchronization.FastSync
 
                 _codeDb.Flush();
 
-                // FinalizeSync is no longer invoked here. StateSyncRunner observes _rootSaved
-                // and calls TreeSync.FinalizeSync at the quiescent point between rounds, so
-                // the mutating GetPivotHeader() call doesn't race with in-flight SaveNodes.
                 Interlocked.Exchange(ref _rootSaved, 1);
             }
 
@@ -785,6 +757,30 @@ namespace Nethermind.Synchronization.FastSync
             }
 
             return dependentItem.Counter == 0;
+        }
+
+        public void VerifyPostSyncCleanUp()
+        {
+            try
+            {
+                lock (_dependencies)
+                {
+                    if (_dependencies.Count != 0)
+                    {
+                        if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
+                    }
+
+                    _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
+                }
+
+                if (_pendingItems.Count != 0)
+                {
+                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
+                }
+
+                CleanupMemory();
+            }
+            catch (ObjectDisposedException) { }
         }
 
         private void CleanupMemory()

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -66,10 +66,11 @@ namespace Nethermind.Synchronization.FastSync
         private readonly IBlockTree _blockTree;
         private readonly IStateSyncPivot _stateSyncPivot;
 
-        // This is not exactly a lock for read and write, but a RWLock serves it well. It protects the five field
-        // below which need to be cleared atomically during reset root, hence the write lock, while allowing
-        // concurrent request handling with the read lock.
-        private readonly ReaderWriterLockSlim _syncStateLock = new();
+        // The five fields below were previously guarded by an RWLock so HandleResponse (read)
+        // could run concurrently with ResetStateRoot / CleanupMemory (write). The lock is no
+        // longer needed: SimpleDispatcher.Run drains all in-flight workers before returning,
+        // and StateSyncRunner only calls reset/cleanup outside dispatcher.Run, so the drain is
+        // the sole synchronisation barrier.
         private readonly ConcurrentDictionary<StateSyncBatch, object?> _ongoingRequests = new();
         private Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>> _dependencies = new();
         private readonly LruKeyCache<StateSyncItem.NodeKey> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");
@@ -148,7 +149,6 @@ namespace Nethermind.Synchronization.FastSync
 
             try
             {
-                _syncStateLock.EnterReadLock();
                 try
                 {
                     if (!_ongoingRequests.TryRemove(batch, out _))
@@ -324,7 +324,6 @@ namespace Nethermind.Synchronization.FastSync
                 }
                 finally
                 {
-                    _syncStateLock.ExitReadLock();
                     batch.Dispose();
                 }
             }
@@ -412,80 +411,72 @@ namespace Nethermind.Synchronization.FastSync
 
         private void ResetStateRoot(long blockNumber, Hash256 stateRoot, SyncFeedState currentState)
         {
-            _syncStateLock.EnterWriteLock();
-            try
+            _lastResetRoot = DateTime.UtcNow;
+            if (currentState != SyncFeedState.Dormant)
             {
-                _lastResetRoot = DateTime.UtcNow;
-                if (currentState != SyncFeedState.Dormant)
+                throw new InvalidOperationException("Cannot reset state sync on an active feed");
+            }
+
+            Interlocked.Exchange(ref _hintsToResetRoot, 0);
+
+            if (_logger.IsInfo) _logger.Info($"Setting state sync state root to {blockNumber} {stateRoot}");
+            _currentSyncStart = DateTime.UtcNow;
+            _currentSyncStartSecondsInSync = _data.SecondsInSync;
+
+            _data.LastReportTime = (DateTime.UtcNow, DateTime.UtcNow);
+            _data.LastSavedNodesCount = _data.SavedNodesCount;
+            _data.LastRequestedNodesCount = _data.RequestedNodesCount;
+            if (_rootNode != stateRoot)
+            {
+                _branchProgress = new BranchProgress(blockNumber, _logger);
+                _blockNumber = blockNumber;
+                _rootNode = stateRoot;
+                lock (_dependencies)
                 {
-                    throw new InvalidOperationException("Cannot reset state sync on an active feed");
+                    // Swap the pending items
+                    _previouslyPendingItems.Clear();
+                    (_newPendingItems, _previouslyPendingItems) = (_previouslyPendingItems, _newPendingItems);
+                    _dependencies.Clear();
                 }
 
-                Interlocked.Exchange(ref _hintsToResetRoot, 0);
-
-                if (_logger.IsInfo) _logger.Info($"Setting state sync state root to {blockNumber} {stateRoot}");
-                _currentSyncStart = DateTime.UtcNow;
-                _currentSyncStartSecondsInSync = _data.SecondsInSync;
-
-                _data.LastReportTime = (DateTime.UtcNow, DateTime.UtcNow);
-                _data.LastSavedNodesCount = _data.SavedNodesCount;
-                _data.LastRequestedNodesCount = _data.RequestedNodesCount;
-                if (_rootNode != stateRoot)
+                if (_logger.IsDebug) _logger.Debug($"Clearing node stacks ({_pendingItems.Description})");
+                _pendingItems.Clear();
+                Interlocked.Exchange(ref _rootSaved, 0);
+            }
+            else
+            {
+                foreach ((StateSyncBatch pendingRequest, _) in _ongoingRequests)
                 {
-                    _branchProgress = new BranchProgress(blockNumber, _logger);
-                    _blockNumber = blockNumber;
-                    _rootNode = stateRoot;
-                    lock (_dependencies)
+                    // re-add the pending request
+                    for (int i = 0; i < pendingRequest.RequestedNodes?.Count; i++)
                     {
-                        // Swap the pending items
-                        _previouslyPendingItems.Clear();
-                        (_newPendingItems, _previouslyPendingItems) = (_previouslyPendingItems, _newPendingItems);
-                        _dependencies.Clear();
+                        AddNodeToPending(pendingRequest.RequestedNodes[i], null, "pending request", true);
                     }
 
-                    if (_logger.IsDebug) _logger.Debug($"Clearing node stacks ({_pendingItems.Description})");
-                    _pendingItems.Clear();
-                    Interlocked.Exchange(ref _rootSaved, 0);
-                }
-                else
-                {
-                    foreach ((StateSyncBatch pendingRequest, _) in _ongoingRequests)
-                    {
-                        // re-add the pending request
-                        for (int i = 0; i < pendingRequest.RequestedNodes?.Count; i++)
-                        {
-                            AddNodeToPending(pendingRequest.RequestedNodes[i], null, "pending request", true);
-                        }
-
-                        pendingRequest.Dispose();
-                    }
-                }
-
-                _ongoingRequests.Clear();
-
-                bool hasOnlyRootNode = false;
-
-                if (_rootNode != Keccak.EmptyTreeHash)
-                {
-                    if (_pendingItems.Count == 1)
-                    {
-                        // state root can only be located on state stream
-                        StateSyncItem? potentialRoot = _pendingItems.PeekState();
-                        if (potentialRoot?.Hash == _rootNode)
-                        {
-                            hasOnlyRootNode = true;
-                        }
-                    }
-
-                    if (!hasOnlyRootNode)
-                    {
-                        AddNodeToPending(new StateSyncItem(_rootNode, null, TreePath.Empty, NodeDataType.State), null, "initial");
-                    }
+                    pendingRequest.Dispose();
                 }
             }
-            finally
+
+            _ongoingRequests.Clear();
+
+            bool hasOnlyRootNode = false;
+
+            if (_rootNode != Keccak.EmptyTreeHash)
             {
-                _syncStateLock.ExitWriteLock();
+                if (_pendingItems.Count == 1)
+                {
+                    // state root can only be located on state stream
+                    StateSyncItem? potentialRoot = _pendingItems.PeekState();
+                    if (potentialRoot?.Hash == _rootNode)
+                    {
+                        hasOnlyRootNode = true;
+                    }
+                }
+
+                if (!hasOnlyRootNode)
+                {
+                    AddNodeToPending(new StateSyncItem(_rootNode, null, TreePath.Empty, NodeDataType.State), null, "initial");
+                }
             }
         }
 
@@ -785,22 +776,14 @@ namespace Nethermind.Synchronization.FastSync
 
         private void CleanupMemory()
         {
-            _syncStateLock.EnterWriteLock();
-            try
+            _ongoingRequests.Clear();
+            _dependencies.Clear();
+            _alreadySavedNode.Clear();
+            _alreadySavedCode.Clear();
+            if (_rootSaved == 1)
             {
-                _ongoingRequests.Clear();
-                _dependencies.Clear();
-                _alreadySavedNode.Clear();
-                _alreadySavedCode.Clear();
-                if (_rootSaved == 1)
-                {
-                    _previouslyPendingItems.Clear();
-                    _newPendingItems.Clear();
-                }
-            }
-            finally
-            {
-                _syncStateLock.ExitWriteLock();
+                _previouslyPendingItems.Clear();
+                _newPendingItems.Clear();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -340,7 +340,6 @@ namespace Nethermind.Synchronization.FastSync
             if (_rootSaved == 1)
             {
                 if (_logger.IsInfo) _logger.Info("StateNode sync: falling asleep - root saved");
-                VerifyPostSyncCleanUp();
                 return true;
             }
 
@@ -381,22 +380,42 @@ namespace Nethermind.Synchronization.FastSync
 
             if (rootNodeKeyExists)
             {
-                try
-                {
-                    _logger.Info($"STATE SYNC FINISHED:{Metrics.StateSyncRequests}, {Metrics.SyncedStateTrieNodes}");
-
-                    VerifyPostSyncCleanUp();
-                }
-                catch (ObjectDisposedException) { }
+                _logger.Info($"STATE SYNC FINISHED:{Metrics.StateSyncRequests}, {Metrics.SyncedStateTrieNodes}");
                 return true;
             }
 
             return false;
         }
 
+        public void FinalizeSync(BlockHeader pivotHeader) => _store.FinalizeSync(pivotHeader);
+
+        public void VerifyPostSyncCleanUp()
+        {
+            try
+            {
+                lock (_dependencies)
+                {
+                    if (_dependencies.Count != 0)
+                    {
+                        if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
+                    }
+
+                    _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
+                }
+
+                if (_pendingItems.Count != 0)
+                {
+                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
+                }
+
+                CleanupMemory();
+            }
+            catch (ObjectDisposedException) { }
+        }
+
         public void ResetStateRoot(SyncFeedState currentState) => ResetStateRoot(_blockNumber, _rootNode, currentState);
 
-        public void ResetStateRootToBestSuggested(SyncFeedState currentState)
+        public BlockHeader? ResetStateRootToBestSuggested(SyncFeedState currentState)
         {
             if (currentState == SyncFeedState.Dormant)
             {
@@ -408,11 +427,12 @@ namespace Nethermind.Synchronization.FastSync
             if (headerForState is null)
             {
                 if (_logger.IsDebug) _logger.Debug($"State pivot header not known.");
-                return;
+                return null;
             }
             if (_logger.IsInfo) _logger.Info($"Starting the node data sync from the {headerForState.ToString(BlockHeader.Format.Short)} {headerForState.StateRoot} root");
 
             ResetStateRoot(headerForState.Number, headerForState.StateRoot!, currentState);
+            return headerForState;
         }
 
         private void ResetStateRoot(long blockNumber, Hash256 stateRoot, SyncFeedState currentState)
@@ -713,12 +733,11 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
-                if (_stateSyncPivot.GetPivotHeader() is { } pivotHeader)
-                {
-                    _store.FinalizeSync(pivotHeader);
-                }
                 _codeDb.Flush();
 
+                // FinalizeSync is no longer invoked here. StateSyncRunner observes _rootSaved
+                // and calls TreeSync.FinalizeSync at the quiescent point between rounds, so
+                // the mutating GetPivotHeader() call doesn't race with in-flight SaveNodes.
                 Interlocked.Exchange(ref _rootSaved, 1);
             }
 
@@ -766,26 +785,6 @@ namespace Nethermind.Synchronization.FastSync
             }
 
             return dependentItem.Counter == 0;
-        }
-
-        private void VerifyPostSyncCleanUp()
-        {
-            lock (_dependencies)
-            {
-                if (_dependencies.Count != 0)
-                {
-                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
-                }
-
-                _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
-            }
-
-            if (_pendingItems.Count != 0)
-            {
-                if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
-            }
-
-            CleanupMemory();
         }
 
         private void CleanupMemory()

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -348,7 +348,8 @@ namespace Nethermind.Synchronization.FastSync
                 return true;
             }
 
-            if (_stateSyncPivot.GetPivotHeader().StateRoot != _rootNode)
+            BlockHeader? pivotHeader = _stateSyncPivot.GetPivotHeader();
+            if (pivotHeader is null || pivotHeader.StateRoot != _rootNode)
             {
                 if (_logger.IsDebug) _logger.Info("StateNode sync: falling asleep - updating state root");
                 return true;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -744,26 +744,22 @@ namespace Nethermind.Synchronization.FastSync
 
         public void VerifyPostSyncCleanUp()
         {
-            try
+            lock (_dependencies)
             {
-                lock (_dependencies)
+                if (_dependencies.Count != 0)
                 {
-                    if (_dependencies.Count != 0)
-                    {
-                        if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
-                    }
-
-                    _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
+                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
                 }
 
-                if (_pendingItems.Count != 0)
-                {
-                    if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
-                }
-
-                CleanupMemory();
+                _dependencies = new Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>>();
             }
-            catch (ObjectDisposedException) { }
+
+            if (_pendingItems.Count != 0)
+            {
+                if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Nodes left after the root node saved - count: {_pendingItems.Count}");
+            }
+
+            CleanupMemory();
         }
 
         private void CleanupMemory()

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -66,11 +66,8 @@ namespace Nethermind.Synchronization.FastSync
         private readonly IBlockTree _blockTree;
         private readonly IStateSyncPivot _stateSyncPivot;
 
-        // The five fields below were previously guarded by an RWLock so HandleResponse (read)
-        // could run concurrently with ResetStateRoot / CleanupMemory (write). The lock is no
-        // longer needed: SimpleDispatcher.Run drains all in-flight workers before returning,
-        // and StateSyncRunner only calls reset/cleanup outside dispatcher.Run, so the drain is
-        // the sole synchronisation barrier.
+        // SimpleDispatcher.Run drains in-flight workers before returning, and StateSyncRunner
+        // only resets / cleans up outside dispatcher.Run — the drain is the sole barrier.
         private readonly ConcurrentDictionary<StateSyncBatch, object?> _ongoingRequests = new();
         private Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>> _dependencies = new();
         private readonly LruKeyCache<StateSyncItem.NodeKey> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -387,14 +387,11 @@ namespace Nethermind.Synchronization.FastSync
 
         public void FinalizeSync(BlockHeader pivotHeader) => _store.FinalizeSync(pivotHeader);
 
-        public void ResetStateRoot(SyncFeedState currentState) => ResetStateRoot(_blockNumber, _rootNode, currentState);
+        public void ResetStateRoot() => ResetStateRoot(_blockNumber, _rootNode);
 
-        public BlockHeader? ResetStateRootToBestSuggested(SyncFeedState currentState)
+        public BlockHeader? ResetStateRootToBestSuggested()
         {
-            if (currentState == SyncFeedState.Dormant)
-            {
-                _stateSyncPivot.UpdateHeaderForcefully();
-            }
+            _stateSyncPivot.UpdateHeaderForcefully();
 
             BlockHeader headerForState = _stateSyncPivot.GetPivotHeader();
 
@@ -405,18 +402,13 @@ namespace Nethermind.Synchronization.FastSync
             }
             if (_logger.IsInfo) _logger.Info($"Starting the node data sync from the {headerForState.ToString(BlockHeader.Format.Short)} {headerForState.StateRoot} root");
 
-            ResetStateRoot(headerForState.Number, headerForState.StateRoot!, currentState);
+            ResetStateRoot(headerForState.Number, headerForState.StateRoot!);
             return headerForState;
         }
 
-        private void ResetStateRoot(long blockNumber, Hash256 stateRoot, SyncFeedState currentState)
+        private void ResetStateRoot(long blockNumber, Hash256 stateRoot)
         {
             _lastResetRoot = DateTime.UtcNow;
-            if (currentState != SyncFeedState.Dormant)
-            {
-                throw new InvalidOperationException("Cannot reset state sync on an active feed");
-            }
-
             Interlocked.Exchange(ref _hintsToResetRoot, 0);
 
             if (_logger.IsInfo) _logger.Info($"Setting state sync state root to {blockNumber} {stateRoot}");


### PR DESCRIPTION
## Summary

Stacks on top of #11102. Addresses the `GetPivotHeader()` race flagged by `svlachakis` in #11102 (root cause discussed in #11457 / #11458): `TreeSync.SaveNode` previously called `_store.FinalizeSync(GetPivotHeader())` inline on the `IsRoot` branch, while parallel `HandleResponse` workers were still writing nodes — and `GetPivotHeader()` is mutating, so the pivot rotation can race with the root commit and corrupt FlatDB `CurrentState`.

This PR pins the pivot per round in the runner and runs all post-sync work at the quiescent point after the dispatcher has fully drained.

## What changed

- **Pivot pinned per round.** `TreeSync.ResetStateRootToBestSuggested` now returns the `BlockHeader` it used. `StateSyncRunner.RunStateSyncRounds` captures that header at the start of each round and, when the round commits the root, uses *that* captured value for `FinalizeSync` — no second `GetPivotHeader()` call.
- **`FinalizeSync` out of `SaveNode`.** The `_store.FinalizeSync(pivotHeader)` call is removed from `TreeSync.SaveNode`'s `IsRoot` branch. The runner invokes `treeSync.FinalizeSync(finalPivot)` once after the outer loop exits via `IsRootComplete`.
- **`VerifyPostSyncCleanUp` out of `IsSyncRoundFinished`.** The two cleanup-firing branches inside the predicate (`_rootSaved == 1` and `NodeExists`) no longer call cleanup as a side effect. The runner calls `treeSync.VerifyPostSyncCleanUp()` once after the loop.
- **`STATE SYNC FINISHED:…` log moved** to the runner so all post-sync reporting is in one place.
- **`_syncStateLock` removed.** It existed to serialise `HandleResponse` (read) against `ResetStateRoot` / `CleanupMemory` (write). With the cleanup moved out and the writers only running from the runner outside `dispatcher.Run`, `SimpleDispatcher.Run`'s drain (`semaphore.WaitAsync(CancellationToken.None)` × maxThreads) is the sole synchronisation barrier — strict happens-before between the last `HandleResponse` and the next reset/cleanup.

## What didn't change

- Round-termination is still signalled by `StateSyncFeed.PrepareRequest` returning null when `treeSync.IsSyncRoundFinished()` is true — natural dispatcher exit, no watcher / per-round CTS.
- Outer break stays on `treeSync.IsRootComplete`. Tightening to the strict `IsRootSaved` (`_rootSaved == 1`) breaks legitimate completion paths (empty-state syncs, snap-prepopulated root) where the `IsRoot` branch in `SaveNode` never fires. The `NodeExists` over-reporting concern stays as #11457 / #11458 territory.
- Other concerns from the race-analysis comment (`GetPivotHeader()` null-deref at `TreeSync.cs:355`, `SyncCompleted` event timing) are pre-existing and untouched here.

## Test plan

- [x] `Nethermind.Synchronization.Test` filtered to StateSync + SnapSync: 932/940 pass, 8 skips (hash-db).
- [ ] E2E sync tests (CI / PR owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)