### PR TITLE
fix: eth62 queue on disconnect

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -34,7 +34,6 @@ using NSubstitute;
 using NUnit.Framework;
 using DotNetty.Buffers;
 using DotNetty.Transport.Channels;
-using Nethermind.Core.Collections;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Serialization.Rlp;
 
@@ -603,19 +602,18 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         }
 
         [Test]
-        public async Task Queued_headers_request_is_cancelled_on_dispose()
+        public void Queued_headers_request_is_cancelled_on_dispose()
         {
             HandleIncomingStatusMessage();
 
-            ISyncPeer peer = _handler;
-            Task<IOwnedReadOnlyList<BlockHeader>> request1 = peer.GetBlockHeaders(1, 1, 0, CancellationToken.None);
-            Task<IOwnedReadOnlyList<BlockHeader>> request2 = peer.GetBlockHeaders(2, 1, 0, CancellationToken.None);
+            Task request1 = ((ISyncPeer)_handler).GetBlockHeaders(1, 1, 0, CancellationToken.None);
             // request1 is in-flight; request2 gets queued and is never sent to the peer
+            Task request2 = ((ISyncPeer)_handler).GetBlockHeaders(2, 1, 0, CancellationToken.None);
 
             _handler.Dispose();
 
-            await Assert.ThatAsync(() => request1, Throws.InstanceOf<TaskCanceledException>());
-            await Assert.ThatAsync(() => request2, Throws.InstanceOf<TaskCanceledException>());
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await request1);
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await request2);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -34,6 +34,7 @@ using NSubstitute;
 using NUnit.Framework;
 using DotNetty.Buffers;
 using DotNetty.Transport.Channels;
+using Nethermind.Core.Collections;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Serialization.Rlp;
 
@@ -599,6 +600,22 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             HandleIncomingStatusMessage();
             Assert.Throws<SubprotocolException>(() => HandleZeroMessage(msg, Eth62MessageCode.BlockHeaders));
+        }
+
+        [Test]
+        public async Task Queued_headers_request_is_cancelled_on_dispose()
+        {
+            HandleIncomingStatusMessage();
+
+            ISyncPeer peer = _handler;
+            Task<IOwnedReadOnlyList<BlockHeader>> request1 = peer.GetBlockHeaders(1, 1, 0, CancellationToken.None);
+            Task<IOwnedReadOnlyList<BlockHeader>> request2 = peer.GetBlockHeaders(2, 1, 0, CancellationToken.None);
+            // request1 is in-flight; request2 gets queued and is never sent to the peer
+
+            _handler.Dispose();
+
+            await Assert.ThatAsync(() => request1, Throws.InstanceOf<TaskCanceledException>());
+            await Assert.ThatAsync(() => request2, Throws.InstanceOf<TaskCanceledException>());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -84,13 +84,20 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
             if (ReferenceEquals(firstTask, task))
             {
-                long elapsed = request.FinishMeasuringTime();
-
                 delayCancellation.Cancel();
 
-                long bytesPerMillisecond = (long)((decimal)request.ResponseSize / Math.Max(1, elapsed));
-                if (Logger.IsTrace) Logger.Trace($"{this} speed is {request.ResponseSize}/{elapsed} = {bytesPerMillisecond}");
-                StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, bytesPerMillisecond);
+                if (task.IsCompletedSuccessfully)
+                {
+                    long elapsed = request.FinishMeasuringTime();
+                    long bytesPerMillisecond = (long)((decimal)request.ResponseSize / Math.Max(1, elapsed));
+                    if (Logger.IsTrace) Logger.Trace($"{this} speed is {request.ResponseSize}/{elapsed} = {bytesPerMillisecond}");
+                    StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, bytesPerMillisecond);
+                }
+                else
+                {
+                    StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, 0L);
+                    if (Logger.IsTrace) Logger.Trace($"{Session} Request {(task.IsCanceled ? "cancelled" : "failed")}: {describeRequestFunc(request.Message)}");
+                }
             }
             else
             {


### PR DESCRIPTION
`MessageQueue` sends one request at a time — a second request while the first is in-flight gets queued without starting its stopwatch. On disconnect, the queued request is cancelled before it is ever sent, leaving the stopwatch null.
  `HandleResponseInner` then tries to finish timing on the cancelled task and crashes.

  Fix: only measure transfer speed when the task completed successfully. Cancelled and faulted tasks report `0` speed instead.

```
  Failure when executing request System.NullReferenceException: Object reference not set to an instance of an object.
     at Nethermind.Network.P2P.ProtocolHandlers.ZeroProtocolHandlerBase.HandleResponseInnerTRequest,TResponse in ZeroProtocolHandlerBase.cs:line 87
     at Nethermind.Network.P2P.ProtocolHandlers.SyncPeerProtocolHandlerBase.SendRequest(GetBlockHeadersMessage message, CancellationToken token) in SyncPeerProtocolHandlerBase.cs:line 139
     at Nethermind.Network.P2P.ProtocolHandlers.SyncPeerProtocolHandlerBase.GetBlockHeaders(Int64 number, Int32 maxBlocks, Int32 skip, CancellationToken token) in SyncPeerProtocolHandlerBase.cs:line 123
     at Nethermind.Synchronization.FastBlocks.HeadersSyncDownloader.Dispatch(PeerInfo peerInfo, HeadersSyncBatch batch, CancellationToken cancellationToken) in HeadersSyncDownloader.cs:line 29
     at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.DoDispatch(CancellationToken cancellationToken, ...) in SyncDispatcher.cs:line 196
```

  ## Types of changes

  - [x] Bugfix (a non-breaking change that fixes an issue)

  ## Testing

  #### Requires testing
  - [x] Yes

  #### If yes, did you write tests?
  - [x] Yes

