### PR TITLE
`eth_signTransaction` eliminate allocations & improvements

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -167,6 +169,30 @@ public partial class EthRpcModuleTests
         return response.Result!;
     }
 
+    [Test]
+    public void SignTransactionResult_Dispose_ReturnsRentedBufferToPool()
+    {
+        TrackingPool pool = new();
+        byte[] rented = pool.Rent(32);
+        OwnedByteMemory raw = new(rented, 16, pool);
+        SignTransactionResult result = new()
+        {
+            Raw = raw,
+            Tx = BuildTx(TxType.EIP1559)
+        };
+
+        // Drive the same disposal path the JSON-RPC pipeline uses for a successful response —
+        // a regression test for the pool-rental leak that occurs when SignTransactionResult
+        // is not IDisposable: TryDispose(object?) skips non-IDisposable values, so Raw never
+        // gets disposed and the rented buffer is lost to GC instead of returning to the pool.
+        JsonRpcSuccessResponse response = new() { Result = result };
+        response.Dispose();
+
+        pool.Returned.Should().ContainSingle().Which.Should().BeSameAs(rented,
+            "the rented buffer must come back to the pool — otherwise pooling is strictly " +
+            "worse than direct allocation");
+    }
+
     private sealed class ParsedSignTransactionResult
     {
         [System.Text.Json.Serialization.JsonPropertyName("raw")]
@@ -174,6 +200,13 @@ public partial class EthRpcModuleTests
 
         [System.Text.Json.Serialization.JsonPropertyName("tx")]
         public required TransactionForRpc Tx { get; init; }
+    }
+
+    private sealed class TrackingPool : ArrayPool<byte>
+    {
+        public List<byte[]> Returned { get; } = [];
+        public override byte[] Rent(int minimumLength) => new byte[minimumLength];
+        public override void Return(byte[] array, bool clearArray = false) => Returned.Add(array);
     }
 
     private static TransactionForRpc BuildTx(TxType type, string? omitField = null, string? fromOverride = null)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
@@ -118,7 +118,7 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.Create();
         ctx.Test.RpcConfig.EnableEthSignTransaction = true;
         string serialized = await ctx.Test.TestEthRpc("eth_signTransaction", param);
-        JsonRpcResponse<SignTransactionResult> response = ctx.Test.JsonSerializer.Deserialize<JsonRpcResponse<SignTransactionResult>>(serialized)!;
+        JsonRpcResponse<ParsedSignTransactionResult> response = ctx.Test.JsonSerializer.Deserialize<JsonRpcResponse<ParsedSignTransactionResult>>(serialized)!;
         response.Result.Should().NotBeNull("precondition: signing must succeed for valid input");
 
         response.Result!.Tx.Should().BeOfType(expectedEchoType,
@@ -132,7 +132,7 @@ public partial class EthRpcModuleTests
     public async Task SignTransaction_WhenValid_RawRoundTripsAndTxEcho(TxType type, Type expectedEchoType)
     {
         TransactionForRpc rpcTx = BuildTx(type);
-        SignTransactionResult result = await SignTransactionForResult(rpcTx);
+        ParsedSignTransactionResult result = await SignTransactionForResult(rpcTx);
 
         Transaction decoded = TxDecoder.Instance.DecodeCompleteNotNull(
             result.Raw,
@@ -157,14 +157,23 @@ public partial class EthRpcModuleTests
         return await ctx.Test.TestEthRpc("eth_signTransaction", rpcTx);
     }
 
-    private async Task<SignTransactionResult> SignTransactionForResult(TransactionForRpc rpcTx)
+    private async Task<ParsedSignTransactionResult> SignTransactionForResult(TransactionForRpc rpcTx)
     {
         using Context ctx = await Context.Create();
         ctx.Test.RpcConfig.EnableEthSignTransaction = true;
         string serialized = await ctx.Test.TestEthRpc("eth_signTransaction", rpcTx);
-        JsonRpcResponse<SignTransactionResult> response = ctx.Test.JsonSerializer.Deserialize<JsonRpcResponse<SignTransactionResult>>(serialized)!;
+        JsonRpcResponse<ParsedSignTransactionResult> response = ctx.Test.JsonSerializer.Deserialize<JsonRpcResponse<ParsedSignTransactionResult>>(serialized)!;
         response.Result.Should().NotBeNull("precondition: signing must succeed for valid input");
         return response.Result!;
+    }
+
+    private sealed class ParsedSignTransactionResult
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("raw")]
+        public required byte[] Raw { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("tx")]
+        public required TransactionForRpc Tx { get; init; }
     }
 
     private static TransactionForRpc BuildTx(TxType type, string? omitField = null, string? fromOverride = null)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.SignTransaction.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Crypto;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Int256;
