### PR TITLE
More RLP limits, sizes, and positions checks

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Core.Eip2930;
@@ -122,5 +123,28 @@ namespace Nethermind.Core.Test.Encoding
 
         [Test]
         public void Get_length_returns_1_for_null() => _decoder.GetLength(null, RlpBehaviors.None).Should().Be(1);
+
+        [Test]
+        public void Rejects_entry_missing_storage_keys_array()
+        {
+            const string error = "storage keys";
+            byte[] invalid = Convert.FromHexString("d6d5940000000000000000000000000000000000000000");
+
+            void DecodeStream()
+            {
+                Rlp.ValueDecoderContext ctx = new RlpStream(invalid).Data.AsSpan().AsRlpValueContext();
+                _decoder.Decode(ref ctx);
+            }
+
+            Assert.That((Action) DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
+
+            void DecodeContext()
+            {
+                Rlp.ValueDecoderContext ctx = invalid.AsSpan().AsRlpValueContext();
+                _decoder.Decode(ref ctx);
+            }
+
+            Assert.That((Action) DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Core.Test.Encoding
                 _decoder.Decode(ref ctx);
             }
 
-            Assert.That((Action) DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
+            Assert.That(DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
 
             void DecodeContext()
             {
@@ -144,7 +144,7 @@ namespace Nethermind.Core.Test.Encoding
                 _decoder.Decode(ref ctx);
             }
 
-            Assert.That((Action) DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
+            Assert.That(DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contain(error));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CkzgLib;
 using FluentAssertions;
+using MathNet.Numerics.Random;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
@@ -149,6 +150,33 @@ public partial class ShardBlobTxDecoderTests
 
         ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)decoded!.NetworkWrapper!;
         Assert.That(wrapper.Proofs, Has.Length.EqualTo(BlobCellProofsCountLimit));
+    }
+
+    // Other clients validate each blob length
+    [Test]
+    public void Rejects_blob_tx_with_invalid_versioned_hash_length(
+        [Values(0, 1, 31, 33)] int invalidLength
+    )
+    {
+        Transaction tx = Build.A.Transaction
+            .WithChainId(TestBlockchainIds.ChainId)
+            .WithShardBlobTxTypeAndFields(4, false)
+            .WithBlobVersionedHashes([
+                Random.Shared.NextBytes(32),
+                Random.Shared.NextBytes(32),
+                Random.Shared.NextBytes(invalidLength),
+                Random.Shared.NextBytes(32)
+            ])
+            .SignedAndResolved()
+            .TestObject;
+
+        byte[] rlp = _txDecoder.Encode(tx).Bytes;
+
+        Assert.That(() =>
+        {
+            Rlp.ValueDecoderContext ctx = new(rlp);
+            _txDecoder.Decode(ref ctx);
+        }, Throws.InstanceOf<RlpException>());
     }
 
     [TestCaseSource(nameof(ShardBlobTxTests))]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CkzgLib;
 using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -18,6 +19,9 @@ namespace Nethermind.Core.Test.Encoding;
 [TestFixture]
 public partial class ShardBlobTxDecoderTests
 {
+    private const int BlobCountLimit = 128;
+    private const int BlobCellProofsCountLimit = BlobCountLimit * Ckzg.CellsPerExtBlob;
+
     private readonly TxDecoder _txDecoder = TxDecoder.Instance;
 
     [SetUp]
@@ -116,6 +120,37 @@ public partial class ShardBlobTxDecoderTests
         tryDecode.Should().Throw<RlpException>();
     }
 
+    [TestCaseSource(nameof(OverLimitCollectionDecodeCases))]
+    public void Decode_rejects_more_than_blob_count_limit_for_decoding(Transaction tx, RlpBehaviors rlpBehaviors)
+    {
+        Rlp encoded = _txDecoder.Encode(tx, rlpBehaviors);
+
+        void DecodeByValueDecoderContext()
+        {
+            Rlp.ValueDecoderContext decoderContext = new(encoded.Bytes);
+            _txDecoder.Decode(ref decoderContext, rlpBehaviors);
+        }
+
+        Assert.That((Action) DecodeByValueDecoderContext, Throws.InstanceOf<RlpException>());
+    }
+
+    [Test]
+    public void Decode_allows_v1_wrapper_proofs_up_to_cell_proof_limit()
+    {
+        Transaction tx = BuildMempoolTransactionWithWrapperCounts(
+            BlobCountLimit,
+            BlobCountLimit,
+            BlobCellProofsCountLimit,
+            ProofVersion.V1);
+        Rlp encoded = _txDecoder.Encode(tx, RlpBehaviors.InMempoolForm);
+
+        Rlp.ValueDecoderContext decoderContext = new(encoded.Bytes);
+        Transaction? decoded = _txDecoder.Decode(ref decoderContext, RlpBehaviors.InMempoolForm);
+
+        ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)decoded!.NetworkWrapper!;
+        Assert.That(wrapper.Proofs, Has.Length.EqualTo(BlobCellProofsCountLimit));
+    }
+
     [TestCaseSource(nameof(ShardBlobTxTests))]
     public void NetworkWrapper_is_decoded_correctly(string rlp, Hash256 signedHash, RlpBehaviors rlpBehaviors)
     {
@@ -147,5 +182,67 @@ public partial class ShardBlobTxDecoderTests
             _txDecoder.Encode(decodedByValueDecoderContext!, rlpBehaviors);
         Assert.That(encoded.Bytes, Is.EquivalentTo(spanIncomingTxRlp));
         Assert.That(encodedWithDecodedByValueDecoderContext.Bytes, Is.EquivalentTo(spanIncomingTxRlp));
+    }
+
+    private static IEnumerable<TestCaseData> OverLimitCollectionDecodeCases()
+    {
+        static Transaction BuildTransactionWithBlobVersionedHashCount(int count) =>
+            Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(1, false)
+                .WithChainId(TestBlockchainIds.ChainId)
+                .WithBlobVersionedHashes(count)
+                .SignedAndResolved()
+                .TestObject;
+
+        yield return new TestCaseData(BuildTransactionWithBlobVersionedHashCount(BlobCountLimit + 1), RlpBehaviors.None)
+        {
+            TestName = "Decode rejects more than 128 blob versioned hashes"
+        };
+        yield return new TestCaseData(BuildMempoolTransactionWithWrapperCounts(BlobCountLimit + 1, 1, 1), RlpBehaviors.InMempoolForm)
+        {
+            TestName = "Decode rejects more than 128 wrapper blobs"
+        };
+        yield return new TestCaseData(BuildMempoolTransactionWithWrapperCounts(1, BlobCountLimit + 1, 1), RlpBehaviors.InMempoolForm)
+        {
+            TestName = "Decode rejects more than 128 wrapper commitments"
+        };
+        yield return new TestCaseData(BuildMempoolTransactionWithWrapperCounts(1, 1, BlobCountLimit + 1), RlpBehaviors.InMempoolForm)
+        {
+            TestName = "Decode rejects more than 128 V0 wrapper proofs"
+        };
+        yield return new TestCaseData(
+            BuildMempoolTransactionWithWrapperCounts(1, 1, BlobCellProofsCountLimit + 1, ProofVersion.V1),
+            RlpBehaviors.InMempoolForm)
+        {
+            TestName = "Decode rejects more than 16384 V1 wrapper proofs"
+        };
+    }
+
+    private static Transaction BuildMempoolTransactionWithWrapperCounts(
+        int blobsCount,
+        int commitmentsCount,
+        int proofsCount,
+        ProofVersion version = ProofVersion.V0)
+    {
+        byte[][] blobs = CreateEmptyByteArrays(blobsCount);
+        byte[][] commitments = CreateEmptyByteArrays(commitmentsCount);
+        byte[][] proofs = CreateEmptyByteArrays(proofsCount);
+        return Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(1, false)
+            .WithChainId(TestBlockchainIds.ChainId)
+            .With(tx => tx.NetworkWrapper = new ShardBlobNetworkWrapper(blobs, commitments, proofs, version))
+            .SignedAndResolved()
+            .TestObject;
+    }
+
+    private static byte[][] CreateEmptyByteArrays(int count)
+    {
+        byte[][] arrays = new byte[count][];
+        for (int i = 0; i < count; i++)
+        {
+            arrays[i] = [];
+        }
+
+        return arrays;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
@@ -132,7 +132,7 @@ public partial class ShardBlobTxDecoderTests
             _txDecoder.Decode(ref decoderContext, rlpBehaviors);
         }
 
-        Assert.That((Action) DecodeByValueDecoderContext, Throws.InstanceOf<RlpException>());
+        Assert.That(DecodeByValueDecoderContext, Throws.InstanceOf<RlpException>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Core.Test.Encoding
     [TestFixture]
     public class TxDecoderTests
     {
-        private static readonly TxDecoder TxDecoder = TxDecoder.Instance;
+        private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
 
         public static IEnumerable<(TransactionBuilder<Transaction>, string)> TestObjectsSource()
         {
@@ -71,12 +71,12 @@ namespace Nethermind.Core.Test.Encoding
         {
             Transaction tx = testCase.Tx;
 
-            Rlp rlp = TxDecoder.Encode(tx);
+            Rlp rlp = _txDecoder.Encode(tx);
 
             Hash256 expectedHash = Keccak.Compute(rlp.Bytes);
 
             Rlp.ValueDecoderContext decoderCtx = new(rlp.Bytes);
-            Transaction decodedTx = TxDecoder.Decode(ref decoderCtx)!;
+            Transaction decodedTx = _txDecoder.Decode(ref decoderCtx)!;
 
             decodedTx.SetPreHash(rlp.Bytes);
 
@@ -91,10 +91,10 @@ namespace Nethermind.Core.Test.Encoding
         [TestCaseSource(nameof(TestCaseSource))]
         public void Roundtrip((Transaction Tx, string Description) testCase)
         {
-            RlpStream rlpStream = new(TxDecoder.GetLength(testCase.Tx, RlpBehaviors.None));
-            TxDecoder.Encode(rlpStream, testCase.Tx);
+            RlpStream rlpStream = new(_txDecoder.GetLength(testCase.Tx, RlpBehaviors.None));
+            _txDecoder.Encode(rlpStream, testCase.Tx);
             Rlp.ValueDecoderContext ctx = new(rlpStream.Data);
-            Transaction? decoded = TxDecoder.Decode(ref ctx);
+            Transaction? decoded = _txDecoder.Decode(ref ctx);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -105,12 +105,12 @@ namespace Nethermind.Core.Test.Encoding
         public void Roundtrip_ValueDecoderContext((Transaction Tx, string Description) testCase)
         {
             RlpStream rlpStream = new(10000);
-            TxDecoder.Encode(rlpStream, testCase.Tx);
+            _txDecoder.Encode(rlpStream, testCase.Tx);
 
             Span<byte> spanIncomingTxRlp = rlpStream.Data.AsSpan();
             Rlp.ValueDecoderContext decoderContext = new(spanIncomingTxRlp);
             rlpStream.Position = 0;
-            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
+            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -121,11 +121,11 @@ namespace Nethermind.Core.Test.Encoding
         public void Roundtrip_ValueDecoderContext_WithMemorySlice((Transaction Tx, string Description) testCase)
         {
             RlpStream rlpStream = new(10000);
-            TxDecoder.Encode(rlpStream, testCase.Tx);
+            _txDecoder.Encode(rlpStream, testCase.Tx);
 
             Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
-            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
+            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -138,11 +138,11 @@ namespace Nethermind.Core.Test.Encoding
             if (testCase.Tx.Data.Length == 0) return;
 
             RlpStream rlpStream = new(10000);
-            TxDecoder.Encode(rlpStream, testCase.Tx);
+            _txDecoder.Encode(rlpStream, testCase.Tx);
 
             Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
-            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
+            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
 
             byte[] data1 = decoded!.Data.ToArray();
             data1.AsSpan().Fill(1);
@@ -158,11 +158,11 @@ namespace Nethermind.Core.Test.Encoding
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
 
-            Transaction decoded = TxDecoder.Decode(ref ctx)!;
+            Transaction decoded = _txDecoder.Decode(ref ctx)!;
             decoded.CalculateHash().Should().Be(testCase.Hash);
 
             RlpStream ourRlpOutput = new(incomingTxRlpBytes.Length * 2);
-            TxDecoder.Encode(ourRlpOutput, decoded);
+            _txDecoder.Encode(ourRlpOutput, decoded);
 
             string ourRlpHex = ourRlpOutput.Data.AsSpan(0, incomingTxRlpBytes.Length).ToHexString();
             ourRlpHex.Should().BeEquivalentTo(testCase.IncomingRlpHex);
@@ -175,8 +175,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = TxDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = _txDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
 
             decoded.CalculateHash().Should().Be(decoded.Hash!);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
@@ -188,8 +188,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = TxDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = _txDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
         }
 
@@ -199,8 +199,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = TxDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = _txDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
         }
 
@@ -218,11 +218,11 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             Span<byte> spanIncomingTxRlp = Bytes.FromHexString(testCase.IncomingRlpHex).AsSpan();
             Rlp.ValueDecoderContext decoderContext = new(spanIncomingTxRlp);
-            Transaction decodedByValueDecoderContext = TxDecoder.Decode(ref decoderContext, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
+            Transaction decodedByValueDecoderContext = _txDecoder.Decode(ref decoderContext, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
             Rlp.ValueDecoderContext ctx2 = new(spanIncomingTxRlp);
-            Transaction decoded = TxDecoder.Decode(ref ctx2, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
-            Rlp encoded = TxDecoder.Encode(decoded);
-            Rlp encodedWithDecodedByValueDecoderContext = TxDecoder.Encode(decodedByValueDecoderContext);
+            Transaction decoded = _txDecoder.Decode(ref ctx2, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
+            Rlp encoded = _txDecoder.Encode(decoded);
+            Rlp encodedWithDecodedByValueDecoderContext = _txDecoder.Encode(decodedByValueDecoderContext);
             decoded.Hash.Should().Be(testCase.Hash);
             decoded.Hash.Should().Be(decodedByValueDecoderContext.Hash!);
             Assert.That(encodedWithDecodedByValueDecoderContext.Bytes, Is.EqualTo(encoded.Bytes));
@@ -232,7 +232,7 @@ namespace Nethermind.Core.Test.Encoding
         public void Rlp_encode_should_return_the_same_as_rlp_stream_encoding(
             (Transaction Tx, string Description) testCase)
         {
-            Rlp rlpStreamResult = TxDecoder.Encode(testCase.Tx, RlpBehaviors.SkipTypedWrapping);
+            Rlp rlpStreamResult = _txDecoder.Encode(testCase.Tx, RlpBehaviors.SkipTypedWrapping);
             Rlp rlpResult = Rlp.Encode(testCase.Tx, false, true, testCase.Tx.ChainId ?? 0);
             Assert.That(rlpStreamResult.Bytes, Is.EqualTo(rlpResult.Bytes));
         }
@@ -273,7 +273,7 @@ namespace Nethermind.Core.Test.Encoding
             void DecodeStream()
             {
                 Rlp.ValueDecoderContext ctx = new(invalidTxBytes);
-                TxDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
             }
 
             Assert.That(DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contains(error).IgnoreCase);
@@ -281,7 +281,7 @@ namespace Nethermind.Core.Test.Encoding
             void DecodeContext()
             {
                 Rlp.ValueDecoderContext ctx = invalidTxBytes.AsSpan().AsRlpValueContext();
-                TxDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
             }
 
             Assert.That(DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contains(error).IgnoreCase);
@@ -404,7 +404,7 @@ namespace Nethermind.Core.Test.Encoding
 
             yield return TestCase(
                 "Signed legacy tx prefixed with 0-byte (simulating 'legacy' type)",
-                Convert.ToHexString([0, .. TxDecoder.Encode(Build.A.Transaction.SignedAndResolved().TestObject).Bytes]),
+                Convert.ToHexString([0, .. _txDecoder.Encode(Build.A.Transaction.SignedAndResolved().TestObject).Bytes]),
                 "legacy"
             );
         }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Core.Test.Encoding
     [TestFixture]
     public class TxDecoderTests
     {
-        private readonly TxDecoder _txDecoder = TxDecoder.Instance;
+        private static readonly TxDecoder TxDecoder = TxDecoder.Instance;
 
         public static IEnumerable<(TransactionBuilder<Transaction>, string)> TestObjectsSource()
         {
@@ -71,12 +71,12 @@ namespace Nethermind.Core.Test.Encoding
         {
             Transaction tx = testCase.Tx;
 
-            Rlp rlp = _txDecoder.Encode(tx);
+            Rlp rlp = TxDecoder.Encode(tx);
 
             Hash256 expectedHash = Keccak.Compute(rlp.Bytes);
 
             Rlp.ValueDecoderContext decoderCtx = new(rlp.Bytes);
-            Transaction decodedTx = _txDecoder.Decode(ref decoderCtx)!;
+            Transaction decodedTx = TxDecoder.Decode(ref decoderCtx)!;
 
             decodedTx.SetPreHash(rlp.Bytes);
 
@@ -91,10 +91,10 @@ namespace Nethermind.Core.Test.Encoding
         [TestCaseSource(nameof(TestCaseSource))]
         public void Roundtrip((Transaction Tx, string Description) testCase)
         {
-            RlpStream rlpStream = new(_txDecoder.GetLength(testCase.Tx, RlpBehaviors.None));
-            _txDecoder.Encode(rlpStream, testCase.Tx);
+            RlpStream rlpStream = new(TxDecoder.GetLength(testCase.Tx, RlpBehaviors.None));
+            TxDecoder.Encode(rlpStream, testCase.Tx);
             Rlp.ValueDecoderContext ctx = new(rlpStream.Data);
-            Transaction? decoded = _txDecoder.Decode(ref ctx);
+            Transaction? decoded = TxDecoder.Decode(ref ctx);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -105,12 +105,12 @@ namespace Nethermind.Core.Test.Encoding
         public void Roundtrip_ValueDecoderContext((Transaction Tx, string Description) testCase)
         {
             RlpStream rlpStream = new(10000);
-            _txDecoder.Encode(rlpStream, testCase.Tx);
+            TxDecoder.Encode(rlpStream, testCase.Tx);
 
             Span<byte> spanIncomingTxRlp = rlpStream.Data.AsSpan();
             Rlp.ValueDecoderContext decoderContext = new(spanIncomingTxRlp);
             rlpStream.Position = 0;
-            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
+            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -121,11 +121,11 @@ namespace Nethermind.Core.Test.Encoding
         public void Roundtrip_ValueDecoderContext_WithMemorySlice((Transaction Tx, string Description) testCase)
         {
             RlpStream rlpStream = new(10000);
-            _txDecoder.Encode(rlpStream, testCase.Tx);
+            TxDecoder.Encode(rlpStream, testCase.Tx);
 
             Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
-            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
+            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
             decoded!.SenderAddress =
                 new EthereumEcdsa(TestBlockchainIds.ChainId).RecoverAddress(decoded);
             decoded.Hash = decoded.CalculateHash();
@@ -138,11 +138,11 @@ namespace Nethermind.Core.Test.Encoding
             if (testCase.Tx.Data.Length == 0) return;
 
             RlpStream rlpStream = new(10000);
-            _txDecoder.Encode(rlpStream, testCase.Tx);
+            TxDecoder.Encode(rlpStream, testCase.Tx);
 
             Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
-            Transaction? decoded = _txDecoder.Decode(ref decoderContext);
+            Transaction? decoded = TxDecoder.Decode(ref decoderContext);
 
             byte[] data1 = decoded!.Data.ToArray();
             data1.AsSpan().Fill(1);
@@ -158,11 +158,11 @@ namespace Nethermind.Core.Test.Encoding
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
 
-            Transaction decoded = _txDecoder.Decode(ref ctx)!;
+            Transaction decoded = TxDecoder.Decode(ref ctx)!;
             decoded.CalculateHash().Should().Be(testCase.Hash);
 
             RlpStream ourRlpOutput = new(incomingTxRlpBytes.Length * 2);
-            _txDecoder.Encode(ourRlpOutput, decoded);
+            TxDecoder.Encode(ourRlpOutput, decoded);
 
             string ourRlpHex = ourRlpOutput.Data.AsSpan(0, incomingTxRlpBytes.Length).ToHexString();
             ourRlpHex.Should().BeEquivalentTo(testCase.IncomingRlpHex);
@@ -175,8 +175,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = _txDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = TxDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
 
             decoded.CalculateHash().Should().Be(decoded.Hash!);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
@@ -188,8 +188,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = _txDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = TxDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
         }
 
@@ -199,8 +199,8 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             byte[] incomingTxRlpBytes = Bytes.FromHexString(testCase.IncomingRlpHex);
             Rlp.ValueDecoderContext ctx = new(incomingTxRlpBytes);
-            Transaction decoded = _txDecoder.Decode(ref ctx)!;
-            Rlp encodedForTreeRoot = _txDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
+            Transaction decoded = TxDecoder.Decode(ref ctx)!;
+            Rlp encodedForTreeRoot = TxDecoder.Encode(decoded, RlpBehaviors.SkipTypedWrapping);
             decoded.Hash.Should().Be(Keccak.Compute(encodedForTreeRoot.Bytes));
         }
 
@@ -218,11 +218,11 @@ namespace Nethermind.Core.Test.Encoding
             TestContext.Out.WriteLine($"Testing {testCase.Hash}");
             Span<byte> spanIncomingTxRlp = Bytes.FromHexString(testCase.IncomingRlpHex).AsSpan();
             Rlp.ValueDecoderContext decoderContext = new(spanIncomingTxRlp);
-            Transaction decodedByValueDecoderContext = _txDecoder.Decode(ref decoderContext, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
+            Transaction decodedByValueDecoderContext = TxDecoder.Decode(ref decoderContext, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
             Rlp.ValueDecoderContext ctx2 = new(spanIncomingTxRlp);
-            Transaction decoded = _txDecoder.Decode(ref ctx2, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
-            Rlp encoded = _txDecoder.Encode(decoded);
-            Rlp encodedWithDecodedByValueDecoderContext = _txDecoder.Encode(decodedByValueDecoderContext);
+            Transaction decoded = TxDecoder.Decode(ref ctx2, wrapping ? RlpBehaviors.SkipTypedWrapping : RlpBehaviors.None)!;
+            Rlp encoded = TxDecoder.Encode(decoded);
+            Rlp encodedWithDecodedByValueDecoderContext = TxDecoder.Encode(decodedByValueDecoderContext);
             decoded.Hash.Should().Be(testCase.Hash);
             decoded.Hash.Should().Be(decodedByValueDecoderContext.Hash!);
             Assert.That(encodedWithDecodedByValueDecoderContext.Bytes, Is.EqualTo(encoded.Bytes));
@@ -232,7 +232,7 @@ namespace Nethermind.Core.Test.Encoding
         public void Rlp_encode_should_return_the_same_as_rlp_stream_encoding(
             (Transaction Tx, string Description) testCase)
         {
-            Rlp rlpStreamResult = _txDecoder.Encode(testCase.Tx, RlpBehaviors.SkipTypedWrapping);
+            Rlp rlpStreamResult = TxDecoder.Encode(testCase.Tx, RlpBehaviors.SkipTypedWrapping);
             Rlp rlpResult = Rlp.Encode(testCase.Tx, false, true, testCase.Tx.ChainId ?? 0);
             Assert.That(rlpStreamResult.Bytes, Is.EqualTo(rlpResult.Bytes));
         }
@@ -273,18 +273,18 @@ namespace Nethermind.Core.Test.Encoding
             void DecodeStream()
             {
                 Rlp.ValueDecoderContext ctx = new(invalidTxBytes);
-                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                TxDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
             }
 
-            Assert.That((Action) DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contains(error));
+            Assert.That(DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contains(error).IgnoreCase);
 
             void DecodeContext()
             {
                 Rlp.ValueDecoderContext ctx = invalidTxBytes.AsSpan().AsRlpValueContext();
-                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                TxDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
             }
 
-            Assert.That((Action) DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contains(error));
+            Assert.That(DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contains(error).IgnoreCase);
         }
 
         public static IEnumerable<(string, Hash256)> SkipTypedWrappingTestCases()
@@ -398,7 +398,15 @@ namespace Nethermind.Core.Test.Encoding
                 new(Convert.FromHexString(invalidTxBytes), error) { TestName = testName };
 
             yield return TestCase("Missing storage keys array in access list",
-                "01e3010101825208808080d6d5940000000000000000000000000000000000000001010101", "storage keys");
+                "01e3010101825208808080d6d5940000000000000000000000000000000000000001010101",
+                "storage keys"
+            );
+
+            yield return TestCase(
+                "Signed legacy tx prefixed with 0-byte (simulating 'legacy' type)",
+                Convert.ToHexString([0, .. TxDecoder.Encode(Build.A.Transaction.SignedAndResolved().TestObject).Bytes]),
+                "legacy"
+            );
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -85,7 +85,7 @@ namespace Nethermind.Core.Test.Encoding
                 .Select(_ => Task.Factory.StartNew(() => decodedTx.Hash.Should().Be(expectedHash), TaskCreationOptions.RunContinuationsAsynchronously))
                 .ToPooledList(32);
 
-            await Task.WhenAll<AndConstraint<ComparableTypeAssertions<Hash256>>>(tasks.AsSpan());
+            await Task.WhenAll(tasks.AsSpan());
         }
 
         [TestCaseSource(nameof(TestCaseSource))]
@@ -266,6 +266,27 @@ namespace Nethermind.Core.Test.Encoding
             duplicates.CalculateHash().Should().NotBe(noDuplicates.CalculateHash());
         }
 
+
+        [TestCaseSource(nameof(InvalidEncodingTestCases))]
+        public void Rejects_invalid_tx_encoding(byte[] invalidTxBytes, string error)
+        {
+            void DecodeStream()
+            {
+                Rlp.ValueDecoderContext ctx = new(invalidTxBytes);
+                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+            }
+
+            Assert.That((Action) DecodeStream, Throws.InstanceOf<RlpException>().With.Message.Contains(error));
+
+            void DecodeContext()
+            {
+                Rlp.ValueDecoderContext ctx = invalidTxBytes.AsSpan().AsRlpValueContext();
+                _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+            }
+
+            Assert.That((Action) DecodeContext, Throws.InstanceOf<RlpException>().With.Message.Contains(error));
+        }
+
         public static IEnumerable<(string, Hash256)> SkipTypedWrappingTestCases()
         {
             yield return
@@ -369,6 +390,15 @@ namespace Nethermind.Core.Test.Encoding
                 "b8cb01f8c887796f6c6f76337803843b9aca00826a40948a8eafb1cf62bfbeb1741769dae1a9dd479961928080f85bf859940000000000000000000000000000000000001337f842a00000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000013370000000000000000000000080a094f3a6bbf5039b1a794e5be7628809bdf757c4ff59e5399dec74c61137074f80a049baf92bb5fb2d6c6bf8287fcd75eaea80ad38d1b8d29ce242c4ac51e1067d52",
                 new Hash256("0x0a956694228afe4577bd94fcf8a3aa8544bbadcecfe0d66ccad8ec7ae56c025f")
             );
+        }
+
+        private static IEnumerable<TestCaseData> InvalidEncodingTestCases()
+        {
+            static TestCaseData TestCase(string testName, string invalidTxBytes, string error) =>
+                new(Convert.FromHexString(invalidTxBytes), error) { TestName = testName };
+
+            yield return TestCase("Missing storage keys array in access list",
+                "01e3010101825208808080d6d5940000000000000000000000000000000000000001010101", "storage keys");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Linq;
 using FluentAssertions;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -76,5 +79,54 @@ public class WithdrawalDecoderTests
         byte[] rlp2 = Rlp.Encode(withdrawal).Bytes;
 
         rlp1.Should().BeEquivalentTo(rlp2);
+    }
+
+    /// <summary>
+    /// The length (sequence header) of each item in the list must be validated, matching the behavior in other clients. <br/>
+    /// Problematic RLP can be formed as this - instead of 2 correct withdrawals, encode a list of two "tampered" ones: <br/>
+    /// - first will contain whole encoded <c>withdrawal_1</c> and starting part of <c>withdrawal_2</c>, <br/>
+    /// - second one will contain remaining <c>withdrawal_2</c> part. <br/>
+    /// Example: <c> [ [w1NoPrefix | w2NoAmount] | w2Amount ] </c> <br/>
+    /// This "fools" outer array decoder - there are still 2 items, yet actual length of each item is encoded incorrectly. <br/>
+    /// Other clients DO validate decoded length against position obtained after decoding all item's fields for each item in the array.
+    /// </summary>
+    [Test]
+    public void Should_fail_on_cross_boundary_rlp()
+    {
+        WithdrawalDecoder decoder = new();
+
+        Withdrawal withdrawal1 = new() { Index = 1, ValidatorIndex = 2, Address = TestItem.AddressA, AmountInGwei = 100 };
+        Withdrawal withdrawal2 = new() { Index = 3, ValidatorIndex = 4, Address = TestItem.AddressB, AmountInGwei = 200 };
+
+        byte[] w1 = decoder.Encode(withdrawal1).Bytes;
+        byte[] w2 = decoder.Encode(withdrawal2).Bytes;
+
+        int amountLen = Rlp.LengthOf(withdrawal2.AmountInGwei);
+        byte[] w2NoAmount = w2[..^amountLen];
+        byte[] w1NoPrefix = w1[1..];
+
+        byte[] tamperedRlp1 = CombineRlpList(w1NoPrefix, w2NoAmount);
+        byte[] tamperedRlp2 = w2[^amountLen..]; // raw bytes only (no list wrapper)
+
+        byte[] rlp = CombineRlpList(tamperedRlp1, tamperedRlp2);
+
+        Action decode = () => rlp.AsRlpValueContext().DecodeArray(decoder!);
+        Assert.That(decode, Throws.InstanceOf<RlpException>().And.Message.Contain("checkpoint failed"));
+    }
+
+    private static byte[] CombineRlpList(params byte[][] encodedItems)
+    {
+        var sequenceLength = encodedItems.Sum(static item => item.Length);
+        var result = new byte[Rlp.LengthOfLength(sequenceLength) + sequenceLength];
+
+        var position = 0;
+        position += Rlp.StartSequence(result, position, sequenceLength);
+        foreach (var item in encodedItems)
+        {
+            item.CopyTo(result.AsSpan(position));
+            position += item.Length;
+        }
+
+        return result;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
@@ -110,14 +110,14 @@ public class WithdrawalDecoderTests
 
         byte[] rlp = CombineRlpList(tamperedRlp1, tamperedRlp2);
 
-        Action decode = () => rlp.AsRlpValueContext().DecodeArray(decoder!);
-        Assert.That(decode, Throws.InstanceOf<RlpException>().And.Message.Contain("checkpoint failed"));
+        void Decode() => rlp.AsRlpValueContext().DecodeArray(decoder!);
+        Assert.That(Decode, Throws.InstanceOf<RlpException>().And.Message.Contain("checkpoint failed"));
     }
 
     private static byte[] CombineRlpList(params byte[][] encodedItems)
     {
         int sequenceLength = encodedItems.Sum(static item => item.Length);
-        byte[] result = new byte[Rlp.LengthOfLength(sequenceLength) + sequenceLength];
+        byte[] result = new byte[Rlp.LengthOfSequence(sequenceLength)];
 
         int position = 0;
         position += Rlp.StartSequence(result, position, sequenceLength);

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/WithdrawalDecoderTests.cs
@@ -116,12 +116,12 @@ public class WithdrawalDecoderTests
 
     private static byte[] CombineRlpList(params byte[][] encodedItems)
     {
-        var sequenceLength = encodedItems.Sum(static item => item.Length);
-        var result = new byte[Rlp.LengthOfLength(sequenceLength) + sequenceLength];
+        int sequenceLength = encodedItems.Sum(static item => item.Length);
+        byte[] result = new byte[Rlp.LengthOfLength(sequenceLength) + sequenceLength];
 
-        var position = 0;
+        int position = 0;
         position += Rlp.StartSequence(result, position, sequenceLength);
-        foreach (var item in encodedItems)
+        foreach (byte[] item in encodedItems)
         {
             item.CopyTo(result.AsSpan(position));
             position += item.Length;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -120,7 +120,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         public ResultWrapper<ParityTxTraceFromReplay> trace_rawTransaction(byte[] data, string[] traceTypes)
         {
             Rlp.ValueDecoderContext ctx = data.AsRlpValueContext();
-            Transaction tx = _txDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+            Transaction tx = _txDecoder.DecodeCompleteNotNull(ref ctx, RlpBehaviors.SkipTypedWrapping);
             tx.CapGasLimit(jsonRpcConfig.GasCap);
             return TraceTx(tx, traceTypes, BlockParameter.Latest);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class ExecutionPayloadTests
+{
+    private static TxType[] TxTypes() => [TxType.AccessList, TxType.EIP1559, TxType.Blob];
+
+    [TestCaseSource(nameof(TxTypes))]
+    public void TryGetTransactions_accepts_clean_typed_tx(TxType txType)
+    {
+        byte[] validRlp = EncodeTx(txType);
+
+        ExecutionPayload payload = new() { Transactions = [validRlp] };
+        TransactionDecodingResult result = payload.TryGetTransactions();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Error, Is.Null);
+            Assert.That(result.Transactions, Has.Length.EqualTo(1));
+        }
+    }
+
+    // Most other clients reject transactions with garbage trailing bytes
+    [TestCaseSource(nameof(TxTypes))]
+    public void TryGetTransactions_rejects_typed_tx_with_trailing_bytes(TxType txType)
+    {
+        byte[] validRlp = EncodeTx(txType);
+        byte[] garbage = [0xDC, 0xAF, 0xAE, 0x1F];
+        byte[] mutated = [.. validRlp, .. garbage];
+
+        ExecutionPayload payload = new() { Transactions = [EncodeTx(txType), mutated, EncodeTx(txType)] };
+        TransactionDecodingResult result = payload.TryGetTransactions();
+
+        Assert.That(result.Error, Contains.Substring("checkpoint failed"));
+    }
+
+    private static byte[] EncodeTx(TxType txType)
+    {
+        TransactionBuilder<Transaction> builder = Build.A.Transaction
+            .WithType(txType)
+            .WithChainId(TestBlockchainIds.ChainId);
+
+        builder = txType switch
+        {
+            TxType.AccessList => builder.WithAccessList(Build.A.AccessList.TestObject),
+            TxType.EIP1559 => builder.WithMaxFeePerGas(50).WithMaxPriorityFeePerGas(10),
+            TxType.Blob => builder.WithBlobVersionedHashes(1).WithMaxFeePerBlobGas(10),
+            _ => builder
+        };
+
+        Transaction tx = builder.SignedAndResolved().TestObject;
+        return TxDecoder.Instance.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -214,7 +214,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
             for (i = 0; i < transactions.Length; i++)
             {
                 Rlp.ValueDecoderContext ctx = new(txData[i]);
-                transactions[i] = rlpDecoder.Decode(ref ctx, RlpBehaviors.SkipTypedWrapping);
+                transactions[i] = rlpDecoder.DecodeCompleteNotNull(ref ctx, RlpBehaviors.SkipTypedWrapping);
             }
 
             return new TransactionDecodingResult(_transactions = transactions);

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
@@ -68,13 +68,17 @@ namespace Nethermind.Network.P2P.Messages
 
             helloMessage.Capabilities = ctx.DecodeArrayPoolList(static (ref Rlp.ValueDecoderContext c) =>
             {
-                c.ReadSequenceLength();
-                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan();
+                int length = c.ReadSequenceLength();
+                int checkPosition = c.Position + length;
+
+                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan(RlpLimit.L8);
                 if (!Contract.P2P.ProtocolParser.TryGetProtocolCode(protocolSpan, out string? protocolCode))
                 {
                     protocolCode = Encoding.UTF8.GetString(protocolSpan);
                 }
                 int version = c.DecodeByte();
+
+                c.Check(checkPosition);
                 return new Capability(protocolCode, version);
             }, limit: RlpLimit.L64);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockHashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockHashesMessageSerializer.cs
@@ -49,8 +49,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         {
             (Hash256, long)[] blockHashes = ctx.DecodeArray(static (ref Rlp.ValueDecoderContext c) =>
             {
-                c.ReadSequenceLength();
-                return (c.DecodeKeccak(), (long)c.DecodeUInt256());
+                int length = c.ReadSequenceLength();
+                int checkPosition = c.Position + length;
+
+                (Hash256, long) result = (c.DecodeKeccak(), (long)c.DecodeUInt256());
+
+                c.Check(checkPosition);
+                return result;
             }, false, limit: RlpLimit);
 
             return new NewBlockHashesMessage(blockHashes);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
@@ -65,8 +65,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                 pathsWithAccounts = new ArrayPoolList<PathWithAccount>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    ctx.ReadSequenceLength();
+                    int length = ctx.ReadSequenceLength();
+                    int checkPosition = ctx.Position + length;
                     pathsWithAccounts.Add(new PathWithAccount(ctx.DecodeKeccak(), _decoder.Decode(ref ctx)));
+                    ctx.Check(checkPosition);
                 }
 
                 message.PathsWithAccounts = pathsWithAccounts;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -72,9 +72,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                 message.Slots = ctx.DecodeArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>(static (ref Rlp.ValueDecoderContext outerCtx) =>
                     outerCtx.DecodeArrayPoolList(static (ref Rlp.ValueDecoderContext innerCtx) =>
                     {
-                        innerCtx.ReadSequenceLength();
+                        int length = innerCtx.ReadSequenceLength();
+                        int checkPosition = innerCtx.Position + length;
                         Hash256 path = innerCtx.DecodeKeccak();
                         byte[] value = innerCtx.DecodeByteArray(StorageSlotValueRlpLimit);
+                        innerCtx.Check(checkPosition);
                         return new PathWithStorageSlot(in path.ValueHash256, value);
                     }, limit: SnapMessageLimits.StorageRangeSlotsPerAccountRlpLimit), limit: SnapMessageLimits.StorageRangeAccountsRlpLimit);
                 message.Proofs = RlpByteArrayList.DecodeList(ref ctx, memoryOwner);

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -612,20 +612,20 @@
         "type": "Project",
         "dependencies": {
           "MathNet.Numerics.FSharp": "[5.0.0, )",
-          "Nethermind.Core": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )"
         }
       },
       "nethermind.api": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Facade": "[1.37.0-unstable, )",
-          "Nethermind.Grpc": "[1.37.0-unstable, )",
-          "Nethermind.History": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Monitoring": "[1.37.0-unstable, )",
-          "Nethermind.Network": "[1.37.0-unstable, )",
-          "Nethermind.Sockets": "[1.37.0-unstable, )"
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Facade": "[1.38.0-unstable, )",
+          "Nethermind.Grpc": "[1.38.0-unstable, )",
+          "Nethermind.History": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Monitoring": "[1.38.0-unstable, )",
+          "Nethermind.Network": "[1.38.0-unstable, )",
+          "Nethermind.Sockets": "[1.38.0-unstable, )"
         }
       },
       "nethermind.blockchain": {
@@ -636,22 +636,22 @@
           "Microsoft.ClearScript.V8.Native.osx-arm64": "[7.5.0, )",
           "Microsoft.ClearScript.V8.Native.osx-x64": "[7.5.0, )",
           "Microsoft.ClearScript.V8.Native.win-x64": "[7.5.0, )",
-          "Nethermind.Abi": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Evm.Precompiles": "[1.37.0-unstable, )",
-          "Nethermind.Network.Stats": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )",
-          "Nethermind.TxPool": "[1.37.0-unstable, )",
+          "Nethermind.Abi": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Evm.Precompiles": "[1.38.0-unstable, )",
+          "Nethermind.Network.Stats": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )",
+          "Nethermind.TxPool": "[1.38.0-unstable, )",
           "Polly": "[8.6.6, )"
         }
       },
       "nethermind.config": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
           "System.Configuration.ConfigurationManager": "[10.0.7, )"
         }
@@ -660,47 +660,47 @@
         "type": "Project",
         "dependencies": {
           "Collections.Pooled": "[1.0.82, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.TxPool": "[1.37.0-unstable, )"
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.TxPool": "[1.38.0-unstable, )"
         }
       },
       "nethermind.consensus.aura": {
         "type": "Project",
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.6.2, )",
-          "Nethermind.Abi": "[1.37.0-unstable, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Facade": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )",
+          "Nethermind.Abi": "[1.38.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Facade": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )",
           "Nito.Collections.Deque": "[1.2.1, )"
         }
       },
       "nethermind.consensus.clique": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )"
         }
       },
       "nethermind.consensus.ethash": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )"
         }
       },
       "nethermind.core": {
@@ -712,7 +712,7 @@
           "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[8.17.0, )",
           "Nethermind.Crypto.SecP256k1": "[1.6.0, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
           "Nethermind.Numerics.Int256": "[1.5.0, )",
           "NonBlocking": "[2.1.2, )",
           "Testably.Abstractions": "[10.2.0, )"
@@ -723,17 +723,17 @@
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "Ckzg.Bindings": "[2.1.7.1596, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
           "Nethermind.Crypto.Bls": "[1.0.5, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
       },
       "nethermind.db": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
           "Nethermind.TurboPForBindings": "[1.0.0, )",
           "NonBlocking": "[2.1.2, )"
         }
