### PR TITLE
fix(trace): evaluate TraceStore filter fallback eagerly

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
@@ -110,6 +110,17 @@ public class TraceStoreRpcModuleTests
             .Should().BeEquivalentTo(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.DbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace)));
     }
 
+    [Test]
+    public void trace_filter_parallel_scan_returns_from_inner_module_when_any_block_trace_is_missing()
+    {
+        TestContext test = new(parallelization: 2);
+
+        test.Module.trace_filter(new TraceFilterForRpc { FromBlock = new BlockParameter(1), ToBlock = BlockParameter.Latest })
+            .Should().BeEquivalentTo(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.NonDbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace)));
+
+        test.InnerModule.Received().trace_filter(Arg.Any<TraceFilterForRpc>());
+    }
+
     private class TestContext
     {
         public ParityLikeTxTrace DbTrace { get; }
@@ -121,14 +132,14 @@ public class TraceStoreRpcModuleTests
         public IReceiptFinder ReceiptFinder { get; }
         public TraceStoreRpcModule Module { get; }
 
-        public TestContext()
+        public TestContext(int parallelization = 0)
         {
             InnerModule = Substitute.For<ITraceRpcModule>();
             Store = new MemDb();
             BlockFinder = Build.A.BlockTree().OfChainLength(3).TestObject;
             ReceiptFinder = Substitute.For<IReceiptFinder>();
             ParityLikeTraceSerializer serializer = new(LimboLogs.Instance);
-            Module = new TraceStoreRpcModule(InnerModule, Store, BlockFinder, ReceiptFinder, serializer, LimboLogs.Instance);
+            Module = new TraceStoreRpcModule(InnerModule, Store, BlockFinder, ReceiptFinder, serializer, LimboLogs.Instance, parallelization);
             Hash256 dbTransaction = Build.A.Transaction.TestObject.Hash!;
             Hash256 dbBlock = BlockFinder.Head!.Hash!;
             DbTrace = new() { BlockHash = dbBlock, TransactionHash = dbTransaction };

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
@@ -110,10 +110,11 @@ public class TraceStoreRpcModuleTests
             .Should().BeEquivalentTo(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.DbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace)));
     }
 
-    [Test]
-    public void trace_filter_parallel_scan_returns_from_inner_module_when_any_block_trace_is_missing()
+    [TestCase(1)]
+    [TestCase(2)]
+    public void trace_filter_returns_from_inner_module_when_any_block_trace_is_missing(int parallelization)
     {
-        TestContext test = new(parallelization: 2);
+        TestContext test = new(parallelization: parallelization);
 
         test.Module.trace_filter(new TraceFilterForRpc { FromBlock = new BlockParameter(1), ToBlock = BlockParameter.Latest })
             .Should().BeEquivalentTo(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.NonDbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace)));

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
@@ -110,6 +110,7 @@ public class TraceStoreRpcModuleTests
             .Should().BeEquivalentTo(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.DbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace)));
     }
 
+    [TestCase(0)]
     [TestCase(1)]
     [TestCase(2)]
     public void trace_filter_returns_from_inner_module_when_any_block_trace_is_missing(int parallelization)

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
@@ -91,49 +91,45 @@ public class TraceStoreRpcModule(ITraceRpcModule traceModule,
             traceFilterForRpc.FromBlock ?? BlockParameter.Latest,
             traceFilterForRpc.ToBlock ?? BlockParameter.Latest);
 
-        IEnumerable<SearchResult<Block>> blocks = _parallelization switch
+        IEnumerable<(SearchResult<Block> BlockSearch, List<ParityLikeTxTrace>? Traces)> blockResults = _parallelization switch
         {
-            0 => blocksSearch.AsParallel().AsOrdered(),
-            1 => blocksSearch,
-            var n => blocksSearch.AsParallel().AsOrdered().WithDegreeOfParallelism(n)
+            0 => blocksSearch.AsParallel().AsOrdered().Select(GetBlockTraces),
+            1 => blocksSearch.Select(GetBlockTraces),
+            var n => blocksSearch.AsParallel().AsOrdered().WithDegreeOfParallelism(n).Select(GetBlockTraces)
         };
 
