### PR TITLE
ci: split build from test to lower peak memory; keep swap

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out PR head
         uses: actions/checkout@v6

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -111,7 +111,12 @@ jobs:
         env:
           DOTNET_EnableHWIntrinsic: ${{ matrix.variant.hw-intrinsic }}
         run: |
-          dotnet test --project ${{ matrix.project }}.csproj -c release \
+          dotnet build ${{ matrix.project }}.csproj -c release \
+            ${{ matrix.variant.dotnet-args }}
+          dotnet build-server shutdown
+          test_args=(--no-build --no-restore)
+
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" \
             ${{ matrix.variant.dotnet-args }}
 
   tests-chunked:
@@ -148,6 +153,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6
@@ -169,7 +175,12 @@ jobs:
           TEST_CHUNK: ${{ matrix.test.chunk }}
           TEST_SKIP_HEAVY: 1
         run: |
-          dotnet test --project ${{ matrix.test.project }}.csproj -c release \
+          dotnet build ${{ matrix.test.project }}.csproj -c release \
+            ${{ matrix.variant.dotnet-args }}
+          dotnet build-server shutdown
+          test_args=(--no-build --no-restore)
+
+          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" \
             ${{ matrix.variant.dotnet-args }}
 
   tests-summary:

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -111,13 +111,11 @@ jobs:
         env:
           DOTNET_EnableHWIntrinsic: ${{ matrix.variant.hw-intrinsic }}
         run: |
