### PR TITLE
fix: charge spawn estimate for CREATE/CREATE2 post-trace bail

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasTxTracerTests.cs
@@ -125,6 +125,55 @@ public class ZkGasTxTracerTests
         Assert.That(meter.TxZkGasUsed, Is.EqualTo(expected));
     }
 
+    // ── spawn opcode — CREATE post-trace bail vs error (regression) ──────────
+
+    /// <summary>
+    /// Regression test for block 11297 mismatch: a CREATE that bails after
+    /// <c>EndInstructionTrace</c> (e.g. EIP-7610 nonce/code collision) reports
+    /// <c>ReportOperationRemainingGas</c> but never fires <c>ReportAction</c>
+    /// nor <c>ReportOperationError</c>. REVM charges the fixed spawn estimate
+    /// in this case, so the deferred CREATE step must be flushed with
+    /// <see cref="ZkGasSchedule.SpawnEstimateCreate"/>, not the raw delta.
+    /// </summary>
+    [Test]
+    public void SpawnOpcode_Create_PostTraceBail_UsesSpawnEstimate()
+    {
+        (ZkGasTxTracer tracer, ZkGasMeter meter) = Make();
+
+        // CREATE = 0xf0
+        tracer.StartOperation(0, Instruction.CREATE, gas: 50_000, env: Env());
+        tracer.ReportOperationRemainingGas(49_968); // 32 raw delta — should be ignored
+        // No ReportAction (post-trace bail) and no ReportOperationError.
+        // Deferred step flushed by the next opcode start.
+        tracer.StartOperation(1, Instruction.STOP, gas: 0, env: Env());
+        tracer.ReportOperationRemainingGas(0);
+
+        ulong spawnCharge = ZkGasSchedule.SpawnEstimateCreate * ZkGasSchedule.OpcodeMultipliers[0xf0];
+        Assert.That(meter.TxZkGasUsed, Is.EqualTo(spawnCharge));
+    }
+
+    /// <summary>
+    /// Regression test for block 259: a CREATE that runs out of gas after
+    /// <c>EndInstructionTrace</c> reports both <c>ReportOperationRemainingGas</c>
+    /// and <c>ReportOperationError</c>. This is NOT a post-trace bail — REVM
+    /// charges the raw measured gas delta, not the spawn estimate.
+    /// </summary>
+    [Test]
+    public void SpawnOpcode_Create_OutOfGasAfterTrace_UsesRawDelta()
+    {
+        (ZkGasTxTracer tracer, ZkGasMeter meter) = Make();
+
+        tracer.StartOperation(0, Instruction.CREATE, gas: 50_000, env: Env());
+        tracer.ReportOperationRemainingGas(49_968); // 32 raw delta
+        tracer.ReportOperationError(EvmExceptionType.OutOfGas);
+        // Deferred step flushed by the next opcode start.
+        tracer.StartOperation(1, Instruction.STOP, gas: 0, env: Env());
+        tracer.ReportOperationRemainingGas(0);
+
+        ulong rawCharge = 32UL * ZkGasSchedule.OpcodeMultipliers[0xf0];
+        Assert.That(meter.TxZkGasUsed, Is.EqualTo(rawCharge));
+    }
+
     /// <summary>
     /// Deferred step is flushed with spawn estimate by
     /// <see cref="ZkGasTxTracer.ReportActionEnd(long, ReadOnlyMemory{byte})"/>

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasTxTracer.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasTxTracer.cs
@@ -37,6 +37,7 @@ public sealed class ZkGasTxTracer : TxTracer
     private byte _deferredOpcode;
     private ulong _deferredGasDelta;
     private bool _deferredSpawned;
+    private bool _deferredErrored;
 
     // Precompile tracking
     private bool _pendingPrecompile;
