### PR TITLE
feat(rpc): add debug_intermediateRoots

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -19,14 +20,14 @@ namespace Nethermind.Blockchain.Tracing;
 /// System-level calls (EIP-4788, EIP-2935) and withdrawals do not produce entries
 /// because <see cref="BlockTracerBase{TTrace,TTracer}"/> only dispatches on user transactions.
 /// </remarks>
-public class IntermediateRootsBlockTracer(IWorldState worldState)
+public class IntermediateRootsBlockTracer(IWorldState worldState, IReleaseSpec spec)
     : BlockTracerBase<Hash256, IntermediateRootsBlockTracer.IntermediateRootsTxTracer>
 {
-    protected override IntermediateRootsTxTracer OnStart(Transaction? tx) => new(worldState);
+    protected override IntermediateRootsTxTracer OnStart(Transaction? tx) => new(worldState, spec);
 
     protected override Hash256 OnEnd(IntermediateRootsTxTracer txTracer) => txTracer.StateRoot;
 
-    public class IntermediateRootsTxTracer(IWorldState worldState) : TxTracer
+    public class IntermediateRootsTxTracer(IWorldState worldState, IReleaseSpec spec) : TxTracer
     {
         public override bool IsTracingReceipt => true;
 
@@ -46,8 +47,11 @@ public class IntermediateRootsBlockTracer(IWorldState worldState)
                 return;
             }
 
-            // Post-Byzantium (EIP-658) the processor does not pre-compute the root,
-            // so we force a recalculation to read it from the live world state.
+            // Post-Byzantium (EIP-658): TransactionProcessor commits with commitRoots=false,
+            // which buffers changes into _blockChanges without flushing them to the trie.
+            // Force a flush so the recomputed root reflects this transaction's effect — the
+            // BlockProcessor's later end-of-block commit is idempotent for already-flushed entries.
+            worldState.Commit(spec, commitRoots: true);
             worldState.RecalculateStateRoot();
             StateRoot = worldState.StateRoot;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
@@ -13,6 +13,12 @@ namespace Nethermind.Blockchain.Tracing;
 /// Captures the world state root after each transaction in a block.
 /// Mirrors geth's <c>debug_intermediateRoots</c> behaviour.
 /// </summary>
+/// <remarks>
+/// Roots are produced per transaction in execution order; a failed transaction still
+/// produces its post-execution root (matching geth's partial-result semantics).
+/// System-level calls (EIP-4788, EIP-2935) and withdrawals do not produce entries
+/// because <see cref="BlockTracerBase{TTrace,TTracer}"/> only dispatches on user transactions.
+/// </remarks>
 public class IntermediateRootsBlockTracer(IWorldState worldState)
     : BlockTracerBase<Hash256, IntermediateRootsBlockTracer.IntermediateRootsTxTracer>
 {
@@ -24,7 +30,7 @@ public class IntermediateRootsBlockTracer(IWorldState worldState)
     {
         public override bool IsTracingReceipt => true;
 
-        public Hash256 StateRoot { get; private set; } = Keccak.Zero;
+        public Hash256 StateRoot { get; private set; }
 
         public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null) =>
             Capture(stateRoot);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/IntermediateRootsBlockTracer.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+
+namespace Nethermind.Blockchain.Tracing;
+
+/// <summary>
+/// Captures the world state root after each transaction in a block.
+/// Mirrors geth's <c>debug_intermediateRoots</c> behaviour.
+/// </summary>
+public class IntermediateRootsBlockTracer(IWorldState worldState)
+    : BlockTracerBase<Hash256, IntermediateRootsBlockTracer.IntermediateRootsTxTracer>
+{
+    protected override IntermediateRootsTxTracer OnStart(Transaction? tx) => new(worldState);
+
+    protected override Hash256 OnEnd(IntermediateRootsTxTracer txTracer) => txTracer.StateRoot;
+
+    public class IntermediateRootsTxTracer(IWorldState worldState) : TxTracer
+    {
+        public override bool IsTracingReceipt => true;
+
+        public Hash256 StateRoot { get; private set; } = Keccak.Zero;
+
+        public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null) =>
+            Capture(stateRoot);
+
+        public override void MarkAsFailed(Address recipient, in GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null) =>
+            Capture(stateRoot);
+
+        private void Capture(Hash256? reportedStateRoot)
+        {
+            if (reportedStateRoot is not null)
+            {
+                StateRoot = reportedStateRoot;
+                return;
+            }
+
+            // Post-Byzantium (EIP-658) the processor does not pre-compute the root,
+            // so we force a recalculation to read it from the live world state.
+            worldState.RecalculateStateRoot();
+            StateRoot = worldState.StateRoot;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GenesisNotTraceableException.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GenesisNotTraceableException.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Consensus.Tracing;
+
+/// <summary>Thrown when a tracer is asked to replay the genesis block, which has no parent state and no transactions.</summary>
+/// <remarks>Callers at the RPC boundary should map this to a clean client-facing error (e.g. invalid input) rather than letting it surface as a generic internal error.</remarks>
+public sealed class GenesisNotTraceableException : InvalidOperationException
+{
+    public GenesisNotTraceableException() : base("genesis is not traceable") { }
+}

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -129,14 +129,27 @@ public class GethStyleTracer(
         ArgumentNullException.ThrowIfNull(blockHash);
         ArgumentNullException.ThrowIfNull(options);
 
-        Block block = blockTree.FindBlock(blockHash) ?? throw new InvalidOperationException($"Cannot find block {blockHash}");
+        // Mirror geth: canonical blocks first, fall back to the bad-block store so the diagnostic
+        // use case (replaying a rejected block to find divergence) works.
+        Block block = blockTree.FindBlock(blockHash)
+                      ?? badBlockStore.GetAll().FirstOrDefault(b => b.Hash == blockHash)
+                      ?? throw new InvalidOperationException($"Cannot find block {blockHash}");
+        if (block.IsGenesis) throw new InvalidOperationException("genesis is not traceable");
+
         BlockHeader? parent = FindParent(block);
 
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
         IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState);
-        scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
-
-        return tracer.BuildResult();
+        try
+        {
+            scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
+            return tracer.BuildResult();
+        }
+        catch
+        {
+            tracer.TryDispose();
+            throw;
+        }
     }
 
     public IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -140,16 +140,8 @@ public class GethStyleTracer(
 
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
         IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState, specProvider.GetSpec(block.Header));
-        try
-        {
-            scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
-            return tracer.BuildResult();
-        }
-        catch
-        {
-            tracer.TryDispose();
-            throw;
-        }
+        scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
+        return tracer.BuildResult();
     }
 
     public IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -139,7 +139,7 @@ public class GethStyleTracer(
         BlockHeader? parent = FindParent(block);
 
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
-        IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState);
+        IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState, specProvider.GetSpec(block.Header));
         try
         {
             scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -19,6 +19,7 @@ using Nethermind.Crypto;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.Tracing;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native;
@@ -122,6 +123,21 @@ public class GethStyleTracer(
     public IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken) => TraceBlockImpl(GetBlockToTrace(blockRlp), options, cancellationToken);
 
     public IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block block, GethTraceOptions options, CancellationToken cancellationToken) => TraceBlockImpl(block, options, cancellationToken);
+
+    public IReadOnlyCollection<Hash256> TraceBlockIntermediateRoots(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(blockHash);
+        ArgumentNullException.ThrowIfNull(options);
+
+        Block block = blockTree.FindBlock(blockHash) ?? throw new InvalidOperationException($"Cannot find block {blockHash}");
+        BlockHeader? parent = FindParent(block);
+
+        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
+        IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState);
+        scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
+
+        return tracer.BuildResult();
+    }
 
     public IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken)
     {

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -134,7 +134,7 @@ public class GethStyleTracer(
         Block block = blockTree.FindBlock(blockHash)
                       ?? badBlockStore.GetAll().FirstOrDefault(b => b.Hash == blockHash)
                       ?? throw new InvalidOperationException($"Cannot find block {blockHash}");
-        if (block.IsGenesis) throw new InvalidOperationException("genesis is not traceable");
+        if (block.IsGenesis) throw new GenesisNotTraceableException();
 
         BlockHeader? parent = FindParent(block);
 

--- a/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
@@ -23,6 +23,14 @@ public interface IGethStyleTracer
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(BlockParameter blockParameter, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block block, GethTraceOptions options, CancellationToken cancellationToken);
+    /// <summary>
+    /// Replays <paramref name="blockHash"/> and returns the world-state root after each transaction
+    /// in execution order. EIP-4788/EIP-2935 system calls and withdrawals do not produce an entry.
+    /// </summary>
+    /// <param name="blockHash">Hash of a canonical or bad-stored block to replay.</param>
+    /// <param name="options">Trace options (state overrides are applied to the parent base state).</param>
+    /// <param name="cancellationToken">Cooperative cancellation.</param>
+    /// <returns>Post-tx state roots in execution order; failed transactions still produce a root.</returns>
     IReadOnlyCollection<Hash256> TraceBlockIntermediateRoots(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBadBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);

--- a/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
@@ -23,6 +23,7 @@ public interface IGethStyleTracer
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(BlockParameter blockParameter, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken);
     IReadOnlyCollection<GethLikeTxTrace> TraceBlock(Block block, GethTraceOptions options, CancellationToken cancellationToken);
+    IReadOnlyCollection<Hash256> TraceBlockIntermediateRoots(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
     IEnumerable<string> TraceBadBlockToFile(Hash256 blockHash, GethTraceOptions options, CancellationToken cancellationToken);
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -440,32 +440,44 @@ public class DebugModuleTests
         actual.Data.Should().BeEquivalentTo(expected);
     }
 
-    [Test]
-    public void Debug_intermediateRoots_fails_when_state_unavailable()
+    private static IEnumerable<TestCaseData> IntermediateRootsErrorCases()
     {
-        Hash256 blockHash = TestItem.KeccakA;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
-        _blockFinder.FindHeader(blockHash).Returns(header);
-        _blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(false);
+        yield return new TestCaseData(
+            (Action<Hash256, IBlockFinder, IBlockchainBridge>)((blockHash, finder, _) =>
+                finder.FindHeader(blockHash).ReturnsNull()),
+            ErrorCodes.ResourceNotFound,
+            "Cannot find header")
+        { TestName = "block_not_found" };
 
-        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
-        ResultWrapper<IReadOnlyCollection<Hash256>> actual = rpcModule.debug_intermediateRoots(blockHash);
-
-        actual.Result.ResultType.Should().Be(ResultType.Failure);
-        actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);
+        yield return new TestCaseData(
+            (Action<Hash256, IBlockFinder, IBlockchainBridge>)((blockHash, finder, bridge) =>
+            {
+                BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+                finder.FindHeader(blockHash).Returns(header);
+                bridge.HasStateForBlock(Arg.Is(header)).Returns(false);
+            }),
+            ErrorCodes.ResourceUnavailable,
+            null)
+        { TestName = "state_unavailable" };
     }
 
-    [Test]
-    public void Debug_intermediateRoots_fails_when_block_not_found()
+    [TestCaseSource(nameof(IntermediateRootsErrorCases))]
+    public void Debug_intermediateRoots_fails(
+        Action<Hash256, IBlockFinder, IBlockchainBridge> setup,
+        int expectedErrorCode,
+        string? expectedErrorSubstring)
     {
         Hash256 blockHash = TestItem.KeccakA;
-        _blockFinder.FindHeader(blockHash).ReturnsNull();
+        setup(blockHash, _blockFinder, _blockchainBridge);
 
         DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
         ResultWrapper<IReadOnlyCollection<Hash256>> actual = rpcModule.debug_intermediateRoots(blockHash);
 
         actual.Result.ResultType.Should().Be(ResultType.Failure);
-        actual.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
-        actual.Result.Error.Should().Contain("Cannot find header");
+        actual.ErrorCode.Should().Be(expectedErrorCode);
+        if (expectedErrorSubstring is not null)
+        {
+            actual.Result.Error.Should().Contain(expectedErrorSubstring);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -419,4 +419,39 @@ public class DebugModuleTests
         actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);
         actual.Result.Error.Should().Contain("No state available");
     }
+
+    [Test]
+    public void Debug_intermediateRoots_returns_post_tx_roots_from_bridge()
+    {
+        Hash256 blockHash = TestItem.KeccakA;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+        _blockFinder.FindHeader(blockHash).Returns(header);
+        _blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(true);
+
+        Hash256[] expected = [TestItem.KeccakB, TestItem.KeccakC];
+        _debugBridge
+            .GetBlockIntermediateRoots(Arg.Is(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions?>())
+            .Returns(expected);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IReadOnlyCollection<Hash256>> actual = rpcModule.debug_intermediateRoots(blockHash);
+
+        actual.Result.ResultType.Should().Be(ResultType.Success);
+        actual.Data.Should().BeEquivalentTo(expected);
+    }
+
+    [Test]
+    public void Debug_intermediateRoots_fails_when_state_unavailable()
+    {
+        Hash256 blockHash = TestItem.KeccakA;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).TestObject;
+        _blockFinder.FindHeader(blockHash).Returns(header);
+        _blockchainBridge.HasStateForBlock(Arg.Is(header)).Returns(false);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IReadOnlyCollection<Hash256>> actual = rpcModule.debug_intermediateRoots(blockHash);
+
+        actual.Result.ResultType.Should().Be(ResultType.Failure);
+        actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -454,4 +454,18 @@ public class DebugModuleTests
         actual.Result.ResultType.Should().Be(ResultType.Failure);
         actual.ErrorCode.Should().Be(ErrorCodes.ResourceUnavailable);
     }
+
+    [Test]
+    public void Debug_intermediateRoots_fails_when_block_not_found()
+    {
+        Hash256 blockHash = TestItem.KeccakA;
+        _blockFinder.FindHeader(blockHash).ReturnsNull();
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        ResultWrapper<IReadOnlyCollection<Hash256>> actual = rpcModule.debug_intermediateRoots(blockHash);
+
+        actual.Result.ResultType.Should().Be(ResultType.Failure);
+        actual.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        actual.Result.Error.Should().Contain("Cannot find header");
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.IntermediateRoots.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.IntermediateRoots.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules;
+
+public partial class DebugRpcModuleTests
+{
+    [Test]
+    public async Task Debug_intermediateRoots_returns_one_root_per_transaction()
+    {
+        using Context context = await Context.Create();
+        await context.Blockchain.AddBlock(CreateTraceBlockTransactions(context.Blockchain));
+
+        Hash256 blockHash = context.Blockchain.BlockTree.Head!.Hash!;
+        ResultWrapper<IReadOnlyCollection<Hash256>> result = context.DebugRpcModule.debug_intermediateRoots(blockHash);
+
+        result.Result.ResultType.Should().Be(ResultType.Success);
+        result.Data.Should().HaveCount(2, "the block has exactly two user transactions");
+        result.Data.Should().OnlyHaveUniqueItems("each tx mutates state, producing a distinct post-tx root");
+        result.Data.Should().NotContain(Keccak.Zero);
+    }
+
+    [Test]
+    public async Task Debug_intermediateRoots_rejects_genesis()
+    {
+        using Context context = await Context.Create();
+        Hash256 genesisHash = context.Blockchain.BlockTree.Genesis!.Hash!;
+
+        Func<ResultWrapper<IReadOnlyCollection<Hash256>>> act =
+            () => context.DebugRpcModule.debug_intermediateRoots(genesisHash);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*genesis*");
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.IntermediateRoots.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.IntermediateRoots.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -34,9 +33,10 @@ public partial class DebugRpcModuleTests
         using Context context = await Context.Create();
         Hash256 genesisHash = context.Blockchain.BlockTree.Genesis!.Hash!;
 
-        Func<ResultWrapper<IReadOnlyCollection<Hash256>>> act =
-            () => context.DebugRpcModule.debug_intermediateRoots(genesisHash);
+        ResultWrapper<IReadOnlyCollection<Hash256>> result = context.DebugRpcModule.debug_intermediateRoots(genesisHash);
 
-        act.Should().Throw<InvalidOperationException>().WithMessage("*genesis*");
+        result.Result.ResultType.Should().Be(ResultType.Failure);
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidInput);
+        result.Result.Error.Should().Contain("genesis");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -166,6 +166,9 @@ public class DebugBridge : IDebugBridge
     public IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Block block, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
         _tracer.TraceBlock(block, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
 
+    public IReadOnlyCollection<Hash256> GetBlockIntermediateRoots(Hash256 blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null) =>
+        _tracer.TraceBlockIntermediateRoots(blockHash, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
+
     public byte[]? GetBlockRlp(BlockParameter parameter)
     {
         if (parameter.BlockNumber is long number)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -309,18 +309,11 @@ public class DebugRpcModule(
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
 
-        try
-        {
-            IReadOnlyCollection<Hash256> roots = debugBridge.GetBlockIntermediateRoots(blockHash, cancellationToken, options);
+        IReadOnlyCollection<Hash256> roots = debugBridge.GetBlockIntermediateRoots(blockHash, cancellationToken, options);
 
-            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_intermediateRoots)} request {blockHash}, roots: {roots.Count}");
+        if (_logger.IsTrace) _logger.Trace($"{nameof(debug_intermediateRoots)} request {blockHash}, roots: {roots.Count}");
 
-            return ResultWrapper<IReadOnlyCollection<Hash256>>.Success(roots);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return ResultWrapper<IReadOnlyCollection<Hash256>>.Fail(ex.Message, ErrorCodes.ResourceNotFound);
-        }
+        return ResultWrapper<IReadOnlyCollection<Hash256>>.Success(roots);
     }
 
     public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockFromFile(string fileName, GethTraceOptions options = null) => throw new NotImplementedException();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm;
 using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Consensus.Tracing;
 using Nethermind.JsonRpc.Data;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -309,7 +310,15 @@ public class DebugRpcModule(
         using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
         CancellationToken cancellationToken = timeout.Token;
 
-        IReadOnlyCollection<Hash256> roots = debugBridge.GetBlockIntermediateRoots(blockHash, cancellationToken, options);
+        IReadOnlyCollection<Hash256> roots;
+        try
+        {
+            roots = debugBridge.GetBlockIntermediateRoots(blockHash, cancellationToken, options);
+        }
+        catch (GenesisNotTraceableException e)
+        {
+            return ResultWrapper<IReadOnlyCollection<Hash256>>.Fail(e.Message, ErrorCodes.InvalidInput);
+        }
 
         if (_logger.IsTrace) _logger.Trace($"{nameof(debug_intermediateRoots)} request {blockHash}, roots: {roots.Count}");
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -298,6 +298,31 @@ public class DebugRpcModule(
         }
     }
 
+    public ResultWrapper<IReadOnlyCollection<Hash256>> debug_intermediateRoots(Hash256 blockHash, GethTraceOptions? options = null)
+    {
+        TryGetHeaderAndCheckState<IReadOnlyCollection<Hash256>>(blockHash, out ResultWrapper<IReadOnlyCollection<Hash256>>? headerError);
+        if (headerError is not null)
+        {
+            return headerError;
+        }
+
+        using CancellationTokenSource? timeout = BuildTimeoutCancellationTokenSource();
+        CancellationToken cancellationToken = timeout.Token;
+
+        try
+        {
+            IReadOnlyCollection<Hash256> roots = debugBridge.GetBlockIntermediateRoots(blockHash, cancellationToken, options);
+
+            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_intermediateRoots)} request {blockHash}, roots: {roots.Count}");
+
+            return ResultWrapper<IReadOnlyCollection<Hash256>>.Success(roots);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ResultWrapper<IReadOnlyCollection<Hash256>>.Fail(ex.Message, ErrorCodes.ResourceNotFound);
+        }
+    }
+
     public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockFromFile(string fileName, GethTraceOptions options = null) => throw new NotImplementedException();
 
     public ResultWrapper<object> debug_dumpBlock(BlockParameter blockParameter) => throw new NotImplementedException();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -24,6 +24,7 @@ public interface IDebugBridge
     IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null);
     IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Rlp blockRlp, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     IReadOnlyCollection<GethLikeTxTrace> GetBlockTrace(Block block, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+    IReadOnlyCollection<Hash256> GetBlockIntermediateRoots(Hash256 blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
     Block? GetBlock(BlockParameter param);
     byte[] GetBlockRlp(BlockParameter param);
     byte[] GetDbValue(string dbName, byte[] key);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -50,6 +50,9 @@ public interface IDebugRpcModule : IRpcModule
     [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block hash and replays the block that is already present in the database.", IsImplemented = true, IsSharable = false)]
     ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByHash(Hash256 blockHash, GethTraceOptions options = null);
 
+    [JsonRpcMethod(Description = "Replays the block already present in the database and returns the world state root after each transaction.", IsImplemented = true, IsSharable = false)]
+    ResultWrapper<IReadOnlyCollection<Hash256>> debug_intermediateRoots(Hash256 blockHash, GethTraceOptions? options = null);
+
     [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = false)]
     ResultWrapper<GethLikeTxTrace[]> debug_traceBlockFromFile(string fileName, GethTraceOptions options = null);
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -50,7 +50,7 @@ public interface IDebugRpcModule : IRpcModule
     [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block hash and replays the block that is already present in the database.", IsImplemented = true, IsSharable = false)]
     ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByHash(Hash256 blockHash, GethTraceOptions options = null);
 
-    [JsonRpcMethod(Description = "Replays the block already present in the database and returns the world state root after each transaction.", IsImplemented = true, IsSharable = false)]
+    [JsonRpcMethod(Description = "Replays a block and returns the world-state root after each transaction in execution order. EIP-4788/EIP-2935 system calls and withdrawals do not produce an entry. Failed transactions still produce a root (geth partial-result semantics). The block must be canonical or in the bad-block store.", IsImplemented = true, IsSharable = false)]
     ResultWrapper<IReadOnlyCollection<Hash256>> debug_intermediateRoots(Hash256 blockHash, GethTraceOptions? options = null);
 
     [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = false)]


### PR DESCRIPTION
Fixes #3456

## Changes

- Add `IntermediateRootsBlockTracer` (`Nethermind.Blockchain.Tracing`) — captures the world state root after each transaction. Falls back to `IWorldState.RecalculateStateRoot()` post-Byzantium where `TransactionProcessor` no longer pre-computes the root.
- Add `IGethStyleTracer.TraceBlockIntermediateRoots(blockHash, options, ct)` and the matching `GethStyleTracer` implementation, mirroring the existing `TraceBlock` pipeline (parent header, scoped world state, `BlockchainProcessor.Process`).
- Add `IDebugBridge.GetBlockIntermediateRoots` plumbing.
- Expose `debug_intermediateRoots(Hash256 blockHash, GethTraceOptions? options = null)` on `IDebugRpcModule` / `DebugRpcModule`. Behaviour matches geth (ethereum/go-ethereum#23594): one root per transaction, in execution order.
- Tests in `DebugModuleTests` cover the success path and the no-state-available failure path.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Adds the `debug_intermediateRoots` JSON-RPC method, which replays a block and returns the world state root after each transaction in execution order. Matches the equivalent geth endpoint.