### PR TITLE
Eliminate ForcedNumberConversion boxing on set

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/GethLikeCustomTraceConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/GethLikeCustomTraceConverter.cs
@@ -19,15 +19,15 @@ public class GethLikeCustomTraceConverter : JsonConverter<GethLikeCustomTrace>
             return;
         }
 
-        NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Raw;
+        NumberConversion previousValue = ForcedNumberConversion.Value;
+        ForcedNumberConversion.Value = NumberConversion.Raw;
         try
         {
             JsonSerializer.Serialize(writer, value.Value, options);
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = previousValue;
+            ForcedNumberConversion.Value = previousValue;
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrameConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracerCallFrameConverter.cs
@@ -12,12 +12,12 @@ public class NativeCallTracerCallFrameConverter : JsonConverter<NativeCallTracer
 {
     public override void Write(Utf8JsonWriter writer, NativeCallTracerCallFrame value, JsonSerializerOptions options)
     {
-        NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
+        NumberConversion previousValue = ForcedNumberConversion.Value;
         try
         {
             writer.WriteStartObject();
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
             writer.WritePropertyName("type"u8);
             JsonSerializer.Serialize(writer, Enum.GetName(value.Type), options);
 
@@ -86,7 +86,7 @@ public class NativeCallTracerCallFrameConverter : JsonConverter<NativeCallTracer
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = previousValue;
+            ForcedNumberConversion.Value = previousValue;
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
@@ -12,19 +12,19 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
 {
     public override void Write(Utf8JsonWriter writer, NativePrestateTracerAccount value, JsonSerializerOptions options)
     {
-        NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
+        NumberConversion previousValue = ForcedNumberConversion.Value;
         try
         {
             writer.WriteStartObject();
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
             if (value.Balance is not null)
             {
                 writer.WritePropertyName("balance"u8);
                 JsonSerializer.Serialize(writer, value.Balance, options);
             }
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Decimal;
+            ForcedNumberConversion.Value = NumberConversion.Decimal;
             if (value.Nonce is not null)
             {
                 writer.WritePropertyName("nonce"u8);
@@ -37,7 +37,7 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
                 JsonSerializer.Serialize(writer, value.Code, options);
             }
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
+            ForcedNumberConversion.Value = NumberConversion.ZeroPaddedHex;
             if (value.Storage?.Count > 0)
             {
                 writer.WritePropertyName("storage"u8);
@@ -48,7 +48,7 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = previousValue;
+            ForcedNumberConversion.Value = previousValue;
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTraceConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTraceConverter.cs
@@ -34,15 +34,15 @@ public class GethLikeTxTraceConverter : JsonConverter<GethLikeTxTrace>
             if (reader.ValueTextEquals("gas"u8))
             {
                 reader.Read();
-                NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
-                ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Raw;
+                NumberConversion previousValue = ForcedNumberConversion.Value;
+                ForcedNumberConversion.Value = NumberConversion.Raw;
                 try
                 {
                     trace.Gas = JsonSerializer.Deserialize<long>(ref reader, options);
                 }
                 finally
                 {
-                    ForcedNumberConversion.ForcedConversion.Value = previousValue;
+                    ForcedNumberConversion.Value = previousValue;
                 }
 
                 continue;
@@ -95,8 +95,8 @@ public class GethLikeTxTraceConverter : JsonConverter<GethLikeTxTrace>
 
         writer.WriteStartObject();
 
-        NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Raw;
+        NumberConversion previousValue = ForcedNumberConversion.Value;
+        ForcedNumberConversion.Value = NumberConversion.Raw;
         try
         {
             writer.WritePropertyName("gas"u8);
@@ -104,7 +104,7 @@ public class GethLikeTxTraceConverter : JsonConverter<GethLikeTxTrace>
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = previousValue;
+            ForcedNumberConversion.Value = previousValue;
         }
 
         writer.WritePropertyName("failed"u8);

--- a/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
@@ -84,24 +84,33 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
     public void Undefined_not_supported(NumberConversion notSupportedConversion)
     {
         ForcedNumberConversion.Value = notSupportedConversion;
-
-        UInt256Converter converter = new();
-        Assert.Throws<NotSupportedException>(
-            () => TestConverter(int.MaxValue, Equals, converter));
-        Assert.Throws<NotSupportedException>(
-            () => TestConverter(UInt256.One, Equals, converter));
-
-        ForcedNumberConversion.Value = NumberConversion.Hex;
+        try
+        {
+            UInt256Converter converter = new();
+            Assert.Throws<NotSupportedException>(
+                () => TestConverter(int.MaxValue, Equals, converter));
+            Assert.Throws<NotSupportedException>(
+                () => TestConverter(UInt256.One, Equals, converter));
+        }
+        finally
+        {
+            ForcedNumberConversion.Value = NumberConversion.Hex;
+        }
     }
 
     [Test]
     public void Raw_works_with_zero_and_this_is_ok()
     {
         ForcedNumberConversion.Value = NumberConversion.Raw;
-        UInt256Converter converter = new();
-        TestConverter(0, Equals, converter);
-
-        ForcedNumberConversion.Value = NumberConversion.Hex;
+        try
+        {
+            UInt256Converter converter = new();
+            TestConverter(0, Equals, converter);
+        }
+        finally
+        {
+            ForcedNumberConversion.Value = NumberConversion.Hex;
+        }
     }
 
     [TestCase("\"0xa00000\"", "10485760")]

--- a/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
@@ -83,7 +83,7 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
     [TestCase((NumberConversion)99)]
     public void Undefined_not_supported(NumberConversion notSupportedConversion)
     {
-        ForcedNumberConversion.ForcedConversion.Value = notSupportedConversion;
+        ForcedNumberConversion.Value = notSupportedConversion;
 
         UInt256Converter converter = new();
         Assert.Throws<NotSupportedException>(
@@ -91,17 +91,17 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
         Assert.Throws<NotSupportedException>(
             () => TestConverter(UInt256.One, Equals, converter));
 
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+        ForcedNumberConversion.Value = NumberConversion.Hex;
     }
 
     [Test]
     public void Raw_works_with_zero_and_this_is_ok()
     {
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Raw;
+        ForcedNumberConversion.Value = NumberConversion.Raw;
         UInt256Converter converter = new();
         TestConverter(0, Equals, converter);
 
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+        ForcedNumberConversion.Value = NumberConversion.Hex;
     }
 
     [TestCase("\"0xa00000\"", "10485760")]
@@ -170,7 +170,7 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
     [Test]
     public void Writes_zero_padded_hex()
     {
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
+        ForcedNumberConversion.Value = NumberConversion.ZeroPaddedHex;
         try
         {
             string result = JsonSerializer.Serialize(UInt256.One, options);
@@ -184,14 +184,14 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
         }
     }
 
     [Test]
     public void Writes_zero_padded_hex_roundtrip()
     {
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
+        ForcedNumberConversion.Value = NumberConversion.ZeroPaddedHex;
         try
         {
             UInt256 value = new(0xdeadbeef, 0xcafebabe, 0x12345678, 0x9abcdef0);
@@ -201,7 +201,7 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
         }
     }
 
@@ -210,7 +210,7 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
     [TestCase(1UL, "\"0x0000000000000000000000000000000000000000000000000000000000000001\"", NumberConversion.ZeroPaddedHex)]
     public void Writes_property_name(ulong value, string expectedKey, NumberConversion conversion)
     {
-        ForcedNumberConversion.ForcedConversion.Value = conversion;
+        ForcedNumberConversion.Value = conversion;
         try
         {
             using System.IO.MemoryStream stream = new();
@@ -227,7 +227,7 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
@@ -19,53 +19,61 @@ public class TxReceiptConverter : JsonConverter<TxReceipt>
 
     public override void Write(Utf8JsonWriter writer, TxReceipt value, JsonSerializerOptions options)
     {
-        writer.WriteStartObject();
-        ReceiptForRpc receipt = new(value.TxHash!, value, 0, default);
-        if (receipt.Type != TxType.Legacy)
-        {
-            writer.WritePropertyName("type");
-            JsonSerializer.Serialize(writer, receipt.Type, options);
-        }
-        writer.WritePropertyName("root");
-        ByteArrayConverter.Convert(writer, (receipt.Root ?? Keccak.Zero).Bytes);
-        writer.WritePropertyName("status");
+        NumberConversion previousValue = ForcedNumberConversion.Value;
         ForcedNumberConversion.Value = NumberConversion.Hex;
-        JsonSerializer.Serialize(writer, receipt.Status, options);
-
-        writer.WritePropertyName("cumulativeGasUsed");
-        JsonSerializer.Serialize(writer, receipt.CumulativeGasUsed, options);
-        writer.WritePropertyName("effectiveGasPrice");
-        JsonSerializer.Serialize(writer, receipt.EffectiveGasPrice, options);
-        writer.WritePropertyName("logsBloom");
-        JsonSerializer.Serialize(writer, receipt.LogsBloom, options);
-        writer.WritePropertyName("logs");
-        JsonSerializer.Serialize(writer, receipt.Logs.Length == 0 ? null : receipt.Logs, options);
-        writer.WritePropertyName("transactionHash");
-        JsonSerializer.Serialize(writer, receipt.TransactionHash, options);
-        writer.WritePropertyName("contractAddress");
-        JsonSerializer.Serialize(writer, receipt.ContractAddress, options);
-        writer.WritePropertyName("gasUsed");
-        JsonSerializer.Serialize(writer, receipt.GasUsed, options);
-        // Diagnostic-only EIP-7778 gas breakdown.
-        if (value.BlockGasUsed > 0)
+        try
         {
-            writer.WritePropertyName("blockGasUsed");
-            JsonSerializer.Serialize(writer, value.BlockGasUsed, options);
+            writer.WriteStartObject();
+            ReceiptForRpc receipt = new(value.TxHash!, value, 0, default);
+            if (receipt.Type != TxType.Legacy)
+            {
+                writer.WritePropertyName("type");
+                JsonSerializer.Serialize(writer, receipt.Type, options);
+            }
+            writer.WritePropertyName("root");
+            ByteArrayConverter.Convert(writer, (receipt.Root ?? Keccak.Zero).Bytes);
+            writer.WritePropertyName("status");
+            JsonSerializer.Serialize(writer, receipt.Status, options);
+
+            writer.WritePropertyName("cumulativeGasUsed");
+            JsonSerializer.Serialize(writer, receipt.CumulativeGasUsed, options);
+            writer.WritePropertyName("effectiveGasPrice");
+            JsonSerializer.Serialize(writer, receipt.EffectiveGasPrice, options);
+            writer.WritePropertyName("logsBloom");
+            JsonSerializer.Serialize(writer, receipt.LogsBloom, options);
+            writer.WritePropertyName("logs");
+            JsonSerializer.Serialize(writer, receipt.Logs.Length == 0 ? null : receipt.Logs, options);
+            writer.WritePropertyName("transactionHash");
+            JsonSerializer.Serialize(writer, receipt.TransactionHash, options);
+            writer.WritePropertyName("contractAddress");
+            JsonSerializer.Serialize(writer, receipt.ContractAddress, options);
+            writer.WritePropertyName("gasUsed");
+            JsonSerializer.Serialize(writer, receipt.GasUsed, options);
+            // Diagnostic-only EIP-7778 gas breakdown.
+            if (value.BlockGasUsed > 0)
+            {
+                writer.WritePropertyName("blockGasUsed");
+                JsonSerializer.Serialize(writer, value.BlockGasUsed, options);
+            }
+            // Diagnostic-only EIP-8037 gas breakdown.
+            if (value.StorageGasUsed > 0 || value.ExecutionGasUsed > 0)
+            {
+                writer.WritePropertyName("executionGasUsed");
+                JsonSerializer.Serialize(writer, value.ExecutionGasUsed, options);
+                writer.WritePropertyName("storageGasUsed");
+                JsonSerializer.Serialize(writer, value.StorageGasUsed, options);
+            }
+            writer.WritePropertyName("blockHash");
+            JsonSerializer.Serialize(writer, receipt.BlockHash ?? Hash256.Zero, options);
+
+            writer.WritePropertyName("transactionIndex");
+            JsonSerializer.Serialize(writer, UInt256.Parse(receipt.TransactionIndex.ToString(), NumberStyles.Integer), options);
+
+            writer.WriteEndObject();
         }
-        // Diagnostic-only EIP-8037 gas breakdown.
-        if (value.StorageGasUsed > 0 || value.ExecutionGasUsed > 0)
+        finally
         {
-            writer.WritePropertyName("executionGasUsed");
-            JsonSerializer.Serialize(writer, value.ExecutionGasUsed, options);
-            writer.WritePropertyName("storageGasUsed");
-            JsonSerializer.Serialize(writer, value.StorageGasUsed, options);
+            ForcedNumberConversion.Value = previousValue;
         }
-        writer.WritePropertyName("blockHash");
-        JsonSerializer.Serialize(writer, receipt.BlockHash ?? Hash256.Zero, options);
-
-        writer.WritePropertyName("transactionIndex");
-        JsonSerializer.Serialize(writer, UInt256.Parse(receipt.TransactionIndex.ToString(), NumberStyles.Integer), options);
-
-        writer.WriteEndObject();
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
@@ -29,7 +29,7 @@ public class TxReceiptConverter : JsonConverter<TxReceipt>
         writer.WritePropertyName("root");
         ByteArrayConverter.Convert(writer, (receipt.Root ?? Keccak.Zero).Bytes);
         writer.WritePropertyName("status");
-        ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+        ForcedNumberConversion.Value = NumberConversion.Hex;
         JsonSerializer.Serialize(writer, receipt.Status, options);
 
         writer.WritePropertyName("cumulativeGasUsed");

--- a/src/Nethermind/Nethermind.Serialization.Json/ForcedNumberConversion.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ForcedNumberConversion.cs
@@ -2,36 +2,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
-
 namespace Nethermind.Serialization.Json;
 
 public static class ForcedNumberConversion
 {
-    public static readonly ThreadAwareAsyncLocal ForcedConversion = new();
-
     [ThreadStatic]
-    private static NumberConversion? _threadCache;
+    private static NumberConversion _threadCache;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static NumberConversion GetFinalConversion() => _threadCache ?? NumberConversion.Hex;
-
-    /// <summary>
-    /// Wrapper around AsyncLocal that also updates a ThreadStatic cache for fast reads.
-    /// </summary>
-    public sealed class ThreadAwareAsyncLocal
+    public static NumberConversion Value
     {
-        private readonly AsyncLocal<NumberConversion?> _asyncLocal = new();
-
-        public NumberConversion? Value
-        {
-            get => _asyncLocal.Value;
-            set
-            {
-                _asyncLocal.Value = value;
-                _threadCache = value;
-            }
-        }
+        get => _threadCache;
+        set => _threadCache = value;
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/NumberConversion.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/NumberConversion.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Serialization.Json
 {
     public enum NumberConversion
     {
-        Hex,
+        Hex = 0,
         Decimal,
         Raw,
         ZeroPaddedHex

--- a/src/Nethermind/Nethermind.Serialization.Json/NumericConverterHelper.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/NumericConverterHelper.cs
@@ -56,7 +56,7 @@ internal static class NumericConverterHelper
     [SkipLocalsInit]
     internal static void Write<T>(Utf8JsonWriter writer, T value) where T : struct, INumberBase<T>
     {
-        switch (ForcedNumberConversion.GetFinalConversion())
+        switch (ForcedNumberConversion.Value)
         {
             case NumberConversion.Hex:
                 if (value == T.Zero)

--- a/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/UInt256Converter.cs
@@ -104,7 +104,7 @@ public class UInt256Converter : JsonConverter<UInt256>
         UInt256 value,
         JsonSerializerOptions options)
     {
-        NumberConversion conversion = ForcedNumberConversion.GetFinalConversion();
+        NumberConversion conversion = ForcedNumberConversion.Value;
         switch (conversion)
         {
             case NumberConversion.Hex:
@@ -129,7 +129,7 @@ public class UInt256Converter : JsonConverter<UInt256>
 
     public override void WriteAsPropertyName(Utf8JsonWriter writer, UInt256 value, JsonSerializerOptions options)
     {
-        NumberConversion conversion = ForcedNumberConversion.GetFinalConversion();
+        NumberConversion conversion = ForcedNumberConversion.Value;
         switch (conversion)
         {
             case NumberConversion.Hex:

--- a/tools/Evm/T8n/JsonConverters/AccountStateJsonConverter.cs
+++ b/tools/Evm/T8n/JsonConverters/AccountStateJsonConverter.cs
@@ -22,12 +22,12 @@ public class AccountStateJsonConverter : JsonConverter<AccountState>
 
     public override void Write(Utf8JsonWriter writer, AccountState value, JsonSerializerOptions options)
     {
-        NumberConversion? previousValue = ForcedNumberConversion.ForcedConversion.Value;
+        NumberConversion previousValue = ForcedNumberConversion.Value;
         try
         {
             writer.WriteStartObject();
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
+            ForcedNumberConversion.Value = NumberConversion.Hex;
             writer.WritePropertyName("balance"u8);
             JsonSerializer.Serialize(writer, value.Balance, options);
 
@@ -43,7 +43,7 @@ public class AccountStateJsonConverter : JsonConverter<AccountState>
                 JsonSerializer.Serialize(writer, value.Code, options);
             }
 
-            ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
+            ForcedNumberConversion.Value = NumberConversion.ZeroPaddedHex;
             if (value.Storage.Count > 0)
             {
                 var storage = value.Storage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToUInt256());
@@ -55,7 +55,7 @@ public class AccountStateJsonConverter : JsonConverter<AccountState>
         }
         finally
         {
-            ForcedNumberConversion.ForcedConversion.Value = previousValue;
+            ForcedNumberConversion.Value = previousValue;
         }
     }
 }


### PR DESCRIPTION
## Changes

- Profiling showed AsyncLocal<NumberConversion?>.set boxing the Nullable on every call (~40 MB Box_Nullable allocations under JSON-heavy RPC), because AsyncLocal stores values via ExecutionContext as object.

<img width="626" height="82" alt="image" src="https://github.com/user-attachments/assets/fec05bbd-9784-4939-88e5-542b9be61280" />

- Drop the AsyncLocal entirely and back the override with a plain [ThreadStatic] NumberConversion field. ThreadStatic on a value type stores it directly per-thread - no boxing - and default(NumberConversion) == Hex (the natural default), so the no-conversion-set path is allocation and indirection free. set/get reduce to a single MOV.

- Collapsing the wrapper class lets callers go straight to ForcedNumberConversion.Value, replacing the indirect ForcedConversion.Value path and the redundant GetFinalConversion() helper. Hex = 0 made explicit so the default's anchor is visible at the enum definition.

- The contract is now thread-local only - the value does not flow with ExecutionContext. All current callers (GethStyle tracing converters, TxReceiptConverter) save/restore synchronously on the same thread, so this matches actual usage; the previous AsyncLocal+ThreadStatic pair could desynchronize on async hops without delivering value.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No