### PR TITLE
Gate batch lookup by network

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
@@ -17,7 +17,6 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Serialization.Rlp;
-using Nethermind.Taiko;
 using Nethermind.Taiko.Config;
 using Nethermind.Taiko.Rpc;
 using Nethermind.Taiko.ZkGas;
@@ -290,6 +289,9 @@ public class CertainBatchLookupTests
 
         TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId, blockFinder);
 
+        // Only the scan-fallback methods are asserted: taikoAuth_lastCertain*ByBatchID have
+        // no scan fallback, so with an empty batch→block mapping they already return null
+        // before the threshold gate is reached and would not prove the gate fired.
         Assert.That(rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result.Data, Is.Null);
         Assert.That(rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result.Data, Is.Null);
     }

--- a/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Taiko.Config;
 using Nethermind.Taiko.Rpc;
+using Nethermind.Taiko.ZkGas;
 using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
@@ -150,7 +151,108 @@ public class CertainBatchLookupTests
         Assert.That(result.Data, Is.Null);
     }
 
-    private static TaikoEngineRpcModule CreateRpcModule(IL1OriginStore l1OriginStore) => new(
+    /// <summary>
+    /// Mirrors taiko-geth PR #558 TestBatchLookupMethodsReturnNilBelowNetworkThreshold and
+    /// alethia-reth PR #177 filters_batch_lookup_results_below_network_threshold. On Mainnet,
+    /// a batch whose resolved block id is strictly below the last-Pacaya block must report
+    /// JSON null on all four taikoAuth_last…ByBatchID methods, even when the underlying
+    /// batch-to-block and L1Origin records are present in the store.
+    /// </summary>
+    [Test]
+    public void TestBatchLookup_MainnetBelowThresholdReturnsNull()
+    {
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId);
+        UInt256 batchId = 1;
+        UInt256 blockId = ZkGasSchedule.TaikoMainnetLastPacayaBatchLookupBlock - 1;
+        L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
+        _store.WriteBatchToLastBlockID(batchId, blockId);
+        _store.WriteL1Origin(blockId, origin);
+
+        ResultWrapper<L1Origin?> lastL1Origin = rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result;
+        Assert.That(lastL1Origin.Result, Is.EqualTo(Result.Success));
+        Assert.That(lastL1Origin.Data, Is.Null);
+
+        ResultWrapper<UInt256?> lastBlockId = rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result;
+        Assert.That(lastBlockId.Result, Is.EqualTo(Result.Success));
+        Assert.That(lastBlockId.Data, Is.Null);
+
+        ResultWrapper<UInt256?> lastCertainBlockId = rpc.taikoAuth_lastCertainBlockIDByBatchID(batchId);
+        Assert.That(lastCertainBlockId.Result, Is.EqualTo(Result.Success));
+        Assert.That(lastCertainBlockId.Data, Is.Null);
+
+        ResultWrapper<L1Origin?> lastCertainL1Origin = rpc.taikoAuth_lastCertainL1OriginByBatchID(batchId);
+        Assert.That(lastCertainL1Origin.Result, Is.EqualTo(Result.Success));
+        Assert.That(lastCertainL1Origin.Data, Is.Null);
+    }
+
+    /// <summary>
+    /// The threshold is the *first* allowed block id (per taiko-geth's <c>blockID.Cmp(threshold) &lt; 0</c>
+    /// and alethia-reth's <c>block_number &lt; threshold</c>). A batch resolving to exactly the
+    /// threshold value must pass through unchanged on every method.
+    /// </summary>
+    [Test]
+    public void TestBatchLookup_MainnetAtThresholdReturnsValue()
+    {
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId);
+        UInt256 batchId = 1;
+        UInt256 blockId = ZkGasSchedule.TaikoMainnetLastPacayaBatchLookupBlock;
+        L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
+        _store.WriteBatchToLastBlockID(batchId, blockId);
+        _store.WriteL1Origin(blockId, origin);
+
+        Assert.That(rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result.Data, Is.Not.Null);
+        Assert.That(rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result.Data, Is.EqualTo(blockId));
+        Assert.That(rpc.taikoAuth_lastCertainBlockIDByBatchID(batchId).Data, Is.EqualTo(blockId));
+        Assert.That(rpc.taikoAuth_lastCertainL1OriginByBatchID(batchId).Data, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// Hoodi has its own last-Pacaya threshold (3_951_005). Same gate, different value.
+    /// </summary>
+    [Test]
+    public void TestBatchLookup_HoodiBelowThresholdReturnsNull()
+    {
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoHoodiChainId);
+        UInt256 batchId = 1;
+        UInt256 blockId = ZkGasSchedule.TaikoHoodiLastPacayaBatchLookupBlock - 1;
+        L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
+        _store.WriteBatchToLastBlockID(batchId, blockId);
+        _store.WriteL1Origin(blockId, origin);
+
+        Assert.That(rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result.Data, Is.Null);
+        Assert.That(rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result.Data, Is.Null);
+        Assert.That(rpc.taikoAuth_lastCertainBlockIDByBatchID(batchId).Data, Is.Null);
+        Assert.That(rpc.taikoAuth_lastCertainL1OriginByBatchID(batchId).Data, Is.Null);
+    }
+
+    /// <summary>
+    /// Devnet and Masaya have no threshold (geth: <c>threshold == 0</c>; reth: <c>None</c>).
+    /// Any block id, including ones well below the Mainnet/Hoodi thresholds, must pass through.
+    /// </summary>
+    [Test]
+    public void TestBatchLookup_DevnetIsUnfiltered()
+    {
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoDevnetChainId);
+        UInt256 batchId = 1;
+        UInt256 blockId = 1;
+        L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
+        _store.WriteBatchToLastBlockID(batchId, blockId);
+        _store.WriteL1Origin(blockId, origin);
+
+        Assert.That(rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result.Data, Is.Not.Null);
+        Assert.That(rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result.Data, Is.EqualTo(blockId));
+        Assert.That(rpc.taikoAuth_lastCertainBlockIDByBatchID(batchId).Data, Is.EqualTo(blockId));
+        Assert.That(rpc.taikoAuth_lastCertainL1OriginByBatchID(batchId).Data, Is.Not.Null);
+    }
+
+    private static TaikoEngineRpcModule CreateRpcModule(IL1OriginStore l1OriginStore, ulong chainId = 0)
+    {
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.ChainId.Returns(chainId);
+        return CreateRpcModuleInternal(l1OriginStore, specProvider);
+    }
+
+    private static TaikoEngineRpcModule CreateRpcModuleInternal(IL1OriginStore l1OriginStore, ISpecProvider specProvider) => new(
         Substitute.For<IAsyncHandler<byte[], ExecutionPayload?>>(),
         Substitute.For<IAsyncHandler<byte[], GetPayloadV2Result?>>(),
         Substitute.For<IAsyncHandler<byte[], GetPayloadV3Result?>>(),
@@ -168,7 +270,7 @@ public class CertainBatchLookupTests
         Substitute.For<IHandler<IReadOnlyList<Hash256>, IReadOnlyList<ExecutionPayloadBodyV2Result?>>>(),
         Substitute.For<IGetPayloadBodiesByRangeV2Handler>(),
         Substitute.For<IEngineRequestsTracker>(),
-        Substitute.For<ISpecProvider>(),
+        specProvider,
         null!,
         Substitute.For<ILogManager>(),
         Substitute.For<ITxPool>(),

--- a/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/CertainBatchLookupTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
@@ -16,6 +17,7 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Taiko;
 using Nethermind.Taiko.Config;
 using Nethermind.Taiko.Rpc;
 using Nethermind.Taiko.ZkGas;
@@ -163,7 +165,7 @@ public class CertainBatchLookupTests
     {
         TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId);
         UInt256 batchId = 1;
-        UInt256 blockId = ZkGasSchedule.TaikoMainnetLastPacayaBatchLookupBlock - 1;
+        UInt256 blockId = ZkGasSchedule.TaikoMainnetBatchLookupThreshold - 1;
         L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
         _store.WriteBatchToLastBlockID(batchId, blockId);
         _store.WriteL1Origin(blockId, origin);
@@ -195,7 +197,7 @@ public class CertainBatchLookupTests
     {
         TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId);
         UInt256 batchId = 1;
-        UInt256 blockId = ZkGasSchedule.TaikoMainnetLastPacayaBatchLookupBlock;
+        UInt256 blockId = ZkGasSchedule.TaikoMainnetBatchLookupThreshold;
         L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
         _store.WriteBatchToLastBlockID(batchId, blockId);
         _store.WriteL1Origin(blockId, origin);
@@ -214,7 +216,7 @@ public class CertainBatchLookupTests
     {
         TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoHoodiChainId);
         UInt256 batchId = 1;
-        UInt256 blockId = ZkGasSchedule.TaikoHoodiLastPacayaBatchLookupBlock - 1;
+        UInt256 blockId = ZkGasSchedule.TaikoHoodiBatchLookupThreshold - 1;
         L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
         _store.WriteBatchToLastBlockID(batchId, blockId);
         _store.WriteL1Origin(blockId, origin);
@@ -229,10 +231,11 @@ public class CertainBatchLookupTests
     /// Devnet and Masaya have no threshold (geth: <c>threshold == 0</c>; reth: <c>None</c>).
     /// Any block id, including ones well below the Mainnet/Hoodi thresholds, must pass through.
     /// </summary>
-    [Test]
-    public void TestBatchLookup_DevnetIsUnfiltered()
+    [TestCase(ZkGasSchedule.TaikoDevnetChainId)]
+    [TestCase(ZkGasSchedule.TaikoMasayaChainId)]
+    public void TestBatchLookup_UnfilteredNetworks(ulong chainId)
     {
-        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoDevnetChainId);
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, chainId);
         UInt256 batchId = 1;
         UInt256 blockId = 1;
         L1Origin origin = new(blockId, Hash256.Zero, 3, Hash256.Zero, null);
