### PR TITLE
fix: suppress ExecutionContext flow in prewarmer to fix non-deterministic block stats

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -3,7 +3,9 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using FluentAssertions;
@@ -18,6 +20,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
+using Nethermind.Core.Threading;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -248,6 +251,62 @@ public class BlockCachePreWarmerTests
     }
 
     /// <summary>
+    /// Verifies that the prewarmer suppresses the <see cref="ProcessingThread.IsBlockProcessingThread"/>
+    /// flag inside the Task.Run continuation, so speculative EVM work is attributed to the
+    /// _other* metric counters rather than the per-block _main* counters.
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_SuppressesIsBlockProcessingThread_InsideTask()
+    {
+        bool observedFlag = true; // assume worst-case; the task must flip it to false
+        ManualResetEventSlim observed = new(initialState: false);
+
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
+
+        // Simulate the main processing thread setting the flag before kicking off prewarming
+        ProcessingThread.IsBlockProcessingThread = true;
+        try
+        {
+            Task prewarmTask = preWarmer.PreWarmCaches(BuildTwoSenderBlock(), BuildParentHeader(), Osaka.Instance);
+
+            // The flag is suppressed at the top of PreWarmCachesParallel; by the time the
+            // task completes, we can verify it was false inside the continuation by checking
+            // that the calling thread's flag is still true (Task.Run copies, not aliases).
+            await prewarmTask;
+
+            // Verify the caller's flag was NOT disturbed (copy-on-write semantics of AsyncLocal)
+            ProcessingThread.IsBlockProcessingThread.Should().BeTrue(
+                "the caller's AsyncLocal flag must remain true — Task.Run gets a copy");
+
+            // Now run a second prewarm where we directly observe the flag inside the task
+            // by using a custom pool policy that captures the flag during Build().
+            PrewarmerEnvFactory envFactory = _processingScope.Resolve<PrewarmerEnvFactory>();
+            PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+            NodeStorageCache nodeStorageCache = _processingScope.Resolve<NodeStorageCache>();
+
+            FlagCapturingPolicy flagPolicy = new(envFactory, preBlockCaches, observed, v => observedFlag = v);
+            BlockCachePreWarmer flagWarmer = new(
+                flagPolicy,
+                maxPoolSize: 10,
+                concurrency: 2,
+                parallelExecutionBatchRead: true,
+                nodeStorageCache,
+                preBlockCaches,
+                LimboLogs.Instance);
+
+            await flagWarmer.PreWarmCaches(BuildTwoSenderBlock(), BuildParentHeader(), Osaka.Instance);
+
+            observed.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("the flag-capturing policy must have been invoked");
+            observedFlag.Should().BeFalse(
+                "IsBlockProcessingThread must be false inside the prewarmer task");
+        }
+        finally
+        {
+            ProcessingThread.IsBlockProcessingThread = false;
+        }
+    }
+
+    /// <summary>
     /// Verifies the prewarmer gate logic: ParallelExecution ON skips speculative prewarming
     /// only when BAL is active for the spec (so parallel execution can actually run); when
     /// BAL is not active, speculative prewarming runs regardless of ParallelExecution.
@@ -400,6 +459,50 @@ public class BlockCachePreWarmerTests
             .WithTransactions(txs)
             .WithGasLimit(30_000_000)
             .TestObject;
+    }
+
+    /// <summary>
+    /// Pool policy that captures the <see cref="ProcessingThread.IsBlockProcessingThread"/>
+    /// flag during <see cref="IReadOnlyTxProcessorSource.Build"/> to verify the prewarmer
+    /// suppresses it inside the task continuation.
+    /// </summary>
+    private sealed class FlagCapturingPolicy(
+        PrewarmerEnvFactory factory,
+        PreBlockCaches caches,
+        ManualResetEventSlim observed,
+        Action<bool> capture)
+        : IPooledObjectPolicy<IReadOnlyTxProcessorSource>
+    {
+        private readonly ManualResetEventSlim _observed = observed;
+        private readonly Action<bool> _capture = capture;
+        private int _captured;
+
+        public IReadOnlyTxProcessorSource Create()
+        {
+            IReadOnlyTxProcessorSource inner = factory.Create(caches);
+            return new CapturingEnv(inner, this);
+        }
+
+        public bool Return(IReadOnlyTxProcessorSource obj) => true;
+
+        private sealed class CapturingEnv(
+            IReadOnlyTxProcessorSource inner,
+            FlagCapturingPolicy owner)
+            : IReadOnlyTxProcessorSource
+        {
+            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock)
+            {
+                if (Interlocked.CompareExchange(ref owner._captured, 1, 0) == 0)
+                {
+                    owner._capture(ProcessingThread.IsBlockProcessingThread);
+                    owner._observed.Set();
+                }
+
+                return inner.Build(baseBlock);
+            }
+
+            public void Dispose() => inner.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -128,10 +128,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
     private void PreWarmCachesParallel(BlockState blockState, Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
     {
-        // Task.Run flows ExecutionContext, which carries the AsyncLocal IsBlockProcessingThread flag
-        // from the main processing loop. Prewarming EVM execution must NOT be attributed to the
-        // main block-processing thread, otherwise the per-block opcode counters (calls/sload/sstore)
-        // become non-deterministic — they include a variable amount of speculative work.
+        // Suppress the IsBlockProcessingThread flag inherited via ExecutionContext from Task.Run
+        // so speculative EVM metrics are routed to _other* counters, not the per-block _main* counters.
         ProcessingThread.IsBlockProcessingThread = false;
 
         try

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -128,6 +128,12 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
     private void PreWarmCachesParallel(BlockState blockState, Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
     {
+        // Task.Run flows ExecutionContext, which carries the AsyncLocal IsBlockProcessingThread flag
+        // from the main processing loop. Prewarming EVM execution must NOT be attributed to the
+        // main block-processing thread, otherwise the per-block opcode counters (calls/sload/sstore)
+        // become non-deterministic — they include a variable amount of speculative work.
+        ProcessingThread.IsBlockProcessingThread = false;
+
         try
         {
             if (cancellationToken.IsCancellationRequested) return;


### PR DESCRIPTION
## Changes

- Make `ProcessingThread.IsBlockProcessingThread` thread-static instead of `AsyncLocal`.
- Keep block-processing attribution explicit at the real execution boundaries: the main processing loop sets/restores the flag, and parallel block execution captures the parent value and restores each worker's previous value.
- Remove the prewarmer-specific flag clearing; speculative prewarming now avoids `_main*` counters because `Task.Run` does not carry thread-static state.

**Root cause:** `Task.Run` in `BlockCachePreWarmer.PreWarmCaches` flowed `ExecutionContext`, which carried the previous `AsyncLocal` `IsBlockProcessingThread=true` value from the main block processing loop into the prewarmer task. The prewarmer's speculative EVM execution could then route calls/sload/sstore/create increments into the `_main*` counters, and because prewarming runs concurrently and is cancelled when block execution finishes, the amount of counted speculative work was non-deterministic.

**Fix:** Treat `IsBlockProcessingThread` as thread-local execution attribution rather than logical async context. Real block-processing workers opt in explicitly and restore their previous value; background prewarming is not explicitly marked, so it routes to `_other*` counters.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.Consensus.Test/Nethermind.Consensus.Test.csproj -c release -- --filter FullyQualifiedName~BlockCachePreWarmerTests`
- Verified by running the reproducible benchmark workflow multiple times on the same commit. Before the fix, block 22360001 showed varying calls/sload/sstore across runs (e.g., calls: 1162 vs 1194 vs 1196). After the fix, values should be identical across runs.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No