@@ -173,8 +174,8 @@ public partial class EthRpcModuleTests
     public void SignTransactionResult_Dispose_ReturnsRentedBufferToPool()
     {
         TrackingPool pool = new();
-        byte[] rented = pool.Rent(32);
-        OwnedByteMemory raw = new(rented, 16, pool);
+        ArrayPoolList<byte> raw = new(pool, capacity: 32, startingCount: 16);
+        byte[] rented = raw.UnsafeGetInternalArray();
         SignTransactionResult result = new()
         {
             Raw = raw,

--- a/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
@@ -1,16 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Text.Json.Serialization;
 using Nethermind.Facade.Eth.RpcTransaction;
 
 namespace Nethermind.JsonRpc.Data;
 
-public class SignTransactionResult
+public class SignTransactionResult : IDisposable
 {
     [JsonPropertyName("raw")]
     public required OwnedByteMemory Raw { get; init; }
 
     [JsonPropertyName("tx")]
     public required TransactionForRpc Tx { get; init; }
+
+    public void Dispose() => Raw?.Dispose();
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
@@ -5,14 +5,12 @@ using System;
 using System.Text.Json.Serialization;
 using Nethermind.Core.Collections;
 using Nethermind.Facade.Eth.RpcTransaction;
-using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc.Data;
 
 public class SignTransactionResult : IDisposable
 {
     [JsonPropertyName("raw")]
-    [JsonConverter(typeof(ArrayPoolListByteHexConverter))]
     public required ArrayPoolList<byte> Raw { get; init; }
 
     [JsonPropertyName("tx")]

--- a/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
@@ -3,14 +3,17 @@
 
 using System;
 using System.Text.Json.Serialization;
+using Nethermind.Core.Collections;
 using Nethermind.Facade.Eth.RpcTransaction;
+using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc.Data;
 
 public class SignTransactionResult : IDisposable
 {
     [JsonPropertyName("raw")]
-    public required OwnedByteMemory Raw { get; init; }
+    [JsonConverter(typeof(ArrayPoolListByteHexConverter))]
+    public required ArrayPoolList<byte> Raw { get; init; }
 
     [JsonPropertyName("tx")]
     public required TransactionForRpc Tx { get; init; }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
@@ -9,7 +9,7 @@ namespace Nethermind.JsonRpc.Data;
 public class SignTransactionResult
 {
     [JsonPropertyName("raw")]
-    public required byte[] Raw { get; init; }
+    public required OwnedByteMemory Raw { get; init; }
 
     [JsonPropertyName("tx")]
     public required TransactionForRpc Tx { get; init; }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/SignTransactionResult.cs
@@ -15,5 +15,5 @@ public class SignTransactionResult : IDisposable
     [JsonPropertyName("tx")]
     public required TransactionForRpc Tx { get; init; }
 
-    public void Dispose() => Raw?.Dispose();
+    public void Dispose() => Raw.Dispose();
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -410,24 +410,22 @@ public partial class EthRpcModule(
         const RlpBehaviors encodeBehaviors = RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm;
         int encodedLength = TxDecoder.Instance.GetLength(tx, encodeBehaviors);
         byte[] rented = ArrayPool<byte>.Shared.Rent(encodedLength);
+        OwnedByteMemory raw = new(rented, encodedLength, ArrayPool<byte>.Shared);
         try
         {
             RlpStream stream = new(new CappedArray<byte>(rented, encodedLength));
             TxDecoder.Instance.Encode(stream, tx, encodeBehaviors);
+            return ResultWrapper<SignTransactionResult>.Success(new SignTransactionResult
+            {
+                Raw = raw,
+                Tx = TransactionForRpc.FromTransaction(tx)
+            });
         }
         catch
         {
-            ArrayPool<byte>.Shared.Return(rented);
+            raw.Dispose();
             throw;
         }
-
-        OwnedByteMemory raw = new(rented, encodedLength, ArrayPool<byte>.Shared);
-
-        return ResultWrapper<SignTransactionResult>.Success(new SignTransactionResult
-        {
-            Raw = raw,
-            Tx = TransactionForRpc.FromTransaction(tx)
-        });
     }
 
     private ResultWrapper<SignTransactionResult>? CheckTxFeeCap(Transaction tx)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -407,23 +407,27 @@ public partial class EthRpcModule(
 
         if (_logger.IsInfo) _logger.Info($"eth_signTransaction signed tx {tx.Hash} from {tx.SenderAddress}");
 
+        return BuildSignedResult(tx);
+    }
+
+    private static ResultWrapper<SignTransactionResult> BuildSignedResult(Transaction tx)
+    {
         const RlpBehaviors encodeBehaviors = RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm;
-        int encodedLength = TxDecoder.Instance.GetLength(tx, encodeBehaviors);
-        byte[] rented = ArrayPool<byte>.Shared.Rent(encodedLength);
-        OwnedByteMemory raw = new(rented, encodedLength, ArrayPool<byte>.Shared);
+        int length = TxDecoder.Instance.GetLength(tx, encodeBehaviors);
+        ArrayPoolList<byte> buffer = new(length, length);
         try
         {
-            RlpStream stream = new(new CappedArray<byte>(rented, encodedLength));
+            RlpStream stream = new(new CappedArray<byte>(buffer.UnsafeGetInternalArray(), length));
             TxDecoder.Instance.Encode(stream, tx, encodeBehaviors);
             return ResultWrapper<SignTransactionResult>.Success(new SignTransactionResult
             {
-                Raw = raw,
+                Raw = buffer,
                 Tx = TransactionForRpc.FromTransaction(tx)
             });
         }
         catch
         {
-            raw.Dispose();
+            buffer.Dispose();
             throw;
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -7,6 +7,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -406,7 +407,21 @@ public partial class EthRpcModule(
 
         if (_logger.IsInfo) _logger.Info($"eth_signTransaction signed tx {tx.Hash} from {tx.SenderAddress}");
 
-        byte[] raw = TxDecoder.Instance.Encode(tx, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm).Bytes;
+        const RlpBehaviors encodeBehaviors = RlpBehaviors.SkipTypedWrapping | RlpBehaviors.InMempoolForm;
+        int encodedLength = TxDecoder.Instance.GetLength(tx, encodeBehaviors);
+        byte[] rented = ArrayPool<byte>.Shared.Rent(encodedLength);
+        try
+        {
+            RlpStream stream = new(new CappedArray<byte>(rented, encodedLength));
+            TxDecoder.Instance.Encode(stream, tx, encodeBehaviors);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+            throw;
+        }
+
+        OwnedByteMemory raw = new(rented, encodedLength, ArrayPool<byte>.Shared);
 
         return ResultWrapper<SignTransactionResult>.Success(new SignTransactionResult
         {

--- a/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
@@ -32,7 +32,8 @@ public sealed class OwnedByteMemory : IDisposable
     {
         ArgumentNullException.ThrowIfNull(pooledBuffer);
         ArgumentNullException.ThrowIfNull(pool);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)length, (uint)pooledBuffer.Length, nameof(length));
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, pooledBuffer.Length, nameof(length));
 
         _pooledArray = pooledBuffer;
         _memory = pooledBuffer.AsMemory(0, length);

--- a/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
@@ -33,7 +33,7 @@ public sealed class OwnedByteMemory : IDisposable
         ArgumentNullException.ThrowIfNull(pooledBuffer);
         ArgumentNullException.ThrowIfNull(pool);
         ArgumentOutOfRangeException.ThrowIfNegative(length);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, pooledBuffer.Length, nameof(length));
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, pooledBuffer.Length);
 
         _pooledArray = pooledBuffer;
         _memory = pooledBuffer.AsMemory(0, length);

--- a/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc;
@@ -15,20 +16,54 @@ namespace Nethermind.JsonRpc;
 [JsonConverter(typeof(OwnedByteMemoryConverter))]
 public sealed class OwnedByteMemory : IDisposable
 {
-    private readonly MemoryManager<byte> _memoryManager;
+    private byte[]? _pooledArray;
+    private IDisposable? _manager;
+    private readonly Memory<byte> _memory;
+    private readonly ArrayPool<byte>? _pool;
 
     public OwnedByteMemory(MemoryManager<byte> memoryManager)
     {
         ArgumentNullException.ThrowIfNull(memoryManager);
-        _memoryManager = memoryManager;
+        _manager = memoryManager;
+        _memory = memoryManager.Memory;
+    }
+
+    public OwnedByteMemory(byte[] pooledBuffer, int length, ArrayPool<byte> pool)
+    {
+        ArgumentNullException.ThrowIfNull(pooledBuffer);
+        ArgumentNullException.ThrowIfNull(pool);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)length, (uint)pooledBuffer.Length, nameof(length));
+
+        _pooledArray = pooledBuffer;
+        _memory = pooledBuffer.AsMemory(0, length);
+        _pool = pool;
     }
 
     /// <summary>
     /// Gets the owned bytes to serialize.
     /// </summary>
-    public Memory<byte> Memory => _memoryManager.Memory;
+    public Memory<byte> Memory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_pooledArray is null && _manager is null, this);
+            return _memory;
+        }
+    }
 
-    public void Dispose() => ((IDisposable)_memoryManager).Dispose();
+    public void Dispose()
+    {
+        if (_pool is not null)
+        {
+            byte[]? array = Interlocked.Exchange(ref _pooledArray, null);
+            if (array is not null) _pool.Return(array);
+        }
+        else
+        {
+            IDisposable? manager = Interlocked.Exchange(ref _manager, null);
+            manager?.Dispose();
+        }
+    }
 }
 
 internal sealed class OwnedByteMemoryConverter : JsonConverter<OwnedByteMemory>

--- a/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/OwnedByteMemory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading;
 using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc;
@@ -16,55 +15,20 @@ namespace Nethermind.JsonRpc;
 [JsonConverter(typeof(OwnedByteMemoryConverter))]
 public sealed class OwnedByteMemory : IDisposable
 {
-    private byte[]? _pooledArray;
-    private IDisposable? _manager;
-    private readonly Memory<byte> _memory;
-    private readonly ArrayPool<byte>? _pool;
+    private readonly MemoryManager<byte> _memoryManager;
 
     public OwnedByteMemory(MemoryManager<byte> memoryManager)
     {
         ArgumentNullException.ThrowIfNull(memoryManager);
-        _manager = memoryManager;
-        _memory = memoryManager.Memory;
-    }
-
-    public OwnedByteMemory(byte[] pooledBuffer, int length, ArrayPool<byte> pool)
-    {
-        ArgumentNullException.ThrowIfNull(pooledBuffer);
-        ArgumentNullException.ThrowIfNull(pool);
-        ArgumentOutOfRangeException.ThrowIfNegative(length);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, pooledBuffer.Length);
-
-        _pooledArray = pooledBuffer;
-        _memory = pooledBuffer.AsMemory(0, length);
-        _pool = pool;
+        _memoryManager = memoryManager;
     }
 
     /// <summary>
     /// Gets the owned bytes to serialize.
     /// </summary>
-    public Memory<byte> Memory
-    {
-        get
-        {
-            ObjectDisposedException.ThrowIf(_pooledArray is null && _manager is null, this);
-            return _memory;
-        }
-    }
+    public Memory<byte> Memory => _memoryManager.Memory;
 
-    public void Dispose()
-    {
-        if (_pool is not null)
-        {
-            byte[]? array = Interlocked.Exchange(ref _pooledArray, null);
-            if (array is not null) _pool.Return(array);
-        }
-        else
-        {
-            IDisposable? manager = Interlocked.Exchange(ref _manager, null);
-            manager?.Dispose();
-        }
-    }
+    public void Dispose() => ((IDisposable)_memoryManager).Dispose();
 }
 
 internal sealed class OwnedByteMemoryConverter : JsonConverter<OwnedByteMemory>

--- a/src/Nethermind/Nethermind.Serialization.Json/ArrayPoolListByteHexConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/ArrayPoolListByteHexConverter.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Nethermind.Core.Collections;
+
+namespace Nethermind.Serialization.Json;
+
+/// <summary>
+/// Serializes an <see cref="ArrayPoolList{T}"/> of bytes as a hex string. Serialize-only — JSON
+/// responses use pool-rented buffers; deserialization back into a pooled list is not supported.
+/// </summary>
+public sealed class ArrayPoolListByteHexConverter : JsonConverter<ArrayPoolList<byte>>
+{
+    public override ArrayPoolList<byte> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        throw new NotSupportedException($"{nameof(ArrayPoolListByteHexConverter)} is serialize-only");
+
+    public override void Write(Utf8JsonWriter writer, ArrayPoolList<byte> value, JsonSerializerOptions options) =>
+        ByteArrayConverter.Convert(writer, value.AsSpan(), skipLeadingZeros: false);
+}

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -91,6 +91,7 @@ namespace Nethermind.Serialization.Json
                     new ByteArrayConverter(),
                     new ByteReadOnlyMemoryConverter(),
                     new NullableByteReadOnlyMemoryConverter(),
+                    new ArrayPoolListByteHexConverter(),
                     new NullableLongConverter(),
                     new NullableULongConverter(),
                     new NullableUInt256Converter(),


### PR DESCRIPTION
Fixes Closes Resolves #11578 

## Changes

- `SignTransactionResult.Raw` is now `ArrayPoolList<byte>` (was `byte[]`). The DTO implements `IDisposable` to release the rental at end of response.
- New `ArrayPoolListByteHexConverter` in `Nethermind.Serialization.Json/` - reusable serialize-only converter that writes `ArrayPoolList<byte>` as a hex string. Lives next to `ByteArrayConverter`.
- New `BuildSignedResult` private helper in `EthRpcModule` - encapsulates the rent/encode/wrap dance under a single try/catch so any throw (from RLP encoding, `FromTransaction`, or wrapper construction) releases the rental through the same path.
- `OwnedByteMemory` is untouched - reverted to its original MemoryManager<byte>-backed form. `debug_getRawBlockAccessList` continues to use it unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No