### PR TITLE
fix: PoW re-sync downloads already processed blocks

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -632,6 +632,35 @@ public partial class BlockDownloaderTests
     }
 
 
+    [Test]
+    public async Task Second_sync_does_not_redownload_blocks()
+    {
+        SyncPeerMock syncPeer = new(10, false, Response.AllCorrect);
+
+        await using IContainer node = CreateNode();
+        Context ctx = node.Resolve<Context>();
+        PeerInfo peerInfo = new(syncPeer);
+        ctx.ConfigureBestPeer(peerInfo);
+
+        await ctx.FullSyncUntilNoRequest(peerInfo);
+        long afterFirstSync = ctx.BlockTree.BestSuggestedHeader!.Number;
+
+        syncPeer.ExtendTree(20);
+
+        // Simulate 5 blocks arriving via P2P - advances BestKnownNumber without going through BlockDownloader
+        for (long i = afterFirstSync + 1; i <= afterFirstSync + 5; i++)
+        {
+            BlockHeader? header = syncPeer.BlockTree.FindHeader(i, BlockTreeLookupOptions.None);
+            if (header is not null) ctx.BlockTree.SuggestHeader(header);
+        }
+        long bestKnownAfterPropagation = ctx.BlockTree.BestKnownNumber;
+
+        using BlocksRequest? secondRequest = await ctx.FullSyncFeedComponent.Feed.PrepareRequest();
+        secondRequest.Should().NotBeNull();
+        secondRequest.BodiesRequests.Count.Should().BeGreaterThan(0);
+        secondRequest.BodiesRequests[0].Number.Should().BeGreaterThan(bestKnownAfterPropagation);
+    }
+
     private class SlowSealValidator : ISealValidator
     {
         public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -83,6 +83,7 @@ public class PowForwardHeaderProvider(
         else
         {
             if (_logger.IsTrace) _logger.Trace($"No header received");
+            _currentBestPeer = null;
         }
 
         if (headers is not null && headers?.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.ToPooledList(headers.Count);


### PR DESCRIPTION
After a successful sync, if a re-sync is triggered (block gap, etc.) and the same best peer is re-allocated, `_currentBestPeer` still holds the stale reference so `OnNewBestPeer` is never called. This leaves
  `_currentNumber` stale, causing the downloader to re-request already-processed headers.
  
                
  Changes                                                                                                                                                                                                                                     
                                                                              
  - Clear `_currentBestPeer` when sync finishes (peer returns no headers), so the next re-sync resets `_currentNumber` to `BestKnownNumber` instead of the stale position.
  - Add regression test covering the scenario
                                                                                                                                                                                                                                              
  Types of changes                                                            

  - Bugfix (a non-breaking change that fixes an issue)                                                                                                                                                                                        
   
  Testing                                                                                                                                                                                                                                     
                                                                              
  Requires testing

  - Yes

  If yes, did you write tests?

  - Yes