@@ -742,8 +742,8 @@
         "type": "Project",
         "dependencies": {
           "ConcurrentHashSet": "[1.3.0, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
           "RocksDB": "[10.4.2.64152, 10.4.2.64152]"
         }
@@ -751,25 +751,25 @@
       "nethermind.db.rpc": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )"
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )"
         }
       },
       "nethermind.era1": {
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.4.2, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Merkleization": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Ssz": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Merkleization": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Ssz": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )",
           "Snappier": "[1.3.0, )"
         }
       },
@@ -777,17 +777,17 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.4.2, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Era1": "[1.37.0-unstable, )",
-          "Nethermind.History": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Merkleization": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Ssz": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Era1": "[1.38.0-unstable, )",
+          "Nethermind.History": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Merkleization": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Ssz": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )",
           "Polly": "[8.6.6, )",
           "Snappier": "[1.3.0, )"
         }
@@ -795,61 +795,61 @@
       "nethermind.ethstats": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Network": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Network": "[1.38.0-unstable, )",
           "Websocket.Client": "[5.3.0, )"
         }
       },
       "nethermind.evm": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )",
-          "Nethermind.Trie": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )",
+          "Nethermind.Trie": "[1.38.0-unstable, )"
         }
       },
       "nethermind.evm.precompiles": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
           "Nethermind.Crypto.Bls": "[1.0.5, )",
           "Nethermind.Crypto.SecP256r1": "[1.0.0, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
           "Nethermind.GmpBindings": "[1.0.3, )",
           "Nethermind.MclBindings": "[1.0.5, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )"
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )"
         }
       },
       "nethermind.externalsigner.plugin": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )"
         }
       },
       "nethermind.facade": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )"
         }
       },
       "nethermind.flashbots": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )"
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )"
         }
       },
       "nethermind.grpc": {
@@ -858,9 +858,9 @@
           "Google.Protobuf": "[3.34.1, )",
           "Google.Protobuf.Tools": "[3.34.1, )",
           "Grpc": "[2.46.6, )",
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )"
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )"
         }
       },
       "nethermind.healthchecks": {
@@ -869,77 +869,77 @@
           "AspNetCore.HealthChecks.UI": "[9.0.0, )",
           "AspNetCore.HealthChecks.UI.InMemory.Storage": "[9.0.0, )",
           "KubernetesClient": "[19.0.2, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )"
         }
       },
       "nethermind.history": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Consensus": "[1.37.0-unstable, )"
