### PR TITLE
feat: intrinsic zk gas

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasBlockTracerTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasBlockTracerTests.cs
@@ -92,7 +92,8 @@ public class ZkGasBlockTracerTests
     {
         IBlockTracer inner = Substitute.For<IBlockTracer>();
         inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
-        ZkGasBlockTracer blockTracer = new(inner);
+        // txIntrinsicZkGas:0 isolates the reset-behavior assertion from the intrinsic charge.
+        ZkGasBlockTracer blockTracer = new(inner, txIntrinsicZkGas: 0);
 
         blockTracer.StartNewBlockTrace(MakeBlock());
 
@@ -136,7 +137,8 @@ public class ZkGasBlockTracerTests
     {
         IBlockTracer inner = Substitute.For<IBlockTracer>();
         inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
-        ZkGasBlockTracer blockTracer = new(inner);
+        // txIntrinsicZkGas:0 isolates the discard-behavior assertion from the intrinsic charge.
+        ZkGasBlockTracer blockTracer = new(inner, txIntrinsicZkGas: 0);
 
         blockTracer.StartNewBlockTrace(MakeBlock());
 
@@ -205,5 +207,64 @@ public class ZkGasBlockTracerTests
         blockTracer.ReportReward(TestItem.AddressA, "block", 1);
 
         inner.Received(1).ReportReward(TestItem.AddressA, "block", (UInt256)1);
+    }
+
+    // ── tx intrinsic ZK gas ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// StartNewTxTrace charges the flat per-transaction intrinsic ZK gas immediately
+    /// after resetting in-flight gas, before any opcode can run.
+    /// </summary>
+    [Test]
+    public void StartNewTxTrace_ChargesIntrinsicBeforeTracing()
+    {
+        IBlockTracer inner = Substitute.For<IBlockTracer>();
+        inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
+        // Explicitly set a known intrinsic to decouple from the schedule constant.
+        const ulong intrinsic = 243_000UL;
+        ZkGasBlockTracer blockTracer = new(inner, txIntrinsicZkGas: intrinsic);
+
+        blockTracer.StartNewBlockTrace(MakeBlock());
+        blockTracer.StartNewTxTrace(MakeTx());
+
+        Assert.That(blockTracer.Meter.TxZkGasUsed, Is.EqualTo(intrinsic),
+            "Intrinsic charge must appear in TxZkGasUsed immediately after StartNewTxTrace");
+    }
+
+    /// <summary>
+    /// When txIntrinsicZkGas is 0 (Masaya), StartNewTxTrace leaves TxZkGasUsed at zero.
+    /// </summary>
+    [Test]
+    public void StartNewTxTrace_IntrinsicIsZero_OnMasaya()
+    {
+        IBlockTracer inner = Substitute.For<IBlockTracer>();
+        inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
+        ZkGasBlockTracer blockTracer = new(inner, txIntrinsicZkGas: 0);
+
+        blockTracer.StartNewBlockTrace(MakeBlock());
+        blockTracer.StartNewTxTrace(MakeTx());
+
+        Assert.That(blockTracer.Meter.TxZkGasUsed, Is.EqualTo(0UL),
+            "Zero intrinsic (Masaya) must leave TxZkGasUsed at zero");
+    }
+
+    /// <summary>
+    /// When the intrinsic alone would push the projected block total past the limit,
+    /// IsLimitExceeded is set immediately by StartNewTxTrace.
+    /// </summary>
+    [Test]
+    public void StartNewTxTrace_IntrinsicAlone_SetsLimitExceeded_WhenBudgetTooSmall()
+    {
+        IBlockTracer inner = Substitute.For<IBlockTracer>();
+        inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
+        const ulong intrinsic = 243_000UL;
+        const ulong tinyLimit = intrinsic - 1; // one under the intrinsic cost
+        ZkGasBlockTracer blockTracer = new(inner, blockZkGasLimit: tinyLimit, txIntrinsicZkGas: intrinsic);
+
+        blockTracer.StartNewBlockTrace(MakeBlock());
+        blockTracer.StartNewTxTrace(MakeTx());
+
+        Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True,
+            "Intrinsic that exceeds the block budget must set IsLimitExceeded");
     }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
@@ -197,4 +197,54 @@ public class ZkGasMeterTests
         // Meter will flag IsLimitExceeded because halfMax >> BlockZkGasLimit
         Assert.That(meter.IsLimitExceeded, Is.True);
     }
