### PR TITLE
perf(merge-sync): cache PosForwardHeaderProvider.GetBlockHeaders

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -63,7 +63,7 @@ public class PosForwardHeaderProviderCacheTests
     }
 
     [TearDown]
-    public void TearDown() => _provider.Dispose();
+    public void TearDown() => _provider.UnsubscribeForTest();
 
     private Task<IOwnedReadOnlyList<BlockHeader?>?> Get(int skip = 0, int max = Requested) =>
         _provider.GetBlockHeaders(skip, max, CancellationToken.None);
@@ -105,7 +105,8 @@ public class PosForwardHeaderProviderCacheTests
         ExpectCalls(expected: 2, between: first =>
         {
             Block reorgBlock = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
-            Assert.That(reorgBlock.Header.Hash, Is.Not.EqualTo(first[10]!.Hash));
+            Assert.That(reorgBlock.Header.Hash, Is.Not.EqualTo(first[10]!.Hash),
+                "precondition: reorg block must hash differently from the cached header at the same height");
             RaiseMainChainUpdate(reorgBlock);
         });
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -33,8 +34,8 @@ public class PosForwardHeaderProviderCacheTests
     public void SetUp()
     {
         _chainLevelHelper = Substitute.For<IChainLevelHelper>();
-        // `ChainLevelHelper.GetStartingPoint` in the typical walk-back path returns the anchor at
-        // `BestKnownNumber`, so the first header is `BestKnownNumber` (here `0`), not `BestKnownNumber + 1`.
+        // `ChainLevelHelper.GetStartingPoint` in the walk-back path returns the anchor at
+        // `BestKnownNumber`, so `headers[0].Number == BestKnownNumber` (here `0`).
         _chainLevelHelper.GetNextHeaders(default, default, default).ReturnsForAnyArgs(_ => BuildSequentialHeaders(start: 0, count: CachedBatchSize));
 
         IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
@@ -50,77 +51,116 @@ public class PosForwardHeaderProviderCacheTests
         _blockTree = Substitute.For<IBlockTree>();
         _blockTree.BestKnownNumber.Returns(0);
 
-        ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
-        ISyncReport syncReport = new NullSyncReport();
-
         _provider = new PosForwardHeaderProvider(
             _chainLevelHelper,
             poSSwitcher,
             _beaconPivot,
             sealValidator,
             _blockTree,
-            syncPeerPool,
-            syncReport,
+            Substitute.For<ISyncPeerPool>(),
+            new NullSyncReport(),
             LimboLogs.Instance);
     }
+
+    [TearDown]
+    public void TearDown() => _provider.Dispose();
+
+    private Task<IOwnedReadOnlyList<BlockHeader?>?> Get(int skip = 0, int max = Requested) =>
+        _provider.GetBlockHeaders(skip, max, CancellationToken.None);
+
+    private void RaiseMainChainUpdate(params Block[] blocks) =>
+        _blockTree.OnUpdateMainChain += Raise.EventWith(_blockTree, new OnUpdateMainChainArgs(new List<Block>(blocks), wereProcessed: true));
+
+    private void AssertChainLevelCalls(int expected) =>
+        _chainLevelHelper.ReceivedWithAnyArgs(expected).GetNextHeaders(default, default, default);
 
     [Test]
     public async Task Second_call_with_same_inputs_is_served_from_cache()
     {
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
 
-        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+        AssertChainLevelCalls(1);
     }
 
     [Test]
     public async Task Cache_is_invalidated_when_process_destination_hash_changes()
     {
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
 
         _beaconPivot.ProcessDestination = BuildHeader(1_000, TestItem.KeccakB);
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
 
-        _chainLevelHelper.ReceivedWithAnyArgs(2).GetNextHeaders(default, default, default);
+        AssertChainLevelCalls(2);
     }
 
     [Test]
     public async Task Cache_miss_when_best_known_number_advances_past_cached_range()
     {
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
 
         _blockTree.BestKnownNumber.Returns((long)CachedBatchSize + 10);
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
 
-        _chainLevelHelper.ReceivedWithAnyArgs(2).GetNextHeaders(default, default, default);
+        AssertChainLevelCalls(2);
     }
 
     [Test]
     public async Task Cached_slice_advances_with_best_known_number()
     {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
         first!.Count.Should().Be(Requested);
         first[0]!.Number.Should().Be(0);
 
         _blockTree.BestKnownNumber.Returns(20L);
-        using IOwnedReadOnlyList<BlockHeader?>? second = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
 
         second!.Count.Should().Be(Requested);
         second[0]!.Number.Should().Be(20);
-        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+        AssertChainLevelCalls(1);
     }
 
     [Test]
     public async Task SkipLastN_is_honored_on_cache_hit()
     {
-        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
 
+        // Request more than the cache holds after the skip-tail trim so the front-cap
+        // exposes `skipLastN`; otherwise `min(available, maxHeader) == maxHeader` and a silently
+        // dropped `skipLastN` would still satisfy the assertion.
         const int skip = 4;
-        using IOwnedReadOnlyList<BlockHeader?>? sliced = await _provider.GetBlockHeaders(skip, Requested, CancellationToken.None);
+        using IOwnedReadOnlyList<BlockHeader?>? sliced = await Get(skip: skip, max: CachedBatchSize);
 
-        sliced!.Count.Should().BeLessThanOrEqualTo(CachedBatchSize - skip);
-        sliced[^1]!.Number.Should().BeLessThanOrEqualTo(CachedBatchSize - skip);
-        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+        sliced!.Count.Should().Be(CachedBatchSize - skip);
+        sliced[^1]!.Number.Should().Be(CachedBatchSize - skip - 1);
+        AssertChainLevelCalls(1);
+    }
+
+    [Test]
+    public async Task Cache_is_invalidated_on_reorg_within_cached_range()
+    {
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
+
+        Block reorgBlock = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
+        reorgBlock.Header.Hash.Should().NotBe(first![10]!.Hash!);
+        RaiseMainChainUpdate(reorgBlock);
+
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
+
+        AssertChainLevelCalls(2);
+    }
+
+    [Test]
+    public async Task Cache_survives_main_chain_update_that_matches_cached_hash()
+    {
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
+
+        Block extensionBlock = new(first![5]!, new BlockBody());
+        RaiseMainChainUpdate(extensionBlock);
+
+        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
+
+        AssertChainLevelCalls(1);
     }
 
     private static BlockHeader[] BuildSequentialHeaders(long start, int count)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Reporting;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test.Synchronization;
