### PR TITLE
RPC: `admin_*` peer-management endpoints improvements

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -114,5 +114,6 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
             ctx.Resolve<IInitConfig>().BaseDbPath, // IInitConfig not accessible from IAdminRpcModule, so we construct it manually here
             ctx.Resolve<ChainSpec>().Parameters,
             ctx.Resolve<ITrustedNodesManager>(),
-            ctx.Resolve<ISubscriptionManager>());
+            ctx.Resolve<ISubscriptionManager>(),
+            ctx.Resolve<IJsonRpcConfig>());
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -39,6 +39,9 @@ namespace Nethermind.JsonRpc.Test.Modules;
 [TestFixture]
 public class AdminModuleTests
 {
+    private const string _enodeString = "enode://e1b7e0dc09aae610c9dec8a0bee62bab9946cc27ebdd2f9e3571ed6d444628f99e91e43f4a14d42d498217608bb3e1d1bc8ec2aa27d7f7e423413b851bae02bc@127.0.0.1:30303";
+    private const string _exampleDataDir = "/example/dbdir";
+
     private IAdminRpcModule _adminRpcModule = null!;
     private EthereumJsonSerializer _serializer = null!;
     private NetworkConfig _networkConfig = null!;
@@ -50,8 +53,6 @@ public class AdminModuleTests
     private IJsonSerializer _jsonSerializer = null!;
     private IBlockTree _blockTree = null!;
     private IStateReader _stateReader = null!;
-    private const string _enodeString = "enode://e1b7e0dc09aae610c9dec8a0bee62bab9946cc27ebdd2f9e3571ed6d444628f99e91e43f4a14d42d498217608bb3e1d1bc8ec2aa27d7f7e423413b851bae02bc@127.0.0.1:30303";
-    private const string _exampleDataDir = "/example/dbdir";
     private ISubscriptionManager _subscriptionManager = null!;
     private IPeerPool _peerPool = null!;
     private IRlpxHost _rlpxPeer = null!;
@@ -70,52 +71,37 @@ public class AdminModuleTests
         _blockTree = Build.A.BlockTree().OfChainLength(5).TestObject;
         _stateReader = Substitute.For<IStateReader>();
         _networkConfig = new NetworkConfig();
+
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         ConcurrentDictionary<PublicKeyAsKey, Peer> dict = new();
-
-        // Create a peer with a validated session
         Peer testPeer = new(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303, true));
         ISession validatedSession = Substitute.For<ISession>();
         validatedSession.IsNetworkIdMatched.Returns(true);
         testPeer.OutSession = validatedSession;
-
         dict.TryAdd(TestItem.PublicKeyA, testPeer);
         peerPool.ActivePeers.Returns(dict);
         _peerPool = peerPool;
+
         _existingSession1 = Substitute.For<ISession>();
         _existingSession2 = Substitute.For<ISession>();
         List<ISession> existingSessionsList = new() { _existingSession1, _existingSession2 };
-        IEnumerable<ISession> existingSessions = existingSessionsList;
-
         _rlpxPeer = Substitute.For<IRlpxHost>();
-        _rlpxPeer.SessionMonitor.Sessions.Returns(existingSessions);
-
-        IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
-        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        Enode enode = new(_enodeString);
-        ChainSpec chainSpec = new()
-        {
-            Parameters = new ChainParameters()
-        };
+        _rlpxPeer.SessionMonitor.Sessions.Returns(existingSessionsList);
 
         SubscriptionFactory subscriptionFactory = new();
-
         subscriptionFactory.RegisterPeerEventsSubscription(_logManager, _peerPool, _rlpxPeer);
-
-        _subscriptionManager = new SubscriptionManager(
-            subscriptionFactory,
-            _logManager);
+        _subscriptionManager = new SubscriptionManager(subscriptionFactory, _logManager);
 
         _adminRpcModule = new AdminRpcModule(
             _blockTree,
             _networkConfig,
             peerPool,
-            staticNodesManager,
+            Substitute.For<IStaticNodesManager>(),
             _stateReader,
-            enode,
+            new Enode(_enodeString),
             _exampleDataDir,
-            chainSpec.Parameters,
-            trustedNodesManager,
+            new ChainSpec { Parameters = new ChainParameters() }.Parameters,
+            Substitute.For<ITrustedNodesManager>(),
             _subscriptionManager);
         _adminRpcModule.Context = new JsonRpcContext(RpcEndpoint.Ws, _jsonRpcDuplexClient);
 
@@ -131,245 +117,152 @@ public class AdminModuleTests
         _existingSession2?.Dispose();
     }
 
-    private JsonRpcResult GetPeerEventsAddResult(PeerEventArgs peerEventArgs, out string subscriptionId, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        _peerPool.PeerAdded += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        return jsonRpcResult;
-    }
-    private JsonRpcResult GetPeerEventsRemovedResult(PeerEventArgs peerEventArgs, out string subscriptionId, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        _peerPool.PeerRemoved += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        return jsonRpcResult;
-    }
-
-    private JsonRpcResult GetPeerEventsMsgReceivedResult(PeerEventArgs peerEventArgs, out string subscriptionId, ISession _session, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        _session.MsgReceived += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        peerEventsSubscription.Dispose();
-        return jsonRpcResult;
-    }
-
-    private JsonRpcResult GetPeerEventsMsgReceivedResultNewSession(PeerEventArgs peerEventArgs, out string subscriptionId, ISession _session, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        SessionEventArgs sessionEventArgs = new(_session);
-        _rlpxPeer.SessionCreated += Raise.EventWith(_rlpxPeer, sessionEventArgs);
-
-        _session.MsgReceived += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        return jsonRpcResult;
-    }
-
-    private JsonRpcResult GetPeerEventsMsgDeliveredResult(PeerEventArgs peerEventArgs, out string subscriptionId, ISession _session, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        _session.MsgDelivered += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        peerEventsSubscription.Dispose();
-        return jsonRpcResult;
-    }
-
-    private JsonRpcResult GetPeerEventsMsgDeliveredResultNewSession(PeerEventArgs peerEventArgs, out string subscriptionId, ISession _session, bool shouldReceiveResult = true)
-    {
-        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
-        JsonRpcResult jsonRpcResult = new();
-        ManualResetEvent manualResetEvent = new(false);
-        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
-        {
-            jsonRpcResult = j;
-            manualResetEvent.Set();
-        }));
-        SessionEventArgs sessionEventArgs = new(_session);
-        _rlpxPeer.SessionCreated += Raise.EventWith(_rlpxPeer, sessionEventArgs);
-
-        _session.MsgDelivered += Raise.EventWith(new object(), peerEventArgs);
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
-        subscriptionId = peerEventsSubscription.Id;
-        return jsonRpcResult;
-    }
-
     [Test]
-    public async Task Test_peers()
+    public async Task AdminPeers_WithSingleStaticPeer_ReturnsOnePeerInfo()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_peers");
+
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         List<PeerInfo> peerInfoList = ((JsonElement)response.Result!).Deserialize<List<PeerInfo>>(EthereumJsonSerializer.JsonOptions)!;
-        peerInfoList.Count.Should().Be(1);
+        peerInfoList.Count.Should().Be(1, because: "the setup wires exactly one validated active peer");
+
         PeerInfo peerInfo = peerInfoList[0];
-        peerInfo.Network.RemoteAddress.Should().NotBeNullOrEmpty(); // Fixed: more flexible network address checking
-        peerInfo.Network.Inbound.Should().BeFalse();
-        peerInfo.Network.Static.Should().BeTrue();
-        peerInfo.Id.Should().NotBeNull();
+        peerInfo.Network.RemoteAddress.Should().NotBeNullOrEmpty(because: "the validated session must report a remote address");
+        peerInfo.Network.Inbound.Should().BeFalse(because: "the test peer is configured with an outbound session");
+        peerInfo.Network.Static.Should().BeTrue(because: "the test peer is constructed with isStatic=true");
+        peerInfo.Id.Should().NotBeNull(because: "every peer carries a public-key identifier");
     }
 
     [Test]
-    public async Task Test_node_info()
+    public async Task AdminNodeInfo_OnDefaultModule_ReturnsExpectedNodeAndProtocolFields()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_nodeInfo");
+
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         NodeInfo nodeInfo = ((JsonElement)response.Result!).Deserialize<NodeInfo>(EthereumJsonSerializer.JsonOptions)!;
-        nodeInfo.Enode.Should().Be(_enodeString);
-        nodeInfo.Id.Should().Be("ae3623ef35c06ab49e9ae4b9f5a2b0f1983c28f85de1ccc98e2174333fdbdf1f");
-        nodeInfo.Ip.Should().Be("127.0.0.1");
-        nodeInfo.Name.Should().Be(ProductInfo.ClientId);
-        nodeInfo.ListenAddress.Should().Be("127.0.0.1:30303");
-        nodeInfo.Ports.Discovery.Should().Be(_networkConfig.DiscoveryPort);
-        nodeInfo.Ports.Listener.Should().Be(_networkConfig.P2PPort);
 
-        nodeInfo.Protocols.Should().HaveCount(1);
-        nodeInfo.Protocols["eth"].Difficulty.Should().Be(_blockTree.Head?.TotalDifficulty ?? 0);
-        nodeInfo.Protocols["eth"].HeadHash.Should().Be(_blockTree.HeadHash);
-        nodeInfo.Protocols["eth"].GenesisHash.Should().Be(_blockTree.GenesisHash);
-        nodeInfo.Protocols["eth"].NetworkId.Should().Be(_blockTree.NetworkId);
-        nodeInfo.Protocols["eth"].ChainId.Should().Be(_blockTree.ChainId);
+        nodeInfo.Enode.Should().Be(_enodeString, because: "admin_nodeInfo echoes the configured local enode URL");
+        nodeInfo.Id.Should().Be("ae3623ef35c06ab49e9ae4b9f5a2b0f1983c28f85de1ccc98e2174333fdbdf1f", because: "node id is the keccak hash of the configured public key");
+        nodeInfo.Ip.Should().Be("127.0.0.1", because: "the configured enode advertises 127.0.0.1");
+        nodeInfo.Name.Should().Be(ProductInfo.ClientId, because: "the node identifies itself with the runtime client id");
+        nodeInfo.ListenAddress.Should().Be("127.0.0.1:30303", because: "listenAddress is host:port from the configured enode");
+        nodeInfo.Ports.Discovery.Should().Be(_networkConfig.DiscoveryPort, because: "discovery port comes from network config");
+        nodeInfo.Ports.Listener.Should().Be(_networkConfig.P2PPort, because: "listener port comes from network config");
+
+        nodeInfo.Protocols.Should().HaveCount(1, because: "only the eth protocol is registered in this test setup");
+        nodeInfo.Protocols["eth"].Difficulty.Should().Be(_blockTree.Head?.TotalDifficulty ?? 0, because: "difficulty mirrors the head total difficulty");
+        nodeInfo.Protocols["eth"].HeadHash.Should().Be(_blockTree.HeadHash, because: "head hash mirrors the block tree head");
+        nodeInfo.Protocols["eth"].GenesisHash.Should().Be(_blockTree.GenesisHash, because: "genesis hash mirrors the block tree genesis");
+        nodeInfo.Protocols["eth"].NetworkId.Should().Be(_blockTree.NetworkId, because: "network id mirrors the block tree network id");
+        nodeInfo.Protocols["eth"].ChainId.Should().Be(_blockTree.ChainId, because: "chain id mirrors the block tree chain id");
     }
 
     [Test]
-    public async Task Test_admin_dataDir()
+    public async Task AdminDataDir_OnDefaultModule_ReturnsConfiguredPath()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_dataDir");
+
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
-        response.Result!.ToString().Should().Be(_exampleDataDir);
+        response.Result!.ToString().Should().Be(_exampleDataDir, because: "admin_dataDir reflects the path passed at module construction");
     }
 
