### PR TITLE
ci: add nightly Docker image build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,6 +1,9 @@
 name: Publish Docker image
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
+
   push:
     branches: [master, release/*, performance]
     paths: [src/Nethermind/**]
@@ -44,7 +47,7 @@ jobs:
         uses: ./.github/actions/publish-docker
         with:
           image-name: ${{ github.event.inputs.image-name || 'nethermind' }}
-          tag: ${{ github.event.inputs.tag || '' }}
+          tag: ${{ github.event.inputs.tag || (github.event_name == 'schedule' && 'nightly') || '' }}
           dockerfile: ${{ github.event.inputs.dockerfile || 'Dockerfile' }}
           build-config: ${{ github.event.inputs.build-config || 'release' }}
           docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## Summary
- Adds a `schedule` trigger (`0 0 * * *`) to the Publish Docker Image workflow, building from `master` at midnight UTC daily
- Tags the resulting image as `nightly`
- No change to existing `push` or `workflow_dispatch` behavior

## Test plan
- [ ] Verify the workflow appears with the schedule trigger in the Actions tab
- [ ] Confirm a manual `workflow_dispatch` still works as before
- [ ] After midnight UTC, confirm the `nightly`-tagged image is published to Docker Hub