### PR TITLE
fix(snap-sync): defer FinalizeSync to end of state sync to prevent canonical chain wipe

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -8,15 +8,17 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -598,6 +600,83 @@ namespace Nethermind.Synchronization.Test.FastSync
             }
 
             remainingRequest.Should().Be(100); // Without the cache this would be 111
+        }
+    }
+
+    // Parameter-free unit tests for TreeSync's post-sync cleanup path. Kept as a
+    // static inner fixture so they don't run once per StateSyncFeedTests fixture
+    // parameterization (peerCount × maxNodeLatency); the behaviour under test is
+    // invariant to those parameters.
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    internal static class TreeSyncCleanUpTests
+    {
+        [Test]
+        public static void VerifyPostSyncCleanUp_WhenPivotStateRootMatchesRootNode_FinalizesSync()
+        {
+            // 1. Active pivot points at state root A.
+            // 2. ResetStateRootToBestSuggested sets _rootNode = A.
+            // 3. Cleanup runs while pivot is still at A.
+            // 4. FinalizeSync must be invoked with pivot A.
+            BlockHeader pivotA = BuildPivot(100, TestItem.KeccakA);
+            IStateSyncPivot stateSyncPivot = Substitute.For<IStateSyncPivot>();
+            stateSyncPivot.GetPivotHeader().Returns(pivotA);
+            ITreeSyncStore store = Substitute.For<ITreeSyncStore>();
+            TreeSync treeSync = BuildTreeSync(store, stateSyncPivot);
+
+            treeSync.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            store.DidNotReceive().FinalizeSync(Arg.Any<BlockHeader>()); // precondition: FinalizeSync must not be called before cleanup runs
+
+            treeSync.VerifyPostSyncCleanUp();
+
+            store.Received(1).FinalizeSync(pivotA);
+        }
+
+        [Test]
+        public static void VerifyPostSyncCleanUp_WhenPivotRotatedAfterReset_SkipsFinalizeSync()
+        {
+            // Issue #11457 regression guard. Previously TreeSync.SaveNode invoked
+            // FinalizeSync with whatever GetPivotHeader returned at the moment of
+            // the IsRoot save; if the pivot had rotated, FinalizeSync was called
+            // with a pivot whose state root had no trie data, persisting a corrupted
+            // CurrentState pointer in the FlatDB and stalling sync after restart.
+            //
+            // 1. Active pivot points at state root A; ResetStateRoot sets _rootNode = A.
+            // 2. Pivot rotates to a different state root B (state root for which no
+            //    trie data exists).
+            // 3. Cleanup runs and observes pivotHeader.StateRoot != _rootNode.
+            // 4. FinalizeSync must be skipped to prevent the corruption.
+            BlockHeader pivotA = BuildPivot(100, TestItem.KeccakA);
+            BlockHeader pivotB = BuildPivot(101, TestItem.KeccakB);
+            IStateSyncPivot stateSyncPivot = Substitute.For<IStateSyncPivot>();
+            stateSyncPivot.GetPivotHeader().Returns(pivotA);
+            ITreeSyncStore store = Substitute.For<ITreeSyncStore>();
+            TreeSync treeSync = BuildTreeSync(store, stateSyncPivot);
+
+            treeSync.ResetStateRootToBestSuggested(SyncFeedState.Dormant);
+            stateSyncPivot.GetPivotHeader().Returns(pivotB);
+            store.DidNotReceive().FinalizeSync(Arg.Any<BlockHeader>()); // precondition: FinalizeSync must not be called before cleanup runs
+
+            treeSync.VerifyPostSyncCleanUp();
+
+            store.DidNotReceive().FinalizeSync(Arg.Any<BlockHeader>());
+        }
+
+        private static BlockHeader BuildPivot(long blockNumber, Hash256 stateRoot) =>
+            Build.A.BlockHeader.WithNumber(blockNumber).WithStateRoot(stateRoot).TestObject;
+
+        private static TreeSync BuildTreeSync(ITreeSyncStore store, IStateSyncPivot stateSyncPivot)
+        {
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            blockTree.NetworkId.Returns(1ul);
+
+            return new TreeSync(
+                new TestMemDb(),
+                store,
+                blockTree,
+                stateSyncPivot,
+                new SyncConfig(),
+                LimboLogs.Instance);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -713,10 +713,6 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
-                if (_stateSyncPivot.GetPivotHeader() is { } pivotHeader)
-                {
-                    _store.FinalizeSync(pivotHeader);
-                }
                 _codeDb.Flush();
 
                 Interlocked.Exchange(ref _rootSaved, 1);
@@ -768,7 +764,7 @@ namespace Nethermind.Synchronization.FastSync
             return dependentItem.Counter == 0;
         }
 
-        private void VerifyPostSyncCleanUp()
+        internal void VerifyPostSyncCleanUp()
         {
             lock (_dependencies)
             {
@@ -786,6 +782,23 @@ namespace Nethermind.Synchronization.FastSync
             }
 
             CleanupMemory();
+
+            if (_stateSyncPivot.GetPivotHeader() is { } pivotHeader)
+            {
+                if (pivotHeader.StateRoot == _rootNode)
+                {
+                    _store.FinalizeSync(pivotHeader);
+                }
+                else
+                {
+                    // State root mismatch at finalize time: the active pivot points at a
+                    // different state root than the one whose trie was just synced.
+                    // Skipping finalize prevents the persistence layer's CurrentState from
+                    // being promoted to a state root for which no trie data exists.
+                    // The next sync round will retry on the new pivot. See issue #11457.
+                    if (_logger.IsWarn) _logger.Warn($"Skipping state sync finalize: saved root {_rootNode} does not match current pivot root {pivotHeader.StateRoot}. The next sync round will retry.");
+                }
+            }
         }
 
         private void CleanupMemory()


### PR DESCRIPTION
Fixes Closes Resolves https://github.com/NethermindEth/nethermind/issues/11457

## Changes

#### Root cause

`TreeSync.SaveNode` called `_store.FinalizeSync(_stateSyncPivot.GetPivotHeader())` the moment the trie root was saved. `GetPivotHeader()` is mutating — calling it can rotate the pivot. On a `"too many empty responses"` rotation, the just-saved root belonged to the old pivot but `FinalizeSync` was invoked with the *new* pivot, persisting a `CurrentState` pointer to a state root with no trie data.

After restart, `FlatFullStateFinder` returned that block number, the sync mode selector skipped state-sync, and the block processor ran against partial state.

#### Fix

Move `FinalizeSync` from `SaveNode` to `VerifyPostSyncCleanUp`, gated on `pivotHeader.StateRoot == _rootNode`. If the pivot rotated, skip finalize; the next round retries on the new pivot.

#### Recovery

Preventative. Existing corrupted DBs from `1.37.1` still need a wipe + resync; the fix only stops the corruption from being created.

#### Tests

Added two unit tests in `StateSyncFeedTests.cs` (static inner fixture to avoid the parameterized parent's 4× duplication):

- match → `FinalizeSync` called, `SyncCompleted` fires
- rotation → `FinalizeSync` skipped (`SyncCompleted` still fires; see follow-up below)
## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Seems reproducible on flat DB, need to test against that