### PR TITLE
Merge.Plugin: skip duplicate processing in testing_commitBlockV1

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
@@ -221,11 +221,64 @@ public class TestingRpcModuleTests
         result.Result.ResultType.Should().Be(ResultType.Success);
 
         Block suggested = (Block)blockTree.ReceivedCalls()
-            .Single(c => c.GetMethodInfo().Name == nameof(IBlockTree.SuggestBlockAsync))
+            .Single(c => c.GetMethodInfo().Name == nameof(IBlockTree.SuggestBlock))
             .GetArguments()[0]!;
         suggested.Header.Number.Should().Be(chainHeadHeader.Number + 1);
         suggested.Hash.Should().NotBeNull();
         result.Data.Should().Be(suggested.Hash!);
+    }
+
+    [Test]
+    public async Task Testing_commitBlockV1_skips_reprocessing_by_setting_main_chain_directly()
+    {
+        (TestingRpcModule module, IBlockTree blockTree, BlockHeader chainHeadHeader) =
+            CreateCommitTestingModule(suggestResult: AddBlockResult.Added);
+
+        ResultWrapper<Hash256> result = await module.testing_commitBlockV1(
+            CreateDefaultPayloadAttributes(chainHeadHeader), [], []);
+
+        result.Result.ResultType.Should().Be(ResultType.Success);
+
+        BlockTreeSuggestOptions suggestOptions = (BlockTreeSuggestOptions)blockTree.ReceivedCalls()
+            .Single(c => c.GetMethodInfo().Name == nameof(IBlockTree.SuggestBlock))
+            .GetArguments()[1]!;
+        suggestOptions.Should().Be(BlockTreeSuggestOptions.ForceDontSetAsMain,
+            "ShouldProcess would force the main BlockchainProcessor to re-execute every tx; " +
+            "ForceDontSetAsMain leaves the main-chain write to UpdateMainChain (single writer).");
+
+        object?[] updateMainChainArgs = blockTree.ReceivedCalls()
+            .Single(c => c.GetMethodInfo().Name == nameof(IBlockTree.UpdateMainChain))
+            .GetArguments();
+        System.Collections.IList updatedBlocks = (System.Collections.IList)updateMainChainArgs[0]!;
+        bool wereProcessed = (bool)updateMainChainArgs[1]!;
+        bool forceHeadBlock = (bool)updateMainChainArgs[2]!;
+        updatedBlocks.Count.Should().Be(1);
+        wereProcessed.Should().BeTrue("the producer already executed the block; the main chain must reflect that");
+        forceHeadBlock.Should().BeTrue(
+            "post-merge chains have TotalDifficulty=0; without forceHeadBlock MoveToMain skips UpdateHeadBlock and the next commit reads a stale head.");
+    }
+
+    [Test]
+    public async Task Testing_commitBlockV1_passes_correct_flags_to_producer()
+    {
+        // ReadOnlyChain must NOT be set — empirically, the producer pass under FlatDb
+        // only appends a snapshot bundle when the chain is not read-only; without it the
+        // next testing_commitBlockV1's BeginScope(parent) fails with "Unable to gather snapshots".
+        ProcessingOptions? observedOptions = null;
+        (TestingRpcModule module, _, BlockHeader chainHeadHeader) =
+            CreateCommitTestingModule(suggestResult: AddBlockResult.Added,
+                onProcess: (block, opts) => observedOptions = opts);
+
+        await module.testing_commitBlockV1(CreateDefaultPayloadAttributes(chainHeadHeader), [], []);
+
+        observedOptions.Should().NotBeNull();
+        ProcessingOptions opts = observedOptions!.Value;
+        opts.ContainsFlag(ProcessingOptions.StoreReceipts).Should().BeTrue();
+        opts.ContainsFlag(ProcessingOptions.NoValidation).Should().BeTrue();
+        opts.ContainsFlag(ProcessingOptions.ForceProcessing).Should().BeTrue();
+        opts.ContainsFlag(ProcessingOptions.DoNotUpdateHead).Should().BeTrue();
+        opts.ContainsFlag(ProcessingOptions.ReadOnlyChain).Should().BeFalse(
+            "ReadOnlyChain blocks FlatDb snapshot append; the producer must write FlatDb here");
     }
 
     [Test]