+
+    // ── TX intrinsic ZK gas ───────────────────────────────────────────────────
+
+    [Test]
+    public void TxIntrinsicZkGas_Schedule_Constant_Is_243000() =>
+        Assert.That(ZkGasSchedule.TxIntrinsicZkGas, Is.EqualTo(243_000UL));
+
+    [Test]
+    public void MasayaTxIntrinsicZkGas_Schedule_Constant_Is_Zero() =>
+        Assert.That(ZkGasSchedule.MasayaTxIntrinsicZkGas, Is.EqualTo(0UL));
+
+    [Test]
+    public void ChargeTxIntrinsic_Adds_Intrinsic_To_InFlight_Tx()
+    {
+        ZkGasMeter meter = new(txIntrinsicZkGas: ZkGasSchedule.TxIntrinsicZkGas);
+
+        bool result = meter.ChargeTxIntrinsic();
+
+        Assert.That(result, Is.True);
+        Assert.That(meter.TxZkGasUsed, Is.EqualTo(ZkGasSchedule.TxIntrinsicZkGas));
+
+        // Confirm the charge is promoted to block total on commit.
+        meter.CommitTransaction();
+        Assert.That(meter.BlockZkGasUsed, Is.EqualTo(ZkGasSchedule.TxIntrinsicZkGas));
+    }
+
+    [Test]
+    public void ChargeTxIntrinsic_IsNoop_WhenIntrinsicIsZero()
+    {
+        ZkGasMeter meter = new(txIntrinsicZkGas: 0); // Masaya schedule
+
+        bool result = meter.ChargeTxIntrinsic();
+
+        Assert.That(result, Is.True);
+        Assert.That(meter.TxZkGasUsed, Is.EqualTo(0UL));
+        Assert.That(meter.IsLimitExceeded, Is.False);
+    }
+
+    [Test]
+    public void ChargeTxIntrinsic_SetsLimitExceeded_WhenRemainingBudgetTooSmall()
+    {
+        const ulong intrinsic = ZkGasSchedule.TxIntrinsicZkGas;
+        // Set block limit one unit below the intrinsic so the charge must fail.
+        ZkGasMeter meter = new(blockZkGasLimit: intrinsic - 1, txIntrinsicZkGas: intrinsic);
+
+        bool result = meter.ChargeTxIntrinsic();
+
+        Assert.That(result, Is.False);
+        Assert.That(meter.IsLimitExceeded, Is.True);
+    }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
@@ -200,6 +200,14 @@ public class ZkGasMeterTests
 
     // ── TX intrinsic ZK gas ───────────────────────────────────────────────────
 
+    [TestCase(ZkGasSchedule.TaikoMainnetChainId, ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoDevnetChainId,  ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoHoodiChainId,   ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoMasayaChainId,  ZkGasSchedule.MasayaTxIntrinsicZkGas)]
+    [TestCase(999_999UL /* unknown */,           ZkGasSchedule.TxIntrinsicZkGas)]
+    public void ResolveTxIntrinsicZkGas_ReturnsExpected_ForChainId(ulong chainId, ulong expected) =>
+        Assert.That(ZkGasSchedule.ResolveTxIntrinsicZkGas(chainId), Is.EqualTo(expected));
+
     [Test]
     public void TxIntrinsicZkGas_Schedule_Constant_Is_243000() =>
         Assert.That(ZkGasSchedule.TxIntrinsicZkGas, Is.EqualTo(243_000UL));

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
@@ -201,10 +201,10 @@ public class ZkGasMeterTests
     // ── TX intrinsic ZK gas ───────────────────────────────────────────────────
 
     [TestCase(ZkGasSchedule.TaikoMainnetChainId, ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoDevnetChainId,  ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoHoodiChainId,   ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoMasayaChainId,  ZkGasSchedule.MasayaTxIntrinsicZkGas)]
-    [TestCase(999_999UL /* unknown */,           ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoDevnetChainId, ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoHoodiChainId, ZkGasSchedule.TxIntrinsicZkGas)]
+    [TestCase(ZkGasSchedule.TaikoMasayaChainId, ZkGasSchedule.MasayaTxIntrinsicZkGas)]
+    [TestCase(999_999UL /* unknown */, ZkGasSchedule.TxIntrinsicZkGas)]
     public void ResolveTxIntrinsicZkGas_ReturnsExpected_ForChainId(ulong chainId, ulong expected) =>
         Assert.That(ZkGasSchedule.ResolveTxIntrinsicZkGas(chainId), Is.EqualTo(expected));
 

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
@@ -200,14 +200,6 @@ public class ZkGasMeterTests
 
     // ── TX intrinsic ZK gas ───────────────────────────────────────────────────
 
-    [TestCase(ZkGasSchedule.TaikoMainnetChainId, ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoDevnetChainId, ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoHoodiChainId, ZkGasSchedule.TxIntrinsicZkGas)]
-    [TestCase(ZkGasSchedule.TaikoMasayaChainId, ZkGasSchedule.MasayaTxIntrinsicZkGas)]
-    [TestCase(999_999UL /* unknown */, ZkGasSchedule.TxIntrinsicZkGas)]
-    public void ResolveTxIntrinsicZkGas_ReturnsExpected_ForChainId(ulong chainId, ulong expected) =>
-        Assert.That(ZkGasSchedule.ResolveTxIntrinsicZkGas(chainId), Is.EqualTo(expected));
-
     [Test]
     public void TxIntrinsicZkGas_Schedule_Constant_Is_243000() =>
         Assert.That(ZkGasSchedule.TxIntrinsicZkGas, Is.EqualTo(243_000UL));

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasScheduleTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasScheduleTests.cs
@@ -33,22 +33,6 @@ public class ZkGasScheduleTests
     }
 
     [Test]
