### PR TITLE
feat(rpc): add eth_fillTransaction

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.FillTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.FillTransaction.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Eth.RpcTransaction;
+using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules.Eth;
+
+public partial class EthRpcModuleTests
+{
+    [Test]
+    public async Task Eth_fillTransaction_fills_nonce_gas_and_chainId_for_legacy()
+    {
+        using Context ctx = await Context.Create();
+
+        // Caller provides gasPrice (forces legacy path), to and value. Nonce, gas, chainId omitted.
+        TransactionForRpc rpcTx = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
+            $"{{\"from\":\"{TestItem.AddressA}\",\"to\":\"{TestItem.AddressB}\",\"value\":\"0x1\",\"gasPrice\":\"0x10\"}}");
+
+        string serialized = await ctx.Test.TestEthRpc("eth_fillTransaction", rpcTx);
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"].Should().BeNull();
+
+        JToken result = parsed["result"]!;
+        result["raw"]!.Value<string>().Should().StartWith("0x");
+
+        JToken tx = result["tx"]!;
+        tx["nonce"]!.Value<string>().Should().NotBeNullOrEmpty();
+        tx["gas"]!.Value<string>().Should().NotBeNullOrEmpty();
+        tx["chainId"]!.Value<string>().Should().NotBeNullOrEmpty();
+        tx["from"]!.Value<string>()!.ToLowerInvariant().Should().Be(TestItem.AddressA.ToString());
+    }
+
+    [Test]
+    public async Task Eth_fillTransaction_fills_eip1559_fees_when_max_fee_omitted()
+    {
+        using Context ctx = await Context.Create();
+
+        TransactionForRpc rpcTx = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
+            $"{{\"from\":\"{TestItem.AddressA}\",\"to\":\"{TestItem.AddressB}\",\"value\":\"0x1\",\"type\":\"0x2\"}}");
+
+        string serialized = await ctx.Test.TestEthRpc("eth_fillTransaction", rpcTx);
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"].Should().BeNull();
+
+        JToken tx = parsed["result"]!["tx"]!;
+        tx["maxFeePerGas"]!.Value<string>().Should().NotBeNullOrEmpty();
+        tx["maxPriorityFeePerGas"]!.Value<string>().Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Eth_fillTransaction_raw_rlp_round_trips()
+    {
+        using Context ctx = await Context.Create();
+
+        TransactionForRpc rpcTx = ctx.Test.JsonSerializer.Deserialize<TransactionForRpc>(
+            $"{{\"from\":\"{TestItem.AddressA}\",\"to\":\"{TestItem.AddressB}\",\"value\":\"0x1\",\"gasPrice\":\"0x10\"}}");
+
+        string serialized = await ctx.Test.TestEthRpc("eth_fillTransaction", rpcTx);
+        JToken result = JToken.Parse(serialized)["result"]!;
+        string rawHex = result["raw"]!.Value<string>()!;
+        byte[] raw = Nethermind.Core.Extensions.Bytes.FromHexString(rawHex);
+
+        Transaction decoded = TxDecoder.Instance.DecodeCompleteNotNull(raw,
+            RlpBehaviors.AllowUnsigned | RlpBehaviors.SkipTypedWrapping);
+        decoded.To.Should().Be(TestItem.AddressB);
+        decoded.Value.Should().Be((UInt256)1);
+        decoded.GasPrice.Should().Be((UInt256)0x10);
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Data/FillTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/FillTransactionResult.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.Json.Serialization;
+using Nethermind.Facade.Eth.RpcTransaction;
+
+namespace Nethermind.JsonRpc.Data;
+
+/// <summary>
+/// Result of <c>eth_fillTransaction</c>: the unsigned RLP-encoded transaction and its
+/// echoed object form with defaults filled in.
+/// </summary>
+public class FillTransactionResult
+{
+    /// <summary>RLP encoding of the unsigned transaction (typed-tx prefix included for non-legacy types).</summary>
+    [JsonPropertyName("raw")]
+    public required byte[] Raw { get; init; }
+
+    /// <summary>Filled transaction echo. Signature fields are zero; signing is the caller's responsibility.</summary>
+    [JsonPropertyName("tx")]
+    public required TransactionForRpc Tx { get; init; }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -524,6 +524,74 @@ public partial class EthRpcModule(
         return @default > 0 ? Math.Min(@default, max) : max;
     }
 
+    public virtual async Task<ResultWrapper<FillTransactionResult>> eth_fillTransaction(TransactionForRpc rpcTx)
+    {
+        ArgumentNullException.ThrowIfNull(rpcTx);
+
+        BlockHeader? head = _blockchainBridge.HeadBlock?.Header;
+        if (head is null)
+            return ResultWrapper<FillTransactionResult>.Fail("head block not available", ErrorCodes.ResourceUnavailable);
+
+        IReleaseSpec spec = _specProvider.GetSpec(head);
+        ulong chainId = _blockchainBridge.GetChainId();
+
+        // All concrete subtypes (AccessList, EIP1559, Blob, SetCode) derive from LegacyTransactionForRpc,
+        // so this gives us a single handle to the shared fields (From, Nonce, GasPrice, ChainId).
+        if (rpcTx is not LegacyTransactionForRpc legacy)
+            return ResultWrapper<FillTransactionResult>.Fail("unsupported transaction type", ErrorCodes.InvalidInput);
+
+        if (legacy.From is null)
+        {
+            Address? defaultAccount = _wallet.GetAccounts().FirstOrDefault();
+            if (defaultAccount is null)
+                return ResultWrapper<FillTransactionResult>.Fail("from address required (no wallet accounts available)", ErrorCodes.InvalidInput);
+            legacy.From = defaultAccount;
+        }
+
+        legacy.ChainId ??= chainId;
+        legacy.Nonce ??= _txPool.GetLatestPendingNonce(legacy.From);
+
+        await FillGasPricing(legacy, head);
+
+        if (rpcTx.Gas is null)
+        {
+            ResultWrapper<UInt256?> est = eth_estimateGas(rpcTx, BlockParameter.Latest);
+            if (est.Result.ResultType != ResultType.Success || est.Data is null)
+                return ResultWrapper<FillTransactionResult>.Fail(est.Result.Error ?? "gas estimation failed", est.ErrorCode);
+            rpcTx.Gas = (long)est.Data.Value.ToUInt64(null);
+        }
+
+        Result<Transaction> conv = rpcTx.ToTransaction(validateUserInput: true, spec: spec);
+        if (!conv.Success(out Transaction tx, out string error))
+            return ResultWrapper<FillTransactionResult>.Fail(error, ErrorCodes.InvalidInput);
+
+        tx.ChainId = chainId;
+
+        byte[] raw = TxDecoder.Instance.Encode(tx, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.AllowUnsigned).Bytes;
+
+        return ResultWrapper<FillTransactionResult>.Success(new FillTransactionResult
+        {
+            Raw = raw,
+            Tx = TransactionForRpc.FromTransaction(tx, new(chainId))
+        });
+    }
+
+    /// <summary>
+    /// Fills fee fields on <paramref name="rpcTx"/>. EIP-1559 path follows geth: tip from the oracle,
+    /// max fee = 2 * baseFee + tip. Legacy path defaults <c>gasPrice</c> from the gas-price oracle.
+    /// </summary>
+    private async Task FillGasPricing(LegacyTransactionForRpc rpcTx, BlockHeader head)
+    {
+        if (rpcTx is EIP1559TransactionForRpc eip1559)
+        {
+            eip1559.MaxPriorityFeePerGas ??= _gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+            eip1559.MaxFeePerGas ??= head.BaseFeePerGas * 2 + eip1559.MaxPriorityFeePerGas.Value;
+            return;
+        }
+
+        rpcTx.GasPrice ??= await _gasPriceOracle.GetGasPriceEstimate();
+    }
+
     private async Task<ResultWrapper<Hash256>> SendTx(Transaction tx,
         TxHandlingOptions txHandlingOptions = TxHandlingOptions.None)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -176,6 +176,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
             ulong? timeoutMs = null);
 
         [JsonRpcMethod(IsImplemented = true,
+            Description = "Fills the defaults (nonce, gas, gasPrice or 1559 fees, chainId) of a transaction and returns the unsigned RLP and the filled object.",
+            IsSharable = false)]
+        Task<ResultWrapper<FillTransactionResult>> eth_fillTransaction(TransactionForRpc rpcTx);
+
+        [JsonRpcMethod(IsImplemented = true,
             Description = "Executes a tx call (does not create a transaction)",
             IsSharable = true,
             ExampleResponse = "0x")]


### PR DESCRIPTION
Closes #11374

## Changes

- Add `eth_fillTransaction` RPC method that fills missing defaults on a partial transaction and returns the unsigned RLP alongside the filled object (geth / reth shape).
- Fill behaviour:
  - `from` defaults to the wallet's first account; errors when no wallet accounts are available.
  - `chainId` defaults to the network chainId.
  - `nonce` defaults to the pending nonce from the tx pool.
  - EIP-1559 transactions: `maxPriorityFeePerGas` from the gas-price oracle, `maxFeePerGas` = `2 * baseFee + tip`.
  - Legacy / access-list: `gasPrice` from the gas-price oracle.
  - `gas` from `eth_estimateGas` on `Latest`.
- Add `FillTransactionResult { raw, tx }` data type.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three integration tests via `TestRpcBlockchain`:
- Legacy path: `gasPrice` honoured, `nonce` / `gas` / `chainId` filled when omitted.
- EIP-1559 path: `maxFeePerGas` + `maxPriorityFeePerGas` filled when omitted.
- Raw RLP round-trips back to the same transaction (`to` / `value` / `gasPrice` asserted).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

New JSON-RPC method `eth_fillTransaction` — fills the defaults (`nonce`, `gas`, gas pricing, `chainId`, `from`) of a partial transaction and returns the unsigned RLP plus the echoed object. Matches geth and reth.

## Remarks

Out of scope for this PR (intentional):
- AccessList auto-generation (belongs in `eth_createAccessList`).
- Blob sidecar handling for type-3 transactions.
- SetCode authorization list filling for type-4.

`FillTransactionResult` has the same shape as `SignTransactionResult` from #11517. Happy to fold the two into one type once that lands.