### PR TITLE
Align EIP-8037 gas accounting with BAL tests v7.1.0

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -5,7 +5,7 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 
 public class Constants
 {
-    public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-spec-tests/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "bal@v7.0.0";
+    public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.1.0";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_bal.tar.gz";
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -36,9 +36,17 @@ internal class TransactionProcessorEip7702Tests
     private IDisposable _worldStateCloser;
 
     [SetUp]
-    public void Setup()
+    public void Setup() => Initialize(Prague.Instance);
+
+    private void UseSpec(IReleaseSpec spec)
     {
-        _specProvider = new TestSpecProvider(Prague.Instance);
+        _worldStateCloser.Dispose();
+        Initialize(spec);
+    }
+
+    private void Initialize(IReleaseSpec spec)
+    {
+        _specProvider = new TestSpecProvider(spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
@@ -49,6 +57,93 @@ internal class TransactionProcessorEip7702Tests
 
     [TearDown]
     public void TearDown() => _worldStateCloser.Dispose();
+
+    public enum AuthorityPreState
+    {
+        Nonexistent,
+        ExistingLeaf,
+        ExistingDelegation
+    }
+
+    public static IEnumerable<TestCaseData> Eip8037AuthRefundCases()
+    {
+        yield return new TestCaseData(AuthorityPreState.Nonexistent, false, 0UL, 0L)
+            .SetName("Nonexistent authority - no auth state refund");
+        yield return new TestCaseData(AuthorityPreState.ExistingLeaf, false, 0UL, GasCostOf.NewAccountState)
+            .SetName("Existing authority leaf - refunds new account state gas");
+        yield return new TestCaseData(AuthorityPreState.ExistingDelegation, false, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
+            .SetName("Existing delegation overwrite - refunds full auth state gas");
+        yield return new TestCaseData(AuthorityPreState.ExistingDelegation, true, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
+            .SetName("Existing delegation clear - refunds full auth state gas");
+    }
+
+    [TestCaseSource(nameof(Eip8037AuthRefundCases))]
+    public void Execute_Eip8037AuthRefunds_UpdateReceiptAndBlockGas(
+        AuthorityPreState authorityPreState,
+        bool clearDelegation,
+        ulong authorityNonce,
+        long expectedStateGasRefund)
+    {
+        UseSpec(Amsterdam.Instance);
+
+        PrivateKey authority = TestItem.PrivateKeyA;
+        PrivateKey sender = TestItem.PrivateKeyB;
+        Address previousDelegation = TestItem.AddressC;
+        Address newDelegation = TestItem.AddressD;
+        Address authTarget = clearDelegation ? Address.Zero : newDelegation;
+
+        _stateProvider.CreateAccount(sender.Address, 1.Ether);
+        DeployCode(previousDelegation, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployCode(newDelegation, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        if (authorityPreState is not AuthorityPreState.Nonexistent)
+        {
+            UInt256 authorityBalance = authorityPreState is AuthorityPreState.ExistingLeaf ? UInt256.One : UInt256.Zero;
+            _stateProvider.CreateAccount(authority.Address, authorityBalance, authorityNonce);
+        }
+
+        if (authorityPreState is AuthorityPreState.ExistingDelegation)
+        {
+            byte[] delegation = [.. Eip7702Constants.DelegationHeader, .. previousDelegation.Bytes];
+            _stateProvider.InsertCode(authority.Address, ValueKeccak.Compute(delegation), delegation, Amsterdam.Instance);
+        }
+
+        long intrinsicRegularGas = GasCostOf.Transaction + GasCostOf.PerAuthBaseRegular;
+        long intrinsicStateGas = GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState;
+        Transaction tx = Build.A.Transaction
+            .WithType(TxType.SetCode)
+            .WithTo(newDelegation)
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + intrinsicStateGas)
+            .WithAuthorizationCode(_ethereumEcdsa.Sign(authority, _specProvider.ChainId, authTarget, authorityNonce))
+            .SignedAndResolved(_ethereumEcdsa, sender, true)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(long.MaxValue)
+            .WithTimestamp(MainnetSpecProvider.AmsterdamBlockTimestamp)
+            .WithTransactions(tx)
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + intrinsicStateGas)
+            .TestObject;
+
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(block);
+        using ITxTracer txTracer = receiptsTracer.StartNewTxTrace(tx);
+        TransactionResult result = _transactionProcessor.Execute(
+            tx,
+            new BlockExecutionContext(block.Header, _specProvider.GetSpec(block.Header)),
+            receiptsTracer);
+        receiptsTracer.EndTxTrace();
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(result.EvmExceptionType, Is.EqualTo(EvmExceptionType.None));
+        Assert.That(tx.SpentGas, Is.EqualTo(intrinsicRegularGas + intrinsicStateGas - expectedStateGasRefund));
+        Assert.That(receiptsTracer.LastReceipt.GasUsedTotal, Is.EqualTo(intrinsicRegularGas + intrinsicStateGas - expectedStateGasRefund));
+        Assert.That(block.Header.GasUsed, Is.EqualTo(Math.Max(intrinsicRegularGas, intrinsicStateGas - expectedStateGasRefund)));
+        Assert.That(_stateProvider.GetNonce(authority.Address), Is.EqualTo((UInt256)(authorityNonce + 1)));
+
+        byte[] expectedCode = clearDelegation
+            ? []
+            : [.. Eip7702Constants.DelegationHeader, .. newDelegation.Bytes];
+        Assert.That(_stateProvider.GetCode(authority.Address), Is.EqualTo(expectedCode));
+    }
 
     [Test]
     public void Execute_TxHasAuthorizationWithCodeThatSavesCallerAddress_ExpectedAddressIsSaved()

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -73,6 +73,8 @@ internal class TransactionProcessorEip7702Tests
             .SetName("Existing authority leaf - refunds new account state gas");
         yield return new TestCaseData(AuthorityPreState.ExistingDelegation, false, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
             .SetName("Existing delegation overwrite - refunds full auth state gas");
+        // The auth-base refund depends on the pre-state delegation slot, so clearing
+        // an existing delegation receives the same refund as overwriting it.
         yield return new TestCaseData(AuthorityPreState.ExistingDelegation, true, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
             .SetName("Existing delegation clear - refunds full auth state gas");
     }

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -63,6 +63,28 @@ public class CodeInfoRepositoryTests
         sut.TryGetDelegation(TestItem.AddressA, _releaseSpec, out _).Should().Be(false);
     }
 
+    [TestCase(false, TestName = "Missing account")]
+    [TestCase(true, TestName = "Existing empty-code account")]
+    public void TryGetDelegation_AccountWithoutCode_DoesNotLoadCodeInfo(bool createAccount)
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        if (createAccount)
+        {
+            stateProvider.CreateAccount(TestItem.AddressA, 0);
+        }
+
+        bool codeInfoLoaderCalled = false;
+        CodeInfoRepository sut = new(stateProvider, new EthereumPrecompileProvider(), (_, _, _) =>
+        {
+            codeInfoLoaderCalled = true;
+            return CodeInfo.Empty;
+        });
+
+        sut.TryGetDelegation(TestItem.AddressA, _releaseSpec, out _).Should().BeFalse();
+
+        codeInfoLoaderCalled.Should().BeFalse();
+    }
 
     public static IEnumerable<TestCaseData> DelegationCodeCases()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -25,7 +25,7 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     {
         Self,
         Existing,
-        Empty
+        Nonexistent
     }
 
     protected override long BlockNumber => MainnetSpecProvider.ParisBlockNumber;
@@ -1020,7 +1020,7 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     [TestCase(0UL, SelfDestructBeneficiaryKind.Self, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_self_keeps_create_state_gas")]
     [TestCase(100UL, SelfDestructBeneficiaryKind.Self, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_self_with_value_keeps_create_state_gas")]
     [TestCase(100UL, SelfDestructBeneficiaryKind.Existing, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_existing_with_value_keeps_create_state_gas")]
-    [TestCase(100UL, SelfDestructBeneficiaryKind.Empty, GasCostOf.CreateState + GasCostOf.NewAccountState, TestName = "Eip8037_create_tx_selfdestruct_to_empty_with_value_keeps_create_and_beneficiary_state_gas")]
+    [TestCase(100UL, SelfDestructBeneficiaryKind.Nonexistent, GasCostOf.CreateState + GasCostOf.NewAccountState, TestName = "Eip8037_create_tx_selfdestruct_to_nonexistent_with_value_keeps_create_and_beneficiary_state_gas")]
     public void Eip8037_create_tx_selfdestruct_initcode_keeps_create_state_gas(
         ulong txValue,
         SelfDestructBeneficiaryKind beneficiaryKind,
@@ -1031,7 +1031,7 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         {
             SelfDestructBeneficiaryKind.Self => contractAddress,
             SelfDestructBeneficiaryKind.Existing => TestItem.AddressC,
-            SelfDestructBeneficiaryKind.Empty => TestItem.AddressC,
+            SelfDestructBeneficiaryKind.Nonexistent => TestItem.AddressD,
             _ => throw new ArgumentOutOfRangeException(nameof(beneficiaryKind))
         };
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -21,6 +21,13 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     private const long DynamicStatePricingBlockGasLimit = 100_000_000;
     private static readonly byte[] DefaultCreate2Salt = [0x01];
 
+    public enum SelfDestructBeneficiaryKind
+    {
+        Self,
+        Existing,
+        Empty
+    }
+
     protected override long BlockNumber => MainnetSpecProvider.ParisBlockNumber;
     protected override ulong Timestamp => MainnetSpecProvider.AmsterdamBlockTimestamp;
 
@@ -858,11 +865,11 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         Assert.That(TestState.GetBalance(beneficiary), Is.EqualTo(100.Ether + UInt256.One));
     }
 
-    [TestCase(false, 0, 0L, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_zero_balance_CREATE")]
-    [TestCase(false, 100, GasCostOf.NewAccountState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_balance_CREATE")]
-    [TestCase(true, 0, 0L, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_zero_balance_CREATE2")]
-    [TestCase(true, 100, GasCostOf.NewAccountState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_balance_CREATE2")]
-    public void Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_charges_balance_transfer_only(
+    [TestCase(false, 0, GasCostOf.CreateState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_zero_balance_CREATE")]
+    [TestCase(false, 100, GasCostOf.CreateState + GasCostOf.NewAccountState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_balance_CREATE")]
+    [TestCase(true, 0, GasCostOf.CreateState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_zero_balance_CREATE2")]
+    [TestCase(true, 100, GasCostOf.CreateState + GasCostOf.NewAccountState, TestName = "Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_with_balance_CREATE2")]
+    public void Eip8037_same_tx_created_selfdestruct_to_new_beneficiary_keeps_created_account_state_gas(
         bool create2,
         int createdBalance,
         long expectedStateGas)
@@ -908,16 +915,16 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
 
         TestAllTracerWithOutput tracer = Execute(Activation, 1_000_000, factoryCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
 
-        long expectedStateGas = GasCostOf.CreateState + GasCostOf.CodeDepositState;
+        long expectedStateGas = 2 * GasCostOf.CreateState + GasCostOf.CodeDepositState;
 
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
         Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(expectedStateGas));
         Assert.That(TestState.GetBalance(beneficiary), Is.EqualTo((UInt256)100));
     }
 
-    [TestCase(false, TestName = "Eip8037_same_tx_selfdestruct_must_refund_created_storage_state_gas_CREATE")]
-    [TestCase(true, TestName = "Eip8037_same_tx_selfdestruct_must_refund_created_storage_state_gas_CREATE2")]
-    public void Eip8037_same_tx_selfdestruct_must_refund_created_storage_state_gas(bool create2)
+    [TestCase(false, TestName = "Eip8037_same_tx_selfdestruct_must_not_refund_created_storage_state_gas_CREATE")]
+    [TestCase(true, TestName = "Eip8037_same_tx_selfdestruct_must_not_refund_created_storage_state_gas_CREATE2")]
+    public void Eip8037_same_tx_selfdestruct_must_not_refund_created_storage_state_gas(bool create2)
     {
         byte[] childInitCode = Prepare.EvmCode
             .SSTORE(0, new byte[] { 1 })
@@ -933,13 +940,13 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         TestAllTracerWithOutput tracer = Execute(Activation, 600_000, factoryCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
 
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
-        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
-            "CREATE account state and created-slot state gas should both be refunded by same-tx SELFDESTRUCT.");
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.CreateState + GasCostOf.SSetState),
+            "CREATE account state and created-slot state gas should not be refunded by same-tx SELFDESTRUCT.");
     }
 
-    [TestCase(false, TestName = "Eip8037_same_tx_selfdestruct_must_refund_code_deposit_state_gas_CREATE")]
-    [TestCase(true, TestName = "Eip8037_same_tx_selfdestruct_must_refund_code_deposit_state_gas_CREATE2")]
-    public void Eip8037_same_tx_selfdestruct_must_refund_code_deposit_state_gas(bool create2)
+    [TestCase(false, TestName = "Eip8037_same_tx_selfdestruct_must_not_refund_code_deposit_state_gas_CREATE")]
+    [TestCase(true, TestName = "Eip8037_same_tx_selfdestruct_must_not_refund_code_deposit_state_gas_CREATE2")]
+    public void Eip8037_same_tx_selfdestruct_must_not_refund_code_deposit_state_gas(bool create2)
     {
         byte[] selfDestructRuntime = Prepare.EvmCode
             .Op(Instruction.ADDRESS)
@@ -962,13 +969,13 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         TestAllTracerWithOutput tracer = Execute(Activation, 600_000, factoryCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
 
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
-        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
-            "CREATE account state and code-deposit state gas should both be refunded after same-tx SELFDESTRUCT.");
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.CreateState + selfDestructRuntime.Length * GasCostOf.CodeDepositState),
+            "CREATE account state and code-deposit state gas should not be refunded after same-tx SELFDESTRUCT.");
         Assert.That(TestState.AccountExists(createdAddress), Is.False);
     }
 
     [Test]
-    public void Eip8037_same_tx_selfdestruct_must_refund_multiple_created_accounts()
+    public void Eip8037_same_tx_selfdestruct_must_not_refund_multiple_created_accounts()
     {
         byte[] childInitCode = Prepare.EvmCode
             .Op(Instruction.ADDRESS)
@@ -986,12 +993,12 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         TestAllTracerWithOutput tracer = Execute(Activation, 800_000, factoryCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
 
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
-        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
-            "Each created-and-destroyed account should have its CREATE account state gas refunded.");
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(2 * GasCostOf.CreateState),
+            "Created-and-destroyed accounts should keep their CREATE account state gas in block-state accounting.");
     }
 
     [Test]
-    public void Eip8037_top_level_create_selfdestruct_must_exclude_intrinsic_create_state_gas_from_block_state_gas()
+    public void Eip8037_top_level_create_selfdestruct_must_keep_intrinsic_create_state_gas_in_block_state_gas()
     {
         byte[] initCode = Prepare.EvmCode
             .Op(Instruction.ADDRESS)
@@ -1005,9 +1012,60 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
 
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
-        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
-            "The destroyed top-level created account does not persist, so its intrinsic CREATE state gas is excluded from block-state accounting.");
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.CreateState),
+            "The destroyed top-level created account should keep its intrinsic CREATE state gas in block-state accounting.");
         Assert.That(tracer.GasConsumedResult.SpentGas - tracer.GasConsumedResult.EffectiveBlockGas, Is.EqualTo(GasCostOf.CreateState));
+    }
+
+    [TestCase(0UL, SelfDestructBeneficiaryKind.Self, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_self_keeps_create_state_gas")]
+    [TestCase(100UL, SelfDestructBeneficiaryKind.Self, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_self_with_value_keeps_create_state_gas")]
+    [TestCase(100UL, SelfDestructBeneficiaryKind.Existing, GasCostOf.CreateState, TestName = "Eip8037_create_tx_selfdestruct_to_existing_with_value_keeps_create_state_gas")]
+    [TestCase(100UL, SelfDestructBeneficiaryKind.Empty, GasCostOf.CreateState + GasCostOf.NewAccountState, TestName = "Eip8037_create_tx_selfdestruct_to_empty_with_value_keeps_create_and_beneficiary_state_gas")]
+    public void Eip8037_create_tx_selfdestruct_initcode_keeps_create_state_gas(
+        ulong txValue,
+        SelfDestructBeneficiaryKind beneficiaryKind,
+        long expectedStateGas)
+    {
+        Address contractAddress = ContractAddress.From(Sender, 0);
+        Address beneficiary = beneficiaryKind switch
+        {
+            SelfDestructBeneficiaryKind.Self => contractAddress,
+            SelfDestructBeneficiaryKind.Existing => TestItem.AddressC,
+            SelfDestructBeneficiaryKind.Empty => TestItem.AddressC,
+            _ => throw new ArgumentOutOfRangeException(nameof(beneficiaryKind))
+        };
+
+        if (beneficiaryKind is SelfDestructBeneficiaryKind.Existing)
+        {
+            byte[] code = Prepare.EvmCode
+                .Op(Instruction.STOP)
+                .Done;
+            TestState.CreateAccount(beneficiary, UInt256.Zero);
+            TestState.InsertCode(beneficiary, code, SpecProvider.GenesisSpec);
+        }
+
+        TestState.CreateAccount(Sender, 100.Ether);
+        TestState.Commit(SpecProvider.GenesisSpec);
+
+        byte[] initCode = Prepare.EvmCode
+            .SELFDESTRUCT(beneficiary)
+            .Done;
+        Transaction transaction = Build.A.Transaction
+            .WithTo(null)
+            .WithGasLimit(1_000_000)
+            .WithGasPrice(1)
+            .WithCode(initCode)
+            .WithValue((UInt256)txValue)
+            .SignedAndResolved(new EthereumEcdsa(SpecProvider.ChainId), SenderKey)
+            .TestObject;
+        Block block = BuildBlock(Activation, SenderRecipientAndMiner.Default, transaction, DynamicStatePricingBlockGasLimit);
+        TestAllTracerWithOutput tracer = CreateTracer();
+
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(expectedStateGas));
+        Assert.That(block.Header.GasUsed, Is.EqualTo(Math.Max(tracer.GasConsumedResult.EffectiveBlockGas, expectedStateGas)));
     }
 
     [TestCase(16_777_216L, TestName = "Eip8037_subcall_set_clear_revert_pays_no_state_gas_spill")]

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -120,6 +120,14 @@ public class CodeInfoRepository : ICodeInfoRepository
         return worldState.InsertCode(authority, codeHash, authorizedBuffer, spec);
     }
 
-    public bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress) =>
-        ICodeInfoRepository.TryGetDelegatedAddress(InternalGetCodeInfo(address, spec).CodeSpan, out delegatedAddress);
+    public bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress)
+    {
+        if (!_worldState.HasCode(address))
+        {
+            delegatedAddress = null;
+            return false;
+        }
+
+        return ICodeInfoRepository.TryGetDelegatedAddress(InternalGetCodeInfo(address, spec).CodeSpan, out delegatedAddress);
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
@@ -844,7 +843,6 @@ namespace Nethermind.Evm.TransactionProcessing
             substate = default;
             gasConsumed = tx.GasLimit;
             byte statusCode = StatusCode.Failure;
-            long selfDestructStateRefund = 0;
 
             // EIP-7702 + EIP-8037: capture the tx-start state reservoir after authorization refunds.
             // The halt path needs this to correctly initialize the reservoir in ResetForHalt.
@@ -919,8 +917,6 @@ namespace Nethermind.Evm.TransactionProcessing
                         }
                     }
 
-                    selfDestructStateRefund = CalculateSelfDestructStateRefund(spec, in substate, in accessedItems, in gasAvailable);
-
                     // EIP-8037: defer destroy list processing to after PayFees so that
                     // burn logs include the priority fee in the balance.
                     bool deferFinalization = spec.IsEip7708Enabled && spec.IsEip8037Enabled;
@@ -955,7 +951,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
-            gasConsumed = Refund(tx, header, spec, opts, in substate, gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, delegationRefunds, selfDestructStateRefund, gas.FloorGas, gas.Standard, postIntrinsicStateReservoir);
+            gasConsumed = Refund(tx, header, spec, opts, in substate, gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, delegationRefunds, gas.FloorGas, gas.Standard, postIntrinsicStateReservoir);
             goto Complete;
         FailContractCreate:
             if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");
@@ -1191,67 +1187,6 @@ namespace Nethermind.Evm.TransactionProcessing
             }
         }
 
-        private long CalculateSelfDestructStateRefund(
-            IReleaseSpec spec,
-            in TransactionSubstate substate,
-            in StackAccessTracker accessedItems,
-            in TGasPolicy gasAfterExecution)
-        {
-            if (!spec.IsEip8037Enabled || substate.ShouldRevert || substate.IsError)
-                return 0;
-
-            BlockAccessList? generatedBlockAccessList = WorldState is IBlockAccessListSource blockAccessListSource
-                ? blockAccessListSource.GeneratedBlockAccessList
-                : null;
-
-            long selfDestructStateRefund = 0;
-            foreach (Address toBeDestroyed in substate.DestroyList)
-            {
-                if (!accessedItems.CreateList.Contains(toBeDestroyed))
-                    continue;
-
-                selfDestructStateRefund = checked(selfDestructStateRefund + TGasPolicy.GetNewAccountStateCost(in gasAfterExecution));
-                selfDestructStateRefund = checked(selfDestructStateRefund + TGasPolicy.GetCodeDepositStateCost(in gasAfterExecution, WorldState.GetCode(toBeDestroyed)?.Length ?? 0));
-                selfDestructStateRefund = checked(selfDestructStateRefund + GetCreatedStorageStateRefund(in gasAfterExecution, generatedBlockAccessList, in accessedItems, toBeDestroyed));
-            }
-
-            return selfDestructStateRefund;
-        }
-
-        private long GetCreatedStorageStateRefund(
-            in TGasPolicy gasAfterExecution,
-            BlockAccessList? generatedBlockAccessList,
-            in StackAccessTracker accessedItems,
-            Address address)
-        {
-            int createdSlots = 0;
-            if (generatedBlockAccessList?.GetAccountChanges(address) is { } accountChanges)
-            {
-                foreach (SlotChanges slotChanges in accountChanges.StorageChanges)
-                {
-                    if (slotChanges.Changes.Count > 0 && slotChanges.Changes.Values[^1].Value != default)
-                    {
-                        createdSlots++;
-                    }
-                }
-            }
-            else
-            {
-                // Non-BAL callers only expose the flat access tracker, so this fallback scans
-                // all touched storage cells. Keep the BAL source path preferred for block
-                // execution; optimize this if selfdestruct refunds become hot outside BAL.
-                foreach (StorageCell storageCell in accessedItems.AccessedStorageCells)
-                {
-                    if (storageCell.Address == address && !WorldState.Get(in storageCell).IsZero())
-                    {
-                        createdSlots++;
-                    }
-                }
-            }
-
-            return checked((long)createdSlots * TGasPolicy.GetStorageSetStateCost(in gasAfterExecution));
-        }
-
         protected bool PrepareDeployment(Address contractAddress)
         {
             if (!WorldState.IsNonZeroAccount(contractAddress, out _))
@@ -1268,7 +1203,7 @@ namespace Nethermind.Evm.TransactionProcessing
         }
 
         protected virtual GasConsumed Refund(Transaction tx, BlockHeader header, IReleaseSpec spec, ExecutionOptions opts,
-            in TransactionSubstate substate, in TGasPolicy unspentGas, in UInt256 gasPrice, int codeInsertRefunds, long selfDestructStateRefund, in TGasPolicy floorGas, in TGasPolicy intrinsicGasStandard, long postIntrinsicStateReservoir)
+            in TransactionSubstate substate, in TGasPolicy unspentGas, in UInt256 gasPrice, int codeInsertRefunds, in TGasPolicy floorGas, in TGasPolicy intrinsicGasStandard, long postIntrinsicStateReservoir)
         {
             TGasPolicy gasAfterExecution = unspentGas;
             long stateGasFloor = TGasPolicy.GetStateReservoir(in intrinsicGasStandard);
@@ -1280,22 +1215,6 @@ namespace Nethermind.Evm.TransactionProcessing
                     stateGasFloor -= refundedTopLevelCreateStateGas;
                     TGasPolicy.RefundStateGas(ref gasAfterExecution, refundedTopLevelCreateStateGas, stateGasFloor, trackSpillRefund: false);
                 }
-            }
-
-            long topLevelCreateStateRefund = selfDestructStateRefund > 0
-                ? Math.Min(
-                    selfDestructStateRefund,
-                    CalculateTopLevelCreateSelfDestructStateRefund(tx, in substate, in gasAfterExecution))
-                : 0;
-            long stateGasRefundToReservoir = selfDestructStateRefund - topLevelCreateStateRefund;
-            if (stateGasRefundToReservoir > 0)
-            {
-                TGasPolicy.RefundStateGas(ref gasAfterExecution, stateGasRefundToReservoir, stateGasFloor);
-            }
-
-            if (topLevelCreateStateRefund > 0)
-            {
-                TGasPolicy.DiscardStateGas(ref gasAfterExecution, topLevelCreateStateRefund, Math.Max(0, stateGasFloor - topLevelCreateStateRefund));
             }
 
             long codeInsertRegularRefund = TGasPolicy.ApplyCodeInsertRefunds(ref gasAfterExecution, codeInsertRefunds, spec, stateGasFloor);
@@ -1319,23 +1238,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 PayRefund(tx, (ulong)(tx.GasLimit - spentGasAfterFloor) * gasPrice, spec);
 
             return new GasConsumed(spentGasAfterFloor, operationGas, blockGas, blockStateGas, Math.Max(spentGas, floorGasLong));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static long CalculateTopLevelCreateSelfDestructStateRefund(
-            Transaction tx,
-            in TransactionSubstate substate,
-            in TGasPolicy gasAfterExecution)
-        {
-            if (!tx.IsContractCreation || tx.SenderAddress is null)
-            {
-                return 0;
-            }
-
-            Address contractAddress = Nethermind.Evm.ContractAddress.From(tx.SenderAddress, tx.Nonce);
-            return substate.DestroyList.Contains(contractAddress)
-                ? TGasPolicy.GetCreateStateCost(in gasAfterExecution)
-                : 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -222,13 +222,16 @@ namespace Nethermind.Evm.TransactionProcessing
 
             int delegationRefunds = 0;
             int delegationAuthBaseRefunds = 0;
+            if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
+
+            if (!(result = Validate8037DelegationRefundBounds(tx, spec, in gasAvailable))) return result;
+
             if (spec.IsEip7702Enabled && tx.HasAuthorizationList)
             {
                 delegationRefunds = ProcessDelegations(tx, spec, accessTracker, out delegationAuthBaseRefunds);
             }
 
-            if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
-            Apply8037DelegationRefunds(spec, in intrinsicGas, ref gasAvailable, ref delegationRefunds, ref delegationAuthBaseRefunds);
+            if (!(result = Apply8037DelegationRefunds(tx, spec, in intrinsicGas, ref gasAvailable, ref delegationRefunds, ref delegationAuthBaseRefunds))) return result;
 
             if (!(result = BuildExecutionEnvironment(tx, spec, _codeInfoRepository, accessTracker, out ExecutionEnvironment e))) return result;
             using ExecutionEnvironment env = e;
@@ -349,7 +352,8 @@ namespace Nethermind.Evm.TransactionProcessing
             return TransactionResult.Ok;
         }
 
-        private static void Apply8037DelegationRefunds(
+        private TransactionResult Apply8037DelegationRefunds(
+            Transaction tx,
             IReleaseSpec spec,
             in IntrinsicGas<TGasPolicy> intrinsicGas,
             ref TGasPolicy gasAvailable,
@@ -362,17 +366,83 @@ namespace Nethermind.Evm.TransactionProcessing
                 long stateGasFloor = TGasPolicy.GetStateReservoir(in intrinsicGasStandard);
                 long newAccountStateCost = TGasPolicy.GetNewAccountStateCost(in gasAvailable);
                 long perAuthBaseStateCost = TGasPolicy.GetPerAuthBaseStateCost(in gasAvailable);
-                long newAccountStateRefund = checked(newAccountStateCost * delegationRefunds);
-                long authBaseStateRefund = checked(perAuthBaseStateCost * delegationAuthBaseRefunds);
-                Debug.Assert(
-                    newAccountStateRefund <= long.MaxValue - authBaseStateRefund,
-                    "Authorization refunds are bounded by intrinsic gas validation.");
-                long stateGasRefund = checked(newAccountStateRefund + authBaseStateRefund);
+                bool refundWithinBounds = TryCalculate8037DelegationRefund(
+                    newAccountStateCost,
+                    perAuthBaseStateCost,
+                    delegationRefunds,
+                    delegationAuthBaseRefunds,
+                    out long stateGasRefund);
+                Debug.Assert(refundWithinBounds, "Authorization refunds are bounded before delegation processing.");
+                if (!refundWithinBounds)
+                {
+                    TraceLogInvalidTx(tx, "AUTHORIZATION_REFUND_OVERFLOW");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail("authorization refund gas overflow");
+                }
+
                 long refundFloor = Math.Max(0, stateGasFloor - stateGasRefund);
                 TGasPolicy.RefundStateGas(ref gasAvailable, stateGasRefund, refundFloor, trackSpillRefund: false);
                 delegationRefunds = 0;
                 delegationAuthBaseRefunds = 0;
             }
+
+            return TransactionResult.Ok;
+        }
+
+        private TransactionResult Validate8037DelegationRefundBounds(Transaction tx, IReleaseSpec spec, in TGasPolicy gasAvailable)
+        {
+            if (!spec.IsEip8037Enabled || !tx.HasAuthorizationList)
+            {
+                return TransactionResult.Ok;
+            }
+
+            long newAccountStateCost = TGasPolicy.GetNewAccountStateCost(in gasAvailable);
+            long perAuthBaseStateCost = TGasPolicy.GetPerAuthBaseStateCost(in gasAvailable);
+            int maxRefunds = tx.AuthorizationList.Length;
+            if (!TryCalculate8037DelegationRefund(
+                    newAccountStateCost,
+                    perAuthBaseStateCost,
+                    maxRefunds,
+                    maxRefunds,
+                    out _))
+            {
+                TraceLogInvalidTx(tx, "AUTHORIZATION_REFUND_OVERFLOW");
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail("authorization refund gas overflow");
+            }
+
+            return TransactionResult.Ok;
+        }
+
+        private static bool TryCalculate8037DelegationRefund(
+            long newAccountStateCost,
+            long perAuthBaseStateCost,
+            int delegationRefunds,
+            int delegationAuthBaseRefunds,
+            out long stateGasRefund)
+        {
+            stateGasRefund = 0;
+            if (newAccountStateCost < 0 ||
+                perAuthBaseStateCost < 0 ||
+                delegationRefunds < 0 ||
+                delegationAuthBaseRefunds < 0)
+            {
+                return false;
+            }
+
+            if ((delegationRefunds != 0 && newAccountStateCost > long.MaxValue / delegationRefunds) ||
+                (delegationAuthBaseRefunds != 0 && perAuthBaseStateCost > long.MaxValue / delegationAuthBaseRefunds))
+            {
+                return false;
+            }
+
+            long newAccountStateRefund = newAccountStateCost * delegationRefunds;
+            long authBaseStateRefund = perAuthBaseStateCost * delegationAuthBaseRefunds;
+            if (newAccountStateRefund > long.MaxValue - authBaseStateRefund)
+            {
+                return false;
+            }
+
+            stateGasRefund = newAccountStateRefund + authBaseStateRefund;
+            return true;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -361,9 +361,14 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 TGasPolicy intrinsicGasStandard = intrinsicGas.Standard;
                 long stateGasFloor = TGasPolicy.GetStateReservoir(in intrinsicGasStandard);
-                long stateGasRefund = checked(
-                    TGasPolicy.GetNewAccountStateCost(in gasAvailable) * delegationRefunds
-                    + TGasPolicy.GetPerAuthBaseStateCost(in gasAvailable) * delegationAuthBaseRefunds);
+                long newAccountStateCost = TGasPolicy.GetNewAccountStateCost(in gasAvailable);
+                long perAuthBaseStateCost = TGasPolicy.GetPerAuthBaseStateCost(in gasAvailable);
+                long newAccountStateRefund = checked(newAccountStateCost * delegationRefunds);
+                long authBaseStateRefund = checked(perAuthBaseStateCost * delegationAuthBaseRefunds);
+                Debug.Assert(
+                    newAccountStateRefund <= long.MaxValue - authBaseStateRefund,
+                    "Authorization refunds are bounded by intrinsic gas validation.");
+                long stateGasRefund = checked(newAccountStateRefund + authBaseStateRefund);
                 long refundFloor = Math.Max(0, stateGasFloor - stateGasRefund);
                 TGasPolicy.RefundStateGas(ref gasAvailable, stateGasRefund, refundFloor, trackSpillRefund: false);
                 delegationRefunds = 0;
@@ -390,7 +395,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 else
                 {
                     bool accountExists = WorldState.AccountExists(authority);
-                    bool hasDelegation = accountExists && WorldState.HasCode(authority) && _codeInfoRepository.TryGetDelegation(authority, spec, out _);
+                    bool hasDelegation = accountExists && _codeInfoRepository.TryGetDelegation(authority, spec, out _);
 
                     if (!accountExists)
                     {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -222,10 +222,15 @@ namespace Nethermind.Evm.TransactionProcessing
             // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method
             using StackAccessTracker accessTracker = new(tracer.IsTracingAccess);
 
-            int delegationRefunds = !spec.IsEip7702Enabled || !tx.HasAuthorizationList ? 0 : ProcessDelegations(tx, spec, accessTracker);
+            int delegationRefunds = 0;
+            int delegationAuthBaseRefunds = 0;
+            if (spec.IsEip7702Enabled && tx.HasAuthorizationList)
+            {
+                delegationRefunds = ProcessDelegations(tx, spec, accessTracker, out delegationAuthBaseRefunds);
+            }
 
             if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
-            Apply8037DelegationRefunds(spec, in intrinsicGas, ref gasAvailable, ref delegationRefunds);
+            Apply8037DelegationRefunds(spec, in intrinsicGas, ref gasAvailable, ref delegationRefunds, ref delegationAuthBaseRefunds);
 
             if (!(result = BuildExecutionEnvironment(tx, spec, _codeInfoRepository, accessTracker, out ExecutionEnvironment e))) return result;
             using ExecutionEnvironment env = e;
@@ -346,23 +351,34 @@ namespace Nethermind.Evm.TransactionProcessing
             return TransactionResult.Ok;
         }
 
-        private static void Apply8037DelegationRefunds(IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, ref TGasPolicy gasAvailable, ref int delegationRefunds)
+        private static void Apply8037DelegationRefunds(
+            IReleaseSpec spec,
+            in IntrinsicGas<TGasPolicy> intrinsicGas,
+            ref TGasPolicy gasAvailable,
+            ref int delegationRefunds,
+            ref int delegationAuthBaseRefunds)
         {
-            if (spec.IsEip8037Enabled && delegationRefunds > 0)
+            if (spec.IsEip8037Enabled && (delegationRefunds > 0 || delegationAuthBaseRefunds > 0))
             {
                 TGasPolicy intrinsicGasStandard = intrinsicGas.Standard;
                 long stateGasFloor = TGasPolicy.GetStateReservoir(in intrinsicGasStandard);
-                TGasPolicy.ApplyCodeInsertRefunds(ref gasAvailable, delegationRefunds, spec, stateGasFloor);
+                long stateGasRefund = checked(
+                    TGasPolicy.GetNewAccountStateCost(in gasAvailable) * delegationRefunds
+                    + TGasPolicy.GetPerAuthBaseStateCost(in gasAvailable) * delegationAuthBaseRefunds);
+                long refundFloor = Math.Max(0, stateGasFloor - stateGasRefund);
+                TGasPolicy.RefundStateGas(ref gasAvailable, stateGasRefund, refundFloor, trackSpillRefund: false);
                 delegationRefunds = 0;
+                delegationAuthBaseRefunds = 0;
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private int ProcessDelegations(Transaction tx, IReleaseSpec spec, in StackAccessTracker accessTracker)
+        private int ProcessDelegations(Transaction tx, IReleaseSpec spec, in StackAccessTracker accessTracker, out int authBaseRefunds)
         {
             Debug.Assert(spec.IsEip7702Enabled && tx.HasAuthorizationList);
 
             int refunds = 0;
+            authBaseRefunds = 0;
             foreach (AuthorizationTuple authTuple in tx.AuthorizationList)
             {
                 Address authority = (authTuple.Authority ??= Ecdsa.RecoverAddress(authTuple))!;
@@ -374,7 +390,10 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
                 else
                 {
-                    if (!WorldState.AccountExists(authority))
+                    bool accountExists = WorldState.AccountExists(authority);
+                    bool hasDelegation = accountExists && WorldState.HasCode(authority) && _codeInfoRepository.TryGetDelegation(authority, spec, out _);
+
+                    if (!accountExists)
                     {
                         WorldState.CreateAccount(authority, 0, 1);
                     }
@@ -382,6 +401,11 @@ namespace Nethermind.Evm.TransactionProcessing
                     {
                         refunds++;
                         WorldState.IncrementNonce(authority);
+                    }
+
+                    if (hasDelegation)
+                    {
+                        authBaseRefunds++;
                     }
 
                     _codeInfoRepository.SetDelegation(authTuple.CodeAddress, authority, spec);

--- a/src/Nethermind/Nethermind.Optimism/OptimismTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismTransactionProcessor.cs
@@ -173,7 +173,7 @@ public class OptimismTransactionProcessor(
     }
 
     protected override GasConsumed Refund(Transaction tx, BlockHeader header, IReleaseSpec spec, ExecutionOptions opts,
-        in TransactionSubstate substate, in EthereumGasPolicy unspentGas, in UInt256 gasPrice, int codeInsertRefunds, long selfDestructStateRefund, in EthereumGasPolicy floorGas, in EthereumGasPolicy intrinsicGasStandard, long postIntrinsicStateReservoir)
+        in TransactionSubstate substate, in EthereumGasPolicy unspentGas, in UInt256 gasPrice, int codeInsertRefunds, in EthereumGasPolicy floorGas, in EthereumGasPolicy intrinsicGasStandard, long postIntrinsicStateReservoir)
     {
         // if deposit: skip refunds, skip tipping coinbase
         // Regolith changes this behaviour to report the actual gasUsed instead of always reporting all gas used.
@@ -185,6 +185,6 @@ public class OptimismTransactionProcessor(
             return gas;
         }
 
-        return base.Refund(tx, header, spec, opts, substate, unspentGas, gasPrice, codeInsertRefunds, selfDestructStateRefund, floorGas, intrinsicGasStandard, postIntrinsicStateReservoir);
+        return base.Refund(tx, header, spec, opts, substate, unspentGas, gasPrice, codeInsertRefunds, floorGas, intrinsicGasStandard, postIntrinsicStateReservoir);
     }
 }


### PR DESCRIPTION
## Changes

- Align EIP-8037 authorization refunds with the BAL devnet v7.1.0 execution-specs behavior: existing authority leaves refund the new-account state component, and existing delegation overwrites/clears also refund the auth-base state component.
- Remove EIP-8037 `SELFDESTRUCT` state-gas refunds so created-and-destroyed accounts, storage, and code-deposit state gas remain in block-state accounting.
- Fix the EIP-7702 auth refund refill case for a non-empty code hash delegation pointer.
- Update the pyspec fixture archive to `ethereum/execution-specs` `tests-bal@v7.1.0` (`fixtures_bal.tar.gz`), matching the BAL devnet 7.1.0 test release.
- Add focused regression coverage for the new execution-specs cases and expanded BAL coverage.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Other: EIP-8037 spec/test alignment

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `dotnet build D:\GitHub\nethermind\src\Nethermind\Nethermind.Blockchain.Test\Nethermind.Blockchain.Test.csproj -c release`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.Blockchain.Test\release\Nethermind.Blockchain.Test.exe --filter "FullyQualifiedName~Execute_Eip8037AuthRefunds_UpdateReceiptAndBlockGas" --minimum-expected-tests 1`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.Blockchain.Test\release\Nethermind.Blockchain.Test.exe --filter "FullyQualifiedName~TransactionProcessorEip7702Tests" --minimum-expected-tests 1`
- `dotnet build D:\GitHub\nethermind\src\Nethermind\Nethermind.Evm.Test\Nethermind.Evm.Test.csproj -c release`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.Evm.Test\release\Nethermind.Evm.Test.exe --filter "FullyQualifiedName~Eip8037RegressionTests" --minimum-expected-tests 1`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.Evm.Test\release\Nethermind.Evm.Test.exe --filter "FullyQualifiedName~Eip8037Tests" --minimum-expected-tests 1`
- `dotnet build D:\GitHub\nethermind\src\Nethermind\Ethereum.Blockchain.Pyspec.Test\Ethereum.Blockchain.Pyspec.Test.csproj -c release`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Ethereum.Blockchain.Pyspec.Test\release\Ethereum.Blockchain.Pyspec.Test.exe --filter "FullyQualifiedName~AmsterdamTransactionTests" --no-progress --output Normal --timeout 10m` (55/55 passed; downloaded `tests-bal@v7.1.0`)
- `git diff --check`

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Follows up BAL devnet 7 with the `tests-bal@v7.1.0` fixture release from `ethereum/execution-specs`.