### PR TITLE
StateComposition: route incremental diff through per-state resolvers

### DIFF
--- a/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Diff/TrieDiffWalkerTests.cs
@@ -74,7 +74,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
 
         using (Assert.EnterMultipleScope())
         {
@@ -117,7 +117,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
 
         // Same slot modified → net zero (leaf at same path means update, not add/remove)
         Assert.That(diff.NetStorageSlots, Is.Zero);
@@ -151,7 +151,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
 
         using (Assert.EnterMultipleScope())
         {
@@ -179,8 +179,8 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff forward = walker.ComputeDiff(root1, root2, resolver);
-        TrieDiff reverse = walker.ComputeDiff(root2, root1, resolver);
+        TrieDiff forward = walker.ComputeDiff(root1, root2, resolver, resolver);
+        TrieDiff reverse = walker.ComputeDiff(root2, root1, resolver, resolver);
 
         using (Assert.EnterMultipleScope())
         {
@@ -220,7 +220,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
         CumulativeTrieStats updated = cumulative.ApplyDiff(diff);
 
         using StateCompositionVisitor v2 = new(LimboLogs.Instance);
@@ -254,20 +254,20 @@ public class TrieDiffWalkerTests
         tree.Commit();
         tree.UpdateRootHash();
         Hash256 root2 = tree.RootHash;
-        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root1, root2, resolver));
+        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root1, root2, resolver, resolver));
 
         tree.Set(TestItem.AddressD, CreateContractNoStorage());
         tree.Set(TestItem.AddressA, CreateEOA(999));
         tree.Commit();
         tree.UpdateRootHash();
         Hash256 root3 = tree.RootHash;
-        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root2, root3, resolver));
+        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root2, root3, resolver, resolver));
 
         tree.Set(TestItem.AddressB, null);
         tree.Commit();
         tree.UpdateRootHash();
         Hash256 root4 = tree.RootHash;
-        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root3, root4, resolver));
+        cumulative = cumulative.ApplyDiff(walker.ComputeDiff(root3, root4, resolver, resolver));
 
         using StateCompositionVisitor v4 = new(LimboLogs.Instance);
         tree.Accept(v4, root4);
@@ -309,7 +309,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
         CumulativeTrieStats updated = cumulative.ApplyDiff(diff);
 
         using StateCompositionVisitor v2 = new(LimboLogs.Instance);
@@ -362,7 +362,7 @@ public class TrieDiffWalkerTests
 
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
-        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff diff = walker.ComputeDiff(root1, root2, resolver, resolver);
         CumulativeTrieStats updated = cumulative.ApplyDiff(diff);
 
         using StateCompositionVisitor v2 = new(LimboLogs.Instance);
@@ -515,7 +515,7 @@ public class TrieDiffWalkerTests
             TrieDiffWalker walker = new();
             for (int b = from; b < to; b++)
             {
-                TrieDiff diff = walker.ComputeDiff(roots[b], roots[b + 1], resolver);
+                TrieDiff diff = walker.ComputeDiff(roots[b], roots[b + 1], resolver, resolver);
                 cumulative = cumulative.ApplyDiff(diff);
             }
 
@@ -599,11 +599,11 @@ public class TrieDiffWalkerTests
         RawScopedTrieStore resolver = new(db);
         TrieDiffWalker walker = new();
 
-        TrieDiff forward = walker.ComputeDiff(root1, root2, resolver);
+        TrieDiff forward = walker.ComputeDiff(root1, root2, resolver, resolver);
         CumulativeTrieStats updated = baseline.ApplyDiff(forward);
 
         // Backward diff root2 → root1 (reorg rollback)
-        TrieDiff backward = walker.ComputeDiff(root2, root1, resolver);
+        TrieDiff backward = walker.ComputeDiff(root2, root1, resolver, resolver);
         CumulativeTrieStats final = updated.ApplyDiff(backward);
 
         using (Assert.EnterMultipleScope())
@@ -617,6 +617,81 @@ public class TrieDiffWalkerTests
             Assert.That(final.AccountTrieBytes, Is.EqualTo(baseline.AccountTrieBytes), "AccountTrieBytes");
             Assert.That(final.ContractsWithStorage, Is.EqualTo(baseline.ContractsWithStorage), "ContractsWithStorage");
             Assert.That(final.EmptyAccounts, Is.EqualTo(baseline.EmptyAccounts), "EmptyAccounts");