-    [Test]
-    public async Task Test_hasStateForBlock()
+    [TestCase(false, TestName = "AdminIsStateRootAvailable_WhenStateMissing_ReturnsFalse")]
+    [TestCase(true, TestName = "AdminIsStateRootAvailable_WhenStatePresent_ReturnsTrue")]
+    public async Task AdminIsStateRootAvailable_ReflectsStateReaderResult(bool stateAvailable)
     {
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_isStateRootAvailable", "latest")).Should().Contain("false");
-        _stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(true);
-        (await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_isStateRootAvailable", "latest")).Should().Contain("true");
+        _stateReader.HasStateForBlock(Arg.Any<BlockHeader>()).Returns(stateAvailable);
+
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_isStateRootAvailable", "latest");
+
+        serialized.Should().Contain(stateAvailable ? "true" : "false", because: "admin_isStateRootAvailable mirrors the state reader's HasStateForBlock answer");
     }
 
-    [Test]
-    public async Task Test_admin_addTrustedPeer()
+    [TestCase(false, false, TestName = "AdminAddTrustedPeer_WhenPersistentFalse_KeepsAsInMemoryTrustedPeer")]
+    [TestCase(true, true, TestName = "AdminAddTrustedPeer_WhenPersistentTrue_AlsoWritesToTrustedNodesFile")]
+    public async Task AdminAddTrustedPeer_WithValidEnode_AddsAsTrustedPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile)
     {
-        // Setup dependencies
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        IPeerPool peerPool = Substitute.For<IPeerPool>();
-
-        ChainSpec chainSpec = new() { Parameters = new ChainParameters() };
-
-        // Mock AddAsync to return true for any enode (to simplify)
         trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        IPeerPool peerPool = Substitute.For<IPeerPool>();
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(peerPool: peerPool, trustedNodesManager: trustedNodesManager);
 
-        // Create the adminRpcModule as IAdminRpcModule (important for RpcTest)
-        IAdminRpcModule adminRpcModule = new AdminRpcModule(
-            _blockTree,
-            _networkConfig,
-            peerPool,
-            Substitute.For<IStaticNodesManager>(),
-            Substitute.For<IStateReader>(),
-            new Enode(_enodeString),
-            _exampleDataDir,
-            chainSpec.Parameters,
-            trustedNodesManager,
-            _subscriptionManager);
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString, persistent);
 
-        // Call admin_addTrustedPeer via the RPC test helper
-        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString);
-
-        // Deserialize the response
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
-        response.Should().NotBeNull("Response should not be null");
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
-        result.Should().BeTrue("The RPC call should succeed and return true");
-
-        // Verify that AddAsync was called once with any Enode
-        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), Arg.Any<bool>());
-
-        // Verify that peerPool.GetOrAdd was called once with any NetworkNode
+        result.Should().BeTrue(because: "a valid enode is added to the trusted peer set and the call must report success as a boolean");
+        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), expectedUpdateFile);
         peerPool.Received(1).GetOrAdd(Arg.Any<NetworkNode>());
     }
 
     [Test]
-    public async Task Test_admin_removeTrustedPeer()
+    public async Task AdminAddTrustedPeer_WhenAlreadyTrusted_StillReturnsTrue()
     {
-        // Setup dependencies
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        IPeerPool peerPool = Substitute.For<IPeerPool>();
+        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
 
-        ChainSpec chainSpec = new() { Parameters = new ChainParameters() };
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString);
 
-        // Mock RemoveAsync to return true for any enode (to simplify)
-        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
-
-        // Create the adminRpcModule as IAdminRpcModule (important for RpcTest)
-        IAdminRpcModule adminRpcModule = new AdminRpcModule(
-            _blockTree,
-            _networkConfig,
-            peerPool,
-            Substitute.For<IStaticNodesManager>(),
-            Substitute.For<IStateReader>(),
-            new Enode(_enodeString),
-            _exampleDataDir,
-            chainSpec.Parameters,
-            trustedNodesManager,
-            _subscriptionManager);
-
-        // Call admin_removeTrustedPeer via the RPC test helper
-        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removeTrustedPeer", _enodeString);
-
-        // Deserialize the response
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
-        response.Should().NotBeNull("Response should not be null");
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
-        result.Should().BeTrue("The RPC call should succeed and return true");
-
-        // Verify that RemoveAsync was called once with any Enode
-        await trustedNodesManager.Received(1).RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>());
+        result.Should().BeTrue(because: "addTrustedPeer is idempotent: trusting an already-trusted peer is success, matching geth's Server.AddTrustedPeer semantics");
     }
 
     [Test]
-    public async Task Smoke_solc() => _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_setSolc");
+    public async Task AdminAddTrustedPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
+    {
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addTrustedPeer", "not-an-enode");
+
+        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
+        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
+    }
+
+    [TestCase(false, false, TestName = "AdminRemoveTrustedPeer_WhenPersistentFalse_DropsInMemoryTrustedEntry")]
+    [TestCase(true, true, TestName = "AdminRemoveTrustedPeer_WhenPersistentTrue_AlsoRemovesFromTrustedNodesFile")]
+    public async Task AdminRemoveTrustedPeer_WithValidEnode_RemovesFromTrustedAndReturnsTrue(bool persistent, bool expectedUpdateFile)
+    {
+        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
+        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
+
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removeTrustedPeer", _enodeString, persistent);
+
+        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
+        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
+        result.Should().BeTrue(because: "a valid enode is removed from the trusted set, reported as a boolean");
+        await trustedNodesManager.Received(1).RemoveAsync(Arg.Any<Enode>(), expectedUpdateFile);
+    }
 
     [Test]
-    public async Task Smoke_test_peers()
+    public async Task AdminRemoveTrustedPeer_WhenPeerNotTrusted_StillReturnsTrue()
+    {
+        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
+        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
+
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removeTrustedPeer", _enodeString);
+
+        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
+        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
+        result.Should().BeTrue(because: "removeTrustedPeer is idempotent: untrusting an unknown peer is success, matching geth's Server.RemoveTrustedPeer semantics");
+    }
+
+    [Test]
+    public async Task AdminRemoveTrustedPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
+    {
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removeTrustedPeer", "not-an-enode");
+
+        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
+        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
+    }
+
+    [Test]
+    public async Task AdminSetSolc_WhenInvoked_DoesNotThrow() =>
+        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_setSolc");
+
+    [Test]
+    public async Task AdminPeerLifecycle_AddRemoveListBothArities_DoesNotThrow()
     {
         _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addPeer", _enodeString);
         _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removePeer", _enodeString);
@@ -378,160 +271,225 @@ public class AdminModuleTests
         _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_peers");
     }
 
+    [TestCase(false, false, TestName = "AdminAddPeer_WhenPersistentFalse_KeepsAsInMemoryStaticPeer")]
+    [TestCase(true, true, TestName = "AdminAddPeer_WhenPersistentTrue_AlsoWritesToStaticNodesFile")]
+    public async Task AdminAddPeer_WithValidEnode_AddsAsStaticPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile)
+    {
+        IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
+        staticNodesManager.AddAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager);
+
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addPeer", _enodeString, persistent);
+
+        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
+        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
+        result.Should().BeTrue(because: "a valid enode is added to the static peer set and the call must report success as a boolean");
+        await staticNodesManager.Received(1).AddAsync(_enodeString, updateFile: expectedUpdateFile);
+    }
+
     [Test]
-    public async Task Admin_unsubscribe_success()
+    public async Task AdminAddPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
+    {
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addPeer", "not-an-enode");
+
+        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
+        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
+    }
+
+    [TestCase(false, false, TestName = "AdminRemovePeer_WhenPersistentFalse_DropsInMemoryStaticEntry")]
+    [TestCase(true, true, TestName = "AdminRemovePeer_WhenPersistentTrue_AlsoRemovesFromStaticNodesFile")]
+    public async Task AdminRemovePeer_WithValidEnode_RemovesFromStaticAndPoolAndReturnsTrue(bool persistent, bool expectedUpdateFile)
+    {
+        IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
+        staticNodesManager.RemoveAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        IPeerPool peerPool = Substitute.For<IPeerPool>();
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager, peerPool: peerPool);
+
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removePeer", _enodeString, persistent);
+
+        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
+        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
+        result.Should().BeTrue(because: "a valid enode is removed from the static peer set and active session, reported as a boolean");
+        await staticNodesManager.Received(1).RemoveAsync(_enodeString, updateFile: expectedUpdateFile);
+        peerPool.Received(1).TryRemove(Arg.Any<PublicKey>(), out Arg.Any<Peer>());
+    }
+
+    [Test]
+    public async Task AdminRemovePeer_WhenPeerNotFound_StillReturnsTrue()
+    {
+        IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
+        staticNodesManager.RemoveAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        IPeerPool peerPool = Substitute.For<IPeerPool>();
+        peerPool.TryRemove(Arg.Any<PublicKey>(), out Arg.Any<Peer>()).Returns(false);
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager, peerPool: peerPool);
+
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removePeer", _enodeString);
+
+        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
+        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
+        result.Should().BeTrue(because: "removePeer is idempotent: removing an unknown peer is success, matching geth's Server.RemovePeer semantics");
+    }
+
+    [Test]
+    public async Task AdminRemovePeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
+    {
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removePeer", "not-an-enode");
+
+        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
+        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
+    }
+
+    [Test]
+    public async Task AdminUnsubscribe_AfterSubscribe_ReturnsTrue()
     {
         string serializedSub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe", "peerEvents");
         string subscriptionId = serializedSub.Substring(serializedSub.Length - 44, 34);
         string expectedSub = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", subscriptionId, "\",\"id\":67}");
-        expectedSub.Should().Be(serializedSub);
+        expectedSub.Should().Be(serializedSub, because: "admin_subscribe returns the subscription id in the result envelope");
 
         string serializedUnsub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_unsubscribe", subscriptionId);
         string expectedUnsub = "{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":67}";
-
-        expectedUnsub.Should().Be(serializedUnsub);
+        expectedUnsub.Should().Be(serializedUnsub, because: "admin_unsubscribe reports success as boolean true");
     }
 
     [Test]
-    public async Task No_subscription_name_admin()
+    public async Task AdminSubscribe_WithoutName_ReturnsInvalidParams()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe");
+
         string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"missing value for required argument 0\"},\"id\":67}";
-        expectedResult.Should().Be(serialized);
+        expectedResult.Should().Be(serialized, because: "missing required argument is a JSON-RPC InvalidParams error");
     }
 
     [Test]
-    public async Task Admin_subscriptions_remove_after_closing_websockets_client()
+    public async Task AdminUnsubscribe_AfterClientCloses_ReturnsFailure()
     {
         string serializedPeerEvents = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe", "peerEvents");
         string peerEventsId = serializedPeerEvents.Substring(serializedPeerEvents.Length - 44, 34);
         string expectedPeerEvents = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", peerEventsId, "\",\"id\":67}");
-        expectedPeerEvents.Should().Be(serializedPeerEvents);
+        expectedPeerEvents.Should().Be(serializedPeerEvents, because: "precondition: subscribe returns the new subscription id");
 
         _jsonRpcDuplexClient.Closed += Raise.Event();
 
         string serializedPeerEventsUnsub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_unsubscribe", peerEventsId);
-        string expectedPeerEventsUnsub =
-            string.Concat("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Failed to unsubscribe: ",
-                peerEventsId, ".\",\"data\":false},\"id\":67}");
-        expectedPeerEventsUnsub.Should().Be(serializedPeerEventsUnsub);
+        string expectedPeerEventsUnsub = string.Concat(
+            "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Failed to unsubscribe: ",
+            peerEventsId, ".\",\"data\":false},\"id\":67}");
+        expectedPeerEventsUnsub.Should().Be(serializedPeerEventsUnsub, because: "after the client closes, the subscription is removed and unsubscribe fails");
     }
 
     [Test]
-    public async Task PeerEventsSubscription_creating_result()
+    public async Task AdminSubscribePeerEvents_OnSubscribe_ReturnsSubscriptionId()
     {
         string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe", "peerEvents");
+
         string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
-        expectedResult.Should().Be(serialized);
+        expectedResult.Should().Be(serialized, because: "the result envelope wraps the subscription id under the \"result\" key");
     }
 
-    [Test]
-    public void Admin_subscription_on_PeerAdded_event()
+    [TestCase(true, "add", TestName = "PeerEvents_OnPeerAdded_NotifiesAddType")]
+    [TestCase(false, "drop", TestName = "PeerEvents_OnPeerRemoved_NotifiesDropType")]
+    public void PeerEventsSubscription_OnPeerLifecycleEvent_NotifiesExpectedType(bool isAdd, string expectedType)
     {
         Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsAddResult(new PeerEventArgs(new Peer(node)), out string subscriptionId);
-        jsonRpcResult.Response.Should().NotBeNull();
+        PeerEventArgs peerEventArgs = new(new Peer(node));
+
+        JsonRpcResult jsonRpcResult = RaisePeerEventAndCapture(
+            isAdd
+                ? () => _peerPool.PeerAdded += Raise.EventWith(new object(), peerEventArgs)
+                : () => _peerPool.PeerRemoved += Raise.EventWith(new object(), peerEventArgs),
+            out string subscriptionId);
+
+        jsonRpcResult.Response.Should().NotBeNull(because: "the subscription must produce a JSON-RPC response when the event fires");
         string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"add\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
+        string expectedResult = BuildExpectedPeerLifecycleNotification(subscriptionId, expectedType, TestItem.PublicKeyA.Hash.ToString(false));
+        expectedResult.Should().Be(serialized, because: $"a peer-{expectedType} event must serialize with type '{expectedType}'");
     }
 