@@ -245,14 +248,60 @@ public class CertainBatchLookupTests
         Assert.That(rpc.taikoAuth_lastCertainL1OriginByBatchID(batchId).Data, Is.Not.Null);
     }
 
-    private static TaikoEngineRpcModule CreateRpcModule(IL1OriginStore l1OriginStore, ulong chainId = 0)
+    /// <summary>
+    /// Exercises the chain-scan fallback in <c>taikoAuth_lastL1OriginByBatchID</c> /
+    /// <c>taikoAuth_lastBlockIDByBatchID</c>: with no batch→block mapping in the DB, the
+    /// scan walks <c>blockFinder.Head</c> backwards, decodes the Shasta proposalId from
+    /// the header's ExtraData, and returns the block number on match. The threshold gate
+    /// must then fire on the scan-returned block id, not just on the DB-cached one. This
+    /// is a regression guard against future refactors that could reorder the gate vs.
+    /// the scan branch in <c>TaikoEngineRpcModule</c>.
+    /// </summary>
+    [Test]
+    public void TestBatchLookup_MainnetScanPathBelowThresholdReturnsNull()
+    {
+        UInt256 batchId = 1;
+        long blockNumber = (long)(ZkGasSchedule.TaikoMainnetBatchLookupThreshold - 1);
+
+        // Shasta extraData layout: [basefeeSharingPctg=0][proposalId=batchId, 6 bytes big-endian].
+        byte[] extraData = new byte[TaikoHeaderHelper.ShastaExtraDataLen];
+        extraData[TaikoHeaderHelper.ShastaExtraDataLen - 1] = 1;
+
+        BlockHeader header = Build.A.BlockHeader
+            .WithNumber(blockNumber)
+            .WithExtraData(extraData)
+            .TestObject;
+        Transaction anchorTx = Build.A.Transaction
+            .WithData(TaikoBlockValidator.AnchorV4Selector)
+            .TestObject;
+        Block block = Build.A.Block
+            .WithHeader(header)
+            .WithTransactions(anchorTx)
+            .TestObject;
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.Head.Returns(block);
+
+        // Write the L1Origin so a missing gate would yield a non-null Data on lastL1OriginByBatchID,
+        // proving the gate (not a missing record) is what produces the null result.
+        UInt256 blockId = (UInt256)(ulong)blockNumber;
+        _store.WriteL1Origin(blockId, new L1Origin(blockId, Hash256.Zero, 3, Hash256.Zero, null));
+        // Deliberately do NOT WriteBatchToLastBlockID — forces the scan fallback.
+
+        TaikoEngineRpcModule rpc = CreateRpcModule(_store, ZkGasSchedule.TaikoMainnetChainId, blockFinder);
+
+        Assert.That(rpc.taikoAuth_lastL1OriginByBatchID(batchId).Result.Data, Is.Null);
+        Assert.That(rpc.taikoAuth_lastBlockIDByBatchID(batchId).Result.Data, Is.Null);
+    }
+
+    private static TaikoEngineRpcModule CreateRpcModule(IL1OriginStore l1OriginStore, ulong chainId = 0, IBlockFinder? blockFinder = null)
     {
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
         specProvider.ChainId.Returns(chainId);
-        return CreateRpcModuleInternal(l1OriginStore, specProvider);
+        return CreateRpcModuleInternal(l1OriginStore, specProvider, blockFinder);
     }
 