+        }
+    }
+
+    [Test]
+    public void DualResolver_OldNodesUnreachableViaNewResolver_DiffStillEmitsBytes()
+    {
+        MemDb oldDb = new();
+        StateTree oldTree = new(new RawScopedTrieStore(oldDb), LimboLogs.Instance);
+        oldTree.Set(TestItem.AddressA, CreateEOA(100));
+        oldTree.Commit();
+        oldTree.UpdateRootHash();
+        Hash256 oldRoot = oldTree.RootHash;
+
+        MemDb newDb = new();
+        StateTree newTree = new(new RawScopedTrieStore(newDb), LimboLogs.Instance);
+        newTree.Set(TestItem.AddressA, CreateEOA(100));
+        newTree.Set(TestItem.AddressB, CreateEOA(200));
+        newTree.Set(TestItem.AddressC, CreateEOA(300));
+        newTree.Commit();
+        newTree.UpdateRootHash();
+        Hash256 newRoot = newTree.RootHash;
+
+        RawScopedTrieStore oldResolver = new(oldDb);
+        RawScopedTrieStore newResolver = new(newDb);
+
+        TrieDiffWalker walker = new();
+        TrieDiff dual = walker.ComputeDiff(oldRoot, newRoot, oldResolver, newResolver);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(dual.AccountsAdded, Is.EqualTo(2),
+                "Dual resolver must observe both new EOAs even though oldDb lacks the new-side trie nodes.");
+            Assert.That(dual.AccountTrieLeavesAdded, Is.GreaterThanOrEqualTo(2));
+            Assert.That(dual.NetAccountTrieBytes, Is.GreaterThan(0),
+                "Net trie bytes must reflect real growth — the FlatDb scoping bug regresses this to zero.");
+        }
+    }
+
+    [Test]
+    public void DualResolver_StorageSubtree_PinsForStorageRoutingWithDisjointStores()
+    {
+        // Same FlatDb scoping bug regresses storage-side counters: a single resolver
+        // scoped on `new` cannot see `old`'s storage nodes, so storage diffs zero out.
+        // Companion to DualResolver_OldNodesUnreachableViaNewResolver_DiffStillEmitsBytes
+        // pinning the ForStorage(addressHash) routing through disjoint MemDbs.
+        MemDb oldDb = new();
+        Hash256 oldStorageRoot = CommitStorage(oldDb, TestItem.AddressA, (UInt256.Zero, [1]));
+        StateTree oldTree = new(new RawScopedTrieStore(oldDb), LimboLogs.Instance);
+        oldTree.Set(TestItem.AddressA, CreateContract(oldStorageRoot));
+        oldTree.Commit();
+        oldTree.UpdateRootHash();
+        Hash256 oldRoot = oldTree.RootHash;
+
+        MemDb newDb = new();
+        Hash256 newStorageRoot = CommitStorage(newDb, TestItem.AddressA,
+            (UInt256.Zero, [1]),
+            (UInt256.One, [2]));
+        StateTree newTree = new(new RawScopedTrieStore(newDb), LimboLogs.Instance);
+        newTree.Set(TestItem.AddressA, CreateContract(newStorageRoot));
+        newTree.Commit();
+        newTree.UpdateRootHash();
+        Hash256 newRoot = newTree.RootHash;
+
+        RawScopedTrieStore oldResolver = new(oldDb);
+        RawScopedTrieStore newResolver = new(newDb);
+
+        TrieDiffWalker walker = new();
+        TrieDiff dual = walker.ComputeDiff(oldRoot, newRoot, oldResolver, newResolver);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(dual.StorageSlotsAdded, Is.EqualTo(1),
+                "Slot 1 added on the new side; ForStorage must resolve new-side storage nodes via newResolver.");
+            Assert.That(dual.NetStorageTrieBytes, Is.GreaterThan(0),
+                "Storage trie bytes must reflect real growth — a single-resolver regression zeroes this out.");
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -17,6 +17,7 @@ using Nethermind.StateComposition.Service;
 using Nethermind.StateComposition.Snapshots;
 using Nethermind.StateComposition.Test.Helpers;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -195,6 +196,56 @@ public class StateCompositionServiceIncrementalRecoveryTests
         }
     }
 
+    [Test]
+    public void RunIncrementalDiff_OpensScopeOnHeadBeforeAcquiringResolver()
+    {
+        long diffErrorsBefore = Metrics.StateCompDiffErrors;
+
+        bool scopeOpened = false;
+        BlockHeader? scopedHeader = null;
+        IReadOnlyTrieStore readOnlyStore = Substitute.For<IReadOnlyTrieStore>();
+        readOnlyStore.BeginScope(Arg.Any<BlockHeader?>())
+            .Returns(call =>
+            {
+                scopeOpened = true;
+                scopedHeader = (BlockHeader?)call[0];
+                return Substitute.For<IDisposable>();
+            });
+        readOnlyStore.GetTrieStore(Arg.Any<Hash256?>())
+            .Returns(_ =>
+            {
+                if (!scopeOpened)
+                    throw new InvalidOperationException("BeginScope has not been called");
+                throw new BeginScopeSentinel();
+            });
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager.CreateReadOnlyTrieStore().Returns(readOnlyStore);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        StateCompositionStateHolder stateHolder = new();
+        SeedBaseline(stateHolder, blockNumber: 100, stateRoot: PrevRoot);
+
+        Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
+        blockTree.Head.Returns(headBlock);
+
+        using StateCompositionService service = new(
+            stateReader, worldStateManager, blockTree, stateHolder,
+            CreateSnapshotStore(), CreateConfig(), LimboLogs.Instance);
+
+        service.RunIncrementalDiff();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scopeOpened, Is.True,
+                "BeginScope must run before GetTrieStore — this is the FlatDb prerequisite.");
+            Assert.That(scopedHeader, Is.SameAs(headBlock.Header),
+                "BeginScope must be invoked with the head block header so the snapshot bundle covers the right state.");
+            Assert.That(Metrics.StateCompDiffErrors, Is.EqualTo(diffErrorsBefore + 1),
+                "BeginScopeSentinel propagates as a generic diff error — confirms the call site executed end-to-end.");
+        }
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string message)
     {
         using CancellationTokenSource cts = new(timeout);
@@ -210,4 +261,6 @@ public class StateCompositionServiceIncrementalRecoveryTests
             Assert.Fail(message);
         }
     }
+
+    private sealed class BeginScopeSentinel : Exception;
 }

--- a/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Service/StateCompositionServiceIncrementalRecoveryTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -81,6 +82,8 @@ public class StateCompositionServiceIncrementalRecoveryTests
 
         Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
         blockTree.Head.Returns(headBlock);
+        blockTree.FindHeader(100, Arg.Any<BlockTreeLookupOptions>())
+            .Returns(Build.A.BlockHeader.WithNumber(100).WithStateRoot(PrevRoot).TestObject);
 
         // Simulate pruned baseline: opening a read-only store for the diff throws
         // the exact exception TrieNode.ResolveNode raises when the root is gone.
@@ -138,6 +141,8 @@ public class StateCompositionServiceIncrementalRecoveryTests
 
         Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
         blockTree.Head.Returns(headBlock);
+        blockTree.FindHeader(100, Arg.Any<BlockTreeLookupOptions>())
+            .Returns(Build.A.BlockHeader.WithNumber(100).WithStateRoot(PrevRoot).TestObject);
 
         worldStateManager.CreateReadOnlyTrieStore()
             .Returns(_ => throw new InvalidOperationException("boom"));
@@ -197,24 +202,22 @@ public class StateCompositionServiceIncrementalRecoveryTests
     }
 
     [Test]
