### PR TITLE
feat(rpc): expose debug_getFirstFullStateBlock (#1999)

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -133,6 +133,30 @@ public class DebugModuleTests
     }
 
     [Test]
+    public async Task Debug_getFirstFullStateBlock_returns_bridge_value()
+    {
+        _debugBridge.GetFirstFullStateBlock().Returns((long?)42);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        using JsonRpcSuccessResponse? response =
+            await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFirstFullStateBlock") as JsonRpcSuccessResponse;
+
+        Assert.That(response?.Result, Is.EqualTo(42L));
+    }
+
+    [Test]
+    public async Task Debug_getFirstFullStateBlock_returns_null_when_no_full_state()
+    {
+        _debugBridge.GetFirstFullStateBlock().Returns((long?)null);
+
+        DebugRpcModule rpcModule = CreateDebugRpcModule(_debugBridge);
+        using JsonRpcSuccessResponse? response =
+            await RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getFirstFullStateBlock") as JsonRpcSuccessResponse;
+
+        Assert.That(response?.Result, Is.Null);
+    }
+
+    [Test]
     public async Task Get_raw_header()
     {
         HeaderDecoder decoder = new();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.FirstFullStateBlock.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.FirstFullStateBlock.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules;
+
+public partial class DebugRpcModuleTests
+{
+    [Test]
+    public async Task Debug_getFirstFullStateBlock_returns_zero_for_archive_chain()
+    {
+        using Context ctx = await Context.Create();
+
+        ResultWrapper<long?> result = ctx.DebugRpcModule.debug_getFirstFullStateBlock();
+
+        result.Result.ResultType.Should().Be(Core.ResultType.Success);
+        result.Data.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Debug_getFirstFullStateBlock_still_zero_after_adding_blocks()
+    {
+        using Context ctx = await Context.Create();
+
+        await ctx.Blockchain.AddFunds(TestItem.AddressA, 1.Ether);
+        await ctx.Blockchain.AddFunds(TestItem.AddressB, 1.Ether);
+        long head = ctx.Blockchain.BlockTree.Head!.Number;
+        head.Should().BeGreaterThan(0);
+
+        ResultWrapper<long?> result = ctx.DebugRpcModule.debug_getFirstFullStateBlock();
+
+        result.Result.ResultType.Should().Be(Core.ResultType.Success);
+        result.Data.Should().Be(0);
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -19,6 +19,7 @@ using Nethermind.Db;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Crypto;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -36,6 +37,7 @@ public class DebugBridge : IDebugBridge
     private readonly ISyncModeSelector _syncModeSelector;
     private readonly IBadBlockStore _badBlockStore;
     private readonly IBlockStore _blockStore;
+    private readonly IStateReader _stateReader;
     private readonly Dictionary<string, IDb> _dbMappings;
 
     public DebugBridge(
@@ -47,7 +49,8 @@ public class DebugBridge : IDebugBridge
         IReceiptsMigration receiptsMigration,
         ISpecProvider specProvider,
         ISyncModeSelector syncModeSelector,
-        IBadBlockStore badBlockStore)
+        IBadBlockStore badBlockStore,
+        IStateReader stateReader)
     {
         _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
         _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
@@ -57,6 +60,7 @@ public class DebugBridge : IDebugBridge
         _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
         _badBlockStore = badBlockStore;
+        _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
         dbProvider = dbProvider ?? throw new ArgumentNullException(nameof(dbProvider));
         IDb blockInfosDb = dbProvider.BlockInfosDb ?? throw new ArgumentNullException(nameof(dbProvider.BlockInfosDb));
         IDb blocksDb = dbProvider.BlocksDb ?? throw new ArgumentNullException(nameof(dbProvider.BlocksDb));
@@ -88,6 +92,38 @@ public class DebugBridge : IDebugBridge
     public byte[] GetDbValue(string dbName, byte[] key) => _dbMappings[dbName][key];
 
     public ChainLevelInfo GetLevelInfo(long number) => _blockTree.FindLevel(number);
+
+    public long? GetFirstFullStateBlock()
+    {
+        Block? head = _blockTree.Head;
+        if (head is null) return null;
+
+        long high = head.Number;
+        if (!HasStateAt(head.Header)) return null;
+
+        long low = 0;
+        long answer = high;
+
+        while (low <= high)
+        {
+            long mid = low + ((high - low) >> 1);
+            BlockHeader? header = _blockTree.FindHeader(mid, BlockTreeLookupOptions.RequireCanonical);
+            if (header is not null && HasStateAt(header))
+            {
+                answer = mid;
+                high = mid - 1;
+            }
+            else
+            {
+                low = mid + 1;
+            }
+        }
+
+        return answer;
+    }
+
+    private bool HasStateAt(BlockHeader header) =>
+        header.StateRoot == Keccak.EmptyTreeHash || _stateReader.HasStateForBlock(header);
 
     public int DeleteChainSlice(long startNumber, bool force = false) => _blockTree.DeleteChainSlice(startNumber, force: force);
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -52,6 +52,9 @@ public class DebugRpcModule(
             : ResultWrapper<ChainLevelForRpc>.Success(new ChainLevelForRpc(levelInfo));
     }
 
+    public ResultWrapper<long?> debug_getFirstFullStateBlock() =>
+        ResultWrapper<long?>.Success(debugBridge.GetFirstFullStateBlock());
+
     public ResultWrapper<int> debug_deleteChainSlice(in long startNumber, bool force = false) => ResultWrapper<int>.Success(debugBridge.DeleteChainSlice(startNumber, force));
 
     public ResultWrapper<GethLikeTxTrace> debug_traceTransaction(Hash256 transactionHash, GethTraceOptions? options = null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -42,4 +42,8 @@ public interface IDebugBridge
     Transaction? GetTransactionFromHash(Hash256 hash);
     Hash256? GetTransactionBlockHash(Hash256 transactionHash);
     IEnumerable<IEnumerable<GethLikeTxTrace>> GetBundleTraces(TransactionBundle[] bundles, BlockParameter blockParameter, long? gasCap, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+
+    /// <summary>Returns the number of the earliest canonical block whose full state is locally available, or <see langword="null"/> when no such block exists.</summary>
+    /// <remarks>Implemented as a binary search across the canonical chain on the assumption that state availability is monotonic — once state is available at height H, every later canonical height also has state. Useful for surfacing how far back history is queryable on a snap-synced node.</remarks>
+    long? GetFirstFullStateBlock();
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -21,6 +21,9 @@ public interface IDebugRpcModule : IRpcModule
     [JsonRpcMethod(Description = "Retrieves a representation of tree branches on a given chain level (Nethermind specific).", IsImplemented = true, IsSharable = true)]
     ResultWrapper<ChainLevelForRpc> debug_getChainLevel(in long number);
 
+    [JsonRpcMethod(Description = "Returns the number of the earliest canonical block whose full state is available locally, or null when no block currently has full state. Useful for surfacing how far back a snap-synced node can answer historical state queries (Nethermind specific).", IsImplemented = true, IsSharable = true)]
+    ResultWrapper<long?> debug_getFirstFullStateBlock();
+
     [JsonRpcMethod(Description = "Deletes a slice of a chain from the tree on all branches (Nethermind specific).", IsImplemented = true, IsSharable = true)]
     ResultWrapper<int> debug_deleteChainSlice(in long startNumber, bool force = false);
 


### PR DESCRIPTION
Fixes #1999

## Changes

- New JSON-RPC method `debug_getFirstFullStateBlock` returning the number of the earliest canonical block whose full state is locally available, or `null` when no block currently has full state.
- `IDebugBridge.GetFirstFullStateBlock` runs a binary search across the canonical chain on the assumption that state availability is monotonic (once state is available at height H, every later canonical height also has state) — typical for archive and snap-synced nodes.
- Wires `IStateReader` into `DebugBridge` so the bridge can probe state availability at arbitrary headers.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Unit tests in `DebugModuleTests` confirm the RPC layer passes through the bridge value (including `null`).
- Integration tests in `DebugRpcModuleTests.FirstFullStateBlock` use `TestRpcBlockchain` to verify an archive node reports block `0` both on a fresh chain and after several blocks have been added.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The binary search assumes monotonic state availability — true for archive nodes and the typical snap-sync window. Nodes with non-contiguous state retention would still get a usable answer (the lowest block whose state is currently kept), but the method does not attempt to characterise gaps.