-    private static TaikoEngineRpcModule CreateRpcModuleInternal(IL1OriginStore l1OriginStore, ISpecProvider specProvider) => new(
+    private static TaikoEngineRpcModule CreateRpcModuleInternal(IL1OriginStore l1OriginStore, ISpecProvider specProvider, IBlockFinder? blockFinder) => new(
         Substitute.For<IAsyncHandler<byte[], ExecutionPayload?>>(),
         Substitute.For<IAsyncHandler<byte[], GetPayloadV2Result?>>(),
         Substitute.For<IAsyncHandler<byte[], GetPayloadV3Result?>>(),
@@ -274,7 +323,7 @@ public class CertainBatchLookupTests
         null!,
         Substitute.For<ILogManager>(),
         Substitute.For<ITxPool>(),
-        Substitute.For<IBlockFinder>(),
+        blockFinder ?? Substitute.For<IBlockFinder>(),
         Substitute.For<IShareableTxProcessorSource>(),
         Substitute.For<IRlpStreamEncoder<Transaction>>(),
         l1OriginStore,

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -31,6 +31,7 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.TxPool;
 using Nethermind.Evm.State;
 using Nethermind.Taiko.Config;
+using Nethermind.Taiko.ZkGas;
 using static Nethermind.Taiko.TaikoBlockValidator;
 
 namespace Nethermind.Taiko.Rpc;
@@ -105,7 +106,35 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
     private static readonly ResultWrapper<L1Origin?> L1OriginByBatchIdNullResult =
         ResultWrapper<L1Origin?>.Success(null);
 
+    /// <summary>
+    /// Cached null-result for <c>taikoAuth_last{Certain,}BlockIDByBatchID</c> when the resolved
+    /// block id sits below this network's last-Pacaya threshold. Geth and reth both report this
+    /// case as success+null rather than the "not found" error, so the driver does not mistake
+    /// the threshold gate for a transient miss.
+    /// </summary>
+    private static readonly ResultWrapper<UInt256?> BlockIdBatchLookupNullResult =
+        ResultWrapper<UInt256?>.Success(null);
+
+    /// <summary>
+    /// Resolved once at construction from <see cref="ISpecProvider.ChainId"/>. <c>null</c> on
+    /// networks with no last-Pacaya threshold (Devnet, Masaya, unknown). On Mainnet and Hoodi,
+    /// any resolved batch-lookup block id strictly less than this value is reported as null.
+    /// </summary>
+    private readonly UInt256? _batchLookupThreshold =
+        ZkGasSchedule.ResolveBatchLookupThreshold(specProvider.ChainId) is { } t
+            ? new UInt256(t)
+            : (UInt256?)null;
+
     private readonly ILogger _taikoLogger = logManager.GetClassLogger<TaikoEngineRpcModule>();
+
+    /// <summary>
+    /// Returns <c>true</c> when this network has a batch-lookup threshold and the resolved
+    /// block id sits strictly below it. Mirrors <c>batchLookupResultBelowThreshold</c> in
+    /// taiko-geth (PR #558) and <c>batch_lookup_result_below_last_pacaya_block_id</c> in
+    /// alethia-reth (PR #177).
+    /// </summary>
+    private bool IsBlockBelowBatchLookupThreshold(UInt256 blockId) =>
+        _batchLookupThreshold is { } threshold && blockId < threshold;
 
     public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, TaikoPayloadAttributes? payloadAttributes = null) => base.engine_forkchoiceUpdatedV1(forkchoiceState, payloadAttributes);
 
@@ -417,6 +446,9 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
             }
         }
 