-    public void RunIncrementalDiff_OpensScopeOnHeadBeforeAcquiringResolver()
+    public void RunIncrementalDiff_OpensScopeOnBothPrevAndHeadBeforeAcquiringResolver()
     {
         long diffErrorsBefore = Metrics.StateCompDiffErrors;
 
-        bool scopeOpened = false;
-        BlockHeader? scopedHeader = null;
+        List<BlockHeader?> scopedHeaders = [];
         IReadOnlyTrieStore readOnlyStore = Substitute.For<IReadOnlyTrieStore>();
         readOnlyStore.BeginScope(Arg.Any<BlockHeader?>())
             .Returns(call =>
             {
-                scopeOpened = true;
-                scopedHeader = (BlockHeader?)call[0];
+                scopedHeaders.Add((BlockHeader?)call[0]);
                 return Substitute.For<IDisposable>();
             });
         readOnlyStore.GetTrieStore(Arg.Any<Hash256?>())
             .Returns(_ =>
             {
-                if (!scopeOpened)
+                if (scopedHeaders.Count == 0)
                     throw new InvalidOperationException("BeginScope has not been called");
                 throw new BeginScopeSentinel();
             });
@@ -227,7 +230,9 @@ public class StateCompositionServiceIncrementalRecoveryTests
         SeedBaseline(stateHolder, blockNumber: 100, stateRoot: PrevRoot);
 
         Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
+        BlockHeader prevHeader = Build.A.BlockHeader.WithNumber(100).WithStateRoot(PrevRoot).TestObject;
         blockTree.Head.Returns(headBlock);
+        blockTree.FindHeader(100, Arg.Any<BlockTreeLookupOptions>()).Returns(prevHeader);
 
         using StateCompositionService service = new(
             stateReader, worldStateManager, blockTree, stateHolder,
@@ -237,12 +242,45 @@ public class StateCompositionServiceIncrementalRecoveryTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(scopeOpened, Is.True,
-                "BeginScope must run before GetTrieStore — this is the FlatDb prerequisite.");
-            Assert.That(scopedHeader, Is.SameAs(headBlock.Header),
-                "BeginScope must be invoked with the head block header so the snapshot bundle covers the right state.");
+            Assert.That(scopedHeaders, Has.Count.EqualTo(2),
+                "Both prev and head must be scoped before any node resolution.");
+            Assert.That(scopedHeaders[0], Is.SameAs(prevHeader),
+                "Prev header must be scoped first so old-side reads land in the prev bundle.");
+            Assert.That(scopedHeaders[1], Is.SameAs(headBlock.Header),
+                "Head header must be scoped before the new-side resolver is acquired.");
             Assert.That(Metrics.StateCompDiffErrors, Is.EqualTo(diffErrorsBefore + 1),
                 "BeginScopeSentinel propagates as a generic diff error — confirms the call site executed end-to-end.");
+        }
+    }
+
+    [Test]
+    public void RunIncrementalDiff_PrevHeaderMissing_InvalidatesBaselineAndRescans()
+    {
+        long invalidationsBefore = Metrics.StateCompBaselineInvalidations;
+        long diffErrorsBefore = Metrics.StateCompDiffErrors;
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        StateCompositionStateHolder stateHolder = new();
+        SeedBaseline(stateHolder, blockNumber: 100, stateRoot: PrevRoot);
+
+        Block headBlock = Build.A.Block.WithNumber(101).WithStateRoot(NewRoot).TestObject;
+        blockTree.Head.Returns(headBlock);
+        blockTree.FindHeader(100, Arg.Any<BlockTreeLookupOptions>()).Returns((BlockHeader?)null);
+
+        using StateCompositionService service = new(
+            stateReader, worldStateManager, blockTree, stateHolder,
+            CreateSnapshotStore(), CreateConfig(), LimboLogs.Instance);
+
+        service.RunIncrementalDiff();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Metrics.StateCompBaselineInvalidations, Is.EqualTo(invalidationsBefore + 1),
+                "Missing prev header must invalidate the baseline.");
+            Assert.That(Metrics.StateCompDiffErrors, Is.EqualTo(diffErrorsBefore),
+                "Missing prev header is a recoverable condition; it must NOT count as a diff error.");
         }
     }
 

