### PR TITLE
perf(blockchain): make ChainHeadSpecProvider lock-free

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Spec/ChainHeadSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Spec/ChainHeadSpecProviderTests.cs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Spec;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Specs.Forks;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Spec;
+
+public class ChainHeadSpecProviderTests
+{
+    [Test]
+    public void GetCurrentHeadSpec_returns_spec_for_current_header()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
+        IReleaseSpec expected = Cancun.Instance;
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(header).Returns(expected);
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(header);
+
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        provider.GetCurrentHeadSpec().Should().BeSameAs(expected);
+    }
+
+    [Test]
+    public void Repeat_call_with_same_head_does_not_resolve_spec_again()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(header).Returns(Cancun.Instance);
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(header);
+
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        for (int i = 0; i < 100; i++) provider.GetCurrentHeadSpec();
+
+        specProvider.Received(1).GetSpec(header);
+    }
+
+    [Test]
+    public void New_head_invalidates_cache_and_re_resolves_spec()
+    {
+        BlockHeader first = Build.A.BlockHeader.WithNumber(42).TestObject;
+        BlockHeader second = Build.A.BlockHeader.WithNumber(43).TestObject;
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(first).Returns(Cancun.Instance);
+        specProvider.GetSpec(second).Returns(Prague.Instance);
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(first, second);
+
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        provider.GetCurrentHeadSpec().Should().BeSameAs(Cancun.Instance);
+        provider.GetCurrentHeadSpec().Should().BeSameAs(Prague.Instance);
+    }
+
+    [Test]
+    public async Task Concurrent_callers_observe_consistent_spec()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(header).Returns(Cancun.Instance);
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(header);
+
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        const int workers = 32;
+        const int iterations = 5_000;
+        Task[] tasks = new Task[workers];
+        for (int w = 0; w < workers; w++)
+        {
+            tasks[w] = Task.Run(() =>
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    provider.GetCurrentHeadSpec().Should().BeSameAs(Cancun.Instance);
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    [Test]
+    public async Task Concurrent_writers_during_head_change_publish_a_consistent_pair()
+    {
+        BlockHeader[] headers =
+        {
+            Build.A.BlockHeader.WithNumber(10).TestObject,
+            Build.A.BlockHeader.WithNumber(11).TestObject,
+            Build.A.BlockHeader.WithNumber(12).TestObject,
+        };
+        IReleaseSpec[] specs = { Cancun.Instance, Prague.Instance, Osaka.Instance };
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        for (int i = 0; i < headers.Length; i++) specProvider.GetSpec(headers[i]).Returns(specs[i]);
+
+        Dictionary<long, IReleaseSpec> expectedByNumber = new();
+        for (int i = 0; i < headers.Length; i++) expectedByNumber[headers[i].Number] = specs[i];
+
+        BlockHeader currentHeader = headers[0];
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(_ => Volatile.Read(ref currentHeader));
+
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        const int workers = 16;
+        Task[] tasks = new Task[workers];
+        for (int w = 0; w < workers; w++)
+        {
+            tasks[w] = Task.Run(() =>
+            {
+                for (int i = 0; i < 2_000; i++)
+                {
+                    BlockHeader observed = blockFinder.FindBestSuggestedHeader();
+                    IReleaseSpec spec = provider.GetCurrentHeadSpec();
+                    // The observed spec must match the spec for some header whose number is
+                    // <= the latest published header. Because writers race, allow any of the
+                    // valid expected mappings.
+                    expectedByNumber.Values.Should().Contain(spec);
+                }
+            });
+        }
+
+        Task rotator = Task.Run(() =>
+        {
+            for (int i = 0; i < headers.Length; i++)
+            {
+                Volatile.Write(ref currentHeader, headers[i]);
+                Thread.Sleep(1);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        await rotator;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Spec/ChainHeadSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Spec/ChainHeadSpecProviderTests.cs
@@ -19,35 +19,16 @@ namespace Nethermind.Blockchain.Test.Spec;
 public class ChainHeadSpecProviderTests
 {
     [Test]
-    public void GetCurrentHeadSpec_returns_spec_for_current_header()
+    public void Repeat_call_with_same_head_resolves_spec_once_and_returns_it()
     {
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
-        IReleaseSpec expected = Cancun.Instance;
-
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(header).Returns(expected);
-
-        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-        blockFinder.FindBestSuggestedHeader().Returns(header);
-
+        (ISpecProvider specProvider, IBlockFinder blockFinder) = SetupForSingleHeader(header, Cancun.Instance);
         ChainHeadSpecProvider provider = new(specProvider, blockFinder);
 
-        provider.GetCurrentHeadSpec().Should().BeSameAs(expected);
-    }
-
-    [Test]
-    public void Repeat_call_with_same_head_does_not_resolve_spec_again()
-    {
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(header).Returns(Cancun.Instance);
-
-        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-        blockFinder.FindBestSuggestedHeader().Returns(header);
-
-        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
-
-        for (int i = 0; i < 100; i++) provider.GetCurrentHeadSpec();
+        for (int i = 0; i < 100; i++)
+        {
+            provider.GetCurrentHeadSpec().Should().BeSameAs(Cancun.Instance);
+        }
 
         specProvider.Received(1).GetSpec(header);
     }
@@ -72,15 +53,24 @@ public class ChainHeadSpecProviderTests
     }
 
     [Test]
-    public async Task Concurrent_callers_observe_consistent_spec()
+    public void Null_header_falls_back_to_zero_fork_activation()
     {
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(header).Returns(Cancun.Instance);
+        specProvider.GetSpec((ForkActivation)0L).Returns(Cancun.Instance);
 
         IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-        blockFinder.FindBestSuggestedHeader().Returns(header);
+        blockFinder.FindBestSuggestedHeader().Returns((BlockHeader?)null);
 
+        ChainHeadSpecProvider provider = new(specProvider, blockFinder);
+
+        provider.GetCurrentHeadSpec().Should().BeSameAs(Cancun.Instance);
+    }
+
+    [Test]
+    public async Task Concurrent_callers_on_stable_head_observe_consistent_spec()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
+        (ISpecProvider specProvider, IBlockFinder blockFinder) = SetupForSingleHeader(header, Cancun.Instance);
         ChainHeadSpecProvider provider = new(specProvider, blockFinder);
 
         const int workers = 32;
@@ -101,8 +91,12 @@ public class ChainHeadSpecProviderTests
     }
 
     [Test]
-    public async Task Concurrent_writers_during_head_change_publish_a_consistent_pair()
+    public async Task Concurrent_callers_during_head_rotation_never_observe_torn_pair()
     {
+        // Each header maps to a distinct spec instance, so any returned spec must be one of
+        // the configured mappings — a torn (number, spec) pair would surface as either null
+        // or an unrecognised reference. Loop the head fast enough that publishes overlap
+        // with reads.
         BlockHeader[] headers =
         {
             Build.A.BlockHeader.WithNumber(10).TestObject,
@@ -112,10 +106,12 @@ public class ChainHeadSpecProviderTests
         IReleaseSpec[] specs = { Cancun.Instance, Prague.Instance, Osaka.Instance };
 
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        for (int i = 0; i < headers.Length; i++) specProvider.GetSpec(headers[i]).Returns(specs[i]);
-
-        Dictionary<long, IReleaseSpec> expectedByNumber = new();
-        for (int i = 0; i < headers.Length; i++) expectedByNumber[headers[i].Number] = specs[i];
+        HashSet<IReleaseSpec> validSpecs = new();
+        for (int i = 0; i < headers.Length; i++)
+        {
+            specProvider.GetSpec(headers[i]).Returns(specs[i]);
+            validSpecs.Add(specs[i]);
+        }
 
         BlockHeader currentHeader = headers[0];
         IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
@@ -123,34 +119,44 @@ public class ChainHeadSpecProviderTests
 
         ChainHeadSpecProvider provider = new(specProvider, blockFinder);
 
+        using CancellationTokenSource cts = new();
         const int workers = 16;
         Task[] tasks = new Task[workers];
         for (int w = 0; w < workers; w++)
         {
             tasks[w] = Task.Run(() =>
             {
-                for (int i = 0; i < 2_000; i++)
+                while (!cts.IsCancellationRequested)
                 {
-                    BlockHeader observed = blockFinder.FindBestSuggestedHeader();
                     IReleaseSpec spec = provider.GetCurrentHeadSpec();
-                    // The observed spec must match the spec for some header whose number is
-                    // <= the latest published header. Because writers race, allow any of the
-                    // valid expected mappings.
-                    expectedByNumber.Values.Should().Contain(spec);
+                    spec.Should().NotBeNull();
+                    validSpecs.Contains(spec).Should().BeTrue();
                 }
             });
         }
 
-        Task rotator = Task.Run(() =>
+        Task rotator = Task.Run(async () =>
         {
-            for (int i = 0; i < headers.Length; i++)
+            for (int round = 0; round < 200; round++)
             {
-                Volatile.Write(ref currentHeader, headers[i]);
-                Thread.Sleep(1);
+                Volatile.Write(ref currentHeader, headers[round % headers.Length]);
+                await Task.Yield();
             }
+            cts.Cancel();
         });
 
         await Task.WhenAll(tasks);
         await rotator;
+    }
+
+    private static (ISpecProvider SpecProvider, IBlockFinder BlockFinder) SetupForSingleHeader(BlockHeader header, IReleaseSpec spec)
+    {
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(header).Returns(spec);
+
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.FindBestSuggestedHeader().Returns(header);
+
+        return (specProvider, blockFinder);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Spec/ChainHeadSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Spec/ChainHeadSpecProvider.cs
@@ -44,8 +44,8 @@ namespace Nethermind.Blockchain.Spec
             BlockHeader? header = _blockFinder.FindBestSuggestedHeader();
             long headerNumber = header?.Number ?? 0;
 
-            // Lock-free fast path: a single reference read returns a fully constructed
-            // (number, spec) pair, so readers never observe a torn pairing.
+            // Reference-type record keeps the (number, spec) publication atomic.
+            // Don't change to a record struct — 16-byte writes are not atomic.
             CachedSpec? snapshot = Volatile.Read(ref _cache);
             if (snapshot is not null && snapshot.Number == headerNumber)
             {
@@ -56,9 +56,6 @@ namespace Nethermind.Blockchain.Spec
                 ? _specProvider.GetSpec(header)
                 : _specProvider.GetSpec((ForkActivation)headerNumber);
 
-            // Concurrent writers race to publish a snapshot for the same headerNumber.
-            // Because GetSpec is deterministic per (number, header), every winner stores
-            // an equivalent value, so a last-writer-wins publish is safe.
             Volatile.Write(ref _cache, new CachedSpec(headerNumber, spec));
             return spec;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Spec/ChainHeadSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Spec/ChainHeadSpecProvider.cs
@@ -14,9 +14,7 @@ namespace Nethermind.Blockchain.Spec
     {
         private readonly ISpecProvider _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         private readonly IBlockFinder _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
-        private long _lastHeader = -1;
-        private IReleaseSpec? _headerSpec;
-        private readonly Lock _lock = new();
+        private CachedSpec? _cache;
 
         public void UpdateMergeTransitionInfo(long? blockNumber, UInt256? terminalTotalDifficulty = null) =>
             _specProvider.UpdateMergeTransitionInfo(blockNumber, terminalTotalDifficulty);
@@ -46,26 +44,25 @@ namespace Nethermind.Blockchain.Spec
             BlockHeader? header = _blockFinder.FindBestSuggestedHeader();
             long headerNumber = header?.Number ?? 0;
 
-            // we are fine with potential concurrency issue here, that the spec will change
-            // between this if and getting actual header spec
-            // this is used only in tx pool and this is not a problem there
-            if (headerNumber == _lastHeader)
+            // Lock-free fast path: a single reference read returns a fully constructed
+            // (number, spec) pair, so readers never observe a torn pairing.
+            CachedSpec? snapshot = Volatile.Read(ref _cache);
+            if (snapshot is not null && snapshot.Number == headerNumber)
             {
-                IReleaseSpec releaseSpec = _headerSpec;
-                if (releaseSpec is not null)
-                {
-                    return releaseSpec;
-                }
+                return snapshot.Spec;
             }
 
-            // we want to make sure updates to both fields are consistent though
-            lock (_lock)
-            {
-                _lastHeader = headerNumber;
-                return _headerSpec = header is not null
-                    ? _specProvider.GetSpec(header)
-                    : _specProvider.GetSpec((ForkActivation)headerNumber);
-            }
+            IReleaseSpec spec = header is not null
+                ? _specProvider.GetSpec(header)
+                : _specProvider.GetSpec((ForkActivation)headerNumber);
+
+            // Concurrent writers race to publish a snapshot for the same headerNumber.
+            // Because GetSpec is deterministic per (number, header), every winner stores
+            // an equivalent value, so a last-writer-wins publish is safe.
+            Volatile.Write(ref _cache, new CachedSpec(headerNumber, spec));
+            return spec;
         }
+
+        private sealed record CachedSpec(long Number, IReleaseSpec Spec);
     }
 }


### PR DESCRIPTION
Resolves #11367

## Changes

- `ChainHeadSpecProvider.GetCurrentHeadSpec` is now lock-free. The cached `(headerNumber, releaseSpec)` pair is wrapped in an immutable `CachedSpec` record and published through a single reference field with `Volatile.Read` / `Volatile.Write`.
- Removed the `Lock _lock`, the paired `_lastHeader` / `_headerSpec` fields, and the read-then-double-checked-write block.
- Behaviour is preserved: a single reference read returns a fully constructed snapshot, so readers never observe a torn `(number, spec)` pair, and concurrent writers race to publish equivalent values for the same headerNumber (`GetSpec(header)` is deterministic).

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`ChainHeadSpecProviderTests` (5 cases): basic resolution, single-resolve on repeated same-head call, re-resolve on head change, 32 readers x 5000 iterations against a stable head, and a head-rotation race with 16 workers asserting every observed spec belongs to the published mapping. No production hot-path callers needed updating.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No