-    [Test]
-    public void Admin_subscription_on_PeerRemoved_event()
+    [TestCase(true, "msgrecv", TestName = "PeerEvents_OnMsgReceived_NotifiesMsgrecvType")]
+    [TestCase(false, "msgsend", TestName = "PeerEvents_OnMsgDelivered_NotifiesMsgsendType")]
+    public void PeerEventsSubscription_OnMessageEvent_NotifiesExpectedType(bool isReceived, string expectedType)
     {
         Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsRemovedResult(new PeerEventArgs(new Peer(node)), out string subscriptionId);
-        jsonRpcResult.Response.Should().NotBeNull();
+        PeerEventArgs peerEventArgs = new(node, "BitTorrent", 1, 2);
+        ISession session = _existingSession1;
+
+        JsonRpcResult jsonRpcResult = RaisePeerEventAndCapture(
+            isReceived
+                ? () => session.MsgReceived += Raise.EventWith(new object(), peerEventArgs)
+                : () => session.MsgDelivered += Raise.EventWith(new object(), peerEventArgs),
+            out string subscriptionId,
+            disposeSubscription: true);
+
+        jsonRpcResult.Response.Should().NotBeNull(because: "the subscription must produce a JSON-RPC response when the event fires");
         string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"drop\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
+        string expectedResult = BuildExpectedMessageNotification(subscriptionId, expectedType, TestItem.PublicKeyA.Hash.ToString(false));
+        expectedResult.Should().Be(serialized, because: $"a {expectedType} event must serialize with type '{expectedType}'");
     }
 
-    [Test]
-    public void Admin_subscription_on_MsgReceived_event()
+    [TestCase(true, "msgrecv", TestName = "PeerEvents_OnMsgReceivedAcrossExistingSessions_NotifiesEach")]
+    [TestCase(false, "msgsend", TestName = "PeerEvents_OnMsgDeliveredAcrossExistingSessions_NotifiesEach")]
+    public void PeerEventsSubscription_OnMessageEventAcrossMultipleSessions_NotifiesEach(bool isReceived, string expectedType)
     {
         Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsMsgReceivedResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId, _existingSession1);
-        jsonRpcResult.Response.Should().NotBeNull();
-        string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"msgrecv\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
+        PeerEventArgs peerEventArgs = new(node, "BitTorrent", 1, 2);
+        string peerHash = TestItem.PublicKeyA.Hash.ToString(false);
+
+        JsonRpcResult firstResult = RaisePeerEventAndCapture(
+            isReceived
+                ? () => _existingSession1.MsgReceived += Raise.EventWith(new object(), peerEventArgs)
+                : () => _existingSession1.MsgDelivered += Raise.EventWith(new object(), peerEventArgs),
+            out string firstSubscriptionId,
+            disposeSubscription: true);
+        firstResult.Response.Should().NotBeNull(because: "the subscription must notify on the first existing session");
+        BuildExpectedMessageNotification(firstSubscriptionId, expectedType, peerHash)
+            .Should().Be(_jsonSerializer.Serialize(firstResult.Response), because: $"first session emits {expectedType}");
+
+        JsonRpcResult secondResult = RaisePeerEventAndCapture(
+            isReceived
+                ? () => _existingSession2.MsgReceived += Raise.EventWith(new object(), peerEventArgs)
+                : () => _existingSession2.MsgDelivered += Raise.EventWith(new object(), peerEventArgs),
+            out string secondSubscriptionId,
+            disposeSubscription: true);
+        secondResult.Response.Should().NotBeNull(because: "the subscription must also notify on the second existing session");
+        BuildExpectedMessageNotification(secondSubscriptionId, expectedType, peerHash)
+            .Should().Be(_jsonSerializer.Serialize(secondResult.Response), because: $"second session emits {expectedType}");
     }
 
-    [Test]
-    public void Admin_subscription_on_MsgDelivered_event()
-    {
-        Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsMsgDeliveredResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId, _existingSession1);
-        jsonRpcResult.Response.Should().NotBeNull();
-        string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"msgsend\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
-    }
-
-    [Test]
-    public void MsgReceived_event_on_all_existing_session()
-    {
-        Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult1 = GetPeerEventsMsgReceivedResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId1, _existingSession1);
-        jsonRpcResult1.Response.Should().NotBeNull();
-        string serialized1 = _jsonSerializer.Serialize(jsonRpcResult1.Response);
-        string expectedResult1 = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId1, "\",\"result\":{\"type\":\"msgrecv\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult1.Should().Be(serialized1);
-
-        JsonRpcResult jsonRpcResult2 = GetPeerEventsMsgReceivedResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId2, _existingSession2);
-        jsonRpcResult2.Response.Should().NotBeNull();
-        string serialized2 = _jsonSerializer.Serialize(jsonRpcResult2.Response);
-        string expectedResult2 = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId2, "\",\"result\":{\"type\":\"msgrecv\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult2.Should().Be(serialized2);
-    }
-
-    [Test]
-    public void MsgDelivered_event_on_all_existing_session()
-    {
-        Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult1 = GetPeerEventsMsgDeliveredResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId1, _existingSession1);
-        jsonRpcResult1.Response.Should().NotBeNull();
-        string serialized1 = _jsonSerializer.Serialize(jsonRpcResult1.Response);
-        string expectedResult1 = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId1, "\",\"result\":{\"type\":\"msgsend\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult1.Should().Be(serialized1);
-
-        JsonRpcResult jsonRpcResult2 = GetPeerEventsMsgDeliveredResult(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId2, _existingSession2);
-        jsonRpcResult2.Response.Should().NotBeNull();
-        string serialized2 = _jsonSerializer.Serialize(jsonRpcResult2.Response);
-        string expectedResult2 = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId2, "\",\"result\":{\"type\":\"msgsend\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult2.Should().Be(serialized2);
-    }
-
-    [Test]
-    public void MsgReceived_event_on_new_session()
+    [TestCase(true, "msgrecv", TestName = "PeerEvents_OnMsgReceivedFromNewSession_NotifiesNewSessionMsg")]
+    [TestCase(false, "msgsend", TestName = "PeerEvents_OnMsgDeliveredFromNewSession_NotifiesNewSessionMsg")]
+    public void PeerEventsSubscription_OnMessageEventFromNewSession_NotifiesNewSessionMessage(bool isReceived, string expectedType)
     {
         ISession newSession = Substitute.For<ISession>();
         Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsMsgReceivedResultNewSession(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId, newSession);
-        jsonRpcResult.Response.Should().NotBeNull();
+        PeerEventArgs peerEventArgs = new(node, "BitTorrent", 1, 2);
+
+        JsonRpcResult jsonRpcResult = RaisePeerEventAndCapture(
+            () =>
+            {
+                _rlpxPeer.SessionCreated += Raise.EventWith(_rlpxPeer, new SessionEventArgs(newSession));
+                if (isReceived)
+                {
+                    newSession.MsgReceived += Raise.EventWith(new object(), peerEventArgs);
+                }
+                else
+                {
+                    newSession.MsgDelivered += Raise.EventWith(new object(), peerEventArgs);
+                }
+            },
+            out string subscriptionId);
+
+        jsonRpcResult.Response.Should().NotBeNull(because: "the subscription must notify on a session created after subscribe");
         string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"msgrecv\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
+        string expectedResult = BuildExpectedMessageNotification(subscriptionId, expectedType, TestItem.PublicKeyA.Hash.ToString(false));
+        expectedResult.Should().Be(serialized, because: $"a {expectedType} event from the new session must serialize with type '{expectedType}'");
     }
 
     [Test]
-    public void MsgDelivered_event_on_new_session()
-    {
-        ISession newSession = Substitute.For<ISession>();
-        Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        JsonRpcResult jsonRpcResult = GetPeerEventsMsgDeliveredResultNewSession(new PeerEventArgs(node, "BitTorrent", 1, 2), out string subscriptionId, newSession);
-        jsonRpcResult.Response.Should().NotBeNull();
-        string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-        string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"type\":\"msgsend\",\"peer\":\"", TestItem.PublicKeyA.Hash.ToString(false), "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
-        expectedResult.Should().Be(serialized);
-    }
-
-    [Test]
-    public void MsgDelivered_after_session_closed()
+    public void PeerEventsSubscription_OnMsgDeliveredAfterDisconnect_DoesNotNotify()
     {
         Node node = new(TestItem.PublicKeyA, "192.168.1.18", 8000, false);
-        DisconnectEventArgs disconnectEventArgs = new(new DisconnectReason(), new DisconnectType(), "");
+        DisconnectEventArgs disconnectEventArgs = new(new DisconnectReason(), new DisconnectType(), string.Empty);
         PeerEventArgs peerEventArgs = new(node, "BitTorrent", 1, 2);
         PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
         JsonRpcResult jsonRpcResult = new();
@@ -541,11 +499,171 @@ public class AdminModuleTests
             jsonRpcResult = j;
             manualResetEvent.Set();
         }));
+
         _existingSession1.Disconnected += Raise.EventWith(_existingSession1, disconnectEventArgs);
         _existingSession1.MsgDelivered += Raise.EventWith(new object(), peerEventArgs);
 
-        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(false);
+        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().BeFalse(because: "after disconnect the session is unhooked and must not raise further notifications");
     }
