### PR TITLE
StateComposition: chunk persisted tracker maps so they don't overflow

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/SnapshotRoundTripTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/SnapshotRoundTripTests.cs
@@ -82,23 +82,15 @@ public class SnapshotRoundTripTests
     }
 
     [Test]
-    public void RoundTrip_PreservesAllFields()
+    public void RoundTrip_PreservesScalarsAndHistogram()
     {
         ImmutableArray<long> hist = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768];
         CumulativeTrieStats stats = BuildStats(codeBytes: 987_654, slotHist: hist);
 
         ValueHash256 addr1 = Keccak.Compute("addr1").ValueHash256;
-        ValueHash256 addr2 = Keccak.Compute("addr2").ValueHash256;
-        Dictionary<ValueHash256, long> slotCounts = new()
-        {
-            [addr1] = 42,
-            [addr2] = 1_000_000,
-        };
-
-        ValueHash256 codeA = Keccak.Compute("codeA").ValueHash256;
-        ValueHash256 codeB = Keccak.Compute("codeB").ValueHash256;
-        Dictionary<ValueHash256, int> refcounts = new() { [codeA] = 3, [codeB] = 1 };
-        Dictionary<ValueHash256, int> sizes = new() { [codeA] = 1024, [codeB] = 2048 };
+        Dictionary<ValueHash256, long> slotCounts = new() { [addr1] = 42 };
+        Dictionary<ValueHash256, int> refcounts = new() { [addr1] = 3 };
+        Dictionary<ValueHash256, int> sizes = new() { [addr1] = 1024 };
 
         StateCompositionSnapshot original = BuildSnapshot(stats,
             blockNumber: 1_000_000, stateRoot: Keccak.Compute("root"),
@@ -109,6 +101,9 @@ public class SnapshotRoundTripTests
 
         StateCompositionSnapshot decoded = RoundTrip(original);
 
+        // Tracker maps are persisted by the store as chunked side-records, not the
+        // decoder, so a raw decoder round-trip materialises them as empty.
+        // StateCompositionSnapshotStoreTests covers their end-to-end persistence.
         using (Assert.EnterMultipleScope())
         {
             Assert.That(decoded.Stats.CodeBytesTotal, Is.EqualTo(987_654));
@@ -117,14 +112,9 @@ public class SnapshotRoundTripTests
             Assert.That(decoded.DiffsSinceBaseline, Is.EqualTo(42));
             Assert.That(decoded.ScanBlockNumber, Is.EqualTo(999_000));
 
-            Assert.That(decoded.SlotCountByAddress, Has.Count.EqualTo(2));
-            Assert.That(decoded.SlotCountByAddress[addr1], Is.EqualTo(42));
-            Assert.That(decoded.SlotCountByAddress[addr2], Is.EqualTo(1_000_000));
-
-            Assert.That(decoded.CodeHashRefcounts[codeA], Is.EqualTo(3));
-            Assert.That(decoded.CodeHashRefcounts[codeB], Is.EqualTo(1));
-            Assert.That(decoded.CodeHashSizes[codeA], Is.EqualTo(1024));
-            Assert.That(decoded.CodeHashSizes[codeB], Is.EqualTo(2048));
+            Assert.That(decoded.SlotCountByAddress, Is.Empty);
+            Assert.That(decoded.CodeHashRefcounts, Is.Empty);
+            Assert.That(decoded.CodeHashSizes, Is.Empty);
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/StateCompositionSnapshotStoreTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Snapshots/StateCompositionSnapshotStoreTests.cs
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.StateComposition.Data;
+using Nethermind.StateComposition.Diff;
+using Nethermind.StateComposition.Snapshots;
+using NUnit.Framework;
+
+namespace Nethermind.StateComposition.Test.Snapshots;
+
+[TestFixture]
+public class StateCompositionSnapshotStoreTests
+{
+    private static CumulativeTrieStats StatsWith(long codeBytes) => new(
+        AccountsTotal: 1, ContractsTotal: 1, StorageSlotsTotal: 1,
+        AccountTrieBranches: 0, AccountTrieExtensions: 0, AccountTrieLeaves: 0, AccountTrieBytes: 0,
+        StorageTrieBranches: 0, StorageTrieExtensions: 0, StorageTrieLeaves: 0, StorageTrieBytes: 0,
+        ContractsWithStorage: 0, EmptyAccounts: 0)
+    { CodeBytesTotal = codeBytes, SlotCountHistogram = ImmutableArray.Create(new long[16]) };
+
+    private static StateCompositionSnapshot BuildSnapshot(
+        long blockNumber,
+        Dictionary<ValueHash256, long>? slotCountByAddress = null,
+        Dictionary<ValueHash256, int>? codeHashRefcounts = null,
+        Dictionary<ValueHash256, int>? codeHashSizes = null) =>
+        new(StatsWith(0), blockNumber, Keccak.Compute($"root-{blockNumber}"),
+            DiffsSinceBaseline: 0, ScanBlockNumber: blockNumber,
+            DepthStats: new CumulativeDepthStats(),
+            SlotCountByAddress: slotCountByAddress ?? [],
+            CodeHashRefcounts: codeHashRefcounts ?? [],
+            CodeHashSizes: codeHashSizes ?? []);
+
+    [Test]
+    public void WriteAndReadLatest_PreservesAllMaps()
+    {
+        StateCompositionSnapshotStore store = new(new MemDb(), LimboLogs.Instance, entriesPerChunk: 1024);
+
+        ValueHash256 a = Keccak.Compute("a").ValueHash256;
+        ValueHash256 b = Keccak.Compute("b").ValueHash256;
+        StateCompositionSnapshot snapshot = BuildSnapshot(
+            blockNumber: 100,
+            slotCountByAddress: new() { [a] = 7, [b] = 1_000_000_000_000 },
+            codeHashRefcounts: new() { [a] = 3, [b] = 1 },
+            codeHashSizes: new() { [a] = 24_000, [b] = 1 });
+
+        store.WriteSnapshot(snapshot);
+        StateCompositionSnapshot? loaded = store.ReadLatestSnapshot();
+
+        Assert.That(loaded, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(loaded!.Value.BlockNumber, Is.EqualTo(100));
+            Assert.That(loaded.Value.SlotCountByAddress[a], Is.EqualTo(7));
+            Assert.That(loaded.Value.SlotCountByAddress[b], Is.EqualTo(1_000_000_000_000));
+            Assert.That(loaded.Value.CodeHashRefcounts[a], Is.EqualTo(3));
+            Assert.That(loaded.Value.CodeHashRefcounts[b], Is.EqualTo(1));
+            Assert.That(loaded.Value.CodeHashSizes[a], Is.EqualTo(24_000));
+            Assert.That(loaded.Value.CodeHashSizes[b], Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void WriteAndReadLatest_LargeMapAcrossManyChunks_PreservesEveryEntry()
+    {
+        const int totalEntries = 5_000;
+        const int chunkSize = 250; // 20 chunks per map
+        StateCompositionSnapshotStore store = new(new MemDb(), LimboLogs.Instance, entriesPerChunk: chunkSize);
+
+        Dictionary<ValueHash256, long> slotCounts = new(totalEntries);
+        Dictionary<ValueHash256, int> codeRefcounts = new(totalEntries);
+        Dictionary<ValueHash256, int> codeSizes = new(totalEntries);
+        for (int i = 0; i < totalEntries; i++)
+        {
+            ValueHash256 hash = Keccak.Compute($"entry-{i}").ValueHash256;
+            slotCounts[hash] = i + 1L;
+            codeRefcounts[hash] = i + 2;
+            codeSizes[hash] = i + 3;
+        }
+
+        store.WriteSnapshot(BuildSnapshot(
+            blockNumber: 42,
+            slotCountByAddress: slotCounts,
+            codeHashRefcounts: codeRefcounts,
+            codeHashSizes: codeSizes));
+
+        StateCompositionSnapshot loaded = store.ReadLatestSnapshot()!.Value;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(loaded.SlotCountByAddress, Has.Count.EqualTo(totalEntries));
+            Assert.That(loaded.CodeHashRefcounts, Has.Count.EqualTo(totalEntries));
+            Assert.That(loaded.CodeHashSizes, Has.Count.EqualTo(totalEntries));
+            foreach (KeyValuePair<ValueHash256, long> kvp in slotCounts)
+            {
+                Assert.That(loaded.SlotCountByAddress[kvp.Key], Is.EqualTo(kvp.Value));
+                Assert.That(loaded.CodeHashRefcounts[kvp.Key], Is.EqualTo(codeRefcounts[kvp.Key]));
+                Assert.That(loaded.CodeHashSizes[kvp.Key], Is.EqualTo(codeSizes[kvp.Key]));
+            }
+        }
+    }
+
+    [Test]
+    public void WriteSnapshot_NewBlock_RemovesPriorBlocksMainAndChunks()
+    {
+        MemDb db = new();
+        StateCompositionSnapshotStore store = new(db, LimboLogs.Instance, entriesPerChunk: 100);
+
+        Dictionary<ValueHash256, long> firstSlots = [];
+        for (int i = 0; i < 250; i++)
+            firstSlots[Keccak.Compute($"first-{i}").ValueHash256] = i;
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 10, slotCountByAddress: firstSlots));
+        int keysAfterFirst = db.GetAllKeys().Count();
+
+        Dictionary<ValueHash256, long> secondSlots = [];
+        for (int i = 0; i < 50; i++)
+            secondSlots[Keccak.Compute($"second-{i}").ValueHash256] = i;
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 11, slotCountByAddress: secondSlots));
+
+        StateCompositionSnapshot loaded = store.ReadLatestSnapshot()!.Value;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(loaded.BlockNumber, Is.EqualTo(11));
+            Assert.That(loaded.SlotCountByAddress, Has.Count.EqualTo(50));
+            // Block 10's main key + chunk keys must all be gone.
+            Assert.That(store.ReadSnapshot(10), Is.Null);
+            Assert.That(db.GetAllKeys().Count(), Is.LessThan(keysAfterFirst));
+        }
+    }
+
+    [Test]
+    public void PurgeOldEntries_KeepsLatestMainAndChunks()
+    {
+        MemDb db = new();
+        StateCompositionSnapshotStore store = new(db, LimboLogs.Instance, entriesPerChunk: 100);
+
+        Dictionary<ValueHash256, long> staleSlots = [];
+        for (int i = 0; i < 250; i++)
+            staleSlots[Keccak.Compute($"stale-{i}").ValueHash256] = i;
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 7, slotCountByAddress: staleSlots));
+
+        // Manually inject an orphaned chunk for a block that is no longer the
+        // latest — simulating a crash mid-write. PurgeOldEntries must drop it.
+        byte[] orphanChunkKey =
+        [
+            0, 0, 0, 0, 0, 0, 0, 5,        // blockNumber = 5
+            0x01,                            // SlotCountKind
+            0, 0, 0, 0,                      // chunk index 0
+        ];
+        db.Set(orphanChunkKey, [0, 0, 0, 0]); // empty chunk payload
+
+        store.PurgeOldEntries();
+
+        Assert.That(db.GetAllKeys().Any(k => k.SequenceEqual(orphanChunkKey)), Is.False,
+            "Orphan chunk for block 5 must be purged.");
+        Assert.That(store.ReadLatestSnapshot()!.Value.BlockNumber, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void ReadSnapshot_TruncatedChunk_DegradesToEmptyMapsInsteadOfThrowing()
+    {
+        // Disk-read boundary: a snapshot whose chunk header was written but the
+        // payload was truncated mid-flush must not propagate
+        // ArgumentOutOfRangeException to the startup path. The reader bails to
+        // "no more entries" so the plugin can fall back to a fresh scan.
+        MemDb db = new();
+        StateCompositionSnapshotStore store = new(db, LimboLogs.Instance, entriesPerChunk: 100);
+
+        Dictionary<ValueHash256, long> slots = [];
+        for (int i = 0; i < 4; i++)
+            slots[Keccak.Compute($"slot-{i}").ValueHash256] = i;
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 1, slotCountByAddress: slots));
+
+        byte[] truncatedChunkKey =
+        [
+            0, 0, 0, 0, 0, 0, 0, 1,        // blockNumber = 1
+            0x01,                            // SlotCountKind
+            0, 0, 0, 0,                      // chunk index 0
+        ];
+        // Header claims 4 entries (160 bytes payload) but only 3 bytes follow.
+        db.Set(truncatedChunkKey, [0, 0, 0, 4, 0xAA, 0xBB, 0xCC]);
+
+        StateCompositionSnapshot loaded = store.ReadLatestSnapshot()!.Value;
+        Assert.That(loaded.SlotCountByAddress, Is.Empty);
+    }
+
+    [Test]
+    public void ReadSnapshot_MidSequenceTruncatedChunk_KeepsPriorEntries()
+    {
+        // First chunk is intact; chunk 1 is truncated mid-flush. Reader must
+        // stop at the corruption boundary, keep chunk 0's entries, and not
+        // throw — the plugin will rescan to repair the missing tail.
+        MemDb db = new();
+        StateCompositionSnapshotStore store = new(db, LimboLogs.Instance, entriesPerChunk: 2);
+
+        Dictionary<ValueHash256, long> slots = [];
+        for (int i = 0; i < 2; i++)
+            slots[Keccak.Compute($"slot-{i}").ValueHash256] = i + 1;
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 1, slotCountByAddress: slots));
+
+        // Manually inject a truncated chunk 1 (header claims 2 entries, only 5 bytes follow).
+        byte[] truncatedChunk1 =
+        [
+            0, 0, 0, 0, 0, 0, 0, 1,        // blockNumber = 1
+            0x01,                            // SlotCountKind
+            0, 0, 0, 1,                      // chunk index 1
+        ];
+        db.Set(truncatedChunk1, [0, 0, 0, 2, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE]);
+
+        StateCompositionSnapshot loaded = store.ReadLatestSnapshot()!.Value;
+        Assert.That(loaded.SlotCountByAddress, Has.Count.EqualTo(2),
+            "Chunk 0's entries survive; truncated chunk 1 stops the iteration without throwing.");
+    }
+
+    [Test]
+    public void EmptyMaps_AreNotPersistedAsChunks()
+    {
+        MemDb db = new();
+        StateCompositionSnapshotStore store = new(db, LimboLogs.Instance, entriesPerChunk: 100);
+
+        store.WriteSnapshot(BuildSnapshot(blockNumber: 1));
+
+        // Only main blob (8-byte key) + LatestKey (8-byte 0xFF) should be present.
+        Assert.That(db.GetAllKeys().Count(), Is.EqualTo(2));
+        StateCompositionSnapshot loaded = store.ReadLatestSnapshot()!.Value;
+        Assert.That(loaded.SlotCountByAddress, Is.Empty);
+        Assert.That(loaded.CodeHashRefcounts, Is.Empty);
+        Assert.That(loaded.CodeHashSizes, Is.Empty);
+    }
+}

