### PR TITLE
fix(devnet-7): reject txs exceeding EIP-8037 intrinsic gas cap; skip BAL no-op code

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -6,6 +6,6 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class Constants
 {
     public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.1.1";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.2.0";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_bal.tar.gz";
 }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -465,6 +465,7 @@ public abstract class BlockchainTestBase
         ("TransactionException.INTRINSIC_GAS_TOO_LOW", ValidationErrorRegex(@"TxGasLimitCapExceeded: Intrinsic gas")),
         ("BlockException.INCORRECT_EXCESS_BLOB_GAS", ValidationErrorRegex(@"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated|Overflow in excess blob gas")),
         ("BlockException.INVALID_BLOCK_HASH", ValidationErrorRegex(@"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+")),
+        ("BlockException.INCORRECT_BLOCK_FORMAT", ValidationErrorRegex(@"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+")),
         ("BlockException.SYSTEM_CONTRACT_EMPTY", ValidationErrorRegex(@"(Withdrawals|Consolidations)Empty: Contract is not deployed\.")),
         ("BlockException.SYSTEM_CONTRACT_CALL_FAILED", ValidationErrorRegex(@"(Withdrawals|Consolidations)Failed: Contract execution failed\.")),
         ("BlockException.INVALID_BAL_HASH", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:")),

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -462,6 +462,7 @@ public abstract class BlockchainTestBase
         ("TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED", ValidationErrorRegex(@"BlockBlobGasExceeded: A block cannot have more than \d+ blob gas, blobs count \d+, blobs gas used: \d+")),
         ("TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED", ValidationErrorRegex(@"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ exceeded MaxBlobGas per transaction=\d+")),
         ("TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM", ValidationErrorRegex(@"TxGasLimitCapExceeded:")),
+        ("TransactionException.INTRINSIC_GAS_TOO_LOW", ValidationErrorRegex(@"TxGasLimitCapExceeded: Intrinsic gas")),
         ("BlockException.INCORRECT_EXCESS_BLOB_GAS", ValidationErrorRegex(@"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated|Overflow in excess blob gas")),
         ("BlockException.INVALID_BLOCK_HASH", ValidationErrorRegex(@"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+")),
         ("BlockException.SYSTEM_CONTRACT_EMPTY", ValidationErrorRegex(@"(Withdrawals|Consolidations)Empty: Contract is not deployed\.")),

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -600,7 +600,7 @@ public class TxValidatorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AsBool, Is.False);
-            Assert.That(result.Error, Does.StartWith("TxGasLimitCapExceeded:"));
+            Assert.That(result.Error, Does.StartWith("intrinsic gas too low"));
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -584,6 +584,27 @@ public class TxValidatorTests
     }
 
     [Test]
+    public void IsWellFormed_Eip8037FloorGasExceedingRegularCap_ReturnsFalse()
+    {
+        byte[] data = new byte[262_000];
+        Array.Fill(data, (byte)0xff);
+        Transaction tx = Build.A.Transaction
+            .WithGasLimit(20_000_000)
+            .WithData(data)
+            .WithChainId(TestBlockchainIds.ChainId)
+            .SignedAndResolved().TestObject;
+
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+        ValidationResult result = txValidator.IsWellFormed(tx, Amsterdam.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.False);
+            Assert.That(result.Error, Does.StartWith("TxGasLimitCapExceeded:"));
+        }
+    }
+
+    [Test]
     public void IsWellFormed_Nonce_Under_Limit([Values(TxType.AccessList, TxType.Legacy)] TxType txType)
     {
         ValidationResult result = IsWellFormed_Nonce_Limit(ulong.MaxValue - 1, txType);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -600,7 +600,7 @@ public class TxValidatorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AsBool, Is.False);
-            Assert.That(result.Error, Does.StartWith("intrinsic gas too low"));
+            Assert.That(result.Error, Does.StartWith("TxGasLimitCapExceeded:"));
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -600,7 +600,7 @@ public class TxValidatorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AsBool, Is.False);
-            Assert.That(result.Error, Does.StartWith("TxGasLimitCapExceeded:"));
+            Assert.That(result.Error, Does.StartWith(TxErrorMessages.IntrinsicGasTooLow));
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -139,7 +139,9 @@ public sealed class IntrinsicGasTxValidator : ITxValidator
             return TxErrorMessages.TxGasLimitCapExceeded(Math.Max(regular, floor), Eip7825Constants.DefaultTxGasLimitCap);
         }
 
-        return transaction.GasLimit < intrinsicGas.MinimalGas.Value
+        // Implicit conversion combines Standard + StateReservoir (EIP-8037) before max'ing with FloorGas.
+        EthereumIntrinsicGas combined = intrinsicGas;
+        return transaction.GasLimit < combined.MinimalGas
             ? TxErrorMessages.IntrinsicGasTooLow
             : ValidationResult.Success;
     }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -136,7 +136,7 @@ public sealed class IntrinsicGasTxValidator : ITxValidator
         IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(transaction, releaseSpec, blockGasLimit);
         if (releaseSpec.IsEip8037Enabled && intrinsicGas.ExceedsCap(Eip7825Constants.DefaultTxGasLimitCap, out long regular, out long floor))
         {
-            return TxErrorMessages.TxGasLimitCapExceeded(Math.Max(regular, floor), Eip7825Constants.DefaultTxGasLimitCap);
+            return TxErrorMessages.TxIntrinsicGasExceedsCap(regular, floor, Eip7825Constants.DefaultTxGasLimitCap);
         }
 
         // Implicit conversion combines Standard + StateReservoir (EIP-8037) before max'ing with FloorGas.

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
 using Nethermind.Crypto;
 using Nethermind.Evm;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.Int256;
 
 namespace Nethermind.Consensus.Validators;
@@ -132,9 +133,13 @@ public sealed class IntrinsicGasTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec, long blockGasLimit)
     {
-        // This is unnecessarily calculated twice - at validation and execution times.
-        EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(transaction, releaseSpec, blockGasLimit);
-        return transaction.GasLimit < intrinsicGas.MinimalGas
+        IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(transaction, releaseSpec, blockGasLimit);
+        if (releaseSpec.IsEip8037Enabled && intrinsicGas.ExceedsCap(Eip7825Constants.DefaultTxGasLimitCap, out long regular, out long floor))
+        {
+            return TxErrorMessages.TxGasLimitCapExceeded(Math.Max(regular, floor), Eip7825Constants.DefaultTxGasLimitCap);
+        }
+
+        return transaction.GasLimit < intrinsicGas.MinimalGas.Value
             ? TxErrorMessages.IntrinsicGasTooLow
             : ValidationResult.Success;
     }

--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListJournalTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListJournalTests.cs
@@ -13,6 +13,17 @@ namespace Nethermind.Core.Test.BlockAccessLists;
 public class BlockAccessListJournalTests
 {
     [Test]
+    public void AddCodeChange_with_equal_before_after_does_not_create_account_changes()
+    {
+        BlockAccessList bal = new();
+        byte[] emptyCode = [];
+
+        bal.AddCodeChange(TestItem.AddressA, emptyCode, emptyCode);
+
+        Assert.That(bal.GetAccountChanges(TestItem.AddressA), Is.Null);
+    }
+
+    [Test]
     public void Restore_reinstates_previous_values_for_interleaved_change_types()
     {
         BlockAccessList bal = new();

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessList.cs
@@ -216,13 +216,13 @@ public class BlockAccessList : IEquatable<BlockAccessList>, IJournal<int>, IRese
 
     public void AddCodeChange(Address address, byte[] before, ReadOnlyMemory<byte> after)
     {
-        _itemCount = null;
-        AccountChanges accountChanges = GetOrAddAccountChanges(address);
-
         if (before.AsSpan().SequenceEqual(after.Span))
         {
             return;
         }
+
+        _itemCount = null;
+        AccountChanges accountChanges = GetOrAddAccountChanges(address);
 
         bool changedDuringTx = HasCodeChangedDuringTx(accountChanges, before, after.Span);
         bool hasPrev = accountChanges.TryPopCodeChange(Index, out CodeChange oldCodeChange);

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -83,7 +83,7 @@ public static class TxErrorMessages
         => $"TxGasLimitCapExceeded: Gas limit {gasLimit} exceeded cap of {gasLimitCap}.";
 
     public static string TxIntrinsicGasExceedsCap(long intrinsicRegularGas, long intrinsicFloorGas, long gasLimitCap)
-        => $"intrinsic gas too low: intrinsic (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
+        => $"TxGasLimitCapExceeded: Intrinsic gas (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
 
     public const string NonceTooHigh = "NonceTooHigh: Nonce exceeds max nonce";
 

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -83,7 +83,7 @@ public static class TxErrorMessages
         => $"TxGasLimitCapExceeded: Gas limit {gasLimit} exceeded cap of {gasLimitCap}.";
 
     public static string TxIntrinsicGasExceedsCap(long intrinsicRegularGas, long intrinsicFloorGas, long gasLimitCap)
-        => $"TxGasLimitCapExceeded: Intrinsic gas (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
+        => $"intrinsic gas too low: intrinsic (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
 
     public const string NonceTooHigh = "NonceTooHigh: Nonce exceeds max nonce";
 

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -82,6 +82,9 @@ public static class TxErrorMessages
     public static string TxGasLimitCapExceeded(long gasLimit, long gasLimitCap)
         => $"TxGasLimitCapExceeded: Gas limit {gasLimit} exceeded cap of {gasLimitCap}.";
 
+    public static string TxIntrinsicGasExceedsCap(long intrinsicRegularGas, long intrinsicFloorGas, long gasLimitCap)
+        => $"TxGasLimitCapExceeded: Intrinsic gas (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
+
     public const string NonceTooHigh = "NonceTooHigh: Nonce exceeds max nonce";
 
 }

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -83,7 +83,7 @@ public static class TxErrorMessages
         => $"TxGasLimitCapExceeded: Gas limit {gasLimit} exceeded cap of {gasLimitCap}.";
 
     public static string TxIntrinsicGasExceedsCap(long intrinsicRegularGas, long intrinsicFloorGas, long gasLimitCap)
-        => $"TxGasLimitCapExceeded: Intrinsic gas (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
+        => $"{IntrinsicGasTooLow}: Intrinsic gas (regular {intrinsicRegularGas}, floor {intrinsicFloorGas}) exceeded cap of {gasLimitCap}.";
 
     public const string NonceTooHigh = "NonceTooHigh: Nonce exceeds max nonce";
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -721,6 +721,24 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Eip7702_null_address_delegation_to_empty_code_records_nonce_without_code_change()
+    {
+        InitWorldState(TestState, []);
+
+        AuthorizationTuple authorization = SignAuthorization(TestItem.PrivateKeyA, Address.Zero, nonce: 1);
+
+        BlockAccessList bal = ExecuteSetCodeCall(authorization);
+        AccountChanges? senderChanges = bal.GetAccountChanges(TestItem.AddressA);
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNonceChange(bal, TestItem.AddressA, 2);
+            Assert.That(senderChanges, Is.Not.Null);
+            Assert.That(senderChanges!.CodeChanges, Is.Empty);
+        }
+    }
+
+    [Test]
     public void Eip7702_multi_hop_delegation_resolves_one_hop_in_bal()
     {
         Address authority = TestItem.AddressB;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -36,6 +36,39 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
             ? Prepare.EvmCode.Create2(initCode, salt ?? DefaultCreate2Salt, value)
             : Prepare.EvmCode.Create(initCode, value);
 
+    [Test]
+    public void Eip8037_rejects_tx_when_calldata_floor_exceeds_tx_max_regular_gas()
+    {
+        byte[] calldata = new byte[262_000];
+        Array.Fill(calldata, (byte)0xff);
+
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(20_000_000)
+            .WithGasPrice(1)
+            .WithData(calldata)
+            .To(Recipient)
+            .SignedAndResolved(new EthereumEcdsa(SpecProvider.ChainId), SenderKey)
+            .TestObject;
+        (Block block, _) = PrepareTx(
+            Activation,
+            transaction.GasLimit,
+            transaction: transaction,
+            blockGasLimit: DynamicStatePricingBlockGasLimit);
+
+        IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(transaction, Spec);
+        Assert.That(intrinsicGas.FloorGas.Value, Is.GreaterThan(Eip7825Constants.DefaultTxGasLimitCap));
+
+        TestAllTracerWithOutput tracer = CreateTracer();
+        TransactionResult result = _processor.Execute(
+            transaction,
+            new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)),
+            tracer);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.GasLimitBelowIntrinsicGas));
+        Assert.That(TestState.GetNonce(Sender), Is.EqualTo(UInt256.Zero));
+    }
+
     /// <summary>
     /// When a nested CREATE's child frame has too little regular gas to cover both
     /// the regular code deposit cost AND the state-gas spill, the CREATE must fail.

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -530,6 +530,49 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         Assert.That(TestState.AccountExists(createdAddress), Is.False);
     }
 
+    [Test]
+    public void Eip8037_delegatecall_sstore_restoration_refund_credits_local_reservoir()
+    {
+        byte[] childCode = Prepare.EvmCode
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.SSTORE)
+            .PushData(0)
+            .PushData(1)
+            .Op(Instruction.SSTORE)
+            .Create([], UInt256.Zero)
+            .Op(Instruction.POP)
+            .PushData(1)
+            .PushData(2)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 0);
+        TestState.InsertCode(TestItem.AddressC, childCode, SpecProvider.GenesisSpec);
+
+        byte[] parentCode = Prepare.EvmCode
+            .PushData(1)
+            .PushData(0)
+            .Op(Instruction.SSTORE)
+            .PushData(1)
+            .PushData(1)
+            .Op(Instruction.SSTORE)
+            .DelegateCall(TestItem.AddressC, 400_000)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput tracer = Execute(Activation, 487_640, parentCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.CreateState + GasCostOf.SSetState));
+        Assert.That(TestState.GetNonce(Recipient), Is.EqualTo(UInt256.One));
+        AssertStorage(new StorageCell(Recipient, 0), UInt256.Zero);
+        AssertStorage(new StorageCell(Recipient, 1), UInt256.Zero);
+        AssertStorage(new StorageCell(Recipient, 2), UInt256.One);
+    }
+
     private Address SetupStaticCreateAttempt(bool create2)
     {
         byte[] childInitCode = Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -481,6 +481,29 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         Assert.That(tracer.GasConsumedResult.EffectiveBlockGas, Is.EqualTo(gasLimit));
     }
 
+    [Test]
+    public void Eip8037_create_state_refund_helpers_are_disabled_before_amsterdam()
+    {
+        byte[] childInitCode = Prepare.EvmCode
+            .PushData(33_000)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        byte[] code = Prepare.EvmCode
+            .Create(childInitCode, UInt256.Zero)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        const long gasLimit = 500_000;
+        TestAllTracerWithOutput tracer = Execute(MainnetSpecProvider.PragueActivation, gasLimit, code, blockGasLimit: DynamicStatePricingBlockGasLimit);
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(tracer.GasConsumedResult.SpentGas, Is.EqualTo(493_018));
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero);
+    }
+
     [TestCase(false, TestName = "Eip8037_create_in_static_context_must_not_charge_state_gas_or_increment_nonce_CREATE")]
     [TestCase(true, TestName = "Eip8037_create_in_static_context_must_not_charge_state_gas_or_increment_nonce_CREATE2")]
     public void Eip8037_create_in_static_context_must_not_charge_state_gas_or_increment_nonce(bool create2)
@@ -571,6 +594,44 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         AssertStorage(new StorageCell(Recipient, 0), UInt256.Zero);
         AssertStorage(new StorageCell(Recipient, 1), UInt256.Zero);
         AssertStorage(new StorageCell(Recipient, 2), UInt256.One);
+    }
+
+    [Test]
+    public void Eip8037_reverted_ancestor_discards_descendant_storage_refund_credit()
+    {
+        byte[] descendantCode = Prepare.EvmCode
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 0);
+        TestState.InsertCode(TestItem.AddressC, descendantCode, SpecProvider.GenesisSpec);
+
+        byte[] intermediateCode = Prepare.EvmCode
+            .DelegateCall(TestItem.AddressC, 400_000)
+            .Op(Instruction.POP)
+            .Revert(0, 0)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressD, 0);
+        TestState.InsertCode(TestItem.AddressD, intermediateCode, SpecProvider.GenesisSpec);
+
+        byte[] parentCode = Prepare.EvmCode
+            .PushData(1)
+            .PushData(0)
+            .Op(Instruction.SSTORE)
+            .DelegateCall(TestItem.AddressD, 600_000)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput tracer = Execute(Activation, 900_000, parentCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState));
+        AssertStorage(new StorageCell(Recipient, 0), UInt256.One);
     }
 
     private Address SetupStaticCreateAttempt(bool create2)

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -319,10 +319,9 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     {
         long refundableStateGas = Math.Max(0, gas.StateGasUsed - stateGasFloor);
         long appliedRefund = Math.Min(amount, refundableStateGas);
-        long unrefundedSpill = GetUnrefundedStateGasSpill(in gas);
         if (trackSpillRefund)
         {
-            gas.StateGasSpillRefunded += Math.Min(appliedRefund, unrefundedSpill);
+            TrackStateGasSpillRefund(ref gas, appliedRefund);
         }
 
         gas.StateReservoir += appliedRefund;
@@ -330,10 +329,48 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void DiscardStateGas(ref EthereumGasPolicy gas, long amount, long stateGasFloor)
+    public static long DiscardStateGas(ref EthereumGasPolicy gas, long amount, long stateGasFloor, bool trackSpillRefund)
     {
         long discardableStateGas = Math.Max(0, gas.StateGasUsed - stateGasFloor);
-        gas.StateGasUsed -= Math.Min(amount, discardableStateGas);
+        long appliedRefund = Math.Min(amount, discardableStateGas);
+        if (trackSpillRefund)
+        {
+            TrackStateGasSpillRefund(ref gas, appliedRefund);
+        }
+
+        gas.StateGasUsed -= appliedRefund;
+        return amount - appliedRefund;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void AddStateGasRefundToReservoir(ref EthereumGasPolicy gas, long amount, bool trackSpillRefund)
+    {
+        if (trackSpillRefund)
+        {
+            TrackStateGasSpillRefund(ref gas, amount);
+        }
+
+        gas.StateReservoir += amount;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RemoveStateGasRefundFromReservoir(ref EthereumGasPolicy gas, long amount)
+    {
+        long fromReservoir = Math.Min(amount, gas.StateReservoir);
+        gas.StateReservoir -= fromReservoir;
+        amount -= fromReservoir;
+
+        if (amount > 0)
+        {
+            gas.StateGasUsed -= Math.Min(amount, gas.StateGasUsed);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void TrackStateGasSpillRefund(ref EthereumGasPolicy gas, long amount)
+    {
+        long unrefundedSpill = GetUnrefundedStateGasSpill(in gas);
+        gas.StateGasSpillRefunded += Math.Min(amount, unrefundedSpill);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -111,7 +111,12 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     // Drop state-gas from block-state accounting without refunding to the gas budget;
     // reverted state charges stay paid by the tx but don't contribute to committed state gas.
-    static virtual void DiscardStateGas(ref TSelf gas, long amount, long stateGasFloor) { }
+    static virtual long DiscardStateGas(ref TSelf gas, long amount, long stateGasFloor, bool trackSpillRefund) => amount;
+
+    static virtual void AddStateGasRefundToReservoir(ref TSelf gas, long amount, bool trackSpillRefund) =>
+        TSelf.UpdateGasUp(ref gas, amount);
+
+    static virtual void RemoveStateGasRefundFromReservoir(ref TSelf gas, long amount) { }
 
     // EIP-8037 top-level halt: snap state-gas back to (R0, intrinsicStateUsed, 0); the
     // post-reset StateGasUsed feeds SpentGas so the user doesn't pay for uncommitted state.

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -219,4 +219,16 @@ public readonly record struct IntrinsicGas<TGasPolicy>(TGasPolicy Standard, TGas
 {
     public TGasPolicy MinimalGas { get; } = TGasPolicy.Max(Standard, FloorGas);
     public static explicit operator TGasPolicy(IntrinsicGas<TGasPolicy> gas) => gas.MinimalGas;
+
+    /// <summary>
+    /// EIP-8037: rejects a transaction whose intrinsic regular or floor gas exceeds <paramref name="cap"/>.
+    /// </summary>
+    public bool ExceedsCap(long cap, out long regular, out long floor)
+    {
+        TGasPolicy standard = Standard;
+        TGasPolicy floorGas = FloorGas;
+        regular = TGasPolicy.GetRemainingGas(in standard);
+        floor = TGasPolicy.GetRemainingGas(in floorGas);
+        return regular > cap || floor > cap;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -622,6 +622,12 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
+            if (spec.IsEip8037Enabled && intrinsicGas.ExceedsCap(Eip7825Constants.DefaultTxGasLimitCap, out long regular, out long floor))
+            {
+                TraceLogInvalidTx(tx, $"TX_INTRINSIC_REGULAR_GAS_EXCEEDS_MAX {Math.Max(regular, floor)} > {Eip7825Constants.DefaultTxGasLimitCap}");
+                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas;
+            }
+
             TGasPolicy standard = intrinsicGas.Standard;
             TGasPolicy minimal = intrinsicGas.MinimalGas;
             long minGasRequired = spec.IsEip8037Enabled
@@ -636,8 +642,7 @@ namespace Nethermind.Evm.TransactionProcessing
             if (tx.GasLimit < minGasRequired)
             {
                 TraceLogInvalidTx(tx, $"GAS_LIMIT_BELOW_INTRINSIC_GAS {tx.GasLimit} < {minGasRequired}");
-                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas.WithDetail(
-                    $"intrinsic gas too low: have {tx.GasLimit}, want {minGasRequired}");
+                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas;
             }
 
             if (validate)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -624,8 +624,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (spec.IsEip8037Enabled && intrinsicGas.ExceedsCap(Eip7825Constants.DefaultTxGasLimitCap, out long regular, out long floor))
             {
-                TraceLogInvalidTx(tx, $"TX_INTRINSIC_REGULAR_GAS_EXCEEDS_MAX {Math.Max(regular, floor)} > {Eip7825Constants.DefaultTxGasLimitCap}");
-                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas;
+                long required = Math.Max(regular, floor);
+                TraceLogInvalidTx(tx, $"TX_INTRINSIC_REGULAR_GAS_EXCEEDS_MAX {required} > {Eip7825Constants.DefaultTxGasLimitCap}");
+                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas.WithDetail($"intrinsic gas too low: have {tx.GasLimit}, want {required}");
             }
 
             TGasPolicy standard = intrinsicGas.Standard;
@@ -642,7 +643,7 @@ namespace Nethermind.Evm.TransactionProcessing
             if (tx.GasLimit < minGasRequired)
             {
                 TraceLogInvalidTx(tx, $"GAS_LIMIT_BELOW_INTRINSIC_GAS {tx.GasLimit} < {minGasRequired}");
-                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas;
+                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas.WithDetail($"intrinsic gas too low: have {tx.GasLimit}, want {minGasRequired}");
             }
 
             if (validate)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -624,9 +624,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (spec.IsEip8037Enabled && intrinsicGas.ExceedsCap(Eip7825Constants.DefaultTxGasLimitCap, out long regular, out long floor))
             {
-                long required = Math.Max(regular, floor);
-                TraceLogInvalidTx(tx, $"TX_INTRINSIC_REGULAR_GAS_EXCEEDS_MAX {required} > {Eip7825Constants.DefaultTxGasLimitCap}");
-                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas.WithDetail($"intrinsic gas too low: have {tx.GasLimit}, want {required}");
+                TraceLogInvalidTx(tx, $"TX_INTRINSIC_GAS_EXCEEDS_CAP regular={regular} floor={floor} > {Eip7825Constants.DefaultTxGasLimitCap}");
+                return TransactionResult.ErrorType.GasLimitBelowIntrinsicGas.WithDetail(
+                    TxErrorMessages.TxIntrinsicGasExceedsCap(regular, floor, Eip7825Constants.DefaultTxGasLimitCap));
             }
 
             TGasPolicy standard = intrinsicGas.Standard;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -295,7 +295,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     {
                         // On revert, return remaining regular gas and restore state gas to parent reservoir.
                         TGasPolicy.UpdateGasUp(ref _currentState.Gas, TGasPolicy.GetRemainingGas(in previousState.Gas));
-                        RemoveAdvancedStateGasRefund(previousState);
+                        RemoveAdvancedStateGasRefund(previousState, ref previousState.Gas);
                         TGasPolicy.RestoreChildStateGas(ref _currentState.Gas, in previousState.Gas);
                         if (previousState.ExecutionType.IsAnyCreate())
                         {
@@ -614,7 +614,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     {
         VmState<TGasPolicy> childState = _currentState;
         _currentState = _stateStack.Pop();
-        RemoveAdvancedStateGasRefund(childState);
+        RemoveAdvancedStateGasRefund(childState, ref childState.Gas);
         TGasPolicy.RestoreChildStateGasOnHalt(ref _currentState.Gas, in childState.Gas);
         _currentState.IsContinuation = true;
         childState.Dispose();
@@ -686,18 +686,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
             childState.StateGasRefundPending = 0;
             childState.StateGasRefundAdvanced = 0;
         }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void RemoveAdvancedStateGasRefund(VmState<TGasPolicy> vmState)
-    {
-        if (vmState.StateGasRefundAdvanced > 0)
-        {
-            TGasPolicy.RemoveStateGasRefundFromReservoir(ref vmState.Gas, vmState.StateGasRefundAdvanced);
-            vmState.StateGasRefundAdvanced = 0;
-        }
-
-        vmState.StateGasRefundPending = 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -255,12 +255,18 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
                     if (!callResult.ShouldRevert)
                     {
+                        bool isCreate = previousState.ExecutionType.IsAnyCreate();
+                        if (!isCreate)
+                        {
+                            IncorporateChildStateGasRefunds(previousState);
+                        }
+
                         // Refund the remaining gas from the completed call frame (success path).
                         TGasPolicy.Refund(ref _currentState.Gas, in previousState.Gas);
                         long gasAvailableForCodeDeposit = TGasPolicy.GetRemainingGas(previousState.Gas);
 
                         // Process contract creation calls differently from regular calls.
-                        if (previousState.ExecutionType.IsAnyCreate())
+                        if (isCreate)
                         {
                             PrepareCreateData(previousState, ref previousCallOutput);
                             HandleCreate(
@@ -279,13 +285,17 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                         if (previousStateSucceeded)
                         {
                             previousState.CommitToParent(_currentState);
-                            IncorporateChildStateGasRefunds(previousState);
+                            if (isCreate)
+                            {
+                                IncorporateChildStateGasRefunds(previousState);
+                            }
                         }
                     }
                     else
                     {
                         // On revert, return remaining regular gas and restore state gas to parent reservoir.
                         TGasPolicy.UpdateGasUp(ref _currentState.Gas, TGasPolicy.GetRemainingGas(in previousState.Gas));
+                        RemoveAdvancedStateGasRefund(previousState);
                         TGasPolicy.RestoreChildStateGas(ref _currentState.Gas, in previousState.Gas);
                         if (previousState.ExecutionType.IsAnyCreate())
                         {
@@ -450,6 +460,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
             // the child's stateGasUsed (since the child's state changes are being reverted).
             TGasPolicy.RevertRefundToHalt(ref _currentState.Gas, in previousState.Gas);
             CreditStateGasRefund(ref _currentState.Gas, TGasPolicy.GetCreateStateCost(in _currentState.Gas), trackSpillRefund: false);
+            RemoveAdvancedStateGasRefund(previousState, ref _currentState.Gas);
             _worldState.Restore(previousState.Snapshot);
             if (!previousState.IsCreateOnPreExistingAccount)
             {
@@ -603,6 +614,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     {
         VmState<TGasPolicy> childState = _currentState;
         _currentState = _stateStack.Pop();
+        RemoveAdvancedStateGasRefund(childState);
         TGasPolicy.RestoreChildStateGasOnHalt(ref _currentState.Gas, in childState.Gas);
         _currentState.IsContinuation = true;
         childState.Dispose();
@@ -644,7 +656,12 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         long pendingRefund = amount - appliedRefund;
         if (pendingRefund > 0)
         {
+            // The restored state gas may have been paid by an ancestor frame. It is still
+            // immediately spendable in the restoring frame, but the state-gas-used reduction
+            // must propagate upward separately so child state gas is not erased on return.
+            TGasPolicy.AddStateGasRefundToReservoir(ref gas, pendingRefund, trackSpillRefund);
             vmState.StateGasRefundPending += pendingRefund;
+            vmState.StateGasRefundAdvanced += pendingRefund;
         }
     }
 
@@ -653,8 +670,45 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     {
         if (childState.StateGasRefundPending > 0)
         {
-            CreditStateGasRefund(ref _currentState.Gas, childState.StateGasRefundPending);
+            long pendingRefund = childState.StateGasRefundPending;
+            long unappliedRefund = TGasPolicy.DiscardStateGas(
+                ref _currentState.Gas,
+                pendingRefund,
+                _currentState.InitialStateGasUsed,
+                trackSpillRefund: true);
+
+            if (unappliedRefund > 0)
+            {
+                _currentState.StateGasRefundPending += unappliedRefund;
+            }
+
+            childState.StateGasRefundPending = 0;
+            childState.StateGasRefundAdvanced = 0;
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RemoveAdvancedStateGasRefund(VmState<TGasPolicy> vmState)
+    {
+        if (vmState.StateGasRefundAdvanced > 0)
+        {
+            TGasPolicy.RemoveStateGasRefundFromReservoir(ref vmState.Gas, vmState.StateGasRefundAdvanced);
+            vmState.StateGasRefundAdvanced = 0;
+        }
+
+        vmState.StateGasRefundPending = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RemoveAdvancedStateGasRefund(VmState<TGasPolicy> vmState, ref TGasPolicy gas)
+    {
+        if (vmState.StateGasRefundAdvanced > 0)
+        {
+            TGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, vmState.StateGasRefundAdvanced);
+            vmState.StateGasRefundAdvanced = 0;
+        }
+
+        vmState.StateGasRefundPending = 0;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -623,11 +623,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RefundRevertedTopLevelStateGas()
     {
-        if (!Spec.IsEip8037Enabled)
-        {
-            return;
-        }
-
         // EIP-8037 top-level REVERT: gas_left is preserved, so the spilled portion of
         // state_gas_used (originally drawn from gas_left) is still in the user's pocket.
         // Refund the full state_gas_used — reservoir-portion AND spilled-portion — to the
@@ -673,11 +668,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void IncorporateChildStateGasRefunds(VmState<TGasPolicy> childState)
     {
-        if (!Spec.IsEip8037Enabled)
-        {
-            return;
-        }
-
         if (childState.StateGasRefundPending > 0)
         {
             long pendingRefund = childState.StateGasRefundPending;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -623,6 +623,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RefundRevertedTopLevelStateGas()
     {
+        if (!Spec.IsEip8037Enabled)
+        {
+            return;
+        }
+
         // EIP-8037 top-level REVERT: gas_left is preserved, so the spilled portion of
         // state_gas_used (originally drawn from gas_left) is still in the user's pocket.
         // Refund the full state_gas_used — reservoir-portion AND spilled-portion — to the
@@ -638,7 +643,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void CreditStateGasRefund(ref TGasPolicy gas, long amount, bool trackSpillRefund = true)
     {
-        if (amount <= 0)
+        if (!Spec.IsEip8037Enabled || amount <= 0)
         {
             return;
         }
@@ -668,6 +673,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void IncorporateChildStateGasRefunds(VmState<TGasPolicy> childState)
     {
+        if (!Spec.IsEip8037Enabled)
+        {
+            return;
+        }
+
         if (childState.StateGasRefundPending > 0)
         {
             long pendingRefund = childState.StateGasRefundPending;
@@ -680,6 +690,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
             if (unappliedRefund > 0)
             {
                 _currentState.StateGasRefundPending += unappliedRefund;
+                _currentState.StateGasRefundAdvanced += unappliedRefund;
             }
 
             childState.StateGasRefundPending = 0;

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -28,6 +28,9 @@ public class VmState<TGasPolicy> : IDisposable
     public TGasPolicy Gas;
     public long InitialStateGasUsed;
     public long StateGasRefundPending;
+    // State-gas refund already made spendable in this frame while its accounting correction
+    // still has to reach the ancestor frame that originally paid the state gas.
+    public long StateGasRefundAdvanced;
     internal long OutputDestination { get; private set; } // TODO: move to CallEnv
     internal long OutputLength { get; private set; } // TODO: move to CallEnv
     public long Refund { get; set; }
@@ -127,9 +130,11 @@ public class VmState<TGasPolicy> : IDisposable
         }
         _accessTracker.TakeSnapshot();
         Debug.Assert(StateGasRefundPending == 0, "Pooled VmState returned with uncleared StateGasRefundPending.");
+        Debug.Assert(StateGasRefundAdvanced == 0, "Pooled VmState returned with uncleared StateGasRefundAdvanced.");
         Gas = gas;
         InitialStateGasUsed = TGasPolicy.GetStateGasUsed(in gas);
         StateGasRefundPending = 0;
+        StateGasRefundAdvanced = 0;
         OutputDestination = outputDestination;
         OutputLength = outputLength;
         Refund = 0;
@@ -198,6 +203,7 @@ public class VmState<TGasPolicy> : IDisposable
         _env = null;
         _snapshot = default;
         StateGasRefundPending = 0;
+        StateGasRefundAdvanced = 0;
 
         _statePool.Enqueue(this);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V4.cs
@@ -234,6 +234,32 @@ public partial class EngineModuleTests
         Assert.That(response.ErrorCode, Is.EqualTo(ErrorCodes.InvalidParams));
     }
 
+    [Test]
+    public async Task NewPayloadV4_returns_invalid_params_for_block_access_list()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Prague.Instance);
+        Block block = Build.A.Block
+            .WithNumber(chain.BlockTree.Head!.Number + 1)
+            .WithParentBeaconBlockRoot(Keccak.Zero)
+            .WithBlobGasUsed(0)
+            .WithExcessBlobGas(0)
+            .TestObject;
+        ExecutionPayloadV3 executionPayload = ExecutionPayloadV3.Create(block);
+        executionPayload.BlockAccessList = Bytes.FromHexString("0xc0");
+
+        ResultWrapper<PayloadStatusV1> response = await chain.EngineRpcModule.engine_newPayloadV4(
+            executionPayload,
+            [],
+            Keccak.Zero,
+            []);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Failure));
+            Assert.That(response.ErrorCode, Is.EqualTo(ErrorCodes.InvalidParams));
+        }
+    }
+
     [TestCase(30)]
     public async Task can_progress_chain_one_by_one_v4(int count)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -206,6 +206,32 @@ public partial class EngineModuleTests
             ? NewPayloadV5_via_manual_block(blockHash, receiptsRoot, stateRoot)
             : NewPayloadV5_via_engine_built(blockHash, receiptsRoot, stateRoot, eip8037Enabled, useSerializedRpc: !useEnginePipeline);
 
+    [Test]
+    public async Task NewPayloadV5_returns_invalid_params_without_block_access_list()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
+        Block block = Build.A.Block
+            .WithNumber(chain.BlockTree.Head!.Number + 1)
+            .WithParentBeaconBlockRoot(Keccak.Zero)
+            .WithBlobGasUsed(0)
+            .WithExcessBlobGas(0)
+            .WithSlotNumber(1)
+            .TestObject;
+        ExecutionPayloadV4 executionPayload = ExecutionPayloadV4.Create(block);
+
+        ResultWrapper<PayloadStatusV1> response = await chain.EngineRpcModule.engine_newPayloadV5(
+            executionPayload,
+            [],
+            Keccak.Zero,
+            []);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Failure));
+            Assert.That(response.ErrorCode, Is.EqualTo(ErrorCodes.InvalidParams));
+        }
+    }
+
     [TestCase(
         "0x43b3722358b0a8b570fdfd846a5b836ad2fae3f7f58b3ac3519858472a997214",
         "0xb7cd7ecf731166baf69674234dc243d3f8931976b0f1a379beafe0981d01bd2e",

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -82,6 +83,12 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
             return result;
         }
 
+        result = ValidateEngineApiVersionParams(spec, version, out error);
+        if (result != ValidationResult.Success)
+        {
+            return result;
+        }
+
         TransactionDecodingResult transactionDecodingResult = executionPayload.TryGetTransactions();
         if (transactionDecodingResult.Error is not null)
         {
@@ -102,6 +109,39 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
         }
 
         executionPayload.ParentBeaconBlockRoot = parentBeaconBlockRoot;
+
+        error = null;
+        return ValidationResult.Success;
+    }
+
+    private ValidationResult ValidateEngineApiVersionParams(IReleaseSpec spec, int version, out string? error)
+    {
+        if (version < EngineApiVersions.NewPayload.V5)
+        {
+            if (executionPayload.BlockAccessList is not null)
+            {
+                error = "Block access list must not be set before engine_newPayloadV5";
+                return ValidationResult.Fail;
+            }
+
+            if (executionPayload.SlotNumber is not null)
+            {
+                error = "Slot number must not be set before engine_newPayloadV5";
+                return ValidationResult.Fail;
+            }
+        }
+
+        if (spec.BlockLevelAccessListsEnabled && executionPayload.BlockAccessList is null)
+        {
+            error = "Block access list must be set";
+            return ValidationResult.Fail;
+        }
+
+        if (spec.IsEip7843Enabled && executionPayload.SlotNumber is null)
+        {
+            error = "Slot number must be set";
+            return ValidationResult.Fail;
+        }
 
         error = null;
         return ValidationResult.Success;


### PR DESCRIPTION
## Changes

- Reject transactions at both validation (`TxValidator`) and execution (`TransactionProcessor`) when the EIP-8037 intrinsic regular or floor gas exceeds the EIP-7825 per-transaction cap. A calldata-heavy transaction can push floor pricing over the cap even when the declared `GasLimit` is below it, so the shared check now lives on `IntrinsicGas<TGasPolicy>.ExceedsCap`.

- Fix EIP-8037 state-gas refund propagation for nested frames. Restored state gas can be made spendable in the current frame while the accounting correction is still propagated to the ancestor frame that paid it, and advanced refunds are removed again on revert/halt/create failure paths. The refund helpers also remain disabled before Amsterdam.

- `BlockAccessList.AddCodeChange` now short-circuits before invalidating the cached item count or allocating an `AccountChanges` entry when `before` equals `after`, so EIP-7702 authorizations that resolve to no code change, such as null-address delegation, no longer create empty BAL account changes.

- Update BAL pyspec fixtures to `tests-bal@v7.2.0` and extend EEST validation-error mapping for the new intrinsic-cap and malformed BAL hash field cases.

- Add regression coverage for the intrinsic-cap rejection, no-op BAL code changes, null-address delegation BAL output, pre-Amsterdam state-refund behavior, and nested EIP-8037 storage refund accounting.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Nethermind.Evm` release build
- `Nethermind.Blockchain.Test` release build and focused `IsWellFormed_Eip8037FloorGasExceedingRegularCap_ReturnsFalse`
- `Nethermind.Evm.Test` release build and focused EIP-8037/BAL regressions
- Focused pyspec `bal_hash_field` engine fixtures