-        IEnumerable<(SearchResult<Block>? Error, bool MissingTraces, IEnumerable<ParityTxTraceFromStore> Traces)> blockResults = blocks
-            .Select(blockSearch =>
-            {
-                if (blockSearch.IsError)
-                {
-                    return (Error: (SearchResult<Block>?)blockSearch, MissingTraces: false, Traces: Enumerable.Empty<ParityTxTraceFromStore>());
-                }
-
-                Block block = blockSearch.Object!;
-                if (TryGetBlockTraces(block.Header, out List<ParityLikeTxTrace>? traces) && traces is not null)
-                {
-                    return (Error: (SearchResult<Block>?)null, MissingTraces: false, Traces: traces.SelectMany(ParityTxTraceFromStore.FromTxTrace));
-                }
-
-                return (Error: (SearchResult<Block>?)null, MissingTraces: true, Traces: Enumerable.Empty<ParityTxTraceFromStore>());
-            });
-
-        List<ParityTxTraceFromStore> txTraces = [];
-        foreach ((SearchResult<Block>? error, bool missingTraces, IEnumerable<ParityTxTraceFromStore> blockTraces) in blockResults)
+        List<List<ParityLikeTxTrace>> blockTraces = [];
+        foreach ((SearchResult<Block> blockSearch, List<ParityLikeTxTrace>? traces) in blockResults)
         {
-            if (error is not null)
+            if (blockSearch.IsError)
             {
-                return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Fail(error.Value);
+                return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Fail(blockSearch);
             }
 
-            if (missingTraces)
+            if (traces is null)
             {
                 // fallback when we miss any traces in db
                 return _traceModule.trace_filter(traceFilterForRpc);
             }
 
-            txTraces.AddRange(blockTraces);
+            blockTraces.Add(traces);
         }
 
+        IEnumerable<ParityTxTraceFromStore> txTraces = blockTraces.SelectMany(static traces => traces.SelectMany(ParityTxTraceFromStore.FromTxTrace));
         TxTraceFilter txTracerFilter = new(traceFilterForRpc.FromAddress, traceFilterForRpc.ToAddress, traceFilterForRpc.After, traceFilterForRpc.Count);
         return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(txTracerFilter.FilterTxTraces(txTraces));
+
+        (SearchResult<Block> BlockSearch, List<ParityLikeTxTrace>? Traces) GetBlockTraces(SearchResult<Block> blockSearch)
+        {
+            if (blockSearch.IsError)
+            {
+                return (blockSearch, null);
+            }
+
+            Block block = blockSearch.Object!;
+            TryGetBlockTraces(block.Header, out List<ParityLikeTxTrace>? traces);
+            return (blockSearch, traces);
+        }
     }
 
     public ResultWrapper<IEnumerable<ParityTxTraceFromStore>> trace_block(BlockParameter blockParameter)

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
@@ -91,51 +91,49 @@ public class TraceStoreRpcModule(ITraceRpcModule traceModule,
             traceFilterForRpc.FromBlock ?? BlockParameter.Latest,
             traceFilterForRpc.ToBlock ?? BlockParameter.Latest);
 
-        SearchResult<Block>? error = null;
-        bool missingTraces = false;
-
         IEnumerable<SearchResult<Block>> blocks = _parallelization switch
         {
             0 => blocksSearch.AsParallel().AsOrdered(),
             1 => blocksSearch,
-            var n => blocksSearch.AsParallel().WithDegreeOfParallelism(n).AsOrdered()
+            var n => blocksSearch.AsParallel().AsOrdered().WithDegreeOfParallelism(n)
         };
 