+
+    [Test]
+    public void AdminPeers_WithGethStaticPeerExposingSnap_ReturnsBothCapabilities()
+    {
+        Capability[] capabilities = [new Capability("eth", 68), new Capability("snap", 1)];
+        Peer peer = CreateTestPeer("Geth/v1.15.10-stable-2bf8a789/linux-amd64/go1.24.2", capabilities, isStatic: true);
+        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
+
+        ResultWrapper<PeerInfo[]> result = module.admin_peers();
+
+        result.Data.Should().HaveCount(1, because: "the peer pool was seeded with exactly one peer");
+        PeerInfo peerInfo = result.Data[0];
+        peerInfo.Id.Should().Be(TestItem.PublicKeyA, because: "the peer id is the public key passed to CreateTestPeer");
+        peerInfo.Name.Should().Be("Geth/v1.15.10-stable-2bf8a789/linux-amd64/go1.24.2", because: "the peer's client id is reported under name");
+        peerInfo.Network.Static.Should().BeTrue(because: "isStatic was set to true on the test peer");
+        peerInfo.Network.Inbound.Should().BeFalse(because: "the test peer was set up with an outbound session");
+        peerInfo.Caps.Should().BeEquivalentTo(capabilities, because: "all advertised capabilities must surface in admin_peers");
+    }
+
+    [Test]
+    public void AdminPeers_WhenPeerHasNoCapabilities_ReturnsEmptyCaps()
+    {
+        Peer peer = CreateTestPeer("TestClient", []);
+        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
+
+        ResultWrapper<PeerInfo[]> result = module.admin_peers();
+
+        result.Data[0].Caps.Should().BeEmpty(because: "a peer with no capabilities must report an empty caps array");
+    }
+
+    [Test]
+    public void AdminPeers_WithMultipleEthVersionsAndSnap_ReturnsAllProtocols()
+    {
+        Capability[] capabilities = [new Capability("eth", 67), new Capability("eth", 68), new Capability("snap", 1)];
+        Peer peer = CreateTestPeer("erigon/v3.0.12-39c6a6ff/linux-amd64/go1.23.10", capabilities);
+        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
+
+        ResultWrapper<PeerInfo[]> result = module.admin_peers();
+
+        PeerInfo peerInfo = result.Data[0];
+        peerInfo.Caps.Should().BeEquivalentTo(capabilities, because: "all advertised eth versions plus snap must be reported");
+        peerInfo.Protocols.Should().ContainKeys(new[] { "eth", "snap" }, because: "both eth and snap protocols are present in the capabilities");
+    }
+
+    [Test]
+    public void AdminPeers_OnInboundPeer_MarksNetworkInboundTrue()
+    {
+        Peer peer = CreateTestPeer("TestClient", [], isInbound: true);
+        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
+
+        ResultWrapper<PeerInfo[]> result = module.admin_peers();
+
+        PeerInfo peerInfo = result.Data[0];
+        peerInfo.Network.Inbound.Should().BeTrue(because: "the peer was created with isInbound=true");
+        peerInfo.Network.RemoteAddress.Should().Be("192.168.1.100:45678", because: "inbound sessions report the originating remote address");
+    }
+
+    [TestCase(68, "Nethermind/v1.25.4+2bf8a789/linux-x64/dotnet8.0.8", TestName = "AdminPeers_WithEthOnlyV68Peer_DoesNotIncludeSnap")]
+    [TestCase(66, "Geth/v1.10.0-stable/linux-amd64/go1.16.15", TestName = "AdminPeers_WithLegacyEthV66Peer_DoesNotIncludeSnap")]
+    public void AdminPeers_WithEthOnlyPeer_DoesNotIncludeSnapProtocol(int ethVersion, string clientId)
+    {
+        Capability[] capabilities = [new Capability("eth", ethVersion)];
+        Peer peer = CreateTestPeer(clientId, capabilities);
+        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
+
+        ResultWrapper<PeerInfo[]> result = module.admin_peers();
+
+        PeerInfo peerInfo = result.Data[0];
+        peerInfo.Caps.Should().BeEquivalentTo(capabilities, because: "only the advertised eth capability must surface");
+        peerInfo.Protocols.Should().ContainKey("eth", because: "the eth protocol entry must be present");
+        peerInfo.Protocols.Should().NotContainKey("snap", because: "snap was not advertised by this peer");
+    }
+
+    [Test]
+    public void PeerInfo_WithHashedPublicKeyJson_DeserializesSuccessfully()
+    {
+        const string fullKeyHex = "a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
+        byte[] fullPublicKeyBytes = Bytes.FromHexString(fullKeyHex);
+        byte[] expectedHashBytes = Keccak.Compute(fullPublicKeyBytes).Bytes.ToArray();
+        string expectedHashHex = Convert.ToHexString(expectedHashBytes).ToLower();
+        string json = $$"""
+            {
+                "id": "0x{{expectedHashHex}}",
+                "name": "test-peer",
+                "enode": "enode://{{fullKeyHex}}@127.0.0.1:30303",
+                "caps": [],
+                "network": { "localAddress": "127.0.0.1", "remoteAddress": "127.0.0.1:30303" },
+                "protocols": { "eth": { "version": 0 } }
+            }
+            """;
+        EthereumJsonSerializer serializer = new();
+
+        PeerInfo peerInfo = serializer.Deserialize<PeerInfo>(json);
+
+        peerInfo.Id.Should().NotBeNull(because: "a hashed-id PeerInfo JSON must still produce a non-null id");
+        peerInfo.Id.Bytes.Length.Should().Be(64, because: "the public key payload retains its 64-byte length even when the JSON only carried the 32-byte hash");
+        peerInfo.Id.Bytes.AsSpan(32, 32).ToArray().Should().BeEquivalentTo(expectedHashBytes, because: "the hash bytes from the JSON must occupy the last 32 bytes of the public key payload");
+    }
+
+    private IAdminRpcModule BuildAdminRpcModuleWith(
+        IStaticNodesManager? staticNodesManager = null,
+        ITrustedNodesManager? trustedNodesManager = null,
+        IPeerPool? peerPool = null)
+    {
+        ChainSpec chainSpec = new() { Parameters = new ChainParameters() };
+        return new AdminRpcModule(
+            _blockTree,
+            _networkConfig,
+            peerPool ?? Substitute.For<IPeerPool>(),
+            staticNodesManager ?? Substitute.For<IStaticNodesManager>(),
+            Substitute.For<IStateReader>(),
+            new Enode(_enodeString),
+            _exampleDataDir,
+            chainSpec.Parameters,
+            trustedNodesManager ?? Substitute.For<ITrustedNodesManager>(),
+            _subscriptionManager);
+    }
+
+    private JsonRpcResult RaisePeerEventAndCapture(Action raiseEvent, out string subscriptionId, bool disposeSubscription = false, bool shouldReceive = true)
+    {
+        PeerEventsSubscription peerEventsSubscription = new(_jsonRpcDuplexClient, _logManager, _peerPool, _rlpxPeer);
+        JsonRpcResult jsonRpcResult = new();
+        ManualResetEvent manualResetEvent = new(false);
+        peerEventsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
+        {
+            jsonRpcResult = j;
+            manualResetEvent.Set();
+        }));
+
+        raiseEvent();
+
+        manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceive, because: "the subscription should fire within the timeout");
+        subscriptionId = peerEventsSubscription.Id;
+        if (disposeSubscription)
+        {
+            peerEventsSubscription.Dispose();
+        }
+        return jsonRpcResult;
+    }
+
+    private static string BuildExpectedPeerLifecycleNotification(string subscriptionId, string type, string peerHash) =>
+        string.Concat(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"",
+            subscriptionId,
+            "\",\"result\":{\"type\":\"",
+            type,
+            "\",\"peer\":\"",
+            peerHash,
+            "\",\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
+
+    private static string BuildExpectedMessageNotification(string subscriptionId, string type, string peerHash) =>
+        string.Concat(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"admin_subscription\",\"params\":{\"subscription\":\"",
+            subscriptionId,
+            "\",\"result\":{\"type\":\"",
+            type,
+            "\",\"peer\":\"",
+            peerHash,
+            "\",\"protocol\":\"BitTorrent\",\"msgPacketType\":1,\"msgSize\":2,\"local\":\"192.168.1.18\",\"remote\":\"192.168.1.18:8000\"}}}");
 
     private static AdminRpcModule CreateMinimalAdminModule(IPeerPool peerPool)
     {
@@ -553,14 +671,13 @@ public class AdminModuleTests
         NetworkConfig networkConfig = new();
         IStateReader stateReader = Substitute.For<IStateReader>();
         ISubscriptionManager subscriptionManager = Substitute.For<ISubscriptionManager>();
-
         return new AdminRpcModule(
             blockTree,
             networkConfig,
             peerPool,
             Substitute.For<IStaticNodesManager>(),
             stateReader,
-            new Enode("enode://e1b7e0dc09aae610c9dec8a0bee62bab9946cc27ebdd2f9e3571ed6d444628f99e91e43f4a14d42d498217608bb3e1d1bc8ec2aa27d7f7e423413b851bae02bc@127.0.0.1:30303"),
+            new Enode(_enodeString),
             "/test/data",
             new ChainParameters(),
             Substitute.For<ITrustedNodesManager>(),
@@ -571,7 +688,6 @@ public class AdminModuleTests
     {
         ConcurrentDictionary<PublicKeyAsKey, Peer> peers = new();
         peers.TryAdd(TestItem.PublicKeyA, peer);
-
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         peerPool.ActivePeers.Returns(peers);
         return peerPool;
@@ -579,21 +695,14 @@ public class AdminModuleTests
 
     private static Peer CreateTestPeer(string clientId, Capability[] capabilities, bool isStatic = false, bool isInbound = false)
     {
-        // Create node
-        Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303, isStatic);
-        node.ClientId = clientId;
-
-        // Create peer
+        Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303, isStatic) { ClientId = clientId };
         Peer peer = new(node);
-
-        // Create session
         ISession session = Substitute.For<ISession>();
         session.RemoteHost.Returns("192.168.1.100");
         session.RemotePort.Returns(isInbound ? 45678 : 30303);
         session.LocalPort.Returns(30303);
         session.IsNetworkIdMatched.Returns(true);
 
-        // Setup capabilities
         if (capabilities.Length > 0)
         {
             IP2PProtocolHandler protocolHandler = Substitute.For<IP2PProtocolHandler>();
@@ -606,162 +715,14 @@ public class AdminModuleTests
             session.TryGetProtocolHandler("p2p", out Arg.Any<IProtocolHandler>()).Returns(false);
         }
 
-        // Attach session
-        if (isInbound) peer.InSession = session;
-        else peer.OutSession = session;
-
+        if (isInbound)
+        {
+            peer.InSession = session;
+        }
+        else
+        {
+            peer.OutSession = session;
+        }
         return peer;
-    }
-
-    [Test]
-    public void Admin_peers_returns_geth_with_snap_capabilities()
-    {
-        // Arrange
-        Peer peer = CreateTestPeer("Geth/v1.15.10-stable-2bf8a789/linux-amd64/go1.24.2",
-            new[] { new Capability("eth", 68), new Capability("snap", 1) }, isStatic: true);
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        result.Data.Should().HaveCount(1);
-        PeerInfo peerInfo = result.Data[0];
-
-        peerInfo.Id.Should().Be(TestItem.PublicKeyA);
-        peerInfo.Name.Should().Be("Geth/v1.15.10-stable-2bf8a789/linux-amd64/go1.24.2");
-        peerInfo.Network.Static.Should().BeTrue();
-        peerInfo.Network.Inbound.Should().BeFalse();
-        peerInfo.Caps.Should().BeEquivalentTo(new[] {
-            new Capability("eth", 68), new Capability("snap", 1) });
-    }
-
-    [Test]
-    public void Admin_peers_handles_empty_capabilities_correctly()
-    {
-        // Arrange
-        Peer peer = CreateTestPeer("TestClient", Array.Empty<Capability>());
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        result.Data[0].Caps.Should().BeEmpty();
-    }
-
-    [Test]
-    public void Admin_peers_supports_multiple_eth_versions_with_snap()
-    {
-        // Arrange
-        Capability[] capabilities = new[] {
-            new Capability("eth", 67), new Capability("eth", 68), new Capability("snap", 1) };
-        Peer peer = CreateTestPeer("erigon/v3.0.12-39c6a6ff/linux-amd64/go1.23.10", capabilities);
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        PeerInfo peerInfo = result.Data[0];
-        peerInfo.Caps.Should().BeEquivalentTo(capabilities);
-        peerInfo.Protocols.Should().ContainKeys("eth", "snap");
-    }
-
-    [Test]
-    public void Admin_peers_identifies_inbound_connections()
-    {
-        // Arrange
-        Peer peer = CreateTestPeer("TestClient", Array.Empty<Capability>(), isInbound: true);
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        PeerInfo peerInfo = result.Data[0];
-        peerInfo.Network.Inbound.Should().BeTrue();
-        peerInfo.Network.RemoteAddress.Should().Be("192.168.1.100:45678");
-    }
-
-    [Test]
-    public void Admin_peers_handles_eth_only_protocols()
-    {
-        // Arrange
-        Peer peer = CreateTestPeer("Nethermind/v1.25.4+2bf8a789/linux-x64/dotnet8.0.8",
-            new[] { new Capability("eth", 68) });
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        PeerInfo peerInfo = result.Data[0];
-        peerInfo.Caps.Should().BeEquivalentTo(new[] { new Capability("eth", 68) });
-        peerInfo.Protocols.Should().ContainKey("eth");
-        peerInfo.Protocols.Should().NotContainKey("snap");
-    }
-
-    [Test]
-    public void Admin_peers_uses_first_eth_version_for_protocol_info()
-    {
-        // Arrange
-        Capability[] capabilities = new[] {
-            new Capability("eth", 67), new Capability("eth", 68), new Capability("snap", 1) };
-        Peer peer = CreateTestPeer("erigon/v3.0.12", capabilities);
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        PeerInfo peerInfo = result.Data[0];
-        peerInfo.Caps.Should().BeEquivalentTo(capabilities);
-        peerInfo.Protocols.Should().ContainKeys("eth", "snap");
-    }
-
-    [Test]
-    public void Admin_peers_supports_legacy_eth_versions()
-    {
-        // Arrange
-        Peer peer = CreateTestPeer("Geth/v1.10.0-stable/linux-amd64/go1.16.15",
-            new[] { new Capability("eth", 66) });
-        AdminRpcModule module = CreateMinimalAdminModule(CreatePeerPool(peer));
-
-        // Act
-        ResultWrapper<PeerInfo[]> result = module.admin_peers();
-
-        // Assert
-        PeerInfo peerInfo = result.Data[0];
-        peerInfo.Caps.Should().BeEquivalentTo(new[] { new Capability("eth", 66) });
-        peerInfo.Protocols.Should().ContainKey("eth");
-        peerInfo.Protocols.Should().NotContainKey("snap"); // Old versions don't support snap
-    }
-
-    [Test]
-    public void PeerInfo_WithHashedPublicKeyJson_DeserializesSuccessfully()
-    {
-        const string fullKeyHex = "a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
-        byte[] fullPublicKeyBytes = Bytes.FromHexString(fullKeyHex);
-        byte[] expectedHashBytes = Keccak.Compute(fullPublicKeyBytes).Bytes.ToArray();
-        string expectedHashHex = Convert.ToHexString(expectedHashBytes).ToLower();
-
-        string json = $$"""
-            {
-                "id": "0x{{expectedHashHex}}",
-                "name": "test-peer",
-                "enode": "enode://{{fullKeyHex}}@127.0.0.1:30303",
-                "caps": [],
-                "network": { "localAddress": "127.0.0.1", "remoteAddress": "127.0.0.1:30303" },
-                "protocols": { "eth": { "version": 0 } }
-            }
-            """;
-
-        EthereumJsonSerializer serializer = new();
-        PeerInfo peerInfo = serializer.Deserialize<PeerInfo>(json);
-
-        peerInfo.Id.Should().NotBeNull();
-        peerInfo.Id.Bytes.Length.Should().Be(64);
-        peerInfo.Id.Bytes.AsSpan(32, 32).ToArray().Should().BeEquivalentTo(expectedHashBytes);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -197,17 +197,20 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task AdminAddTrustedPeer_WhenAlreadyTrusted_StillReturnsTrue()
+    public async Task AdminAddTrustedPeer_WhenAlreadyTrusted_SkipsAddAsyncAndPoolInsert()
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
-        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
+        trustedNodesManager.IsTrusted(Arg.Any<Enode>()).Returns(true);
+        IPeerPool peerPool = Substitute.For<IPeerPool>();
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager, peerPool: peerPool);
 
         string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString);
 
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "addTrustedPeer is idempotent: trusting an already-trusted peer is success, matching geth's Server.AddTrustedPeer semantics");
+        await trustedNodesManager.DidNotReceive().AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        peerPool.DidNotReceive().GetOrAdd(Arg.Any<NetworkNode>());
     }
 
     [TestCase("admin_addPeer", "not-an-enode", TestName = "AdminAddPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -102,7 +102,8 @@ public class AdminModuleTests
             _exampleDataDir,
             new ChainSpec { Parameters = new ChainParameters() }.Parameters,
             Substitute.For<ITrustedNodesManager>(),
-            _subscriptionManager);
+            _subscriptionManager,
+            new JsonRpcConfig());
         _adminRpcModule.Context = new JsonRpcContext(RpcEndpoint.Ws, _jsonRpcDuplexClient);
 
         _serializer = new EthereumJsonSerializer();