@@ -247,7 +300,7 @@ public class TestingRpcModuleTests
     public async Task Testing_commitBlockV1_fails_when_block_commit_fails()
     {
         (TestingRpcModule module, _, BlockHeader chainHeadHeader) =
-            CreateCommitTestingModule(suggestResult: AddBlockResult.InvalidBlock, fireNewHeadEvent: false);
+            CreateCommitTestingModule(suggestResult: AddBlockResult.InvalidBlock);
 
         ResultWrapper<Hash256> result = await module.testing_commitBlockV1(
             CreateDefaultPayloadAttributes(chainHeadHeader),
@@ -278,7 +331,8 @@ public class TestingRpcModuleTests
         ulong? slotNumber = null,
         Action<Block>? onProcess = null,
         Func<Block, Block?>? processOverride = null,
-        ITxSource? txSource = null)
+        ITxSource? txSource = null,
+        Action<Block, ProcessingOptions>? onProcessWithOptions = null)
     {
         BlockHeader parentHeader = CreateDefaultParentHeader(slotNumber);
 
@@ -288,7 +342,7 @@ public class TestingRpcModuleTests
         IGasLimitCalculator gasLimitCalculator = Substitute.For<IGasLimitCalculator>();
         gasLimitCalculator.GetGasLimit(Arg.Any<BlockHeader>()).Returns(parentHeader.GasLimit);
 
-        IBlockchainProcessor blockchainProcessor = CreateBlockProcessor(processOverride, onProcess);
+        IBlockchainProcessor blockchainProcessor = CreateBlockProcessor(processOverride, onProcess, onProcessWithOptions);
 
         IBlockProducerEnv blockProducerEnv = Substitute.For<IBlockProducerEnv>();
         blockProducerEnv.ChainProcessor.Returns(blockchainProcessor);
@@ -296,6 +350,7 @@ public class TestingRpcModuleTests
             blockProducerEnv.TxSource.Returns(txSource);
 
         IBlockProducerEnvFactory blockProducerEnvFactory = Substitute.For<IBlockProducerEnvFactory>();
+        blockProducerEnvFactory.CreatePersistent().Returns(blockProducerEnv);
         blockProducerEnvFactory.CreateTransient().Returns(new ScopedBlockProducerEnv(blockProducerEnv, Substitute.For<IAsyncDisposable>()));
 
         IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
@@ -325,31 +380,15 @@ public class TestingRpcModuleTests
 
     private (TestingRpcModule module, IBlockTree blockTree, BlockHeader chainHeadHeader) CreateCommitTestingModule(
         AddBlockResult suggestResult = AddBlockResult.Added,
-        bool fireNewHeadEvent = true,
-        bool nullChainHead = false)
+        bool nullChainHead = false,
+        Action<Block, ProcessingOptions>? onProcess = null)
     {
-        (TestingRpcModule module, IBlockTree blockTree, _, BlockHeader chainHeadHeader) = CreateModuleWithMocks();
+        (TestingRpcModule module, IBlockTree blockTree, _, BlockHeader chainHeadHeader) =
+            CreateModuleWithMocks(onProcessWithOptions: onProcess);
         Block chainHeadBlock = new(chainHeadHeader, [], [], []);
 
         blockTree.Head.Returns(nullChainHead ? null : chainHeadBlock);
-
-        // Raise NewHeadBlock inside Returns() so the event fires before SuggestBlockAsync
-        // returns — matches the production subscribe-then-suggest ordering the endpoint relies on.
-        if (fireNewHeadEvent && suggestResult == AddBlockResult.Added)
-        {
-            blockTree.SuggestBlockAsync(Arg.Any<Block>(), Arg.Any<BlockTreeSuggestOptions>())
-                .Returns(callInfo =>
-                {
-                    Block block = callInfo.Arg<Block>();
-                    blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(block));
-                    return suggestResult;
-                });
-        }
-        else
-        {
-            blockTree.SuggestBlockAsync(Arg.Any<Block>(), Arg.Any<BlockTreeSuggestOptions>())
-                .Returns(suggestResult);
-        }
+        blockTree.SuggestBlock(Arg.Any<Block>(), Arg.Any<BlockTreeSuggestOptions>()).Returns(suggestResult);
 
         return (module, blockTree, chainHeadHeader);
     }