--- a/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Branches.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Branches.cs
@@ -11,7 +11,7 @@ namespace Nethermind.StateComposition.Diff;
 
 internal sealed partial class TrieDiffWalker
 {
-    private void DiffBranches(TrieNode oldBranch, TrieNode newBranch, ref TreePath path, ITrieNodeResolver resolver, bool isStorage, int depth)
+    private void DiffBranches(TrieNode oldBranch, TrieNode newBranch, ref TreePath path, ResolverPair resolvers, bool isStorage, int depth)
     {
         RecordNode(NodeType.Branch, oldBranch.FullRlp.Length, isStorage, added: false);
         RecordNode(NodeType.Branch, newBranch.FullRlp.Length, isStorage, added: true);
@@ -42,81 +42,82 @@ internal sealed partial class TrieDiffWalker
             int prevLen = path.Length;
             path.AppendMut(i);
             DiffBranchChild(oldBranch, newBranch, i, oldChildHash, newChildHash,
-                oldIsNull, newIsNull, ref path, resolver, isStorage, childDepth);
+                oldIsNull, newIsNull, ref path, resolvers, isStorage, childDepth);
             path.TruncateMut(prevLen);
         }
     }
 
     private void DiffBranchChild(TrieNode oldBranch, TrieNode newBranch, int i,
         Hash256? oldChildHash, Hash256? newChildHash, bool oldIsNull, bool newIsNull,
-        ref TreePath path, ITrieNodeResolver resolver, bool isStorage, int childDepth)
+        ref TreePath path, ResolverPair resolvers, bool isStorage, int childDepth)
     {
         if (oldChildHash is not null && newChildHash is not null)
         {
-            DiffSubtree(oldChildHash, newChildHash, ref path, resolver, isStorage, childDepth);
+            DiffSubtree(oldChildHash, newChildHash, ref path, resolvers, isStorage, childDepth);
             return;
         }
 
         if (oldIsNull)
         {
-            CollectBranchSlotSide(newBranch, i, newChildHash, ref path, resolver, isStorage, added: true, childDepth);
+            CollectBranchSlotSide(newBranch, i, newChildHash, ref path, resolvers, isStorage, added: true, childDepth);
             return;
         }
 
         if (newIsNull)
         {
-            CollectBranchSlotSide(oldBranch, i, oldChildHash, ref path, resolver, isStorage, added: false, childDepth);
+            CollectBranchSlotSide(oldBranch, i, oldChildHash, ref path, resolvers, isStorage, added: false, childDepth);
             return;
         }
 
-        TrieNode? oldChild = oldBranch.GetChildWithChildPath(resolver, ref path, i);
-        TrieNode? newChild = newBranch.GetChildWithChildPath(resolver, ref path, i);
+        TrieNode? oldChild = oldBranch.GetChildWithChildPath(resolvers.Old, ref path, i);
+        TrieNode? newChild = newBranch.GetChildWithChildPath(resolvers.New, ref path, i);
 
         if (oldChild is not null && newChild is not null)
         {
-            oldChild.ResolveNode(resolver, in path);
-            newChild.ResolveNode(resolver, in path);
-            DiffNodes(oldChild, newChild, ref path, resolver, isStorage, childDepth);
+            oldChild.ResolveNode(resolvers.Old, in path);
+            newChild.ResolveNode(resolvers.New, in path);
+            DiffNodes(oldChild, newChild, ref path, resolvers, isStorage, childDepth);
         }
         else if (oldChild is not null)
         {
-            oldChild.ResolveNode(resolver, in path);
-            CollectSubtree(oldChild, ref path, resolver, isStorage, added: false, childDepth);
+            oldChild.ResolveNode(resolvers.Old, in path);
+            CollectSubtree(oldChild, ref path, resolvers, isStorage, added: false, childDepth);
         }
         else if (newChild is not null)
         {
-            newChild.ResolveNode(resolver, in path);
-            CollectSubtree(newChild, ref path, resolver, isStorage, added: true, childDepth);
+            newChild.ResolveNode(resolvers.New, in path);
+            CollectSubtree(newChild, ref path, resolvers, isStorage, added: true, childDepth);
         }
     }
 
     private void CollectBranchSlotSide(TrieNode branch, int i, Hash256? childHash,
-        ref TreePath path, ITrieNodeResolver resolver, bool isStorage, bool added, int childDepth)
+        ref TreePath path, ResolverPair resolvers, bool isStorage, bool added, int childDepth)
     {
+        ITrieNodeResolver side = resolvers.Pick(added);
         if (childHash is not null)
         {
-            TrieNode child = resolver.FindCachedOrUnknown(in path, childHash);
-            child.ResolveNode(resolver, in path);
-            CollectSubtree(child, ref path, resolver, isStorage, added, childDepth);
+            TrieNode child = side.FindCachedOrUnknown(in path, childHash);
+            child.ResolveNode(side, in path);
+            CollectSubtree(child, ref path, resolvers, isStorage, added, childDepth);
             return;
         }
 
-        TrieNode? inlineChild = branch.GetChildWithChildPath(resolver, ref path, i);
+        TrieNode? inlineChild = branch.GetChildWithChildPath(side, ref path, i);
         if (inlineChild is not null)
         {
-            inlineChild.ResolveNode(resolver, in path);
-            CollectSubtree(inlineChild, ref path, resolver, isStorage, added, childDepth);
+            inlineChild.ResolveNode(side, in path);
+            CollectSubtree(inlineChild, ref path, resolvers, isStorage, added, childDepth);
         }
     }
 
     private void DiffMismatchedNodes(TrieNode oldNode, TrieNode newNode, ref TreePath path,
-        ITrieNodeResolver resolver, bool isStorage, int depth)
+        ResolverPair resolvers, bool isStorage, int depth)
     {
         Dictionary<ValueHash256, (TrieNode Leaf, TreePath Path)> oldLeaves = [];
         Dictionary<ValueHash256, (TrieNode Leaf, TreePath Path)> newLeaves = [];
 
-        CollectSubtreeForDiff(oldNode, ref path, resolver, isStorage, added: false, oldLeaves, depth);
-        CollectSubtreeForDiff(newNode, ref path, resolver, isStorage, added: true, newLeaves, depth);
+        CollectSubtreeForDiff(oldNode, ref path, resolvers, isStorage, added: false, oldLeaves, depth);
+        CollectSubtreeForDiff(newNode, ref path, resolvers, isStorage, added: true, newLeaves, depth);
 
         foreach (KeyValuePair<ValueHash256, (TrieNode Leaf, TreePath Path)> kvp in newLeaves)
         {
@@ -128,13 +129,13 @@ internal sealed partial class TrieDiffWalker
                 if (!isStorage)
                 {
                     TreePath leafPath = oldEntry.Path;
-                    DecodeAndDiffAccountLeaves(oldEntry.Leaf, newLeaf, ref leafPath);
+                    DecodeAndDiffAccountLeaves(oldEntry.Leaf, newLeaf, ref leafPath, resolvers);
                 }
             }
             else
             {
                 TreePath leafPath = newLeafPath;
-                CollectLeaf(newLeaf, ref leafPath, added: true, isStorage);
+                CollectLeaf(newLeaf, ref leafPath, added: true, isStorage, resolvers);
             }
         }
 
@@ -142,7 +143,7 @@ internal sealed partial class TrieDiffWalker
         {
             (TrieNode oldLeaf, TreePath oldLeafPath) = kvp.Value;
             TreePath leafPath = oldLeafPath;
-            CollectLeaf(oldLeaf, ref leafPath, added: false, isStorage);
+            CollectLeaf(oldLeaf, ref leafPath, added: false, isStorage, resolvers);
         }
     }
 }

