### PR TITLE
XDC Fix sync

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockTreeTests.cs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Xdc.Types;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+[TestFixture, Parallelizable(ParallelScope.All)]
+internal class XdcBlockTreeTests
+{
+    [Test]
+    public void Suggest_BlockBelowFinalizedHeight_WhenKnown_ReturnsAlreadyKnown()
+    {
+        (XdcBlockTree blockTree, IXdcConsensusContext consensus) = BuildBlockTree();
+
+        Block genesis = XdcBlock(0, Keccak.Zero);
+        Block block1 = XdcBlock(1, genesis.Hash!);
+        Block block2 = XdcBlock(2, block1.Hash!);
+
+        blockTree.SuggestBlock(genesis);
+        blockTree.SuggestBlock(block1);
+        blockTree.SuggestBlock(block2);
+        blockTree.UpdateHeadBlock(block2.Hash!);
+
+        consensus.HighestCommitBlock.Returns(new BlockRoundInfo(block2.Hash!, 1, block2.Number));
+
+        blockTree.SuggestBlock(block1).Should().Be(AddBlockResult.AlreadyKnown);
+    }
+
+    [Test]
+    public void Suggest_BlockBelowFinalizedHeight_WhenUnknown_ReturnsInvalidBlock()
+    {
+        (XdcBlockTree blockTree, IXdcConsensusContext consensus) = BuildBlockTree();
+
+        Block genesis = XdcBlock(0, Keccak.Zero);
+        Block block1 = XdcBlock(1, genesis.Hash!);
+        Block block2 = XdcBlock(2, block1.Hash!);
+
+        blockTree.SuggestBlock(genesis);
+        blockTree.SuggestBlock(block1);
+        blockTree.SuggestBlock(block2);
+        blockTree.UpdateHeadBlock(block2.Hash!);
+
+        consensus.HighestCommitBlock.Returns(new BlockRoundInfo(block2.Hash!, 1, block2.Number));
+
+        Block unknown = XdcBlock(1, genesis.Hash!, nonce: 1);
+        blockTree.SuggestBlock(unknown).Should().Be(AddBlockResult.InvalidBlock);
+    }
+
+    [Test]
+    public void Suggest_BlockAboveFinalizedHeight_ConnectedToFinalizedChain_ReturnsAdded()
+    {
+        (XdcBlockTree blockTree, IXdcConsensusContext consensus) = BuildBlockTree();
+
+        Block genesis = XdcBlock(0, Keccak.Zero);
+        Block block1 = XdcBlock(1, genesis.Hash!);
+        Block block2 = XdcBlock(2, block1.Hash!);
+        Block block3 = XdcBlock(3, block2.Hash!);
+
+        blockTree.SuggestBlock(genesis);
+        blockTree.SuggestBlock(block1);
+        blockTree.SuggestBlock(block2);
+        blockTree.SuggestBlock(block3);
+        blockTree.UpdateHeadBlock(block3.Hash!);
+
+        consensus.HighestCommitBlock.Returns(new BlockRoundInfo(block2.Hash!, 1, block2.Number));
+
+        Block block3Alt = XdcBlock(3, block2.Hash!, nonce: 1);
+        blockTree.SuggestBlock(block3Alt).Should().Be(AddBlockResult.Added);
+    }
+
+    [Test]
+    public void Suggest_BlockAboveFinalizedHeight_ForkBeforeFinalized_ReturnsInvalidBlock()
+    {
+        (XdcBlockTree blockTree, IXdcConsensusContext consensus) = BuildBlockTree();
+
+        Block genesis = XdcBlock(0, Keccak.Zero);
+        Block block1 = XdcBlock(1, genesis.Hash!);
+        Block block2 = XdcBlock(2, block1.Hash!);
+        Block block3 = XdcBlock(3, block2.Hash!);
+
+        // block2Fork forks at height 2 — same height as the finalized block
+        Block block2Fork = XdcBlock(2, block1.Hash!, nonce: 1);
+        Block block3Fork = XdcBlock(3, block2Fork.Hash!);
+
+        blockTree.SuggestBlock(genesis);
+        blockTree.SuggestBlock(block1);
+        blockTree.SuggestBlock(block2);
+        blockTree.SuggestBlock(block2Fork);
+        blockTree.SuggestBlock(block3);
+        blockTree.UpdateHeadBlock(block3.Hash!);
+
+        consensus.HighestCommitBlock.Returns(new BlockRoundInfo(block2.Hash!, 1, block2.Number));
+
+        blockTree.SuggestBlock(block3Fork).Should().Be(AddBlockResult.InvalidBlock);
+    }
+
+    [Test]
+    public void Suggest_BlockAboveFinalizedHeight_UnknownParent_ReturnsUnknownParent()
+    {
+        (XdcBlockTree blockTree, IXdcConsensusContext consensus) = BuildBlockTree();
+
+        Block genesis = XdcBlock(0, Keccak.Zero);
+        Block block1 = XdcBlock(1, genesis.Hash!);
+        blockTree.SuggestBlock(genesis);
+        blockTree.SuggestBlock(block1);
+        blockTree.UpdateHeadBlock(block1.Hash!);
+
+        consensus.HighestCommitBlock.Returns(new BlockRoundInfo(block1.Hash!, 1, block1.Number));
+
+        Block disconnected = XdcBlock(2, Keccak.Compute("other"));
+        blockTree.SuggestBlock(disconnected).Should().Be(AddBlockResult.UnknownParent);
+    }
+
+    private static Block XdcBlock(long number, Hash256 parentHash, ulong nonce = 0)
+    {
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithNumber(number)
+            .WithParentHash(parentHash)
+            .TestObject;
+        header.Nonce = nonce;
+        header.Hash = header.CalculateHash().ToHash256();
+        return Build.A.Block.WithHeader(header).TestObject;
+    }
+
+    private static (XdcBlockTree, IXdcConsensusContext) BuildBlockTree()
+    {
+        IXdcConsensusContext consensus = Substitute.For<IXdcConsensusContext>();
+        consensus.HighestCommitBlock.Returns((BlockRoundInfo)null!);
+
+        XdcHeaderStore xdcHeaderStore = new(new TestMemDb(), new TestMemDb());
+        BlockTreeBuilder builder = Build.A.BlockTree(MainnetSpecProvider.Instance)
+            .WithHeaderStore(xdcHeaderStore)
+            .WithoutSettingHead;
+
+        XdcBlockTree blockTree = new(
+            consensus,
+            builder.BlockStore,
+            xdcHeaderStore,
+            builder.BlockInfoDb,
+            builder.MetadataDb,
+            builder.BadBlockStore,
+            builder.BlockAccessListStore,
+            builder.ChainLevelInfoRepository,
+            MainnetSpecProvider.Instance,
+            builder.BloomStorage,
+            builder.SyncConfig,
+            LimboLogs.Instance);
+
+        return (blockTree, consensus);
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/InitializeBlockchainXdc.cs
+++ b/src/Nethermind/Nethermind.Xdc/InitializeBlockchainXdc.cs
@@ -8,6 +8,7 @@ using Nethermind.Init.Steps;
 using Nethermind.TxPool;
 using Nethermind.Xdc.TxPool;
 using System.Collections.Generic;
+using Nethermind.Consensus.Producers;
 
 namespace Nethermind.Xdc;
 
@@ -35,6 +36,9 @@ internal class InitializeBlockchainXdc(INethermindApi api, IChainHeadInfoProvide
         _api.DisposeStack.Push(txPool);
         return txPool;
     }
+
+    // Consensus loop must run on all nodes to keep QC/TC state current
+    protected override IBlockProductionPolicy CreateBlockProductionPolicy() => AlwaysStartBlockProductionPolicy.Instance;
 
     protected new IComparer<Transaction> CreateTxPoolTxComparer() => new XdcTransactionComparerProvider(_api.SpecProvider!, _api.BlockTree!).GetDefaultComparer();
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
@@ -35,18 +35,21 @@ internal class XdcBlockTree(
 
     protected override AddBlockResult Suggest(Block? block, BlockHeader header, BlockTreeSuggestOptions options = BlockTreeSuggestOptions.ShouldProcess)
     {
+        if (!CanAcceptNewBlocks) return AddBlockResult.CannotAccept;
+
         BlockRoundInfo finalizedBlockInfo = _xdcConsensus.HighestCommitBlock;
         if (finalizedBlockInfo is null)
             return base.Suggest(block, header, options);
-        if (finalizedBlockInfo.Hash == header.Hash)
-        {
-            //Weird case if re-suggesting the finalized block
-            return AddBlockResult.AlreadyKnown;
-        }
+
         if (finalizedBlockInfo.BlockNumber >= header.Number)
         {
-            return AddBlockResult.InvalidBlock;
+            // During sync, already-finalized blocks may be re-suggested (e.g. gap filling).
+            // Accept them as AlreadyKnown instead of treating them as invalid reorg attempts.
+            return IsKnownBlock(header.Number, header.Hash) && (BestSuggestedHeader?.Number ?? 0) >= header.Number
+                ? AddBlockResult.AlreadyKnown
+                : AddBlockResult.InvalidBlock;
         }
+
         BlockHeader current = header;
         for (long i = header.Number; i >= finalizedBlockInfo.BlockNumber; i--)
         {


### PR DESCRIPTION
Non-mining nodes never started the consensus loop, leaving their `QC/TC` context empty. `SyncInfo` messages can populate it, but they arrive rarely, leaving `HighestCommitBlock` stale or null, which made `XdcBlockTree.Suggest` very slow.

Another issue is that during syncs, `BlockDownloader` can re-suggest already-processed blocks. These were incorrectly rejected as `InvalidBlock`, stalling sync.                                                                                                                        
   
  ## Changes                                                                                                                                                                                                                                  
                                                                               
  - Always start the consensus loop so `QC/TC` state stays up to date on all nodes
  - Check `AlreadyKnown` before the finalization boundary in `XdcBlockTree.Suggest`
                                                                                                                                                                                                                                              
  ## Types of changes
                                                                                                                                                                                                                                              
  - [x] Bugfix (a non-breaking change that fixes an issue)    