### PR TITLE
ci: add fork-author guard to evm-opcode-benchmark-diff workflow

### DIFF
--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -21,6 +21,10 @@ permissions:
 jobs:
   check-trigger:
     name: Check if EVM benchmark needed
+    # Fork-author guard: block fork PRs from dispatching downstream jobs to the
+    # self-hosted `benchmark` runner pool. Matches the guard used by sibling
+    # benchmark workflows (run-block-processing-benchmark.yml, run-expb-reproducible-benchmarks.yml).
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}


### PR DESCRIPTION
The `evm-opcode-benchmark-diff.yml` workflow dispatches its `compare-evm-opcodes` job to the self-hosted `benchmark` runner pool on every fork `pull_request` event matching the path filter. Unlike its siblings `run-block-processing-benchmark.yml` and
`run-expb-reproducible-benchmarks.yml`, it does not gate on the PR head repo matching the workflow's repository.

This gates the entry job on
`github.event.pull_request.head.repo.full_name == github.repository`, mirroring the guard pattern already used by sibling benchmark workflows. Because the downstream self-hosted job is conditioned on `needs.check-trigger.outputs.should_run == 'true'`, skipping the entry job short-circuits dispatch to the self-hosted pool entirely.

No change for internal PRs.

## Changes

- Add fork-author guard (`if: github.event.pull_request.head.repo.full_name == github.repository`) to the `check-trigger` job in `.github/workflows/evm-opcode-benchmark-diff.yml`, mirroring the pattern already used by `run-block-processing-benchmark.yml` and `run-expb-reproducible-benchmarks.yml`.
- Skipping `check-trigger` for fork PRs leaves `needs.check-trigger.outputs.should_run` unset, so the downstream `compare-evm-opcodes` job (which dispatches to the self-hosted `benchmark` runner pool) is short-circuited and never runs on fork-supplied code.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No


## Remarks