--- a/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Collection.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Collection.cs
@@ -16,18 +16,18 @@ internal sealed partial class TrieDiffWalker
 {
     private interface ILeafHandler
     {
-        void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage);
+        void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage, ResolverPair resolvers);
     }
 
     private struct SemanticLeafHandler(TrieDiffWalker walker) : ILeafHandler
     {
-        public readonly void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage)
-            => walker.CollectLeaf(leaf, ref path, added, isStorage);
+        public readonly void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage, ResolverPair resolvers)
+            => walker.CollectLeaf(leaf, ref path, added, isStorage, resolvers);
     }
 
     private struct DictionaryLeafHandler(Dictionary<ValueHash256, (TrieNode Leaf, TreePath Path)> leaves) : ILeafHandler
     {
-        public readonly void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage)
+        public readonly void Handle(TrieNode leaf, ref TreePath path, bool added, bool isStorage, ResolverPair resolvers)
         {
             TreePath pathAtLeaf = path;
             int prevLen = path.Length;
@@ -38,10 +38,11 @@ internal sealed partial class TrieDiffWalker
         }
     }
 
-    private void WalkStructure<TH>(TrieNode node, ref TreePath path, ITrieNodeResolver resolver,
+    private void WalkStructure<TH>(TrieNode node, ref TreePath path, ResolverPair resolvers,
         bool isStorage, bool added, int depth, ref TH leafHandler)
         where TH : struct, ILeafHandler
     {
+        ITrieNodeResolver side = resolvers.Pick(added);
         RecordNode(node.NodeType, node.FullRlp.Length, isStorage, added);
 
         if (trackDepth)
@@ -74,20 +75,20 @@ internal sealed partial class TrieDiffWalker
                         {
                             int prevLen = path.Length;
                             path.AppendMut(i);
-                            TrieNode child = resolver.FindCachedOrUnknown(in path, childHash);
-                            child.ResolveNode(resolver, in path);
-                            WalkStructure(child, ref path, resolver, isStorage, added, childDepth, ref leafHandler);
+                            TrieNode child = side.FindCachedOrUnknown(in path, childHash);
+                            child.ResolveNode(side, in path);
+                            WalkStructure(child, ref path, resolvers, isStorage, added, childDepth, ref leafHandler);
                             path.TruncateMut(prevLen);
                         }
                         else if (!node.IsChildNull(i))
                         {
                             int prevLen = path.Length;
                             path.AppendMut(i);
-                            TrieNode? child = node.GetChildWithChildPath(resolver, ref path, i);
+                            TrieNode? child = node.GetChildWithChildPath(side, ref path, i);
                             if (child is not null)
                             {
-                                child.ResolveNode(resolver, in path);
-                                WalkStructure(child, ref path, resolver, isStorage, added, childDepth, ref leafHandler);
+                                child.ResolveNode(side, in path);
+                                WalkStructure(child, ref path, resolvers, isStorage, added, childDepth, ref leafHandler);
                             }
                             path.TruncateMut(prevLen);
                         }
@@ -105,18 +106,18 @@ internal sealed partial class TrieDiffWalker
 
                     if (childHash is not null)
                     {
-                        TrieNode child = resolver.FindCachedOrUnknown(in path, childHash);
-                        child.ResolveNode(resolver, in path);
-                        WalkStructure(child, ref path, resolver, isStorage, added, childDepth, ref leafHandler);
+                        TrieNode child = side.FindCachedOrUnknown(in path, childHash);
+                        child.ResolveNode(side, in path);
+                        WalkStructure(child, ref path, resolvers, isStorage, added, childDepth, ref leafHandler);
                     }
                     else
                     {
                         TreePath childPath = path;
-                        TrieNode? child = node.GetChildWithChildPath(resolver, ref childPath, 0);
+                        TrieNode? child = node.GetChildWithChildPath(side, ref childPath, 0);
                         if (child is not null)
                         {
-                            child.ResolveNode(resolver, in path);
-                            WalkStructure(child, ref path, resolver, isStorage, added, childDepth, ref leafHandler);
+                            child.ResolveNode(side, in path);
+                            WalkStructure(child, ref path, resolvers, isStorage, added, childDepth, ref leafHandler);
                         }
                     }
 
@@ -125,25 +126,25 @@ internal sealed partial class TrieDiffWalker
                 }
 
             case NodeType.Leaf:
-                leafHandler.Handle(node, ref path, added, isStorage);
+                leafHandler.Handle(node, ref path, added, isStorage, resolvers);
                 break;
         }
     }
 
-    private void CollectSubtree(TrieNode node, ref TreePath path, ITrieNodeResolver resolver, bool isStorage, bool added, int depth)
+    private void CollectSubtree(TrieNode node, ref TreePath path, ResolverPair resolvers, bool isStorage, bool added, int depth)
     {
         SemanticLeafHandler handler = new(this);
-        WalkStructure(node, ref path, resolver, isStorage, added, depth, ref handler);
+        WalkStructure(node, ref path, resolvers, isStorage, added, depth, ref handler);
     }
 