+
+public class PosForwardHeaderProviderCacheTests
+{
+    private const int CachedBatchSize = 64;
+    private const int Requested = 16;
+
+    private IChainLevelHelper _chainLevelHelper = null!;
+    private IBeaconPivot _beaconPivot = null!;
+    private IBlockTree _blockTree = null!;
+    private PosForwardHeaderProvider _provider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _chainLevelHelper = Substitute.For<IChainLevelHelper>();
+        _chainLevelHelper.GetNextHeaders(default, default, default).ReturnsForAnyArgs(_ => BuildSequentialHeaders(start: 1, count: CachedBatchSize));
+
+        IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
+        poSSwitcher.HasEverReachedTerminalBlock().Returns(true);
+
+        _beaconPivot = Substitute.For<IBeaconPivot>();
+        _beaconPivot.BeaconPivotExists().Returns(true);
+        _beaconPivot.ProcessDestination = BuildHeader(1_000, TestItem.KeccakA);
+
+        ISealValidator sealValidator = Substitute.For<ISealValidator>();
+        sealValidator.ValidateSeal(Arg.Any<BlockHeader>(), Arg.Any<bool>()).Returns(true);
+
+        _blockTree = Substitute.For<IBlockTree>();
+        _blockTree.BestKnownNumber.Returns(0);
+
+        ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+        ISyncReport syncReport = new NullSyncReport();
+
+        _provider = new PosForwardHeaderProvider(
+            _chainLevelHelper,
+            poSSwitcher,
+            _beaconPivot,
+            sealValidator,
+            _blockTree,
+            syncPeerPool,
+            syncReport,
+            LimboLogs.Instance);
+    }
+
+    [Test]
+    public async Task Second_call_with_same_inputs_is_served_from_cache()
+    {
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+    }
+
+    [Test]
+    public async Task Cache_is_invalidated_when_process_destination_hash_changes()
+    {
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        _beaconPivot.ProcessDestination = BuildHeader(1_000, TestItem.KeccakB);
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        _chainLevelHelper.ReceivedWithAnyArgs(2).GetNextHeaders(default, default, default);
+    }
+
+    [Test]
+    public async Task Cache_miss_when_best_known_number_advances_past_cached_range()
+    {
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        _blockTree.BestKnownNumber.Returns((long)CachedBatchSize + 10);
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        _chainLevelHelper.ReceivedWithAnyArgs(2).GetNextHeaders(default, default, default);
+    }
+
+    [Test]
+    public async Task Cached_slice_advances_with_best_known_number()
+    {
+        using IOwnedReadOnlyList<BlockHeader?>? first = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+        first!.Count.Should().Be(Requested);
+        first[0]!.Number.Should().Be(1);
+
+        _blockTree.BestKnownNumber.Returns(20L);
+        using IOwnedReadOnlyList<BlockHeader?>? second = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        second!.Count.Should().Be(Requested);
+        second[0]!.Number.Should().Be(21);
+        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+    }
+
+    [Test]
+    public async Task SkipLastN_is_honored_on_cache_hit()
+    {
+        await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
+
+        const int skip = 4;
+        using IOwnedReadOnlyList<BlockHeader?>? sliced = await _provider.GetBlockHeaders(skip, Requested, CancellationToken.None);
+
+        sliced!.Count.Should().BeLessThanOrEqualTo(CachedBatchSize - skip);
+        sliced[^1]!.Number.Should().BeLessThanOrEqualTo(CachedBatchSize - skip);
+        _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
+    }
+
+    private static BlockHeader[] BuildSequentialHeaders(long start, int count)
+    {
+        BlockHeader[] headers = new BlockHeader[count];
+        BlockHeader? parent = null;
+        for (int i = 0; i < count; i++)
+        {
+            BlockHeaderBuilder builder = Build.A.BlockHeader.WithNumber(start + i);
+            if (parent is not null) builder = builder.WithParent(parent);
+            headers[i] = builder.TestObject;
+            parent = headers[i];
+        }
+        return headers;
+    }
+
+    private static BlockHeader BuildHeader(long number, Hash256 hash) =>
+        Build.A.BlockHeader.WithNumber(number).WithHash(hash).TestObject;
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -109,14 +108,14 @@ public class PosForwardHeaderProviderCacheTests
     public async Task Cached_slice_advances_with_best_known_number()
     {
         using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
-        first!.Count.Should().Be(Requested);
-        first[0]!.Number.Should().Be(0);
+        Assert.That(first!.Count, Is.EqualTo(Requested));
+        Assert.That(first[0]!.Number, Is.EqualTo(0));
 
         _blockTree.BestKnownNumber.Returns(20L);
         using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
 
-        second!.Count.Should().Be(Requested);
-        second[0]!.Number.Should().Be(20);
+        Assert.That(second!.Count, Is.EqualTo(Requested));
+        Assert.That(second[0]!.Number, Is.EqualTo(20));
         AssertChainLevelCalls(1);
     }
 
@@ -131,8 +130,8 @@ public class PosForwardHeaderProviderCacheTests
         const int skip = 4;
         using IOwnedReadOnlyList<BlockHeader?>? sliced = await Get(skip: skip, max: CachedBatchSize);
 
-        sliced!.Count.Should().Be(CachedBatchSize - skip);
-        sliced[^1]!.Number.Should().Be(CachedBatchSize - skip - 1);
+        Assert.That(sliced!.Count, Is.EqualTo(CachedBatchSize - skip));
+        Assert.That(sliced[^1]!.Number, Is.EqualTo(CachedBatchSize - skip - 1));
         AssertChainLevelCalls(1);
     }
 
@@ -142,7 +141,7 @@ public class PosForwardHeaderProviderCacheTests
         using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
 
         Block reorgBlock = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