--- a/src/Nethermind/Nethermind.StateComposition/Snapshots/StateCompositionSnapshotDecoder.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Snapshots/StateCompositionSnapshotDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -13,7 +12,10 @@ using Nethermind.StateComposition.Diff;
 namespace Nethermind.StateComposition.Snapshots;
 
 /// <summary>
-/// RLP encoder/decoder for <see cref="StateCompositionSnapshot"/>.
+/// RLP encoder/decoder for the fixed-size portion of <see cref="StateCompositionSnapshot"/>.
+/// The three contract-keyed tracker maps are written separately as raw chunked
+/// records by <see cref="StateCompositionSnapshotStore"/>; the decoder hands back
+/// empty dictionaries and the store fills them on read.
 /// Field order:
 ///   0. schema version byte (current = 1)
 ///   1. 13 longs (CumulativeTrieStats)
@@ -24,9 +26,6 @@ namespace Nethermind.StateComposition.Snapshots;
 ///        + TotalBranchNodes + TotalBranchChildren
 ///   5. codeBytesTotal (long)
 ///   6. 16 longs of SlotCountHistogram
-///   7. slotCountByAddress: int count, then count × (keccak hash, long slot count)
-///   8. codeHashRefcounts: int count, then count × (keccak hash, int refcount)
-///   9. codeHashSizes: int count, then count × (keccak hash, int size)
 /// Legacy snapshots (wrong version or pre-version schema) fail to decode with
 /// <see cref="RlpException"/> and are discarded by the plugin, which then
 /// triggers a fresh scan to rebuild the baseline with the new schema.
