### PR TITLE
Fix eth_syncing at beacon sync pivot

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -19,6 +19,8 @@ namespace Nethermind.Facade.Eth
         ISyncProgressResolver syncProgressResolver,
         ILogManager logManager) : IEthSyncingInfo
     {
+        public const int MaxDistanceForSynced = 8;
+
         private readonly IBlockTree _blockTree = blockTree;
         private readonly ISyncConfig _syncConfig = syncConfig;
         private readonly ILogger _logger = logManager.GetClassLogger<EthSyncingInfo>();
@@ -28,7 +30,7 @@ namespace Nethermind.Facade.Eth
 
         public SyncingResult GetFullInfo()
         {
-            (bool isSyncing, long headNumberOrZero, long bestSuggestedNumber) = _blockTree.IsSyncing(maxDistanceForSynced: 8);
+            (bool isSyncing, long headNumberOrZero, long bestSuggestedNumber) = _blockTree.IsSyncing(maxDistanceForSynced: MaxDistanceForSynced);
             SyncMode syncMode = _syncModeSelector.Current;
 
             if (_logger.IsTrace) _logger.Trace($"Start - EthSyncingInfo - BestSuggestedNumber: {bestSuggestedNumber}, HeadNumberOrZero: {headNumberOrZero}, IsSyncing: {isSyncing} {_syncConfig}. LowestInsertedBodyNumber: {_syncPointers.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_syncPointers.LowestInsertedReceiptBlockNumber}");

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Eth;
+using Nethermind.Synchronization.ParallelSync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Taiko.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class TaikoEthSyncingInfoTests
+{
+    /// <summary>
+    /// Regression: on Taiko, BeaconSync inserts headers without bumping BestSuggestedHeader.
+    /// Once Head catches the beacon pivot, isSyncing must return false even though
+    /// FindBestSuggestedHeader() lags or returns null.
+    /// </summary>
+    [Test]
+    public void GetFullInfo_BeaconPivot_HeadCaughtUp_NotSyncing()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
+        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(1000L).TestObject).TestObject);
+
+        TaikoEthSyncingInfo info = new(blockTree, Substitute.For<IEthSyncingInfo>());
+        SyncingResult result = info.GetFullInfo();
+
+        Assert.That(result.IsSyncing, Is.False);
+        Assert.That(result, Is.EqualTo(SyncingResult.NotSyncing));
+    }
+
+    /// <summary>Mid bulk-sync: beacon header ahead of Head → isSyncing=true with HighestBlock from beacon.</summary>
+    [Test]
+    public void GetFullInfo_BeaconPivot_HeadBehind_Syncing()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
+        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(500L).TestObject).TestObject);
+
+        IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
+        inner.SyncMode.Returns(SyncMode.FastSync);
+
+        SyncingResult result = new TaikoEthSyncingInfo(blockTree, inner).GetFullInfo();
+
+        Assert.That(result.IsSyncing, Is.True);
+        Assert.That(result.CurrentBlock, Is.EqualTo(500L));
+        Assert.That(result.HighestBlock, Is.EqualTo(1000L));
+        Assert.That(result.SyncMode, Is.EqualTo(SyncMode.FastSync));
+    }
+
+    /// <summary>Genesis: nothing seen yet → isSyncing=true with zero pointers.</summary>
+    [Test]
+    public void GetFullInfo_Genesis_Syncing()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
+        blockTree.BestSuggestedBeaconHeader.Returns((BlockHeader?)null);
+        blockTree.Head.Returns((Block?)null);
+
+        SyncingResult result = new TaikoEthSyncingInfo(blockTree, Substitute.For<IEthSyncingInfo>()).GetFullInfo();
+
+        Assert.That(result.IsSyncing, Is.True);
+        Assert.That(result.CurrentBlock, Is.Zero);
+        Assert.That(result.HighestBlock, Is.Zero);
+    }
+
+    /// <summary>Engine-API path advanced BestSuggestedHeader past beacon: max picks suggested.</summary>
+    [Test]
+    public void GetFullInfo_TakesMaxOfBothPointers()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(2000L).TestObject);
+        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(500L).TestObject).TestObject);
+
+        SyncingResult result = new TaikoEthSyncingInfo(blockTree, Substitute.For<IEthSyncingInfo>()).GetFullInfo();
+
+        Assert.That(result.IsSyncing, Is.True);
+        Assert.That(result.HighestBlock, Is.EqualTo(2000L));
+    }
+
+    [Test]
+    public void UpdateAndGetSyncTime_DelegatesToInner()
+    {
+        IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
+        inner.UpdateAndGetSyncTime().Returns(TimeSpan.FromSeconds(42));
+
+        TaikoEthSyncingInfo info = new(Substitute.For<IBlockTree>(), inner);
+
+        Assert.That(info.UpdateAndGetSyncTime(), Is.EqualTo(TimeSpan.FromSeconds(42)));
+        inner.Received(1).UpdateAndGetSyncTime();
+    }
+
+    [Test]
+    public void SyncMode_DelegatesToInner()
+    {
+        IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
+        inner.SyncMode.Returns(SyncMode.WaitingForBlock);
+
+        Assert.That(new TaikoEthSyncingInfo(Substitute.For<IBlockTree>(), inner).SyncMode, Is.EqualTo(SyncMode.WaitingForBlock));
+    }
+}

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
@@ -16,72 +17,15 @@ namespace Nethermind.Taiko.Test;
 [Parallelizable(ParallelScope.All)]
 public class TaikoEthSyncingInfoTests
 {
-    /// <summary>
-    /// Regression: on Taiko, BeaconSync inserts headers without bumping BestSuggestedHeader.
-    /// Once Head catches the beacon pivot, isSyncing must return false even though
-    /// FindBestSuggestedHeader() lags or returns null.
-    /// </summary>
-    [Test]
-    public void GetFullInfo_BeaconPivot_HeadCaughtUp_NotSyncing()
+    [TestCaseSource(nameof(GetFullInfoCases))]
+    public void GetFullInfo_ReturnsExpected(long? suggested, long? beacon, long? head, SyncMode innerMode, SyncingResult expected)
     {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
-        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
-        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(1000L).TestObject).TestObject);
-
-        TaikoEthSyncingInfo info = new(blockTree, Substitute.For<IEthSyncingInfo>());
-        SyncingResult result = info.GetFullInfo();
-
-        Assert.That(result.IsSyncing, Is.False);
-        Assert.That(result, Is.EqualTo(SyncingResult.NotSyncing));
-    }
-
-    [Test]
-    public void GetFullInfo_BeaconPivot_HeadBehind_Syncing()
-    {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
-        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
-        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(500L).TestObject).TestObject);
-
         IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
