### PR TITLE
add checks for empty auth and create contract for 7702

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -427,8 +427,8 @@ public abstract class BlockchainTestBase
         ("TransactionException.TYPE_3_TX_ZERO_BLOBS", "blob transaction must have at least 1 blob"),
         ("TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH", "InvalidBlobVersionedHashVersion: Blob version not supported"),
         ("TransactionException.TYPE_3_TX_CONTRACT_CREATION", "blob transaction of type create"),
-        ("TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST", "MissingAuthorizationList: Must be set"),
-        ("TransactionException.TYPE_4_TX_CONTRACT_CREATION", "NotAllowedCreateTransaction: To must be set"),
+        ("TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST", "EIP-7702 transaction with empty auth list"),
+        ("TransactionException.TYPE_4_TX_CONTRACT_CREATION", "EIP-7702 transaction cannot be used to create contract"),
         ("TransactionException.TYPE_4_TX_PRE_FORK", "InvalidTxType: Transaction type in"),
         // HeaderBlobGasMismatch covers both wrong header.BlobGasUsed and an
         // inflated header value when real tx blob gas stays below the limit.

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -125,11 +125,11 @@ public abstract class TransactionTestBase
 
     private static readonly System.Collections.Generic.Dictionary<string, string[]> s_exceptionToErrorFragments = new()
     {
-        ["TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST"] = ["MissingAuthorizationList", "Must be set"],
+        ["TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST"] = ["EIP-7702 transaction with empty auth list"],
         ["TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT"] = ["InvalidAuthorityList", .. s_rlpDecodeFragments],
         ["TransactionException.TYPE_4_INVALID_AUTHORITY_SIGNATURE"] = ["InvalidAuthoritySignature", .. s_rlpDecodeFragments],
         ["TransactionException.TYPE_4_INVALID_AUTHORITY_SIGNATURE_S_TOO_HIGH"] = ["InvalidAuthoritySignature", "S value too high", .. s_rlpDecodeFragments],
-        ["TransactionException.TYPE_4_TX_CONTRACT_CREATION"] = ["NotAllowedCreateTransaction"],
+        ["TransactionException.TYPE_4_TX_CONTRACT_CREATION"] = ["EIP-7702 transaction cannot be used to create contract"],
         ["TransactionException.TYPE_4_TX_PRE_FORK"] = ["InvalidTxType"],
         ["TransactionException.TYPE_3_TX_PRE_FORK"] = ["InvalidTxType"],
         ["TransactionException.TYPE_2_TX_PRE_FORK"] = ["InvalidTxType"],

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -333,7 +333,6 @@ internal class TransactionProcessorEip7702Tests
         Assert.That(Eip7702Constants.IsDelegatedCode(actual), Is.EqualTo(expectDelegation));
     }
 
-    [TestCase(0)]
     [TestCase(1)]
     [TestCase(10)]
     [TestCase(99)]
@@ -562,7 +561,7 @@ internal class TransactionProcessorEip7702Tests
         Transaction tx1 = Build.A.Transaction
             .WithType(TxType.SetCode)
             .WithTo(signer.Address)
-            .WithGasLimit(60_000)
+            .WithGasLimit(100_000)
             .WithAuthorizationCode(_ethereumEcdsa.Sign(
                     signer,
                     _specProvider.ChainId,
@@ -570,12 +569,13 @@ internal class TransactionProcessorEip7702Tests
                     0))
             .SignedAndResolved(_ethereumEcdsa, sender, true)
             .TestObject;
+        // tx2 clears the delegation by authorizing address(0), then calls signer — no code runs
         Transaction tx2 = Build.A.Transaction
             .WithType(TxType.SetCode)
             .WithNonce(1)
             .WithTo(signer.Address)
-            .WithGasLimit(60_000)
-            .WithAuthorizationCode([])
+            .WithGasLimit(100_000)
+            .WithAuthorizationCode(_ethereumEcdsa.Sign(signer, _specProvider.ChainId, Address.Zero, 1))
             .SignedAndResolved(_ethereumEcdsa, sender, true)
             .TestObject;
         Block block = Build.A.Block.WithNumber(long.MaxValue)

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -33,7 +33,7 @@ public static class TxErrorMessages
         $"InvalidTransaction: Cannot be {nameof(ShardBlobNetworkWrapper)}.";
 
     public const string NotAllowedCreateTransaction =