@@ -42,8 +41,6 @@ public sealed class StateCompositionSnapshotDecoder : RlpValueDecoder<StateCompo
     /// as missing and trigger a fresh scan.
     /// </summary>
     private const byte SchemaVersion = 1;
-
-    private delegate TValue DecodeValueDelegate<TValue>(ref Rlp.ValueDecoderContext ctx);
 
     public override void Encode(RlpStream stream, StateCompositionSnapshot item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
@@ -111,13 +108,6 @@ public sealed class StateCompositionSnapshotDecoder : RlpValueDecoder<StateCompo
         for (int i = 0; i < CumulativeTrieStats.SlotHistogramLength; i++)
             length += EncodeLong(stream, hist.IsDefault ? 0L : hist[i]);
 
-        length += EncodeOrLengthMap(stream, item.SlotCountByAddress,
-            static (s, v) => s.Encode(v), static v => Rlp.LengthOf(v));
-        length += EncodeOrLengthMap(stream, item.CodeHashRefcounts,
-            static (s, v) => s.Encode(v), static v => Rlp.LengthOf(v));
-        length += EncodeOrLengthMap(stream, item.CodeHashSizes,
-            static (s, v) => s.Encode(v), static v => Rlp.LengthOf(v));
-
         return length;
     }
 
@@ -131,39 +121,6 @@ public sealed class StateCompositionSnapshotDecoder : RlpValueDecoder<StateCompo
     {
         stream?.Encode(value);
         return Rlp.LengthOf(value);
-    }
-
-    private static int EncodeOrLengthMap<TValue>(
-        RlpStream? stream,
-        IReadOnlyDictionary<ValueHash256, TValue> map,
-        System.Action<RlpStream, TValue> encodeValue,
-        System.Func<TValue, int> lengthOfValue)
-    {
-        int total = EncodeInt(stream, map.Count);
-        foreach (KeyValuePair<ValueHash256, TValue> kvp in map)
-        {
-            if (stream is not null)
-            {
-                stream.Encode(new Hash256(kvp.Key));
-                encodeValue(stream, kvp.Value);
-            }
-            total += Rlp.LengthOfKeccakRlp + lengthOfValue(kvp.Value);
-        }
-        return total;
-    }
-
-    private static Dictionary<ValueHash256, TValue> DecodeMap<TValue>(
-        ref Rlp.ValueDecoderContext ctx,
-        DecodeValueDelegate<TValue> decodeValue)
-    {
-        int count = ctx.DecodePositiveInt();
-        Dictionary<ValueHash256, TValue> map = new(count);
-        for (int i = 0; i < count; i++)
-        {
-            ValueHash256 key = ctx.DecodeKeccak();
-            map[key] = decodeValue(ref ctx);
-        }
-        return map;
     }
 
     public override int GetLength(StateCompositionSnapshot item, RlpBehaviors rlpBehaviors = RlpBehaviors.None) => Rlp.LengthOfSequence(EncodeOrLength(null, item));