-        inner.SyncMode.Returns(SyncMode.FastSync);
+        inner.SyncMode.Returns(innerMode);
 
-        SyncingResult result = new TaikoEthSyncingInfo(blockTree, inner).GetFullInfo();
+        SyncingResult result = new TaikoEthSyncingInfo(BlockTreeWith(suggested, beacon, head), inner).GetFullInfo();
 
-        Assert.That(result.IsSyncing, Is.True);
-        Assert.That(result.CurrentBlock, Is.EqualTo(500L));
-        Assert.That(result.HighestBlock, Is.EqualTo(1000L));
-        Assert.That(result.SyncMode, Is.EqualTo(SyncMode.FastSync));
-    }
-
-    [Test]
-    public void GetFullInfo_Genesis_Syncing()
-    {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.FindBestSuggestedHeader().Returns((BlockHeader?)null);
-        blockTree.BestSuggestedBeaconHeader.Returns((BlockHeader?)null);
-        blockTree.Head.Returns((Block?)null);
-
-        SyncingResult result = new TaikoEthSyncingInfo(blockTree, Substitute.For<IEthSyncingInfo>()).GetFullInfo();
-
-        Assert.That(result.IsSyncing, Is.True);
-        Assert.That(result.CurrentBlock, Is.Zero);
-        Assert.That(result.HighestBlock, Is.Zero);
-    }
-
-    [Test]
-    public void GetFullInfo_TakesMaxOfBothPointers()
-    {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(2000L).TestObject);
-        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
-        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(500L).TestObject).TestObject);
-
-        SyncingResult result = new TaikoEthSyncingInfo(blockTree, Substitute.For<IEthSyncingInfo>()).GetFullInfo();
-
-        Assert.That(result.IsSyncing, Is.True);
-        Assert.That(result.HighestBlock, Is.EqualTo(2000L));
+        Assert.That(result, Is.EqualTo(expected));
     }
 
     [Test]
