### PR TITLE
refactor(evm): collapse CALL 63/64 gas-rule branch into single OOG check

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
 using Nethermind.Specs;
 using NUnit.Framework;
 
@@ -49,6 +51,61 @@ namespace Nethermind.Evm.Test
                 .Done;
 
             TestAllTracerWithOutput result = Execute(Activation, 21020, code);
+            Assert.That(result.Error, Is.EqualTo("OutOfGas"));
+        }
+
+        /// <summary>
+        /// Post-EIP-150 (Tangerine Whistle and later): the 63/64 cap clamps any caller-supplied
+        /// gasLimit to a value strictly less than <c>long.MaxValue</c>, so the post-clamp
+        /// <c>(long)gasLimit</c> cast never trips even when the user pushes <c>UInt256.MaxValue</c>.
+        /// </summary>
+        [Test]
+        public void Call_with_gas_above_long_max_post_eip150_is_capped_not_out_of_gas()
+        {
+            byte[] code = Prepare.EvmCode
+                .PushData(0)               // retLength
+                .PushData(0)               // retOffset
+                .PushData(0)               // argsLength
+                .PushData(0)               // argsOffset
+                .PushData(0)               // value
+                .PushData(TestItem.AddressC)
+                .PushData(UInt256.MaxValue) // gasLimit — high bits set; cap clamps it
+                .Op(Instruction.CALL)
+                .Done;
+
+            TestAllTracerWithOutput result = Execute(Activation, 200_000, code);
+            Assert.That(result.Error, Is.Null, "CALL must succeed: 63/64 cap clamps gasLimit to a long-representable value");
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        }
+    }
+
+    /// <summary>
+    /// Pre-EIP-150 (Frontier / Homestead) CALL behaviour for caller-supplied <c>gasLimit</c>
+    /// values larger than <see cref="long.MaxValue"/>. With the 63/64 rule inactive, the only
+    /// guard before <c>(long)gasLimit</c> is the explicit <c>gasLimit &gt;= long.MaxValue</c>
+    /// OOG check; without it, the UInt256→long cast throws <c>OverflowException</c> instead of
+    /// the EVM-correct <c>OutOfGas</c>. This locks the guard in place against future refactors.
+    /// </summary>
+    public class CallTestsPreEip150 : VirtualMachineTestsBase
+    {
+        protected override long BlockNumber => 0;
+        protected override ulong Timestamp => 0;
+
+        [Test]
+        public void Call_with_gas_above_long_max_out_of_gas()
+        {
+            byte[] code = Prepare.EvmCode
+                .PushData(0)               // retLength
+                .PushData(0)               // retOffset
+                .PushData(0)               // argsLength
+                .PushData(0)               // argsOffset
+                .PushData(0)               // value
+                .PushData(TestItem.AddressC)
+                .PushData(UInt256.MaxValue) // gasLimit — high bits set, exceeds long.MaxValue
+                .Op(Instruction.CALL)
+                .Done;
+
+            TestAllTracerWithOutput result = Execute(Activation, 200_000, code);
             Assert.That(result.Error, Is.EqualTo("OutOfGas"));
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -60,7 +60,11 @@ namespace Nethermind.Evm.Test
         /// <c>(long)gasLimit</c> cast never trips even when the user pushes <c>UInt256.MaxValue</c>.
         /// </summary>
         [Test]
-        public void Call_with_gas_above_long_max_post_eip150_is_capped_not_out_of_gas()
+        [TestCase(Instruction.CALL)]
+        [TestCase(Instruction.CALLCODE)]
+        [TestCase(Instruction.DELEGATECALL)]
+        [TestCase(Instruction.STATICCALL)]
+        public void Call_with_gas_above_long_max_post_eip150_is_capped_not_out_of_gas(Instruction instruction)
         {
             byte[] code = Prepare.EvmCode
                 .PushData(0)               // retLength
@@ -70,7 +74,7 @@ namespace Nethermind.Evm.Test
                 .PushData(0)               // value
                 .PushData(TestItem.AddressC)
                 .PushData(UInt256.MaxValue) // gasLimit — high bits set; cap clamps it
-                .Op(Instruction.CALL)
+                .Op(instruction)
                 .Done;
 
             TestAllTracerWithOutput result = Execute(Activation, 200_000, code);
@@ -91,8 +95,12 @@ namespace Nethermind.Evm.Test
         protected override long BlockNumber => 0;
         protected override ulong Timestamp => 0;
 
+        // DELEGATECALL and STATICCALL are not yet available at this fork (Homestead / Byzantium),
+        // so the pre-EIP-150 guard can only be exercised through CALL and CALLCODE here.
         [Test]
-        public void Call_with_gas_above_long_max_out_of_gas()
+        [TestCase(Instruction.CALL)]
+        [TestCase(Instruction.CALLCODE)]
+        public void Call_with_gas_above_long_max_out_of_gas(Instruction instruction)
         {
             byte[] code = Prepare.EvmCode
                 .PushData(0)               // retLength
@@ -102,7 +110,7 @@ namespace Nethermind.Evm.Test
                 .PushData(0)               // value
                 .PushData(TestItem.AddressC)
                 .PushData(UInt256.MaxValue) // gasLimit — high bits set, exceeds long.MaxValue
-                .Op(Instruction.CALL)
+                .Op(instruction)
                 .Done;
 
             TestAllTracerWithOutput result = Execute(Activation, 200_000, code);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -204,23 +203,20 @@ public static partial class EvmInstructions
         }
 
         long gasAvailable = TGasPolicy.GetRemainingGas(in gas);
-        long gasLimitUl;
 
+        // EIP-150 63/64 cap. The cap (gasAvailable - gasAvailable/64) is a non-negative long
+        // bounded by 63/64 * long.MaxValue, so min(cap, gasLimit) always fits in long when the
+        // rule is active. The single `>= long.MaxValue` OOG below covers both the post-cap
+        // case (cap < long.MaxValue, never trips) and the no-cap pre-Tangerine-Whistle case
+        // where the caller-supplied gasLimit exceeds the host's representable range.
         if (spec.Use63Over64Rule)
         {
-            // EIP-150: cap is a non-negative long, so min(gasLimit, cap) fits without 256-bit math.
-            Debug.Assert(gasAvailable >= 0, "GetRemainingGas must be non-negative; (ulong)cap below would otherwise wrap.");
-            long cap = gasAvailable - gasAvailable / 64;
-            gasLimitUl = gasLimit.IsUint64 && gasLimit.u0 <= (ulong)cap
-                ? (long)gasLimit.u0
-                : cap;
-        }
-        else
-        {
-            if (!gasLimit.IsUint64 || gasLimit.u0 >= long.MaxValue) goto OutOfGas;
-            gasLimitUl = (long)gasLimit.u0;
+            gasLimit = UInt256.Min((UInt256)(gasAvailable - gasAvailable / 64), gasLimit);
         }
 
+        if (gasLimit >= long.MaxValue) goto OutOfGas;
+
+        long gasLimitUl = (long)gasLimit;
         if (!TGasPolicy.UpdateGas(ref gas, gasLimitUl)) goto OutOfGas;
 
         // Add call stipend if value is being transferred.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -205,13 +206,22 @@ public static partial class EvmInstructions
         long gasAvailable = TGasPolicy.GetRemainingGas(in gas);
 
         // EIP-150 63/64 cap. The cap (gasAvailable - gasAvailable/64) is a non-negative long
-        // bounded by 63/64 * long.MaxValue, so min(cap, gasLimit) always fits in long when the
-        // rule is active. The single `>= long.MaxValue` OOG below covers both the post-cap
-        // case (cap < long.MaxValue, never trips) and the no-cap pre-Tangerine-Whistle case
-        // where the caller-supplied gasLimit exceeds the host's representable range.
+        // bounded by 63/64 * long.MaxValue, so clamping gasLimit to cap always yields a value
+        // that fits in long when the rule is active. The single `>= long.MaxValue` OOG below
+        // covers both the post-cap case (cap < long.MaxValue, never trips) and the no-cap
+        // pre-Tangerine-Whistle case where the caller-supplied gasLimit exceeds the host's
+        // representable range.
         if (spec.Use63Over64Rule)
         {
-            gasLimit = UInt256.Min((UInt256)(gasAvailable - gasAvailable / 64), gasLimit);
+            Debug.Assert(gasAvailable >= 0, "GetRemainingGas must be non-negative; (ulong)cap below would otherwise wrap.");
+            long cap = gasAvailable - gasAvailable / 64;
+            // Fast path: when gasLimit fits in 64 bits and is already within cap, skip the
+            // UInt256 assignment entirely. The full 256-bit comparison in UInt256.Min would
+            // dominate the common case where the caller supplies a small uint64-sized limit.
+            if (!gasLimit.IsUint64 || gasLimit.u0 > (ulong)cap)
+            {
+                gasLimit = (UInt256)cap;
+            }
         }
 
         if (gasLimit >= long.MaxValue) goto OutOfGas;


### PR DESCRIPTION
Replaces the explicit `IsUint64 && u0 <= (ulong)cap`/else branches with `UInt256.Min(cap, gasLimit)` followed by a single `>= long.MaxValue` OOG check. Semantically identical for both Use63Over64Rule paths:

  * Active (Tangerine Whistle+): cap = gasAvailable - gasAvailable/64 is a non-negative long bounded by 63/64 * long.MaxValue, so the min is always strictly less than long.MaxValue and the subsequent check is a no-op.

  * Inactive (Frontier/Homestead): caller-supplied gasLimit is checked against long.MaxValue exactly as before — anything failing master's `!IsUint64 || u0 >= long.MaxValue` test trips `>= long.MaxValue` here.

Drops the Debug.Assert and the System.Diagnostics import.

Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
