### PR TITLE
fix: drop buffered frame bytes on `FrameQueue.Clear`

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/FrameQueueTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/FrameQueueTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using FluentAssertions;
+using Nethermind.Logging;
+using Nethermind.Optimism.CL.Decoding;
+using NUnit.Framework;
+
+namespace Nethermind.Optimism.Test.CL;
+
+public class FrameQueueTests
+{
+    [Test]
+    public void Clear_DropsBufferedFrameData()
+    {
+        FrameQueue queue = new(LimboLogs.Instance);
+
+        // A non-last frame with a leading byte that is not a valid channel-compression marker
+        // (not zlib `*8`/`*F` and not brotli `0x01`).
+        Frame staleFrame = new()
+        {
+            ChannelId = 1,
+            FrameNumber = 0,
+            FrameData = [0x77, 0x77, 0x77],
+            IsLast = false,
+        };
+        queue.ConsumeFrame(staleFrame).Should().BeNull();
+
+        queue.Clear();
+
+        // Build a self-contained brotli-encoded channel: marker byte `0x01` followed by a
+        // brotli stream of an empty RLP byte array (`0x80`).
+        byte[] brotli = BrotliCompress([0x80]);
+        byte[] channelPayload = new byte[brotli.Length + 1];
+        channelPayload[0] = 0x01;
+        brotli.CopyTo(channelPayload, 1);
+
+        Frame freshFrame = new()
+        {
+            ChannelId = 2,
+            FrameNumber = 0,
+            FrameData = channelPayload,
+            IsLast = true,
+        };
+
+        // If Clear() leaks `_frameData`, the leftover `0x77` prefix makes ChannelDecoder
+        // throw "Unsupported compression algorithm 119" before the fresh payload is read.
+        BatchV1[]? result = null;
+        Action consume = () => result = queue.ConsumeFrame(freshFrame);
+        consume.Should().NotThrow();
+        result.Should().NotBeNull();
+    }
+
+    private static byte[] BrotliCompress(ReadOnlySpan<byte> data)
+    {
+        using MemoryStream output = new();
+        using (BrotliStream brotli = new(output, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            brotli.Write(data);
+        }
+        return output.ToArray();
+    }
+}

--- a/src/Nethermind/Nethermind.Optimism/CL/Decoding/FrameQueue.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Decoding/FrameQueue.cs
@@ -57,5 +57,9 @@ public class FrameQueue(ILogManager logManager) : IFrameQueue
 
         return null;
     }
-    public void Clear() => _latestFrame = null;
+    public void Clear()
+    {
+        _frameData.Clear();
+        _latestFrame = null;
+    }
 }


### PR DESCRIPTION
`FrameQueue.Clear()` only nulled `_latestFrame` and left `_frameData` populated. After a pipeline reset, the next first frame got appended onto stale bytes, so `ChannelDecoder.DecodeChannel` either threw on a bogus compression marker or fed corrupted data downstream. The `List<byte>` also kept its capacity.
 `Clear()` now also calls `_frameData.Clear()`.
