### PR TITLE
TransactionForRpc improvements

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AccessListTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AccessListTransactionForRpc.cs
@@ -36,9 +36,9 @@ public class AccessListTransactionForRpc : LegacyTransactionForRpc, IFromTransac
         V = YParity ?? 0;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/BlobTransactionForRpc.cs
@@ -35,7 +35,7 @@ public class BlobTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction<
         BlobVersionedHashes = transaction.BlobVersionedHashes ?? [];
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
         if (BlobVersionedHashes is null || BlobVersionedHashes.Length == 0)
             return RpcTransactionErrors.AtLeastOneBlobInBlobTransaction;
@@ -55,7 +55,7 @@ public class BlobTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction<
         if (validateUserInput && MaxFeePerBlobGas?.IsZero == true)
             return RpcTransactionErrors.ZeroMaxFeePerBlobGas;
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (!baseResult) return baseResult;
 
         Transaction tx = baseResult.Data;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/EIP1559TransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/EIP1559TransactionForRpc.cs
@@ -37,7 +37,7 @@ public class EIP1559TransactionForRpc : AccessListTransactionForRpc, IFromTransa
             : transaction.MaxFeePerGas;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
         if (validateUserInput)
         {
@@ -49,7 +49,7 @@ public class EIP1559TransactionForRpc : AccessListTransactionForRpc, IFromTransa
                 return RpcTransactionErrors.MaxFeePerGasSmallerThanMaxPriorityFeePerGas(MaxFeePerGas, MaxPriorityFeePerGas);
         }
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/LegacyTransactionForRpc.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Text.Json.Serialization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -92,23 +91,31 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         }
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
         if (validateUserInput && To is null && Input is null or { Length: 0 })
             return RpcTransactionErrors.ContractCreationWithoutData;
 
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
         tx.Nonce = Nonce ?? UInt256.Zero; // TODO: Should we pick the last nonce?
         tx.To = To;
-        tx.GasLimit = Gas ?? 90_000;
         tx.Value = Value ?? UInt256.Zero;
         tx.Data = Input;
         tx.GasPrice = GasPrice ?? UInt256.Zero;
         tx.ChainId = ChainId;
         tx.SenderAddress = From ?? Address.Zero;
+
+        // null Gas → caller didn't specify, default to gasCap (uncapped if gasCap is unset).
+        // explicit Gas (including 0) → use as-is, capped at gasCap. This matches Geth: gas: 0x0
+        // is a literal request that fails the intrinsic gas check, not a "missing" signal.
+        long effectiveCap = gasCap is null or 0 ? long.MaxValue : gasCap.Value;
+        tx.GasLimit = Gas is null
+            ? effectiveCap
+            : long.Min(Gas.Value, effectiveCap);
+
         if ((R?.IsZero == false || S?.IsZero == false) && (R is not null || S is not null))
         {
             ulong v = V is null ? 0
@@ -120,18 +127,6 @@ public class LegacyTransactionForRpc : TransactionForRpc, ITxTyped, IFromTransac
         }
 
         return tx;
-    }
-
-    public override void EnsureDefaults(long? gasCap)
-    {
-        if (gasCap is null or 0)
-            gasCap = long.MaxValue;
-
-        Gas = Gas is null or 0
-            ? gasCap
-            : Math.Min(gasCap.Value, Gas.Value);
-
-        From ??= Address.Zero;
     }
 
     public override bool ShouldSetBaseFee() => GasPrice.IsPositive();

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/SetCodeTransactionForRpc.cs
@@ -22,9 +22,9 @@ public class SetCodeTransactionForRpc : EIP1559TransactionForRpc, IFromTransacti
     public SetCodeTransactionForRpc(Transaction transaction, in TransactionForRpcContext extraData)
         : base(transaction, extraData) => AuthorizationList = AuthorizationListForRpc.FromAuthorizationList(transaction.AuthorizationList);
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/TransactionForRpc.cs
@@ -69,7 +69,7 @@ public abstract class TransactionForRpc
         BlockTimestamp = extraData.BlockTimestamp;
     }
 