-    private void CollectSubtreeForDiff(TrieNode node, ref TreePath path, ITrieNodeResolver resolver,
+    private void CollectSubtreeForDiff(TrieNode node, ref TreePath path, ResolverPair resolvers,
         bool isStorage, bool added, Dictionary<ValueHash256, (TrieNode Leaf, TreePath Path)> leaves, int depth)
     {
         DictionaryLeafHandler handler = new(leaves);
-        WalkStructure(node, ref path, resolver, isStorage, added, depth, ref handler);
+        WalkStructure(node, ref path, resolvers, isStorage, added, depth, ref handler);
     }
 
-    private void CollectLeaf(TrieNode leaf, ref TreePath path, bool added, bool isStorage)
+    private void CollectLeaf(TrieNode leaf, ref TreePath path, bool added, bool isStorage, ResolverPair resolvers)
     {
         if (isStorage)
         {
@@ -203,17 +204,18 @@ internal sealed partial class TrieDiffWalker
 
         if (account.HasStorage)
         {
-            ITrieNodeResolver storageResolver = _rootResolver.GetStorageTrieNodeResolver(addressHash);
+            ResolverPair storageResolvers = resolvers.ForStorage(addressHash);
+            ITrieNodeResolver storageSide = storageResolvers.Pick(added);
             TreePath storagePath = TreePath.Empty;
             Hash256 storageRoot = new(account.StorageRoot);
 
-            TrieNode storageRootNode = storageResolver.FindCachedOrUnknown(in storagePath, storageRoot);
-            storageRootNode.ResolveNode(storageResolver, in storagePath);
+            TrieNode storageRootNode = storageSide.FindCachedOrUnknown(in storagePath, storageRoot);
+            storageRootNode.ResolveNode(storageSide, in storagePath);
 
             BeginContractStorage(addressHash.ValueHash256);
             try
             {
-                CollectSubtree(storageRootNode, ref storagePath, storageResolver, isStorage: true, added, depth: 0);
+                CollectSubtree(storageRootNode, ref storagePath, storageResolvers, isStorage: true, added, depth: 0);
             }
             finally
             {

--- a/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Extensions.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Extensions.cs
@@ -4,13 +4,12 @@
 using System;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.StateComposition.Diff;
 
 internal sealed partial class TrieDiffWalker
 {
-    private void DiffExtensions(TrieNode oldExt, TrieNode newExt, ref TreePath path, ITrieNodeResolver resolver, bool isStorage, int depth)
+    private void DiffExtensions(TrieNode oldExt, TrieNode newExt, ref TreePath path, ResolverPair resolvers, bool isStorage, int depth)
     {
         byte[]? oldKey = oldExt.Key;
         byte[]? newKey = newExt.Key;
@@ -39,30 +38,30 @@ internal sealed partial class TrieDiffWalker
 
             if (oldChildHash is not null && newChildHash is not null)
             {
-                DiffSubtree(oldChildHash, newChildHash, ref path, resolver, isStorage, childDepth);
+                DiffSubtree(oldChildHash, newChildHash, ref path, resolvers, isStorage, childDepth);
             }
             else
             {
                 TreePath oldChildPath = path;
-                TrieNode? oldChild = oldExt.GetChildWithChildPath(resolver, ref oldChildPath, 0);
+                TrieNode? oldChild = oldExt.GetChildWithChildPath(resolvers.Old, ref oldChildPath, 0);
                 TreePath newChildPath = path;
-                TrieNode? newChild = newExt.GetChildWithChildPath(resolver, ref newChildPath, 0);
+                TrieNode? newChild = newExt.GetChildWithChildPath(resolvers.New, ref newChildPath, 0);
 
                 if (oldChild is not null && newChild is not null)
                 {
-                    oldChild.ResolveNode(resolver, in path);
-                    newChild.ResolveNode(resolver, in path);
-                    DiffNodes(oldChild, newChild, ref path, resolver, isStorage, childDepth);
+                    oldChild.ResolveNode(resolvers.Old, in path);
+                    newChild.ResolveNode(resolvers.New, in path);
+                    DiffNodes(oldChild, newChild, ref path, resolvers, isStorage, childDepth);
                 }
                 else if (oldChild is not null)
                 {
-                    oldChild.ResolveNode(resolver, in path);
-                    CollectSubtree(oldChild, ref path, resolver, isStorage, added: false, childDepth);
+                    oldChild.ResolveNode(resolvers.Old, in path);
+                    CollectSubtree(oldChild, ref path, resolvers, isStorage, added: false, childDepth);
                 }
                 else if (newChild is not null)
                 {
-                    newChild.ResolveNode(resolver, in path);
-                    CollectSubtree(newChild, ref path, resolver, isStorage, added: true, childDepth);
+                    newChild.ResolveNode(resolvers.New, in path);
+                    CollectSubtree(newChild, ref path, resolvers, isStorage, added: true, childDepth);
                 }
             }
 
@@ -74,7 +73,7 @@ internal sealed partial class TrieDiffWalker
             // Use DiffMismatchedNodes to match shared leaves by path instead of independently
             // collecting both subtrees, which would emit spurious CodeHashChange / SlotCountChange
             // events for leaves that exist on both sides.
-            DiffMismatchedNodes(oldExt, newExt, ref path, resolver, isStorage, depth);
+            DiffMismatchedNodes(oldExt, newExt, ref path, resolvers, isStorage, depth);
         }
     }
 }

--- a/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Leaves.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.Leaves.cs
@@ -7,13 +7,12 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.StateComposition.Diff;
 
 internal sealed partial class TrieDiffWalker
 {
-    private void DiffLeaves(TrieNode oldLeaf, TrieNode newLeaf, ref TreePath path, bool isStorage, int depth)
+    private void DiffLeaves(TrieNode oldLeaf, TrieNode newLeaf, ref TreePath path, ResolverPair resolvers, bool isStorage, int depth)
     {
         RecordNode(NodeType.Leaf, oldLeaf.FullRlp.Length, isStorage, added: false);
         RecordNode(NodeType.Leaf, newLeaf.FullRlp.Length, isStorage, added: true);
@@ -30,10 +29,10 @@ internal sealed partial class TrieDiffWalker
             return;
         }
 
-        DecodeAndDiffAccountLeaves(oldLeaf, newLeaf, ref path);
+        DecodeAndDiffAccountLeaves(oldLeaf, newLeaf, ref path, resolvers);
     }
 
-    private void DecodeAndDiffAccountLeaves(TrieNode oldLeaf, TrieNode newLeaf, ref TreePath path)
+    private void DecodeAndDiffAccountLeaves(TrieNode oldLeaf, TrieNode newLeaf, ref TreePath path, ResolverPair resolvers)
     {
         if (!TryDecodeAccount(oldLeaf, out AccountStruct oldAccount) ||
             !TryDecodeAccount(newLeaf, out AccountStruct newAccount))
@@ -65,13 +64,13 @@ internal sealed partial class TrieDiffWalker
         Hash256? normalizedOldStorage = oldAccount.HasStorage ? new Hash256(oldAccount.StorageRoot) : null;
         Hash256? normalizedNewStorage = newAccount.HasStorage ? new Hash256(newAccount.StorageRoot) : null;
 
-        ITrieNodeResolver storageResolver = _rootResolver.GetStorageTrieNodeResolver(addressHash);
+        ResolverPair storageResolvers = resolvers.ForStorage(addressHash);
         TreePath storagePath = TreePath.Empty;
 
         BeginContractStorage(addressHash.ValueHash256);
         try
         {
-            DiffSubtree(normalizedOldStorage, normalizedNewStorage, ref storagePath, storageResolver, isStorage: true, depth: 0);
+            DiffSubtree(normalizedOldStorage, normalizedNewStorage, ref storagePath, storageResolvers, isStorage: true, depth: 0);
         }
         finally
         {

--- a/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Diff/TrieDiffWalker.cs
@@ -19,7 +19,16 @@ internal sealed partial class TrieDiffWalker(bool trackDepth = false)
     private readonly List<SlotCountChange> _slotCountChanges = [];
     private readonly List<CodeHashChange> _codeHashChanges = [];
 
-    private ITrieNodeResolver _rootResolver = null!;
+    // Old and new state share neither node hashes nor — under FlatDb — a single
+    // snapshot bundle. Each side resolves nodes through its own scoped store so a
+    // diff walker scoped on the new head can still descend the previous root's
+    // disjoint subtrees instead of treating them as Unknown.
+    private readonly record struct ResolverPair(ITrieNodeResolver Old, ITrieNodeResolver New)
+    {
+        public ITrieNodeResolver Pick(bool added) => added ? New : Old;
+        public ResolverPair ForStorage(Hash256? address) =>
+            new(Old.GetStorageTrieNodeResolver(address), New.GetStorageTrieNodeResolver(address));
+    }
 
     // Active contract context for per-account slot tracking.
     // Set by BeginContractStorage / cleared by EndContractStorage around every
@@ -48,9 +57,10 @@ internal sealed partial class TrieDiffWalker(bool trackDepth = false)
     private int _contractsWithStorageAdded, _contractsWithStorageRemoved;
     private int _emptyAccountsAdded, _emptyAccountsRemoved;
 
-    public TrieDiff ComputeDiff(Hash256? oldRoot, Hash256? newRoot, ITrieNodeResolver rootResolver)
+    public TrieDiff ComputeDiff(Hash256? oldRoot, Hash256? newRoot,
+        ITrieNodeResolver oldResolver, ITrieNodeResolver newResolver)
     {
-        _rootResolver = rootResolver;
+        ResolverPair resolvers = new(oldResolver, newResolver);
         ResetCounters();
         if (trackDepth) _depthDelta.Reset();
 
@@ -60,7 +70,7 @@ internal sealed partial class TrieDiffWalker(bool trackDepth = false)
         if (oldHash == newHash) return TrieDiff.Empty;
 
         TreePath path = TreePath.Empty;
-        DiffSubtree(oldHash, newHash, ref path, _rootResolver, isStorage: false, depth: 0);
+        DiffSubtree(oldHash, newHash, ref path, resolvers, isStorage: false, depth: 0);
 
         return new TrieDiff(
             _accountsAdded, _accountsRemoved,
@@ -112,35 +122,35 @@ internal sealed partial class TrieDiffWalker(bool trackDepth = false)
         _codeHashChanges.Add(new CodeHashChange(addressHash, oldNormalized, newNormalized));
     }
 
-    private void DiffSubtree(Hash256? oldHash, Hash256? newHash, ref TreePath path, ITrieNodeResolver resolver, bool isStorage, int depth)
+    private void DiffSubtree(Hash256? oldHash, Hash256? newHash, ref TreePath path, ResolverPair resolvers, bool isStorage, int depth)
     {
         if (oldHash == newHash) return;
 
         if (oldHash is null)
         {
-            TrieNode newNode = resolver.FindCachedOrUnknown(in path, newHash!);
-            newNode.ResolveNode(resolver, in path);
-            CollectSubtree(newNode, ref path, resolver, isStorage, added: true, depth: depth);
+            TrieNode newNode = resolvers.New.FindCachedOrUnknown(in path, newHash!);
+            newNode.ResolveNode(resolvers.New, in path);
+            CollectSubtree(newNode, ref path, resolvers, isStorage, added: true, depth: depth);
             return;
         }
 
         if (newHash is null)
         {
-            TrieNode oldNode = resolver.FindCachedOrUnknown(in path, oldHash);
-            oldNode.ResolveNode(resolver, in path);
-            CollectSubtree(oldNode, ref path, resolver, isStorage, added: false, depth: depth);
+            TrieNode oldNode = resolvers.Old.FindCachedOrUnknown(in path, oldHash);
+            oldNode.ResolveNode(resolvers.Old, in path);
+            CollectSubtree(oldNode, ref path, resolvers, isStorage, added: false, depth: depth);
             return;
         }
 
-        TrieNode oldResolved = resolver.FindCachedOrUnknown(in path, oldHash);
-        oldResolved.ResolveNode(resolver, in path);
-        TrieNode newResolved = resolver.FindCachedOrUnknown(in path, newHash);
-        newResolved.ResolveNode(resolver, in path);
+        TrieNode oldResolved = resolvers.Old.FindCachedOrUnknown(in path, oldHash);
+        oldResolved.ResolveNode(resolvers.Old, in path);
+        TrieNode newResolved = resolvers.New.FindCachedOrUnknown(in path, newHash);
+        newResolved.ResolveNode(resolvers.New, in path);
 
-        DiffNodes(oldResolved, newResolved, ref path, resolver, isStorage, depth);
+        DiffNodes(oldResolved, newResolved, ref path, resolvers, isStorage, depth);
     }
 
-    private void DiffNodes(TrieNode oldNode, TrieNode newNode, ref TreePath path, ITrieNodeResolver resolver, bool isStorage, int depth)
+    private void DiffNodes(TrieNode oldNode, TrieNode newNode, ref TreePath path, ResolverPair resolvers, bool isStorage, int depth)
     {
         if (oldNode.NodeType != newNode.NodeType)
         {
@@ -148,20 +158,20 @@ internal sealed partial class TrieDiffWalker(bool trackDepth = false)
             // Can't just collect both subtrees independently — that would double-count
             // accounts/contracts/slots that exist in both. Instead, enumerate leaves
             // from both sides, match by full path, and diff semantically.
-            DiffMismatchedNodes(oldNode, newNode, ref path, resolver, isStorage, depth);
+            DiffMismatchedNodes(oldNode, newNode, ref path, resolvers, isStorage, depth);
             return;
         }
 
         switch (oldNode.NodeType)
         {
             case NodeType.Branch:
-                DiffBranches(oldNode, newNode, ref path, resolver, isStorage, depth);
+                DiffBranches(oldNode, newNode, ref path, resolvers, isStorage, depth);
                 break;
             case NodeType.Extension:
-                DiffExtensions(oldNode, newNode, ref path, resolver, isStorage, depth);
+                DiffExtensions(oldNode, newNode, ref path, resolvers, isStorage, depth);
                 break;
             case NodeType.Leaf:
-                DiffLeaves(oldNode, newNode, ref path, isStorage, depth);
+                DiffLeaves(oldNode, newNode, ref path, resolvers, isStorage, depth);
                 break;
         }
     }

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
@@ -54,11 +55,32 @@ internal sealed partial class StateCompositionService
             head = _blockTree.Head;
             if (head?.Header.StateRoot is null || prevRoot == Hash256.Zero || head.Header.StateRoot == prevRoot) return;
 
-            using IReadOnlyTrieStore readOnlyStore = _worldStateManager.CreateReadOnlyTrieStore();
-            using IDisposable scope = readOnlyStore.BeginScope(head.Header);
-            IScopedTrieStore resolver = readOnlyStore.GetTrieStore(null);
+            BlockHeader? prevHeader = _blockTree.FindHeader(_stateHolder.IncrementalBlock, BlockTreeLookupOptions.RequireCanonical);
+            if (prevHeader is null)
+            {
+                Metrics.StateCompBaselineInvalidations++;
+                _stateHolder.InvalidateBaseline();
+                if (_logger.IsWarn)
+                    _logger.Warn(
+                        $"StateComposition: baseline header at block {_stateHolder.IncrementalBlock} no longer canonical " +
+                        $"(prevRoot={prevRoot}); invalidated baseline and scheduling a full rescan.");
+                ScheduleBaselineRescan(head);
+                return;
+            }
 
-            TrieDiff diff = _diffWalker.ComputeDiff(prevRoot, head.Header.StateRoot, resolver);
+            // Diffing across two state roots needs each side resolved against
+            // its own scope: under FlatDb, `BeginScope` only materialises the
+            // bundle for one block, so a single resolver makes the other
+            // side's nodes look Unknown and silently zeroes the diff.
+
+            using IReadOnlyTrieStore oldStore = _worldStateManager.CreateReadOnlyTrieStore();
+            using IDisposable oldScope = oldStore.BeginScope(prevHeader);
+            using IReadOnlyTrieStore newStore = _worldStateManager.CreateReadOnlyTrieStore();
+            using IDisposable newScope = newStore.BeginScope(head.Header);
+            IScopedTrieStore oldResolver = oldStore.GetTrieStore(null);
+            IScopedTrieStore newResolver = newStore.GetTrieStore(null);
+
+            TrieDiff diff = _diffWalker.ComputeDiff(prevRoot, head.Header.StateRoot, oldResolver, newResolver);
             // Size-lookup lambda is invoked once per newly-observed code hash,
             // not per reference, so cost stays bounded by distinct new hashes.
             CumulativeTrieStats updated = _stateHolder.ApplyIncrementalDiffAndUpdate(

--- a/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Service/StateCompositionService.Incremental.cs
@@ -55,6 +55,7 @@ internal sealed partial class StateCompositionService
             if (head?.Header.StateRoot is null || prevRoot == Hash256.Zero || head.Header.StateRoot == prevRoot) return;
 
             using IReadOnlyTrieStore readOnlyStore = _worldStateManager.CreateReadOnlyTrieStore();
+            using IDisposable scope = readOnlyStore.BeginScope(head.Header);
             IScopedTrieStore resolver = readOnlyStore.GetTrieStore(null);
 
             TrieDiff diff = _diffWalker.ComputeDiff(prevRoot, head.Header.StateRoot, resolver);


### PR DESCRIPTION
> Stacks on top of #11585 (PR-1). Please review that first; this PR's diff against `master` includes the BeginScope commit.

## Changes

- After PR-1's `BeginScope` fix, `TrieDiffWalker` still resolved both old and new sides through the same scope. Under FlatDb the head bundle returns `Unknown` for the prev-root nodes, leaf decode silently fails, and `ComputeDiff` returns a zero-byte `TrieDiff` — `accountTrieBytes` never moves past the bootstrap baseline.
- Open two `IReadOnlyTrieStore` instances; scope each on its own header (`prevHeader` via `IBlockTree.FindHeader(IncrementalBlock)`, `headBlock.Header`); thread both resolvers through `TrieDiffWalker` via a new `ResolverPair` value type. Storage-trie traversals derive a per-contract pair via `ForStorage(addressHash)`.
- `ComputeDiff` is single-signature `(oldRoot, newRoot, oldResolver, newResolver)`. The transitional single-resolver overload and the `_resolvers` instance field are removed — the leaf-handler interface takes the `ResolverPair` so `CollectLeaf` derives its storage resolvers without an out-of-band field.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- \`TrieDiffWalkerTests.DualResolver_OldNodesUnreachableViaNewResolver_DiffStillEmitsBytes\` — disjoint per-state \`MemDb\`s prove the dual-resolver path resolves prev nodes against the prev-side store; the legacy single-resolver setup silently zeroes out.
- \`RunIncrementalDiff_OpensScopeOnBothPrevAndHeadBeforeAcquiringResolver\` — pins the scoping order: prev first, head second, before any resolver is acquired.
- \`RunIncrementalDiff_PrevHeaderMissing_FallsThroughToBaselineRecovery\` — non-archive configs may have pruned the prev block; falls through to the \`MissingTrieNodeException\` recovery path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Stacked on #11585.