+          "Nethermind.Consensus": "[1.38.0-unstable, )"
         }
       },
       "nethermind.hive": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )"
         }
       },
       "nethermind.init": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Db.Rocks": "[1.37.0-unstable, )",
-          "Nethermind.Db.Rpc": "[1.37.0-unstable, )",
-          "Nethermind.Era1": "[1.37.0-unstable, )",
-          "Nethermind.EraE": "[1.37.0-unstable, )",
-          "Nethermind.Network.Discovery": "[1.37.0-unstable, )",
-          "Nethermind.Network.Dns": "[1.37.0-unstable, )",
-          "Nethermind.Network.Enr": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )",
-          "Nethermind.State.Flat": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Db.Rocks": "[1.38.0-unstable, )",
+          "Nethermind.Db.Rpc": "[1.38.0-unstable, )",
+          "Nethermind.Era1": "[1.38.0-unstable, )",
+          "Nethermind.EraE": "[1.38.0-unstable, )",
+          "Nethermind.Network.Discovery": "[1.38.0-unstable, )",
+          "Nethermind.Network.Dns": "[1.38.0-unstable, )",
+          "Nethermind.Network.Enr": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )",
+          "Nethermind.State.Flat": "[1.38.0-unstable, )"
         }
       },
       "nethermind.init.snapshot": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
           "ZstdSharp.Port": "[0.8.7, )"
         }
       },
       "nethermind.jsonrpc": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Abi": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Facade": "[1.37.0-unstable, )",