-        "NotAllowedCreateTransaction: To must be set.";
+        "EIP-7702 transaction cannot be used to create contract";
 
     public const string BlobTxMissingMaxFeePerBlobGas =
         "BlobTxMissingMaxFeePerBlobGas: Must be set.";
@@ -72,7 +72,7 @@ public static class TxErrorMessages
 
     public const string NotAllowedAuthorizationList = $"NotAllowedAuthorizationList: Only transactions with type {nameof(TxType.SetCode)} can have authorization_list.";
 
-    public const string MissingAuthorizationList = "MissingAuthorizationList: Must be set.";
+    public const string MissingAuthorizationList = "EIP-7702 transaction with empty auth list";
 
     public const string InvalidAuthoritySignature = "InvalidAuthoritySignature: Invalid signature in authorization list.";
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -608,6 +608,20 @@ namespace Nethermind.Evm.TransactionProcessing
                 return TransactionResult.TransactionSizeOverMaxInitCodeSize;
             }
 
+            if (tx.SupportsAuthorizationList)
+            {
+                if (tx.IsContractCreation)
+                {
+                    TraceLogInvalidTx(tx, "SETCODE_TX_CREATE");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.NotAllowedCreateTransaction} (sender {tx.SenderAddress})");
+                }
+                if (!tx.HasAuthorizationList)
+                {
+                    TraceLogInvalidTx(tx, "EMPTY_AUTHORIZATION_LIST");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.MissingAuthorizationList} (sender {tx.SenderAddress})");
+                }
+            }
+
             TGasPolicy standard = intrinsicGas.Standard;
             TGasPolicy minimal = intrinsicGas.MinimalGas;
             long minGasRequired = spec.IsEip8037Enabled

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/AuthorizationListForRpc.cs
@@ -28,7 +28,7 @@ public class AuthorizationListForRpc : IEnumerable<RpcAuthTuple>
         public UInt256 ChainId { get; set; }
         public ulong Nonce { get; set; }
         public Address Address { get; set; }
-        public ulong YParity { get; set; }
+        public ulong? YParity { get; set; }
         public UInt256 S { get; set; }
         public UInt256 R { get; set; }
 
@@ -61,7 +61,7 @@ public class AuthorizationListForRpc : IEnumerable<RpcAuthTuple>
             (ulong)tuple.ChainId,
             tuple.Address,
             tuple.Nonce,
-            new Signature(tuple.R, tuple.S, (ulong)tuple.YParity + Signature.VOffset))
+            new Signature(tuple.R, tuple.S, tuple.YParity.GetValueOrDefault() + Signature.VOffset))
         ).ToArray();
 
     public IEnumerator<RpcAuthTuple> GetEnumerator() => _tuples.GetEnumerator();
@@ -73,6 +73,14 @@ public class AuthorizationListForRpc : IEnumerable<RpcAuthTuple>
         public override AuthorizationListForRpc? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             List<RpcAuthTuple>? list = JsonSerializer.Deserialize<List<RpcAuthTuple>>(ref reader, options);
+            if (list is not null)
+            {
+                foreach (RpcAuthTuple tuple in list)
+                {
+                    if (tuple.YParity is null)
+                        throw new JsonException("missing yParity");
+                }
+            }
             return list is null ? null : new AuthorizationListForRpc(list);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -681,7 +681,7 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
 
         JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
-            .Should().Be($"failed with {ctx.Test.BlockTree.Head!.GasLimit} gas: {TxErrorMessages.MissingAuthorizationList} (sender 0x0001020304050607080910111213141516171819)");
+            .Should().Be($"{TxErrorMessages.MissingAuthorizationList} (sender 0x0001020304050607080910111213141516171819)");
     }
 
     [Test]
@@ -696,7 +696,7 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
 
         JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