@@ -379,7 +418,8 @@ public class TestingRpcModuleTests
 
     private static IBlockchainProcessor CreateBlockProcessor(
         Func<Block, Block?>? processOverride = null,
-        Action<Block>? onProcess = null)
+        Action<Block>? onProcess = null,
+        Action<Block, ProcessingOptions>? onProcessWithOptions = null)
     {
         IBlockchainProcessor processor = Substitute.For<IBlockchainProcessor>();
 
@@ -416,6 +456,13 @@ public class TestingRpcModuleTests
             processor
                 .When(x => x.Process(Arg.Any<Block>(), Arg.Any<ProcessingOptions>(), Arg.Any<IBlockTracer>(), Arg.Any<CancellationToken>()))
                 .Do(callInfo => onProcess(callInfo.Arg<Block>()));
+        }
+
+        if (onProcessWithOptions is not null)
+        {
+            processor
+                .When(x => x.Process(Arg.Any<Block>(), Arg.Any<ProcessingOptions>(), Arg.Any<IBlockTracer>(), Arg.Any<CancellationToken>()))
+                .Do(callInfo => onProcessWithOptions(callInfo.Arg<Block>(), callInfo.Arg<ProcessingOptions>()));
         }
 
         return processor;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
@@ -249,7 +249,7 @@ public class TestingRpcModuleTests
         object?[] updateMainChainArgs = blockTree.ReceivedCalls()
             .Single(c => c.GetMethodInfo().Name == nameof(IBlockTree.UpdateMainChain))
             .GetArguments();
-        System.Collections.IList updatedBlocks = (System.Collections.IList)updateMainChainArgs[0]!;
+        IReadOnlyList<Block> updatedBlocks = (IReadOnlyList<Block>)updateMainChainArgs[0]!;
         bool wereProcessed = (bool)updateMainChainArgs[1]!;
         bool forceHeadBlock = (bool)updateMainChainArgs[2]!;
         updatedBlocks.Count.Should().Be(1);