@@ -224,12 +181,8 @@ public sealed class StateCompositionSnapshotDecoder : RlpValueDecoder<StateCompo
             SlotCountHistogram = ImmutableArray.Create(hist),
         };
 
-        Dictionary<ValueHash256, long> slotCountByAddress = DecodeMap(ref ctx, static (ref c) => c.DecodeLong());
-        Dictionary<ValueHash256, int> codeHashRefcounts = DecodeMap(ref ctx, static (ref c) => c.DecodeInt());
-        Dictionary<ValueHash256, int> codeHashSizes = DecodeMap(ref ctx, static (ref c) => c.DecodeInt());
-
         return new StateCompositionSnapshot(
             stats, blockNumber, stateRoot, diffsSinceBaseline, scanBlockNumber, depthStats,
-            slotCountByAddress, codeHashRefcounts, codeHashSizes);
+            SlotCountByAddress: [], CodeHashRefcounts: [], CodeHashSizes: []);
     }
 }

--- a/src/Nethermind/Nethermind.StateComposition/Snapshots/StateCompositionSnapshotStore.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Snapshots/StateCompositionSnapshotStore.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using Autofac.Features.AttributeFilters;
+using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -14,14 +16,7 @@ using Nethermind.StateComposition.Data;
 
 namespace Nethermind.StateComposition.Snapshots;
 