-    public void Resolve_returns_masaya_limit_for_masaya_chain_id() =>
-        Assert.That(
-            ZkGasSchedule.ResolveBlockZkGasLimit(ZkGasSchedule.TaikoMasayaChainId),
-            Is.EqualTo(ZkGasSchedule.MasayaBlockZkGasLimit));
-
-    [TestCase(ZkGasSchedule.TaikoMainnetChainId)]
-    [TestCase(ZkGasSchedule.TaikoDevnetChainId)]
-    [TestCase(ZkGasSchedule.TaikoHoodiChainId)]
-    [TestCase(0UL)]
-    [TestCase(1UL)]
-    public void Resolve_returns_default_limit_for_other_chain_ids(ulong chainId) =>
-        Assert.That(
-            ZkGasSchedule.ResolveBlockZkGasLimit(chainId),
-            Is.EqualTo(ZkGasSchedule.BlockZkGasLimit));
-
-    [Test]
     public void Meter_default_ctor_uses_canonical_block_limit()
     {
         ZkGasMeter meter = new();

--- a/src/Nethermind/Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs
+++ b/src/Nethermind/Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs
@@ -78,9 +78,13 @@ public class BlockInvalidTxExecutor(ITransactionProcessorAdapter txProcessor, IW
             {
                 if (!txProcessor.Execute(tx, receiptsTracer))
                 {
-                    // if the transaction was invalid, we ignore it and continue
+                    // if the transaction was invalid, we ignore it and continue.
+                    // CancelTransaction clears any IsLimitExceeded set by the intrinsic
+                    // charge in StartNewTxTrace so it does not trip the pre-loop guard
+                    // on the next iteration and prematurely terminate block production.
                     worldState.Restore(snap);
                     receiptsTracer.Restore(receiptsSnap);
+                    if (enforceZkGas) zkGasMeterHolder!.Meter?.CancelTransaction();
                     continue;
                 }
             }
@@ -90,6 +94,7 @@ public class BlockInvalidTxExecutor(ITransactionProcessorAdapter txProcessor, IW
                 // they are detected later in the processing pipeline
                 worldState.Restore(snap);
                 receiptsTracer.Restore(receiptsSnap);
+                if (enforceZkGas) zkGasMeterHolder!.Meter?.CancelTransaction();
                 continue;
             }
 

--- a/src/Nethermind/Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs
+++ b/src/Nethermind/Nethermind.Taiko/BlockTransactionExecutors/BlockInvalidTxExecutor.cs
@@ -79,9 +79,7 @@ public class BlockInvalidTxExecutor(ITransactionProcessorAdapter txProcessor, IW
                 if (!txProcessor.Execute(tx, receiptsTracer))
                 {
                     // if the transaction was invalid, we ignore it and continue.
-                    // CancelTransaction clears any IsLimitExceeded set by the intrinsic
-                    // charge in StartNewTxTrace so it does not trip the pre-loop guard
-                    // on the next iteration and prematurely terminate block production.
+                    // CancelTransaction clears IsLimitExceeded set by the intrinsic charge.
                     worldState.Restore(snap);
                     receiptsTracer.Restore(receiptsSnap);
                     if (enforceZkGas) zkGasMeterHolder!.Meter?.CancelTransaction();

--- a/src/Nethermind/Nethermind.Taiko/TaikoBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoBlockProcessor.cs
@@ -60,6 +60,7 @@ public class TaikoBlockProcessor(
 {
     private readonly ZkGasMeterHolder? _zkGasMeterHolder = zkGasMeterHolder;
     private readonly ulong _blockZkGasLimit = ZkGasSchedule.ResolveBlockZkGasLimit(specProvider.ChainId);
+    private readonly ulong _txIntrinsicZkGas = ZkGasSchedule.ResolveTxIntrinsicZkGas(specProvider.ChainId);
 
     /// <summary>
     /// Wraps the incoming block tracer with ZK gas metering, delegates to
@@ -74,7 +75,7 @@ public class TaikoBlockProcessor(
         IReleaseSpec spec,
         CancellationToken token)
     {
-        ZkGasBlockTracer zkGasTracer = new(blockTracer, _zkGasMeterHolder, _blockZkGasLimit);
+        ZkGasBlockTracer zkGasTracer = new(blockTracer, _zkGasMeterHolder, _blockZkGasLimit, _txIntrinsicZkGas);
 
         TxReceipt[] receipts = base.ProcessBlock(block, zkGasTracer, options, spec, token);
 

--- a/src/Nethermind/Nethermind.Taiko/TaikoBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoBlockProcessor.cs
@@ -59,8 +59,6 @@ public class TaikoBlockProcessor(
         balManager)
 {
     private readonly ZkGasMeterHolder? _zkGasMeterHolder = zkGasMeterHolder;
-    private readonly ulong _blockZkGasLimit = ZkGasSchedule.ResolveBlockZkGasLimit(specProvider.ChainId);
-    private readonly ulong _txIntrinsicZkGas = ZkGasSchedule.ResolveTxIntrinsicZkGas(specProvider.ChainId);
 
     /// <summary>
     /// Wraps the incoming block tracer with ZK gas metering, delegates to
@@ -75,11 +73,16 @@ public class TaikoBlockProcessor(
         IReleaseSpec spec,
         CancellationToken token)
     {
-        ZkGasBlockTracer zkGasTracer = new(blockTracer, _zkGasMeterHolder, _blockZkGasLimit, _txIntrinsicZkGas);
+        ITaikoReleaseSpec? taikoSpec = spec as ITaikoReleaseSpec;
+        ZkGasBlockTracer zkGasTracer = new(
+            blockTracer,
+            _zkGasMeterHolder,
+            taikoSpec?.UnzenBlockZkGasLimit ?? ZkGasSchedule.BlockZkGasLimit,
+            taikoSpec?.UnzenTxIntrinsicZkGas ?? ZkGasSchedule.TxIntrinsicZkGas);
 
         TxReceipt[] receipts = base.ProcessBlock(block, zkGasTracer, options, spec, token);
 
-        if (spec is ITaikoReleaseSpec { IsUnzenEnabled: true })
+        if (taikoSpec is { IsUnzenEnabled: true })
         {
             // During validation (NewPayload), reject blocks that exceed the ZK gas limit.
             // During production (ProducingBlock), the executor already stopped adding

--- a/src/Nethermind/Nethermind.Taiko/TaikoSpec/ITaikoReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSpec/ITaikoReleaseSpec.cs
@@ -15,6 +15,8 @@ public interface ITaikoReleaseSpec : IReleaseSpec
     public bool IsPacayaEnabled { get; }
     public bool IsShastaEnabled { get; }
     public bool IsUnzenEnabled { get; }
+    public ulong UnzenBlockZkGasLimit { get; }
+    public ulong UnzenTxIntrinsicZkGas { get; }
     public bool UseSurgeGasPriceOracle { get; }
     public Address TaikoL2Address { get; }
     public bool IsRip7728Enabled { get; }

--- a/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoCancunReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoCancunReleaseSpec.cs
@@ -4,6 +4,7 @@
 using System.Collections.Frozen;
 using Nethermind.Core;
 using Nethermind.Specs.Forks;
+using Nethermind.Taiko.ZkGas;
 
 namespace Nethermind.Taiko.TaikoSpec;
 
@@ -21,6 +22,8 @@ public class TaikoOntakeReleaseSpec : Shanghai, ITaikoReleaseSpec
     public bool IsPacayaEnabled { get; set; }
     public bool IsShastaEnabled { get; set; }
     public bool IsUnzenEnabled { get; set; }
+    public ulong UnzenBlockZkGasLimit { get; set; } = ZkGasSchedule.BlockZkGasLimit;
+    public ulong UnzenTxIntrinsicZkGas { get; set; } = ZkGasSchedule.TxIntrinsicZkGas;
     public bool UseSurgeGasPriceOracle { get; set; }
     public Address TaikoL2Address { get; set; } = new("0x1670000000000000000000000000000000010001");
     public bool IsRip7728Enabled { get; set; }
@@ -61,6 +64,8 @@ public class TaikoUnzenReleaseSpec : Osaka, ITaikoReleaseSpec
     public bool IsPacayaEnabled { get; set; }
     public bool IsShastaEnabled { get; set; }
     public bool IsUnzenEnabled { get; set; }
+    public ulong UnzenBlockZkGasLimit { get; set; } = ZkGasSchedule.BlockZkGasLimit;
+    public ulong UnzenTxIntrinsicZkGas { get; set; } = ZkGasSchedule.TxIntrinsicZkGas;
     public bool UseSurgeGasPriceOracle { get; set; }
     public Address TaikoL2Address { get; set; } = new("0x1670000000000000000000000000000000010001");
     public bool IsRip7728Enabled { get; set; }

--- a/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoChainSpecBasedSpecProvider.cs
@@ -5,6 +5,7 @@ using Nethermind.Core;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.Taiko.ZkGas;
 
 namespace Nethermind.Taiko.TaikoSpec;
 
@@ -26,6 +27,8 @@ public class TaikoChainSpecBasedSpecProvider(ChainSpec chainSpec,
         releaseSpec.IsPacayaEnabled = (chainSpecEngineParameters.PacayaTransition ?? long.MaxValue) <= releaseStartBlock;
         releaseSpec.IsShastaEnabled = (chainSpecEngineParameters.ShastaTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
         releaseSpec.IsUnzenEnabled = (chainSpecEngineParameters.UnzenTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+        releaseSpec.UnzenBlockZkGasLimit = chainSpecEngineParameters.UnzenBlockZkGasLimit ?? ZkGasSchedule.BlockZkGasLimit;
+        releaseSpec.UnzenTxIntrinsicZkGas = chainSpecEngineParameters.UnzenTxIntrinsicZkGas ?? ZkGasSchedule.TxIntrinsicZkGas;
         releaseSpec.UseSurgeGasPriceOracle = chainSpecEngineParameters.UseSurgeGasPriceOracle ?? false;
         releaseSpec.TaikoL2Address = chainSpecEngineParameters.TaikoL2Address;
         releaseSpec.IsRip7728Enabled = (chainSpecEngineParameters.Rip7728TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoChainSpecEngineParameters.cs
@@ -15,6 +15,8 @@ public class TaikoChainSpecEngineParameters : IChainSpecEngineParameters
     public long? PacayaTransition { get; set; }
     public ulong? ShastaTimestamp { get; set; }
     public ulong? UnzenTimestamp { get; set; }
+    public ulong? UnzenBlockZkGasLimit { get; set; }
+    public ulong? UnzenTxIntrinsicZkGas { get; set; }
     public bool? UseSurgeGasPriceOracle { get; set; }
     public ulong? Rip7728TransitionTimestamp { get; set; }
     public ulong? L1StaticCallTransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSpec/TaikoReleaseSpec.cs
@@ -13,6 +13,8 @@ public class TaikoReleaseSpec : ReleaseSpec, ITaikoReleaseSpec
     public bool IsPacayaEnabled { get; set; }
     public bool IsShastaEnabled { get; set; }
     public bool IsUnzenEnabled { get; set; }
+    public ulong UnzenBlockZkGasLimit { get; set; }
+    public ulong UnzenTxIntrinsicZkGas { get; set; }
     public bool UseSurgeGasPriceOracle { get; set; }
     public required Address TaikoL2Address { get; set; }
     public bool IsRip7728Enabled { get; set; }

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
@@ -64,7 +64,9 @@ public sealed class ZkGasBlockTracer : IBlockTracer
         // Charge the flat per-transaction intrinsic ZK gas before any opcode runs.
         // Mirrors charge_tx_intrinsic_zk_gas in alethia-reth PR #180 (executor.rs).
         // A value of 0 (Masaya) makes this a no-op, preserving historical consensus.
-        _meter.ChargeTxIntrinsic();
+        // Return value is intentionally discarded: failure sets IsLimitExceeded, which
+        // BlockInvalidTxExecutor checks post-execution and responds to via CancelTransaction.
+        _ = _meter.ChargeTxIntrinsic();
         ITxTracer innerTxTracer = _inner.StartNewTxTrace(tx);
         ZkGasTxTracer zkTracer = new(_meter);
         return new CompositeTxTracer(innerTxTracer, zkTracer);

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
@@ -18,10 +18,12 @@ public sealed class ZkGasBlockTracer : IBlockTracer
     private readonly IBlockTracer _inner;
     private readonly ZkGasMeter _meter;
 
-    public ZkGasBlockTracer(IBlockTracer inner, ZkGasMeterHolder? holder = null, ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit)
+    public ZkGasBlockTracer(IBlockTracer inner, ZkGasMeterHolder? holder = null,
+        ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit,
+        ulong txIntrinsicZkGas = ZkGasSchedule.TxIntrinsicZkGas)
     {
         _inner = inner;
-        _meter = new ZkGasMeter(blockZkGasLimit);
+        _meter = new ZkGasMeter(blockZkGasLimit, txIntrinsicZkGas);
         // Publish once: the meter reference is stable across blocks (we Reset it in
         // StartNewBlockTrace rather than reallocating), so the holder never needs
         // re-pointing for the lifetime of this tracer.
@@ -49,12 +51,20 @@ public sealed class ZkGasBlockTracer : IBlockTracer
     }
 
     /// <summary>
-    /// Resets in-flight transaction gas, obtains the inner per-tx tracer,
-    /// creates a <see cref="ZkGasTxTracer"/>, and returns a composite of both.
+    /// Resets in-flight transaction gas, charges the flat per-transaction intrinsic ZK gas
+    /// (taiko-mono PR #21669), obtains the inner per-tx tracer, creates a
+    /// <see cref="ZkGasTxTracer"/>, and returns a composite of both.
+    /// If the intrinsic charge alone exceeds the block budget, <see cref="ZkGasMeter.IsLimitExceeded"/>
+    /// is set and <see cref="BlockTransactionExecutors.BlockInvalidTxExecutor"/> will roll back
+    /// the transaction after execution.
     /// </summary>
     public ITxTracer StartNewTxTrace(Transaction? tx)
     {
         _meter.ResetTransaction();
+        // Charge the flat per-transaction intrinsic ZK gas before any opcode runs.
+        // Mirrors charge_tx_intrinsic_zk_gas in alethia-reth PR #180 (executor.rs).
+        // A value of 0 (Masaya) makes this a no-op, preserving historical consensus.
+        _meter.ChargeTxIntrinsic();
         ITxTracer innerTxTracer = _inner.StartNewTxTrace(tx);
         ZkGasTxTracer zkTracer = new(_meter);
         return new CompositeTxTracer(innerTxTracer, zkTracer);

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasBlockTracer.cs
@@ -50,22 +50,9 @@ public sealed class ZkGasBlockTracer : IBlockTracer
         _inner.StartNewBlockTrace(block);
     }
 
-    /// <summary>
-    /// Resets in-flight transaction gas, charges the flat per-transaction intrinsic ZK gas
-    /// (taiko-mono PR #21669), obtains the inner per-tx tracer, creates a
-    /// <see cref="ZkGasTxTracer"/>, and returns a composite of both.
-    /// If the intrinsic charge alone exceeds the block budget, <see cref="ZkGasMeter.IsLimitExceeded"/>
-    /// is set and <see cref="BlockTransactionExecutors.BlockInvalidTxExecutor"/> will roll back
-    /// the transaction after execution.
-    /// </summary>
     public ITxTracer StartNewTxTrace(Transaction? tx)
     {
         _meter.ResetTransaction();
-        // Charge the flat per-transaction intrinsic ZK gas before any opcode runs.
-        // Mirrors charge_tx_intrinsic_zk_gas in alethia-reth PR #180 (executor.rs).
-        // A value of 0 (Masaya) makes this a no-op, preserving historical consensus.
-        // Return value is intentionally discarded: failure sets IsLimitExceeded, which
-        // BlockInvalidTxExecutor checks post-execution and responds to via CancelTransaction.
         _ = _meter.ChargeTxIntrinsic();
         ITxTracer innerTxTracer = _inner.StartNewTxTrace(tx);
         ZkGasTxTracer zkTracer = new(_meter);

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
@@ -8,18 +8,27 @@ namespace Nethermind.Taiko.ZkGas;
 /// Tracks per-transaction and per-block ZK gas usage, enforcing the block limit.
 /// </summary>
 /// <remarks>
-/// Production code should resolve the limit via
-/// <see cref="ZkGasSchedule.ResolveBlockZkGasLimit(ulong)"/> using the chain id from the
-/// active spec provider so Masaya gets its larger budget while every other network keeps
-/// the canonical 100M cap. The default <see cref="ZkGasSchedule.BlockZkGasLimit"/> is used
-/// when the meter is constructed without an explicit limit (tests and network-agnostic
-/// call sites).
+/// Production code should resolve both limits via
+/// <see cref="ZkGasSchedule.ResolveBlockZkGasLimit(ulong)"/> and
+/// <see cref="ZkGasSchedule.ResolveTxIntrinsicZkGas(ulong)"/> using the chain id from the
+/// active spec provider so Masaya gets its larger block budget and zero intrinsic while
+/// every other network gets the canonical 100M cap and 243 000 intrinsic. The defaults
+/// are used when the meter is constructed without explicit values (tests and
+/// network-agnostic call sites).
 /// </remarks>
 /// <param name="blockZkGasLimit">Maximum ZK gas permitted within a single block.</param>
-public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit)
+/// <param name="txIntrinsicZkGas">
+/// Flat ZK gas charged once per transaction before any opcode runs. Pass 0 for Masaya
+/// to preserve historical consensus; use <see cref="ZkGasSchedule.TxIntrinsicZkGas"/>
+/// (243 000) for all other networks.
+/// </param>
+public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, ulong txIntrinsicZkGas = ZkGasSchedule.TxIntrinsicZkGas)
 {
     /// <summary>Per-block ZK gas ceiling captured at construction time.</summary>
     private readonly ulong _blockZkGasLimit = blockZkGasLimit;
+
+    /// <summary>Flat ZK gas charged once per transaction before EVM execution begins.</summary>
+    private readonly ulong _txIntrinsicZkGas = txIntrinsicZkGas;
 
     /// <summary>Finalized ZK gas accumulated from fully committed transactions.</summary>
     private ulong _blockZkGasUsed;
@@ -93,6 +102,15 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit)
         _txZkGasUsed = 0;
         IsLimitExceeded = false;
     }
+
+    /// <summary>
+    /// Charges the flat per-transaction intrinsic ZK gas before EVM execution begins.
+    /// Mirrors <c>charge_tx_intrinsic</c> in alethia-reth PR #180 (<c>meter.rs</c>).
+    /// When <see cref="_txIntrinsicZkGas"/> is 0 (Masaya) the call is a true no-op and
+    /// returns <c>true</c>. Returns <c>false</c> and sets <see cref="IsLimitExceeded"/>
+    /// when the charge would push the projected block total past the limit.
+    /// </summary>
+    public bool ChargeTxIntrinsic() => ChargeAmount(_txIntrinsicZkGas, 1);
 
     /// <summary>
     /// Charges ZK gas for a single opcode execution.

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
@@ -7,27 +7,13 @@ namespace Nethermind.Taiko.ZkGas;
 /// Checked ZK gas accounting for a single block execution.
 /// Tracks per-transaction and per-block ZK gas usage, enforcing the block limit.
 /// </summary>
-/// <remarks>
-/// Production code should resolve both limits via
-/// <see cref="ZkGasSchedule.ResolveBlockZkGasLimit(ulong)"/> and
-/// <see cref="ZkGasSchedule.ResolveTxIntrinsicZkGas(ulong)"/> using the chain id from the
-/// active spec provider so Masaya gets its larger block budget and zero intrinsic while
-/// every other network gets the canonical 100M cap and 243 000 intrinsic. The defaults
-/// are used when the meter is constructed without explicit values (tests and
-/// network-agnostic call sites).
-/// </remarks>
 /// <param name="blockZkGasLimit">Maximum ZK gas permitted within a single block.</param>
-/// <param name="txIntrinsicZkGas">
-/// Flat ZK gas charged once per transaction before any opcode runs. Pass 0 for Masaya
-/// to preserve historical consensus; use <see cref="ZkGasSchedule.TxIntrinsicZkGas"/>
-/// (243 000) for all other networks.
-/// </param>
+/// <param name="txIntrinsicZkGas">Flat ZK gas charged once per transaction before any opcode runs.</param>
 public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, ulong txIntrinsicZkGas = ZkGasSchedule.TxIntrinsicZkGas)
 {
     /// <summary>Per-block ZK gas ceiling captured at construction time.</summary>
     private readonly ulong _blockZkGasLimit = blockZkGasLimit;
 
-    /// <summary>Flat ZK gas charged once per transaction before EVM execution begins.</summary>
     private readonly ulong _txIntrinsicZkGas = txIntrinsicZkGas;
 
     /// <summary>Finalized ZK gas accumulated from fully committed transactions.</summary>
@@ -103,13 +89,7 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
         IsLimitExceeded = false;
     }
 
-    /// <summary>
-    /// Charges the flat per-transaction intrinsic ZK gas before EVM execution begins.
-    /// Mirrors <c>charge_tx_intrinsic</c> in alethia-reth PR #180 (<c>meter.rs</c>).
-    /// When <see cref="_txIntrinsicZkGas"/> is 0 (Masaya) the call is a true no-op and
-    /// returns <c>true</c>. Returns <c>false</c> and sets <see cref="IsLimitExceeded"/>
-    /// when the charge would push the projected block total past the limit.
-    /// </summary>
+    /// <summary>Charges the flat per-transaction intrinsic ZK gas before EVM execution begins.</summary>
     public bool ChargeTxIntrinsic() => ChargeAmount(_txIntrinsicZkGas, 1);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
@@ -43,6 +43,34 @@ public static class ZkGasSchedule
     public const ulong MasayaBlockZkGasLimit = 1_000_000_000;
 
     /// <summary>
+    /// Fixed ZK gas charged once per transaction before any opcode or precompile runs,
+    /// applied on Devnet, Hoodi, and Mainnet (Unzen). Covers the proving cost of
+    /// per-transaction sender ecrecovery.
+    /// Sourced from taiko-mono PR #21669; mirrors <c>TX_INTRINSIC_ZK_GAS</c> in
+    /// alethia-reth PR #180 (<c>crates/evm/src/zk_gas/unzen.rs</c>).
+    /// </summary>
+    public const ulong TxIntrinsicZkGas = 243_000;
+
+    /// <summary>
+    /// Per-transaction intrinsic ZK gas for Taiko Masaya. Pinned at 0 because Masaya
+    /// activated Unzen before taiko-mono PR #21669 landed; charging the non-zero value
+    /// retroactively would break consensus on already-finalized blocks whose
+    /// <c>difficulty</c> header field encodes the finalized block ZK gas.
+    /// Mirrors <c>MASAYA_TX_INTRINSIC_ZK_GAS</c> in alethia-reth PR #180.
+    /// </summary>
+    public const ulong MasayaTxIntrinsicZkGas = 0;
+
+    /// <summary>
+    /// Returns the per-transaction intrinsic ZK gas for the given chain id.
+    /// <see cref="TaikoMasayaChainId"/> returns 0 to preserve historical block consensus;
+    /// all other networks return <see cref="TxIntrinsicZkGas"/> (243 000).
+    /// </summary>
+    /// <param name="chainId">Chain id from <see cref="Nethermind.Core.Specs.ISpecProvider.ChainId"/>.</param>
+    /// <returns>The flat intrinsic ZK gas charged once per transaction.</returns>
+    public static ulong ResolveTxIntrinsicZkGas(ulong chainId) =>
+        chainId == TaikoMasayaChainId ? MasayaTxIntrinsicZkGas : TxIntrinsicZkGas;
+
+    /// <summary>
     /// Returns the Unzen block ZK gas limit for the given chain id. Masaya
     /// (<see cref="TaikoMasayaChainId"/>) uses <see cref="MasayaBlockZkGasLimit"/>;
     /// every other network uses <see cref="BlockZkGasLimit"/>. Opcode multipliers,

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasSchedule.cs
@@ -7,11 +7,6 @@ namespace Nethermind.Taiko.ZkGas;
 
 /// <summary>
 /// Consensus-owned ZK gas schedule for the Unzen hardfork.
-/// All values (multipliers, spawn estimates, and <see cref="BlockZkGasLimit"/>) are
-/// taken verbatim from the canonical Taiko protocol specification:
-/// <see href="https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md"/>.
-/// The alethia-reth reference implementation lives in
-/// <c>crates/evm/src/zk_gas/unzen.rs</c> in the alethia-reth repository.
 /// Each opcode/precompile has a multiplier: zkGas = rawGas × multiplier.
 /// </summary>
 public static class ZkGasSchedule
@@ -28,58 +23,20 @@ public static class ZkGasSchedule
     /// <summary>Chain id of the Taiko Hoodi testnet.</summary>
     public const ulong TaikoHoodiChainId = 167_013;
 
-    /// <summary>
-    /// Default Unzen block ZK gas limit applied to Devnet, Hoodi and Mainnet.
-    /// </summary>
+    /// <summary>Default Unzen block ZK gas limit.</summary>
     public const ulong BlockZkGasLimit = 100_000_000;
 
-    /// <summary>
-    /// Masaya-specific Unzen block ZK gas limit. Masaya runs with a larger ZK budget
-    /// (1B) so that load tests can drive the chain near its execution gas ceiling
-    /// without the prover budget becoming the binding constraint.
-    /// Mirrors <c>MASAYA_BLOCK_ZK_GAS_LIMIT</c> in alethia-reth's
-    /// <c>crates/evm/src/zk_gas/unzen.rs</c>.
-    /// </summary>
+    /// <summary>Masaya-specific block ZK gas limit (1B). Masaya activated Unzen with a larger budget for load testing.</summary>
     public const ulong MasayaBlockZkGasLimit = 1_000_000_000;
 
-    /// <summary>
-    /// Fixed ZK gas charged once per transaction before any opcode or precompile runs,
-    /// applied on Devnet, Hoodi, and Mainnet (Unzen). Covers the proving cost of
-    /// per-transaction sender ecrecovery.
-    /// Sourced from taiko-mono PR #21669; mirrors <c>TX_INTRINSIC_ZK_GAS</c> in
-    /// alethia-reth PR #180 (<c>crates/evm/src/zk_gas/unzen.rs</c>).
-    /// </summary>
+    /// <summary>Fixed ZK gas charged per transaction before any opcode runs; covers proving cost of sender ecrecovery.</summary>
     public const ulong TxIntrinsicZkGas = 243_000;
 
     /// <summary>
-    /// Per-transaction intrinsic ZK gas for Taiko Masaya. Pinned at 0 because Masaya
-    /// activated Unzen before taiko-mono PR #21669 landed; charging the non-zero value
-    /// retroactively would break consensus on already-finalized blocks whose
-    /// <c>difficulty</c> header field encodes the finalized block ZK gas.
-    /// Mirrors <c>MASAYA_TX_INTRINSIC_ZK_GAS</c> in alethia-reth PR #180.
+    /// Per-transaction intrinsic ZK gas for Masaya. Pinned at 0 because Masaya activated Unzen before
+    /// this constant landed; retroactively charging would break consensus on finalized blocks.
     /// </summary>
     public const ulong MasayaTxIntrinsicZkGas = 0;
-
-    /// <summary>
-    /// Returns the per-transaction intrinsic ZK gas for the given chain id.
-    /// <see cref="TaikoMasayaChainId"/> returns 0 to preserve historical block consensus;
-    /// all other networks return <see cref="TxIntrinsicZkGas"/> (243 000).
-    /// </summary>
-    /// <param name="chainId">Chain id from <see cref="Nethermind.Core.Specs.ISpecProvider.ChainId"/>.</param>
-    /// <returns>The flat intrinsic ZK gas charged once per transaction.</returns>
-    public static ulong ResolveTxIntrinsicZkGas(ulong chainId) =>
-        chainId == TaikoMasayaChainId ? MasayaTxIntrinsicZkGas : TxIntrinsicZkGas;
-
-    /// <summary>
-    /// Returns the Unzen block ZK gas limit for the given chain id. Masaya
-    /// (<see cref="TaikoMasayaChainId"/>) uses <see cref="MasayaBlockZkGasLimit"/>;
-    /// every other network uses <see cref="BlockZkGasLimit"/>. Opcode multipliers,
-    /// precompile multipliers and spawn estimates are identical across all networks.
-    /// </summary>
-    /// <param name="chainId">Chain id from <see cref="Nethermind.Core.Specs.ISpecProvider.ChainId"/>.</param>
-    /// <returns>The block ZK gas limit in ZK gas units.</returns>
-    public static ulong ResolveBlockZkGasLimit(ulong chainId) =>
-        chainId == TaikoMasayaChainId ? MasayaBlockZkGasLimit : BlockZkGasLimit;
 
     /// <summary>
     /// Mainnet batch-lookup threshold: the first allowed block id (first Shasta block).


### PR DESCRIPTION
## Changes

- Adds `TxIntrinsicZkGas = 243_000` and `MasayaTxIntrinsicZkGas = 0` to ZkGasSchedule with ResolveTxIntrinsicZkGas(chainId) helper
- Adds `ZkGasMeter.ChargeTxIntrinsic()` — charges the flat intrinsic into the in-flight tx total before EVM dispatch
- `ZkGasBlockTracer.StartNewTxTrace` calls `ChargeTxIntrinsic()` after reset and before EVM dispatch
- Masaya pinned at 0 to preserve consensus on already-finalized blocks
- Unit tests for constant pinning, Masaya no-op, charge promotion on commit, and IsLimitExceeded when intrinsic alone busts the budget

Ports https://github.com/taikoxyz/taiko-mono/pull/21669 and mirrors https://github.com/taikoxyz/alethia-reth/pull/180.



## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)


## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes


## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