@@ -182,7 +183,7 @@ public class AdminModuleTests
     public async Task AdminAddTrustedPeer_WithValidEnode_AddsAsTrustedPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile)
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(peerPool: peerPool, trustedNodesManager: trustedNodesManager);
 
@@ -191,7 +192,7 @@ public class AdminModuleTests
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "a valid enode is added to the trusted peer set and the call must report success as a boolean");
-        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), expectedUpdateFile);
+        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), expectedUpdateFile, Arg.Any<CancellationToken>());
         peerPool.Received(1).GetOrAdd(Arg.Any<NetworkNode>());
     }
 
@@ -199,7 +200,7 @@ public class AdminModuleTests
     public async Task AdminAddTrustedPeer_WhenAlreadyTrusted_StillReturnsTrue()
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
 
         string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString);
@@ -209,12 +210,19 @@ public class AdminModuleTests
         result.Should().BeTrue(because: "addTrustedPeer is idempotent: trusting an already-trusted peer is success, matching geth's Server.AddTrustedPeer semantics");
     }
 
-    [Test]
-    public async Task AdminAddTrustedPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
+    [TestCase("admin_addPeer", "not-an-enode", TestName = "AdminAddPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_addPeer", "enode://badhex@127.0.0.1:30303", TestName = "AdminAddPeer_WhenEnodePublicKeyInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_removePeer", "not-an-enode", TestName = "AdminRemovePeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_removePeer", "enode://badhex@127.0.0.1:30303", TestName = "AdminRemovePeer_WhenEnodePublicKeyInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_addTrustedPeer", "not-an-enode", TestName = "AdminAddTrustedPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_addTrustedPeer", "enode://badhex@127.0.0.1:30303", TestName = "AdminAddTrustedPeer_WhenEnodePublicKeyInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_removeTrustedPeer", "not-an-enode", TestName = "AdminRemoveTrustedPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]
+    [TestCase("admin_removeTrustedPeer", "enode://badhex@127.0.0.1:30303", TestName = "AdminRemoveTrustedPeer_WhenEnodePublicKeyInvalid_ReturnsInvalidParamsError")]
+    public async Task AdminPeerMethods_WithInvalidEnode_ReturnsInvalidParamsError(string method, string badEnode)
     {
-        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addTrustedPeer", "not-an-enode");
+        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, method, badEnode);
 
-        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
+        serialized.Should().Contain("\"code\":-32602", because: "all four peer-management methods must return InvalidParams whether parsing fails at scheme or content level");
         serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
     }
 
@@ -223,7 +231,7 @@ public class AdminModuleTests
     public async Task AdminRemoveTrustedPeer_WithValidEnode_RemovesFromTrustedAndReturnsTrue(bool persistent, bool expectedUpdateFile)
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
 
         string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removeTrustedPeer", _enodeString, persistent);
@@ -231,14 +239,14 @@ public class AdminModuleTests
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "a valid enode is removed from the trusted set, reported as a boolean");
-        await trustedNodesManager.Received(1).RemoveAsync(Arg.Any<Enode>(), expectedUpdateFile);
+        await trustedNodesManager.Received(1).RemoveAsync(Arg.Any<Enode>(), expectedUpdateFile, Arg.Any<CancellationToken>());
     }
 
     [Test]
     public async Task AdminRemoveTrustedPeer_WhenPeerNotTrusted_StillReturnsTrue()
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        trustedNodesManager.RemoveAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
 
         string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_removeTrustedPeer", _enodeString);
@@ -249,34 +257,15 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task AdminRemoveTrustedPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
-    {
-        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removeTrustedPeer", "not-an-enode");
-
-        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
-        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
-    }
-
-    [Test]
     public async Task AdminSetSolc_WhenInvoked_DoesNotThrow() =>
         _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_setSolc");
-
-    [Test]
-    public async Task AdminPeerLifecycle_AddRemoveListBothArities_DoesNotThrow()
-    {
-        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addPeer", _enodeString);
-        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removePeer", _enodeString);
-        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addPeer", _enodeString, true);
-        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removePeer", _enodeString, true);
-        _ = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_peers");
-    }
 
     [TestCase(false, false, TestName = "AdminAddPeer_WhenPersistentFalse_KeepsAsInMemoryStaticPeer")]
     [TestCase(true, true, TestName = "AdminAddPeer_WhenPersistentTrue_AlsoWritesToStaticNodesFile")]
     public async Task AdminAddPeer_WithValidEnode_AddsAsStaticPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile)
     {
         IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
-        staticNodesManager.AddAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        staticNodesManager.AddAsync(Arg.Any<NetworkNode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager);
 
         string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addPeer", _enodeString, persistent);
@@ -284,16 +273,7 @@ public class AdminModuleTests
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "a valid enode is added to the static peer set and the call must report success as a boolean");
-        await staticNodesManager.Received(1).AddAsync(_enodeString, updateFile: expectedUpdateFile);
-    }
-
-    [Test]
-    public async Task AdminAddPeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
-    {
-        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_addPeer", "not-an-enode");
-
-        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
-        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
+        await staticNodesManager.Received(1).AddAsync(Arg.Is<NetworkNode>(n => n.Enode!.Info == _enodeString), expectedUpdateFile, Arg.Any<CancellationToken>());
     }
 
     [TestCase(false, false, TestName = "AdminRemovePeer_WhenPersistentFalse_DropsInMemoryStaticEntry")]
@@ -301,7 +281,7 @@ public class AdminModuleTests
     public async Task AdminRemovePeer_WithValidEnode_RemovesFromStaticAndPoolAndReturnsTrue(bool persistent, bool expectedUpdateFile)
     {
         IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
-        staticNodesManager.RemoveAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        staticNodesManager.RemoveAsync(Arg.Any<NetworkNode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager, peerPool: peerPool);
 
@@ -310,7 +290,7 @@ public class AdminModuleTests
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "a valid enode is removed from the static peer set and active session, reported as a boolean");
-        await staticNodesManager.Received(1).RemoveAsync(_enodeString, updateFile: expectedUpdateFile);
+        await staticNodesManager.Received(1).RemoveAsync(Arg.Is<NetworkNode>(n => n.Enode!.Info == _enodeString), expectedUpdateFile, Arg.Any<CancellationToken>());
         peerPool.Received(1).TryRemove(Arg.Any<PublicKey>(), out Arg.Any<Peer>());
     }
 
@@ -318,7 +298,7 @@ public class AdminModuleTests
     public async Task AdminRemovePeer_WhenPeerNotFound_StillReturnsTrue()
     {
         IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
-        staticNodesManager.RemoveAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.FromResult(false));
+        staticNodesManager.RemoveAsync(Arg.Any<NetworkNode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         peerPool.TryRemove(Arg.Any<PublicKey>(), out Arg.Any<Peer>()).Returns(false);
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(staticNodesManager: staticNodesManager, peerPool: peerPool);
@@ -328,15 +308,6 @@ public class AdminModuleTests
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         result.Should().BeTrue(because: "removePeer is idempotent: removing an unknown peer is success, matching geth's Server.RemovePeer semantics");
-    }
-
-    [Test]
-    public async Task AdminRemovePeer_WhenEnodeMalformed_ReturnsInvalidParamsError()
-    {
-        string serialized = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_removePeer", "not-an-enode");
-
-        serialized.Should().Contain("\"code\":-32602", because: "malformed enode is a JSON-RPC InvalidParams error");
-        serialized.Should().Contain("invalid enode", because: "the error message must identify the failing parameter");
     }
 
     [Test]
@@ -620,7 +591,8 @@ public class AdminModuleTests
             _exampleDataDir,
             chainSpec.Parameters,
             trustedNodesManager ?? Substitute.For<ITrustedNodesManager>(),
-            _subscriptionManager);
+            _subscriptionManager,
+            new JsonRpcConfig());
     }
 
     private JsonRpcResult RaisePeerEventAndCapture(Action raiseEvent, out string subscriptionId, bool disposeSubscription = false, bool shouldReceive = true)
@@ -681,7 +653,8 @@ public class AdminModuleTests
             "/test/data",
             new ChainParameters(),
             Substitute.For<ITrustedNodesManager>(),
-            subscriptionManager);
+            subscriptionManager,
+            new JsonRpcConfig());
     }
 
     private static IPeerPool CreatePeerPool(Peer peer)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -91,69 +91,53 @@ public class AdminRpcModule : IAdminRpcModule
         _nodeInfo.Protocols[Protocol.Eth].Config = _parameters;
     }
 
-    public async Task<ResultWrapper<string>> admin_addPeer(string enode, bool addToStaticNodes = false)
+    public async Task<ResultWrapper<bool>> admin_addPeer(string enode, bool persistent = false)
     {
-        bool added;
-        if (addToStaticNodes)
+        if (!Enode.IsEnode(enode, out _))
         {
-            added = await _staticNodesManager.AddAsync(enode);
-        }
-        else
-        {
-            NetworkNode networkNode = new(enode);
-            _peerPool.GetOrAdd(new Node(networkNode));
-            added = true;
+            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
         }
 
-        return added
-            ? ResultWrapper<string>.Success(enode)
-            : ResultWrapper<string>.Fail("Failed to add peer.");
+        await _staticNodesManager.AddAsync(enode, updateFile: persistent);
+        return ResultWrapper<bool>.Success(true);
     }
 
-    public async Task<ResultWrapper<string>> admin_removePeer(string enode, bool removeFromStaticNodes = false)
+    public async Task<ResultWrapper<bool>> admin_removePeer(string enode, bool persistent = false)
     {
-        bool removed;
-        if (removeFromStaticNodes)
+        if (!Enode.IsEnode(enode, out _))
         {
-            removed = await _staticNodesManager.RemoveAsync(enode);
-        }
-        else
-        {
-            removed = _peerPool.TryRemove(new NetworkNode(enode).NodeId, out Peer _);
+            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
         }
 
-        return removed
-            ? ResultWrapper<string>.Success(enode)
-            : ResultWrapper<string>.Fail("Failed to remove peer.");
+        NetworkNode networkNode = new(enode);
+        await _staticNodesManager.RemoveAsync(enode, updateFile: persistent);
+        _peerPool.TryRemove(networkNode.NodeId, out _);
+        return ResultWrapper<bool>.Success(true);
     }
 
-    public async Task<ResultWrapper<bool>> admin_addTrustedPeer(string enode)
+    public async Task<ResultWrapper<bool>> admin_addTrustedPeer(string enode, bool persistent = false)
     {
+        if (!Enode.IsEnode(enode, out _))
+        {
+            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
+        }
+
         Enode enodeObj = new(enode);
-
-        if (_trustedNodesManager.IsTrusted(enodeObj) || await _trustedNodesManager.AddAsync(enodeObj, updateFile: true))
-        {
-            _peerPool.GetOrAdd(new NetworkNode(enodeObj));
-            return ResultWrapper<bool>.Success(true);
-        }
-        else
-        {
-            return ResultWrapper<bool>.Fail("Failed to add trusted peer.");
-        }
+        await _trustedNodesManager.AddAsync(enodeObj, updateFile: persistent);
+        _peerPool.GetOrAdd(new NetworkNode(enodeObj));
+        return ResultWrapper<bool>.Success(true);
     }
 