-          "Nethermind.Network.Dns": "[1.37.0-unstable, )",
-          "Nethermind.Sockets": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )",
-          "Nethermind.Wallet": "[1.37.0-unstable, )"
+          "Nethermind.Abi": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Facade": "[1.38.0-unstable, )",
+          "Nethermind.Network.Dns": "[1.38.0-unstable, )",
+          "Nethermind.Sockets": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )",
+          "Nethermind.Wallet": "[1.38.0-unstable, )"
         }
       },
       "nethermind.jsonrpc.tracestore": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )"
         }
       },
       "nethermind.keystore": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )",
           "SCrypt": "[2.0.0.2, )"
         }
       },
@@ -950,41 +950,41 @@
         "type": "Project",
         "dependencies": {
           "NLog": "[5.5.1, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )"
+          "Nethermind.Logging": "[1.38.0-unstable, )"
         }
       },
       "nethermind.merge.aura": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Consensus.AuRa": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )"
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Consensus.AuRa": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )"
         }
       },
       "nethermind.merge.plugin": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )"
         }
       },
       "nethermind.merkleization": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Ssz": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Ssz": "[1.38.0-unstable, )"
         }
       },
       "nethermind.monitoring": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
           "prometheus-net.AspNetCore": "[8.2.1, )"
         }
       },