+        if (IsBlockBelowBatchLookupThreshold(blockId.Value))
+            return L1OriginByBatchIdNullResult;
+
         L1Origin? origin = l1OriginStore.ReadL1Origin(blockId.Value);
         // Debug: a known block can lack its L1Origin record briefly between insertion and
         // the driver's taikoAuth_updateL1Origin writeback — expected, not a fault.
@@ -439,12 +471,17 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
             }
         }
 
+        if (IsBlockBelowBatchLookupThreshold(blockId.Value))
+            return BlockIdBatchLookupNullResult;
+
         return ResultWrapper<UInt256?>.Success(blockId);
     }
 
     public ResultWrapper<UInt256?> taikoAuth_lastCertainBlockIDByBatchID(UInt256 batchId)
     {
         UInt256? blockId = l1OriginStore.ReadBatchToLastBlockID(batchId);
+        if (blockId is { } b && IsBlockBelowBatchLookupThreshold(b))
+            return BlockIdBatchLookupNullResult;
         return ResultWrapper<UInt256?>.Success(blockId);
     }
 
@@ -453,8 +490,11 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
         UInt256? blockId = l1OriginStore.ReadBatchToLastBlockID(batchId);
         if (blockId is null)
         {
-            return ResultWrapper<L1Origin?>.Success(null);
+            return L1OriginByBatchIdNullResult;
         }