-        IEnumerable<ParityTxTraceFromStore> txTraces = blocks
-            .SelectMany(blockSearch =>
+        IEnumerable<(SearchResult<Block>? Error, bool MissingTraces, IEnumerable<ParityTxTraceFromStore> Traces)> blockResults = blocks
+            .Select(blockSearch =>
             {
                 if (blockSearch.IsError)
                 {
-                    error = blockSearch;
-                    return [];
+                    return (Error: (SearchResult<Block>?)blockSearch, MissingTraces: false, Traces: Enumerable.Empty<ParityTxTraceFromStore>());
                 }
 
                 Block block = blockSearch.Object!;
                 if (TryGetBlockTraces(block.Header, out List<ParityLikeTxTrace>? traces) && traces is not null)
                 {
-                    return traces.SelectMany(ParityTxTraceFromStore.FromTxTrace);
+                    return (Error: (SearchResult<Block>?)null, MissingTraces: false, Traces: traces.SelectMany(ParityTxTraceFromStore.FromTxTrace));
                 }
-                else
-                {
-                    missingTraces = true;
-                    return [];
-                }
+
+                return (Error: (SearchResult<Block>?)null, MissingTraces: true, Traces: Enumerable.Empty<ParityTxTraceFromStore>());
             });
 
-        if (error is not null)
+        List<ParityTxTraceFromStore> txTraces = [];
+        foreach ((SearchResult<Block>? error, bool missingTraces, IEnumerable<ParityTxTraceFromStore> blockTraces) in blockResults)
         {
-            return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Fail(error.Value);
+            if (error is not null)
+            {
+                return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Fail(error.Value);
+            }
+
+            if (missingTraces)
+            {
+                // fallback when we miss any traces in db
+                return _traceModule.trace_filter(traceFilterForRpc);
+            }
+
+            txTraces.AddRange(blockTraces);
         }
-        else if (missingTraces)
-        {
-            // fallback when we miss any traces in db
-            return _traceModule.trace_filter(traceFilterForRpc);
-        }
-        else
-        {
-            TxTraceFilter txTracerFilter = new(traceFilterForRpc.FromAddress, traceFilterForRpc.ToAddress, traceFilterForRpc.After, traceFilterForRpc.Count);
-            return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(txTracerFilter.FilterTxTraces(txTraces));
-        }
+
+        TxTraceFilter txTracerFilter = new(traceFilterForRpc.FromAddress, traceFilterForRpc.ToAddress, traceFilterForRpc.After, traceFilterForRpc.Count);
+        return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(txTracerFilter.FilterTxTraces(txTraces));
     }
 
     public ResultWrapper<IEnumerable<ParityTxTraceFromStore>> trace_block(BlockParameter blockParameter)

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
@@ -98,7 +98,7 @@ public class TraceStoreRpcModule(ITraceRpcModule traceModule,
             var n => blocksSearch.AsParallel().AsOrdered().WithDegreeOfParallelism(n).Select(GetBlockTraces)
         };
 
-        List<List<ParityLikeTxTrace>> blockTraces = [];
+        List<List<ParityLikeTxTrace>>? blockTraces = null;
         foreach ((SearchResult<Block> blockSearch, List<ParityLikeTxTrace>? traces) in blockResults)
         {
             if (blockSearch.IsError)
@@ -112,10 +112,12 @@ public class TraceStoreRpcModule(ITraceRpcModule traceModule,
                 return _traceModule.trace_filter(traceFilterForRpc);
             }
 
-            blockTraces.Add(traces);
+            (blockTraces ??= []).Add(traces);
         }
 
-        IEnumerable<ParityTxTraceFromStore> txTraces = blockTraces.SelectMany(static traces => traces.SelectMany(ParityTxTraceFromStore.FromTxTrace));
+        IEnumerable<ParityTxTraceFromStore> txTraces = blockTraces is null
+            ? []
+            : blockTraces.SelectMany(static traces => traces.SelectMany(ParityTxTraceFromStore.FromTxTrace));
         TxTraceFilter txTracerFilter = new(traceFilterForRpc.FromAddress, traceFilterForRpc.ToAddress, traceFilterForRpc.After, traceFilterForRpc.Count);
         return ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(txTracerFilter.FilterTxTraces(txTraces));
 


### PR DESCRIPTION
## Changes

- Make `trace_filter` collect per-block TraceStore lookup results before returning a success response.
- Preserve ordered parallel scanning while avoiding shared mutable closure state inside PLINQ.
- Fall back to the inner trace module as soon as any requested block is missing stored traces.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added a parallel `trace_filter` regression test covering mixed stored and missing traces.
- `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes --include ...` passes for changed files.
- `dotnet test --project src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/Nethermind.JsonRpc.TraceStore.Test.csproj -c release --no-restore` passes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No