@@ -103,5 +47,41 @@ public class TaikoEthSyncingInfoTests
         inner.SyncMode.Returns(SyncMode.WaitingForBlock);
 
         Assert.That(new TaikoEthSyncingInfo(Substitute.For<IBlockTree>(), inner).SyncMode, Is.EqualTo(SyncMode.WaitingForBlock));
+    }
+
+    private static IBlockTree BlockTreeWith(long? suggested, long? beacon, long? head)
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindBestSuggestedHeader().Returns(suggested is long s ? Build.A.BlockHeader.WithNumber(s).TestObject : null);
+        blockTree.BestSuggestedBeaconHeader.Returns(beacon is long b ? Build.A.BlockHeader.WithNumber(b).TestObject : null);
+        blockTree.Head.Returns(head is long h ? Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(h).TestObject).TestObject : null);
+        return blockTree;
+    }
+
+    private static IEnumerable<TestCaseData> GetFullInfoCases()
+    {
+        // Regression: BeaconSync inserts headers via BestSuggestedBeaconHeader only, so
+        // FindBestSuggestedHeader can lag (or be null) even after Head reaches the pivot.
+        // Before the fix, isSyncing stuck at true once Head caught up.
+        yield return new TestCaseData(
+            (long?)null, (long?)1000L, (long?)1000L, SyncMode.None,
+            SyncingResult.NotSyncing
+        ).SetName("BeaconPivot_HeadCaughtUp_NotSyncing");
+
+        yield return new TestCaseData(
+            (long?)null, (long?)1000L, (long?)500L, SyncMode.FastSync,
+            new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 1000L, SyncMode = SyncMode.FastSync }
+        ).SetName("BeaconPivot_HeadBehind_Syncing");
+
+        yield return new TestCaseData(
+            (long?)null, (long?)null, (long?)null, SyncMode.None,
+            new SyncingResult { IsSyncing = true, CurrentBlock = 0L, HighestBlock = 0L, SyncMode = SyncMode.None }
+        ).SetName("Genesis_Syncing");
+
+        // Both pointers populated — decorator must take max(suggested, beacon).
+        yield return new TestCaseData(
+            (long?)2000L, (long?)1000L, (long?)500L, SyncMode.None,
+            new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 2000L, SyncMode = SyncMode.None }
+        ).SetName("TakesMaxOfBothPointers");
     }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
@@ -36,7 +36,6 @@ public class TaikoEthSyncingInfoTests
         Assert.That(result, Is.EqualTo(SyncingResult.NotSyncing));
     }
 
-    /// <summary>Mid bulk-sync: beacon header ahead of Head → isSyncing=true with HighestBlock from beacon.</summary>
     [Test]
     public void GetFullInfo_BeaconPivot_HeadBehind_Syncing()
     {
@@ -56,7 +55,6 @@ public class TaikoEthSyncingInfoTests
         Assert.That(result.SyncMode, Is.EqualTo(SyncMode.FastSync));
     }
 
-    /// <summary>Genesis: nothing seen yet → isSyncing=true with zero pointers.</summary>
     [Test]
     public void GetFullInfo_Genesis_Syncing()
     {
@@ -72,7 +70,6 @@ public class TaikoEthSyncingInfoTests
         Assert.That(result.HighestBlock, Is.Zero);
     }
 