@@ -84,11 +85,16 @@ public sealed class ZkGasTxTracer : TxTracer
         if (IsSpawnOpcode(_currentOpcode))
         {
             // Defer: we don't yet know if this opcode will open a child frame.
-            // ReportAction will mark it as spawned if it does.
+            // Resolution happens in one of three places:
+            //  1. ReportAction (success path, CALL or CREATE) → _deferredSpawned = true
+            //  2. ReportOperationError (instruction error path)  → _deferredErrored = true
+            //  3. Otherwise (CREATE/CREATE2 post-trace bail: EIP-7610 collision,
+            //     dead-account-clear) → treated as spawned at flush time.
             _hasDeferredStep = true;
             _deferredOpcode = _currentOpcode;
             _deferredGasDelta = rawGas;
             _deferredSpawned = false;
+            _deferredErrored = false;
         }
         else
         {
@@ -170,6 +176,14 @@ public sealed class ZkGasTxTracer : TxTracer
     /// </summary>
     public override void ReportOperationError(EvmExceptionType error)
     {
+        // Remember that the just-deferred spawn op errored (e.g. OOG between
+        // EndInstructionTrace and child-frame dispatch). At flush time this
+        // suppresses the post-trace-bail "treat as spawned" path for CREATE/CREATE2.
+        if (_hasDeferredStep)
+        {
+            _deferredErrored = true;
+        }
+
         if (error == EvmExceptionType.StaticCallViolation)
         {
             ulong staticGas = GetRevmStaticGasForOpcode(_currentOpcode);
@@ -212,9 +226,15 @@ public sealed class ZkGasTxTracer : TxTracer
     }
 
     /// <summary>
-    /// Flushes any deferred spawn opcode charge. If the opcode was marked as spawned
-    /// (by ReportAction), uses the fixed spawn estimate; otherwise uses the measured
-    /// gas delta.
+    /// Flushes any deferred spawn opcode charge.
+    ///
+    /// Charge selection:
+    ///  - <c>_deferredSpawned</c> set by ReportAction (child frame dispatched) → spawn estimate.
+    ///  - Else if CREATE/CREATE2 reached ReportOperationRemainingGas without erroring,
+    ///    it must have been a post-trace bail (EIP-7610 collision, dead-account-clear);
+    ///    REVM treats this as spawned too → spawn estimate.
+    ///  - Otherwise (CALL-family with no dispatch, or any spawn op that errored mid-flight)
+    ///    → measured raw gas delta.
     /// </summary>
     private void FlushDeferredStep()
     {
@@ -223,7 +243,10 @@ public sealed class ZkGasTxTracer : TxTracer
 
         _hasDeferredStep = false;
 
-        ulong rawGas = _deferredSpawned
+        bool isCreate = _deferredOpcode == 0xf0 || _deferredOpcode == 0xf5;
+        bool treatAsSpawned = _deferredSpawned || (isCreate && !_deferredErrored);
+
+        ulong rawGas = treatAsSpawned
             ? GetSpawnEstimate(_deferredOpcode)
             : _deferredGasDelta;
 

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasTxTracer.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasTxTracer.cs
@@ -88,8 +88,8 @@ public sealed class ZkGasTxTracer : TxTracer
             // Resolution happens in one of three places:
             //  1. ReportAction (success path, CALL or CREATE) → _deferredSpawned = true
             //  2. ReportOperationError (instruction error path)  → _deferredErrored = true
-            //  3. Otherwise (CREATE/CREATE2 post-trace bail: EIP-7610 collision,
-            //     dead-account-clear) → treated as spawned at flush time.
+            //  3. Otherwise (CREATE/CREATE2 post-trace bail on EIP-7610 collision)
+            //     → treated as spawned at flush time.
             _hasDeferredStep = true;
             _deferredOpcode = _currentOpcode;
             _deferredGasDelta = rawGas;
@@ -231,7 +231,7 @@ public sealed class ZkGasTxTracer : TxTracer
     /// Charge selection:
     ///  - <c>_deferredSpawned</c> set by ReportAction (child frame dispatched) → spawn estimate.
     ///  - Else if CREATE/CREATE2 reached ReportOperationRemainingGas without erroring,
-    ///    it must have been a post-trace bail (EIP-7610 collision, dead-account-clear);
+    ///    it must have been a post-trace bail (EIP-7610 collision);
     ///    REVM treats this as spawned too → spawn estimate.
     ///  - Otherwise (CALL-family with no dispatch, or any spawn op that errored mid-flight)
     ///    → measured raw gas delta.


### PR DESCRIPTION
## Changes

- Charge the fixed spawn estimate for CREATE/CREATE2 when the handler post-trace-bails (EIP-7610 collision, dead-account-clear), matching alethia-reth/REVM. Previously the raw measured delta was charged, producing a different `block.Header.Difficulty` from upstream and rejecting the block.
- Implemented with a `_deferredErrored` flag set in `ReportOperationError`, so mid-instruction errors still bill raw delta.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [ ] No

#### Notes on testing

Verified by syncing the Taiko Surge devnet past previously-rejected blocks. `Nethermind.Taiko.Test` (200 passed) and `Nethermind.Evm.Test` (3561 passed) green.

## Documentation

#### Requires documentation update
- [ ] No

#### Requires explanation in Release Notes
- [ ] No