### PR TITLE
test: mark Should_process_block_as_expected_V2/V4/V6 as NonParallelizable

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -35,6 +35,7 @@ public partial class EngineModuleTests
         "0xe89937a887c84cf0422c4445780f573929fa8bdec06eaac39be91cd428a9c249",
         "0x0cb5b20122ce36c5d13058d8d6ec33b9fee729730f41a3adeacfb76dd8116ab7",
         "0x0c26dbd2461b7b5d")]
+    [NonParallelizable]
     public virtual async Task Should_process_block_as_expected_V2(string latestValidHash, string blockHash,
         string stateRoot, string payloadId)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -28,6 +28,7 @@ public partial class EngineModuleTests
         "0xc1ecac4884c36982061392807b9307fb0d701a05d9d9fd7dc7e82d2ec96cf9af",
         "0x8ffb712de6b72f59def7b84f361e6c23519f7f8674d7e6552e23617a996d8ed3",
         "0x0f0b18188ed90425")]
+    [NonParallelizable]
     public virtual async Task Should_process_block_as_expected_V4(string latestValidHash, string blockHash,
         string stateRoot, string payloadId)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -40,6 +40,7 @@ public partial class EngineModuleTests
     }
 
     [TestCase("0xb54389c226c76c61de0a8ebea2fe74cb0119295d34b8c01d0897901867c41c63", "0x14c38ed94cf91d5323eb3aaa7ff6c64c4c059a0a898658fcbc37f9723c25e6b3", "0x8a792f3d13211724decede460a451cdac669b5aaae37a01c2110d9f3114bc8a2", "0xfe420b1626a1f16d")]
+    [NonParallelizable]
     public virtual async Task Should_process_block_as_expected_V6(
         string latestValidHash,
         string blockHash,


### PR DESCRIPTION
## Summary

`Should_process_block_as_expected_V2/V4/V6` flake on busy CI runners with `TaskCanceledException` at `engine_getPayloadV{N}` — example: PR #11531 [job 75036080709](https://github.com/NethermindEth/nethermind/actions/runs/25562101676/job/75036080709) where all three failed at the same wall-clock instant after 4m37s with identical stack signatures (the JSON-RPC ``InvalidBlockLevelAccessListHash`` lines in the same log are unrelated stdout from other tests).

These tests:
* are declared on a fixture marked `[Parallelizable(ParallelScope.All)]` with `[TestFixture(true)]`/`[TestFixture(false)]` — so each test runs twice concurrently (parallel-execution-on and -off variants).
* boot a full `MergeTestBlockchain` (block tree, txpool, payload service, Autofac container).
* await `PayloadPreparationService` output through async continuations.

Under heavy CI parallelism the test thread pool can starve and the awaited continuation never runs to completion before fixture-scope cancellation fires, producing `TaskCanceledException` in `CountingStreamPipeWriter.FlushAsyncInternal`. PR #11531 (`eth_getHeaderByHash`/`ByNumber`) only touches `Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs` and friends — there's no plausible code path to break BAL or block processing — so the failure is environmental.

## Changes

`[NonParallelizable]` on the three test methods. Same workaround already applied to other timing-sensitive engine tests (`EngineModuleTests.PayloadProduction.cs:189`, `RelayBuilder.cs:95`, `V1.cs:658/696/730`).

#### What types of changes does your code introduce?

- [x] Bugfix (non-breaking; CI-stability fix)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes (existing tests, attribute-only change)
- [ ] No

#### Notes on testing

* Local: all 6 instances (3 tests × 2 fixture variants) pass in 5s.