-    /// <summary>Engine-API path advanced BestSuggestedHeader past beacon: max picks suggested.</summary>
     [Test]
     public void GetFullInfo_TakesMaxOfBothPointers()
     {

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using Nethermind.Blockchain;
-using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
 using Nethermind.Synchronization.ParallelSync;
@@ -18,14 +17,12 @@ namespace Nethermind.Taiko.Test;
 public class TaikoEthSyncingInfoTests
 {
     [TestCaseSource(nameof(GetFullInfoCases))]
-    public void GetFullInfo_ReturnsExpected(long? suggested, long? beacon, long? head, SyncMode innerMode, SyncingResult expected)
+    public SyncingResult GetFullInfo_ReturnsExpected(long? suggested, long? beacon, long? head, SyncMode innerMode)
     {
         IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
         inner.SyncMode.Returns(innerMode);
 
-        SyncingResult result = new TaikoEthSyncingInfo(BlockTreeWith(suggested, beacon, head), inner).GetFullInfo();
-
-        Assert.That(result, Is.EqualTo(expected));
+        return new TaikoEthSyncingInfo(BlockTreeWith(suggested, beacon, head), inner).GetFullInfo();
     }
 
     [Test]
@@ -63,25 +60,21 @@ public class TaikoEthSyncingInfoTests
         // Regression: BeaconSync inserts headers via BestSuggestedBeaconHeader only, so
         // FindBestSuggestedHeader can lag (or be null) even after Head reaches the pivot.
         // Before the fix, isSyncing stuck at true once Head caught up.
-        yield return new TestCaseData(
-            (long?)null, (long?)1000L, (long?)1000L, SyncMode.None,
-            SyncingResult.NotSyncing
-        ).SetName("BeaconPivot_HeadCaughtUp_NotSyncing");
+        yield return new TestCaseData((long?)null, (long?)1000L, (long?)1000L, SyncMode.None)
+            .Returns(SyncingResult.NotSyncing)
+            .SetName("BeaconPivot_HeadCaughtUp_NotSyncing");
 
-        yield return new TestCaseData(
-            (long?)null, (long?)1000L, (long?)500L, SyncMode.FastSync,
-            new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 1000L, SyncMode = SyncMode.FastSync }
-        ).SetName("BeaconPivot_HeadBehind_Syncing");
+        yield return new TestCaseData((long?)null, (long?)1000L, (long?)500L, SyncMode.FastSync)
+            .Returns(new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 1000L, SyncMode = SyncMode.FastSync })
+            .SetName("BeaconPivot_HeadBehind_Syncing");
 
-        yield return new TestCaseData(
-            (long?)null, (long?)null, (long?)null, SyncMode.None,
-            new SyncingResult { IsSyncing = true, CurrentBlock = 0L, HighestBlock = 0L, SyncMode = SyncMode.None }
-        ).SetName("Genesis_Syncing");
+        yield return new TestCaseData((long?)null, (long?)null, (long?)null, SyncMode.None)
+            .Returns(new SyncingResult { IsSyncing = true, CurrentBlock = 0L, HighestBlock = 0L, SyncMode = SyncMode.None })
+            .SetName("Genesis_Syncing");
 
         // Both pointers populated — decorator must take max(suggested, beacon).
-        yield return new TestCaseData(
-            (long?)2000L, (long?)1000L, (long?)500L, SyncMode.None,
-            new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 2000L, SyncMode = SyncMode.None }
-        ).SetName("TakesMaxOfBothPointers");
+        yield return new TestCaseData((long?)2000L, (long?)1000L, (long?)500L, SyncMode.None)
+            .Returns(new SyncingResult { IsSyncing = true, CurrentBlock = 500L, HighestBlock = 2000L, SyncMode = SyncMode.None })
+            .SetName("TakesMaxOfBothPointers");
     }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEthSyncingInfoTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
@@ -26,15 +27,26 @@ public class TaikoEthSyncingInfoTests
     }
 
     [Test]
-    public void UpdateAndGetSyncTime_DelegatesToInner()
+    public void UpdateAndGetSyncTime_TracksTaikoIsSyncing_NotInner()
     {
+        // Regression: inner.UpdateAndGetSyncTime() keys off the inner's beacon-unaware
+        // IsSyncing(), which is `false` during the very plateau this decorator exists
+        // to fix. The stopwatch must run on the decorator's corrected IsSyncing().
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.BestSuggestedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(1000L).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(500L).TestObject).TestObject);
+
         IEthSyncingInfo inner = Substitute.For<IEthSyncingInfo>();
-        inner.UpdateAndGetSyncTime().Returns(TimeSpan.FromSeconds(42));
+        TaikoEthSyncingInfo info = new(blockTree, inner);
 
-        TaikoEthSyncingInfo info = new(Substitute.For<IBlockTree>(), inner);
+        Assert.That(info.UpdateAndGetSyncTime(), Is.EqualTo(TimeSpan.Zero), "first call: starts the stopwatch");
+        Thread.Sleep(10);
+        Assert.That(info.UpdateAndGetSyncTime(), Is.GreaterThan(TimeSpan.Zero), "subsequent call while syncing: elapsed");
 