-          dotnet build ${{ matrix.project }}.csproj -c release \
-            ${{ matrix.variant.dotnet-args }}
+          dotnet build ${{ matrix.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
           dotnet build-server shutdown
           test_args=(--no-build --no-restore)
 
-          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" \
-            ${{ matrix.variant.dotnet-args }}
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
 
   tests-chunked:
     name: Run ${{ matrix.test.project }} (${{ matrix.test.chunk }}) [${{ matrix.variant.label }}]
@@ -175,13 +173,11 @@ jobs:
           TEST_CHUNK: ${{ matrix.test.chunk }}
           TEST_SKIP_HEAVY: 1
         run: |
-          dotnet build ${{ matrix.test.project }}.csproj -c release \
-            ${{ matrix.variant.dotnet-args }}
+          dotnet build ${{ matrix.test.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
           dotnet build-server shutdown
           test_args=(--no-build --no-restore)
 
-          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" \
-            ${{ matrix.variant.dotnet-args }}
+          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
 
   tests-summary:
     name: Tests summary

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -112,7 +112,7 @@ jobs:
           DOTNET_EnableHWIntrinsic: ${{ matrix.variant.hw-intrinsic }}
         run: |
           dotnet build ${{ matrix.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
@@ -174,7 +174,7 @@ jobs:
           TEST_SKIP_HEAVY: 1
         run: |
           dotnet build ${{ matrix.test.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -282,7 +282,7 @@ jobs:
           # parallel-variant fixture. Default Pyspec chunks instead exclude the variant
           # classes by name so they don't double-run the heavy Amsterdam fixture set.
           dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           run_test --no-build --no-restore
 
   tests-summary:

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -281,13 +281,9 @@ jobs:
           # Variant matrix entries set `matrix.filter` to scope to a specific Amsterdam
           # parallel-variant fixture. Default Pyspec chunks instead exclude the variant
           # classes by name so they don't double-run the heavy Amsterdam fixture set.
-          if [ "$IS_PYSPEC" = "true" ]; then
-            dotnet build ${{ matrix.project }}.csproj -c release
-            dotnet build-server shutdown
-            run_test --no-build --no-restore
-          else
-            run_test
-          fi
+          dotnet build ${{ matrix.project }}.csproj -c release
+          dotnet build-server shutdown
+          run_test --no-build --no-restore
 
   tests-summary:
     name: Tests summary

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -111,8 +111,12 @@ jobs:
         working-directory: src/Nethermind/${{ matrix.project }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          dotnet build ${{ matrix.project }}.csproj -c release
+          dotnet build-server shutdown
+          test_args=(--no-build --no-restore)
+
           set +e
-          dotnet test --project ${{ matrix.project }}.csproj -c release $flags
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
           rc=$?
           set -e
           if [[ $rc -eq 0 ]]; then
@@ -121,7 +125,7 @@ jobs:
             exit 1
           else
             echo "::warning::Test process crashed (exit code $rc), retrying..."
-            dotnet test --project ${{ matrix.project }}.csproj -c release $flags
+            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
           fi
 
       - name: Upload coverage report
@@ -191,8 +195,12 @@ jobs:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          dotnet build ${{ matrix.project }}.csproj -c release
+          dotnet build-server shutdown
+          test_args=(--no-build --no-restore)
+
           set +e
-          dotnet test --project ${{ matrix.project }}.csproj -c release $flags
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
           rc=$?
           set -e
           if [[ $rc -eq 0 ]]; then
@@ -201,7 +209,7 @@ jobs:
             exit 1
           else
             echo "::warning::Test process crashed (exit code $rc), retrying..."
-            dotnet test --project ${{ matrix.project }}.csproj -c release $flags
+            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
           fi
 
       - name: Upload coverage report
@@ -261,6 +269,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6
@@ -280,8 +289,12 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.test.chunk }}
         run: |
+          dotnet build ${{ matrix.test.project }}.csproj -c release
+          dotnet build-server shutdown
+          test_args=(--no-build --no-restore)
+
           set +e
-          dotnet test --project ${{ matrix.test.project }}.csproj -c release
+          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}"
           rc=$?
           set -e
           if [[ $rc -eq 0 ]]; then
@@ -290,7 +303,7 @@ jobs:
             exit 1
           else
             echo "::warning::Test process crashed (exit code $rc), retrying..."
-            dotnet test --project ${{ matrix.test.project }}.csproj -c release
+            dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}"
           fi
 
   tests-summary:

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e
@@ -196,7 +196,7 @@ jobs:
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e
@@ -290,7 +290,7 @@ jobs:
           TEST_CHUNK: ${{ matrix.test.chunk }}
         run: |
           dotnet build ${{ matrix.test.project }}.csproj -c release
-          dotnet build-server shutdown
+          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/run-gas-benchmarks.yml
+++ b/.github/workflows/run-gas-benchmarks.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           large-packages: false
           tool-cache: false
+          swap-storage: false
 
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

Two related CI memory improvements applied across all GitHub Actions workflows:

**Split `dotnet build` from `dotnet test` to lower peak memory** (3 test workflows):
- Run `dotnet build` separately, then `dotnet build-server shutdown` to release the build-server process before the test run starts.
- Test step then runs with `--no-build --no-restore` so it never re-spawns a build server.
- Cuts peak resident memory during the heaviest test matrices, where the build server and the test host previously lived side-by-side.
- Applied to `nethermind-tests.yml`, `nethermind-tests-checked.yml`, `nethermind-tests-flat.yml`. The flat workflow already did this for the `IS_PYSPEC=true` branch only; the conditional is removed so all matrix entries get uniform treatment.

**Keep swap on every runner that uses `jlumbroso/free-disk-space`** (9 workflows total):
- `swap-storage: false` (i.e. "do not remove the swap file") added to every invocation of the disk-cleanup action. The action's default removes swap to free disk; for memory-bound runners that's the wrong tradeoff - swap is the OOM safety net.
- Applied to: `nethermind-tests.yml`, `nethermind-tests-checked.yml`, `nethermind-tests-flat.yml`, `build-solutions.yml`, `code-lint.yml`, `codeql.yml`, `evm-opcode-benchmark-diff.yml`, `publish-docker.yml`, `run-gas-benchmarks.yml`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [x] No