### PR TITLE
test: stabilize getPayloadV1 improving-blocks and Simple_test_sync

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -390,8 +390,8 @@ public partial class EngineModuleTests
         improvementContextFactory.CreatedContexts.Should().OnlyContain(static i => i.Disposed);
     }
 
-    [Test, Retry(3)]
     [Parallelizable(ParallelScope.None)] // Timing sensitive
+    [Test, Retry(3)]
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         TimeSpan delay = TimeSpan.FromMilliseconds(10);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -395,8 +395,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
-        // PayloadPreparationService stops scheduling improvements past startDateTime + timePerSlot * 1.3,
-        // so the 3 add-tx/wait rounds below must fit inside that window — keep timePerSlot generous.
+        // Must stay above the PayloadPreparationService slot-cutoff (timePerSlot * 1.3) for all 3 wait rounds.
         TimeSpan timePerSlot = 500 * delay;
         using MergeTestBlockchain chain = await CreateBlockchainWithImprovementContext(
             ctx => new StoringBlockImprovementContextFactory(new BlockImprovementContextFactory(ctx.Resolve<IBlockProducer>()!, TimeSpan.FromSeconds(ctx.Resolve<IMergeConfig>().SecondsPerSlot))),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -391,10 +391,13 @@ public partial class EngineModuleTests
     }
 
     [Test, Retry(3)]
+    [Parallelizable(ParallelScope.None)] // Timing sensitive
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
-        TimeSpan timePerSlot = 50 * delay;
+        // PayloadPreparationService stops scheduling improvements past startDateTime + timePerSlot * 1.3,
+        // so the 3 add-tx/wait rounds below must fit inside that window — keep timePerSlot generous.
+        TimeSpan timePerSlot = 500 * delay;
         using MergeTestBlockchain chain = await CreateBlockchainWithImprovementContext(
             ctx => new StoringBlockImprovementContextFactory(new BlockImprovementContextFactory(ctx.Resolve<IBlockProducer>()!, TimeSpan.FromSeconds(ctx.Resolve<IMergeConfig>().SecondsPerSlot))),
             timePerSlot, delay: delay);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -229,7 +229,11 @@ public class SyncDispatcherTests
         }
     }
 
-    [Test, MaxTime(10000)]
+    // [NonParallelizable]: the dispatcher loop relies on Task.Run / Task.Yield continuations completing
+    // promptly. Under the class-level [Parallelizable(ParallelScope.All)] it competes with the rest of
+    // the suite for thread-pool capacity, and on slow CI the batched dispatch can stretch >20s — well
+    // past the 10s MaxTime budget. Bump to 30s to match the sibling pattern below.
+    [Test, NonParallelizable, MaxTime(30_000)]
     public async Task Simple_test_sync()
     {
         TestSyncFeed syncFeed = new();

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -229,10 +229,6 @@ public class SyncDispatcherTests
         }
     }
 
-    // [NonParallelizable]: the dispatcher loop relies on Task.Run / Task.Yield continuations completing
-    // promptly. Under the class-level [Parallelizable(ParallelScope.All)] it competes with the rest of
-    // the suite for thread-pool capacity, and on slow CI the batched dispatch can stretch >20s — well
-    // past the 10s MaxTime budget. Bump to 30s to match the sibling pattern below.
     [Test, NonParallelizable, MaxTime(30_000)]
     public async Task Simple_test_sync()
     {


### PR DESCRIPTION
## Changes

Two unrelated flaky tests, same family of bug: timing-sensitive tests starved by class-level `[Parallelizable(ParallelScope.All)]` under CI thread-pool pressure.

### `getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks` (`EngineModuleTests.PayloadProduction.cs`)

- Add `[Parallelizable(ParallelScope.None)]` matching timing-sensitive siblings at lines 189 and 522.
- Bump `timePerSlot` from `50 * delay` (500 ms) to `500 * delay` (5 s).

`PayloadPreparationService.CalculateImprovementDelay` returns `Timeout.InfiniteTimeSpan` when the next improvement cannot finish before `startDateTime + timePerSlot * 1.3` — at which point the improvement-loop continuation in `CreateBlockImprovementContext` `return`s and no further `BlockImproved` events fire for that payload. With `timePerSlot = 500 ms`, the test had a hard ~650 ms window to complete three `AddTransactions → WaitForImprovedBlock` rounds; on the Flat-DB CI runner the window is regularly missed and the third wait sits until the default 30 s `TestTimeout` cancels it (the 31 s `TaskCanceledException` signature). Slot length is irrelevant to the test's assertions (`transactionsLength.Should().Equal(3, 6, 11)` and 11 final txs), so widening the cutoff to ~6.5 s is safe.

Seen on the Flat-DB workflow in #11506 and #11523.

### `Simple_test_sync` (`SyncDispatcherTests.cs`)

- Add `[NonParallelizable]` and bump `MaxTime(10000)` → `MaxTime(30_000)`.

`SyncDispatcherTests` is `[Parallelizable(ParallelScope.All)]` at the class level. The dispatcher loop relies on Task.Run / Task.Yield continuations completing promptly; under thread-pool starvation the batched dispatch stretched >20 s, well past the 10 s `MaxTime` budget. Matches the sibling pattern already in place for `When_ConcurrentHandleResponseIsRunning_Then_BlockDispose` directly below it (line 257).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Both tests pass locally:
- `getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks` — both `TestFixture(true)` and `TestFixture(false)` variants in ~5 s.
- `Simple_test_sync` — ~650 ms.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
