### PR TITLE
feat(processing): parallel-safe gas-price aggregation, base-fee fallback

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -1028,15 +1028,6 @@ public class BlockProcessorTests
         }
     }
 
-    /// <summary>
-    /// Runs the parallel validation executor over a single block with the given baseFee and transaction set,
-    /// then returns the aggregated <see cref="Nethermind.Evm.Metrics.GetBlockGasPrices"/> tuple (or <see langword="null"/>
-    /// if the block produced no aggregate).
-    /// </summary>
-    /// <remarks>
-    /// Skips via <see cref="Assume"/> on single-CPU hosts (parallel executor degrades there) and resets the
-    /// static block-stats metrics before running so callers see only this block's contribution.
-    /// </remarks>
     private static (float Min, float EstMedian, float Ave, float Max)? RunParallelValidationAndGetGasPrices(
         UInt256 baseFeePerGas,
         Transaction[] transactions)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -975,13 +975,8 @@ public class BlockProcessorTests
     [NonParallelizable]
     public void Parallel_validation_aggregates_block_gas_price_metrics_after_processing()
     {
-        Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
-        Nethermind.Evm.Metrics.ResetBlockStats();
-
         const int txCount = 4;
         const ulong oneGwei = 1_000_000_000UL;
-        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
 
         Transaction[] transactions = new Transaction[txCount];
         for (int i = 0; i < txCount; i++)
@@ -995,21 +990,9 @@ public class BlockProcessorTests
                 .TestObject;
         }
 
-        Block block = Build.A.Block
-            .WithNumber(1)
-            .WithGasLimit(txCount * 21_000)
-            .WithBaseFeePerGas((UInt256)oneGwei)
-            .WithTransactions(transactions)
-            .WithBlockAccessList(new BlockAccessList())
-            .TestObject;
+        (float Min, float EstMedian, float Ave, float Max)? prices =
+            RunParallelValidationAndGetGasPrices((UInt256)oneGwei, transactions);
 
-        using RecordingTransactionProcessorAdapter txProcessor = new();
-        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
-            CreateParallelValidationExecutor(stateProvider, txProcessor);
-
-        executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
-
-        (float Min, float EstMedian, float Ave, float Max)? prices = Nethermind.Evm.Metrics.GetBlockGasPrices();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(prices, Is.Not.Null,
@@ -1021,44 +1004,42 @@ public class BlockProcessorTests
         }
     }
 
-    [Test]
+    [TestCase(2_000_000_000UL, 2f, TestName = "Parallel_validation_seeds_block_gas_price_with_baseFee_for_empty_block")]
+    [TestCase(0UL, null, TestName = "Parallel_validation_does_not_seed_block_gas_price_for_zero_baseFee_empty_block")]
     [NonParallelizable]
-    public void Parallel_validation_seeds_block_gas_price_with_baseFee_for_empty_block()
+    public void Parallel_validation_empty_block_seeding(ulong baseFeeWei, float? expectedSeedGwei)
     {
-        Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
-        Nethermind.Evm.Metrics.ResetBlockStats();
+        (float Min, float EstMedian, float Ave, float Max)? prices =
+            RunParallelValidationAndGetGasPrices((UInt256)baseFeeWei, []);
 
-        const ulong twoGwei = 2_000_000_000UL;
-        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        if (expectedSeedGwei is null)
+        {
+            Assert.That(prices, Is.Null,
+                "Zero-baseFee empty block must leave aggregates uninitialized so the log row stays blank rather than rendering 0.000.");
+            return;
+        }
 
-        Block block = Build.A.Block
-            .WithNumber(1)
-            .WithGasLimit(21_000)
-            .WithBaseFeePerGas((UInt256)twoGwei)
-            .WithTransactions([])
-            .WithBlockAccessList(new BlockAccessList())
-            .TestObject;
-
-        using RecordingTransactionProcessorAdapter txProcessor = new();
-        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
-            CreateParallelValidationExecutor(stateProvider, txProcessor);
-
-        executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
-
-        (float Min, float EstMedian, float Ave, float Max)? prices = Nethermind.Evm.Metrics.GetBlockGasPrices();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(prices, Is.Not.Null, "Empty block with non-zero baseFee must seed the aggregates.");
-            Assert.That(prices!.Value.Min, Is.EqualTo(2f).Within(0.001f));
-            Assert.That(prices!.Value.Max, Is.EqualTo(2f).Within(0.001f));
-            Assert.That(prices!.Value.Ave, Is.EqualTo(2f).Within(0.001f));
+            Assert.That(prices!.Value.Min, Is.EqualTo(expectedSeedGwei.Value).Within(0.001f));
+            Assert.That(prices!.Value.Max, Is.EqualTo(expectedSeedGwei.Value).Within(0.001f));
+            Assert.That(prices!.Value.Ave, Is.EqualTo(expectedSeedGwei.Value).Within(0.001f));
         }
     }
 