-    public virtual Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public virtual Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
         => new Transaction { Type = ResolveType(spec) };
 
     private TxType ResolveType(IReleaseSpec? spec)
@@ -78,7 +78,6 @@ public abstract class TransactionForRpc
         return spec is not null && !spec.IsEip2930Enabled && IsTypeDefaulted ? TxType.Legacy : type;
     }
 
-    public abstract void EnsureDefaults(long? gasCap);
     public abstract bool ShouldSetBaseFee();
 
     internal class TransactionJsonConverter : JsonConverter<TransactionForRpc>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -61,8 +61,8 @@ public class DebugModuleTests
         _blockFinder.FindHeader(Arg.Any<BlockParameter>()).ReturnsForAnyArgs(header);
         _blockchainBridge.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
         _debugBridge
-            .GetBundleTraces(Arg.Any<TransactionBundle[]>(), Arg.Any<BlockParameter>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
-            .Returns(static c => StreamBundles(c.ArgAt<CancellationToken>(2)));
+            .GetBundleTraces(Arg.Any<TransactionBundle[]>(), Arg.Any<BlockParameter>(), Arg.Any<long?>(), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+            .Returns(static c => StreamBundles(c.ArgAt<CancellationToken>(3)));
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         TransactionBundle bundle = new() { Transactions = [new LegacyTransactionForRpc { To = TestItem.AddressC }] };

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
@@ -247,7 +247,7 @@ public partial class DebugRpcModuleTests
         // Returns gas available at start of execution as a uint256
         Address contractAddress = new("0xc200000000000000000000000000000000000000");
 
-        // No Gas set — should default to gasCap via EnsureDefaults, not blockGasLimit
+        // No Gas set — debug_traceCallMany defaults missing gas to gasCap, not blockGasLimit
         LegacyTransactionForRpc tx = new() { To = contractAddress };
 
         TransactionBundle bundle = new()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1459,47 +1459,42 @@ public partial class EthRpcModuleTests
     }
 
     [TestCase(null)]
-    [TestCase(0)]
-    public static void Should_handle_gasCap_as_max_if_null_or_zero(long? gasCap)
+    [TestCase(0L)]
+    public static void ToTransaction_uses_long_max_when_gasCap_is_null_or_zero(long? gasCap)
     {
         LegacyTransactionForRpc rpcTx = new();
 
-        rpcTx.EnsureDefaults(gasCap);
+        Transaction tx = (Transaction)rpcTx.ToTransaction(gasCap: gasCap);
 
-        Assert.That(rpcTx.Gas, Is.EqualTo(long.MaxValue), "Gas must be set to max if gasCap is null or 0");
+        Assert.That(tx.GasLimit, Is.EqualTo(long.MaxValue), "GasLimit must default to long.MaxValue when gasCap is null or 0");
     }
 
     [Test]
-    public static void Should_handle_fromAddress_as_zero_if_null()
+    public static void ToTransaction_defaults_sender_to_zero_when_from_is_null()
     {
         LegacyTransactionForRpc rpcTx = new();
 
-        rpcTx.EnsureDefaults(0);
+        Transaction tx = (Transaction)rpcTx.ToTransaction();
 
-        Assert.That(rpcTx.From, Is.EqualTo(Address.Zero), "From address must be set to zero if tx.from is null");
+        Assert.That(tx.SenderAddress, Is.EqualTo(Address.Zero), "SenderAddress must default to Address.Zero when From is null");
     }
 
-    [Ignore(reason: "Shows disparity across 'default' methods")]
-    [TestCase(null)]
-    [TestCase(0)]
-    public static void ToTransactionWithDefaults_and_EnsureDefaults_same_GasLimit(long? gasCap)
+    [TestCase(null, null, long.MaxValue)]
+    [TestCase(null, 0L, long.MaxValue)]
+    [TestCase(null, 1_000_000L, 1_000_000L)]
+    [TestCase(0L, null, 0L)]
+    [TestCase(0L, 1_000_000L, 0L)]
+    [TestCase(50_000L, null, 50_000L)]
+    [TestCase(50_000L, 0L, 50_000L)]
+    [TestCase(50_000L, 100_000L, 50_000L)]
+    [TestCase(200_000L, 100_000L, 100_000L)]
+    public static void ToTransaction_caps_and_defaults_gas(long? gas, long? gasCap, long expectedGasLimit)
     {
-        long toTransactionWitDefaultsGasLimit;
-        {
-            LegacyTransactionForRpc rpcTx = new();
-            Result<Transaction> tx = rpcTx.ToTransaction();
-            toTransactionWitDefaultsGasLimit = ((Transaction)tx).GasLimit;
-        }
+        LegacyTransactionForRpc rpcTx = new() { Gas = gas };
 
-        long ensureDefaultsGasLimit;
-        {
-            LegacyTransactionForRpc rpcTx = new();
-            rpcTx.EnsureDefaults(gasCap);
-            Result<Transaction> tx = rpcTx.ToTransaction();
-            ensureDefaultsGasLimit = ((Transaction)tx).GasLimit;
-        }
+        Transaction tx = (Transaction)rpcTx.ToTransaction(gasCap: gasCap);
 
-        toTransactionWitDefaultsGasLimit.Should().Be(ensureDefaultsGasLimit);
+        tx.GasLimit.Should().Be(expectedGasLimit);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -208,20 +208,20 @@ public class DebugBridge : IDebugBridge
 
     public Hash256? GetTransactionBlockHash(Hash256 transactionHash) => _receiptStorage.FindBlockHash(transactionHash);
 
-    public IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTraces(TransactionBundle[] bundles, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null)
+    public IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTraces(TransactionBundle[] bundles, BlockParameter blockParameter, long? gasCap, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null)
     {
         foreach (TransactionBundle bundle in bundles)
         {
-            yield return GetBundleTrace(bundle, blockParameter, cancellationToken, gethTraceOptions);
+            yield return GetBundleTrace(bundle, blockParameter, gasCap, cancellationToken, gethTraceOptions);
         }
     }
 
-    private IEnumerable<GethLikeTxTrace> GetBundleTrace(TransactionBundle bundle, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions)
+    private IEnumerable<GethLikeTxTrace> GetBundleTrace(TransactionBundle bundle, BlockParameter blockParameter, long? gasCap, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions)
     {
         foreach (TransactionForRpc txForRpc in bundle.Transactions)
         {
             GethLikeTxTrace? trace;
-            Result<Transaction> txResult = txForRpc.ToTransaction(validateUserInput: true);
+            Result<Transaction> txResult = txForRpc.ToTransaction(validateUserInput: true, gasCap: gasCap);
             if (txResult.IsError)
             {
                 trace = CreateFailTrace(txForRpc.Gas);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -504,11 +504,15 @@ public class DebugRpcModule(
         // debug_traceCallMany defaults missing gas to gasCap (not block gas limit). The simulate engine
         // decides "explicit vs default" from the request's Gas field, so we set it here to opt out of the
         // engine's BlockGasLeft fallback. eth_simulateV1 deliberately does not do this.
-        foreach (TransactionBundle bundle in bundles)
+        // When gasCap is unset/0 ("no cap"), we leave Gas null so the engine's normal fallback applies.
+        if (jsonRpcConfig.GasCap is not null and not 0)
         {
-            foreach (TransactionForRpc call in bundle.Transactions)
+            foreach (TransactionBundle bundle in bundles)
             {
-                call.Gas ??= jsonRpcConfig.GasCap;
+                foreach (TransactionForRpc call in bundle.Transactions)
+                {
+                    call.Gas ??= jsonRpcConfig.GasCap;
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -90,9 +90,7 @@ public class DebugRpcModule(
             return headerError;
         }
 
-        call.EnsureDefaults(jsonRpcConfig.GasCap);
-
-        Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(header!));
+        Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, gasCap: jsonRpcConfig.GasCap, spec: specProvider.GetSpec(header!));
         if (!txResult.Success(out Transaction? tx, out string? error))
         {
             return ResultWrapper<GethLikeTxTrace>.Fail(error, ErrorCodes.InvalidInput);
@@ -463,13 +461,11 @@ public class DebugRpcModule(
 
     private ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> TraceCallMany(TransactionBundle[] bundles, BlockParameter blockParameter, GethTraceOptions? options, BlockHeader header)
     {
-        PrepareTransactions(bundles, header);
-
         CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
         try
         {
             IEnumerable<IEnumerable<GethLikeTxTrace>> bundleTraces = debugBridge
-                .GetBundleTraces(bundles, blockParameter, timeout.Token, options);
+                .GetBundleTraces(bundles, blockParameter, jsonRpcConfig.GasCap, timeout.Token, options);
 
             if (_logger.IsTrace)
             {
@@ -505,7 +501,17 @@ public class DebugRpcModule(
 
     private ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> TraceCallManyWithOverrides(TransactionBundle[] bundles, GethTraceOptions? options, BlockHeader header)
     {
-        PrepareTransactions(bundles, header);
+        // debug_traceCallMany defaults missing gas to gasCap (not block gas limit). The simulate engine
+        // decides "explicit vs default" from the request's Gas field, so we set it here to opt out of the
+        // engine's BlockGasLeft fallback. eth_simulateV1 deliberately does not do this.
+        foreach (TransactionBundle bundle in bundles)
+        {
+            foreach (TransactionForRpc call in bundle.Transactions)
+            {
+                call.Gas ??= jsonRpcConfig.GasCap;
+            }
+        }
+
         SimulatePayload<TransactionForRpc> simulatePayload = new()
         {
             BlockStateCalls = bundles.Select(bundle => new BlockStateCall<TransactionForRpc>
@@ -554,17 +560,6 @@ public class DebugRpcModule(
             .Select(blockResult => blockResult.Traces);
 
         return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Success(bundleTraces);
-    }
-
-    private void PrepareTransactions(TransactionBundle[] bundles, BlockHeader header)
-    {
-        foreach (TransactionBundle bundle in bundles)
-        {
-            foreach (TransactionForRpc call in bundle.Transactions)
-            {
-                call.EnsureDefaults(jsonRpcConfig.GasCap);
-            }
-        }
     }
 
     private ResultWrapper<byte[]> GetBlockRlpOrFail(BlockParameter blockParameter)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -41,5 +41,5 @@ public interface IDebugBridge
     TxReceipt[]? GetReceiptsForBlock(BlockParameter param);
     Transaction? GetTransactionFromHash(Hash256 hash);
     Hash256? GetTransactionBlockHash(Hash256 transactionHash);
-    IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTraces(TransactionBundle[] bundles, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+    IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTraces(TransactionBundle[] bundles, BlockParameter blockParameter, long? gasCap, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -33,7 +33,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             protected override Result<Transaction> Prepare(TransactionForRpc call, BlockHeader header)
             {
                 IReleaseSpec spec = GetSpec(header);
-                Result<Transaction> result = call.ToTransaction(validateUserInput: true, spec: spec);
+                Result<Transaction> result = call.ToTransaction(validateUserInput: true, gasCap: _rpcConfig.GasCap, spec: spec);
                 if (result.IsError) return result;
 
                 Transaction tx = result.Data;
@@ -78,11 +78,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 Dictionary<Address, AccountOverride>? stateOverride = null,
                 SearchResult<BlockHeader>? searchResult = null)
             {
-
-                // enforces gas cap
                 NoBaseFee = !transactionCall.ShouldSetBaseFee();
-
-                transactionCall.EnsureDefaults(_rpcConfig.GasCap);
 
                 return base.Execute(transactionCall, blockParameter, stateOverride, searchResult);
             }
@@ -160,7 +156,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 SearchResult<BlockHeader>? searchResult = null)
             {
                 // Match Geth: when no gas is specified, binary search is bounded by blockGasLimit (then
-                // capped at gasCap by EnsureDefaults). eth_call uses gasCap directly because it is a
+                // capped at gasCap inside ToTransaction). eth_call uses gasCap directly because it is a
                 // pure simulation; estimateGas is computing gas for a real transaction that must fit in a block.
                 if (transactionCall.Gas is null)
                 {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -54,7 +54,7 @@ public class SimulateTxExecutor<TTrace>(
                         bool hadNonceInRequest = asLegacy?.Nonce is not null;
 
                         IReleaseSpec spec = specProvider.GetSpec(header);
-                        Result<Transaction> txResult = callTransactionModel.ToTransaction(validateUserInput: call.Validation, spec: spec);
+                        Result<Transaction> txResult = callTransactionModel.ToTransaction(validateUserInput: call.Validation, gasCap: _rpcConfig.GasCap, spec: spec);
                         if (!txResult.Success(out Transaction? tx, out string? error))
                         {
                             return error;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -30,7 +30,8 @@ namespace Nethermind.JsonRpc.Modules.Proof
         IOverridableEnv<ITracer> tracerEnv,
         IBlockFinder blockFinder,
         IReceiptFinder receiptFinder,
-        ISpecProvider specProvider)
+        ISpecProvider specProvider,
+        IJsonRpcConfig jsonRpcConfig)
         : IProofRpcModule
     {
         private readonly HeaderDecoder _headerDecoder = new();
@@ -65,17 +66,10 @@ namespace Nethermind.JsonRpc.Modules.Proof
             callHeader.TotalDifficulty = sourceHeader.TotalDifficulty + callHeader.Difficulty;
             callHeader.Hash = callHeader.CalculateHash();
 
-            Result<Transaction> txResult = tx.ToTransaction(validateUserInput: true);
+            Result<Transaction> txResult = tx.ToTransaction(validateUserInput: true, gasCap: jsonRpcConfig.GasCap);
             if (!txResult.Success(out Transaction? transaction, out string? error))
             {
                 return ResultWrapper<CallResultWithProof>.Fail(error, ErrorCodes.InvalidInput);
-            }
-
-            transaction.SenderAddress ??= Address.Zero;
-
-            if (transaction.GasLimit == 0)
-            {
-                transaction.GasLimit = callHeader.GasLimit;
             }
 
             Block block = new(callHeader, new[] { transaction }, []);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -59,13 +59,12 @@ namespace Nethermind.JsonRpc.Modules.Trace
         public ResultWrapper<ParityTxTraceFromReplay> trace_call(TransactionForRpc call, string[] traceTypes, BlockParameter? blockParameter = null, Dictionary<Address, AccountOverride>? stateOverride = null)
         {
             blockParameter ??= BlockParameter.Latest;
-            call.EnsureDefaults(jsonRpcConfig.GasCap);
 
             SearchResult<BlockHeader> headerSearch = blockFinder.SearchForHeader(blockParameter);
             if (headerSearch.IsError)
                 return ResultWrapper<ParityTxTraceFromReplay>.Fail(headerSearch);
 
-            Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(headerSearch.Object!));
+            Result<Transaction> txResult = call.ToTransaction(validateUserInput: true, gasCap: jsonRpcConfig.GasCap, spec: specProvider.GetSpec(headerSearch.Object!));
             return !txResult.Success(out Transaction? transaction, out string? error)
                 ? ResultWrapper<ParityTxTraceFromReplay>.Fail(error, ErrorCodes.InvalidInput)
                 : TraceTx(transaction, traceTypes, blockParameter, stateOverride);
@@ -96,8 +95,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
             Transaction[] txs = new Transaction[calls.Count];
             for (int i = 0; i < calls.Count; i++)
             {
-                calls[i].Transaction.EnsureDefaults(jsonRpcConfig.GasCap);
-                Result<Transaction> txResult = calls[i].Transaction.ToTransaction(validateUserInput: true, spec: specProvider.GetSpec(header));
+                Result<Transaction> txResult = calls[i].Transaction.ToTransaction(validateUserInput: true, gasCap: jsonRpcConfig.GasCap, spec: specProvider.GetSpec(header));
                 if (!txResult.Success(out Transaction? tx, out string? error))
                 {
                     return ResultWrapper<IEnumerable<ParityTxTraceFromReplay>>.Fail(error, ErrorCodes.InvalidInput);

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/DepositTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/DepositTransactionForRpcTests.cs
@@ -104,4 +104,38 @@ public class DepositTransactionForRpcTests
         Func<Result<Transaction>> toTransaction = () => rpcTx.ToTransaction();
         toTransaction.Should().NotThrow();
     }
+
+    private static DepositTransactionForRpc DepositTxWithGas(long? gas) => new()
+    {
+        SourceHash = Hash256.Zero,
+        From = Address.Zero,
+        Value = 0,
+        Input = [],
+        Gas = gas,
+    };
+
+    [TestCase(5_000L, null, 5_000L)]
+    [TestCase(5_000L, 0L, 5_000L)]
+    [TestCase(5_000L, 1_000L, 1_000L)]
+    [TestCase(5_000L, 10_000L, 5_000L)]
+    [TestCase(null, 1_000L, 1_000L)]
+    public void ToTransaction_caps_and_defaults_gas(long? gas, long? gasCap, long expectedGasLimit)
+    {
+        DepositTransactionForRpc rpcTx = DepositTxWithGas(gas);
+
+        Transaction tx = (Transaction)rpcTx.ToTransaction(gasCap: gasCap);
+
+        tx.GasLimit.Should().Be(expectedGasLimit);
+    }
+
+    [TestCase(null, null)]
+    [TestCase(null, 0L)]
+    public void ToTransaction_throws_when_gas_missing_and_no_cap(long? gas, long? gasCap)
+    {
+        DepositTransactionForRpc rpcTx = DepositTxWithGas(gas);
+
+        Func<Result<Transaction>> toTransaction = () => rpcTx.ToTransaction(gasCap: gasCap);
+
+        toTransaction.Should().Throw<ArgumentNullException>().WithParameterName(nameof(DepositTransactionForRpc.Gas));
+    }
 }

--- a/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
@@ -79,10 +79,12 @@ public class DepositTransactionForRpc : TransactionForRpc, IFromTransaction<Depo
         tx.IsOPSystemTransaction = IsSystemTx ?? false;
         tx.Data = Input ?? throw new ArgumentNullException(nameof(Input));
 
-        long? effectiveGas = Gas ?? gasCap;
-        tx.GasLimit = effectiveGas ?? throw new ArgumentNullException(nameof(Gas));
-        if (gasCap is not null and not 0)
-            tx.GasLimit = long.Min(tx.GasLimit, gasCap.Value);
+        // Deposit txs require an explicit Gas; the original EnsureDefaults granted a graceful fallback to
+        // gasCap when the request omitted it, which we preserve. gasCap is null/0 mean "no cap" (matching
+        // LegacyTransactionForRpc), so neither substitutes for a missing Gas — that case still throws.
+        long effectiveCap = gasCap is null or 0 ? long.MaxValue : gasCap.Value;
+        long? gasOrDefault = Gas ?? (effectiveCap == long.MaxValue ? null : effectiveCap);
+        tx.GasLimit = long.Min(gasOrDefault ?? throw new ArgumentNullException(nameof(Gas)), effectiveCap);
 
         return tx;
     }

--- a/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/DepositTransactionForRpc.cs
@@ -65,9 +65,9 @@ public class DepositTransactionForRpc : TransactionForRpc, IFromTransaction<Depo
         DepositReceiptVersion = receipt?.DepositReceiptVersion;
     }
 
-    public override Result<Transaction> ToTransaction(bool validateUserInput = false, IReleaseSpec? spec = null)
+    public override Result<Transaction> ToTransaction(bool validateUserInput = false, long? gasCap = null, IReleaseSpec? spec = null)
     {
-        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, spec);
+        Result<Transaction> baseResult = base.ToTransaction(validateUserInput, gasCap, spec);
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
@@ -76,21 +76,15 @@ public class DepositTransactionForRpc : TransactionForRpc, IFromTransaction<Depo
         tx.To = To;
         tx.Mint = Mint ?? 0;
         tx.Value = Value ?? throw new ArgumentNullException(nameof(Value));
-        tx.GasLimit = Gas ?? throw new ArgumentNullException(nameof(Gas));
         tx.IsOPSystemTransaction = IsSystemTx ?? false;
         tx.Data = Input ?? throw new ArgumentNullException(nameof(Input));
 
+        long? effectiveGas = Gas ?? gasCap;
+        tx.GasLimit = effectiveGas ?? throw new ArgumentNullException(nameof(Gas));
+        if (gasCap is not null and not 0)
+            tx.GasLimit = long.Min(tx.GasLimit, gasCap.Value);
+
         return tx;
-    }
-
-    public override void EnsureDefaults(long? gasCap)
-    {
-        if (Gas is not null && gasCap is not null)
-        {
-            Gas = Math.Min(Gas.Value, gasCap.Value);
-        }
-
-        Gas ??= gasCap;
     }
 
     public override bool ShouldSetBaseFee() => false;


### PR DESCRIPTION
Fixes Closes Resolves #10547 

## Changes

Removes `TransactionForRpc.EnsureDefaults` entirely and folds defaulting + gas-cap enforcement into `ToTransaction(gasCap)`. The "two methods, easy to forget one" pattern that produced the original bugs is structurally gone.

## What changed

- `TransactionForRpc.EnsureDefaults` (abstract) and its overrides in `LegacyTransactionForRpc` and Optimism's `DepositTransactionForRpc` are deleted.
- `ToTransaction(validateUserInput, gasCap, spec)` is now the single conversion entry point. It always sets `SenderAddress` (defaults to `Address.Zero`) and `GasLimit` (defaults to `gasCap`, or `long.MaxValue` if unset; capped at `gasCap` when provided).
- The hardcoded `Gas ?? 90_000` magic in `LegacyTransactionForRpc.ToTransaction` is removed.
- `IDebugBridge.GetBundleTraces` takes `long? gasCap`; the bridge converts internally. `DebugRpcModule.PrepareTransactions` is removed.

## Bugs closed

- **`proof_call` had no gas-cap enforcement** — a caller sending `gas: 0` got the full block gas limit, ignoring `GasCap`. Now properly capped via injected `IJsonRpcConfig`.
- **`SimulateTxExecutor.Prepare` skipped defaulting** — `gas: null` fell back to a hardcoded 90,000 instead of `gasCap`. Now consistent with all other paths.
- **`IDebugBridge.GetBundleTraces` relied on the caller** to pre-prepare transactions — now self-contained.

## Behavior change worth flagging

`gas: 0` is now treated as a literal request (intrinsic-gas error), not as a "missing" signal that defaults to `gasCap`. This matches Geth and is required by the `multicall-insufficient-gas-38013` Hive spec test. `gas: null` is the only "missing" signal.

`debug_traceCallMany` and `eth_simulateV1` need different default-gas policies for `gas: null` (gasCap vs. block gas limit). This is now expressed by a localized `call.Gas ??= jsonRpcConfig.GasCap` in `DebugRpcModule.TraceCallManyWithOverrides`, with a comment explaining why `eth_simulateV1` deliberately omits it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

Hive tests Job: https://github.com/NethermindEth/nethermind/actions/runs/25330905724

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No