### PR TITLE
feat(consensus): cap deposit requests per produced block (EIP-8254)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Config;
 using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.ExecutionRequests;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
@@ -353,7 +354,7 @@ namespace Nethermind.Blockchain.Test
             ISpecProvider specProvider = new TestSingleReleaseSpecProvider(spec);
 
             BlockProcessor.BlockProductionTransactionPicker txPicker = new(specProvider, mempoolLength / 1.KiB - 1);
-            BlockProcessor.BlockProductionTransactionsExecutor txExecutor = new(transactionProcessor, stateProvider, txPicker, LimboLogs.Instance, NullBlockAccessListManager.Instance);
+            BlockProcessor.BlockProductionTransactionsExecutor txExecutor = new(transactionProcessor, stateProvider, specProvider, txPicker, LimboLogs.Instance, NullBlockAccessListManager.Instance);
 
             txExecutor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, spec));
             txExecutor.ProcessTransactions(blockToProduce, ProcessingOptions.ProducingBlock, new());
@@ -410,6 +411,68 @@ namespace Nethermind.Blockchain.Test
             Assert.That(selectedTransactions[1], Is.SameAs(secondTx));
         }
 
+        [Test]
+        public void BlockProductionTransactionsExecutor_skips_transaction_that_would_exceed_deposit_request_cap()
+        {
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+            Transaction atCap = BuildTransaction(1, Eip6110Constants.MainnetDepositContractAddress);
+            Transaction overCap = BuildTransaction(2, Eip6110Constants.MainnetDepositContractAddress);
+            Transaction normal = BuildTransaction(3, TestItem.AddressB);
+            Transaction[] transactions = [atCap, overCap, normal];
+
+            for (int i = 0; i < transactions.Length; i++)
+            {
+                stateProvider.CreateAccount(transactions[i].SenderAddress!, 1.Ether);
+            }
+
+            IReleaseSpec spec = Prague.Instance;
+            stateProvider.Commit(spec);
+            stateProvider.CommitTree(0);
+
+            Block block = Build.A.Block
+                .WithNumber(0)
+                .WithBaseFeePerGas(0)
+                .WithGasLimit(GasCostOf.Transaction * transactions.Length)
+                .WithTransactions(transactions)
+                .TestObject;
+            BlockToProduce blockToProduce = new(block.Header, block.Transactions, block.Uncles);
+            ISpecProvider specProvider = new TestSingleReleaseSpecProvider(spec);
+
+            Dictionary<Hash256, int> depositRequestsByTxHash = new()
+            {
+                [atCap.Hash!] = Eip6110Constants.MaxDepositRequestsPerBlock,
+                [overCap.Hash!] = 1
+            };
+
+            BlockProcessor.BlockProductionTransactionsExecutor txExecutor = new(
+                new DepositRequestCountingTransactionProcessor(stateProvider, depositRequestsByTxHash),
+                stateProvider,
+                specProvider,
+                new BlockProcessor.BlockProductionTransactionPicker(specProvider, BlocksConfig.DefaultMaxTxKilobytes),
+                LimboLogs.Instance,
+                NullBlockAccessListManager.Instance);
+
+            FeesTracer feesTracer = new();
+            BlockReceiptsTracer receiptsTracer = new();
+            receiptsTracer.SetOtherTracer(feesTracer);
+            receiptsTracer.StartNewBlockTrace(blockToProduce);
+
+            txExecutor.SetBlockExecutionContext(new BlockExecutionContext(blockToProduce.Header, spec));
+            TxReceipt[] receipts = txExecutor.ProcessTransactions(blockToProduce, ProcessingOptions.ProducingBlock, receiptsTracer);
+            Transaction[] selectedTransactions = blockToProduce.Transactions.ToArray();
+
+            Assert.That(selectedTransactions, Has.Length.EqualTo(2));
+            Assert.That(selectedTransactions[0], Is.SameAs(atCap));
+            Assert.That(selectedTransactions[1], Is.SameAs(normal));
+            Assert.That(receipts, Has.Length.EqualTo(2));
+            Assert.That(blockToProduce.Header.GasUsed, Is.EqualTo(GasCostOf.Transaction * 2));
+            Assert.That(feesTracer.Fees, Is.EqualTo((UInt256)2));
+            Assert.That(stateProvider.GetNonce(overCap.SenderAddress!), Is.EqualTo(UInt256.Zero));
+            Assert.That(stateProvider.GetNonce(normal.SenderAddress!), Is.EqualTo(UInt256.One));
+        }
+
         private static Transaction[] RunBlockProduction(
             ITransactionProcessorAdapter transactionProcessor,
             IWorldState stateProvider,
@@ -420,6 +483,7 @@ namespace Nethermind.Blockchain.Test
             BlockProcessor.BlockProductionTransactionsExecutor txExecutor = new(
                 transactionProcessor,
                 stateProvider,
+                specProvider,
                 new BlockProcessor.BlockProductionTransactionPicker(specProvider, BlocksConfig.DefaultMaxTxKilobytes),
                 LimboLogs.Instance,
                 NullBlockAccessListManager.Instance);
@@ -440,6 +504,57 @@ namespace Nethermind.Blockchain.Test
         {
             BlockToProduce blockToProduce = new(block.Header, block.Transactions, block.Uncles);
             return RunBlockProduction(transactionProcessor, stateProvider, new TestSingleReleaseSpecProvider(spec), blockToProduce, spec);
+        }
+
+        private static Transaction BuildTransaction(int id, Address to) =>
+            Build.A.Transaction
+                .WithSenderAddress(Address.FromNumber((UInt256)id))
+                .WithTo(to)
+                .WithValue(0)
+                .WithGasPrice(1)
+                .WithGasLimit(GasCostOf.Transaction)
+                .WithHash(TestItem.KeccakFromNumber(id))
+                .TestObject;
+
+        private sealed class DepositRequestCountingTransactionProcessor(
+            IWorldState stateProvider,
+            IReadOnlyDictionary<Hash256, int> depositRequestsByTxHash) : ITransactionProcessorAdapter
+        {
+            public TransactionResult Execute(Transaction transaction, ITxTracer txTracer)
+            {
+                stateProvider.IncrementNonce(transaction.SenderAddress!);
+                txTracer.ReportFees(1, UInt256.Zero);
+
+                GasConsumed gasConsumed = GasCostOf.Transaction;
+                txTracer.MarkAsSuccess(
+                    transaction.To ?? Address.Zero,
+                    in gasConsumed,
+                    [],
+                    CreateDepositLogs(depositRequestsByTxHash.GetValueOrDefault(transaction.Hash!, 0)));
+
+                return TransactionResult.Ok;
+            }
+
+            public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) { }
+
+            private static LogEntry[] CreateDepositLogs(int count)
+            {
+                if (count == 0)
+                {
+                    return [];
+                }
+
+                LogEntry[] logs = new LogEntry[count];
+                for (int i = 0; i < logs.Length; i++)
+                {
+                    logs[i] = new LogEntry(
+                        Eip6110Constants.MainnetDepositContractAddress,
+                        [],
+                        [ExecutionRequestsProcessor.DepositEventAbi.Hash]);
+                }
+
+                return logs;
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -253,6 +253,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     protected int _currentIndex { get; private set; }
     private readonly List<TxReceipt> _txReceipts = new();
     private readonly List<(long Regular, long State)> _cumulativeBlockGasPerTx = new();  // Track pre-refund block gas for restore (regular + EIP-8037 state)
+    private readonly Stack<(int Receipts, int Other)> _otherTracerSnapshots = new();
     private long _cumulativeReceiptGas;  // Track cumulative post-refund gas for receipts
     protected Transaction? CurrentTx;
     public ReadOnlySpan<TxReceipt> TxReceipts => CollectionsMarshal.AsSpan(_txReceipts);
@@ -285,10 +286,34 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     public ITxTracer InnerTracer => _currentTxTracer;
 
-    public int TakeSnapshot() => _txReceipts.Count;
+    public int TakeSnapshot()
+    {
+        int snapshot = _txReceipts.Count;
+        if (_otherTracer is IJournal<int> journal)
+        {
+            _otherTracerSnapshots.Push((snapshot, journal.TakeSnapshot()));
+        }
+
+        return snapshot;
+    }
 
     public void Restore(int snapshot)
     {
+        if (_otherTracer is IJournal<int> journal)
+        {
+            int otherToRestore = 0;
+            bool hasOther = false;
+            while (_otherTracerSnapshots.TryPeek(out (int Receipts, int Other) top) && top.Receipts >= snapshot)
+            {
+                otherToRestore = _otherTracerSnapshots.Pop().Other;
+                hasOther = true;
+            }
+            if (hasOther)
+            {
+                journal.Restore(otherToRestore);
+            }
+        }
+
         int numToRemove = _txReceipts.Count - snapshot;
         if (numToRemove > 0)
         {
@@ -305,6 +330,8 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
         // Restore receipt gas from remaining receipts (post-refund)
         _cumulativeReceiptGas = _txReceipts.Count > 0 ? _txReceipts[^1].GasUsedTotal : 0;
+        _currentIndex = snapshot;
+        CurrentTx = null;
     }
 
     public void ReportReward(Address author, string rewardType, UInt256 rewardValue) =>
@@ -318,6 +345,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentTxTracer = NullTxTracer.Instance;
         _txReceipts.Clear();
         _cumulativeBlockGasPerTx.Clear();
+        _otherTracerSnapshots.Clear();
         _cumulativeReceiptGas = 0;
 
         _otherTracer.StartNewBlockTrace(block);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -286,6 +286,12 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     public ITxTracer InnerTracer => _currentTxTracer;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns the current receipt count and, when the wrapped other-tracer also implements
+    /// <see cref="IJournal{Int32}"/>, takes its snapshot in lockstep so a later <see cref="Restore"/>
+    /// can rewind both consistently.
+    /// </remarks>
     public int TakeSnapshot()
     {
         int snapshot = _txReceipts.Count;
@@ -297,10 +303,21 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         return snapshot;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Cascades to any <see cref="IJournal{Int32}"/> other-tracer by popping every entry whose
+    /// receipt depth is &gt;= <paramref name="snapshot"/> and restoring it to the deepest popped state.
+    /// <paramref name="snapshot"/> must be a value previously returned by <see cref="TakeSnapshot"/>;
+    /// passing a raw <see cref="TxReceipts"/>.Length probe risks rewinding the other-tracer to an
+    /// unrelated earlier state.
+    /// </remarks>
     public void Restore(int snapshot)
     {
         if (_otherTracer is IJournal<int> journal)
         {
+            Debug.Assert(_otherTracerSnapshots.Count > 0,
+                "Restore called without a preceding TakeSnapshot for the other tracer");
+
             int otherToRestore = 0;
             bool hasOther = false;
             while (_otherTracerSnapshots.TryPeek(out (int Receipts, int Other) top) && top.Receipts >= snapshot)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -167,6 +167,7 @@ public class StartBlockProducerAuRa(
         BlockProcessor.BlockProductionTransactionsExecutor transactionExecutor = new(
             new BuildUpTransactionProcessorAdapter(txProcessor),
             worldState,
+            specProvider,
             new BlockProcessor.BlockProductionTransactionPicker(specProvider, blocksConfig.BlockProductionMaxTxKilobytes),
             logManager,
             balManager);

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
@@ -23,6 +23,12 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
     public static readonly AbiSignature DepositEventAbi = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
     private readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
 
+    /// <summary>Tests whether <paramref name="log"/> is an EIP-6110 deposit event emitted by the configured deposit contract.</summary>
+    public static bool IsDepositLog(LogEntry log, Address depositContractAddress) =>
+        log.Address == depositContractAddress
+        && log.Topics.Length >= 1
+        && log.Topics[0] == DepositEventAbi.Hash;
+
     private const long GasLimit = 30_000_000L;
 
     private readonly ITransactionProcessor _transactionProcessor;
@@ -104,7 +110,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                 for (int j = 0; j < logEntries.Length; j++)
                 {
                     LogEntry log = logEntries[j];
-                    if (log.Address == spec.DepositContractAddress && log.Topics.Length >= 1 && log.Topics[0] == DepositEventAbi.Hash)
+                    if (IsDepositLog(log, spec.DepositContractAddress))
                     {
                         Span<byte> depositRequestBuffer = new byte[ExecutionRequestExtensions.DepositRequestsBytesSize];
                         DecodeDepositRequest(block, log, depositRequestBuffer);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -122,7 +123,7 @@ namespace Nethermind.Consensus.Processing
 
                     if (result)
                     {
-                        // Mock processors in tests can return success without producing a receipt; guard before LastReceipt.
+                        // Stub adapters in tests can return Ok without emitting a receipt; production adapters always do.
                         TxReceipt? txReceipt = receiptsTracer.TxReceipts.Length > receiptsCountBeforeTx ? receiptsTracer.LastReceipt : null;
                         if (depositRequestsLimiter.Enabled
                             && txReceipt?.Logs is { Length: > 0 } logs
@@ -177,9 +178,17 @@ namespace Nethermind.Consensus.Processing
                 throw new InvalidOperationException(
                     $"Transaction {tx.ToShortString()} exceeded the EIP-8254 deposit request cap without a rollback snapshot. Deposit requests in tx: {depositRequestsInTx}.");
 
+            /// <summary>Per-block tally of EIP-6110 deposit requests included while building, gated by the EIP-8254 cap.</summary>
             private struct DepositRequestsLimiter(IReleaseSpec spec)
             {
-                private const long MinDepositLogGas = GasCostOf.Log + GasCostOf.LogTopic;
+                // 5x32 offsets + 5x32 lengths + ceil-32-pad(48+32+8+96+8) = 576 bytes (see ExecutionRequestsProcessor.DepositEventAbi).
+                private const int DepositEventAbiEncodedDataSize = 576;
+
+                // LOG-only floor (375 + 375 + 8*576 = 5358). Deposit contract burns more before each emit, so this
+                // over-estimates max deposits/tx as a divisor in CanExceedCap. ThrowDepositRequestCapInvariantViolation
+                // backstops any miscount.
+                private const long MinDepositLogGas =
+                    GasCostOf.Log + GasCostOf.LogTopic + GasCostOf.LogData * DepositEventAbiEncodedDataSize;
                 private readonly Address? _depositContractAddress = spec.DepositContractAddress;
                 private int _depositRequests;
 
@@ -210,11 +219,7 @@ namespace Nethermind.Consensus.Processing
 
                 private readonly int CountDepositRequests(LogEntry[] logs)
                 {
-                    if (_depositContractAddress is null)
-                    {
-                        return 0;
-                    }
-
+                    Debug.Assert(_depositContractAddress is not null, "Reachable only via TryAdd, which is gated by Enabled.");
                     Address depositContract = _depositContractAddress;
                     int depositRequests = 0;
                     for (int i = 0; i < logs.Length; i++)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -3,12 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.ExecutionRequests;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
@@ -24,6 +27,7 @@ namespace Nethermind.Consensus.Processing
         public class BlockProductionTransactionsExecutor(
             ITransactionProcessorAdapter transactionProcessor,
             IWorldState stateProvider,
+            ISpecProvider specProvider,
             IBlockProductionTransactionPicker txPicker,
             ILogManager logManager,
             IBlockAccessListManager balManager)
@@ -58,6 +62,8 @@ namespace Nethermind.Consensus.Processing
                 // Don't use blockToProduce.Transactions.Count() as that would fully enumerate which is expensive
                 int txCount = blockToProduce is not null ? defaultTxCount : block.Transactions.Length;
                 IEnumerable<Transaction> transactions = blockToProduce?.Transactions ?? block.Transactions;
+                IReleaseSpec spec = specProvider.GetSpec(block.Header);
+                DepositRequestsLimiter depositRequestsLimiter = new(spec);
 
                 using ArrayPoolListRef<Transaction> includedTx = new(txCount);
 
@@ -68,7 +74,7 @@ namespace Nethermind.Consensus.Processing
                     // Check if we have gone over time or the payload has been requested
                     if (token.IsCancellationRequested) break;
 
-                    TxAction action = ProcessTransaction(block, currentTx, i++, receiptsTracer, processingOptions, consideredTx);
+                    TxAction action = ProcessTransaction(block, currentTx, i++, receiptsTracer, processingOptions, consideredTx, ref depositRequestsLimiter);
                     if (action == TxAction.Stop) break;
 
                     consideredTx.Add(currentTx);
@@ -96,7 +102,8 @@ namespace Nethermind.Consensus.Processing
                 int index,
                 BlockReceiptsTracer receiptsTracer,
                 ProcessingOptions processingOptions,
-                HashSet<Transaction> transactionsInBlock)
+                HashSet<Transaction> transactionsInBlock,
+                ref DepositRequestsLimiter depositRequestsLimiter)
             {
                 AddingTxEventArgs args = txPicker.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider);
 
@@ -106,13 +113,43 @@ namespace Nethermind.Consensus.Processing
                 }
                 else
                 {
+                    bool rollbackOnDepositRequestOverflow = depositRequestsLimiter.CanExceedCap(currentTx.GasLimit);
+                    Snapshot stateSnapshot = rollbackOnDepositRequestOverflow ? stateProvider.TakeSnapshot() : default;
+                    int receiptsCountBeforeTx = rollbackOnDepositRequestOverflow ? receiptsTracer.TakeSnapshot() : receiptsTracer.TxReceipts.Length;
+
                     ITransactionProcessorAdapter processor = balManager.Enabled ? balManager.GetTxProcessor() : transactionProcessor;
                     TransactionResult result = processor.ProcessTransaction(currentTx, receiptsTracer, processingOptions, stateProvider);
 
                     if (result)
                     {
-                        _transactionProcessed?.Invoke(this,
-                            new TxProcessedEventArgs(index, currentTx, block.Header, receiptsTracer.TxReceipts[index]));
+                        // Mock processors in tests can return success without producing a receipt; guard before LastReceipt.
+                        TxReceipt? txReceipt = receiptsTracer.TxReceipts.Length > receiptsCountBeforeTx ? receiptsTracer.LastReceipt : null;
+                        if (depositRequestsLimiter.Enabled
+                            && txReceipt?.Logs is { Length: > 0 } logs
+                            && !depositRequestsLimiter.TryAdd(logs, out int depositRequestsInTx))
+                        {
+                            if (!rollbackOnDepositRequestOverflow)
+                            {
+                                ThrowDepositRequestCapInvariantViolation(currentTx, depositRequestsInTx);
+                            }
+
+                            stateProvider.Restore(stateSnapshot);
+                            receiptsTracer.Restore(receiptsCountBeforeTx);
+                            balManager.Rollback();
+                            ResetGasUsed(currentTx);
+                            if (_logger.IsDebug)
+                            {
+                                args.Set(TxAction.Skip, $"EIP-8254 deposit request cap reached: transaction has {depositRequestsInTx} deposit request(s)");
+                                DebugSkipReason(currentTx, args);
+                            }
+                            return TxAction.Skip;
+                        }
+
+                        if (txReceipt is not null)
+                        {
+                            _transactionProcessed?.Invoke(this,
+                                new TxProcessedEventArgs(index, currentTx, block.Header, txReceipt));
+                        }
                         balManager.NextTransaction();
                     }
                     else
@@ -127,6 +164,69 @@ namespace Nethermind.Consensus.Processing
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 void DebugSkipReason(Transaction currentTx, AddingTxEventArgs args)
                     => _logger.Debug($"Skipping transaction {currentTx.ToShortString()} because: {args.Reason}.");
+            }
+
+            private static void ResetGasUsed(Transaction tx)
+            {
+                tx.SpentGas = 0;
+                tx.BlockGasUsed = 0;
+            }
+
+            [DoesNotReturn, MethodImpl(MethodImplOptions.NoInlining)]
+            private static void ThrowDepositRequestCapInvariantViolation(Transaction tx, int depositRequestsInTx) =>
+                throw new InvalidOperationException(
+                    $"Transaction {tx.ToShortString()} exceeded the EIP-8254 deposit request cap without a rollback snapshot. Deposit requests in tx: {depositRequestsInTx}.");
+
+            private struct DepositRequestsLimiter(IReleaseSpec spec)
+            {
+                private const long MinDepositLogGas = GasCostOf.Log + GasCostOf.LogTopic;
+                private readonly Address? _depositContractAddress = spec.DepositContractAddress;
+                private int _depositRequests;
+
+                public readonly bool Enabled => _depositContractAddress is not null;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public readonly bool CanExceedCap(long gasLimit) =>
+                    Enabled
+                    && (long)_depositRequests + gasLimit / MinDepositLogGas > Eip6110Constants.MaxDepositRequestsPerBlock;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public bool TryAdd(LogEntry[] logs, out int depositRequestsInTx)
+                {
+                    depositRequestsInTx = CountDepositRequests(logs);
+                    if (depositRequestsInTx == 0)
+                    {
+                        return true;
+                    }
+
+                    if (_depositRequests + depositRequestsInTx > Eip6110Constants.MaxDepositRequestsPerBlock)
+                    {
+                        return false;
+                    }
+
+                    _depositRequests += depositRequestsInTx;
+                    return true;
+                }
+
+                private readonly int CountDepositRequests(LogEntry[] logs)
+                {
+                    if (_depositContractAddress is null)
+                    {
+                        return 0;
+                    }
+
+                    Address depositContract = _depositContractAddress;
+                    int depositRequests = 0;
+                    for (int i = 0; i < logs.Length; i++)
+                    {
+                        if (ExecutionRequestsProcessor.IsDepositLog(logs[i], depositContract))
+                        {
+                            depositRequests++;
+                        }
+                    }
+
+                    return depositRequests;
+                }
             }
         }
     }

--- a/src/Nethermind/Nethermind.Core/Eip6110Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip6110Constants.cs
@@ -6,6 +6,8 @@ namespace Nethermind.Core;
 public static class Eip6110Constants
 {
     public const string ContractAddressKey = "DEPOSIT_CONTRACT_ADDRESS";
+    /// <summary>Maximum number of EIP-6110 deposit requests permitted per produced block (EIP-8254).</summary>
+    public const int MaxDepositRequestsPerBlock = 8192;
 
     public static readonly Address MainnetDepositContractAddress = new("0x00000000219ab540356cbb839cbe05303d7705fa");
     public static readonly Address HoleskyDepositContractAddress = new("0x4242424242424242424242424242424242424242");

--- a/src/Nethermind/Nethermind.Evm/Tracing/FeesTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/FeesTracer.cs
@@ -3,15 +3,17 @@
 
 using Nethermind.Core;
 using Nethermind.Int256;
+using System.Collections.Generic;
 
 namespace Nethermind.Evm.Tracing;
 
-public class FeesTracer : TxTracer, IBlockTracer
+public class FeesTracer : TxTracer, IBlockTracer, IJournal<int>
 {
     public override bool IsTracingFees => true;
 
     public UInt256 Fees { get; private set; } = UInt256.Zero;
     public UInt256 BurntFees { get; private set; } = UInt256.Zero;
+    private readonly List<(UInt256 Fees, UInt256 BurntFees)> _snapshots = [];
 
     public override void ReportFees(UInt256 fees, UInt256 burntFees)
     {
@@ -27,6 +29,7 @@ public class FeesTracer : TxTracer, IBlockTracer
     {
         Fees = UInt256.Zero;
         BurntFees = UInt256.Zero;
+        _snapshots.Clear();
     }
 
     public ITxTracer StartNewTxTrace(Transaction? tx) => this;
@@ -34,4 +37,16 @@ public class FeesTracer : TxTracer, IBlockTracer
     public void EndTxTrace() { }
 
     public void EndBlockTrace() { }
+
+    public int TakeSnapshot()
+    {
+        _snapshots.Add((Fees, BurntFees));
+        return _snapshots.Count - 1;
+    }
+
+    public void Restore(int snapshot)
+    {
+        (Fees, BurntFees) = _snapshots[snapshot];
+        _snapshots.RemoveRange(snapshot, _snapshots.Count - snapshot);
+    }
 }


### PR DESCRIPTION
## Changes

Implements EIP-8254 (deposit-request cap during block production) and tightens the rollback plumbing it depends on.

### Why 8192

The 8192 ceiling is **not** a Nethermind heuristic. The consensus-layer beacon block encodes `execution_requests.deposit_requests` as an SSZ `List` bounded by `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD = 8192`. An execution payload exceeding that bound is unencodable on the CL side, so EIP-8254 requires the EL to enforce the limit while building, never emit an unencodable payload, and let the validator queue surplus deposits into later blocks instead.

### EIP-8254 enforcement

- New `Eip6110Constants.MaxDepositRequestsPerBlock = 8192`.
- `DepositRequestsLimiter` (ref struct) inside `BlockProductionTransactionsExecutor` counts deposit-event logs per receipt (matched by `spec.DepositContractAddress` + `ExecutionRequestsProcessor.DepositEventAbi.Hash` topic via the new shared `IsDepositLog` predicate) and refuses any tx that would breach the cap.
- `CanExceedCap(gasLimit)` gates the snapshot/restore work so we only pay rollback overhead for txs whose gas could plausibly emit enough log events to breach the cap.
- Rollback path on cap-breach: `stateProvider.Restore(snapshot)`, `receiptsTracer.Restore(snapshot)`, `balManager.Rollback()`, `ResetGasUsed(currentTx)`. The picker loop continues so subsequent unrelated txs can still be included.
- `BlockProductionTransactionsExecutor` constructor now takes `ISpecProvider` to resolve `spec.DepositContractAddress` per block. AuRa wiring updated in `StartBlockProducerAuRa`.

### Snapshot/Restore plumbing fixes (load-bearing for the rollback above)

- `BlockReceiptsTracer.Restore` now also rewinds `CurrentTx` and `_currentIndex`. Previously only the receipts list shrank, leaving the tracer in a half-rolled-back state where the next tx would land at the wrong index.
- `Snapshot`/`Restore` now cascade through any `IJournal<int>`-implementing other-tracer (e.g. `FeesTracer`) via a `Stack<(int Receipts, int Other)>` LIFO. Fee accumulators stay consistent with receipts on rollback. Silently-discarded snapshots accumulated during a successful block are cleared on `StartNewBlockTrace`.
- `FeesTracer` now implements `IJournal<int>`: captures `(Fees, BurntFees)` on `TakeSnapshot`, restores on `Restore`.

### Shared helper extraction

- `ExecutionRequestsProcessor.IsDepositLog(LogEntry, Address)` is the single source of truth for the deposit-event predicate, used by both `ProcessDeposits` (validator-side) and `DepositRequestsLimiter` (builder-side). Eliminates an inline-duplicated predicate across two layers.

### Hot-path hygiene

- Diagnostic interpolated string for the cap-skip path is now built only when `_logger.IsDebug` is true, eliminating a per-cap-breach allocation in production.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`BlockProductionTransactionsExecutor_skips_transaction_that_would_exceed_deposit_request_cap` drives a 3-tx block where:

1. Tx 1 fills the cap exactly (`MaxDepositRequestsPerBlock` deposit logs)
2. Tx 2 would breach the cap by 1
3. Tx 3 is unrelated (no deposit logs)

Asserts:

- Tx 2 is skipped, txs 1 and 3 are included
- The produced block has only 2 receipts
- `block.Header.GasUsed == 2 * GasCostOf.Transaction` (gas accounting rolled back)
- Skipped sender's nonce stays at 0 (state rolled back)
- `FeesTracer.Fees == 2` (fees accumulator rolled back via the new `IJournal<int>` cascade - this is the assertion that proves the other-tracer rollback wiring works)

Existing 16 `TransactionsExecutorTests` continue to pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EIP-8254 (deposit-request cap during block production) is now enforced. Locally-built blocks will never exceed `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD = 8192` deposit requests; surplus deposits are queued by the deposit contract and included in subsequent blocks per the EIP.

## Remarks

The new `DepositRequestsLimiter.CanExceedCap(gasLimit)` gas-based gate means the snapshot/restore work is only paid for txs whose `gasLimit / (LOG + LOGTOPIC)` would plausibly push the accumulator over 8192. In normal mainnet block-building this gate is false for almost every tx, so the EIP-8254 path adds essentially zero overhead on the steady-state hot path.

The rollback dance (`stateProvider.Restore` + `receiptsTracer.Restore` + `balManager.Rollback` + `ResetGasUsed`) is the same shape as `Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs`, but the two sites have different invariants (Taiko skips invalid txs; the EIP-8254 path skips txs that processed cleanly but would breach the SSZ cap). Not extracted to a shared helper at this point.