-        Assert.That(info.UpdateAndGetSyncTime(), Is.EqualTo(TimeSpan.FromSeconds(42)));
-        inner.Received(1).UpdateAndGetSyncTime();
+        // Head catches the beacon pivot — decorator now reports not-syncing, stopwatch stops.
+        blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(1000L).TestObject).TestObject);
+        Assert.That(info.UpdateAndGetSyncTime(), Is.EqualTo(TimeSpan.Zero), "after catch-up: stops");
+        inner.DidNotReceive().UpdateAndGetSyncTime();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Facade.Eth;
+using Nethermind.Synchronization.ParallelSync;
+
+namespace Nethermind.Taiko;
+
+/// <remarks>
+/// Beacon-sync inserts headers only bump <c>BestSuggestedBeaconHeader</c>, not
+/// <c>BestSuggestedHeader</c>. This decorator widens the suggested-header read to
+/// <c>max(BestSuggestedHeader, BestSuggestedBeaconHeader)</c> so <c>eth_syncing</c>
+/// reports <c>false</c> once <c>Head</c> catches the beacon pivot. FastSync branch
+/// is omitted — Taiko's chainspec disables it.
+/// </remarks>
+public sealed class TaikoEthSyncingInfo(
+    IBlockTree blockTree,
+    IEthSyncingInfo inner) : IEthSyncingInfo
+{
+    private const int MaxDistanceForSynced = 8;
+
+    public SyncingResult GetFullInfo()
+    {
+        long suggestedHeader = blockTree.FindBestSuggestedHeader()?.Number ?? 0;
+        long beaconSuggestedHeader = blockTree.BestSuggestedBeaconHeader?.Number ?? 0;
+        long bestSuggestedNumber = Math.Max(suggestedHeader, beaconSuggestedHeader);
+        long headNumberOrZero = blockTree.Head?.Number ?? 0;
+        bool isSyncing = bestSuggestedNumber == 0 || bestSuggestedNumber > headNumberOrZero + MaxDistanceForSynced;
+
+        if (isSyncing)
+        {
+            return new SyncingResult
+            {
+                CurrentBlock = headNumberOrZero,
+                HighestBlock = bestSuggestedNumber,
+                StartingBlock = 0L,
+                SyncMode = inner.SyncMode,
+                IsSyncing = true
+            };
+        }
+
+        return SyncingResult.NotSyncing;
+    }
+
+    public bool IsSyncing() => GetFullInfo().IsSyncing;
+    public TimeSpan UpdateAndGetSyncTime() => inner.UpdateAndGetSyncTime();
+    public SyncMode SyncMode => inner.SyncMode;
+}

--- a/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using Nethermind.Blockchain;
 using Nethermind.Facade.Eth;
 using Nethermind.Synchronization.ParallelSync;
@@ -14,12 +15,18 @@ namespace Nethermind.Taiko;
 /// <c>max(BestSuggestedHeader, BestSuggestedBeaconHeader)</c> so <c>eth_syncing</c>
 /// reports <c>false</c> once <c>Head</c> catches the beacon pivot. FastSync branch
 /// is omitted — Taiko's chainspec disables it.