-    public async Task<ResultWrapper<bool>> admin_removeTrustedPeer(string enode)
+    public async Task<ResultWrapper<bool>> admin_removeTrustedPeer(string enode, bool persistent = false)
     {
-        Enode enodeObj = new(enode);
+        if (!Enode.IsEnode(enode, out _))
+        {
+            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
+        }
 
-        if (await _trustedNodesManager.RemoveAsync(enodeObj, updateFile: true))
-        {
-            return ResultWrapper<bool>.Success(true);
-        }
-        else
-        {
-            return ResultWrapper<bool>.Fail("Failed to remove trusted peer.");
-        }
+        Enode enodeObj = new(enode);
+        await _trustedNodesManager.RemoveAsync(enodeObj, updateFile: persistent);
+        return ResultWrapper<bool>.Success(true);
     }
 
     public ResultWrapper<PeerInfo[]> admin_peers(bool includeDetails = false)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -81,10 +81,17 @@ public class AdminRpcModule : IAdminRpcModule
 
         // Static-set removal triggers session disconnect via the NodeRemoved event chain
         // (CompositeNodeSource -> PeerPool.NodeSourceOnNodeRemoved -> TryRemove -> MarkDisconnected).
-        // The direct TryRemove below is the idempotent fallback for non-static (discovered) peers,
+        // The direct TryRemove in finally is the idempotent fallback for non-static (discovered) peers,
         // matching geth's Server.RemovePeer which works on any connected peer regardless of static membership.
-        await _staticNodesManager.RemoveAsync(networkNode!, updateFile: persistent, timeout.Token);
-        _peerPool.TryRemove(networkNode!.NodeId, out _);
+        // The finally guarantees the fallback runs even if SaveFileAsync is cancelled (persistent=true + RPC timeout).
+        try
+        {
+            await _staticNodesManager.RemoveAsync(networkNode!, updateFile: persistent, timeout.Token);
+        }
+        finally
+        {
+            _peerPool.TryRemove(networkNode!.NodeId, out _);
+        }
         return ResultWrapper<bool>.Success(true);
     }
 
@@ -93,8 +100,18 @@ public class AdminRpcModule : IAdminRpcModule
         if (TryParseAsEnode(enode, out Enode? enodeObj) is { } error) return error;
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        await _trustedNodesManager.AddAsync(enodeObj!, updateFile: persistent, timeout.Token);
-        _peerPool.GetOrAdd(new NetworkNode(enodeObj!));
+        // GetOrAdd in finally guarantees the synchronous-pool-insertion contract holds even if
+        // AddAsync is cancelled (persistent=true + RPC timeout, or channel-write cancellation):
+        // without this, a peer could be added to the trusted in-memory dict but never reach the pool
+        // because the channel feed it depends on was aborted.
+        try
+        {
+            await _trustedNodesManager.AddAsync(enodeObj!, updateFile: persistent, timeout.Token);
+        }
+        finally
+        {
+            _peerPool.GetOrAdd(new NetworkNode(enodeObj!));
+        }
         return ResultWrapper<bool>.Success(true);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -80,11 +80,6 @@ public class AdminRpcModule : IAdminRpcModule
         if (TryParseAsNetworkNode(enode, out NetworkNode? networkNode) is { } error) return error;
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        // Static-set removal triggers session disconnect via the NodeRemoved event chain
-        // (CompositeNodeSource -> PeerPool.NodeSourceOnNodeRemoved -> TryRemove -> MarkDisconnected).
-        // The direct TryRemove in finally is the idempotent fallback for non-static (discovered) peers,
-        // matching geth's Server.RemovePeer which works on any connected peer regardless of static membership.
-        // The finally guarantees the fallback runs even if SaveFileAsync is cancelled (persistent=true + RPC timeout).
         try
         {
             await _staticNodesManager.RemoveAsync(networkNode!, updateFile: persistent, timeout.Token);
@@ -107,10 +102,6 @@ public class AdminRpcModule : IAdminRpcModule
 
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        // GetOrAdd in finally guarantees the synchronous-pool-insertion contract holds even if
-        // AddAsync is cancelled (persistent=true + RPC timeout, or channel-write cancellation):
-        // without this, a peer could be added to the trusted in-memory dict but never reach the pool
-        // because the channel feed it depends on was aborted.
         try
         {
             await _trustedNodesManager.AddAsync(enodeObj!, updateFile: persistent, timeout.Token);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -59,10 +59,10 @@ public class AdminRpcModule : IAdminRpcModule
         _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
         _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         _trustedNodesManager = trustedNodesManager ?? throw new ArgumentNullException(nameof(trustedNodesManager));
+        _subscriptionManager = subscriptionManager ?? throw new ArgumentNullException(nameof(subscriptionManager));
         _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
 
         BuildNodeInfo();
-        _subscriptionManager = subscriptionManager;
     }
 
     public async Task<ResultWrapper<bool>> admin_addPeer(string enode, bool persistent = false)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -198,7 +199,7 @@ public class AdminRpcModule : IAdminRpcModule
             node = new NetworkNode(enode);
             return null;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is ArgumentException or FormatException or SocketException)
         {
             node = null;
             return ResultWrapper<bool>.Fail($"invalid enode: {ex.Message}", ErrorCodes.InvalidParams);
@@ -212,7 +213,7 @@ public class AdminRpcModule : IAdminRpcModule
             parsed = new Enode(enode);
             return null;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is ArgumentException or FormatException or SocketException)
         {
             parsed = null;
             return ResultWrapper<bool>.Fail($"invalid enode: {ex.Message}", ErrorCodes.InvalidParams);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -99,6 +99,12 @@ public class AdminRpcModule : IAdminRpcModule
     public async Task<ResultWrapper<bool>> admin_addTrustedPeer(string enode, bool persistent = false)
     {
         if (TryParseAsEnode(enode, out Enode? enodeObj) is { } error) return error;
+
+        if (_trustedNodesManager.IsTrusted(enodeObj!))
+        {
+            return ResultWrapper<bool>.Success(true);
+        }
+
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
         // GetOrAdd in finally guarantees the synchronous-pool-insertion contract holds even if

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -13,7 +13,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Network;
 using Nethermind.Network.Config;
 using Nethermind.Specs.ChainSpecStyle;
-using Nethermind.Stats.Model;
 using Nethermind.JsonRpc.Modules.Subscribe;
 using System.Text.Json;
 using Nethermind.State;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
@@ -34,6 +35,7 @@ public class AdminRpcModule : IAdminRpcModule
     private NodeInfo _nodeInfo = null!;
     private readonly ITrustedNodesManager _trustedNodesManager;
     private readonly ISubscriptionManager _subscriptionManager;
+    private readonly IJsonRpcConfig _jsonRpcConfig;
 
     public AdminRpcModule(
         IBlockTree blockTree,
@@ -45,7 +47,8 @@ public class AdminRpcModule : IAdminRpcModule
         string dataDir,
         ChainParameters parameters,
         ITrustedNodesManager trustedNodesManager,
-        ISubscriptionManager subscriptionManager)
+        ISubscriptionManager subscriptionManager,
+        IJsonRpcConfig jsonRpcConfig)
     {
         _enode = enode ?? throw new ArgumentNullException(nameof(enode));
         _dataDir = dataDir ?? throw new ArgumentNullException(nameof(dataDir));
@@ -56,86 +59,51 @@ public class AdminRpcModule : IAdminRpcModule
         _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
         _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         _trustedNodesManager = trustedNodesManager ?? throw new ArgumentNullException(nameof(trustedNodesManager));
+        _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
 
         BuildNodeInfo();
         _subscriptionManager = subscriptionManager;
     }
 
-    private void BuildNodeInfo()
-    {
-        _nodeInfo = new NodeInfo
-        {
-            Name = ProductInfo.ClientId,
-            Enode = _enode.Info,
-            Id = (_enode.PublicKey?.Hash ?? Keccak.Zero).ToString(false),
-            Ip = _enode.HostIp?.ToString(),
-            ListenAddress = $"{_enode.HostIp}:{_enode.Port}",
-            Ports =
-            {
-                Discovery = _networkConfig.DiscoveryPort,
-                Listener = _networkConfig.P2PPort
-            }
-        };
-
-        UpdateEthProtocolInfo();
-    }
-
-    private void UpdateEthProtocolInfo()
-    {
-        _nodeInfo.Protocols[Protocol.Eth].Difficulty = _blockTree.Head?.TotalDifficulty ?? 0;
-        _nodeInfo.Protocols[Protocol.Eth].NetworkId = _blockTree.NetworkId;
-        _nodeInfo.Protocols[Protocol.Eth].ChainId = _blockTree.ChainId;
-        _nodeInfo.Protocols[Protocol.Eth].HeadHash = _blockTree.HeadHash;
-        _nodeInfo.Protocols[Protocol.Eth].GenesisHash = _blockTree.GenesisHash;
-        _nodeInfo.Protocols[Protocol.Eth].Config = _parameters;
-    }
-
     public async Task<ResultWrapper<bool>> admin_addPeer(string enode, bool persistent = false)
     {
-        if (!Enode.IsEnode(enode, out _))
-        {
-            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
-        }
+        if (TryParseAsNetworkNode(enode, out NetworkNode? networkNode) is { } error) return error;
+        using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        await _staticNodesManager.AddAsync(enode, updateFile: persistent);
+        await _staticNodesManager.AddAsync(networkNode!, updateFile: persistent, timeout.Token);
         return ResultWrapper<bool>.Success(true);
     }
 
     public async Task<ResultWrapper<bool>> admin_removePeer(string enode, bool persistent = false)
     {
-        if (!Enode.IsEnode(enode, out _))
-        {
-            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
-        }
+        if (TryParseAsNetworkNode(enode, out NetworkNode? networkNode) is { } error) return error;
+        using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        NetworkNode networkNode = new(enode);
-        await _staticNodesManager.RemoveAsync(enode, updateFile: persistent);
-        _peerPool.TryRemove(networkNode.NodeId, out _);
+        // Static-set removal triggers session disconnect via the NodeRemoved event chain
+        // (CompositeNodeSource -> PeerPool.NodeSourceOnNodeRemoved -> TryRemove -> MarkDisconnected).
+        // The direct TryRemove below is the idempotent fallback for non-static (discovered) peers,
+        // matching geth's Server.RemovePeer which works on any connected peer regardless of static membership.
+        await _staticNodesManager.RemoveAsync(networkNode!, updateFile: persistent, timeout.Token);
+        _peerPool.TryRemove(networkNode!.NodeId, out _);
         return ResultWrapper<bool>.Success(true);
     }
 
     public async Task<ResultWrapper<bool>> admin_addTrustedPeer(string enode, bool persistent = false)
     {
-        if (!Enode.IsEnode(enode, out _))
-        {
-            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
-        }
+        if (TryParseAsEnode(enode, out Enode? enodeObj) is { } error) return error;
+        using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        Enode enodeObj = new(enode);
-        await _trustedNodesManager.AddAsync(enodeObj, updateFile: persistent);
-        _peerPool.GetOrAdd(new NetworkNode(enodeObj));
+        await _trustedNodesManager.AddAsync(enodeObj!, updateFile: persistent, timeout.Token);
+        _peerPool.GetOrAdd(new NetworkNode(enodeObj!));
         return ResultWrapper<bool>.Success(true);
     }
 
     public async Task<ResultWrapper<bool>> admin_removeTrustedPeer(string enode, bool persistent = false)
     {
-        if (!Enode.IsEnode(enode, out _))
-        {
-            return ResultWrapper<bool>.Fail($"invalid enode: {enode}", ErrorCodes.InvalidParams);
-        }
+        if (TryParseAsEnode(enode, out Enode? enodeObj) is { } error) return error;
+        using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
-        Enode enodeObj = new(enode);
-        await _trustedNodesManager.RemoveAsync(enodeObj, updateFile: persistent);
+        await _trustedNodesManager.RemoveAsync(enodeObj!, updateFile: persistent, timeout.Token);
         return ResultWrapper<bool>.Success(true);
     }
 
@@ -148,9 +116,6 @@ public class AdminRpcModule : IAdminRpcModule
 
         return ResultWrapper<PeerInfo[]>.Success(validatedPeers);
     }
-
-    private static bool IsValidatedPeer(Peer peer) => peer.InSession?.IsNetworkIdMatched == true ||
-               peer.OutSession?.IsNetworkIdMatched == true;
 
     public ResultWrapper<NodeInfo> admin_nodeInfo()
     {
@@ -203,4 +168,66 @@ public class AdminRpcModule : IAdminRpcModule
     }
 
     public JsonRpcContext Context { get; set; }
