### PR TITLE
test: bump TestBlockchain.DefaultTimeout 10s -> 30s

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Core.Test.Blockchain;
 
 public class TestBlockchain : IDisposable
 {
-    public const int DefaultTimeout = 10000;
+    public const int DefaultTimeout = 30000;
     protected long TestTimeout { get; init; } = DefaultTimeout;
     public IStateReader StateReader => _fromContainer.StateReader;
     public IEthereumEcdsa EthereumEcdsa => _fromContainer.EthereumEcdsa;


### PR DESCRIPTION
## Summary

- `executePayloadV1_accepts_already_known_block(true)` flakes on `TEST_USE_FLAT=1` runs with `TaskCanceledException` at exactly **10s 489ms**, inside `TestBlockchain.Build()` while waiting for the `NewHeadBlock` event after genesis loads.
- The cancellation token used there is `this.CancellationToken`, which derives from `TestTimeout` (default `10000`), **not** the test's `[CancelAfter(30000)]`.
- PR #11380 bumped per-test `[CancelAfter]` values from 10s/5s to 30s but missed this internal one. Aligning `DefaultTimeout` with that fix.

Stack from the failing run:
```
System.Threading.Tasks.TaskCanceledException : A task was canceled.
   at Nethermind.Core.Events.Wait.ForEventCondition[T](...) in Nethermind.Core/Events/Wait.cs:33
   at Nethermind.Core.Test.Blockchain.TestBlockchain.Build(...) in TestBlockchain.cs:227
   at MergeTestBlockchain.Build(ISpecProvider) in BaseEngineModuleTests.cs:292
   at EngineModuleTests.executePayloadV1_accepts_already_known_block(...) in EngineModuleTests.V1.cs:464
```

Side effects of the bump:
- `BlockProcessorTests.cs:146` uses `DefaultTimeout * 10` — 100s ceiling becomes 300s. Just a higher upper bound; passing tests don't notice.
- `TestRpcBlockchain.cs:72` uses it as a fallback when no explicit timeout is passed.

## Test plan

- [ ] CI green on Nethermind tests (Flat DB) — specifically `Nethermind.Merge.Plugin.Test`.
- [ ] No regressions in existing tests that rely on the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)