### PR TITLE
fix(snap-sync): refresh pivot instead of punishing the only peer (#6803)

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
@@ -120,5 +120,49 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
                 feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
             }
         }
+
+        // Regression for #6803: with a single peer connected, repeated failures must trigger
+        // a pivot refresh rather than punish the only peer available.
+        [Test]
+        public void Single_peer_with_consecutive_failures_refreshes_pivot_instead_of_punishing()
+        {
+            PeerInfo peer = new(null!);
+
+            ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
+
+            Synchronization.SnapSync.SnapSyncFeed feed = new(snapProvider, LimboLogs.Instance);
+
+            SyncResponseHandlingResult? lastResult = null;
+            for (int i = 0; i <= 6; i++)
+            {
+                lastResult = feed.AnalyzeResponsePerPeer(AddRangeResult.DifferentRootHash, peer);
+            }
+
+            Assert.That(lastResult, Is.Not.EqualTo(SyncResponseHandlingResult.LesserQuality));
+            snapProvider.Received(1).UpdatePivot();
+        }
+
+        // When a single peer has produced a recent success, a brief failure burst must still
+        // be tolerated and not trigger a pivot refresh on the first failure threshold breach.
+        [Test]
+        public void Single_peer_with_recent_success_is_not_punished_below_threshold()
+        {
+            PeerInfo peer = new(null!);
+
+            ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
+
+            Synchronization.SnapSync.SnapSyncFeed feed = new(snapProvider, LimboLogs.Instance);
+
+            feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer);
+            for (int i = 0; i < AllowedInvalidResponses; i++)
+            {
+                SyncResponseHandlingResult result = feed.AnalyzeResponsePerPeer(AddRangeResult.DifferentRootHash, peer);
+                Assert.That(result, Is.Not.EqualTo(SyncResponseHandlingResult.LesserQuality));
+            }
+
+            snapProvider.DidNotReceive().UpdatePivot();
+        }
+
+        private const int AllowedInvalidResponses = 5;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
@@ -138,7 +138,7 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
                 lastResult = feed.AnalyzeResponsePerPeer(AddRangeResult.DifferentRootHash, peer);
             }
 
-            Assert.That(lastResult, Is.Not.EqualTo(SyncResponseHandlingResult.LesserQuality));
+            Assert.That(lastResult, Is.EqualTo(SyncResponseHandlingResult.OK));
             snapProvider.Received(1).UpdatePivot();
         }
 
@@ -192,6 +192,6 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             snapProvider.DidNotReceive().UpdatePivot();
         }
 
-        private const int AllowedInvalidResponses = 5;
+        private const int AllowedInvalidResponses = Synchronization.SnapSync.SnapSyncFeed.AllowedInvalidResponses;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
@@ -163,6 +163,35 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             snapProvider.DidNotReceive().UpdatePivot();
         }
 
+        // Regression: a freshly added peer that fails its first AllowedInvalidResponses
+        // requests must still be punished when the log contains entries from other,
+        // healthy peers — even if those entries sit further back than the newcomer's
+        // recent failures.
+        [Test]
+        public void New_peer_failing_burst_is_punished_when_log_holds_other_healthy_peers()
+        {
+            PeerInfo healthyPeer = new(null!);
+            PeerInfo newPeer = new(null!);
+
+            ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
+
+            Synchronization.SnapSync.SnapSyncFeed feed = new(snapProvider, LimboLogs.Instance);
+
+            for (int i = 0; i < AllowedInvalidResponses; i++)
+            {
+                feed.AnalyzeResponsePerPeer(AddRangeResult.OK, healthyPeer);
+            }
+
+            SyncResponseHandlingResult? lastResult = null;
+            for (int i = 0; i <= AllowedInvalidResponses; i++)
+            {
+                lastResult = feed.AnalyzeResponsePerPeer(AddRangeResult.DifferentRootHash, newPeer);
+            }
+
+            Assert.That(lastResult, Is.EqualTo(SyncResponseHandlingResult.LesserQuality));
+            snapProvider.DidNotReceive().UpdatePivot();
+        }
+
         private const int AllowedInvalidResponses = 5;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -142,11 +142,17 @@ namespace Nethermind.Synchronization.SnapSync
                 int allLastSuccess = 0;
                 int allLastFailures = 0;
                 int peerLastFailures = 0;
