### PR TITLE
fix: prevent negative RequestSize crash when beacon pivot destination advances mid-sync

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -305,10 +305,8 @@ public class BeaconHeadersSyncTests
     [Test]
     public async Task Does_not_request_headers_when_destination_advances_past_lowest_requested()
     {
-        // Regression: BeaconPivot.PivotDestinationNumber tracks Head.Number - MaxDepth + 1, so it
-        // can rise above _lowestRequestedHeaderNumber while a sync is in flight. The previous `==`
-        // check in ShouldBuildANewBatch missed this case, producing a batch with a negative
-        // RequestSize and crashing HeaderStore.FindReversedHeaders with ArgumentOutOfRangeException.
+        // PivotDestinationNumber rising above _lowestRequestedHeaderNumber mid-sync must not produce
+        // a batch with negative RequestSize.
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         blockTree.SyncPivot.Returns((1000, Keccak.Zero));
         blockTree.LowestInsertedBeaconHeader.Returns((BlockHeader?)null);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -303,6 +303,49 @@ public class BeaconHeadersSyncTests
     }
 
     [Test]
+    public async Task Does_not_request_headers_when_destination_advances_past_lowest_requested()
+    {
+        // Regression: BeaconPivot.PivotDestinationNumber tracks Head.Number - MaxDepth + 1, so it
+        // can rise above _lowestRequestedHeaderNumber while a sync is in flight. The previous `==`
+        // check in ShouldBuildANewBatch missed this case, producing a batch with a negative
+        // RequestSize and crashing HeaderStore.FindReversedHeaders with ArgumentOutOfRangeException.
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.SyncPivot.Returns((1000, Keccak.Zero));
+        blockTree.LowestInsertedBeaconHeader.Returns((BlockHeader?)null);
+
+        IBeaconPivot beaconPivot = Substitute.For<IBeaconPivot>();
+        beaconPivot.PivotNumber.Returns(2000);
+        beaconPivot.PivotHash.Returns(TestItem.KeccakA);
+        beaconPivot.PivotParentHash.Returns(TestItem.KeccakB);
+        beaconPivot.PivotDestinationNumber.Returns(1100);
+
+        Context ctx = new()
+        {
+            BlockTree = blockTree,
+            SyncConfig = new SyncConfig
+            {
+                FastSync = true,
+                PivotNumber = 1000,
+                PivotHash = Keccak.Zero.ToString(),
+                PivotTotalDifficulty = "1000"
+            },
+            BeaconPivot = beaconPivot,
+        };
+        BeaconHeadersSyncFeed feed = ctx.Feed;
+        feed.InitializeFeed();
+
+        using HeadersSyncBatch? first = await feed.PrepareRequest();
+        first.Should().NotBeNull();
+        first!.RequestSize.Should().BeGreaterThan(0);
+
+        // Simulate Head advancing so that PivotDestinationNumber moves above _lowestRequestedHeaderNumber.
+        beaconPivot.PivotDestinationNumber.Returns(first.StartNumber + 10);
+
+        using HeadersSyncBatch? second = await feed.PrepareRequest();
+        second.Should().BeNull();
+    }
+
+    [Test]
     public async Task When_pivot_changed_during_header_sync_after_chain_merged__do_not_return_null_request()
     {
         ISyncConfig syncConfig = new SyncConfig

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -256,7 +256,10 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private bool ShouldBuildANewBatch()
         {
-            bool destinationHeaderRequested = _lowestRequestedHeaderNumber == HeadersDestinationNumber;
+            // `<=` rather than `==` because `HeadersDestinationNumber` (e.g. `BeaconPivot.PivotDestinationNumber`,
+            // which tracks `Head.Number - Reorganization.MaxDepth + 1`) can advance above `_lowestRequestedHeaderNumber`
+            // mid-sync. Without this, `BuildNewBatch` would produce a negative `RequestSize` and crash.
+            bool destinationHeaderRequested = _lowestRequestedHeaderNumber <= HeadersDestinationNumber;
 
             bool isImmediateSync = !_syncConfig.DownloadHeadersInFastSync;
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -256,9 +256,8 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private bool ShouldBuildANewBatch()
         {
-            // `<=` rather than `==` because `HeadersDestinationNumber` (e.g. `BeaconPivot.PivotDestinationNumber`,
-            // which tracks `Head.Number - Reorganization.MaxDepth + 1`) can advance above `_lowestRequestedHeaderNumber`
-            // mid-sync. Without this, `BuildNewBatch` would produce a negative `RequestSize` and crash.
+            // `<=` because `HeadersDestinationNumber` (beacon: `PivotDestinationNumber`) can advance
+            // above `_lowestRequestedHeaderNumber` mid-sync; `==` would let `BuildNewBatch` produce a negative `RequestSize`.
             bool destinationHeaderRequested = _lowestRequestedHeaderNumber <= HeadersDestinationNumber;
 
             bool isImmediateSync = !_syncConfig.DownloadHeadersInFastSync;


### PR DESCRIPTION
## Changes

- Widen the `destinationHeaderRequested` guard in `HeadersSyncFeed.ShouldBuildANewBatch` from `==` to `<=`.
- Add `BeaconHeadersSyncTests.Does_not_request_headers_when_destination_advances_past_lowest_requested` regression test.

### Root cause

`HeadersSyncFeed.cs:259` checked `_lowestRequestedHeaderNumber == HeadersDestinationNumber`. For beacon headers, `HeadersDestinationNumber` resolves to `BeaconPivot.PivotDestinationNumber`, which is `Head.Number - Reorganization.MaxDepth + 1` — it advances upward as the chain head progresses.

When it crossed above `_lowestRequestedHeaderNumber` mid-sync, the `==` check missed the case, `BuildNewBatch` produced a negative `RequestSize` via `Math.Min(_lowestRequestedHeaderNumber - HeadersDestinationNumber, requestSize)`, and `HeaderStore.FindReversedHeaders` crashed in `new Dictionary<>(negativeCount)`:

```
Beacon headers downloader failed System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'capacity')
   at System.Collections.Generic.Dictionary`2..ctor(Int32 capacity, IEqualityComparer`1 comparer)
   at Nethermind.Blockchain.Headers.HeaderStore.FindReversedHeaders(...) HeaderStore.cs:line 114
   at Nethermind.Synchronization.FastBlocks.HeadersSyncFeed.ProcessPersistedPortion(...) HeadersSyncFeed.cs:line 560
```

`AllHeadersDownloaded` is independent and already uses `<=`, so the feed correctly stays active (no premature `FinishAndCleanUp`); if the destination later moves back below the lowest requested, batches resume.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New regression test mocks `IBeaconPivot`, runs one batch to advance `_lowestRequestedHeaderNumber`, then bumps `PivotDestinationNumber` above it and asserts the next `PrepareRequest()` returns null instead of building a negative-`RequestSize` batch. Verified the test fails on the `==` form and passes on the `<=` form. All 192 existing header-sync tests across `Nethermind.Merge.Plugin.Test` and `Nethermind.Synchronization.Test` continue to pass.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Opus 4.7 (1M context)