+
+        if (IsBlockBelowBatchLookupThreshold(blockId.Value))
+            return L1OriginByBatchIdNullResult;
 
         L1Origin? origin = l1OriginStore.ReadL1Origin(blockId.Value);
         return ResultWrapper<L1Origin?>.Success(origin);

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
@@ -53,6 +53,36 @@ public static class ZkGasSchedule
     public static ulong ResolveBlockZkGasLimit(ulong chainId) =>
         chainId == TaikoMasayaChainId ? MasayaBlockZkGasLimit : BlockZkGasLimit;
 
+    /// <summary>
+    /// Mainnet block number of the last Pacaya block accepted by batch lookup RPCs.
+    /// Resolved batch lookup results strictly below this value are reported to the
+    /// driver as JSON null. Sourced from taiko-geth PR #558 and alethia-reth PR #177.
+    /// </summary>
+    public const ulong TaikoMainnetLastPacayaBatchLookupBlock = 4_990_434;
+
+    /// <summary>
+    /// Hoodi block number of the last Pacaya block accepted by batch lookup RPCs.
+    /// Resolved batch lookup results strictly below this value are reported to the
+    /// driver as JSON null. Sourced from taiko-geth PR #558 and alethia-reth PR #177.
+    /// </summary>
+    public const ulong TaikoHoodiLastPacayaBatchLookupBlock = 3_951_005;
+
+    /// <summary>
+    /// Returns the per-network minimum block id for batch lookup RPC results, or
+    /// <c>null</c> on networks with no threshold (Devnet, Masaya, unknown). When a
+    /// threshold is configured, <c>taikoAuth_last{Certain,}{L1Origin,BlockID}ByBatchID</c>
+    /// must report JSON null for any resolved block id strictly below it. Mirrors
+    /// <c>batchLookupBlockThresholds</c> in taiko-geth (PR #558) and
+    /// <c>batch_lookup_last_pacaya_block_threshold</c> in alethia-reth (PR #177).
+    /// </summary>
+    /// <param name="chainId">Chain id from <see cref="Nethermind.Core.Specs.ISpecProvider.ChainId"/>.</param>
+    public static ulong? ResolveBatchLookupThreshold(ulong chainId) => chainId switch
+    {
+        TaikoMainnetChainId => TaikoMainnetLastPacayaBatchLookupBlock,
+        TaikoHoodiChainId => TaikoHoodiLastPacayaBatchLookupBlock,
+        _ => null,
+    };
+
     /// <summary>Fail-safe multiplier for any opcode or precompile not explicitly listed.</summary>
     public const ushort FailsafeMultiplier = ushort.MaxValue;
 

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
@@ -54,18 +54,22 @@ public static class ZkGasSchedule
         chainId == TaikoMasayaChainId ? MasayaBlockZkGasLimit : BlockZkGasLimit;
 
     /// <summary>
