### PR TITLE
Update BAL pyspec fixtures to v7.1.1

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -6,6 +6,6 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class Constants
 {
     public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.1.0";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.1.1";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_bal.tar.gz";
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -69,12 +69,14 @@ internal class TransactionProcessorEip7702Tests
     {
         yield return new TestCaseData(AuthorityPreState.Nonexistent, false, 0UL, 0L)
             .SetName("Nonexistent authority - no auth state refund");
+        yield return new TestCaseData(AuthorityPreState.Nonexistent, true, 0UL, GasCostOf.PerAuthBaseState)
+            .SetName("Nonexistent authority clear - refunds auth-base state gas");
         yield return new TestCaseData(AuthorityPreState.ExistingLeaf, false, 0UL, GasCostOf.NewAccountState)
             .SetName("Existing authority leaf - refunds new account state gas");
+        yield return new TestCaseData(AuthorityPreState.ExistingLeaf, true, 0UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
+            .SetName("Existing authority leaf clear - refunds full auth state gas");
         yield return new TestCaseData(AuthorityPreState.ExistingDelegation, false, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
             .SetName("Existing delegation overwrite - refunds full auth state gas");
-        // The auth-base refund depends on the pre-state delegation slot, so clearing
-        // an existing delegation receives the same refund as overwriting it.
         yield return new TestCaseData(AuthorityPreState.ExistingDelegation, true, 1UL, GasCostOf.NewAccountState + GasCostOf.PerAuthBaseState)
             .SetName("Existing delegation clear - refunds full auth state gas");
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -465,6 +465,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 {
                     bool accountExists = WorldState.AccountExists(authority);
                     bool hasDelegation = accountExists && _codeInfoRepository.TryGetDelegation(authority, spec, out _);
+                    bool clearsDelegation = authTuple.CodeAddress == Address.Zero;
 
                     if (!accountExists)
                     {
@@ -476,7 +477,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         WorldState.IncrementNonce(authority);
                     }
 
-                    if (hasDelegation)
+                    if (hasDelegation || clearsDelegation)
                     {
                         authBaseRefunds++;
                     }


### PR DESCRIPTION
## Changes

- Update the default Ethereum execution-specs BAL pyspec fixture archive from `tests-bal@v7.1.0` to `tests-bal@v7.1.1`.
- Implement the `tests-bal@v7.1.1` EIP-8037/EIP-7702 auth state-gas refund behavior for valid delegation clears (`auth.address == 0`), including authorities without a prior delegation.
- Add regression coverage for the missing clear-to-zero auth refund cases.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Other: BAL pyspec fixture update

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `dotnet build D:\GitHub\nethermind\src\Nethermind\Nethermind.Blockchain.Test\Nethermind.Blockchain.Test.csproj -c release --no-restore`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.Blockchain.Test\release\Nethermind.Blockchain.Test.exe --filter "FullyQualifiedName~Execute_Eip8037AuthRefunds_UpdateReceiptAndBlockGas" --minimum-expected-tests 1` (6/6 passed)
- `dotnet build D:\GitHub\nethermind\src\Nethermind\Ethereum.Blockchain.Pyspec.Test\Ethereum.Blockchain.Pyspec.Test.csproj -c release --no-restore`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Ethereum.Blockchain.Pyspec.Test\release\Ethereum.Blockchain.Pyspec.Test.exe --filter "FullyQualifiedName~test_blobhash_opcode_contexts_tx_types" --no-progress --output Normal` (69/69 passed)
- `git diff --check`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`tests-bal@v7.1.1` is a BAL devnet 7 patch release on top of `tests-bal@v7.1.0` that adds coverage for the EIP-7702 auth state-gas refund refill on delegation clear.