+
+    private CancellationTokenSource BuildTimeoutCancellationTokenSource() => _jsonRpcConfig.BuildTimeoutCancellationToken();
+
+    private static bool IsValidatedPeer(Peer peer) => peer.InSession?.IsNetworkIdMatched == true ||
+                                                      peer.OutSession?.IsNetworkIdMatched == true;
+
+    private static ResultWrapper<bool>? TryParseAsNetworkNode(string enode, out NetworkNode? node)
+    {
+        try
+        {
+            node = new NetworkNode(enode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            node = null;
+            return ResultWrapper<bool>.Fail($"invalid enode: {ex.Message}", ErrorCodes.InvalidParams);
+        }
+    }
+
+    private static ResultWrapper<bool>? TryParseAsEnode(string enode, out Enode? parsed)
+    {
+        try
+        {
+            parsed = new Enode(enode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            parsed = null;
+            return ResultWrapper<bool>.Fail($"invalid enode: {ex.Message}", ErrorCodes.InvalidParams);
+        }
+    }
+
+    private void BuildNodeInfo()
+    {
+        _nodeInfo = new NodeInfo
+        {
+            Name = ProductInfo.ClientId,
+            Enode = _enode.Info,
+            Id = (_enode.PublicKey?.Hash ?? Keccak.Zero).ToString(false),
+            Ip = _enode.HostIp?.ToString(),
+            ListenAddress = $"{_enode.HostIp}:{_enode.Port}",
+            Ports =
+            {
+                Discovery = _networkConfig.DiscoveryPort,
+                Listener = _networkConfig.P2PPort
+            }
+        };
+
+        UpdateEthProtocolInfo();
+    }
+
+    private void UpdateEthProtocolInfo()
+    {
+        _nodeInfo.Protocols[Protocol.Eth].Difficulty = _blockTree.Head?.TotalDifficulty ?? 0;
+        _nodeInfo.Protocols[Protocol.Eth].NetworkId = _blockTree.NetworkId;
+        _nodeInfo.Protocols[Protocol.Eth].ChainId = _blockTree.ChainId;
+        _nodeInfo.Protocols[Protocol.Eth].HeadHash = _blockTree.HeadHash;
+        _nodeInfo.Protocols[Protocol.Eth].GenesisHash = _blockTree.GenesisHash;
+        _nodeInfo.Protocols[Protocol.Eth].Config = _parameters;
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -9,28 +9,28 @@ namespace Nethermind.JsonRpc.Modules.Admin;
 [RpcModule(ModuleType.Admin)]
 public interface IAdminRpcModule : IContextAwareRpcModule
 {
-    [JsonRpcMethod(Description = "Adds given node.",
-        EdgeCaseHint = "",
-        ResponseDescription = "Added node",
-        ExampleResponse = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"",
+    [JsonRpcMethod(Description = "Adds the given node as a static peer. The connection is maintained for the lifetime of the process. Set `persistent` to also write the peer to static-nodes.json so it is restored on restart.",
+        EdgeCaseHint = "Returns `true` even if the peer was already in the static set.",
+        ResponseDescription = "`true` if the peer is in the static set after the call.",
+        ExampleResponse = "true",
         IsImplemented = true)]
-    Task<ResultWrapper<string>> admin_addPeer(
-        [JsonRpcParameter(Description = "Given node", ExampleValue = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"")]
+    Task<ResultWrapper<bool>> admin_addPeer(
+        [JsonRpcParameter(Description = "Enode URL of the peer to add", ExampleValue = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"")]
         string enode,
-        [JsonRpcParameter(Description = "Adding to static nodes if `true` (optional)", ExampleValue = "true")]
-        bool addToStaticNodes = false);
+        [JsonRpcParameter(Description = "If `true`, also persist the peer to static-nodes.json so it is reloaded on the next start (optional, defaults to `false`).", ExampleValue = "true")]
+        bool persistent = false);
 
 
-    [JsonRpcMethod(Description = "Removes given node.",
-        EdgeCaseHint = "",
-        ResponseDescription = "Removed node",
-        ExampleResponse = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"",
+    [JsonRpcMethod(Description = "Removes the given node from the static peer set and disconnects any active session. Set `persistent` to also remove the peer from static-nodes.json so it is not restored on restart.",
+        EdgeCaseHint = "Returns `true` even if the peer was not present (idempotent).",
+        ResponseDescription = "`true` if the input enode was valid and the removal was attempted.",
+        ExampleResponse = "true",
         IsImplemented = true)]
-    Task<ResultWrapper<string>> admin_removePeer(
-        [JsonRpcParameter(Description = "Given node", ExampleValue = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"")]
+    Task<ResultWrapper<bool>> admin_removePeer(
+        [JsonRpcParameter(Description = "Enode URL of the peer to remove", ExampleValue = "\"enode://deed356ddcaa1eb33a859b818a134765fff2a3dd5cd5b3d6cbe08c9424dca53b947bdc1c64e6f1257e29bb2960ac0a4fb56e307f360b7f8d4ddf48024cdb9d68@85.221.141.144:30303\"")]
         string enode,
-        [JsonRpcParameter(Description = "Removing from static nodes if `true` (optional)", ExampleValue = "true")]
-        bool removeFromStaticNodes = false);
+        [JsonRpcParameter(Description = "If `true`, also remove the peer from static-nodes.json so it is not reloaded on the next start (optional, defaults to `false`).", ExampleValue = "true")]
+        bool persistent = false);
 
 
     [JsonRpcMethod(Description = "Displays a list of connected peers including information about them (`clientId`, `host`, `port`, `address`, `isBootnode`, `isStatic`, `enode`).",
@@ -67,25 +67,27 @@ public interface IAdminRpcModule : IContextAwareRpcModule
         IsImplemented = true)]
     ResultWrapper<bool> admin_isStateRootAvailable(BlockParameter block);
 
-    [JsonRpcMethod(Description = "Adds given node as a trusted peer, allowing the node to always connect even if slots are full.",
-        EdgeCaseHint = "",
-        ResponseDescription = "Boolean indicating success",
+    [JsonRpcMethod(Description = "Adds the given node to the trusted peer set so it can always connect even when slots are full. Set `persistent` to also write the peer to trusted-nodes.json so it is restored on restart.",
+        EdgeCaseHint = "Returns `true` even if the peer was already trusted (idempotent).",
+        ResponseDescription = "`true` if the peer is in the trusted set after the call.",
         ExampleResponse = "true",
         IsImplemented = true)]
     Task<ResultWrapper<bool>> admin_addTrustedPeer(
-        [JsonRpcParameter(Description = "Given node", ExampleValue = "\"enode://...\"")]
-        string enode
-);
+        [JsonRpcParameter(Description = "Enode URL of the peer to trust", ExampleValue = "\"enode://...\"")]
+        string enode,
+        [JsonRpcParameter(Description = "If `true`, also persist the peer to trusted-nodes.json so it is reloaded on the next start (optional, defaults to `false`).", ExampleValue = "true")]
+        bool persistent = false);
 
-    [JsonRpcMethod(Description = "Removes the given node from the trusted peers list.",
-        EdgeCaseHint = "",
-        ResponseDescription = "Boolean indicating success",
+    [JsonRpcMethod(Description = "Removes the given node from the trusted peer set. Set `persistent` to also remove the peer from trusted-nodes.json so it is not re-trusted on restart.",
+        EdgeCaseHint = "Returns `true` even if the peer was not trusted (idempotent).",
+        ResponseDescription = "`true` if the input enode was valid and the removal was attempted.",
         ExampleResponse = "true",
         IsImplemented = true)]
     Task<ResultWrapper<bool>> admin_removeTrustedPeer(
-        [JsonRpcParameter(Description = "Given node", ExampleValue = "\"enode://...\"")]
-        string enode
-);
+        [JsonRpcParameter(Description = "Enode URL of the peer to untrust", ExampleValue = "\"enode://...\"")]
+        string enode,
+        [JsonRpcParameter(Description = "If `true`, also remove the peer from trusted-nodes.json so it is not reloaded on the next start (optional, defaults to `false`).", ExampleValue = "true")]
+        bool persistent = false);
 
     [JsonRpcMethod(Description = "Subscribes to a particular event over WebSocket. For every event that matches the subscription, a notification with event details and subscription id is sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<string> admin_subscribe(string subscriptionName, string? args = null);

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -277,7 +277,7 @@ namespace Nethermind.Network.Test
         {
             await using Context ctx = new();
             ctx.NetworkConfig.MaxActivePeers = 1;
-            ctx.StaticNodesManager.IsStatic(enode2String).Returns(true);
+            ctx.StaticNodesManager.IsStatic(Arg.Is<NetworkNode>(n => n.Enode!.Info == enode2String)).Returns(true);
 
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();

--- a/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.Config;
 using Nethermind.Core.Test.IO;
 using Nethermind.Logging;
 using Nethermind.Network.StaticNodes;
@@ -20,8 +21,10 @@ namespace Nethermind.Network.Test
     {
         private IStaticNodesManager _staticNodesManager;
 
-        private const string Enode =
+        private const string EnodeString =
             "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303";
+
+        private static readonly NetworkNode Enode = new(EnodeString);
 
         [SetUp]
         public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -38,5 +38,7 @@ public class TrustedNodesManagerTests
 
         nodeRemovedFired.Should().BeTrue(
             because: "NodeRemoved must fire before the file write, so a cancelled SaveFileAsync cannot leave the peer untrusted-in-memory yet still connected via the missed disconnect event chain");
+        manager.Nodes.Should().NotContain(n => n.NodeId == enode.PublicKey,
+            because: "the in-memory dict must already be cleared before the cancellation point, so an aborted file write cannot leave the peer trusted in memory");
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Config;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class TrustedNodesManagerTests
+{
+    private const string EnodeString =
+        "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303";
+
+    [Test]
+    public async Task RemoveAsync_WhenSaveFileCancelled_StillFiresNodeRemoved()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "[]");
+        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        Enode enode = new(EnodeString);
+        await manager.AddAsync(enode, updateFile: false);
+
+        bool nodeRemovedFired = false;
+        manager.NodeRemoved += (_, _) => nodeRemovedFired = true;
+
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await FluentActions.Awaiting(() => manager.RemoveAsync(enode, updateFile: true, cts.Token))
+            .Should().ThrowAsync<System.OperationCanceledException>(because: "the pre-cancelled token must abort SaveFileAsync");
+
+        nodeRemovedFired.Should().BeTrue(
+            because: "NodeRemoved must fire before the file write, so a cancelled SaveFileAsync cannot leave the peer untrusted-in-memory yet still connected via the missed disconnect event chain");
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -18,6 +18,9 @@ public class TrustedNodesManagerTests
     private const string EnodeString =
         "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303";
 
+    private const string EnodeStringSamePubkeyDifferentAddress =
+        "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@10.0.0.1:31313";
+
     [Test]
     public async Task RemoveAsync_WhenSaveFileCancelled_StillFiresNodeRemoved()
     {
@@ -40,5 +43,21 @@ public class TrustedNodesManagerTests
             because: "NodeRemoved must fire before the file write, so a cancelled SaveFileAsync cannot leave the peer untrusted-in-memory yet still connected via the missed disconnect event chain");
         manager.Nodes.Should().NotContain(n => n.NodeId == enode.PublicKey,
             because: "the in-memory dict must already be cleared before the cancellation point, so an aborted file write cannot leave the peer trusted in memory");
+    }
+
+    [Test]
+    public async Task IsTrusted_AfterAdd_ReturnsTrueRegardlessOfHostOrPort()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "[]");
+        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        Enode enodeOriginal = new(EnodeString);
+        await manager.AddAsync(enodeOriginal, updateFile: false);
+
+        manager.IsTrusted(enodeOriginal).Should().BeTrue(because: "precondition: the peer was just added");
+
+        Enode enodeSamePubkeyDifferentAddress = new(EnodeStringSamePubkeyDifferentAddress);
+        manager.IsTrusted(enodeSamePubkeyDifferentAddress).Should().BeTrue(
+            because: "trust is keyed by public key only, matching geth's Server.trusted map (p2p/server.go:644 trusted[enode.ID()]); a trusted peer at a different address is still trusted");
     }
 }

--- a/src/Nethermind/Nethermind.Network/IStaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/IStaticNodesManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 
@@ -11,7 +12,7 @@ public interface IStaticNodesManager : INodeSource
 {
     IEnumerable<NetworkNode> Nodes { get; }
     Task InitAsync();
-    Task<bool> AddAsync(string enode, bool updateFile = true);
-    Task<bool> RemoveAsync(string enode, bool updateFile = true);
-    bool IsStatic(string enode);
+    Task<bool> AddAsync(NetworkNode node, bool updateFile = true, CancellationToken cancellationToken = default);
+    Task<bool> RemoveAsync(NetworkNode node, bool updateFile = true, CancellationToken cancellationToken = default);
+    bool IsStatic(NetworkNode node);
 }

--- a/src/Nethermind/Nethermind.Network/ITrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/ITrustedNodesManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 
@@ -11,7 +12,7 @@ public interface ITrustedNodesManager : INodeSource
 {
     IEnumerable<NetworkNode> Nodes { get; }
     Task InitAsync();
-    Task<bool> AddAsync(Enode enode, bool updateFile = true);
-    Task<bool> RemoveAsync(Enode enode, bool updateFile = true);
+    Task<bool> AddAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default);
+    Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default);
     bool IsTrusted(Enode enode);
 }

--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
@@ -131,7 +132,7 @@ public abstract class NodesManager(string path, ILogger logger)
         return nodes;
     }
 
-    protected virtual Task SaveFileAsync()
+    protected virtual Task SaveFileAsync(CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
@@ -140,6 +141,6 @@ public abstract class NodesManager(string path, ILogger logger)
             EthereumJsonSerializer.JsonOptionsIndented
             );
 
-        return File.WriteAllTextAsync(path, contents);
+        return File.WriteAllTextAsync(path, contents, cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -29,54 +29,49 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         _nodes = nodes;
     }
 
-    public async Task<bool> AddAsync(string enode, bool updateFile = true)
+    public async Task<bool> AddAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
-        NetworkNode networkNode = new(enode);
         if (!_nodes.TryAdd(networkNode.NodeId, networkNode))
         {
-            if (_logger.IsInfo) _logger.Info($"Static node was already added: {enode}");
+            if (_logger.IsInfo) _logger.Info($"Static node was already added: {networkNode}");
             return false;
         }
 
-        if (_logger.IsInfo) _logger.Info($"Static node added: {enode}");
+        if (_logger.IsInfo) _logger.Info($"Static node added: {networkNode}");
 
         Node node = new(networkNode, isStatic: true);
         NodeAdded?.Invoke(this, new NodeEventArgs(node));
 
         if (updateFile)
         {
-            await SaveFileAsync();
+            await SaveFileAsync(cancellationToken);
         }
 
         return true;
     }
 
-    public async Task<bool> RemoveAsync(string enode, bool updateFile = true)
+    public async Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
-        NetworkNode networkNode = new(enode);
         if (!_nodes.TryRemove(networkNode.NodeId, out _))
         {
-            if (_logger.IsInfo) _logger.Info($"Static node was not found: {enode}");
+            if (_logger.IsInfo) _logger.Info($"Static node was not found: {networkNode}");
             return false;
         }
 
-        if (_logger.IsInfo) _logger.Info($"Static node was removed: {enode}");
+        if (_logger.IsInfo) _logger.Info($"Static node was removed: {networkNode}");
         Node node = new(networkNode);
         NodeRemoved?.Invoke(this, new NodeEventArgs(node));
         if (updateFile)
         {
-            await SaveFileAsync();
+            await SaveFileAsync(cancellationToken);
         }
 
         return true;
     }
 
-    public bool IsStatic(string enode)
-    {
-        NetworkNode node = new(enode);
-        return _nodes.TryGetValue(node.NodeId, out NetworkNode staticNode) && string.Equals(staticNode.Host,
-            node.Host, StringComparison.OrdinalIgnoreCase);
-    }
+    public bool IsStatic(NetworkNode node) =>
+        _nodes.TryGetValue(node.NodeId, out NetworkNode staticNode) &&
+        string.Equals(staticNode.Host, node.Host, StringComparison.OrdinalIgnoreCase);
 
     public async IAsyncEnumerable<Node> DiscoverNodes([EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
@@ -52,7 +52,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
         }
     }
 
-    public async Task<bool> AddAsync(Enode enode, bool updateFile = true)
+    public async Task<bool> AddAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
         NetworkNode networkNode = new(enode);
         if (!_nodes.TryAdd(networkNode.NodeId, networkNode))
@@ -71,16 +71,16 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
 
         // Publish the newly added node to the channel so DiscoverNodes will yield it.
         Node newNode = new(networkNode) { IsTrusted = true };
-        await _nodeChannel.Writer.WriteAsync(newNode);
+        await _nodeChannel.Writer.WriteAsync(newNode, cancellationToken);
 
         if (updateFile)
         {
-            await SaveFileAsync();
+            await SaveFileAsync(cancellationToken);
         }
         return true;
     }
 
-    public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true)
+    public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
         NetworkNode networkNode = new(enode.ToString());
         if (!_nodes.TryRemove(networkNode.NodeId, out _))
@@ -99,7 +99,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
 
         if (updateFile)
         {
-            await SaveFileAsync();
+            await SaveFileAsync(cancellationToken);
         }
 
         OnNodeRemoved(networkNode);

--- a/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
@@ -97,12 +97,15 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
             _logger.Info($"Trusted node was removed: {enode}");
         }
 
+        // Fire NodeRemoved (drives PeerPool disconnect via the event chain) BEFORE the file write,
+        // so a cancelled SaveFileAsync cannot leave the peer untrusted-in-memory yet still connected.
+        // Mirrors StaticNodesManager.RemoveAsync ordering.
+        OnNodeRemoved(networkNode);
+
         if (updateFile)
         {
             await SaveFileAsync(cancellationToken);
         }
-
-        OnNodeRemoved(networkNode);
 
         return true;
     }

--- a/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
@@ -110,19 +110,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
         return true;
     }
 