-/// <summary>
-/// Persists <see cref="StateCompositionSnapshot"/> entries to a dedicated RocksDB database.
-/// Keys are 8-byte big-endian block numbers for natural sort order.
-/// A sentinel key stores the latest block number for O(1) lookup.
-/// </summary>
-internal sealed class StateCompositionSnapshotStore(
-    [KeyFilter("stateComposition")] IDb db,
-    ILogManager logManager)
+internal sealed class StateCompositionSnapshotStore
 {
     public const string DbName = "stateComposition";
 
@@ -30,22 +25,55 @@ internal sealed class StateCompositionSnapshotStore(
     // long.MaxValue big-endian: theoretical collision with a real block-number key
     // lands ~3.5 trillion years out at 12s blocks, so no schema migration needed.
     private static readonly byte[] LatestKey = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-    private readonly ILogger _logger = logManager.GetClassLogger<StateCompositionSnapshotStore>();
+
+    // The three tracker maps scale with the contract count (134M+ on mainnet,
+    // ~5 GB encoded) and would overflow the int-bounded RLP buffer if written as
+    // a single blob. They are written as fixed-width chunks under
+    // <blockNumber:8> || <kind:1> || <chunkIdx:4> = 13-byte composite keys,
+    // distinguished from the 8-byte main-snapshot key.
+    private const byte SlotCountKind = 0x01;
+    private const byte CodeRefcountKind = 0x02;
+    private const byte CodeSizeKind = 0x03;
+    private const int DefaultEntriesPerChunk = 1_000_000;
+    private const int MainKeyLength = 8;
+    private const int ChunkKeyLength = 13;
+
+    private readonly IDb _db;
+    private readonly int _entriesPerChunk;
+    private readonly ILogger _logger;
+
+    public StateCompositionSnapshotStore(
+        [KeyFilter("stateComposition")] IDb db,
+        ILogManager logManager)
+        : this(db, logManager, DefaultEntriesPerChunk)
+    {
+    }
+
+    internal StateCompositionSnapshotStore(IDb db, ILogManager logManager, int entriesPerChunk)
+    {
+        // Max entry size across both writer paths is 40 bytes (32-byte hash + 8-byte long);
+        // the 4-byte chunk-count prefix plus chunkCount * entrySize must fit in an int.
+        const int maxEntriesPerChunk = (int.MaxValue - 4) / 40;
+        if (entriesPerChunk <= 0 || entriesPerChunk > maxEntriesPerChunk)
+            throw new ArgumentOutOfRangeException(nameof(entriesPerChunk),
+                $"entriesPerChunk must be in (0, {maxEntriesPerChunk}]; got {entriesPerChunk}.");
+        _db = db;
+        _entriesPerChunk = entriesPerChunk;
+        _logger = logManager.GetClassLogger<StateCompositionSnapshotStore>();
+    }
 
     public void WriteSnapshot(StateCompositionSnapshot snapshot)
     {
-        // Write order: put new → update LatestKey → remove old. A crash after the
-        // put but before the LatestKey update leaves the old entry reachable via
-        // LatestKey, so the next boot's PurgeOldEntries keeps it and warm-restart
-        // still works. The reverse order (remove-first) would let PurgeOldEntries
-        // delete the freshly written snapshot because LatestKey still pointed at
-        // the already-removed old block.
+        // Write order: main blob → map chunks → LatestKey → purge old block. A
+        // crash anywhere before the LatestKey update leaves the previous block
+        // reachable; a crash after leaves the next boot's PurgeOldEntries to
+        // reconcile orphaned partial chunks.
         long prevBlock = long.MinValue;
-        byte[]? prevBytes = db.Get(LatestKey);
-        if (prevBytes is not null && prevBytes.Length >= 8)
+        byte[]? prevBytes = _db.Get(LatestKey);
+        if (prevBytes is not null && prevBytes.Length >= MainKeyLength)
             prevBlock = BinaryPrimitives.ReadInt64BigEndian(prevBytes);
 
-        Span<byte> key = stackalloc byte[8];
+        Span<byte> key = stackalloc byte[MainKeyLength];
         BinaryPrimitives.WriteInt64BigEndian(key, snapshot.BlockNumber);
 
         int length = Decoder.GetLength(snapshot);
@@ -54,40 +82,38 @@ internal sealed class StateCompositionSnapshotStore(
         {
             RlpStream stream = new(buffer);
             Decoder.Encode(stream, snapshot);
-            db.PutSpan(key, buffer.AsSpan(0, length));
+            _db.PutSpan(key, buffer.AsSpan(0, length));
         }
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
-        Span<byte> blockBytes = stackalloc byte[8];
+        WriteLongMap(snapshot.BlockNumber, SlotCountKind, snapshot.SlotCountByAddress);
+        WriteIntMap(snapshot.BlockNumber, CodeRefcountKind, snapshot.CodeHashRefcounts);
+        WriteIntMap(snapshot.BlockNumber, CodeSizeKind, snapshot.CodeHashSizes);
+
+        Span<byte> blockBytes = stackalloc byte[MainKeyLength];
         BinaryPrimitives.WriteInt64BigEndian(blockBytes, snapshot.BlockNumber);
-        db.PutSpan(LatestKey, blockBytes);
+        _db.PutSpan(LatestKey, blockBytes);
 
         if (prevBlock != long.MinValue && prevBlock != snapshot.BlockNumber)
-        {
-            Span<byte> prevKey = stackalloc byte[8];
-            BinaryPrimitives.WriteInt64BigEndian(prevKey, prevBlock);
-            db.Remove(prevKey);
-        }
+            RemoveBlockEntries(prevBlock);
     }
 
     public StateCompositionSnapshot? ReadSnapshot(long blockNumber)
     {
-        Span<byte> key = stackalloc byte[8];
+        Span<byte> key = stackalloc byte[MainKeyLength];
         BinaryPrimitives.WriteInt64BigEndian(key, blockNumber);
 
-        byte[]? data = db.Get(key);
+        byte[]? data = _db.Get(key);
         if (data is null) return null;
 
-        // Legacy snapshots from earlier schema versions will mis-align the decoder
-        // and throw. Log once and treat as "no snapshot" so the plugin falls back
-        // to a fresh scan — callers don't need to distinguish "missing" from "corrupt".
+        StateCompositionSnapshot snapshot;
         try
         {
             Rlp.ValueDecoderContext ctx = data.AsRlpValueContext();
-            return Decoder.Decode(ref ctx);
+            snapshot = Decoder.Decode(ref ctx);
         }
         catch (Exception ex) when (ex is RlpException or InvalidDataException or EndOfStreamException or IOException)
         {
@@ -96,12 +122,23 @@ internal sealed class StateCompositionSnapshotStore(
                              $"(reason: {ex.Message}). Falling back to a fresh scan to rebuild the cached baseline.");
             return null;
         }
+
+        Dictionary<ValueHash256, long> slotCounts = ReadLongMap(blockNumber, SlotCountKind);
+        Dictionary<ValueHash256, int> codeRefcounts = ReadIntMap(blockNumber, CodeRefcountKind);
+        Dictionary<ValueHash256, int> codeSizes = ReadIntMap(blockNumber, CodeSizeKind);
+
+        return snapshot with
+        {
+            SlotCountByAddress = slotCounts,
+            CodeHashRefcounts = codeRefcounts,
+            CodeHashSizes = codeSizes,
+        };
     }
 
     public StateCompositionSnapshot? ReadLatestSnapshot()
     {
-        byte[]? latestBytes = db.Get(LatestKey);
-        if (latestBytes is null || latestBytes.Length < 8) return null;
+        byte[]? latestBytes = _db.Get(LatestKey);
+        if (latestBytes is null || latestBytes.Length < MainKeyLength) return null;
 
         long latestBlock = BinaryPrimitives.ReadInt64BigEndian(latestBytes);
         return ReadSnapshot(latestBlock);
@@ -109,25 +146,198 @@ internal sealed class StateCompositionSnapshotStore(
 
     public void PurgeOldEntries()
     {
-        byte[]? latestBytes = db.Get(LatestKey);
+        byte[]? latestBytes = _db.Get(LatestKey);
         long latestBlock = -1;
-        if (latestBytes is not null && latestBytes.Length >= 8)
+        if (latestBytes is not null && latestBytes.Length >= MainKeyLength)
             latestBlock = BinaryPrimitives.ReadInt64BigEndian(latestBytes);
 
-        Span<byte> latestKey = stackalloc byte[8];
-        BinaryPrimitives.WriteInt64BigEndian(latestKey, latestBlock);
-
         int removed = 0;
-        foreach (byte[] key in db.GetAllKeys())
+        foreach (byte[] key in _db.GetAllKeys())
         {
-            if (key.AsSpan().SequenceEqual(LatestKey)) continue;
-            if (latestBlock >= 0 && key.AsSpan().SequenceEqual(latestKey)) continue;
+            ReadOnlySpan<byte> span = key;
+            if (span.SequenceEqual(LatestKey)) continue;
 
-            db.Remove(key);
+            long blockOfKey = (span.Length == MainKeyLength || span.Length == ChunkKeyLength)
+                ? BinaryPrimitives.ReadInt64BigEndian(span[..MainKeyLength])
+                : long.MinValue;
+
+            if (latestBlock >= 0 && blockOfKey == latestBlock) continue;
+
+            _db.Remove(key);
             removed++;
         }
 
         if (removed > 0 && _logger.IsInfo)
             _logger.Info($"StateComposition: purged {removed} old snapshot entries");
+    }
+
+    private void RemoveBlockEntries(long blockNumber)
+    {
+        Span<byte> mainKey = stackalloc byte[MainKeyLength];
+        BinaryPrimitives.WriteInt64BigEndian(mainKey, blockNumber);
+        _db.Remove(mainKey);
+
+        Span<byte> chunkKey = stackalloc byte[ChunkKeyLength];
+        BinaryPrimitives.WriteInt64BigEndian(chunkKey[..MainKeyLength], blockNumber);
+        foreach (byte kind in (ReadOnlySpan<byte>)[SlotCountKind, CodeRefcountKind, CodeSizeKind])
+        {
+            chunkKey[8] = kind;
+            int chunkIdx = 0;
+            while (true)
+            {
+                BinaryPrimitives.WriteInt32BigEndian(chunkKey[9..13], chunkIdx);
+                if (_db.Get(chunkKey) is null) break;
+                _db.Remove(chunkKey);
+                chunkIdx++;
+            }
+        }
+    }
+
+    private void WriteLongMap(long blockNumber, byte kind, IReadOnlyDictionary<ValueHash256, long> map)
+    {
+        if (map.Count == 0) return;
+
+        const int entrySize = 32 + 8;
+        using IEnumerator<KeyValuePair<ValueHash256, long>> entries = map.GetEnumerator();
+        WriteMap(blockNumber, kind, map.Count, entries, entrySize, static (kvp, dst) =>
+        {
+            kvp.Key.Bytes.CopyTo(dst);
+            BinaryPrimitives.WriteInt64BigEndian(dst[32..40], kvp.Value);
+        });
+    }
+
+    private void WriteIntMap(long blockNumber, byte kind, IReadOnlyDictionary<ValueHash256, int> map)
+    {
+        if (map.Count == 0) return;
+
+        const int entrySize = 32 + 4;
+        using IEnumerator<KeyValuePair<ValueHash256, int>> entries = map.GetEnumerator();
+        WriteMap(blockNumber, kind, map.Count, entries, entrySize, static (kvp, dst) =>
+        {
+            kvp.Key.Bytes.CopyTo(dst);
+            BinaryPrimitives.WriteInt32BigEndian(dst[32..36], kvp.Value);
+        });
+    }
+
+    private delegate void EntryWriter<TValue>(KeyValuePair<ValueHash256, TValue> kvp, Span<byte> dst);
+
+    private void WriteMap<TValue>(
+        long blockNumber,
+        byte kind,
+        int count,
+        IEnumerator<KeyValuePair<ValueHash256, TValue>> entries,
+        int entrySize,
+        EntryWriter<TValue> writeEntry)
+    {
+        Span<byte> chunkKey = stackalloc byte[ChunkKeyLength];
+        BinaryPrimitives.WriteInt64BigEndian(chunkKey[..MainKeyLength], blockNumber);
+        chunkKey[8] = kind;
+
+        int chunkIdx = 0;
+        int remaining = count;
+        while (remaining > 0)
+        {
+            int chunkCount = Math.Min(_entriesPerChunk, remaining);
+            int payloadLength = 4 + chunkCount * entrySize;
+            byte[] buf = ArrayPool<byte>.Shared.Rent(payloadLength);
+            try
+            {
+                BinaryPrimitives.WriteInt32BigEndian(buf.AsSpan(0, 4), chunkCount);
+                int pos = 4;
+                for (int i = 0; i < chunkCount; i++)
+                {
+                    if (!entries.MoveNext())
+                        throw new InvalidOperationException("StateComposition snapshot: dictionary mutated during persistence");
+                    writeEntry(entries.Current, buf.AsSpan(pos, entrySize));
+                    pos += entrySize;
+                }
+                BinaryPrimitives.WriteInt32BigEndian(chunkKey[9..13], chunkIdx);
+                _db.PutSpan(chunkKey, buf.AsSpan(0, payloadLength));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buf);
+            }
+            remaining -= chunkCount;
+            chunkIdx++;
+        }
+    }
+
+    private Dictionary<ValueHash256, long> ReadLongMap(long blockNumber, byte kind)
+    {
+        Dictionary<ValueHash256, long> result = [];
+        ReadMap(blockNumber, kind, 32 + 8, (entry, dict) =>
+        {
+            ValueHash256 hash = new(entry[..32]);
+            long value = BinaryPrimitives.ReadInt64BigEndian(entry[32..40]);
+            dict[hash] = value;
+        }, result);
+        return result;
+    }
+
+    private Dictionary<ValueHash256, int> ReadIntMap(long blockNumber, byte kind)
+    {
+        Dictionary<ValueHash256, int> result = [];
+        ReadMap(blockNumber, kind, 32 + 4, (entry, dict) =>
+        {
+            ValueHash256 hash = new(entry[..32]);
+            int value = BinaryPrimitives.ReadInt32BigEndian(entry[32..36]);
+            dict[hash] = value;
+        }, result);
+        return result;
+    }
+
+    private void ReadMap<TDict>(
+        long blockNumber,
+        byte kind,
+        int entrySize,
+        EntryReader<TDict> readEntry,
+        TDict dict)
+    {
+        Span<byte> chunkKey = stackalloc byte[ChunkKeyLength];
+        BinaryPrimitives.WriteInt64BigEndian(chunkKey[..MainKeyLength], blockNumber);
+        chunkKey[8] = kind;
+        int chunkIdx = 0;
+        while (true)
+        {
+            BinaryPrimitives.WriteInt32BigEndian(chunkKey[9..13], chunkIdx);
+            byte[]? data = _db.Get(chunkKey);
+            if (data is null) break;
+
+            // Disk-read boundary: validate the chunk-count prefix and the
+            // declared payload length before slicing, so a truncated or
+            // mid-read corrupted chunk degrades to "no more entries"
+            // instead of throwing ArgumentOutOfRangeException up the stack.
+            // Truncation mid-sequence (chunkIdx > 0) leaves a partially-loaded
+            // map; warn once so a follow-up rescan can be diagnosed and the
+            // discrepancy isn't silent.
+            if (data.Length < 4)
+            {
+                LogChunkTruncated(blockNumber, kind, chunkIdx);
+                break;
+            }
+            int chunkCount = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(0, 4));
+            if (chunkCount < 0 || data.Length < 4 + (long)chunkCount * entrySize)
+            {
+                LogChunkTruncated(blockNumber, kind, chunkIdx);
+                break;
+            }
+            int pos = 4;
+            for (int i = 0; i < chunkCount; i++)
+            {
+                readEntry(data.AsSpan(pos, entrySize), dict);
+                pos += entrySize;
+            }
+            chunkIdx++;
+        }
+    }
+
+    private delegate void EntryReader<TDict>(ReadOnlySpan<byte> entry, TDict dict);
+
+    private void LogChunkTruncated(long blockNumber, byte kind, int chunkIdx)
+    {
+        if (_logger.IsWarn)
+            _logger.Warn($"StateComposition: corrupt chunk {chunkIdx} for block {blockNumber} kind {kind:x2}; " +
+                         $"loaded {chunkIdx} valid chunk(s) before truncation. Plugin will rescan.");
     }
 }


### PR DESCRIPTION
## Changes

- `StateCompositionSnapshotStore.WriteSnapshot` previously RLP-encoded all three contract-keyed tracker maps (`SlotCountByAddress`, `CodeHashRefcounts`, `CodeHashSizes`) into a single int-bounded blob. On a baseline (~134M contracts) the encoded length wrapped negative and `ArrayPool.Rent` rejected it with `ArgumentOutOfRangeException`. The shutdown flush silently dropped the snapshot — next start logged "no persisted snapshot found" and paid a 2h+ bootstrap rescan.
- Move the three maps out of the RLP blob and write them as fixed-width chunks under composite keys `<blockNumber:8> + <kind:1> + <chunkIdx:4>` so each chunk's payload is bounded.
- Decoder hands back empty dictionaries; the store fills them by reading chunks. `PurgeOldEntries` sweeps both main and chunk keys for stale blocks.
- `ReadMap` length-guards a truncated chunk so a corrupt payload degrades to "no more entries" instead of throwing. Write-side `Dictionary` enumerators are wrapped in `using`. A `LogChunkTruncated` warn fires at `chunkIdx > 0` so operators can correlate the follow-up rescan with the corruption point.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New \`StateCompositionSnapshotStoreTests\`: chunked round-trip with maps larger than the chunk size; orphan-chunk purge; empty maps emit no chunks; truncated chunk degrades to empty maps without throwing; mid-sequence truncated chunk keeps prior entries. \`SnapshotRoundTripTests\` updated for the decoder-without-maps contract. End-to-end validated on a mainnet-forked archive bloatnet: persisted snapshot survives graceful restart.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No