### PR TITLE
Make AddSelfDestructLog available for the use in Arbitrum plugin

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1431,7 +1431,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void AddSelfDestructLog<TEip8037, TEip7708>(Address executingAccount, Address inheritor, in UInt256 value)
+    public void AddSelfDestructLog<TEip8037, TEip7708>(Address executingAccount, Address inheritor, in UInt256 value)
         where TEip8037 : struct, IFlag
         where TEip7708 : struct, IFlag
     {


### PR DESCRIPTION
## Changes

Unfortunately, we have to reimplement the whole `InstructionSelfDestruct` to have Stylus check to be applied in the right spot. To do that, we'd like to reuse `AddSelfDestructLog`.

Enabler for https://github.com/NethermindEth/nethermind-arbitrum/pull/890

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