@@ -992,31 +992,31 @@
         "type": "Project",
         "dependencies": {
           "Crc32.NET": "[1.2.0, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
           "Nethermind.DotNetty.Handlers": "[1.0.2.76, )",
-          "Nethermind.Network.Contract": "[1.37.0-unstable, )",
-          "Nethermind.Network.Stats": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )",
+          "Nethermind.Network.Contract": "[1.38.0-unstable, )",
+          "Nethermind.Network.Stats": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )",
           "Snappier": "[1.3.0, )"
         }
       },
       "nethermind.network.contract": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )"
+          "Nethermind.Config": "[1.38.0-unstable, )"
         }
       },
       "nethermind.network.discovery": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Facade": "[1.37.0-unstable, )",
-          "Nethermind.Network": "[1.37.0-unstable, )",
-          "Nethermind.Network.Enr": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Facade": "[1.38.0-unstable, )",
+          "Nethermind.Network": "[1.38.0-unstable, )",
+          "Nethermind.Network.Enr": "[1.38.0-unstable, )",
           "PierTwo.Lantern.Discv5.WireProtocol": "[1.0.0-preview.8, )"
         }
       },
@@ -1024,222 +1024,223 @@
         "type": "Project",
         "dependencies": {
           "DnsClient": "[1.8.0, )",
-          "Nethermind.Network": "[1.37.0-unstable, )",
-          "Nethermind.Network.Enr": "[1.37.0-unstable, )"
+          "Nethermind.Network": "[1.38.0-unstable, )",
+          "Nethermind.Network.Enr": "[1.38.0-unstable, )"
         }
       },
       "nethermind.network.enr": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Network": "[1.37.0-unstable, )"
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Network": "[1.38.0-unstable, )"
         }
       },
       "nethermind.network.stats": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Network.Contract": "[1.37.0-unstable, )"
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Network.Contract": "[1.38.0-unstable, )"
         }
       },
       "nethermind.opcodetracing.plugin": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )"
         }
       },
       "nethermind.optimism": {
         "type": "Project",
         "dependencies": {
           "Google.Protobuf": "[3.34.1, )",
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
           "Nethermind.Libp2p": "[1.0.0-preview.45, )",
           "Nethermind.Libp2p.Protocols.PubsubPeerDiscovery": "[1.0.0-preview.45, )",
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )",
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )",
           "Snappier": "[1.3.0, )"
         }
       },
       "nethermind.seq": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )"