-        reorgBlock.Header.Hash.Should().NotBe(first![10]!.Hash!);
+        Assert.That(reorgBlock.Header.Hash, Is.Not.EqualTo(first![10]!.Hash!));
         RaiseMainChainUpdate(reorgBlock);
 
         using IOwnedReadOnlyList<BlockHeader?>? second = await Get();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -33,7 +33,9 @@ public class PosForwardHeaderProviderCacheTests
     public void SetUp()
     {
         _chainLevelHelper = Substitute.For<IChainLevelHelper>();
-        _chainLevelHelper.GetNextHeaders(default, default, default).ReturnsForAnyArgs(_ => BuildSequentialHeaders(start: 1, count: CachedBatchSize));
+        // `ChainLevelHelper.GetStartingPoint` in the typical walk-back path returns the anchor at
+        // `BestKnownNumber`, so the first header is `BestKnownNumber` (here `0`), not `BestKnownNumber + 1`.
+        _chainLevelHelper.GetNextHeaders(default, default, default).ReturnsForAnyArgs(_ => BuildSequentialHeaders(start: 0, count: CachedBatchSize));
 
         IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
         poSSwitcher.HasEverReachedTerminalBlock().Returns(true);
@@ -98,13 +100,13 @@ public class PosForwardHeaderProviderCacheTests
     {
         using IOwnedReadOnlyList<BlockHeader?>? first = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
         first!.Count.Should().Be(Requested);
-        first[0]!.Number.Should().Be(1);
+        first[0]!.Number.Should().Be(0);
 
         _blockTree.BestKnownNumber.Returns(20L);
         using IOwnedReadOnlyList<BlockHeader?>? second = await _provider.GetBlockHeaders(0, Requested, CancellationToken.None);
 
         second!.Count.Should().Be(Requested);
-        second[0]!.Number.Should().Be(21);
+        second[0]!.Number.Should().Be(20);
         _chainLevelHelper.ReceivedWithAnyArgs(1).GetNextHeaders(default, default, default);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PosForwardHeaderProviderCacheTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,36 +74,72 @@ public class PosForwardHeaderProviderCacheTests
     private void AssertChainLevelCalls(int expected) =>
         _chainLevelHelper.ReceivedWithAnyArgs(expected).GetNextHeaders(default, default, default);
 
-    [Test]
-    public async Task Second_call_with_same_inputs_is_served_from_cache()
+    private async Task ExpectCalls(int expected, Action<IOwnedReadOnlyList<BlockHeader?>> between, int firstSkip = 0, int firstMax = Requested, int secondSkip = 0, int secondMax = Requested)
     {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
-        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
-
-        AssertChainLevelCalls(1);
+        using IOwnedReadOnlyList<BlockHeader?>? first = await Get(firstSkip, firstMax);
+        between(first!);
+        using IOwnedReadOnlyList<BlockHeader?>? _ = await Get(secondSkip, secondMax);
+        AssertChainLevelCalls(expected);
     }
 
     [Test]
-    public async Task Cache_is_invalidated_when_process_destination_hash_changes()
+    public Task Second_call_with_same_inputs_is_served_from_cache() =>
+        ExpectCalls(expected: 1, between: _ => { });
+
+    [Test]
+    public Task Cache_is_invalidated_when_process_destination_hash_changes() =>
+        ExpectCalls(expected: 2, between: _ =>
+            _beaconPivot.ProcessDestination = BuildHeader(1_000, TestItem.KeccakB));
+
+    [Test]
+    public Task Cache_miss_when_best_known_number_advances_past_cached_range() =>
+        ExpectCalls(expected: 2, between: _ =>
+            _blockTree.BestKnownNumber.Returns((long)CachedBatchSize + 10));
+
+    [Test]
+    public Task Cache_is_invalidated_when_skipLastN_changes() =>
+        ExpectCalls(expected: 2, between: _ => { }, secondSkip: 4);
+
+    [Test]
+    public Task Cache_is_invalidated_on_reorg_within_cached_range() =>
+        ExpectCalls(expected: 2, between: first =>
+        {
+            Block reorgBlock = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
+            Assert.That(reorgBlock.Header.Hash, Is.Not.EqualTo(first[10]!.Hash));
+            RaiseMainChainUpdate(reorgBlock);
+        });
+
+    [Test]
+    public async Task Cache_is_invalidated_on_ascending_reorg_starting_below_cached_range()
     {
+        const long cacheStart = 100;
+        _chainLevelHelper.GetNextHeaders(default, default, default).ReturnsForAnyArgs(_ => BuildSequentialHeaders(start: cacheStart, count: CachedBatchSize));
+        _blockTree.BestKnownNumber.Returns(cacheStart);
+
         using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
 
-        _beaconPivot.ProcessDestination = BuildHeader(1_000, TestItem.KeccakB);
-        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
+        Block belowBlock = Build.A.Block.WithNumber(cacheStart - 5).WithDifficulty(2).TestObject;
+        Block insideBlock = Build.A.Block.WithNumber(cacheStart + 3).WithDifficulty(2).TestObject;
+        Assert.That(insideBlock.Header.Hash, Is.Not.EqualTo(first![3]!.Hash));
+        RaiseMainChainUpdate(belowBlock, insideBlock);
 
+        using IOwnedReadOnlyList<BlockHeader?>? _ = await Get();
         AssertChainLevelCalls(2);
     }
 
     [Test]
-    public async Task Cache_miss_when_best_known_number_advances_past_cached_range()
-    {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
+    public Task Cache_is_invalidated_on_descending_reorg_with_top_above_cache() =>
+        ExpectCalls(expected: 2, between: _ =>
+        {
+            Block above = Build.A.Block.WithNumber(CachedBatchSize + 50).WithDifficulty(2).TestObject;
+            Block inside = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
+            RaiseMainChainUpdate(above, inside);
+        });
 
-        _blockTree.BestKnownNumber.Returns((long)CachedBatchSize + 10);
-        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
-
-        AssertChainLevelCalls(2);
-    }
+    [Test]
+    public Task Cache_survives_main_chain_update_that_matches_cached_hash() =>
+        ExpectCalls(expected: 1, between: first =>
+            RaiseMainChainUpdate(new Block(first[5]!, new BlockBody())));
 
     [Test]
     public async Task Cached_slice_advances_with_best_known_number()
@@ -116,49 +153,6 @@ public class PosForwardHeaderProviderCacheTests
 
         Assert.That(second!.Count, Is.EqualTo(Requested));
         Assert.That(second[0]!.Number, Is.EqualTo(20));
-        AssertChainLevelCalls(1);
-    }
-
-    [Test]
-    public async Task SkipLastN_is_honored_on_cache_hit()
-    {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
-
-        // Request more than the cache holds after the skip-tail trim so the front-cap
-        // exposes `skipLastN`; otherwise `min(available, maxHeader) == maxHeader` and a silently
-        // dropped `skipLastN` would still satisfy the assertion.
-        const int skip = 4;
-        using IOwnedReadOnlyList<BlockHeader?>? sliced = await Get(skip: skip, max: CachedBatchSize);
-
-        Assert.That(sliced!.Count, Is.EqualTo(CachedBatchSize - skip));
-        Assert.That(sliced[^1]!.Number, Is.EqualTo(CachedBatchSize - skip - 1));
-        AssertChainLevelCalls(1);
-    }
-
-    [Test]
-    public async Task Cache_is_invalidated_on_reorg_within_cached_range()
-    {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
-
-        Block reorgBlock = Build.A.Block.WithNumber(10).WithDifficulty(2).TestObject;
-        Assert.That(reorgBlock.Header.Hash, Is.Not.EqualTo(first![10]!.Hash!));
-        RaiseMainChainUpdate(reorgBlock);
-
-        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
-
-        AssertChainLevelCalls(2);
-    }
-
-    [Test]
-    public async Task Cache_survives_main_chain_update_that_matches_cached_hash()
-    {
-        using IOwnedReadOnlyList<BlockHeader?>? first = await Get();
-
-        Block extensionBlock = new(first![5]!, new BlockBody());
-        RaiseMainChainUpdate(extensionBlock);
-
-        using IOwnedReadOnlyList<BlockHeader?>? second = await Get();
-
         AssertChainLevelCalls(1);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -10,7 +10,6 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Synchronization.Blocks;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -18,29 +18,45 @@ using Nethermind.Synchronization.Reporting;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 
-public class PosForwardHeaderProvider(
-    IChainLevelHelper chainLevelHelper,
-    IPoSSwitcher poSSwitcher,
-    IBeaconPivot beaconPivot,
-    ISealValidator sealValidator,
-    IBlockTree blockTree,
-    ISyncPeerPool syncPeerPool,
-    ISyncReport syncReport,
-    ILogManager logManager
-) : PowForwardHeaderProvider(sealValidator, blockTree, syncPeerPool, syncReport, logManager)
+public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
 {
     private const int CacheBatchMultiplier = 4;
 
-    private readonly ILogger _logger = logManager.GetClassLogger<PosForwardHeaderProvider>();
-    private readonly IBlockTree _blockTree = blockTree;
-    private readonly ISyncReport _syncReport = syncReport;
+    private readonly IChainLevelHelper _chainLevelHelper;
+    private readonly IPoSSwitcher _poSSwitcher;
+    private readonly IBeaconPivot _beaconPivot;
+    private readonly ILogger _logger;
+    private readonly IBlockTree _blockTree;
+    private readonly ISyncReport _syncReport;
 
     private readonly Lock _cacheLock = new();
     private BlockHeader[]? _cachedHeaders;
     private Hash256? _cachedProcessDestinationHash;
     private long _cachedProcessDestinationNumber;
 
-    private bool ShouldUsePreMerge() => !beaconPivot.BeaconPivotExists() && !poSSwitcher.HasEverReachedTerminalBlock();
+    public PosForwardHeaderProvider(
+        IChainLevelHelper chainLevelHelper,
+        IPoSSwitcher poSSwitcher,
+        IBeaconPivot beaconPivot,
+        ISealValidator sealValidator,
+        IBlockTree blockTree,
+        ISyncPeerPool syncPeerPool,
+        ISyncReport syncReport,
+        ILogManager logManager)
+        : base(sealValidator, blockTree, syncPeerPool, syncReport, logManager)
+    {
+        _chainLevelHelper = chainLevelHelper;
+        _poSSwitcher = poSSwitcher;
+        _beaconPivot = beaconPivot;
+        _blockTree = blockTree;
+        _syncReport = syncReport;
+        _logger = logManager.GetClassLogger<PosForwardHeaderProvider>();
+
+        // Invalidate the cache on reorgs that don't change `BeaconPivot.ProcessDestination`.
+        _blockTree.OnUpdateMainChain += BlockTreeOnUpdateMainChain;
+    }
+
+    private bool ShouldUsePreMerge() => !_beaconPivot.BeaconPivotExists() && !_poSSwitcher.HasEverReachedTerminalBlock();
 
     public override Task<IOwnedReadOnlyList<BlockHeader?>?> GetBlockHeaders(int skipLastN, int maxHeader, CancellationToken cancellation)
     {
@@ -49,14 +65,22 @@ public class PosForwardHeaderProvider(
             return base.GetBlockHeaders(skipLastN, maxHeader, cancellation);
         }
 
-        _syncReport.FullSyncBlocksDownloaded.TargetValue = Math.Max(beaconPivot.PivotNumber, beaconPivot.PivotDestinationNumber);
+        _syncReport.FullSyncBlocksDownloaded.TargetValue = Math.Max(_beaconPivot.PivotNumber, _beaconPivot.PivotDestinationNumber);
 
         ArrayPoolList<BlockHeader?>? slice = TryServeFromCache(maxHeader, skipLastN);
         if (slice is not null)
         {
-            // Re-validate per slice so terminal-block / random-index checks run on the served window
-            // rather than only at fill time.
-            ValidateSeals(slice, cancellation);
+            try
+            {
+                // Re-validate per slice so terminal-block / random-index checks run on the served window
+                // rather than only at fill time.
+                ValidateSeals(slice, cancellation);
+            }
+            catch
+            {
+                slice.Dispose();
+                throw;
+            }
             if (_logger.IsTrace) _logger.Trace($"Served {slice.Count} headers from forward-header cache");
             return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(slice);
         }
@@ -65,7 +89,7 @@ public class PosForwardHeaderProvider(
         int fetchSize = Math.Max(maxHeader * CacheBatchMultiplier, MinCachedHeaderBatchSize);
         // Forward `skipLastN` so `ChainLevelHelper` enforces the same chain-tip exclusion as the
         // pre-cache implementation; trim the slice tail again at serve time to honour per-call values.
-        BlockHeader?[]? fresh = chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: skipLastN);
+        BlockHeader?[]? fresh = _chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: skipLastN);
         if (fresh is null || fresh.Length <= 1)
         {
             if (_logger.IsTrace) _logger.Trace("Chain level helper got no headers suggestion");
@@ -96,7 +120,7 @@ public class PosForwardHeaderProvider(
 
         if (cached is null) return null;
 
-        BlockHeader? processDestination = beaconPivot.ProcessDestination;
+        BlockHeader? processDestination = _beaconPivot.ProcessDestination;
         Hash256? currentHash = processDestination?.Hash;
         long currentNumber = processDestination?.Number ?? long.MaxValue;
         if (cachedHash != currentHash || cachedNumber != currentNumber) return null;
@@ -124,12 +148,39 @@ public class PosForwardHeaderProvider(
     {
         if (headers.Length < MinCachedHeaderBatchSize) return;
 
-        BlockHeader? destination = beaconPivot.ProcessDestination;
+        BlockHeader? destination = _beaconPivot.ProcessDestination;
         lock (_cacheLock)
         {
             _cachedHeaders = headers;
             _cachedProcessDestinationHash = destination?.Hash;
             _cachedProcessDestinationNumber = destination?.Number ?? long.MaxValue;
+        }
+    }
+
+    private void BlockTreeOnUpdateMainChain(object? sender, OnUpdateMainChainArgs e)
+    {
+        if (e.Blocks.Count == 0) return;
+
+        Block firstBlock = e.Blocks[0];
+        long firstNumber = firstBlock.Number;
+        Hash256? firstHash = firstBlock.Hash;
+
+        lock (_cacheLock)
+        {
+            BlockHeader[]? cached = _cachedHeaders;
+            if (cached is null) return;
+
+            long cacheStart = cached[0].Number;
+            long cacheEnd = cached[^1].Number;
+            if (firstNumber < cacheStart || firstNumber > cacheEnd) return;
+
+            int idx = (int)(firstNumber - cacheStart);
+            if (cached[idx].Hash != firstHash)
+            {
+                _cachedHeaders = null;
+                _cachedProcessDestinationHash = null;
+                _cachedProcessDestinationNumber = 0;
+            }
         }
     }
 
@@ -149,11 +200,11 @@ public class PosForwardHeaderProvider(
     private void TryUpdateTerminalBlock(BlockHeader currentHeader) =>
         // Needed to know what is the terminal block so in fast sync, for each
         // header, it calls this.
-        poSSwitcher.TryUpdateTerminalBlock(currentHeader);
+        _poSSwitcher.TryUpdateTerminalBlock(currentHeader);
 
     // Used only in get block header in pre merge forward header provider, this hook stops pre merge forward header provider.
     protected override bool ImprovementRequirementSatisfied(PeerInfo? bestPeer) => (bestPeer!.TotalDifficulty is null || bestPeer.TotalDifficulty > (_blockTree.BestSuggestedHeader?.TotalDifficulty ?? UInt256.Zero)) &&
-            !poSSwitcher.HasEverReachedTerminalBlock();
+            !_poSSwitcher.HasEverReachedTerminalBlock();
 
     protected override IOwnedReadOnlyList<BlockHeader> FilterPosHeader(IOwnedReadOnlyList<BlockHeader> response)
     {
@@ -163,11 +214,11 @@ public class PosForwardHeaderProvider(
         if (responseSpan.Length > 0)
         {
             BlockHeader lastBlockHeader = responseSpan[^1];
-            bool lastBlockIsPostMerge = poSSwitcher.GetBlockConsensusInfo(responseSpan[^1]).IsPostMerge;
+            bool lastBlockIsPostMerge = _poSSwitcher.GetBlockConsensusInfo(responseSpan[^1]).IsPostMerge;
             if (lastBlockIsPostMerge) // Initial check to prevent creating new array every time
             {
                 int preMergeHeadersCount = 0;
-                while (preMergeHeadersCount < responseSpan.Length && !poSSwitcher.GetBlockConsensusInfo(responseSpan[preMergeHeadersCount]).IsPostMerge)
+                while (preMergeHeadersCount < responseSpan.Length && !_poSSwitcher.GetBlockConsensusInfo(responseSpan[preMergeHeadersCount]).IsPostMerge)
                 {
                     preMergeHeadersCount++;
                 }
@@ -195,12 +246,14 @@ public class PosForwardHeaderProvider(
 
         if (addResult == AddBlockResult.Added)
         {
-            if ((beaconPivot.ProcessDestination?.Number ?? long.MaxValue) < currentBlock.Number)
+            if ((_beaconPivot.ProcessDestination?.Number ?? long.MaxValue) < currentBlock.Number)
             {
                 // Move the process destination in front, otherwise `ChainLevelHelper` would continue returning
                 // already processed header starting from `ProcessDestination`.
-                beaconPivot.ProcessDestination = currentBlock.Header;
+                _beaconPivot.ProcessDestination = currentBlock.Header;
             }
         }
     }
+
+    public void Dispose() => _blockTree.OnUpdateMainChain -= BlockTreeOnUpdateMainChain;
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -18,7 +18,7 @@ using Nethermind.Synchronization.Reporting;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 
-public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
+public class PosForwardHeaderProvider : PowForwardHeaderProvider
 {
     private const int CacheBatchMultiplier = 4;
 
@@ -105,47 +105,40 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
         if (fresh.Length >= fetchSize) UpdateCache(fresh, skipLastN);
 
         int take = Math.Min(fresh.Length, maxHeader);
-        ArrayPoolList<BlockHeader?> result = new(take);
-        result.AddRange(((BlockHeader?[])fresh).AsSpan(0, take));
+        ArrayPoolList<BlockHeader?> result = new(((BlockHeader?[])fresh).AsSpan(0, take));
         return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(result);
     }
 
     private ArrayPoolList<BlockHeader?>? TryServeFromCache(int maxHeader, int skipLastN)
     {
-        BlockHeader?[]? cached;
-        Hash256? cachedHash;
-        long cachedNumber;
-        int cachedSkip;
+        BlockHeader?[] cached;
+        int offset;
+        int take;
         lock (_cacheLock)
         {
+            if (_cachedHeaders is null || _cachedSkipLastN != skipLastN) return null;
+
+            BlockHeader? processDestination = _beaconPivot.ProcessDestination;
+            Hash256? currentHash = processDestination?.Hash;
+            long currentNumber = processDestination?.Number ?? long.MaxValue;
+            if (_cachedProcessDestinationHash != currentHash || _cachedProcessDestinationNumber != currentNumber) return null;
+
             cached = _cachedHeaders;
-            cachedHash = _cachedProcessDestinationHash;
-            cachedNumber = _cachedProcessDestinationNumber;
-            cachedSkip = _cachedSkipLastN;
+            // `cached[0]` is the anchor that `BlockDownloader.AssembleRequest` consumes as `parentHeader`;
+            // start at `BestKnownNumber` (not `+1`) so the anchor stays at slice index 0.
+            long desiredStart = Math.Min(_blockTree.BestKnownNumber, currentNumber);
+            long cacheStart = cached[0]!.Number;
+            long cacheEnd = cached[^1]!.Number;
+            if (desiredStart < cacheStart || desiredStart > cacheEnd) return null;
+
+            offset = (int)(desiredStart - cacheStart);
+            int available = cached.Length - offset;
+            if (available <= 1) return null;
+
+            take = Math.Min(available, maxHeader);
         }
 
-        if (cached is null || cachedSkip != skipLastN) return null;
-
-        BlockHeader? processDestination = _beaconPivot.ProcessDestination;
-        Hash256? currentHash = processDestination?.Hash;
-        long currentNumber = processDestination?.Number ?? long.MaxValue;
-        if (cachedHash != currentHash || cachedNumber != currentNumber) return null;
-
-        // `cached[0]` is the anchor that `BlockDownloader.AssembleRequest` consumes as `parentHeader`;
-        // start at `BestKnownNumber` (not `+1`) so the anchor stays at slice index 0.
-        long desiredStart = Math.Min(_blockTree.BestKnownNumber, currentNumber);
-        long cacheStart = cached[0]!.Number;
-        long cacheEnd = cached[^1]!.Number;
-        if (desiredStart < cacheStart || desiredStart > cacheEnd) return null;
-
-        int offset = (int)(desiredStart - cacheStart);
-        int available = cached.Length - offset;
-        if (available <= 1) return null;
-
-        int take = Math.Min(available, maxHeader);
-        ArrayPoolList<BlockHeader?> slice = new(take);
-        slice.AddRange(cached.AsSpan(offset, take));
-        return slice;
+        return new ArrayPoolList<BlockHeader?>(cached.AsSpan(offset, take));
     }
 
     private void UpdateCache(BlockHeader[] headers, int skipLastN)
@@ -188,6 +181,7 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
                     _cachedProcessDestinationNumber = 0;
                     _cachedSkipLastN = 0;
                 }
+                // First in-range block's hash commits to all earlier blocks in this update.
                 return;
             }
         }
@@ -251,5 +245,5 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
         }
     }
 
-    public void Dispose() => _blockTree.OnUpdateMainChain -= BlockTreeOnUpdateMainChain;
+    internal void UnsubscribeForTest() => _blockTree.OnUpdateMainChain -= BlockTreeOnUpdateMainChain;
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -30,7 +30,6 @@ public class PosForwardHeaderProvider(
 ) : PowForwardHeaderProvider(sealValidator, blockTree, syncPeerPool, syncReport, logManager)
 {
     private const int CacheBatchMultiplier = 4;
-    private const int MinCachedHeaderBatchSize = 32;
 
     private readonly ILogger _logger = logManager.GetClassLogger<PosForwardHeaderProvider>();
     private readonly IBlockTree _blockTree = blockTree;
@@ -52,14 +51,14 @@ public class PosForwardHeaderProvider(
 
         _syncReport.FullSyncBlocksDownloaded.TargetValue = Math.Max(beaconPivot.PivotNumber, beaconPivot.PivotDestinationNumber);
 
-        BlockHeader?[]? slice = TryServeFromCache(maxHeader, skipLastN);
+        ArrayPoolList<BlockHeader?>? slice = TryServeFromCache(maxHeader, skipLastN);
         if (slice is not null)
         {
             // Re-validate per slice so terminal-block / random-index checks run on the served window
             // rather than only at fill time.
-            ValidateSeals(slice!, cancellation);
-            if (_logger.IsTrace) _logger.Trace($"Served {slice.Length} headers from forward-header cache");
-            return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(slice.ToPooledList(slice.Length));
+            ValidateSeals(slice, cancellation);
+            if (_logger.IsTrace) _logger.Trace($"Served {slice.Count} headers from forward-header cache");
+            return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(slice);
         }
 
         // Fetch a larger batch than asked so subsequent peer allocations can be served from the cache.
@@ -83,7 +82,7 @@ public class PosForwardHeaderProvider(
         return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(BuildSlice(fresh!, maxHeader, skipLastN: 0));
     }
 
-    private BlockHeader?[]? TryServeFromCache(int maxHeader, int skipLastN)
+    private ArrayPoolList<BlockHeader?>? TryServeFromCache(int maxHeader, int skipLastN)
     {
         BlockHeader[]? cached;
         Hash256? cachedHash;
@@ -95,7 +94,7 @@ public class PosForwardHeaderProvider(
             cachedNumber = _cachedProcessDestinationNumber;
         }
 
-        if (cached is null || cached.Length == 0) return null;
+        if (cached is null) return null;
 
         BlockHeader? processDestination = beaconPivot.ProcessDestination;
         Hash256? currentHash = processDestination?.Hash;
@@ -116,8 +115,8 @@ public class PosForwardHeaderProvider(
         if (available <= 1) return null;
 
         int take = Math.Min(available, maxHeader);
-        BlockHeader?[] slice = new BlockHeader[take];
-        Array.Copy(cached, offset, slice!, 0, take);
+        ArrayPoolList<BlockHeader?> slice = new(take);
+        for (int i = 0; i < take; i++) slice.Add(cached[offset + i]);
         return slice;
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -55,13 +55,18 @@ public class PosForwardHeaderProvider(
         BlockHeader?[]? slice = TryServeFromCache(maxHeader, skipLastN);
         if (slice is not null)
         {
+            // Re-validate per slice so terminal-block / random-index checks run on the served window
+            // rather than only at fill time.
+            ValidateSeals(slice!, cancellation);
             if (_logger.IsTrace) _logger.Trace($"Served {slice.Length} headers from forward-header cache");
             return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(slice.ToPooledList(slice.Length));
         }
 
         // Fetch a larger batch than asked so subsequent peer allocations can be served from the cache.
         int fetchSize = Math.Max(maxHeader * CacheBatchMultiplier, MinCachedHeaderBatchSize);
-        BlockHeader?[]? fresh = chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: 0);
+        // Forward `skipLastN` so `ChainLevelHelper` enforces the same chain-tip exclusion as the
+        // pre-cache implementation; trim the slice tail again at serve time to honour per-call values.
+        BlockHeader?[]? fresh = chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: skipLastN);
         if (fresh is null || fresh.Length <= 1)
         {
             if (_logger.IsTrace) _logger.Trace("Chain level helper got no headers suggestion");
@@ -71,9 +76,11 @@ public class PosForwardHeaderProvider(
         // Alternatively we can do this in BeaconHeadersSyncFeed, but this seems easier.
         ValidateSeals(fresh!, cancellation);
 
-        UpdateCache(fresh!);
+        // Only cache a full-sized batch; a truncated fetch implies we reached the chain tip and the
+        // cached tail would diverge from the original `skipLastBlockCount` semantics on later calls.
+        if (fresh.Length >= fetchSize) UpdateCache(fresh!);
 
-        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(BuildSlice(fresh!, maxHeader, skipLastN));
+        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(BuildSlice(fresh!, maxHeader, skipLastN: 0));
     }
 
     private BlockHeader?[]? TryServeFromCache(int maxHeader, int skipLastN)
@@ -95,7 +102,11 @@ public class PosForwardHeaderProvider(
         long currentNumber = processDestination?.Number ?? long.MaxValue;
         if (cachedHash != currentHash || cachedNumber != currentNumber) return null;
 
-        long desiredStart = Math.Min(_blockTree.BestKnownNumber + 1, currentNumber);
+        // `ChainLevelHelper.GetStartingPoint` returns the *anchor* (last processed block) in the
+        // active beacon-sync walk-back path, i.e. `headers[0].Number == BestKnownNumber`.
+        // Use `BestKnownNumber` (not `+1`) so the served slice retains the anchor at index 0,
+        // matching the contract `BlockDownloader.AssembleRequest` relies on.
+        long desiredStart = Math.Min(_blockTree.BestKnownNumber, currentNumber);
         long cacheStart = cached[0].Number;
         long cacheEnd = cached[^1].Number;
         if (desiredStart < cacheStart || desiredStart > cacheEnd) return null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -8,6 +8,7 @@ using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -28,9 +29,17 @@ public class PosForwardHeaderProvider(
     ILogManager logManager
 ) : PowForwardHeaderProvider(sealValidator, blockTree, syncPeerPool, syncReport, logManager)
 {
+    private const int CacheBatchMultiplier = 4;
+    private const int MinCachedHeaderBatchSize = 32;
+
     private readonly ILogger _logger = logManager.GetClassLogger<PosForwardHeaderProvider>();
     private readonly IBlockTree _blockTree = blockTree;
     private readonly ISyncReport _syncReport = syncReport;
+
+    private readonly Lock _cacheLock = new();
+    private BlockHeader[]? _cachedHeaders;
+    private Hash256? _cachedProcessDestinationHash;
+    private long _cachedProcessDestinationNumber;
 
     private bool ShouldUsePreMerge() => !beaconPivot.BeaconPivotExists() && !poSSwitcher.HasEverReachedTerminalBlock();
 
@@ -43,18 +52,88 @@ public class PosForwardHeaderProvider(
 
         _syncReport.FullSyncBlocksDownloaded.TargetValue = Math.Max(beaconPivot.PivotNumber, beaconPivot.PivotDestinationNumber);
 
-        // TODO: Previously it does not get block more than best peer's head number. Why?
-        BlockHeader?[]? headers = chainLevelHelper.GetNextHeaders(maxHeader, long.MaxValue, skipLastN);
-        if (headers is null || headers.Length <= 1)
+        BlockHeader?[]? slice = TryServeFromCache(maxHeader, skipLastN);
+        if (slice is not null)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Served {slice.Length} headers from forward-header cache");
+            return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(slice.ToPooledList(slice.Length));
+        }
+
+        // Fetch a larger batch than asked so subsequent peer allocations can be served from the cache.
+        int fetchSize = Math.Max(maxHeader * CacheBatchMultiplier, MinCachedHeaderBatchSize);
+        BlockHeader?[]? fresh = chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: 0);
+        if (fresh is null || fresh.Length <= 1)
         {
             if (_logger.IsTrace) _logger.Trace("Chain level helper got no headers suggestion");
             return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(null);
         }
 
         // Alternatively we can do this in BeaconHeadersSyncFeed, but this seems easier.
-        ValidateSeals(headers!, cancellation);
+        ValidateSeals(fresh!, cancellation);
 
-        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(headers.ToPooledList(headers.Length));
+        UpdateCache(fresh!);
+
+        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(BuildSlice(fresh!, maxHeader, skipLastN));
+    }
+
+    private BlockHeader?[]? TryServeFromCache(int maxHeader, int skipLastN)
+    {
+        BlockHeader[]? cached;
+        Hash256? cachedHash;
+        long cachedNumber;
+        lock (_cacheLock)
+        {
+            cached = _cachedHeaders;
+            cachedHash = _cachedProcessDestinationHash;
+            cachedNumber = _cachedProcessDestinationNumber;
+        }
+
+        if (cached is null || cached.Length == 0) return null;
+
+        BlockHeader? processDestination = beaconPivot.ProcessDestination;
+        Hash256? currentHash = processDestination?.Hash;
+        long currentNumber = processDestination?.Number ?? long.MaxValue;
+        if (cachedHash != currentHash || cachedNumber != currentNumber) return null;
+
+        long desiredStart = Math.Min(_blockTree.BestKnownNumber + 1, currentNumber);
+        long cacheStart = cached[0].Number;
+        long cacheEnd = cached[^1].Number;
+        if (desiredStart < cacheStart || desiredStart > cacheEnd) return null;
+
+        int offset = (int)(desiredStart - cacheStart);
+        int available = cached.Length - offset - skipLastN;
+        if (available <= 1) return null;
+
+        int take = Math.Min(available, maxHeader);
+        BlockHeader?[] slice = new BlockHeader[take];
+        Array.Copy(cached, offset, slice!, 0, take);
+        return slice;
+    }
+
+    private void UpdateCache(BlockHeader[] headers)
+    {
+        if (headers.Length < MinCachedHeaderBatchSize) return;
+
+        BlockHeader? destination = beaconPivot.ProcessDestination;
+        lock (_cacheLock)
+        {
+            _cachedHeaders = headers;
+            _cachedProcessDestinationHash = destination?.Hash;
+            _cachedProcessDestinationNumber = destination?.Number ?? long.MaxValue;
+        }
+    }
+
+    private static IOwnedReadOnlyList<BlockHeader?> BuildSlice(BlockHeader?[] fresh, int maxHeader, int skipLastN)
+    {
+        int take = Math.Max(0, Math.Min(fresh.Length - skipLastN, maxHeader));
+        if (take == fresh.Length)
+        {
+            return fresh.ToPooledList(fresh.Length);
+        }
+
+        ArrayPoolList<BlockHeader?> result = new(take);
+        for (int i = 0; i < take; i++) result.Add(fresh[i]);
+        return result;
     }
 
     private void TryUpdateTerminalBlock(BlockHeader currentHeader) =>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -30,9 +31,10 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
     private readonly ISyncReport _syncReport;
 
     private readonly Lock _cacheLock = new();
-    private BlockHeader[]? _cachedHeaders;
+    private BlockHeader?[]? _cachedHeaders;
     private Hash256? _cachedProcessDestinationHash;
     private long _cachedProcessDestinationNumber;
+    private int _cachedSkipLastN;
 
     public PosForwardHeaderProvider(
         IChainLevelHelper chainLevelHelper,
@@ -89,7 +91,7 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
         int fetchSize = Math.Max(maxHeader * CacheBatchMultiplier, MinCachedHeaderBatchSize);
         // Forward `skipLastN` so `ChainLevelHelper` enforces the same chain-tip exclusion as the
         // pre-cache implementation; trim the slice tail again at serve time to honour per-call values.
-        BlockHeader?[]? fresh = _chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: skipLastN);
+        BlockHeader[]? fresh = _chainLevelHelper.GetNextHeaders(fetchSize, long.MaxValue, skipLastBlockCount: skipLastN);
         if (fresh is null || fresh.Length <= 1)
         {
             if (_logger.IsTrace) _logger.Trace("Chain level helper got no headers suggestion");
@@ -97,104 +99,99 @@ public class PosForwardHeaderProvider : PowForwardHeaderProvider, IDisposable
         }
 
         // Alternatively we can do this in BeaconHeadersSyncFeed, but this seems easier.
-        ValidateSeals(fresh!, cancellation);
+        ValidateSeals(fresh, cancellation);
 
         // Only cache a full-sized batch; a truncated fetch implies we reached the chain tip and the
         // cached tail would diverge from the original `skipLastBlockCount` semantics on later calls.
-        if (fresh.Length >= fetchSize) UpdateCache(fresh!);
+        if (fresh.Length >= fetchSize) UpdateCache(fresh, skipLastN);
 
-        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(BuildSlice(fresh!, maxHeader, skipLastN: 0));
+        int take = Math.Min(fresh.Length, maxHeader);
+        ArrayPoolList<BlockHeader?> result = new(take);
+        result.AddRange(((BlockHeader?[])fresh).AsSpan(0, take));
+        return Task.FromResult<IOwnedReadOnlyList<BlockHeader?>?>(result);
     }
 
     private ArrayPoolList<BlockHeader?>? TryServeFromCache(int maxHeader, int skipLastN)
     {
-        BlockHeader[]? cached;
+        BlockHeader?[]? cached;
         Hash256? cachedHash;
         long cachedNumber;
+        int cachedSkip;
         lock (_cacheLock)
         {
             cached = _cachedHeaders;
             cachedHash = _cachedProcessDestinationHash;
             cachedNumber = _cachedProcessDestinationNumber;
+            cachedSkip = _cachedSkipLastN;
         }
 
-        if (cached is null) return null;
+        if (cached is null || cachedSkip != skipLastN) return null;
 
         BlockHeader? processDestination = _beaconPivot.ProcessDestination;
         Hash256? currentHash = processDestination?.Hash;
         long currentNumber = processDestination?.Number ?? long.MaxValue;
         if (cachedHash != currentHash || cachedNumber != currentNumber) return null;
 
-        // `ChainLevelHelper.GetStartingPoint` returns the *anchor* (last processed block) in the
-        // active beacon-sync walk-back path, i.e. `headers[0].Number == BestKnownNumber`.
-        // Use `BestKnownNumber` (not `+1`) so the served slice retains the anchor at index 0,
-        // matching the contract `BlockDownloader.AssembleRequest` relies on.
+        // `cached[0]` is the anchor that `BlockDownloader.AssembleRequest` consumes as `parentHeader`;
+        // start at `BestKnownNumber` (not `+1`) so the anchor stays at slice index 0.
         long desiredStart = Math.Min(_blockTree.BestKnownNumber, currentNumber);
-        long cacheStart = cached[0].Number;
-        long cacheEnd = cached[^1].Number;
+        long cacheStart = cached[0]!.Number;
+        long cacheEnd = cached[^1]!.Number;
         if (desiredStart < cacheStart || desiredStart > cacheEnd) return null;
 
         int offset = (int)(desiredStart - cacheStart);
-        int available = cached.Length - offset - skipLastN;
+        int available = cached.Length - offset;
         if (available <= 1) return null;
 
         int take = Math.Min(available, maxHeader);
         ArrayPoolList<BlockHeader?> slice = new(take);
-        for (int i = 0; i < take; i++) slice.Add(cached[offset + i]);
+        slice.AddRange(cached.AsSpan(offset, take));
         return slice;
     }
 
-    private void UpdateCache(BlockHeader[] headers)
+    private void UpdateCache(BlockHeader[] headers, int skipLastN)
     {
-        if (headers.Length < MinCachedHeaderBatchSize) return;
-
         BlockHeader? destination = _beaconPivot.ProcessDestination;
         lock (_cacheLock)
         {
             _cachedHeaders = headers;
             _cachedProcessDestinationHash = destination?.Hash;
             _cachedProcessDestinationNumber = destination?.Number ?? long.MaxValue;
+            _cachedSkipLastN = skipLastN;
         }
     }
 
     private void BlockTreeOnUpdateMainChain(object? sender, OnUpdateMainChainArgs e)
     {
-        if (e.Blocks.Count == 0) return;
-
-        Block firstBlock = e.Blocks[0];
-        long firstNumber = firstBlock.Number;
-        Hash256? firstHash = firstBlock.Hash;
+        IReadOnlyList<Block> blocks = e.Blocks;
+        if (blocks.Count == 0) return;
 
         lock (_cacheLock)
         {
-            BlockHeader[]? cached = _cachedHeaders;
+            BlockHeader?[]? cached = _cachedHeaders;
             if (cached is null) return;
 
-            long cacheStart = cached[0].Number;
-            long cacheEnd = cached[^1].Number;
-            if (firstNumber < cacheStart || firstNumber > cacheEnd) return;
+            long cacheStart = cached[0]!.Number;
+            long cacheEnd = cached[^1]!.Number;
 
-            int idx = (int)(firstNumber - cacheStart);
-            if (cached[idx].Hash != firstHash)
+            // `UpdateMainChain` can fire in either ascending or descending order, and reorgs may
+            // start below `cacheStart`; scan until we hit a block inside the cached range.
+            for (int i = 0; i < blocks.Count; i++)
             {
-                _cachedHeaders = null;
-                _cachedProcessDestinationHash = null;
-                _cachedProcessDestinationNumber = 0;
+                Block block = blocks[i];
+                if (block.Number < cacheStart || block.Number > cacheEnd) continue;
+
+                int idx = (int)(block.Number - cacheStart);
+                if (cached[idx]!.Hash != block.Hash)
+                {
+                    _cachedHeaders = null;
+                    _cachedProcessDestinationHash = null;
+                    _cachedProcessDestinationNumber = 0;
+                    _cachedSkipLastN = 0;
+                }
+                return;
             }
         }
-    }
-
-    private static IOwnedReadOnlyList<BlockHeader?> BuildSlice(BlockHeader?[] fresh, int maxHeader, int skipLastN)
-    {
-        int take = Math.Max(0, Math.Min(fresh.Length - skipLastN, maxHeader));
-        if (take == fresh.Length)
-        {
-            return fresh.ToPooledList(fresh.Length);
-        }
-
-        ArrayPoolList<BlockHeader?> result = new(take);
-        for (int i = 0; i < take; i++) result.Add(fresh[i]);
-        return result;
     }
 
     private void TryUpdateTerminalBlock(BlockHeader currentHeader) =>

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -37,7 +37,7 @@ public class PowForwardHeaderProvider(
     private readonly Random _rnd = new();
     private readonly Guid _sealValidatorUserGuid = Guid.NewGuid();
 
-    private const int MinCachedHeaderBatchSize = 32;
+    protected const int MinCachedHeaderBatchSize = 32;
 
     private IPeerAllocationStrategy _bestPeerAllocationStrategy =
         new TotalDiffStrategy(new ByTotalDifficultyPeerAllocationStrategy(null), TotalDiffStrategy.TotalDiffSelectionType.AtLeastTheSame);


### PR DESCRIPTION
Resolves #8573

## Changes

- `PosForwardHeaderProvider.GetBlockHeaders` now fetches a `4 * maxHeader` batch from `ChainLevelHelper` once, caches it, and serves subsequent calls by slicing the cached array.
- Cache is invalidated when `IBeaconPivot.ProcessDestination` (hash or number) changes, when `BestKnownNumber` advances past the cached end, or when the requested slice cannot be satisfied without going below the cached start.
- Pre-merge path (`base.GetBlockHeaders`) is unchanged; the `LastResponseBatch` mechanism in `PowForwardHeaderProvider` continues to drive that branch.
- `ValidateSeals` runs once per cache fill (on the freshly fetched array) rather than on every peer allocation.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`PosForwardHeaderProviderCacheTests` (5 cases) covers: cache hit on identical inputs, invalidation when `ProcessDestination.Hash` changes, invalidation when `BestKnownNumber` advances past the cached range, slice advances with `BestKnownNumber` while inside the range, and `skipLastN` honored on cache hits. Existing `ForwardHeaderProviderTests` (37/38 pass, 1 pre-existing skip) continue to pass.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

Invalidation strategy follows the hint left in the issue: with no explicit signal for when `ChainLevelHelper` would return different headers, identity of `BeaconPivot.ProcessDestination` (set by `NewPayload`/`ForkchoiceUpdated`) plus `BestKnownNumber` advance covers the cases where the underlying chain-level data could have moved. Happy to swap to a more aggressive (e.g. `BlockTree.NewHeadBlock`) invalidation if reviewers prefer.