-    /// Mainnet block number of the last Pacaya block accepted by batch lookup RPCs.
-    /// Resolved batch lookup results strictly below this value are reported to the
-    /// driver as JSON null. Sourced from taiko-geth PR #558 and alethia-reth PR #177.
+    /// Mainnet batch-lookup threshold: the first allowed block id (first Shasta block).
+    /// Resolved batch lookup results <em>strictly less than</em> this value are reported
+    /// to the driver as JSON null; the value itself passes through unchanged. Sourced
+    /// from taiko-geth PR #558 and alethia-reth PR #177. Named for the comparison
+    /// semantics rather than the upstream "last Pacaya" label, which is inverted
+    /// relative to the strict-<c>&lt;</c> operator.
     /// </summary>
-    public const ulong TaikoMainnetLastPacayaBatchLookupBlock = 4_990_434;
+    public const ulong TaikoMainnetBatchLookupThreshold = 4_990_434;
 
     /// <summary>
-    /// Hoodi block number of the last Pacaya block accepted by batch lookup RPCs.
-    /// Resolved batch lookup results strictly below this value are reported to the
-    /// driver as JSON null. Sourced from taiko-geth PR #558 and alethia-reth PR #177.
+    /// Hoodi batch-lookup threshold: the first allowed block id (first Shasta block).
+    /// Resolved batch lookup results <em>strictly less than</em> this value are reported
+    /// to the driver as JSON null; the value itself passes through unchanged. Sourced
+    /// from taiko-geth PR #558 and alethia-reth PR #177.
     /// </summary>
-    public const ulong TaikoHoodiLastPacayaBatchLookupBlock = 3_951_005;
+    public const ulong TaikoHoodiBatchLookupThreshold = 3_951_005;
 
     /// <summary>
     /// Returns the per-network minimum block id for batch lookup RPC results, or
@@ -78,8 +82,8 @@ public static class ZkGasSchedule
     /// <param name="chainId">Chain id from <see cref="Nethermind.Core.Specs.ISpecProvider.ChainId"/>.</param>
     public static ulong? ResolveBatchLookupThreshold(ulong chainId) => chainId switch
     {
-        TaikoMainnetChainId => TaikoMainnetLastPacayaBatchLookupBlock,
-        TaikoHoodiChainId => TaikoHoodiLastPacayaBatchLookupBlock,
+        TaikoMainnetChainId => TaikoMainnetBatchLookupThreshold,
+        TaikoHoodiChainId => TaikoHoodiBatchLookupThreshold,
         _ => null,
     };
 


### PR DESCRIPTION
Mirrors https://github.com/taikoxyz/taiko-geth/pull/558 and https://github.com/taikoxyz/alethia-reth/pull/177. Without this filter, NMC's RPC output for those four methods diverges from geth/reth on Mainnet and Hoodi for any batch whose resolved block id is in the Pacaya range. Devnet/Masaya are unaffected.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No