-    [Test]
-    [NonParallelizable]
-    public void Parallel_validation_does_not_seed_block_gas_price_for_zero_baseFee_empty_block()
+    /// <summary>
+    /// Runs the parallel validation executor over a single block with the given baseFee and transaction set,
+    /// then returns the aggregated <see cref="Nethermind.Evm.Metrics.GetBlockGasPrices"/> tuple (or <see langword="null"/>
+    /// if the block produced no aggregate).
+    /// </summary>
+    /// <remarks>
+    /// Skips via <see cref="Assume"/> on single-CPU hosts (parallel executor degrades there) and resets the
+    /// static block-stats metrics before running so callers see only this block's contribution.
+    /// </remarks>
+    private static (float Min, float EstMedian, float Ave, float Max)? RunParallelValidationAndGetGasPrices(
+        UInt256 baseFeePerGas,
+        Transaction[] transactions)
     {
         Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
         Nethermind.Evm.Metrics.ResetBlockStats();
@@ -1066,11 +1047,12 @@ public class BlockProcessorTests
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
 
+        long gasLimit = Math.Max(transactions.Length, 1) * 21_000;
         Block block = Build.A.Block
             .WithNumber(1)
-            .WithGasLimit(21_000)
-            .WithBaseFeePerGas(UInt256.Zero)
-            .WithTransactions([])
+            .WithGasLimit(gasLimit)
+            .WithBaseFeePerGas(baseFeePerGas)
+            .WithTransactions(transactions)
             .WithBlockAccessList(new BlockAccessList())
             .TestObject;
 
@@ -1080,8 +1062,7 @@ public class BlockProcessorTests
 
         executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
 
-        Assert.That(Nethermind.Evm.Metrics.GetBlockGasPrices(), Is.Null,
-            "Zero-baseFee empty block must leave aggregates uninitialized so the log row stays blank rather than rendering 0.000.");
+        return Nethermind.Evm.Metrics.GetBlockGasPrices();
     }
 
     private static BlockAccessListManager CreateAmsterdamBalManager()

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -971,6 +971,119 @@ public class BlockProcessorTests
         Assert.Throws<TaskCanceledException>(() => gasResults[1].GetResult());
     }
 