+          "Nethermind.Config": "[1.38.0-unstable, )"
         }
       },
       "nethermind.serialization.json": {
         "type": "Project",
         "dependencies": {
           "Microsoft.ClearScript.V8": "[7.5.0, )",
-          "Nethermind.Core": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )"
         }
       },
       "nethermind.serialization.rlp": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
+          "Ckzg.Bindings": "[2.1.7.1596, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
           "Nethermind.DotNetty.Buffers": "[1.0.2.76, )"
         }
       },
       "nethermind.serialization.ssz": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )"
         }
       },
       "nethermind.shutter": {
         "type": "Project",
         "dependencies": {
           "Google.Protobuf": "[3.34.1, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
           "Nethermind.Libp2p": "[1.0.0-preview.45, )",
           "Nethermind.Libp2p.Protocols.PubsubPeerDiscovery": "[1.0.0-preview.45, )",
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )",
-          "Nethermind.Merkleization": "[1.37.0-unstable, )",
-          "Nethermind.Network.Discovery": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Ssz": "[1.37.0-unstable, )",
-          "Nethermind.Specs": "[1.37.0-unstable, )"
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )",
+          "Nethermind.Merkleization": "[1.38.0-unstable, )",
+          "Nethermind.Network.Discovery": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Ssz": "[1.38.0-unstable, )",
+          "Nethermind.Specs": "[1.38.0-unstable, )"
         }
       },
       "nethermind.sockets": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )"
         }
       },
       "nethermind.specs": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )",
           "ZstdSharp.Port": "[0.8.7, )"
         }
       },
       "nethermind.state": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.Trie": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.Trie": "[1.38.0-unstable, )"
         }
       },
       "nethermind.state.flat": {
         "type": "Project",
         "dependencies": {
           "Collections.Pooled": "[1.0.82, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )",
-          "Nethermind.Synchronization": "[1.37.0-unstable, )",
-          "Nethermind.Trie": "[1.37.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )",
+          "Nethermind.Synchronization": "[1.38.0-unstable, )",
+          "Nethermind.Trie": "[1.38.0-unstable, )",
           "System.IO.Hashing": "[10.0.7, )"
         }
       },
       "nethermind.statecomposition": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
-          "Nethermind.Trie": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
+          "Nethermind.Trie": "[1.38.0-unstable, )"
         }
       },
       "nethermind.synchronization": {
         "type": "Project",
         "dependencies": {
           "ConcurrentHashSet": "[1.3.0, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.History": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Network.Contract": "[1.37.0-unstable, )",
-          "Nethermind.Trie": "[1.37.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.History": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Network.Contract": "[1.38.0-unstable, )",
+          "Nethermind.Trie": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )"
         }
       },
       "nethermind.taiko": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Blockchain": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Evm.Precompiles": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )",
-          "Nethermind.JsonRpc": "[1.37.0-unstable, )",
-          "Nethermind.Logging": "[1.37.0-unstable, )",
-          "Nethermind.Merge.Plugin": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Json": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Blockchain": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Evm.Precompiles": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )",
+          "Nethermind.JsonRpc": "[1.38.0-unstable, )",
+          "Nethermind.Logging": "[1.38.0-unstable, )",
+          "Nethermind.Merge.Plugin": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Json": "[1.38.0-unstable, )"
         }
       },
       "nethermind.trie": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )"
         }
       },
       "nethermind.txpool": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Config": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Crypto": "[1.37.0-unstable, )",
-          "Nethermind.Db": "[1.37.0-unstable, )",
-          "Nethermind.Evm": "[1.37.0-unstable, )",
-          "Nethermind.Network.Contract": "[1.37.0-unstable, )",
-          "Nethermind.State": "[1.37.0-unstable, )",
+          "Nethermind.Config": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Crypto": "[1.38.0-unstable, )",
+          "Nethermind.Db": "[1.38.0-unstable, )",
+          "Nethermind.Evm": "[1.38.0-unstable, )",
+          "Nethermind.Network.Contract": "[1.38.0-unstable, )",
+          "Nethermind.State": "[1.38.0-unstable, )",
           "NonBlocking": "[2.1.2, )"
         }
       },
       "nethermind.upnp.plugin": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
+          "Nethermind.Api": "[1.38.0-unstable, )",
           "Open.NAT.Core": "[2.1.0.5, )"
         }
       },
       "nethermind.wallet": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.KeyStore": "[1.37.0-unstable, )",
-          "Nethermind.Serialization.Rlp": "[1.37.0-unstable, )",
-          "Nethermind.TxPool": "[1.37.0-unstable, )"
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.KeyStore": "[1.38.0-unstable, )",
+          "Nethermind.Serialization.Rlp": "[1.38.0-unstable, )",
+          "Nethermind.TxPool": "[1.38.0-unstable, )"
         }
       },
       "nethermind.xdc": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Api": "[1.37.0-unstable, )",