+/// <para>
+/// The sync-duration stopwatch is maintained here rather than delegated to
+/// <paramref name="inner"/>, because <see cref="EthSyncingInfo.UpdateAndGetSyncTime"/>
+/// keys off the inner's beacon-unaware <see cref="EthSyncingInfo.IsSyncing"/>, which
+/// reports <c>false</c> during the very plateau this decorator exists to fix.
+/// </para>
 /// </remarks>
 public sealed class TaikoEthSyncingInfo(
     IBlockTree blockTree,
     IEthSyncingInfo inner) : IEthSyncingInfo
 {
-    private const int MaxDistanceForSynced = 8;
+    private readonly Stopwatch _syncStopwatch = new();
 
     public SyncingResult GetFullInfo()
     {
@@ -27,7 +34,7 @@ public sealed class TaikoEthSyncingInfo(
         long beaconSuggestedHeader = blockTree.BestSuggestedBeaconHeader?.Number ?? 0;
         long bestSuggestedNumber = Math.Max(suggestedHeader, beaconSuggestedHeader);
         long headNumberOrZero = blockTree.Head?.Number ?? 0;
-        bool isSyncing = bestSuggestedNumber == 0 || bestSuggestedNumber > headNumberOrZero + MaxDistanceForSynced;
+        bool isSyncing = bestSuggestedNumber == 0 || bestSuggestedNumber > headNumberOrZero + EthSyncingInfo.MaxDistanceForSynced;
 
         if (isSyncing)
         {
@@ -45,6 +52,26 @@ public sealed class TaikoEthSyncingInfo(
     }
 
     public bool IsSyncing() => GetFullInfo().IsSyncing;
-    public TimeSpan UpdateAndGetSyncTime() => inner.UpdateAndGetSyncTime();
+
+    public TimeSpan UpdateAndGetSyncTime()
+    {
+        if (!_syncStopwatch.IsRunning)
+        {
+            if (IsSyncing())
+            {
+                _syncStopwatch.Start();
+            }
+            return TimeSpan.Zero;
+        }
+
+        if (!IsSyncing())
+        {
+            _syncStopwatch.Stop();
+            return TimeSpan.Zero;
+        }
+
+        return _syncStopwatch.Elapsed;
+    }
+
     public SyncMode SyncMode => inner.SyncMode;
 }

--- a/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoEthSyncingInfo.cs
@@ -9,6 +9,10 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Taiko;
 
+/// <summary>
+/// Taiko-specific decorator for <see cref="IEthSyncingInfo"/> that accounts for
+/// beacon-sync headers when computing the <c>eth_syncing</c> response.
+/// </summary>
 /// <remarks>
 /// Beacon-sync inserts headers only bump <c>BestSuggestedBeaconHeader</c>, not
 /// <c>BestSuggestedHeader</c>. This decorator widens the suggested-header read to

--- a/src/Nethermind/Nethermind.Taiko/TaikoSynchronizerModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSynchronizerModule.cs
@@ -4,18 +4,20 @@
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Core;
+using Nethermind.Facade.Eth;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Taiko;
 
 /// <remarks>
-/// On Taiko, every block header has <c>TotalDifficulty == 0</c> (post-merge from genesis —
-/// taiko-geth's <c>params/taiko_config.go</c> sets <c>TerminalTotalDifficulty: 0</c>),
-/// while <c>Difficulty</c> is repurposed as the per-block ZK gas used (non-consensus).
-/// The default <see cref="CumulativeTotalDifficultyStrategy"/> computes
-/// <c>(TD ?? 0) - Difficulty</c> and underflows during fast-block header insertion,
-/// stopping snap-sync. Mirror taiko-geth's behaviour: parent TD is always zero on Taiko.
+/// Wires Taiko-specific sync decorators:
+/// <see cref="ZeroTotalDifficultyStrategy"/> (Taiko's <c>TotalDifficulty</c> is always 0;
+/// the default cumulative strategy underflows on the per-block ZK-gas <c>Difficulty</c>),
+/// <see cref="TaikoSyncProgressResolver"/> (widens
+/// <see cref="ISyncProgressResolver.FindBestHeader"/> for the snapshot-invariant check),
+/// and <see cref="TaikoEthSyncingInfo"/> (widens the suggested-header read for
+/// <c>eth_syncing</c>).
 /// </remarks>
 public sealed class TaikoSynchronizerModule : Module
 {
@@ -23,5 +25,7 @@ public sealed class TaikoSynchronizerModule : Module
         .AddSingleton<ITotalDifficultyStrategy, ZeroTotalDifficultyStrategy>()
         .AddDecorator<ISyncProgressResolver>((ctx, inner) =>
             new TaikoSyncProgressResolver(ctx.Resolve<IBlockTree>(), inner))
+        .AddDecorator<IEthSyncingInfo>((ctx, inner) =>
+            new TaikoEthSyncingInfo(ctx.Resolve<IBlockTree>(), inner))
         .AddSingleton<TaikoBeaconHeadAdvancer>();
 }


### PR DESCRIPTION
While syncing nmc node against the taiko devnet, there is this weird long plateau where the node stayed at the beacon-sync pivot while `eth_syncing` kept returning `{ isSyncing: true, highestBlock: 0x0 }`. This plateau ends only when the driver's `--p2p.syncTimeout` (default 1h) is expired and it switches to event-sync.

This and the companion PR in taiko-mono fix that: https://github.com/taikoxyz/taiko-mono/pull/21670

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

Tested out by running a fresh node against taiko devnet to verify that the fix works. 

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
