### PR TITLE
StateComposition: scope read-only trie store before incremental diff

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -17,6 +17,7 @@ using Nethermind.StateComposition.Service;
 using Nethermind.StateComposition.Snapshots;
 using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -195,6 +196,56 @@ public class StateCompositionServiceIncrementalRecoveryTests
         }
     }
 
+    [Test]
+    public void RunIncrementalDiff_OpensScopeOnHeadBeforeAcquiringResolver()
+    {
+        long diffErrorsBefore = Metrics.StateCompDiffErrors;
+
+        bool scopeOpened = false;
+        BlockHeader? scopedHeader = null;
+        IReadOnlyTrieStore readOnlyStore = Substitute.For<IReadOnlyTrieStore>();
+        readOnlyStore.BeginScope(Arg.Any<BlockHeader?>())
+            .Returns(call =>
+            {
+                scopeOpened = true;
+                scopedHeader = (BlockHeader?)call[0];
+                return Substitute.For<IDisposable>();
+            });
+        readOnlyStore.GetTrieStore(Arg.Any<Hash256?>())
+            .Returns(_ =>
+            {
+                if (!scopeOpened)
+                    throw new InvalidOperationException("BeginScope has not been called");
+                throw new BeginScopeSentinel();
+            });
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager.CreateReadOnlyTrieStore().Returns(readOnlyStore);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        StateCompositionStateHolder stateHolder = new();
+        SeedBaseline(stateHolder, blockNumber: 100, stateRoot: PrevRoot);
+
+        Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
+        blockTree.Head.Returns(headBlock);
+
+        using StateCompositionService service = new(
+            stateReader, worldStateManager, blockTree, stateHolder,
+            CreateSnapshotStore(), CreateConfig(), LimboLogs.Instance);
+
+        service.RunIncrementalDiff();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scopeOpened, Is.True,
+                "BeginScope must run before GetTrieStore — this is the FlatDb prerequisite.");
+            Assert.That(scopedHeader, Is.SameAs(headBlock.Header),
+                "BeginScope must be invoked with the head block header so the snapshot bundle covers the right state.");
+            Assert.That(Metrics.StateCompDiffErrors, Is.EqualTo(diffErrorsBefore + 1),
+                "BeginScopeSentinel propagates as a generic diff error — confirms the call site executed end-to-end.");
+        }
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string message)
     {
         using CancellationTokenSource cts = new(timeout);
@@ -210,4 +261,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
             Assert.Fail(message);
         }
     }
+
+    private sealed class BeginScopeSentinel : Exception;
 }

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -199,8 +199,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
     [Test]
     public void RunIncrementalDiff_OpensScopeOnHeadBeforeAcquiringResolver()
     {
-        long diffErrorsBefore = Metrics.StateCompDiffErrors;
-
         bool scopeOpened = false;
         BlockHeader? scopedHeader = null;
         IReadOnlyTrieStore readOnlyStore = Substitute.For<IReadOnlyTrieStore>();
@@ -241,8 +239,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
                 "BeginScope must run before GetTrieStore — this is the FlatDb prerequisite.");
             Assert.That(scopedHeader, Is.SameAs(headBlock.Header),
                 "BeginScope must be invoked with the head block header so the snapshot bundle covers the right state.");
-            Assert.That(Metrics.StateCompDiffErrors, Is.EqualTo(diffErrorsBefore + 1),
-                "BeginScopeSentinel propagates as a generic diff error — confirms the call site executed end-to-end.");
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -55,6 +55,7 @@ internal sealed partial class StateCompositionService
             if (head?.Header.StateRoot is null || prevRoot == Hash256.Zero || head.Header.StateRoot == prevRoot) return;
 
             using IReadOnlyTrieStore readOnlyStore = _worldStateManager.CreateReadOnlyTrieStore();
+            using IDisposable scope = readOnlyStore.BeginScope(head.Header);
             IScopedTrieStore resolver = readOnlyStore.GetTrieStore(null);
 
             TrieDiff diff = _diffWalker.ComputeDiff(prevRoot, head.Header.StateRoot, resolver);


### PR DESCRIPTION
## Changes

- `StateCompositionService.RunIncrementalDiff` wraps the read-only trie store with `BeginScope(head.Header)` before calling `GetTrieStore`. Without this, `FlatReadOnlyTrieStore` throws `InvalidOperationException(\"BeginScope has not been called\")` on the first node lookup, the outer catch swallows it as a generic diff error, and the cumulative byte/depth gauges stop advancing past the bootstrap baseline. The pruning store's `BeginScope` is a no-op so the call is safe on both backends.
- Bootstrap scan path is unaffected — it routes through `IStateReader.RunTreeVisitor`, which scopes internally.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

\`RunIncrementalDiff_OpensScopeOnHeadBeforeAcquiringResolver\` pins the scoping order: \`BeginScope\` must run before \`GetTrieStore\` and must propagate the head block header. End-to-end validated on a mainnet-forked archive bloatnet: \`nethermind_state_comp_account_trie_bytes\` advances per commit instead of stalling at the bootstrap baseline.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No