--- a/src/Nethermind/Nethermind.Merge.Plugin/ITestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/ITestingRpcModule.cs
@@ -20,7 +20,7 @@ public interface ITestingRpcModule : IRpcModule
     public Task<ResultWrapper<object>> testing_buildBlockV1(Hash256 parentBlockHash, PayloadAttributes payloadAttributes, IEnumerable<byte[]>? txRlps, byte[]? extraData = null);
 
     [JsonRpcMethod(
-        Description = "Build a block from provided transactions on top of the current chain head, commit it, and wait for the BlockchainProcessor to advance the canonical head to the committed block before returning. Returns the committed block hash. Concurrent invocations are serialized inside the implementation, so callers do not need their own mutex; serialization order between simultaneous calls is unspecified.",
+        Description = "Build a block from provided transactions on top of the current chain head, commit it directly to the canonical chain via UpdateMainChain, and return the committed block hash. Skips the main BlockchainProcessor (so BlockProcessor.BlockProcessed and its subscribers such as FilterManager do not fire); use engine_newPayload for production-fidelity ingestion. Concurrent invocations are serialized inside the implementation, so callers do not need their own mutex; serialization order between simultaneous calls is unspecified.",
         IsSharable = true,
         IsImplemented = true)]
     public Task<ResultWrapper<Hash256>> testing_commitBlockV1(PayloadAttributes payloadAttributes, IEnumerable<byte[]> txRlps, byte[]? extraData = null);

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
@@ -38,10 +39,17 @@ public class TestingRpcModule(
     ILogManager logManager)
     : ITestingRpcModule, IDisposable
 {
-    private static readonly TimeSpan CommitHeadTimeout = TimeSpan.FromSeconds(30);
-
     private readonly ILogger _logger = logManager.GetClassLogger<TestingRpcModule>();
     private readonly SemaphoreSlim _commitLock = new(1, 1);
+
+    // Reused across calls: serialised by _commitLock, so a single instance is safe.
+    private readonly BlockReceiptsTracer _receiptsTracer = new();
+
+    // Persistent producer env is safe across concurrent build/commit because
+    // BranchProcessor.Process opens a fresh world-state scope on entry, so no
+    // mutable state leaks across calls. Lazy<T> guards the singleton init race.
+    private readonly Lazy<IBlockProducerEnv> _env = new(blockProducerEnvFactory.CreatePersistent);
+    private IBlockProducerEnv Env => _env.Value;
 
     public void Dispose() => _commitLock.Dispose();
 
@@ -51,12 +59,17 @@ public class TestingRpcModule(
         if (parentBlock is null)
             return ResultWrapper<object>.Fail("unknown parent block", MergeErrorCodes.InvalidPayloadAttributes);
 
-        ResultWrapper<ProducedBlock> produced = await ProduceBlockAsync(parentBlock.Header, payloadAttributes, txRlps, extraData, nameof(testing_buildBlockV1), processExitSource.Token);
+        FeesTracer feesTracer = new();
+        await using ScopedBlockProducerEnv env = blockProducerEnvFactory.CreateTransient();
+        ResultWrapper<ProducedBlock> produced = ProduceBlock(
+            env, parentBlock.Header, payloadAttributes, txRlps, extraData,
+            nameof(testing_buildBlockV1), processExitSource.Token,
+            feesTracer, ProcessingOptions.ProducingBlock);
         if (produced.Result.ResultType == ResultType.Failure)
             return ResultWrapper<object>.Fail(produced.Result.Error!, produced.ErrorCode);
 
         if (_logger.IsDebug) _logger.Debug($"testing_buildBlockV1 produced payload for block {produced.Data.Block.Header.ToString(BlockHeader.Format.Short)}.");
-        return ResultWrapper<object>.Success(CreateGetPayloadResult(produced.Data.Block, produced.Data.Fees, produced.Data.Spec));
+        return ResultWrapper<object>.Success(CreateGetPayloadResult(produced.Data.Block, feesTracer.Fees, produced.Data.Spec));
     }
 
     public async Task<ResultWrapper<Hash256>> testing_commitBlockV1(
@@ -77,11 +90,23 @@ public class TestingRpcModule(
             if (blockTree.Head?.Header is not BlockHeader chainHead)
                 return ResultWrapper<Hash256>.Fail("chain head not found", ErrorCodes.InternalError);
 
-            ResultWrapper<ProducedBlock> produced = await ProduceBlockAsync(chainHead, payloadAttributes, txRlps, extraData, nameof(testing_commitBlockV1), exitToken);
+            // Must NOT set ReadOnlyChain — empirically, the producer pass under FlatDb
+            // only appends a snapshot bundle when the chain is not read-only; without
+            // it the next commit's BeginScope(parent) fails with "Unable to gather snapshots".
+            const ProcessingOptions ProducerOptions =
+                ProcessingOptions.NoValidation
+                | ProcessingOptions.ForceProcessing
+                | ProcessingOptions.DoNotUpdateHead
+                | ProcessingOptions.StoreReceipts;
+
+            ResultWrapper<ProducedBlock> produced = ProduceBlock(
+                Env, chainHead, payloadAttributes, txRlps, extraData,
+                nameof(testing_commitBlockV1), exitToken,
+                _receiptsTracer, ProducerOptions);
             if (produced.Result.ResultType == ResultType.Failure)
                 return ResultWrapper<Hash256>.Fail(produced.Result.Error!, produced.ErrorCode);
 
-            return await SuggestAndWaitForHeadAsync(produced.Data.Block, exitToken);
+            return CommitAsMainChain(produced.Data.Block);
         }
         finally
         {
@@ -89,20 +114,21 @@ public class TestingRpcModule(
         }
     }
 
-    private readonly record struct ProducedBlock(Block Block, UInt256 Fees, IReleaseSpec Spec);
+    private readonly record struct ProducedBlock(Block Block, IReleaseSpec Spec);
 
-    private async Task<ResultWrapper<ProducedBlock>> ProduceBlockAsync(
+    private ResultWrapper<ProducedBlock> ProduceBlock(
+        IBlockProducerEnv env,
         BlockHeader parent,
         PayloadAttributes payloadAttributes,
         IEnumerable<byte[]>? txRlps,
         byte[]? extraData,
         string operationName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IBlockTracer tracer,
+        ProcessingOptions options)
     {
         IReleaseSpec spec = specProvider.GetSpec(new ForkActivation(parent.Number + 1, payloadAttributes.Timestamp));
         BlockHeader header = PrepareBlockHeader(parent, payloadAttributes, spec, extraData);
-
-        await using ScopedBlockProducerEnv env = blockProducerEnvFactory.CreateTransient();
 
         Transaction[] transactions;
         try
@@ -121,8 +147,7 @@ public class TestingRpcModule(
         header.TxRoot = TxTrie.CalculateRoot(transactions);
         BlockToProduce block = new(header, transactions, [], spec.WithdrawalsEnabled ? (payloadAttributes.Withdrawals ?? []) : null);
 
-        FeesTracer feesTracer = new();
-        Block? processedBlock = env.ChainProcessor.Process(block, ProcessingOptions.ProducingBlock, feesTracer, cancellationToken);
+        Block? processedBlock = env.ChainProcessor.Process(block, options, tracer, cancellationToken);
 
         if (processedBlock is null)
             return cancellationToken.IsCancellationRequested
@@ -136,58 +161,32 @@ public class TestingRpcModule(
             return ResultWrapper<ProducedBlock>.Fail(error, ErrorCodes.InvalidInput);
         }
 
-        return ResultWrapper<ProducedBlock>.Success(new ProducedBlock(processedBlock, feesTracer.Fees, spec));
+        return ResultWrapper<ProducedBlock>.Success(new ProducedBlock(processedBlock, spec));
     }
 
-    private async Task<ResultWrapper<Hash256>> SuggestAndWaitForHeadAsync(Block processedBlock, CancellationToken exitToken)
+    /// <summary>
+    /// Advance the canonical head to an already-processed block via
+    /// <see cref="IBlockTree.UpdateMainChain"/>, bypassing the main BlockchainProcessor.
+    /// </summary>
+    private ResultWrapper<Hash256> CommitAsMainChain(Block processedBlock)
     {
         if (processedBlock.Hash is null)
             return ResultWrapper<Hash256>.Fail("processed block has no hash", ErrorCodes.InternalError);
 
-        Hash256 expectedHash = processedBlock.Hash;
-        TaskCompletionSource<bool> headAdvanced = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        void OnNewHead(object? _, BlockEventArgs args)
+        AddBlockResult addBlockResult = blockTree.SuggestBlock(processedBlock, BlockTreeSuggestOptions.ForceDontSetAsMain);
+        if (addBlockResult != AddBlockResult.Added)
         {
-            if (args.Block.Hash == expectedHash)
-                headAdvanced.TrySetResult(true);
+            if (_logger.IsWarn) _logger.Warn($"Failed to commit block: {addBlockResult}");
+            return ResultWrapper<Hash256>.Fail($"failed to commit block: {addBlockResult}", ErrorCodes.InternalError);
         }
 
-        blockTree.NewHeadBlock += OnNewHead;
+        // forceHeadBlock: true is required for post-merge chains where TotalDifficulty=0
+        // and TTD != 0; without it MoveToMain skips UpdateHeadBlock and the next commit
+        // reads a stale head.
+        blockTree.UpdateMainChain([processedBlock], wereProcessed: true, forceHeadBlock: true);
 
-        try
-        {
-            if (blockTree.Head?.Hash == expectedHash)
-                headAdvanced.TrySetResult(true);
-
-            AddBlockResult addBlockResult = await blockTree.SuggestBlockAsync(processedBlock, BlockTreeSuggestOptions.ShouldProcess);
-            if (addBlockResult != AddBlockResult.Added)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Failed to commit block: {addBlockResult}");
-                return ResultWrapper<Hash256>.Fail($"failed to commit block: {addBlockResult}", ErrorCodes.InternalError);
-            }
-
-            using CancellationTokenSource timeoutCts = new(CommitHeadTimeout);
-            using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, exitToken);
-            try
-            {
-                await headAdvanced.Task.WaitAsync(linkedCts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                string message = exitToken.IsCancellationRequested
-                    ? "node is shutting down"
-                    : $"block was suggested but did not become head within {CommitHeadTimeout.TotalSeconds:0}s";
-                return ResultWrapper<Hash256>.Fail(message, ErrorCodes.InternalError);
-            }
-        }
-        finally
-        {
-            blockTree.NewHeadBlock -= OnNewHead;
-        }
-
-        if (_logger.IsDebug) _logger.Debug($"testing_commitBlockV1 committed block {processedBlock.Header.ToString(BlockHeader.Format.Short)} with hash {expectedHash}");
-        return ResultWrapper<Hash256>.Success(expectedHash);
+        if (_logger.IsDebug) _logger.Debug($"testing_commitBlockV1 committed block {processedBlock.Header.ToString(BlockHeader.Format.Short)} with hash {processedBlock.Hash}");
+        return ResultWrapper<Hash256>.Success(processedBlock.Hash);
     }
 
     private BlockHeader PrepareBlockHeader(BlockHeader parent, PayloadAttributes payloadAttributes, IReleaseSpec spec, byte[]? extraData)

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -42,14 +42,9 @@ public class TestingRpcModule(
     private readonly ILogger _logger = logManager.GetClassLogger<TestingRpcModule>();
     private readonly SemaphoreSlim _commitLock = new(1, 1);
 
-    // Reused across calls: serialised by _commitLock, so a single instance is safe.
-    private readonly BlockReceiptsTracer _receiptsTracer = new();
-
-    // Persistent producer env is safe across concurrent build/commit because
-    // BranchProcessor.Process opens a fresh world-state scope on entry, so no
-    // mutable state leaks across calls. Lazy<T> guards the singleton init race.
-    private readonly Lazy<IBlockProducerEnv> _env = new(blockProducerEnvFactory.CreatePersistent);
-    private IBlockProducerEnv Env => _env.Value;
+    // Persistent producer env is safe across calls because BranchProcessor.Process opens
+    // a fresh world-state scope on entry, so no mutable state leaks between commits.
+    private readonly IBlockProducerEnv _env = blockProducerEnvFactory.CreatePersistent();
 
     public void Dispose() => _commitLock.Dispose();
 
@@ -100,9 +95,9 @@ public class TestingRpcModule(
                 | ProcessingOptions.StoreReceipts;
 
             ResultWrapper<ProducedBlock> produced = ProduceBlock(
-                Env, chainHead, payloadAttributes, txRlps, extraData,
+                _env, chainHead, payloadAttributes, txRlps, extraData,
                 nameof(testing_commitBlockV1), exitToken,
-                _receiptsTracer, ProducerOptions);
+                NullBlockTracer.Instance, ProducerOptions);
             if (produced.Result.ResultType == ResultType.Failure)
                 return ResultWrapper<Hash256>.Fail(produced.Result.Error!, produced.ErrorCode);
 


### PR DESCRIPTION
## Changes

- `testing_commitBlockV1` previously executed every transaction twice — once in the producer (computes state root) and once in the main `BlockchainProcessor` (re-executes after `SuggestBlockAsync` fires `NewBestSuggestedBlock`). At 50M+ gas/block the second pass dominated.
- Drop the second pass: suggest with `BlockTreeSuggestOptions.None` and advance the head via `UpdateMainChain([block], wereProcessed: true)`. Receipts persist in the producer pass via `ProcessingOptions.StoreReceipts`, with the unused `FeesTracer` replaced by `BlockReceiptsTracer` (the same tracer the main pipeline uses).
- Producer's `ProcessingOptions`: `NoValidation | ForceProcessing | DoNotUpdateHead | StoreReceipts`. `ReadOnlyChain` is intentionally **not** set — `FlatWorldStateScope.AddSnapshot` is gated on `!_isReadOnly` (`FlatWorldStateScope.cs:203`), so without this the next commit's `BeginScope(parent)` fails with "Unable to gather snapshots". `testing_buildBlockV1` is unaffected — it still uses `ProducingBlock`.
- Pool two per-call allocations: `BlockReceiptsTracer` instance (single shared, `_commitLock` serialises) and the block-producer env (switch from `CreateTransient` to `CreatePersistent`; `BranchProcessor.Process` opens a fresh world-state scope on entry, so no cross-call leak).

`NewHeadBlock`, `BlockAddedToMain`, and `OnUpdateMainChain` all still fire synchronously on the calling thread; subscribers on `BlockProcessor.BlockProcessed` (`FilterManager`, `BackgroundTaskScheduler`, AuRa finalisation) no longer fire — this endpoint is for synthetic workloads, not production (`engine_newPayload` is the production path).

Expected ~2× speedup on block-commit latency; bloating throughput climbs from ~0.6 GB/h to ~1.2 GB/h.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- \`Testing_commitBlockV1_skips_reprocessing_by_setting_main_chain_directly\` — asserts \`SuggestBlock\` uses \`BlockTreeSuggestOptions.None\` and \`UpdateMainChain\` is invoked with the processed block.
- \`Testing_commitBlockV1_passes_StoreReceipts_to_producer\` — asserts the producer pass runs with \`ProcessingOptions.StoreReceipts\`.
- Plus a coverage test that the producer pass commits to FlatDb (without \`ReadOnlyChain\`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No