### PR TITLE
StateComposition: refuse to publish a partial-scan baseline

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceTests.cs
@@ -23,6 +23,7 @@ using Nethermind.StateComposition.Service;
 using Nethermind.StateComposition.Snapshots;
 using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.StateComposition.Visitors;
+using Nethermind.Trie;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -102,6 +103,86 @@ public class StateCompositionServiceTests
             Assert.That(result.IsSuccess, Is.True);
             Assert.That(harness.StateHolder.HasScanBaseline, Is.True);
             Assert.That(harness.StateHolder.LastScanMetadata.IsComplete, Is.True);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeAsync_PartialScan_DoesNotPublishBaseline()
+    {
+        IStateReader stateReader = Substitute.For<IStateReader>();
+
+        stateReader.WhenForAnyArgs(x =>
+            x.RunTreeVisitor<StateCompositionContext>(null!, null))
+            .Do(call =>
+            {
+                ITreeVisitor<StateCompositionContext> visitor =
+                    call.Arg<ITreeVisitor<StateCompositionContext>>();
+                visitor.VisitMissingNode(
+                    new StateCompositionContext(TreePath.Empty, 0, false, null),
+                    new ValueHash256(new byte[32]));
+            });
+
+        await using Harness harness = CreateHarness(stateReader);
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+
+        Result<StateCompositionStats> result = await harness.Service.AnalyzeAsync(header, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True, "scan still returns its (partial) stats to the caller");
+            Assert.That(harness.StateHolder.HasScanBaseline, Is.False,
+                "partial scan must not seed the baseline");
+            Assert.That(harness.StateHolder.LastScanMetadata.IsComplete, Is.False,
+                "scan metadata must not record completion");
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeAsync_PartialScan_PreservesPriorBaseline()
+    {
+        IStateReader stateReader = Substitute.For<IStateReader>();
+
+        int callCount = 0;
+        stateReader.WhenForAnyArgs(x =>
+            x.RunTreeVisitor<StateCompositionContext>(null!, null))
+            .Do(call =>
+            {
+                if (Interlocked.Increment(ref callCount) > 1)
+                {
+                    ITreeVisitor<StateCompositionContext> visitor =
+                        call.Arg<ITreeVisitor<StateCompositionContext>>();
+                    visitor.VisitMissingNode(
+                        new StateCompositionContext(TreePath.Empty, 0, false, null),
+                        new ValueHash256(new byte[32]));
+                }
+            });
+
+        await using Harness harness = CreateHarness(stateReader);
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+
+        Result<StateCompositionStats> firstScan = await harness.Service.AnalyzeAsync(header, CancellationToken.None);
+        Assert.That(firstScan.IsSuccess, Is.True);
+        Assert.That(harness.StateHolder.HasScanBaseline, Is.True,
+            "complete scan must seed the baseline");
+        Hash256 priorRoot = harness.StateHolder.LastProcessedStateRoot;
+        long priorBlock = harness.StateHolder.IncrementalBlock;
+        TimeSpan priorDuration = harness.StateHolder.LastScanMetadata.Duration;
+
+        Result<StateCompositionStats> partialScan = await harness.Service.AnalyzeAsync(header, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(partialScan.IsSuccess, Is.True, "scan still returns its (partial) stats");
+            Assert.That(harness.StateHolder.HasScanBaseline, Is.True,
+                "partial scan must NOT clear the prior complete baseline");
+            Assert.That(harness.StateHolder.LastScanMetadata.IsComplete, Is.True,
+                "prior complete scan's metadata must be retained");
+            Assert.That(harness.StateHolder.LastProcessedStateRoot, Is.EqualTo(priorRoot),
+                "prior baseline state root must be untouched");
+            Assert.That(harness.StateHolder.IncrementalBlock, Is.EqualTo(priorBlock),
+                "prior baseline block must be untouched");
+            Assert.That(harness.StateHolder.LastScanMetadata.Duration, Is.EqualTo(priorDuration),
+                "prior baseline duration must be untouched");
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.cs
@@ -137,9 +137,9 @@ internal sealed partial class StateCompositionService : IStoppableService, IDisp
 
             PublishScanResults(stats, dist, header, sw, scanComplete);
 
-            if (_logger.IsInfo)
-                _logger.Info($"StateComposition: scan {(scanComplete ? "completed" : "finished with MISSING NODES")} " +
-                             $"in {sw.Elapsed}. Accounts={stats.AccountsTotal}, Contracts={stats.ContractsTotal}, " +
+            if (scanComplete && _logger.IsInfo)
+                _logger.Info($"StateComposition: scan completed in {sw.Elapsed}. " +
+                             $"Accounts={stats.AccountsTotal}, Contracts={stats.ContractsTotal}, " +
                              $"StorageSlots={stats.StorageSlotsTotal}");
 
             return Result<StateCompositionStats>.Success(stats);
@@ -258,6 +258,19 @@ internal sealed partial class StateCompositionService : IStoppableService, IDisp
 
     private void PublishScanResults(StateCompositionStats stats, TrieDepthDistribution dist, BlockHeader header, Stopwatch sw, bool isComplete)
     {
+        // A scan that hit MissingNodesObserved walked only the reachable subset of
+        // the trie. Publishing it would clobber a complete prior baseline with a
+        // strict subset and let the next snapshot flush persist the loss. Keep
+        // the existing in-memory state and let the next head retrigger the scan.
+        if (!isComplete)
+        {
+            if (_logger.IsWarn)
+                _logger.Warn($"StateComposition: scan at block {header.Number} finished with missing nodes " +
+                             $"(partial accounts={stats.AccountsTotal:N0}). Refusing to publish a partial baseline; " +
+                             $"prior incremental state retained, next head will retrigger the scan.");
+            return;
+        }
+
         CumulativeTrieStats cumulativeBaseline = CumulativeTrieStats.FromScanStats(stats);
 
         // Seed and publish under _diffLock so a concurrent incremental diff cannot
@@ -267,7 +280,7 @@ internal sealed partial class StateCompositionService : IStoppableService, IDisp
         lock (_diffLock)
         {
             _stateHolder.PublishScanBaseline(
-                stats, dist, header.Number, header.StateRoot!, sw.Elapsed, isComplete,
+                stats, dist, header.Number, header.StateRoot!, sw.Elapsed, isComplete: true,
                 cumulativeBaseline,
                 slotCountByAddress: stats.SlotCountByAddress,
                 codeHashRefcounts: stats.CodeHashRefcounts,


### PR DESCRIPTION
## Changes

- `PublishScanResults` is gated on `isComplete`. A scan that observed `MissingNodesObserved` walked only the reachable subset of the trie; the previous code committed those partial counters as the new baseline regardless. On mainnet that surfaced as restoring ~42% of the trie (181M of 434M accounts), poisoning every downstream consumer until the next successful scan.
- Partial scans now log a warning and leave the prior incremental baseline intact for the next head retry.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

\`AnalyzeAsync_PartialScan_DoesNotPublishBaseline\` — visitor reports a missing node; assert that the baseline is **not** seeded and the prior baseline is preserved.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No