-            .Should().Be($"failed with {ctx.Test.BlockTree.Head!.GasLimit} gas: {TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
+            .Should().Be($"{TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
     }
 
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -24,6 +24,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System.Text;
 using Nethermind.Abi;
+using Nethermind.Core.Messages;
 
 namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
@@ -666,6 +667,36 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest", stateOverride, blockOverride);
         JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
             .Should().StartWith("intrinsic gas too low");
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_setCode_empty_authorization_list_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
+
+        JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
+            .Should().Be($"failed with {ctx.Test.BlockTree.Head!.GasLimit} gas: {TxErrorMessages.MissingAuthorizationList} (sender 0x0001020304050607080910111213141516171819)");
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_setCode_contract_creation_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","nonce":"0x1","yParity":"0x1","r":"0xa8f2b4c1d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1","s":"0x1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"}]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
+
+        JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
+            .Should().Be($"failed with {ctx.Test.BlockTree.Head!.GasLimit} gas: {TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
     }
 
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -703,4 +703,19 @@ public partial class EthRpcModuleTests
             .Should().Be($"{TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
     }
 
+    [Test]
+    public async Task Eth_estimateGas_setCode_missing_yParity_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            $$$"""{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","type":"0x4","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
+
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32602);
+    }
+
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -669,38 +669,26 @@ public partial class EthRpcModuleTests
             .Should().StartWith("intrinsic gas too low");
     }
 
-    [Test]
-    public async Task Eth_estimateGas_setCode_empty_authorization_list_returns_error()
+    [TestCase(
+        """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""",
+        TxErrorMessages.MissingAuthorizationList + " (sender 0x0001020304050607080910111213141516171819)",
+        TestName = "Empty authorization list")]
+    [TestCase(
+        """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0x0000000000000000000000000000000000000001","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""",
+        TxErrorMessages.NotAllowedCreateTransaction + " (sender 0x0001020304050607080910111213141516171819)",
+        TestName = "Contract creation")]
+    public async Task Eth_estimateGas_setCode_invalid_transaction_returns_error(string txJson, string expectedMessage)
     {
         TestSpecProvider specProvider = new(Prague.Instance);
         using Context ctx = await Context.Create(specProvider);
 
-        object transaction = JsonSerializer.Deserialize<object>(
-            """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""")!;
+        object transaction = JsonSerializer.Deserialize<object>(txJson)!;
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
 
         JToken parsed = JToken.Parse(serialized);
         parsed["error"]!["code"]!.Value<int>().Should().Be(-32000);
-        parsed["error"]!["message"]!.Value<string>()
-            .Should().Be($"{TxErrorMessages.MissingAuthorizationList} (sender 0x0001020304050607080910111213141516171819)");
-    }
-
-    [Test]
-    public async Task Eth_estimateGas_setCode_contract_creation_returns_error()
-    {
-        TestSpecProvider specProvider = new(Prague.Instance);
-        using Context ctx = await Context.Create(specProvider);
-
-        object transaction = JsonSerializer.Deserialize<object>(
-            $$$"""{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
-
-        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
-
-        JToken parsed = JToken.Parse(serialized);
-        parsed["error"]!["code"]!.Value<int>().Should().Be(-32000);
-        parsed["error"]!["message"]!.Value<string>()
-            .Should().Be($"{TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
+        parsed["error"]!["message"]!.Value<string>().Should().Be(expectedMessage);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -680,7 +680,9 @@ public partial class EthRpcModuleTests
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
 
-        JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32000);
+        parsed["error"]!["message"]!.Value<string>()
             .Should().Be($"{TxErrorMessages.MissingAuthorizationList} (sender 0x0001020304050607080910111213141516171819)");
     }
 
@@ -691,11 +693,13 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.Create(specProvider);
 
         object transaction = JsonSerializer.Deserialize<object>(
-            """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","nonce":"0x1","yParity":"0x1","r":"0xa8f2b4c1d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1","s":"0x1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"}]}""")!;
+            $$$"""{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
 
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
 
-        JToken.Parse(serialized)["error"]!["message"]!.Value<string>()
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32000);
+        parsed["error"]!["message"]!.Value<string>()
             .Should().Be($"{TxErrorMessages.NotAllowedCreateTransaction} (sender 0x0001020304050607080910111213141516171819)");
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -27,6 +27,7 @@ using Nethermind.Blockchain;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Nethermind.Abi;
+using Nethermind.Core.Messages;
 
 namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
@@ -912,6 +913,38 @@ public partial class EthRpcModuleTests
 
         UInt256 overriddenFee = Bytes.FromHexString(resultHex!).ToUInt256();
         overriddenFee.Should().Be((UInt256)0x02);
+    }
+
+    [Test]
+    public async Task Eth_call_setCode_empty_authorization_list_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
+
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32003);
+        parsed["error"]!["message"]!.Value<string>().Should().Contain(TxErrorMessages.MissingAuthorizationList);
+    }
+
+    [Test]
+    public async Task Eth_call_setCode_contract_creation_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","nonce":"0x1","yParity":"0x1","r":"0xa8f2b4c1d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1","s":"0x1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"}]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
+
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32003);
+        parsed["error"]!["message"]!.Value<string>().Should().Contain(TxErrorMessages.NotAllowedCreateTransaction);
     }
 
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -938,7 +938,7 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.Create(specProvider);
 
         object transaction = JsonSerializer.Deserialize<object>(
-            """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","nonce":"0x1","yParity":"0x1","r":"0xa8f2b4c1d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1","s":"0x1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"}]}""")!;
+            $$$"""{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
 
         string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -915,36 +916,26 @@ public partial class EthRpcModuleTests
         overriddenFee.Should().Be((UInt256)0x02);
     }
 
-    [Test]
-    public async Task Eth_call_setCode_empty_authorization_list_returns_error()
+    [TestCase(
+        """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""",
+        TxErrorMessages.MissingAuthorizationList,
+        TestName = "Empty authorization list")]
+    [TestCase(
+        """{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"0x0000000000000000000000000000000000000001","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""",
+        TxErrorMessages.NotAllowedCreateTransaction,
+        TestName = "Contract creation")]
+    public async Task Eth_call_setCode_invalid_transaction_returns_error(string txJson, string expectedMessage)
     {
         TestSpecProvider specProvider = new(Prague.Instance);
         using Context ctx = await Context.Create(specProvider);
 
-        object transaction = JsonSerializer.Deserialize<object>(
-            """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""")!;
+        object transaction = JsonSerializer.Deserialize<object>(txJson)!;
 
         string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
 
         JToken parsed = JToken.Parse(serialized);
         parsed["error"]!["code"]!.Value<int>().Should().Be(-32003);
-        parsed["error"]!["message"]!.Value<string>().Should().Contain(TxErrorMessages.MissingAuthorizationList);
-    }
-
-    [Test]
-    public async Task Eth_call_setCode_contract_creation_returns_error()
-    {
-        TestSpecProvider specProvider = new(Prague.Instance);
-        using Context ctx = await Context.Create(specProvider);
-
-        object transaction = JsonSerializer.Deserialize<object>(
-            $$$"""{"from":"0x0001020304050607080910111213141516171819","value":"0x0","type":"0x4","data":"0x60006000f3","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","yParity":"0x0","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
-
-        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
-
-        JToken parsed = JToken.Parse(serialized);
-        parsed["error"]!["code"]!.Value<int>().Should().Be(-32003);
-        parsed["error"]!["message"]!.Value<string>().Should().Contain(TxErrorMessages.NotAllowedCreateTransaction);
+        parsed["error"]!["message"]!.Value<string>().Should().Contain(expectedMessage);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -947,4 +947,19 @@ public partial class EthRpcModuleTests
         parsed["error"]!["message"]!.Value<string>().Should().Contain(TxErrorMessages.NotAllowedCreateTransaction);
     }
 
+    [Test]
+    public async Task Eth_call_setCode_missing_yParity_returns_error()
+    {
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(
+            $$$"""{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","type":"0x4","authorizationList":[{"chainId":"0x1","address":"{{{TestItem.AddressA}}}","nonce":"0x1","r":"0x0101010101010101010101010101010101010101010101010101010101010101","s":"0x0101010101010101010101010101010101010101010101010101010101010101"}]}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest");
+
+        JToken parsed = JToken.Parse(serialized);
+        parsed["error"]!["code"]!.Value<int>().Should().Be(-32602);
+    }
+
 }


### PR DESCRIPTION
Fixes Closes Resolves #11604

## Changes

- Added the requires checks in pre check and aligned message with geth 
- Also estimateGas is returns error code -32000 and eth_call returns -32003 as per this 

```
Code choice: -32003 for insufficient funds
Geth returns -32000 (its default JSON-RPC error code for plain fmt.Errorf chains — rpc/errors.go:61 errcodeDefault). EIP-1474 reserves -32003 ("Transaction rejected") for this scenario, which is more semantically correct than Geth's default-fallthrough.

Nethermind has used -32003 for years; the PR keeps it. The message format is byte-aligned with Geth; the code is aligned with EIP-1474. This is the one deliberate divergence.
```

https://github.com/NethermindEth/nethermind/pull/11335
Please verify @svlachakis 

Also i changed the message for consistency with geth 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No


## Remarks