-          "Nethermind.Consensus": "[1.37.0-unstable, )",
-          "Nethermind.Core": "[1.37.0-unstable, )",
-          "Nethermind.Init": "[1.37.0-unstable, )"
+          "Nethermind.Api": "[1.38.0-unstable, )",
+          "Nethermind.Consensus": "[1.38.0-unstable, )",
+          "Nethermind.Core": "[1.38.0-unstable, )",
+          "Nethermind.Init": "[1.38.0-unstable, )"
         }
       },
       "AspNetCore.HealthChecks.UI": {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Eip2930/AccessListDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Eip2930/AccessListDecoder.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
@@ -36,27 +36,28 @@ namespace Nethermind.Serialization.Rlp.Eip2930
                 Address address = decoderContext.DecodeAddress() ?? throw new RlpException("Invalid tx access list format - address is null");
                 accessListBuilder.AddAddress(address);
 
-                if (decoderContext.Position < check)
+                if (decoderContext.Position >= accessListItemCheck)
                 {
-                    int storagesLength = decoderContext.ReadSequenceLength();
-                    int storagesCheck = decoderContext.Position + storagesLength;
-                    while (decoderContext.Position < storagesCheck)
-                    {
-                        int storageItemCheck = decoderContext.Position + IndexLength + 1;
-                        UInt256 index = decoderContext.DecodeUInt256(IndexLength);
-                        accessListBuilder.AddStorage(index);
-                        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
-                        {
-                            decoderContext.Check(storageItemCheck);
-                        }
-                    }
+                    throw new RlpException("Invalid tx access list format - storage keys missing");
+                }
+
+                int storagesLength = decoderContext.ReadSequenceLength();
+                int storagesCheck = decoderContext.Position + storagesLength;
+                while (decoderContext.Position < storagesCheck)
+                {
+                    int storageItemCheck = decoderContext.Position + IndexLength + 1;
+                    UInt256 index = decoderContext.DecodeUInt256(IndexLength);
+                    accessListBuilder.AddStorage(index);
+
                     if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
                     {
-                        decoderContext.Check(storagesCheck);
+                        decoderContext.Check(storageItemCheck);
                     }
                 }
+
                 if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes)
                 {
+                    decoderContext.Check(storagesCheck);
                     decoderContext.Check(accessListItemCheck);
                 }
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -131,13 +131,6 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
-        public T DecodeComplete(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
-        {
-            T result = Decode(ref decoderContext, rlpBehaviors);
-            decoderContext.CheckEnd();
-            return result;
-        }
-
         protected abstract T DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -33,11 +33,75 @@ namespace Nethermind.Serialization.Rlp
 
     public static class RlpValueDecoderExtensions
     {
-        public static T Decode<T>(this IRlpValueDecoder<T> decoder, ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        extension<T>(IRlpValueDecoder<T> decoder)
         {
-            Rlp.ValueDecoderContext context = new(bytes);
-            return decoder.Decode(ref context, rlpBehaviors);
+            public T Decode(ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                Rlp.ValueDecoderContext context = new(bytes);
+                return decoder.Decode(ref context, rlpBehaviors);
+            }
+
+            /// <summary>
+            /// Decodes instance of <typeparamref name="T"/> from <paramref name="context"/>
+            /// and verifies that the end of the stream has been reached.
+            /// </summary>
+            public T DecodeComplete(ref Rlp.ValueDecoderContext context, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                T value = decoder.Decode(ref context, rlpBehaviors);
+                context.CheckEnd();
+                return value;
+            }
+
+            /// <summary>
+            /// Decodes instance of <typeparamref name="T"/> from <paramref name="bytes"/>
+            /// and verifies that the end of the stream has been reached.
+            /// </summary>
+            public T DecodeComplete(ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                Rlp.ValueDecoderContext context = new(bytes);
+                return decoder.DecodeComplete(ref context, rlpBehaviors);
+            }
         }
+
+        extension<T>(IRlpValueDecoder<T> decoder) where T : class
+        {
+            public T DecodeGuardNotNull(ref Rlp.ValueDecoderContext context, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
+                decoder.Decode(ref context, rlpBehaviors) ?? ThrowNullDecodedValue<T>();
+
+            public T DecodeGuardNotNull(ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                Rlp.ValueDecoderContext context = new(bytes);
+                return decoder.DecodeGuardNotNull(ref context, rlpBehaviors);
+            }
+
+            /// <summary>
+            /// Decodes instance of <typeparamref name="T"/> from <paramref name="context"/>
+            /// and verifies that the end of the stream has been reached.
+            /// Throws if decoded value is <c>null</c>.
+            /// </summary>
+            public T DecodeCompleteNotNull(ref Rlp.ValueDecoderContext context, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                T value = decoder.DecodeGuardNotNull(ref context, rlpBehaviors);
+                context.CheckEnd();
+                return value;
+            }
+
+            /// <summary>
+            /// Decodes instance of <typeparamref name="T"/> from <paramref name="bytes"/>
+            /// and verifies that the end of the stream has been reached.
+            /// Throws if decoded value is <c>null</c>.
+            /// </summary>
+            public T DecodeCompleteNotNull(ReadOnlySpan<byte> bytes, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+            {
+                Rlp.ValueDecoderContext context = new(bytes);
+                return decoder.DecodeCompleteNotNull(ref context, rlpBehaviors);
+            }
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        private static T ThrowNullDecodedValue<T>() where T : class
+            => throw new RlpException($"{typeof(T).Name} decoding returned null");
     }
 
     public abstract class RlpStreamEncoder<T> : IRlpStreamEncoder<T>
@@ -65,6 +129,13 @@ namespace Nethermind.Serialization.Rlp
                 ThrowRlpException(e);
                 return default;
             }
+        }
+
+        public T DecodeComplete(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            T result = Decode(ref decoderContext, rlpBehaviors);
+            decoderContext.CheckEnd();
+            return result;
         }
 
         protected abstract T DecodeInternal(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ckzg.Bindings" />
     <PackageReference Include="Nethermind.DotNetty.Buffers" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Serialization.Rlp
         public int Length => Bytes.Length;
 
         private static readonly Dictionary<RlpDecoderKey, IRlpDecoder> _decoderBuilder = new();
-        private static Lock _decoderLock = new();
+        private static readonly Lock _decoderLock = new();
 
         public static void ResetDecoders()
         {
@@ -1257,7 +1257,7 @@ namespace Nethermind.Serialization.Rlp
                 return result;
             }
 
-            public byte[][] DecodeByteArrays()
+            public byte[][] DecodeByteArrays(RlpLimit? limit = null)
             {
                 int length = ReadSequenceLength();
                 if (length is 0)
@@ -1267,6 +1267,7 @@ namespace Nethermind.Serialization.Rlp
 
                 int checkPosition = Position + length;
                 int itemsCount = PeekNumberOfItemsRemaining(checkPosition);
+                GuardLimit(itemsCount, limit);
                 byte[][] result = new byte[itemsCount][];
 
                 for (int i = 0; i < itemsCount; i++)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -177,12 +177,14 @@ namespace Nethermind.Serialization.Rlp
 
         public static T Decode<T>(ref ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            IRlpValueDecoder<T>? rlpDecoder = GetValueDecoder<T>();
+            IRlpValueDecoder<T> rlpDecoder = GetValueDecoder<T>() ??
+                throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
+
             bool shouldCheckStream = decoderContext.Position == 0 && (rlpBehaviors & RlpBehaviors.AllowExtraBytes) != RlpBehaviors.AllowExtraBytes;
-            int length = decoderContext.Length;
-            T? result = rlpDecoder is not null ? rlpDecoder.Decode(ref decoderContext, rlpBehaviors) : throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
-            if (shouldCheckStream)
-                decoderContext.Check(length);
+            T? result = shouldCheckStream
+                ? rlpDecoder.DecodeComplete(ref decoderContext, rlpBehaviors)
+                : rlpDecoder.Decode(ref decoderContext, rlpBehaviors);
+
             return result;
         }
 
@@ -674,6 +676,14 @@ namespace Nethermind.Serialization.Rlp
                 if (Position != nextCheck)
                 {
                     throw new RlpException($"Data checkpoint failed. Expected {nextCheck} and is {Position}");
+                }
+            }
+
+            public readonly void CheckEnd()
+            {
+                if (Position != Length)
+                {
+                    throw new RlpException($"Data checkpoint failed. Expected to reach the end of the sequence, but is at {Position}");
                 }
             }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -457,7 +457,6 @@ namespace Nethermind.Serialization.Rlp
             return (bits + 7) / 8;
         }
 
-
         public static Rlp Encode(Hash256? keccak)
         {
             if (keccak is null)
@@ -1030,20 +1029,22 @@ namespace Nethermind.Serialization.Rlp
                 return result;
             }
 
-            public byte[] DecodeByteArray(RlpLimit? limit = null) => ByteSpanToArray(DecodeByteArraySpan(limit));
+            public byte[] DecodeByteArray(RlpLimit? limit = null, int size = -1) => ByteSpanToArray(DecodeByteArraySpan(limit, size));
 
-            public ReadOnlySpan<byte> DecodeByteArraySpan(RlpLimit? limit = null)
+            public ReadOnlySpan<byte> DecodeByteArraySpan(RlpLimit? limit = null, int size = -1)
             {
                 int position = Position;
                 int prefix = ReadByte();
                 ReadOnlySpan<byte> span = RlpStream.SingleBytes;
                 if ((uint)prefix < (uint)span.Length)
                 {
+                    GuardSize(actual: 1, expected: size);
                     return span.Slice(prefix, 1);
                 }
 
                 if (prefix is EmptyByteArrayByte)
                 {
+                    GuardSize(actual: 0, expected: size);
                     return default;
                 }
 
@@ -1051,6 +1052,8 @@ namespace Nethermind.Serialization.Rlp
                 {
                     int length = prefix - 128;
                     GuardLimit(length, limit);
+                    GuardSize(actual: length, expected: size);
+
                     ReadOnlySpan<byte> buffer = Read(length);
 
                     if (length == 1 && buffer[0] < 128)
@@ -1061,11 +1064,11 @@ namespace Nethermind.Serialization.Rlp
                     return buffer;
                 }
 
-                return DecodeLargerByteArraySpan(prefix, limit);
+                return DecodeLargerByteArraySpan(prefix, limit, size);
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private ReadOnlySpan<byte> DecodeLargerByteArraySpan(int prefix, RlpLimit? limit = null)
+            private ReadOnlySpan<byte> DecodeLargerByteArraySpan(int prefix, RlpLimit? limit = null, int size = -1)
             {
                 if (prefix < 192)
                 {
@@ -1080,8 +1083,9 @@ namespace Nethermind.Serialization.Rlp
                     {
                         RlpHelpers.ThrowUnexpectedLength(length);
                     }
-                    GuardLimit(length, limit);
 
+                    GuardSize(actual: length, expected: size);
+                    GuardLimit(length, limit);
                     return Read(length);
                 }
 
@@ -1257,7 +1261,7 @@ namespace Nethermind.Serialization.Rlp
                 return result;
             }
 
-            public byte[][] DecodeByteArrays(RlpLimit? limit = null)
+            public byte[][] DecodeByteArrays(RlpLimit? limit = null, int innerSize = -1)
             {
                 int length = ReadSequenceLength();
                 if (length is 0)
@@ -1272,7 +1276,7 @@ namespace Nethermind.Serialization.Rlp
 
                 for (int i = 0; i < itemsCount; i++)
                 {
-                    result[i] = DecodeByteArray();
+                    result[i] = DecodeByteArray(size: innerSize);
                 }
 
                 Check(checkPosition);
@@ -1476,6 +1480,11 @@ namespace Nethermind.Serialization.Rlp
             [StackTraceHidden]
             public readonly void GuardLimit(int count, RlpLimit? limit = null) =>
                 Rlp.GuardLimit(count, Length - Position, limit);
+
+            // ReSharper disable once MemberHidesStaticFromOuterClass
+            [StackTraceHidden]
+            public static void GuardSize(int actual, int expected) =>
+                Rlp.GuardSize(actual, expected);
         }
 
         public override bool Equals(object? other) => Equals(other as Rlp);
@@ -1734,6 +1743,15 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
+        [StackTraceHidden]
+        public static void GuardSize(int actual, int expected)
+        {
+            if (expected >= 0 && actual != expected)
+            {
+                ThrowUnexpectedCount(actual, expected);
+            }
+        }
+
         [DoesNotReturn]
         [StackTraceHidden]
         private static void ThrowCountOverLimit(uint count, int bytesLeft, RlpLimit limit)
@@ -1747,7 +1765,13 @@ namespace Nethermind.Serialization.Rlp
 
         [DoesNotReturn]
         [StackTraceHidden]
-        private static void ThrowBufferTooSmall(Span<byte> buffer, int minLength) => throw new ArgumentException($"Buffer is too small. Minimal length: {minLength}, actual length: {buffer.Length}");
+        private static void ThrowUnexpectedCount(int count, int expected) =>
+            throw new RlpException($"Expected collection count of {expected}, got {count}");
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        private static void ThrowBufferTooSmall(Span<byte> buffer, int minLength) =>
+            throw new ArgumentException($"Buffer is too small. Minimal length: {minLength}, actual length: {buffer.Length}");
     }
 
     public readonly partial struct RlpDecoderKey(Type type, string key = RlpDecoderKey.Default) : IEquatable<RlpDecoderKey>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -66,6 +66,14 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
 
     public void RegisterDecoder(TxType type, ITxDecoder decoder) => _decoders[(int)type] = decoder;
 
+    private static void ThrowIfLegacy(TxType txType)
+    {
+        if (txType is TxType.Legacy)
+        {
+            throw new RlpException("Legacy transactions are not allowed in EIP-2718 Typed Transaction Envelope");
+        }
+    }
+
     private ITxDecoder GetDecoder(TxType txType) =>
         _decoders.TryGetByTxType(txType, out ITxDecoder decoder)
             ? decoder
@@ -98,6 +106,7 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
                 txSequenceStart = decoderContext.Position;
                 transactionSequence = decoderContext.Peek(decoderContext.Length);
                 txType = (TxType)decoderContext.ReadByte();
+                ThrowIfLegacy(txType);
             }
         }
         else
@@ -108,6 +117,7 @@ public class TxDecoder<T> : RlpValueDecoder<T> where T : Transaction, new()
                 txSequenceStart = decoderContext.Position;
                 transactionSequence = decoderContext.Peek(contentLength);
                 txType = (TxType)decoderContext.ReadByte();
+                ThrowIfLegacy(txType);
             }
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using CkzgLib;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -10,6 +11,15 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     : BaseEIP1559TxDecoder<T>(TxType.Blob, transactionFactory) where T : Transaction, new()
 {
+    private const int BlobCountLimit = 128;
+    private const int BlobCellProofsCountLimit = BlobCountLimit * Ckzg.CellsPerExtBlob;
+
+    private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(BlobCountLimit, nameof(Transaction.BlobVersionedHashes));
+    private static readonly RlpLimit NetworkWrapperBlobsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Blobs));
+    private static readonly RlpLimit NetworkWrapperCommitmentsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Commitments));
+    private static readonly RlpLimit NetworkWrapperProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Proofs));
+    private static readonly RlpLimit NetworkWrapperCellProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCellProofsCountLimit, nameof(ShardBlobNetworkWrapper.Proofs));
+
     public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
         ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