-    public bool IsTrusted(Enode enode)
-    {
-        if (enode.PublicKey is null)
-        {
-            return false;
-        }
-        if (_nodes.TryGetValue(enode.PublicKey, out NetworkNode storedNode))
-        {
-            // Compare not only the public key, but also the host and port.
-            return storedNode.Host == enode.HostIp?.ToString() && storedNode.Port == enode.Port;
-        }
-        return false;
-    }
+    public bool IsTrusted(Enode enode) => _nodes.ContainsKey(enode.PublicKey);
 
     public event EventHandler<NodeEventArgs>? NodeRemoved;
 

--- a/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodes/TrustedNodesManager.cs
@@ -82,7 +82,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
 
     public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
-        NetworkNode networkNode = new(enode.ToString());
+        NetworkNode networkNode = new(enode);
         if (!_nodes.TryRemove(networkNode.NodeId, out _))
         {
             if (_logger.IsInfo)


### PR DESCRIPTION
Fixes Closes Resolves https://github.com/NethermindEth/nethermind/issues/11490

## Summary

### Wire-level breaking changes (all four endpoints)

- Return type `string → bool` on `addPeer/removePeer` (already `bool` on the trusted pair)
- Param renamed: `addToStaticNodes → persistent`, `removeFromStaticNodes → persistent` (consistent across all four)
- `addTrustedPeer` and `removeTrustedPeer` gained the new optional `persistent` parameter

### Default-semantic changes (the same call now does something different)

- `admin_addPeer(enode)`: now maintains the connection (Geth-equivalent); was a one-shot dial
- `admin_removePeer(enode)`: now removes from static set + disconnects + idempotent; was pool-only and reported failure on unknown peers
- `admin_addTrustedPeer(enode)`: no longer writes to `trusted-nodes.json` by default
- `admin_removeTrustedPeer(enode)`: no longer writes to `trusted-nodes.json` by default; now idempotent on unknown peers

### Validation (all four)

- Malformed enode now returns `-32602 InvalidParams` with `"invalid enode: ..."` instead of an opaque internal RPC error.

### Further Refactoring

- Replaced Enode.IsEnode pre-check with TryParseAsNetworkNode/TryParseAsEnode helpers wrapping full-parse construction in try/catch (catches valid-scheme/invalid-content inputs)
- Plumbed IJsonRpcConfig-derived CancellationToken through
- `IStaticNodesManager`/`ITrustedNodesManager`/`NodesManager.SaveFileAsync`; dropped string-typed overloads of `IStaticNodesManager.AddAsync`/`RemoveAsync`/`IsStatic` (test-only, replaced with `NetworkNode`-typed) to eliminate the double-parse + double-DNS-lookup; consolidated 4 single-method malformed-enode tests into one parameterized `[TestCase]` covering both scheme-fail and content-fail paths
- Added _subscriptionManager null-guard, fixed field-assignment ordering, and removed the `enode.ToString()` round-trip in `TrustedNodesManager.RemoveAsync`

---

## Changes

---

### `admin_addPeer`

| Behavior | Geth (only mode) | Nethermind BEFORE — default (`addToStaticNodes=false`) | Nethermind BEFORE — `addToStaticNodes=true` | Nethermind AFTER — default (`persistent=false`) | Nethermind AFTER — `persistent=true` |
|----------|------------------|---------------------------------------------------------|---------------------------------------------|--------------------------------------------------|--------------------------------------|
| Adds to in-memory static set | ✅ | ❌ pool dict only | ✅ | ✅ matches Geth | ✅ |
| Maintains connection (auto-redial) | ✅ | ❌ one-shot dial | ✅ | ✅ matches Geth | ✅ |
| Writes to `static-nodes.json` | ❌ | ❌ | ✅ | ❌ matches Geth | ✅ (NM extension) |
| Validates enode upfront | ✅ clean error | ❌ throws on bad input → opaque | ❌ same | ✅ `Enode.IsEnode` → `-32602` | ✅ same |
| Return type | `bool` | `string` (echoes enode) | `string` | `bool` matches Geth | `bool` |

---

### `admin_removePeer`

| Behavior | Geth | NM BEFORE — default (`removeFromStaticNodes=false`) | NM BEFORE — `removeFromStaticNodes=true` | NM AFTER — default | NM AFTER — `persistent=true` |
|----------|------|------------------------------------------------------|------------------------------------------|--------------------|------------------------------|
| Removes from in-memory static set | ✅ | ❌ pool only | ✅ | ✅ matches Geth | ✅ |
| Disconnects active session | ✅ | ✅ via direct `TryRemove` | ✅ via event chain | ✅ via event chain + direct `TryRemove` fallback | ✅ |
| Removes non-static (discovered) peer too | ✅ | ✅ | ❌ static set only | ✅ matches Geth (idempotent fallback) | ✅ |
| Writes to `static-nodes.json` | ❌ | ❌ | ✅ | ❌ matches Geth | ✅ (NM extension) |
| Idempotent on unknown peer | ✅ returns `true` | ❌ Fail | ❌ Fail | ✅ returns `true` matches Geth | ✅ |
| Validates enode upfront | ✅ | ❌ throws | ❌ throws | ✅ `-32602` | ✅ |
| Return type | `bool` | `string` | `string` | `bool` matches Geth | `bool` |

---

### `admin_addTrustedPeer`

| Behavior | Geth | NM BEFORE | NM AFTER — default | NM AFTER — `persistent=true` |
|----------|------|-----------|--------------------|------------------------------|
| Adds to in-memory trusted set | ✅ | ✅ | ✅ | ✅ |
| Writes to `trusted-nodes.json` | ❌ | ✅ always (`updateFile: true` hardcoded) | ❌ matches Geth | ✅ (NM extension) |
| Synchronously inserts into peer pool | ❌ relies on dialer | ✅ `_peerPool.GetOrAdd` | ✅ kept (NM nuance — avoids 1s `FeedFromNodeSource` throttle) | ✅ kept |
| Idempotent on already-trusted | ✅ | ✅ via `IsTrusted` short-circuit | ✅ via ignoring `AddAsync` return | ✅ |
| Validates enode upfront | ✅ | ❌ throws | ✅ `-32602` | ✅ |
| Return type | `bool` | `bool` | `bool` matches Geth | `bool` |

---

### `admin_removeTrustedPeer`

| Behavior | Geth | NM BEFORE | NM AFTER — default | NM AFTER — `persistent=true` |
|----------|------|-----------|--------------------|------------------------------|
| Removes from in-memory trusted set | ✅ | ✅ | ✅ | ✅ |
| Writes to `trusted-nodes.json` | ❌ | ✅ always (`updateFile: true` hardcoded) | ❌ matches Geth | ✅ (NM extension) |
| Disconnects active session | ❌ stays connected, loses privilege | ✅ via event chain (`NodeRemoved → PeerPool.TryRemove → MarkDisconnected`) | ✅ kept (NM-specific, deliberate) | ✅ kept |
| Idempotent on unknown peer | ✅ returns `true` | ❌ Fail | ✅ returns `true` matches Geth | ✅ |
| Validates enode upfront | ✅ | ❌ throws | ✅ `-32602` | ✅ |
| Return type | `bool` | `bool` | `bool` matches Geth | `bool` |

---

### Nethermind extensions Geth doesn't have

| Extension | Endpoints | Effect |
|-----------|-----------|--------|
| `persistent: true` flag | `admin_addPeer`, `admin_removePeer` | Also write/remove the entry to/from `static-nodes.json` so it survives restart |
| `persistent: true` flag | `admin_addTrustedPeer`, `admin_removeTrustedPeer` | Also write/remove the entry to/from `trusted-nodes.json` so trust survives restart |
| Synchronous pool insertion | `admin_addTrustedPeer` | Avoids the up-to-1s `PeerPool.FeedFromNodeSource` throttle delay; the peer is in the pool the moment the RPC returns |
| Disconnect on untrust | `admin_removeTrustedPeer` | Geth leaves the peer connected after untrusting; Nethermind disconnects via the existing `NodeRemoved` event chain — operationally cleaner ("force reconnect under non-trusted rules") |

---

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No