+    [Test]
+    [NonParallelizable]
+    public void Parallel_validation_aggregates_block_gas_price_metrics_after_processing()
+    {
+        Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
+        Nethermind.Evm.Metrics.ResetBlockStats();
+
+        const int txCount = 4;
+        const ulong oneGwei = 1_000_000_000UL;
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        Transaction[] transactions = new Transaction[txCount];
+        for (int i = 0; i < txCount; i++)
+        {
+            transactions[i] = Build.A.Transaction
+                .WithType(TxType.EIP1559)
+                .WithNonce((UInt256)i)
+                .WithGasLimit(21_000)
+                .WithMaxFeePerGas((UInt256)((ulong)(2 + i) * oneGwei))
+                .WithMaxPriorityFeePerGas((UInt256)oneGwei)
+                .TestObject;
+        }
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithGasLimit(txCount * 21_000)
+            .WithBaseFeePerGas((UInt256)oneGwei)
+            .WithTransactions(transactions)
+            .WithBlockAccessList(new BlockAccessList())
+            .TestObject;
+
+        using RecordingTransactionProcessorAdapter txProcessor = new();
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
+            CreateParallelValidationExecutor(stateProvider, txProcessor);
+
+        executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+
+        (float Min, float EstMedian, float Ave, float Max)? prices = Nethermind.Evm.Metrics.GetBlockGasPrices();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(prices, Is.Not.Null,
+                "AggregateBlockGasPriceMetrics must populate the block-gas-price aggregates after a parallel run.");
+            Assert.That(prices!.Value.Min, Is.GreaterThan(0f), "Min must be folded from at least one user tx.");
+            Assert.That(prices!.Value.Max, Is.GreaterThanOrEqualTo(prices!.Value.Min));
+            Assert.That(BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution,
+                Is.True, "Flag must mark the parallel path on the writing thread.");
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void Parallel_validation_seeds_block_gas_price_with_baseFee_for_empty_block()
+    {
+        Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
+        Nethermind.Evm.Metrics.ResetBlockStats();
+
+        const ulong twoGwei = 2_000_000_000UL;
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithGasLimit(21_000)
+            .WithBaseFeePerGas((UInt256)twoGwei)
+            .WithTransactions([])
+            .WithBlockAccessList(new BlockAccessList())
+            .TestObject;
+
+        using RecordingTransactionProcessorAdapter txProcessor = new();
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
+            CreateParallelValidationExecutor(stateProvider, txProcessor);
+
+        executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+
+        (float Min, float EstMedian, float Ave, float Max)? prices = Nethermind.Evm.Metrics.GetBlockGasPrices();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(prices, Is.Not.Null, "Empty block with non-zero baseFee must seed the aggregates.");
+            Assert.That(prices!.Value.Min, Is.EqualTo(2f).Within(0.001f));
+            Assert.That(prices!.Value.Max, Is.EqualTo(2f).Within(0.001f));
+            Assert.That(prices!.Value.Ave, Is.EqualTo(2f).Within(0.001f));
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void Parallel_validation_does_not_seed_block_gas_price_for_zero_baseFee_empty_block()
+    {
+        Assume.That(Environment.ProcessorCount, Is.GreaterThan(1));
+        Nethermind.Evm.Metrics.ResetBlockStats();
+
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithGasLimit(21_000)
+            .WithBaseFeePerGas(UInt256.Zero)
+            .WithTransactions([])
+            .WithBlockAccessList(new BlockAccessList())
+            .TestObject;
+
+        using RecordingTransactionProcessorAdapter txProcessor = new();
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
+            CreateParallelValidationExecutor(stateProvider, txProcessor);
+
+        executor.ProcessTransactions(block, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+
+        Assert.That(Nethermind.Evm.Metrics.GetBlockGasPrices(), Is.Null,
+            "Zero-baseFee empty block must leave aggregates uninitialized so the log row stays blank rather than rendering 0.000.");
+    }
+
     private static BlockAccessListManager CreateAmsterdamBalManager()
     {
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -44,6 +44,8 @@ public partial class BlockProcessor
                 }
             }
 
+            Metrics.SeedBlockGasPriceIfEmpty(in block.Header.BaseFeePerGas);
+
             return [.. receiptsTracer.TxReceipts];
 
             [DebuggerHidden]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -38,11 +38,16 @@ public partial class BlockProcessor
         private int[] _txExecutionOrder = [];
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
 
-        // Reflects how the most recent block was executed; consumed by ProcessingStats to label
-        // the "Processed" log line. Per-chunk (last block wins on multi-block batches), which is
-        // fine for the typical live-head case of one block per slot. volatile so cross-thread
-        // monitoring readers (Prometheus scrapers, dashboards) see fresh writes without barriers.
-        public static volatile bool LastBlockUsedParallelExecution;
+        // Reflects how the most recent block was executed on the current processing thread; consumed by
+        // ProcessingStats on the same thread to label the Block-throughput log line. ThreadStatic so
+        // concurrent processing pipelines (tests, multi-context hosts) cannot overwrite each other's
+        // value, and so a stale write from one BlockProcessor instance cannot leak into another's log.
+        [ThreadStatic] private static bool _lastBlockUsedParallelExecution;
+        public static bool LastBlockUsedParallelExecution
+        {
+            get => _lastBlockUsedParallelExecution;
+            private set => _lastBlockUsedParallelExecution = value;
+        }
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {
@@ -77,6 +82,10 @@ public partial class BlockProcessor
             return receipts;
         }
 
+        // Recomputes effective gas price for each tx serially after parallel workers join; the
+        // alternative (per-worker thread-local accumulators merged after join) was rejected because
+        // avg/median don't compose losslessly across partitions and the cost here is bounded:
+        // ~150 txs/block * (one Min/Add UInt256 op + a few float ops) ~ <20us, vs ~100ms block work.
         private void AggregateBlockGasPriceMetrics(Block block)
         {
             IReleaseSpec spec = specProvider.GetSpec(block.Header);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -15,6 +15,7 @@ using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using Nethermind.Logging;
 
 namespace Nethermind.Consensus.Processing;
@@ -37,6 +38,11 @@ public partial class BlockProcessor
         private int[] _txExecutionOrder = [];
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
 
+        // Reflects how the most recent block was executed; consumed by ProcessingStats to label
+        // the "Processed" log line. Per-chunk (last block wins on multi-block batches), which is
+        // fine for the typical live-head case of one block per slot.
+        public static bool LastBlockUsedParallelExecution { get; private set; }
+
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {
             balManager.SetBlockExecutionContext(blockExecutionContext);
@@ -47,14 +53,45 @@ public partial class BlockProcessor
         {
             if (!balManager.Enabled)
             {
+                LastBlockUsedParallelExecution = false;
                 return inner.ProcessTransactions(block, processingOptions, receiptsTracer, token);
             }
 
             Metrics.ResetBlockStats();
 
-            return !block.IsGenesis && balManager.ParallelExecutionEnabled
+            bool parallel = !block.IsGenesis && balManager.ParallelExecutionEnabled;
+            LastBlockUsedParallelExecution = parallel;
+            TxReceipt[] receipts = parallel
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
+
+            if (parallel)
+            {
+                AggregateBlockGasPriceMetrics(block);
+            }
+            else
+            {
+                Metrics.SeedBlockGasPriceIfEmpty(in block.Header.BaseFeePerGas);
+            }
+            return receipts;
+        }
+
+        private void AggregateBlockGasPriceMetrics(Block block)
+        {
+            IReleaseSpec spec = specProvider.GetSpec(block.Header);
+            UInt256 baseFee = block.Header.BaseFeePerGas;
+            bool eip1559 = spec.IsEip1559Enabled;
+
+            Transaction[] txs = block.Transactions;
+            for (int i = 0; i < txs.Length; i++)
+            {
+                Transaction tx = txs[i];
+                if (tx.IsSystem()) continue;
+                UInt256 effective = tx.CalculateEffectiveGasPrice(eip1559, in baseFee);
+                Metrics.UpdateBlockGasPrice(in effective);
+            }
+
+            Metrics.SeedBlockGasPriceIfEmpty(in baseFee);
         }
 
         private TxReceipt[] ProcessTransactionsSequential(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token)
@@ -132,6 +169,8 @@ public partial class BlockProcessor
                         {
                             bool previousIsBlockProcessingThread = ProcessingThread.IsBlockProcessingThread;
                             ProcessingThread.IsBlockProcessingThread = state.isBlockProcessingThread;
+                            bool previousSuppress = Metrics.SuppressInlineGasPriceUpdate;
+                            Metrics.SuppressInlineGasPriceUpdate = true;
                             try
                             {
                                 if (i == 0)
@@ -192,6 +231,7 @@ public partial class BlockProcessor
                             finally
                             {
                                 ProcessingThread.IsBlockProcessingThread = previousIsBlockProcessingThread;
+                                Metrics.SuppressInlineGasPriceUpdate = previousSuppress;
                             }
                         });
                 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -40,8 +40,9 @@ public partial class BlockProcessor
 
         // Reflects how the most recent block was executed; consumed by ProcessingStats to label
         // the "Processed" log line. Per-chunk (last block wins on multi-block batches), which is
-        // fine for the typical live-head case of one block per slot.
-        public static bool LastBlockUsedParallelExecution { get; private set; }
+        // fine for the typical live-head case of one block per slot. volatile so cross-thread
+        // monitoring readers (Prometheus scrapers, dashboards) see fresh writes without barriers.
+        public static volatile bool LastBlockUsedParallelExecution;
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -320,7 +320,27 @@ namespace Nethermind.Consensus.Processing
             double bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1_000_000.0;
             double chunkMs = (chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000.0);
             double runMs = (data.RunMicroseconds == 0 ? -1 : data.RunMicroseconds / 1000.0);
-            string blockGas = Evm.Metrics.BlockMinGasPrice != float.MaxValue ? $"⛽ Gas gwei: {Evm.Metrics.BlockMinGasPrice:N3} .. {whiteText}{Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice):N3}{resetColor} ({Evm.Metrics.BlockAveGasPrice:N3}) .. {Evm.Metrics.BlockMaxGasPrice:N3}" : "";
+            string blockGas;
+            if (Evm.Metrics.BlockMinGasPrice == float.MaxValue)
+            {
+                blockGas = "";
+            }
+            else
+            {
+                float gasMin = Evm.Metrics.BlockMinGasPrice;
+                float gasMax = Evm.Metrics.BlockMaxGasPrice;
+                float gasAve = Evm.Metrics.BlockAveGasPrice;
+                float gasMed = Math.Max(gasMin, Evm.Metrics.BlockEstMedianGasPrice);
+                // Step down GWei -> MWei -> KWei -> Wei until min renders non-zero at :N3.
+                // 0.0005 is the rounding threshold for :N3, so min*scale must reach it.
+                string gasUnit;
+                float gasScale;
+                if (gasMin >= 0.0005f) { gasUnit = "GWei"; gasScale = 1f; }
+                else if (gasMin >= 5e-7f) { gasUnit = "MWei"; gasScale = 1_000f; }
+                else if (gasMin >= 5e-10f) { gasUnit = "KWei"; gasScale = 1_000_000f; }
+                else { gasUnit = "Wei"; gasScale = 1_000_000_000f; }
+                blockGas = $"⛽ Gas {gasUnit}: {gasMin * gasScale:N3} .. {whiteText}{gasMed * gasScale:N3}{resetColor} ({gasAve * gasScale:N3}) .. {gasMax * gasScale:N3}";
+            }
             string mgasColor = whiteText;
 
             NewProcessingStatistics?.Invoke(this, new BlockStatistics()
@@ -343,9 +363,16 @@ namespace Nethermind.Consensus.Processing
 
             if (_logger.IsInfo)
             {
+                // Execution-mode indicator (⛓️ = parallel BAL executor, 🔗 = sequential). Appended at
+                // end-of-line so emoji-cell-width variation across terminals can't drift the
+                // mid-line pipes against the Blocks/Throughput rows below.
+                string execMode = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution
+                    ? " \u26D3\uFE0F"
+                    : " \U0001f517";
+
                 if (chunkBlocks > 1)
                 {
-                    _logger.Info($"Processed    {chunkFirstBlockNumber,10}...{block.Number,9}   | {chunkMs,10:N1} ms  | slot    {runMs,11:N0} ms |{blockGas}");
+                    _logger.Info($"Processed    {chunkFirstBlockNumber,10}...{block.Number,9}   | {chunkMs,10:N1} ms  | slot    {runMs,11:N0} ms |{blockGas}{execMode}");
                 }
                 else
                 {
@@ -372,7 +399,7 @@ namespace Nethermind.Consensus.Processing
                         < 2000 => orangeText,
                         _ => redText
                     };
-                    _logger.Info($"Processed          {block.Number,10}         | {chunkColor}{chunkMs,10:N1}{resetColor} ms  | slot    {runMs,11:N0} ms |{blockGas}");
+                    _logger.Info($"Processed          {block.Number,10}         | {chunkColor}{chunkMs,10:N1}{resetColor} ms  | slot    {runMs,11:N0} ms |{blockGas}{execMode}");
                 }
 
                 string mgasPerSecondColor = (mgasPerSecond / (block.GasLimit / 1_000_000.0)) switch

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -363,16 +363,16 @@ namespace Nethermind.Consensus.Processing
 
             if (_logger.IsInfo)
             {
-                // Execution-mode indicator (⛓️ = parallel BAL executor, 🔗 = sequential). Appended at
-                // end-of-line so emoji-cell-width variation across terminals can't drift the
-                // mid-line pipes against the Blocks/Throughput rows below.
+                // Execution-mode indicator (⛓️ = parallel BAL executor, 🔗 = sequential). Appended after
+                // the ops count on the Block throughput row so emoji-cell-width variation across terminals
+                // can't drift the mid-line pipes on the rows above.
                 string execMode = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution
                     ? " \u26D3\uFE0F"
                     : " \U0001f517";
 
                 if (chunkBlocks > 1)
                 {
-                    _logger.Info($"Processed    {chunkFirstBlockNumber,10}...{block.Number,9}   | {chunkMs,10:N1} ms  | slot    {runMs,11:N0} ms |{blockGas}{execMode}");
+                    _logger.Info($"Processed    {chunkFirstBlockNumber,10}...{block.Number,9}   | {chunkMs,10:N1} ms  | slot    {runMs,11:N0} ms |{blockGas}");
                 }
                 else
                 {
@@ -399,7 +399,7 @@ namespace Nethermind.Consensus.Processing
                         < 2000 => orangeText,
                         _ => redText
                     };
-                    _logger.Info($"Processed          {block.Number,10}         | {chunkColor}{chunkMs,10:N1}{resetColor} ms  | slot    {runMs,11:N0} ms |{blockGas}{execMode}");
+                    _logger.Info($"Processed          {block.Number,10}         | {chunkColor}{chunkMs,10:N1}{resetColor} ms  | slot    {runMs,11:N0} ms |{blockGas}");
                 }
 
                 string mgasPerSecondColor = (mgasPerSecond / (block.GasLimit / 1_000_000.0)) switch
@@ -452,11 +452,11 @@ namespace Nethermind.Consensus.Processing
 
                 if (recoveryQueue > 0 || processingQueue > 0)
                 {
-                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| recover {recoveryQueue,5:N0} | process {processingQueue,5:N0} | ops {chunkOpCodes,11:N0}");
+                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| recover {recoveryQueue,5:N0} | process {processingQueue,5:N0} | ops {chunkOpCodes,11:N0}{execMode}");
                 }
                 else
                 {
-                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| exec code{resetColor} cache {cachedContractsUsed,7:N0} |{resetColor} new {contractsAnalysed,6:N0} | ops {chunkOpCodes,11:N0}");
+                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| exec code{resetColor} cache {cachedContractsUsed,7:N0} |{resetColor} new {contractsAnalysed,6:N0} | ops {chunkOpCodes,11:N0}{execMode}");
                 }
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -146,6 +146,9 @@ namespace Nethermind.Consensus.Processing
             blockData.CurrentContractsAnalyzed = Evm.Metrics.MainThreadContractsAnalysed;
             blockData.CurrentCreatesOps = Evm.Metrics.MainThreadCreates;
             blockData.CurrentSelfDestructOps = Evm.Metrics.MainThreadSelfDestructs;
+            // Snapshot the ThreadStatic exec-mode flag now (block-processing thread); GenerateReport
+            // runs on a thread-pool thread where the TLS slot is the default false.
+            blockData.UsedParallelExecution = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution;
 
             CaptureReportData(blockData);
         }
@@ -366,7 +369,7 @@ namespace Nethermind.Consensus.Processing
                 // Execution-mode indicator (⛓️ = parallel BAL executor, 🔗 = sequential). Appended after
                 // the ops count on the Block throughput row so emoji-cell-width variation across terminals
                 // can't drift the mid-line pipes on the rows above.
-                string execMode = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution
+                string execMode = data.UsedParallelExecution
                     ? " \u26D3\uFE0F"
                     : " \U0001f517";
 
@@ -500,6 +503,7 @@ namespace Nethermind.Consensus.Processing
                 data.GasUsed = 0;
                 data.TransactionCount = 0;
                 data.BlobCount = 0;
+                data.UsedParallelExecution = false;
 
                 return true;
             }
@@ -535,6 +539,7 @@ namespace Nethermind.Consensus.Processing
             public long StartCallOps;
             public long StartSStoreOps;
             public long StartSLoadOps;
+            public bool UsedParallelExecution;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Threading;
@@ -10,6 +11,8 @@ using System.Threading;
 [assembly: InternalsVisibleTo("Nethermind.Consensus")]
 
 namespace Nethermind.Evm;
+
+using Int256;
 
 public class Metrics
 {
@@ -225,5 +228,40 @@ public class Metrics
         BlockMaxGasPrice = 0.0f;
         BlockEstMedianGasPrice = 0.0f;
         BlockMinGasPrice = float.MaxValue;
+    }
+
+    // Parallel BAL workers race on the static aggregates; setter-restorer dance around
+    // each worker invocation defers folding to a serial post-pass.
+    [ThreadStatic] private static bool _suppressInlineGasPriceUpdate;
+    internal static bool SuppressInlineGasPriceUpdate
+    {
+        get => _suppressInlineGasPriceUpdate;
+        set => _suppressInlineGasPriceUpdate = value;
+    }
+
+    // Gas prices fit in ulong in practice (ulong.MaxValue ~ 1.8e19 wei == 1.8e10 gwei,
+    // far above any realistic effective gas price). Using .u0 dodges the multi-limb
+    // UInt256 -> double conversion in favour of a single cvtsi2sd.
+    internal static void UpdateBlockGasPrice(in UInt256 effectiveGasPrice)
+    {
+        if (!effectiveGasPrice.IsUint64) return;
+        float gasPrice = (float)(effectiveGasPrice.u0 / 1_000_000_000.0);
+        BlockMinGasPrice = Math.Min(gasPrice, BlockMinGasPrice);
+        BlockMaxGasPrice = Math.Max(gasPrice, BlockMaxGasPrice);
+        BlockAveGasPrice = (BlockAveGasPrice * BlockTransactions + gasPrice) / (BlockTransactions + 1);
+        BlockEstMedianGasPrice += BlockAveGasPrice * 0.01f * float.Sign(gasPrice - BlockEstMedianGasPrice);
+        BlockTransactions++;
+    }
+
+    // No-op when at least one user tx already folded (BlockMinGasPrice has moved off MaxValue).
+    internal static void SeedBlockGasPriceIfEmpty(in UInt256 baseFee)
+    {
+        if (BlockMinGasPrice != float.MaxValue) return;
+        if (!baseFee.IsUint64) return;
+        float gasPrice = (float)(baseFee.u0 / 1_000_000_000.0);
+        BlockMinGasPrice = gasPrice;
+        BlockMaxGasPrice = gasPrice;
+        BlockAveGasPrice = gasPrice;
+        BlockEstMedianGasPrice = gasPrice;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -253,11 +253,13 @@ public class Metrics
         BlockTransactions++;
     }
 
-    // No-op when at least one user tx already folded (BlockMinGasPrice has moved off MaxValue).
+    // No-op when at least one user tx already folded (BlockMinGasPrice has moved off MaxValue),
+    // or when baseFee is zero (pre-EIP-1559 chains, some rollups, genesis) - rendering "0.000"
+    // for empty zero-baseFee blocks would be less informative than the prior blank output.
     internal static void SeedBlockGasPriceIfEmpty(in UInt256 baseFee)
     {
         if (BlockMinGasPrice != float.MaxValue) return;
-        if (!baseFee.IsUint64) return;
+        if (!baseFee.IsUint64 || baseFee.IsZero) return;
         float gasPrice = (float)(baseFee.u0 / 1_000_000_000.0);
         BlockMinGasPrice = gasPrice;
         BlockMaxGasPrice = gasPrice;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
 
-            UpdateMetrics(opts, effectiveGasPrice);
+            UpdateMetrics(opts, in effectiveGasPrice);
 
             bool deleteCallerAccount = RecoverSenderIfNeeded(tx, spec, opts, effectiveGasPrice);
 
@@ -446,18 +446,14 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual IReleaseSpec GetSpec(BlockHeader header) => VirtualMachine.BlockExecutionContext.Spec;
 
-        private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
+        // Parallel BAL workers set Metrics.SuppressInlineGasPriceUpdate so racy folds
+        // defer to a serial post-pass in the parallel executor.
+        private static void UpdateMetrics(ExecutionOptions opts, in UInt256 effectiveGasPrice)
         {
-            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
+            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp
+                && !Metrics.SuppressInlineGasPriceUpdate)
             {
-                float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
-
-                Metrics.BlockMinGasPrice = Math.Min(gasPrice, Metrics.BlockMinGasPrice);
-                Metrics.BlockMaxGasPrice = Math.Max(gasPrice, Metrics.BlockMaxGasPrice);
-
-                Metrics.BlockAveGasPrice = (Metrics.BlockAveGasPrice * Metrics.BlockTransactions + gasPrice) / (Metrics.BlockTransactions + 1);
-                Metrics.BlockEstMedianGasPrice += Metrics.BlockAveGasPrice * 0.01f * float.Sign(gasPrice - Metrics.BlockEstMedianGasPrice);
-                Metrics.BlockTransactions++;
+                Metrics.UpdateBlockGasPrice(in effectiveGasPrice);
             }
         }
 


### PR DESCRIPTION
## Changes

- Parallel BAL workers defer inline gas-price folds via Metrics.SuppressInlineGasPriceUpdate; the executor recomputes serially in AggregateBlockGasPriceMetrics after workers join, giving race-free min/max and deterministic avg/median.
- SeedBlockGasPriceIfEmpty seeds all four aggregates with block.Header.BaseFeePerGas when no user tx contributed (empty / system-only blocks). Intentionally skips zero-baseFee chains (pre-EIP-1559, some rollups, genesis) - rendering "0.000" for those would be less informative than the prior blank output, so they retain the current behavior.
- ProcessingStats auto-steps the gas-price unit GWei -> MWei -> KWei -> Wei when min would render 0.000 at :N3 precision, keeping low-base-fee values visible (e.g. 7 wei renders as "Gas KWei: 0.007" instead of "Gas GWei: 0.000").
- Append execution-mode indicator to the "Block throughput" log line, after the ops count: chains for parallel BAL, link for sequential. Reads as `... | ops   1,516,057 🔗` (or ⛓️). Emoji at end-of-line of the lowest per-block row so cell-width variation across terminals cannot drift the mid-line pipes on the Block / Block-throughput rows above. The exec-mode flag is `[ThreadStatic]` so concurrent processing pipelines (tests, multi-context hosts) do not race on the same global; ProcessingStats reads on the same thread the executor wrote on.
- UpdateBlockGasPrice and SeedBlockGasPriceIfEmpty use IsUint64 / .u0 fast path to avoid the multi-limb UInt256 -> double conversion in the hot tx-execution path; single cvtsi2sd instead of an out-of-line helper call.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Three new tests in `Nethermind.Blockchain.Test/BlockProcessorTests.cs` (each `[NonParallelizable]` since the fixture is `Parallelizable(ParallelScope.All)` and Metrics is static state):

- `Parallel_validation_aggregates_block_gas_price_metrics_after_processing` - asserts `Metrics.GetBlockGasPrices()` is populated and `LastBlockUsedParallelExecution` is true after a parallel run with EIP-1559 txs at varied gas prices.
- `Parallel_validation_seeds_block_gas_price_with_baseFee_for_empty_block` - empty block + 2 gwei baseFee seeds aggregates to 2.0.
- `Parallel_validation_does_not_seed_block_gas_price_for_zero_baseFee_empty_block` - zero baseFee + empty block leaves aggregates uninitialized (`GetBlockGasPrices()` returns null).

`Nethermind.Blockchain.Test/BlockProcessorTests`: 43/43 pass.