@@ -86,7 +96,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     {
         base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
-        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays();
+        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit);
     }
 
     protected override void EncodePayload(Transaction transaction, RlpStream stream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -102,15 +112,16 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
         if (!decoderContext.IsSequenceNext())
         {
             version = (ProofVersion)decoderContext.ReadByte();
-            if (version != ProofVersion.V1)
+            if (version > ProofVersion.V1)
             {
                 throw new RlpException($"Unknown version of {nameof(ShardBlobNetworkWrapper)}. Expected no more than {(int)ProofVersion.V1} and is {version}");
             }
         }
 
-        byte[][] blobs = decoderContext.DecodeByteArrays();
-        byte[][] commitments = decoderContext.DecodeByteArrays();
-        byte[][] proofs = decoderContext.DecodeByteArrays();
+        byte[][] blobs = decoderContext.DecodeByteArrays(NetworkWrapperBlobsCountLimit);
+        byte[][] commitments = decoderContext.DecodeByteArrays(NetworkWrapperCommitmentsCountLimit);
+        RlpLimit proofsCountLimit = version is ProofVersion.V1 ? NetworkWrapperCellProofsCountLimit : NetworkWrapperProofsCountLimit;
+        byte[][] proofs = decoderContext.DecodeByteArrays(proofsCountLimit);
 
         transaction.NetworkWrapper = new ShardBlobNetworkWrapper(blobs, commitments, proofs, version);
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -17,8 +17,8 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(BlobCountLimit, nameof(Transaction.BlobVersionedHashes));
     private static readonly RlpLimit NetworkWrapperBlobsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Blobs));
     private static readonly RlpLimit NetworkWrapperCommitmentsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Commitments));
-    private static readonly RlpLimit NetworkWrapperProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, nameof(ShardBlobNetworkWrapper.Proofs));
-    private static readonly RlpLimit NetworkWrapperCellProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCellProofsCountLimit, nameof(ShardBlobNetworkWrapper.Proofs));
+    private static readonly RlpLimit NetworkWrapperProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCountLimit, $"{nameof(ShardBlobNetworkWrapper.Proofs)} {ProofVersion.V0}");
+    private static readonly RlpLimit NetworkWrapperCellProofsCountLimit = RlpLimit.For<ShardBlobNetworkWrapper>(BlobCellProofsCountLimit, $"{nameof(ShardBlobNetworkWrapper.Proofs)} {ProofVersion.V1}");
 
     public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
         ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -96,7 +96,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
     {
         base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
-        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit);
+        transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit, innerSize: Hash256.Size);
     }
 
     protected override void EncodePayload(Transaction transaction, RlpStream stream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
@@ -17,15 +17,23 @@ public sealed class WithdrawalDecoder() : RlpValueDecoder<Withdrawal>
             return null;
         }
 
-        decoderContext.ReadSequenceLength();
+        int sequenceLength = decoderContext.ReadSequenceLength();
+        int checkPosition = decoderContext.Position + sequenceLength;
 
-        return new()
+        Withdrawal withdrawal = new()
         {
             Index = decoderContext.DecodeULong(),
             ValidatorIndex = decoderContext.DecodeULong(),
             Address = decoderContext.DecodeAddress(),
             AmountInGwei = decoderContext.DecodeULong()
         };
+
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
+        {
+            decoderContext.Check(checkPosition);
+        }
+
+        return withdrawal;
     }
 
     public override void Encode(RlpStream stream, Withdrawal? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.TxPool;
@@ -56,7 +57,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
             ctx.DecodeUInt256(),
             ctx.DecodeUInt256(),
             ctx.DecodeUInt256(),
-            ctx.DecodeByteArrays(),
+            ctx.DecodeByteArrays(innerSize: Hash256.Size),
             ctx.DecodeULong(),
             ctx.DecodePositiveInt(),
             ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 ? (ProofVersion)ctx.ReadByte() : default);

--- a/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
@@ -23,9 +23,7 @@ internal sealed class QuorumCertificateDecoder : RlpValueDecoder<QuorumCertifica
 
         BlockRoundInfo? blockInfo = _blockInfoDecoder.Decode(ref decoderContext, rlpBehaviors);
 
-        byte[][]? signatureBytes = decoderContext.DecodeByteArrays();
-        if (signatureBytes is not null && signatureBytes.Any(s => s.Length != 65))
-            throw new RlpException("One or more invalid signature lengths in quorum certificate.");
+        byte[][]? signatureBytes = decoderContext.DecodeByteArrays(innerSize: Signature.Size);
         Signature[]? signatures = null;
         if (signatureBytes is not null)
         {

--- a/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/QuorumCertificateDecoder.cs
@@ -6,7 +6,6 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.RLP;
 using Nethermind.Xdc.Types;
 using System;
-using System.Linq;
 using BlockRoundInfo = Nethermind.Xdc.Types.BlockRoundInfo;
 
 namespace Nethermind.Xdc;

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
@@ -23,9 +23,7 @@ public sealed class TimeoutCertificateDecoder : RlpValueDecoder<TimeoutCertifica
 
         ulong round = decoderContext.DecodeULong();
 
-        byte[][]? signatureBytes = decoderContext.DecodeByteArrays();
-        if (signatureBytes is not null && signatureBytes.Any(s => s.Length != 65))
-            throw new RlpException("One or more invalid signature lengths in timeout certificate.");
+        byte[][]? signatureBytes = decoderContext.DecodeByteArrays(innerSize: Signature.Size);
         Signature[]? signatures = null;
         if (signatureBytes is not null)
         {

--- a/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/TimeoutCertificateDecoder.cs
@@ -5,7 +5,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.Types;
 using System;
-using System.Linq;
 
 namespace Nethermind.Xdc.RLP;
 


### PR DESCRIPTION
RLP fixes related to collection sizes, limits, and post-decode positions checks.

## Changes                          

- Reject legacy txs in typed (EIP-2718) envelope encoding
- Limit and size checks support in `Rlp.DecodeByteArrays`
- RLP size/length validation after decoding tx access list, blob txs, and withdrawal fields
- Post-decode position checks in inner decode loops
- Reject txs with trailing bytes in execution payload
- Tests for the fixes: tx, access list, blob, withdrawal, and execution payload decoders

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes