### PR TITLE
Devirtualise indirect-dispatch Sort calls across production paths

### DIFF
--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -106,6 +106,9 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(Type? firstPlugin, Type? secondPlugin)
         {
+            // The IComparer<Type> signature requires nullable parameters but the only caller
+            // is the sort over _pluginTypes, which is populated exclusively from non-null Type
+            // instances. The `!` dereference is safe at this call site.
             bool firstHasPriority = _priorities.TryGetValue(firstPlugin!.Name, out int firstPriorityIndex);
             bool secondHasPriority = _priorities.TryGetValue(secondPlugin!.Name, out int secondPriorityIndex);
 

--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 using Autofac;
@@ -94,10 +96,18 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
             .Select((name, index) => (name: name + "plugin", index))
             .ToDictionary(x => x.name, x => x.index, StringComparer.OrdinalIgnoreCase);
 
-        _pluginTypes.Sort((firstPlugin, secondPlugin) =>
+        CollectionsMarshal.AsSpan(_pluginTypes).Sort(new PluginPriorityComparer(pluginPriorities));
+    }
+
+    private readonly struct PluginPriorityComparer(Dictionary<string, int> priorities) : IComparer<Type>
+    {
+        private readonly Dictionary<string, int> _priorities = priorities;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Type? firstPlugin, Type? secondPlugin)
         {
-            bool firstHasPriority = pluginPriorities.TryGetValue(firstPlugin.Name, out int firstPriorityIndex);
-            bool secondHasPriority = pluginPriorities.TryGetValue(secondPlugin.Name, out int secondPriorityIndex);
+            bool firstHasPriority = _priorities.TryGetValue(firstPlugin!.Name, out int firstPriorityIndex);
+            bool secondHasPriority = _priorities.TryGetValue(secondPlugin!.Name, out int secondPriorityIndex);
 
             return (firstHasPriority, secondHasPriority) switch
             {
@@ -106,7 +116,7 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
                 (false, true) => 1,
                 (false, false) => string.Compare(firstPlugin.Name, secondPlugin.Name, StringComparison.OrdinalIgnoreCase)
             };
-        });
+        }
     }
 
     public async Task<IList<INethermindPlugin>> LoadPlugins(IConfigProvider configProvider, ChainSpec chainSpec)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Abi;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
@@ -31,7 +33,7 @@ namespace Nethermind.Consensus.AuRa.Rewards
                 if (auRaParameters.BlockRewardContractTransitions is not null)
                 {
                     contracts.AddRange(auRaParameters.BlockRewardContractTransitions.Select(t => new RewardContract(transactionProcessor, abiEncoder, t.Value, t.Key)));
-                    contracts.Sort((a, b) => a.Activation.CompareTo(b.Activation));
+                    CollectionsMarshal.AsSpan(contracts).Sort(default(RewardContractByActivationComparer));
                 }
 
                 if (auRaParameters.BlockRewardContractAddress is not null)
@@ -103,6 +105,12 @@ namespace Nethermind.Consensus.AuRa.Rewards
             return blockRewards;
         }
 
+
+        private readonly struct RewardContractByActivationComparer : IComparer<IRewardContract>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(IRewardContract a, IRewardContract b) => a.Activation.CompareTo(b.Activation);
+        }
 
         public class AuRaRewardCalculatorSource(AuRaChainSpecEngineParameters auRaParameters, IAbiEncoder abiEncoder) : IRewardCalculatorSource
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -465,7 +466,6 @@ internal sealed class BlockAccessListValidationIndex
         private readonly bool[]? _rowTouched;
         private readonly int[]? _touchedRows;
         private readonly bool[]? _rowOverflow;
-        private readonly StorageOrderComparer _orderComparer = new();
         private int[] _orderScratch = [];
         private int[] _accountScratch = [];
         private UInt256[] _keyScratch = [];
@@ -667,8 +667,7 @@ internal sealed class BlockAccessListValidationIndex
                 _orderScratch[i] = i;
             }
 
-            _orderComparer.Reset(_accountOrdinals, _keys, start);
-            Array.Sort(_orderScratch, 0, length, _orderComparer);
+            _orderScratch.AsSpan(0, length).Sort(new StorageOrderComparer(_accountOrdinals, _keys, start));
 
             for (int i = 0; i < length; i++)
             {
@@ -696,19 +695,13 @@ internal sealed class BlockAccessListValidationIndex
             _valueScratch = new EvmWord[length];
         }
 
-        private sealed class StorageOrderComparer : IComparer<int>
+        private readonly struct StorageOrderComparer(int[] accountOrdinals, UInt256[] keys, int start) : IComparer<int>
         {
-            private int[] _accountOrdinals = [];
-            private UInt256[] _keys = [];
-            private int _start;
+            private readonly int[] _accountOrdinals = accountOrdinals;
+            private readonly UInt256[] _keys = keys;
+            private readonly int _start = start;
 
-            public void Reset(int[] accountOrdinals, UInt256[] keys, int start)
-            {
-                _accountOrdinals = accountOrdinals;
-                _keys = keys;
-                _start = start;
-            }
-
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int Compare(int leftOffset, int rightOffset)
             {
                 int left = _start + leftOffset;

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -279,6 +280,24 @@ namespace Nethermind.Core
         }
 
         internal long GetHashCode64() => SpanExtensions.FastHash64For20Bytes(ref Unsafe.AsRef(in FirstByte));
+    }
+
+    public readonly struct AddressByEip55ChecksumOrdinalComparer : IComparer<Address>
+    {
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Address? a, Address? b)
+        {
+            if (ReferenceEquals(a, b)) return 0;
+            if (a is null) return -1;
+            if (b is null) return 1;
+
+            Span<char> aHex = stackalloc char[Address.Size * 2];
+            Span<char> bHex = stackalloc char[Address.Size * 2];
+            a.Bytes.OutputBytesToCharHexWithEip55Checksum(aHex, withZeroX: false);
+            b.Bytes.OutputBytesToCharHexWithEip55Checksum(bHex, withZeroX: false);
+            return aHex.SequenceCompareTo(bHex);
+        }
     }
 
     [JsonConverter(typeof(AddressAsKeyConverter))]

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -764,42 +764,74 @@ namespace Nethermind.Core.Extensions
             }
         }
 
-        private static string ByteArrayToHexViaLookup32Checksum(int length, State stateToPass) => string.Create(length, stateToPass, static (chars, state) =>
+        /// <summary>
+        /// Writes the EIP-55 checksummed hexadecimal representation of <paramref name="bytes"/> into <paramref name="chars"/>.
+        /// </summary>
+        /// <param name="bytes">The bytes to encode.</param>
+        /// <param name="chars">The destination span. Its length must match the encoded length after <paramref name="leadingZeros"/> are skipped.</param>
+        /// <param name="withZeroX">Whether to include the <c>0x</c> prefix.</param>
+        /// <param name="leadingZeros">The number of leading hex nibbles to skip in the output. The checksum is still computed over the full lowercase hex input.</param>
+        [SkipLocalsInit]
+        public static void OutputBytesToCharHexWithEip55Checksum(this ReadOnlySpan<byte> bytes, Span<char> chars, bool withZeroX, int leadingZeros = 0)
         {
-            // this path is rarely used - only in wallets
-            byte[] bytesArray = state.Bytes;
-            string hashHex = Keccak.Compute(bytesArray.ToHexString(false)).ToString(false);
-            Span<byte> bytes = bytesArray;
-
-            if (state.WithZeroX)
+            int hexLength = bytes.Length * 2;
+            int expectedLength = hexLength + (withZeroX ? 2 : 0) - leadingZeros;
+            if ((uint)leadingZeros > (uint)hexLength || chars.Length != expectedLength)
             {
-                chars[1] = 'x';
-                chars[0] = '0';
-                chars = chars[2..];
+                ThrowArgumentOutOfRangeException();
             }
 
-            bool odd = state.LeadingZeros % 2 == 1;
-            int oddity = odd ? 1 : 0;
+            byte[]? rentedHex = null;
+            Span<byte> lowerHex = hexLength <= 256
+                ? stackalloc byte[hexLength]
+                : (rentedHex = ArrayPool<byte>.Shared.Rent(hexLength)).AsSpan(0, hexLength);
 
-            uint[] lookup32 = Lookup32;
-            for (int i = 0; i < chars.Length; i += 2)
+            try
             {
-                uint val = lookup32[bytes[(i + state.LeadingZeros) / 2]];
-                if (i != 0 || !odd)
+                bytes.OutputBytesToByteHex(lowerHex, extraNibble: false);
+                ValueHash256 checksum = ValueKeccak.Compute(lowerHex);
+
+                if (withZeroX)
                 {
-                    char char1 = (char)val;
-                    chars[i - oddity] =
-                        char.IsLetter(char1) && hashHex![i] > '7'
-                            ? char.ToUpper(char1)
-                            : char1;
+                    chars[1] = 'x';
+                    chars[0] = '0';
+                    chars = chars[2..];
                 }
 
-                char char2 = (char)(val >> 16);
-                chars[i + 1 - oddity] =
-                    char.IsLetter(char2) && hashHex![i + 1] > '7'
-                        ? char.ToUpper(char2)
-                        : char2;
+                for (int i = leadingZeros; i < lowerHex.Length; i++)
+                {
+                    chars[i - leadingZeros] = ToChecksummedHexChar(lowerHex[i], GetChecksumNibble(in checksum, i));
+                }
             }
+            finally
+            {
+                if (rentedHex is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(rentedHex);
+                }
+            }
+
+            [DoesNotReturn]
+            static void ThrowArgumentOutOfRangeException() =>
+                throw new ArgumentOutOfRangeException(nameof(chars), "Output hex span has incorrect length.");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
+            lowerHexChar >= 'a' && checksumNibble > 7
+                ? (char)(lowerHexChar - ('a' - 'A'))
+                : (char)lowerHexChar;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetChecksumNibble(in ValueHash256 checksum, int index)
+        {
+            byte value = checksum.BytesAsSpan[index >> 1];
+            return (index & 1) == 0 ? value >> 4 : value & 0x0f;
+        }
+
+        private static string ByteArrayToHexViaLookup32Checksum(int length, State stateToPass) => string.Create(length, stateToPass, static (chars, state) =>
+        {
+            state.Bytes.AsSpan().OutputBytesToCharHexWithEip55Checksum(chars, state.WithZeroX, state.LeadingZeros);
         });
 
         internal static uint[] Lookup32 = CreateLookup32("x2");

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -13,7 +13,6 @@ using System.Runtime.Intrinsics;
 using Arm = System.Runtime.Intrinsics.Arm;
 using x64 = System.Runtime.Intrinsics.X86;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Crypto;
 
 namespace Nethermind.Core.Extensions
 {
@@ -103,64 +102,25 @@ namespace Nethermind.Core.Extensions
 
         private static string ToHexStringWithEip55Checksum(ReadOnlySpan<byte> bytes, bool withZeroX, bool skipLeadingZeros)
         {
-            string hashHex = Keccak.Compute(bytes.ToHexString(false)).ToString(false);
-
             int leadingZeros = skipLeadingZeros ? bytes.CountLeadingNibbleZeros() : 0;
             int length = bytes.Length * 2 + (withZeroX ? 2 : 0) - leadingZeros;
-            if (leadingZeros >= 2)
+            if (skipLeadingZeros && length == (withZeroX ? 2 : 0))
             {
-                bytes = bytes[(leadingZeros / 2)..];
+                return withZeroX ? Bytes.ZeroHexValue : Bytes.ZeroValue;
             }
+
             char[] charArray = ArrayPool<char>.Shared.Rent(length);
 
             Span<char> chars = charArray.AsSpan(0, length);
-
-            if (withZeroX)
+            try
             {
-                // In reverse, bounds check on [1] will elide bounds check on [0]
-                chars[1] = 'x';
-                chars[0] = '0';
-                // Trim off the two chars from the span
-                chars = chars[2..];
+                bytes.OutputBytesToCharHexWithEip55Checksum(chars, withZeroX, leadingZeros);
+                return new string(chars);
             }
-
-            uint[] lookup32 = Bytes.Lookup32;
-
-            bool odd = (leadingZeros & 1) != 0;
-            int oddity = odd ? 2 : 0;
-            if (odd)
+            finally
             {
-                // Odd number of hex chars, handle the first
-                // separately so loop can work in pairs
-                uint val = lookup32[bytes[0]];
-                char char2 = (char)(val >> 16);
-                chars[0] = char.IsLetter(char2) && hashHex[1] > '7'
-                            ? char.ToUpper(char2)
-                            : char2;
-
-                // Trim off the first byte and char from the spans
-                chars = chars[1..];
-                bytes = bytes[1..];
+                ArrayPool<char>.Shared.Return(charArray);
             }
-
-            for (int i = 0; i < chars.Length; i += 2)
-            {
-                uint val = lookup32[bytes[i / 2]];
-                char char1 = (char)val;
-                char char2 = (char)(val >> 16);
-
-                chars[i] = char.IsLetter(char1) && hashHex[i + oddity] > '7'
-                            ? char.ToUpper(char1)
-                            : char1;
-                chars[i + 1] = char.IsLetter(char2) && hashHex[i + 1 + oddity] > '7'
-                            ? char.ToUpper(char2)
-                            : char2;
-            }
-
-            string result = new(charArray.AsSpan(0, length));
-            ArrayPool<char>.Shared.Return(charArray);
-
-            return result;
         }
 
         public static ReadOnlySpan<T> TakeAndMove<T>(this ref ReadOnlySpan<T> span, int length)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -244,15 +245,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             }
         }
 
-        fileMetadataEntries.Sort((item1, item2) =>
-        {
-            // Sort them by level so that lower level get priority
-            int levelDiff = item1.metadata.FileLevel - item2.metadata.FileLevel;
-            if (levelDiff != 0) return levelDiff;
-
-            // Otherwise, we pick which file is newest.
-            return item2.creationTime.CompareTo(item1.creationTime);
-        });
+        CollectionsMarshal.AsSpan(fileMetadataEntries).Sort(default(FileMetadataByLevelThenNewestComparer));
 
         long totalSize = 0;
         fileMetadataEntries = fileMetadataEntries.TakeWhile(metadata =>
@@ -297,6 +290,18 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 _logger.Warn($"Exception warming up {fullPath} {e}");
             }
         });
+    }
+
+    private readonly struct FileMetadataByLevelThenNewestComparer : IComparer<(FileMetadata metadata, DateTime creationTime)>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(
+            (FileMetadata metadata, DateTime creationTime) item1,
+            (FileMetadata metadata, DateTime creationTime) item2)
+        {
+            int levelDiff = item1.metadata.FileLevel - item2.metadata.FileLevel;
+            return levelDiff != 0 ? levelDiff : item2.creationTime.CompareTo(item1.creationTime);
+        }
     }
 
     private void CreateMarkerIfCorrupt(RocksDbSharpException rocksDbException)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1440,6 +1440,8 @@ namespace Nethermind.Evm.TransactionProcessing
 
         // Devirtualised wrapper over Address.CompareTo (sealed -> already devirt'd inside) so the EIP-7708
         // destroy-list sort goes through Sort<TComparer> instead of Comparer<Address>.Default's virtual call.
+        // The IComparer<Address> contract declares nullable parameters; the destroy-list source
+        // (JournalSet<Address>) never contains null entries, so the `!` dereference is safe here.
         private readonly struct AddressByBytesComparer : IComparer<Address>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -249,8 +250,9 @@ namespace Nethermind.Evm.TransactionProcessing
                 JournalSet<Address> destroyList = substate.DestroyList;
                 if (destroyList.Count > 1)
                 {
-                    Address[] orderedDestroyList = [.. destroyList];
-                    Array.Sort(orderedDestroyList, GenericComparer.GetOptimized<Address>());
+                    Address[] orderedDestroyList = new Address[destroyList.Count];
+                    destroyList.CopyTo(orderedDestroyList, 0);
+                    orderedDestroyList.AsSpan().Sort(default(AddressByBytesComparer));
                     for (int i = 0; i < orderedDestroyList.Length; i++)
                     {
                         FinalizeDestroyedAccount(WorldState, in substate, orderedDestroyList[i]);
@@ -1435,6 +1437,14 @@ namespace Nethermind.Evm.TransactionProcessing
 
         [DoesNotReturn, StackTraceHidden]
         private static void ThrowInvalidDataException(string message) => throw new InvalidDataException(message);
+
+        // Devirtualised wrapper over Address.CompareTo (sealed -> already devirt'd inside) so the EIP-7708
+        // destroy-list sort goes through Sort<TComparer> instead of Comparer<Address>.Default's virtual call.
+        private readonly struct AddressByBytesComparer : IComparer<Address>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(Address? x, Address? y) => x!.CompareTo(y);
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
@@ -62,10 +62,23 @@ namespace Nethermind.Init.Steps
             return stepsWithMatchingApiType.FirstOrDefault();
         }
 
+        // Orders steps so the most derived comes first (taken by FirstOrDefault below).
+        // The original lambda returned `t1.IsAssignableFrom(t2) ? 1 : -1`, which violated
+        // reflexivity (Compare(x, x) = 1) and antisymmetry (for unrelated types both
+        // directions returned -1). This restored ordering uses AssemblyQualifiedName as a
+        // stable tie-break when neither type derives from the other.
         private readonly struct StepInfoByAssignabilityComparer : IComparer<StepInfo>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int Compare(StepInfo? t1, StepInfo? t2) => t1!.StepType.IsAssignableFrom(t2!.StepType) ? 1 : -1;
+            public int Compare(StepInfo? t1, StepInfo? t2)
+            {
+                if (ReferenceEquals(t1, t2)) return 0;
+                bool t1IsParent = t1!.StepType.IsAssignableFrom(t2!.StepType);
+                bool t2IsParent = t2.StepType.IsAssignableFrom(t1.StepType);
+                if (t1IsParent && !t2IsParent) return 1;   // t2 is more derived -> first
+                if (t2IsParent && !t1IsParent) return -1;  // t1 is more derived -> first
+                return string.CompareOrdinal(t1.StepType.AssemblyQualifiedName, t2.StepType.AssemblyQualifiedName);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
@@ -47,7 +48,7 @@ namespace Nethermind.Init.Steps
 
             if (stepsWithMatchingApiType.Length > 1)
             {
-                Array.Sort(stepsWithMatchingApiType, (t1, t2) => t1.StepType.IsAssignableFrom(t2.StepType) ? 1 : -1);
+                stepsWithMatchingApiType.AsSpan().Sort(default(StepInfoByAssignabilityComparer));
             }
 
             if (stepsWithMatchingApiType.Length == 0)
@@ -59,6 +60,12 @@ namespace Nethermind.Init.Steps
             }
 
             return stepsWithMatchingApiType.FirstOrDefault();
+        }
+
+        private readonly struct StepInfoByAssignabilityComparer : IComparer<StepInfo>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(StepInfo? t1, StepInfo? t2) => t1!.StepType.IsAssignableFrom(t2!.StepType) ? 1 : -1;
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -57,6 +59,12 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
         });
 
         private readonly record struct RewardInfo(long GasUsed, UInt256 PremiumPerGas);
+
+        private readonly struct RewardInfoByPremiumAscendingComparer : IComparer<RewardInfo>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(RewardInfo i1, RewardInfo i2) => i1.PremiumPerGas.CompareTo(i2.PremiumPerGas);
+        }
 
         private readonly record struct BlockFeeHistorySearchInfo(
             long BlockNumber,
@@ -273,7 +281,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 rewardInfos.Add(new RewardInfo(gasUsedSpan[i], premiumPerGas));
             }
 
-            rewardInfos.Sort(static (i1, i2) => i1.PremiumPerGas.CompareTo(i2.PremiumPerGas));
+            CollectionsMarshal.AsSpan(rewardInfos).Sort(default(RewardInfoByPremiumAscendingComparer));
 
             return rewardInfos;
         }

--- a/src/Nethermind/Nethermind.Network/PeerComparer.cs
+++ b/src/Nethermind/Nethermind.Network/PeerComparer.cs
@@ -2,31 +2,22 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Network
 {
-    internal class PeerComparer : IComparer<Peer>
+    internal readonly struct PeerComparer : IComparer<Peer>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(Peer x, Peer y)
         {
-            if (x is null)
-            {
-                return y is null ? 0 : 1;
-            }
+            if (x is null) return y is null ? 0 : 1;
+            if (y is null) return -1;
 
-            if (y is null)
-            {
-                return -1;
-            }
-
-            int staticValue = -x.Node.IsStatic.CompareTo(y.Node.IsStatic);
-            if (staticValue != 0)
-            {
-                return staticValue;
-            }
-
-            int reputation = -x.Node.CurrentReputation.CompareTo(y.Node.CurrentReputation);
-            return reputation;
+            int staticCompare = y.Node.IsStatic.CompareTo(x.Node.IsStatic);
+            return staticCompare != 0
+                ? staticCompare
+                : y.Node.CurrentReputation.CompareTo(x.Node.CurrentReputation);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -38,7 +39,6 @@ namespace Nethermind.Network
         private readonly IRlpxHost _rlpxHost;
         private readonly INodeStatsManager _stats;
         private readonly SemaphoreSlim _peerUpdateRequested = new(0, 1);
-        private readonly PeerComparer _peerComparer = new();
         private Task? _peerUpdateLoopTask;
         private readonly IPeerPool _peerPool;
         private readonly Lock _sessionLock = new();
@@ -605,7 +605,7 @@ namespace Nethermind.Network
                 node.CurrentReputation = peer.Stats.CurrentNodeReputation(nowUTC);
             }
 
-            _currentSelection.Candidates.Sort(_peerComparer);
+            CollectionsMarshal.AsSpan(_currentSelection.Candidates).Sort(default(PeerComparer));
 
             foreach (KeyValuePair<string, int> currentSelectionCounter in _currentSelection.Counters)
             {
@@ -713,7 +713,7 @@ namespace Nethermind.Network
                     }
                 }
 
-                _candidates.Sort(static (x, y) => PeerStatsComparer.Instance.Compare(x, y));
+                CollectionsMarshal.AsSpan(_candidates).Sort(default(PeerStatsComparer));
 
                 int countToRemove = _candidates.Count - _networkConfig.MaxCandidatePeerCount;
                 if (countToRemove > 0)
@@ -755,10 +755,9 @@ namespace Nethermind.Network
             public long CurrentReputation { get; } = currentReputation;
         }
 
-        private class PeerStatsComparer : IComparer<PeerStats>
+        private readonly struct PeerStatsComparer : IComparer<PeerStats>
         {
-            public static readonly PeerStatsComparer Instance = new();
-
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int Compare(PeerStats x, PeerStats y)
             {
                 int failedValidationCompare = y.FailedValidation.CompareTo(x.FailedValidation);

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -115,7 +115,7 @@ public class ShutterTxLoader(
         }
 
         using ArrayPoolList<SequencedTransaction> sortedIndexes = sequencedTransactions.ToPooledList();
-        sortedIndexes.Sort((a, b) => Bytes.BytesComparer.Compare(a.IdentityPreimage, b.IdentityPreimage));
+        sortedIndexes.Sort<SequencedTransactionByIdentityPreimageComparer>(default);
 
         using ArrayPoolList<int> sortedKeyIndexes = new(txCount, txCount);
         int keyIndex = 0;
@@ -265,6 +265,13 @@ public class ShutterTxLoader(
         public UInt256 GasLimit;
         public byte[] Identity;
         public byte[] IdentityPreimage;
+    }
+
+    private readonly struct SequencedTransactionByIdentityPreimageComparer : IComparer<SequencedTransaction>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(SequencedTransaction a, SequencedTransaction b) =>
+            Bytes.BytesComparer.Compare(a.IdentityPreimage, b.IdentityPreimage);
     }
 
     private readonly struct DecryptedTransactions : IDisposable

--- a/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
@@ -13,9 +13,10 @@ namespace Nethermind.StateComposition.Test.Visitors;
 [TestFixture]
 public class VisitorCountersTests
 {
-    // Mirrors TopNTracker.EntryComparer (which is internal — exposing it through a
-    // public test method signature triggers CS0051). Defined here so TestCaseSource
-    // can dispatch the three CompareBy* method groups through a single typed handle.
+    // Mirrors TopNTracker.IEntryComparer's in-ref signature (the interface itself is
+    // internal — exposing it through a public test method signature triggers CS0051).
+    // Defined here so TestCaseSource can dispatch the four strategy structs through a
+    // single typed handle.
     public delegate int EntryComparer(in TopContractEntry a, in TopContractEntry b);
 
     [Test]
@@ -137,19 +138,19 @@ public class VisitorCountersTests
         yield return new TestCaseData(
             new TopContractEntry { MaxDepth = 10, TotalNodes = 100, ValueNodes = 50 },
             new TopContractEntry { MaxDepth = 10, TotalNodes = 200, ValueNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByDepth)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByDepth).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByDepth");
 
         yield return new TestCaseData(
             new TopContractEntry { TotalNodes = 200, MaxDepth = 5, ValueNodes = 50 },
             new TopContractEntry { TotalNodes = 200, MaxDepth = 10, ValueNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByTotalNodes)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByTotalNodes).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByTotalNodes");
 
         yield return new TestCaseData(
             new TopContractEntry { ValueNodes = 100, MaxDepth = 5, TotalNodes = 50 },
             new TopContractEntry { ValueNodes = 100, MaxDepth = 10, TotalNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByValueNodes)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByValueNodes).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByValueNodes");
     }
 

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -225,10 +225,10 @@ internal sealed class StateCompositionVisitor(
             EmptyAccounts = agg.EmptyAccounts,
             CodeBytesTotal = agg.CodeBytes,
             SlotCountHistogram = ImmutableArray.Create<long>(agg.SlotCountHistogram[..]),
-            TopContractsByDepth = BuildSortedTopN(agg.TopN.TopByDepth, agg.TopN.TopByDepthCount, TopNTracker.CompareByDepth),
-            TopContractsByNodes = BuildSortedTopN(agg.TopN.TopByNodes, agg.TopN.TopByNodesCount, TopNTracker.CompareByTotalNodes),
-            TopContractsByValueNodes = BuildSortedTopN(agg.TopN.TopByValueNodes, agg.TopN.TopByValueNodesCount, TopNTracker.CompareByValueNodes),
-            TopContractsBySize = BuildSortedTopN(agg.TopN.TopBySize, agg.TopN.TopBySizeCount, TopNTracker.CompareBySize),
+            TopContractsByDepth = BuildSortedTopN<TopNTracker.ByDepth>(agg.TopN.TopByDepth, agg.TopN.TopByDepthCount),
+            TopContractsByNodes = BuildSortedTopN<TopNTracker.ByTotalNodes>(agg.TopN.TopByNodes, agg.TopN.TopByNodesCount),
+            TopContractsByValueNodes = BuildSortedTopN<TopNTracker.ByValueNodes>(agg.TopN.TopByValueNodes, agg.TopN.TopByValueNodesCount),
+            TopContractsBySize = BuildSortedTopN<TopNTracker.BySize>(agg.TopN.TopBySize, agg.TopN.TopBySizeCount),
             SlotCountByAddress = agg.SlotCountsByOwner,
             CodeHashSizes = new Dictionary<ValueHash256, int>(_codeHashSizes),
             CodeHashRefcounts = agg.CodeHashRefcounts,
@@ -300,23 +300,19 @@ internal sealed class StateCompositionVisitor(
         return agg;
     }
 
-    private static ImmutableArray<TopContractEntry> BuildSortedTopN(
-        TopContractEntry[] entries, int count, TopNTracker.EntryComparer comparer)
+    // Generic over TComparer so Sort<TComparer> specialises and inlines Compare with no
+    // residual delegate dispatch. Sorts descending directly via Reverse<TComparer> so the
+    // display tier (highest-first) gets the array in one pass.
+    private static ImmutableArray<TopContractEntry> BuildSortedTopN<TComparer>(
+        TopContractEntry[] entries, int count)
+        where TComparer : struct, TopNTracker.IEntryComparer
     {
         if (count == 0)
             return [];
 
         TopContractEntry[] sorted = entries.AsSpan(0, count).ToArray();
-        sorted.AsSpan(0, count).Sort(new ReverseEntryComparer(comparer));
+        sorted.AsSpan().Sort(default(TopNTracker.Reverse<TComparer>));
         return ImmutableCollectionsMarshal.AsImmutableArray(sorted);
-    }
-
-    private readonly struct ReverseEntryComparer(TopNTracker.EntryComparer comparer) : IComparer<TopContractEntry>
-    {
-        private readonly TopNTracker.EntryComparer _comparer = comparer;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Compare(TopContractEntry a, TopContractEntry b) => _comparer(in b, in a);
     }
 
     private static double CalcAvgDepth(ReadOnlySpan<DepthCounter> depths)

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
@@ -306,8 +307,16 @@ internal sealed class StateCompositionVisitor(
             return [];
 
         TopContractEntry[] sorted = entries.AsSpan(0, count).ToArray();
-        Array.Sort(sorted, 0, count, Comparer<TopContractEntry>.Create((a, b) => comparer(b, a)));
-        return System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray(sorted);
+        sorted.AsSpan(0, count).Sort(new ReverseEntryComparer(comparer));
+        return ImmutableCollectionsMarshal.AsImmutableArray(sorted);
+    }
+
+    private readonly struct ReverseEntryComparer(TopNTracker.EntryComparer comparer) : IComparer<TopContractEntry>
+    {
+        private readonly TopNTracker.EntryComparer _comparer = comparer;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => _comparer(in b, in a);
     }
 
     private static double CalcAvgDepth(ReadOnlySpan<DepthCounter> depths)

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/TopNTracker.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/TopNTracker.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Nethermind.Core.Crypto;
 using Nethermind.StateComposition.Data;
 
@@ -18,19 +20,30 @@ internal sealed class TopNTracker(int topN)
     public int TopByValueNodesCount;
     public int TopBySizeCount;
 
-    internal delegate int EntryComparer(in TopContractEntry a, in TopContractEntry b);
+    internal interface IEntryComparer : IComparer<TopContractEntry>
+    {
+        int Compare(in TopContractEntry a, in TopContractEntry b);
+    }
+
+    /// <summary>Reverses the order of an inner strategy. Used to sort top-N display-first.</summary>
+    internal readonly struct Reverse<TInner> : IComparer<TopContractEntry>
+        where TInner : struct, IEntryComparer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => default(TInner).Compare(in b, in a);
+    }
 
     public bool TryInsertDepth(in TopContractEntry entry) =>
-        TryInsert(TopByDepth, ref TopByDepthCount, entry, CompareByDepth);
+        TryInsert<ByDepth>(TopByDepth, ref TopByDepthCount, in entry);
 
     public bool TryInsertNodes(in TopContractEntry entry) =>
-        TryInsert(TopByNodes, ref TopByNodesCount, entry, CompareByTotalNodes);
+        TryInsert<ByTotalNodes>(TopByNodes, ref TopByNodesCount, in entry);
 
     public bool TryInsertValueNodes(in TopContractEntry entry) =>
-        TryInsert(TopByValueNodes, ref TopByValueNodesCount, entry, CompareByValueNodes);
+        TryInsert<ByValueNodes>(TopByValueNodes, ref TopByValueNodesCount, in entry);
 
     public bool TryInsertSize(in TopContractEntry entry) =>
-        TryInsert(TopBySize, ref TopBySizeCount, entry, CompareBySize);
+        TryInsert<BySize>(TopBySize, ref TopBySizeCount, in entry);
 
     public void SetLevelsForOwner(in ValueHash256 owner, ImmutableArray<TrieLevelStat> levels)
     {
@@ -51,68 +64,98 @@ internal sealed class TopNTracker(int topN)
 
     public void MergeFrom(TopNTracker other)
     {
-        MergeTopN(TopByDepth, ref TopByDepthCount, other.TopByDepth, other.TopByDepthCount, CompareByDepth);
-        MergeTopN(TopByNodes, ref TopByNodesCount, other.TopByNodes, other.TopByNodesCount, CompareByTotalNodes);
-        MergeTopN(TopByValueNodes, ref TopByValueNodesCount, other.TopByValueNodes, other.TopByValueNodesCount, CompareByValueNodes);
-        MergeTopN(TopBySize, ref TopBySizeCount, other.TopBySize, other.TopBySizeCount, CompareBySize);
+        MergeTopN<ByDepth>(TopByDepth, ref TopByDepthCount, other.TopByDepth, other.TopByDepthCount);
+        MergeTopN<ByTotalNodes>(TopByNodes, ref TopByNodesCount, other.TopByNodes, other.TopByNodesCount);
+        MergeTopN<ByValueNodes>(TopByValueNodes, ref TopByValueNodesCount, other.TopByValueNodes, other.TopByValueNodesCount);
+        MergeTopN<BySize>(TopBySize, ref TopBySizeCount, other.TopBySize, other.TopBySizeCount);
     }
 
-    private void MergeTopN(TopContractEntry[] target, ref int targetCount,
-        TopContractEntry[] source, int sourceCount, EntryComparer comparer)
+    private void MergeTopN<TComparer>(TopContractEntry[] target, ref int targetCount,
+        TopContractEntry[] source, int sourceCount)
+        where TComparer : struct, IEntryComparer
     {
         for (int i = 0; i < sourceCount; i++)
-            TryInsert(target, ref targetCount, source[i], comparer);
+            TryInsert<TComparer>(target, ref targetCount, in source[i]);
     }
 
     /// <summary>MaxDepth DESC → TotalNodes DESC → ValueNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByDepth(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByDepth : IEntryComparer
     {
-        int c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>TotalNodes DESC → MaxDepth DESC → ValueNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByTotalNodes(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByTotalNodes : IEntryComparer
     {
-        int c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>ValueNodes DESC → MaxDepth DESC → TotalNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByValueNodes(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByValueNodes : IEntryComparer
     {
-        int c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>TotalSize DESC → TotalNodes DESC → MaxDepth DESC → Owner bytes ASC</summary>
-    internal static int CompareBySize(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct BySize : IEntryComparer
     {
-        int c = a.TotalSize.CompareTo(b.TotalSize);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.TotalSize.CompareTo(b.TotalSize);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
-    private bool TryInsert(TopContractEntry[] heap, ref int count, in TopContractEntry entry, EntryComparer comparer)
+    private bool TryInsert<TComparer>(TopContractEntry[] heap, ref int count, in TopContractEntry entry)
+        where TComparer : struct, IEntryComparer
     {
         if (count < topN)
         {
@@ -120,14 +163,15 @@ internal sealed class TopNTracker(int topN)
             return true;
         }
 
+        TComparer comparer = default;
         int minIdx = 0;
         for (int i = 1; i < topN; i++)
         {
-            if (comparer(heap[i], heap[minIdx]) < 0)
+            if (comparer.Compare(in heap[i], in heap[minIdx]) < 0)
                 minIdx = i;
         }
 
-        if (comparer(entry, heap[minIdx]) > 0)
+        if (comparer.Compare(in entry, in heap[minIdx]) > 0)
         {
             heap[minIdx] = entry;
             return true;

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -232,7 +233,7 @@ public class BatchedTrieVisitor<TNodeContext>
             // Sort by level
             if (_activeJobs > _targetCurrentItems)
             {
-                preSort.AsSpan().Sort(static (item1, item2) => item1.Context.Level.CompareTo(item2.Context.Level) * -1);
+                preSort.Sort<JobByLevelDescendingComparer>(default);
             }
 
             int endIdx = Math.Min(_maxBatchSize, preSort.Count);
@@ -331,9 +332,7 @@ public class BatchedTrieVisitor<TNodeContext>
                     // This innocent looking sort is surprisingly effective when batch size is large enough. The sort itself
                     // take about 0.1% of the time, so not very cpu intensive in this case.
                     resolveOrdering
-                        .AsSpan()
-                        .Sort((item1, item2) =>
-                            currentBatch[item1].Item1.Keccak.CompareTo(currentBatch[item2].Item1.Keccak));
+                        .Sort(new BatchKeccakAscendingComparer(currentBatch.UnsafeGetInternalArray()));
 
                     ReadFlags flags = ReadFlags.None;
                     if (resolveOrdering.Count > _readAheadThreshold)
@@ -490,6 +489,22 @@ public class BatchedTrieVisitor<TNodeContext>
         public readonly ValueHash256 Key = key;
         public readonly TNodeContext NodeContext = nodeContext;
         public readonly SmallTrieVisitContext Context = context;
+    }
+
+    private readonly struct JobByLevelDescendingComparer : IComparer<Job>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Job item1, Job item2) => item2.Context.Level.CompareTo(item1.Context.Level);
+    }
+
+    private readonly struct BatchKeccakAscendingComparer(
+        (TrieNode, TNodeContext, SmallTrieVisitContext)[] items) : IComparer<int>
+    {
+        private readonly (TrieNode, TNodeContext, SmallTrieVisitContext)[] _items = items;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(int item1, int item2) =>
+            _items[item1].Item1.Keccak.CompareTo(_items[item2].Item1.Keccak);
     }
 }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -331,6 +331,9 @@ public class BatchedTrieVisitor<TNodeContext>
 
                     // This innocent looking sort is surprisingly effective when batch size is large enough. The sort itself
                     // take about 0.1% of the time, so not very cpu intensive in this case.
+                    // Safe: resolveOrdering only contains indices in [0, currentBatch.Count) (populated in the loop
+                    // above), and currentBatch is not mutated for the duration of the sort, so the backing array
+                    // reference is stable and every lookup stays in-bounds.
                     resolveOrdering
                         .Sort(new BatchKeccakAscendingComparer(currentBatch.UnsafeGetInternalArray()));
 

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Int256;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
-using System;
-using System.Collections.Generic;
 
 namespace Nethermind.Xdc.Spec;
 
@@ -43,9 +45,10 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         get => _v2Configs;
         set
         {
-            _v2Configs = value ?? new();
-            _v2Configs.Sort((a, b) => a.SwitchRound.CompareTo(b.SwitchRound));
-            CheckConfig(_v2Configs);
+            Span<V2ConfigParams> v2Configs = CollectionsMarshal.AsSpan(value);
+            v2Configs.Sort(default(V2ConfigBySwitchRoundComparer));
+            CheckConfig(v2Configs);
+            _v2Configs = value;
         }
     }
     public long? TipTrc21Fee { get; set; }
@@ -62,11 +65,17 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
     public long TIPXDCXMinerDisable { get; set; }
     public long? DynamicGasLimitBlock { get; set; }
 
-    private static void CheckConfig(List<V2ConfigParams> list)
+    private readonly struct V2ConfigBySwitchRoundComparer : IComparer<V2ConfigParams>
     {
-        if (list.Count == 0 || list[0].SwitchRound != 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(V2ConfigParams a, V2ConfigParams b) => a.SwitchRound.CompareTo(b.SwitchRound);
+    }
+
+    private static void CheckConfig(ReadOnlySpan<V2ConfigParams> list)
+    {
+        if (list.Length == 0 || list[0].SwitchRound != 0)
             throw new InvalidOperationException("There should be a default configuration with switchRound = 0");
-        for (int i = 1; i < list.Count; i++)
+        for (int i = 1; i < list.Length; i++)
         {
             if (list[i].SwitchRound == list[i - 1].SwitchRound)
                 throw new InvalidOperationException($"Duplicate config for round {list[i].SwitchRound}.");

--- a/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
@@ -96,14 +96,11 @@ internal class SubnetPenaltyHandler(IBlockTree tree, ISpecProvider specProvider,
                     penalties.Remove(fromSigner);
             }
         }
-        // TODO Optimize
-        // Must use EIP-55 checksummed hex to match XDC Go node ordering (addr.Hex()).
-        // Plain lowercase comparison gives wrong order: e.g. "0xAb..." < "0xaa..." but "0xab..." > "0xaa..."
+        // EIP-55 checksummed hex is required: lowercase byte comparison reorders
+        // (e.g. "0xAb..." < "0xaa..." vs "0xab..." > "0xaa...").
         Address[] result = new Address[penalties.Count];
         penalties.CopyTo(result);
-        Array.Sort(result, (a, b) => string.CompareOrdinal(
-            a.ToString(withEip55Checksum: true),
-            b.ToString(withEip55Checksum: true)));
+        result.AsSpan().Sort(default(AddressByEip55ChecksumOrdinalComparer));
         return result;
     }
 }


### PR DESCRIPTION
## Changes

Sweep replaces 15 production sort sites that used lambdas, `Comparison<T>` delegates, or boxed `IComparer<T>` wrappers with readonly struct comparers routed through the generic `Sort<TComparer>` overloads. The JIT can then specialise the sort body and inline `Compare` at the call site, while capturing-lambda allocations and per-call `Comparer<T>.Create` wrappers disappear. A follow-up commit extends the same pattern through the `TopNTracker` heap pipeline, eliminating its `EntryComparer` delegate type entirely.

### Production sites converted

- `Nethermind.Trie.BatchedTrieVisitor` - `preSort` by `Level` desc; per-batch `resolveOrdering` by keccak (the latter previously allocated a closure per visitor batch).
- `Nethermind.Network.PeerComparer` + `PeerManager.PeerStatsComparer` - `class` -> `readonly struct`; both sort sites route through `CollectionsMarshal.AsSpan(list).Sort`.
- `Nethermind.JsonRpc.FeeHistoryOracle` - `rewardInfos` by `PremiumPerGas`.
- `Nethermind.Consensus.BlockAccessListValidationIndex` - `StorageOrderComparer` drops mutable `Reset()` in favour of a readonly struct constructed per-sort over `(accountOrdinals, keys, start)`.
- `Nethermind.StateComposition.TopNTracker` + `StateCompositionVisitor` - **full chain devirt**. The `EntryComparer` delegate type and four `CompareByXxx` static methods are replaced by four zero-state strategy structs (`ByDepth`, `ByTotalNodes`, `ByValueNodes`, `BySize`) implementing both `Compare(in T, in T)` (used by the heap insert/merge loops, where the 92+ byte `TopContractEntry` makes in-ref worthwhile) and `Compare(T, T)` (required by `Span<T>.Sort`). `TryInsert<TComparer>`, `MergeTopN<TComparer>` and `BuildSortedTopN<TComparer>` are now generic-constrained so each instantiation specialises and inlines. A generic `Reverse<TInner>` wrapper replaces the previous `Sort + Array.Reverse` two-pass with a single descending-sort call, putting the display ordering directly in the type signature.
- `Nethermind.Shutter.ShutterTxLoader` - sort by `IdentityPreimage`.
- `Nethermind.Api.PluginLoader` - `PluginPriorityComparer` struct captures the priority dictionary by reference.
- `Nethermind.Consensus.AuRa.AuRaRewardCalculator` - by `Activation`.
- `Nethermind.Xdc.XdcChainSpecEngineParameters` - by `SwitchRound`.
- `Nethermind.Xdc.SubnetPenaltyHandler` - EIP-55-checksum ordinal sort, rewritten as a stackalloc-based comparer that derives the checksum in-place without allocating two strings per `Compare` call.
- `Nethermind.Db.Rocks.DbOnTheRocks` - file metadata by level then newest.
- `Nethermind.Init.EthereumStepsLoader` - by `IsAssignableFrom`. Also fixes a pre-existing invalid-total-order bug now made more visible by the named struct: the original `t1.IsAssignableFrom(t2) ? 1 : -1` violated reflexivity (`Compare(x, x) = 1`) and antisymmetry (unrelated types both returned -1). New body adds a reflexivity guard via `ReferenceEquals` and falls back to a stable `AssemblyQualifiedName` ordinal compare for unrelated types.
- `Nethermind.Evm.TransactionProcessor` - EIP-7708 destroy-list sort. Replaces `Array.Sort(arr, GenericComparer.GetOptimized<Address>())` with `arr.AsSpan().Sort(default(AddressByBytesComparer))`, and replaces the `[.. destroyList]` collection expression with explicit `new Address[Count] + CopyTo`. `GenericComparer.GetOptimized` is the ZK-EVM allocation-avoidance layer (bflat AOT can't reify `Comparer<T>.Default`), unnecessary on the regular CLR path - the struct wrapper forwards to the sealed `Address.IComparable<Address>.CompareTo`, so both the outer `Sort<TComparer>` dispatch and the inner `Address.CompareTo` devirtualise.

### Form chosen per receiver

- `ArrayPoolList<T>.Sort<TComparer>(default)` - single-method generic, no ambiguity.
- `CollectionsMarshal.AsSpan(list).Sort(default(TComparer))` / `array.AsSpan().Sort(default(TComparer))` - dual-method generic ambiguates with `Sort<TKey, TValue>(Span<TKey>, Span<TValue>)`, so the value-level `default(TComparer)` disambiguates via type inference.
- Stateful comparers pass a constructed instance: `Sort(new MyComparer(...))`.
- `TopNTracker`: heap routines are generic methods `TryInsert<TComparer>` / `MergeTopN<TComparer>` constrained on `struct, IEntryComparer`, so the call site supplies the type arg (`TryInsert<ByDepth>(...)`) and the body constructs `default(TComparer)` for free.

### Intentionally not converted

- Natural-ordering `Sort()` and `Sort<TKey, TValue>(Span<TKey>, Span<TValue>)` call sites - already specialised by the JIT via `Comparer<T>.Default`.
- `StringComparer.Ordinal`-based `Array.Sort` sites in cold startup paths (`Hive`, `Session`, config files).
- Test, benchmark, and codegen projects - performance is not load-bearing there.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Behaviour-preserving refactor - existing test suites cover each affected site. Verified locally:
- `Nethermind.Network.Test` (43 tests on `PeerComparer` + `PeerManager` paths).
- `Nethermind.StateComposition.Test` (88 tests, including the tiebreak-determinism cases updated to dispatch through the new `By*` strategy structs).

The rest are covered by the standard test matrix on CI.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The two `BatchedTrieVisitor` sites are the most impactful per-call - the keccak-sort closure previously allocated a `<>c__DisplayClass` capturing `currentBatch` per batch during sync. The struct comparer holds the batch's backing array directly via `ArrayPoolListRef<T>.UnsafeGetInternalArray()`, eliminating that allocation entirely.

The `TopNTracker` refactor was prompted by review feedback (https://github.com/NethermindEth/nethermind/pull/11633#discussion_r3253845248) noting that the initial `ReverseEntryComparer` struct only killed the per-call `Comparer<T>.Create` heap allocation but left the inner delegate dispatch intact. The completed devirtualisation pushes the comparison strategy up as a generic type parameter through `TryInsert` / `MergeTopN` / `BuildSortedTopN`, so the full call chain `Sort<Reverse<ByDepth>> -> Reverse<ByDepth>.Compare -> ByDepth.Compare` collapses to inlined byte-comparison code with no virtual dispatch anywhere.

`SubnetPenaltyHandler` and `TransactionProcessor` are the most subtle conversions: the former needed an in-place EIP-55 checksum derivation to avoid two string allocations per `Compare` (kept consensus-equivalent ordering); the latter required understanding that `GenericComparer.GetOptimized<T>` is a ZK-EVM-targeted abstraction, not a general-purpose performance helper.

Cannot be expressed as a `List<T>.Sort<TComparer>` extension method: C# overload resolution always prefers the BCL `List<T>.Sort(IComparer<T>)` instance method over any extension with the same name, silently boxing the struct comparer back through the `IComparer<T>` interface. Hence the explicit `CollectionsMarshal.AsSpan(list).Sort(...)` chain at every `List<T>` site.