+                bool seenOtherPeer = false;
 
                 lock (_syncLock)
                 {
                     foreach ((PeerInfo peer, AddRangeResult result) item in _resultLog)
                     {
+                        if (item.peer != peer)
+                        {
+                            seenOtherPeer = true;
+                        }
+
                         if (item.result == AddRangeResult.OK)
                         {
                             allLastSuccess++;
@@ -166,6 +172,18 @@ namespace Nethermind.Synchronization.SnapSync
 
                                 if (peerLastFailures > AllowedInvalidResponses)
                                 {
+                                    // With a single peer in the recent window and no successes, the
+                                    // failure stream is more likely a stale pivot than a misbehaving
+                                    // peer — punishing the only available peer would stall sync.
+                                    if (!seenOtherPeer && allLastSuccess == 0)
+                                    {
+                                        _snapProvider.UpdatePivot();
+
+                                        _resultLog.Clear();
+
+                                        break;
+                                    }
+
                                     if (allLastFailures == peerLastFailures)
                                     {
                                         _logger.Trace($"SNAP - peer to be punished:{peer}");

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
+
+[assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
 
 namespace Nethermind.Synchronization.SnapSync
 {
@@ -15,7 +18,7 @@ namespace Nethermind.Synchronization.SnapSync
     {
         private readonly Lock _syncLock = new();
 
-        private const int AllowedInvalidResponses = 5;
+        internal const int AllowedInvalidResponses = 5;
         private readonly LinkedList<(PeerInfo peer, AddRangeResult result)> _resultLog = new();
 
         private const SnapSyncBatch EmptyBatch = null;

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -146,13 +146,20 @@ namespace Nethermind.Synchronization.SnapSync
 
                 lock (_syncLock)
                 {
-                    foreach ((PeerInfo peer, AddRangeResult result) item in _resultLog)
+                    // Scan the whole window first so the single-peer guard cannot fire
+                    // prematurely when a healthy peer's entries sit further back in the log
+                    // than the analyzed peer's recent failures.
+                    foreach ((PeerInfo p, AddRangeResult _) probe in _resultLog)
                     {
-                        if (item.peer != peer)
+                        if (probe.p != peer)
                         {
                             seenOtherPeer = true;
+                            break;
                         }
+                    }
 
+                    foreach ((PeerInfo peer, AddRangeResult result) item in _resultLog)
+                    {
                         if (item.result == AddRangeResult.OK)
                         {
                             allLastSuccess++;
@@ -172,7 +179,7 @@ namespace Nethermind.Synchronization.SnapSync
 
                                 if (peerLastFailures > AllowedInvalidResponses)
                                 {
-                                    // With a single peer in the recent window and no successes, the
+                                    // With a single peer in the entire window and no successes, the
                                     // failure stream is more likely a stale pivot than a misbehaving
                                     // peer — punishing the only available peer would stall sync.
                                     if (!seenOtherPeer && allLastSuccess == 0)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
-
-[assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
 
 namespace Nethermind.Synchronization.SnapSync
 {
@@ -152,9 +149,9 @@ namespace Nethermind.Synchronization.SnapSync
                     // Scan the whole window first so the single-peer guard cannot fire
                     // prematurely when a healthy peer's entries sit further back in the log
                     // than the analyzed peer's recent failures.
-                    foreach ((PeerInfo p, AddRangeResult _) probe in _resultLog)
+                    foreach ((PeerInfo peer, AddRangeResult _) probe in _resultLog)
                     {
-                        if (probe.p != peer)
+                        if (probe.peer != peer)
                         {
                             seenOtherPeer = true;
                             break;


### PR DESCRIPTION
Fixes #6803

## Changes

- Track in `AnalyzeResponsePerPeer` whether the recent result window contains entries from any peer other than the one being analyzed.
- When the only peer observed exceeds `AllowedInvalidResponses` with no offsetting success, call `_snapProvider.UpdatePivot()` and clear the log instead of returning `LesserQuality`. Punishing the only available peer in that case just stalls sync.
- Multi-peer behavior is untouched — the existing `allLastFailures == peerLastFailures` punishment branch still fires when other peers are healthy and only this peer is misbehaving.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two new cases in `AnalyzeResponsePerPeerTests`:
- `Single_peer_with_consecutive_failures_refreshes_pivot_instead_of_punishing` — exercises the #6803 path: six consecutive failures from a sole peer trigger `UpdatePivot` and never return `LesserQuality`.
- `Single_peer_with_recent_success_is_not_punished_below_threshold` — confirms a sub-threshold failure burst after a success neither punishes nor refreshes.

All four pre-existing tests continue to pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Earlier attempts (#6818, #7067) were closed for being too simplistic or lacking tests. This iteration:
- Uses the result log itself as the single-peer signal (no `ISyncPeerPool` injection needed), keeping `SnapSyncFeed` constructor unchanged.
- Only refreshes the pivot when truly observing one peer with zero successes, leaving the multi-peer punishment branch intact.