### PR TITLE
perf: report BloomFilter unmanaged allocation to GC

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BloomFilter/BloomFilter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BloomFilter/BloomFilter.cs
@@ -81,27 +81,40 @@ public sealed unsafe class BloomFilter : IDisposable
         _data = (byte*)NativeMemory.AlignedAlloc(_dataSize, alignment);
         if (_data == null) throw new OutOfMemoryException();
 
-        // Hint the kernel to use huge pages BEFORE we touch the memory (Clear).
-        // This ensures that when Clear() triggers page faults, the kernel allocates 2MB physical pages immediately.
-        if (useHugePages)
-        {
-            Madvise(_data, _dataSize, MADV_HUGEPAGE);
-        }
+        GC.AddMemoryPressure((long)_dataSize);
 
-        // zero init
-        // Note: For huge allocations, this loop will trigger the actual physical memory allocation.
-        new Span<byte>(_data, checked((int)Math.Min(totalBytes, int.MaxValue))).Clear();
-        if (totalBytes > int.MaxValue)
+        try
         {
-            // chunk clear for huge allocations
-            long off = 0;
-            const int Chunk = 8 * 1024 * 1024;
-            while (off < totalBytes)
+            // Hint the kernel to use huge pages BEFORE we touch the memory (Clear).
+            // This ensures that when Clear() triggers page faults, the kernel allocates 2MB physical pages immediately.
+            if (useHugePages)
             {
-                int len = (int)Math.Min(Chunk, totalBytes - off);
-                new Span<byte>(_data + off, len).Clear();
-                off += len;
+                Madvise(_data, _dataSize, MADV_HUGEPAGE);
             }
+
+            // zero init
+            // Note: For huge allocations, this loop will trigger the actual physical memory allocation.
+            new Span<byte>(_data, checked((int)Math.Min(totalBytes, int.MaxValue))).Clear();
+            if (totalBytes > int.MaxValue)
+            {
+                // chunk clear for huge allocations
+                long off = 0;
+                const int Chunk = 8 * 1024 * 1024;
+                while (off < totalBytes)
+                {
+                    int len = (int)Math.Min(Chunk, totalBytes - off);
+                    new Span<byte>(_data + off, len).Clear();
+                    off += len;
+                }
+            }
+        }
+        catch
+        {
+            NativeMemory.AlignedFree(_data);
+            GC.RemoveMemoryPressure((long)_dataSize);
+            _data = null;
+            _dataSize = 0;
+            throw;
         }
     }
 
@@ -192,6 +205,7 @@ public sealed unsafe class BloomFilter : IDisposable
         if (_data != null)
         {
             NativeMemory.AlignedFree(_data);
+            GC.RemoveMemoryPressure((long)_dataSize);
             _data = null;
             _dataSize = 0;
         }


### PR DESCRIPTION
## Summary

- `BloomFilter` allocates its backing buffer with `NativeMemory.AlignedAlloc` (64 B aligned, escalating to 2 MB + `MADV_HUGEPAGE` on Linux for large filters). The allocation is unmanaged and was previously invisible to the GC.
- Add `GC.AddMemoryPressure` after a successful `AlignedAlloc` and `GC.RemoveMemoryPressure` in `Dispose` so the runtime can factor the allocation into Gen2 collection heuristics.
- Wrap the post-allocation `Madvise`/`Clear` work in a try/catch that frees the buffer and removes the pressure if `Clear` throws (e.g., OOM during page-faulting), keeping the add/remove pair balanced.

## Changes

- Type of change: performance / minor

## Testing

- [x] `dotnet build -c release src/Nethermind/Nethermind.State.Flat/Nethermind.State.Flat.csproj` — clean

## Notes

- No public API change, no hot-path change.
- No finalizer added; lifetime model unchanged — callers still own `Dispose`. If the instance is leaked, the pressure is leaked along with the unmanaged buffer (same story as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)