### PR TITLE
Reduce per-message and per-peer allocations across Eth, Snap, RLPx, and sort hot paths

### DIFF
--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -106,6 +106,9 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(Type? firstPlugin, Type? secondPlugin)
         {
+            // The IComparer<Type> signature requires nullable parameters but the only caller
+            // is the sort over _pluginTypes, which is populated exclusively from non-null Type
+            // instances. The `!` dereference is safe at this call site.
             bool firstHasPriority = _priorities.TryGetValue(firstPlugin!.Name, out int firstPriorityIndex);
             bool secondHasPriority = _priorities.TryGetValue(secondPlugin!.Name, out int secondPriorityIndex);
 

--- a/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/PluginLoader.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 using Autofac;
@@ -94,10 +96,18 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
             .Select((name, index) => (name: name + "plugin", index))
             .ToDictionary(x => x.name, x => x.index, StringComparer.OrdinalIgnoreCase);
 
-        _pluginTypes.Sort((firstPlugin, secondPlugin) =>
+        CollectionsMarshal.AsSpan(_pluginTypes).Sort(new PluginPriorityComparer(pluginPriorities));
+    }
+
+    private readonly struct PluginPriorityComparer(Dictionary<string, int> priorities) : IComparer<Type>
+    {
+        private readonly Dictionary<string, int> _priorities = priorities;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Type? firstPlugin, Type? secondPlugin)
         {
-            bool firstHasPriority = pluginPriorities.TryGetValue(firstPlugin.Name, out int firstPriorityIndex);
-            bool secondHasPriority = pluginPriorities.TryGetValue(secondPlugin.Name, out int secondPriorityIndex);
+            bool firstHasPriority = _priorities.TryGetValue(firstPlugin!.Name, out int firstPriorityIndex);
+            bool secondHasPriority = _priorities.TryGetValue(secondPlugin!.Name, out int secondPriorityIndex);
 
             return (firstHasPriority, secondHasPriority) switch
             {
@@ -106,7 +116,7 @@ public class PluginLoader(string pluginPath, IFileSystem fileSystem, ILogger log
                 (false, true) => 1,
                 (false, false) => string.Compare(firstPlugin.Name, secondPlugin.Name, StringComparison.OrdinalIgnoreCase)
             };
-        });
+        }
     }
 
     public async Task<IList<INethermindPlugin>> LoadPlugins(IConfigProvider configProvider, ChainSpec chainSpec)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1363,6 +1363,7 @@ namespace Nethermind.Blockchain
 
             // Yes, this is measurably faster
             using IOwnedReadOnlyList<ChainLevelInfo?> levels = _chainLevelInfoRepository.MultiLoadLevel(blockNumbers);
+            ReadOnlySpan<ChainLevelInfo?> levelsSpan = levels.AsSpan();
 
             for (int i = 0; i < blockInfos.Count; i++)
             {
@@ -1373,7 +1374,7 @@ namespace Nethermind.Blockchain
                     BestKnownNumber = number;
                 }
 
-                ChainLevelInfo? level = levels[i];
+                ChainLevelInfo? level = levelsSpan[i];
 
                 if (level is not null)
                 {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/IActivatedAt.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/IActivatedAt.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 
 namespace Nethermind.Consensus.AuRa
@@ -18,6 +20,19 @@ namespace Nethermind.Consensus.AuRa
     public interface IActivatedAtBlock : IActivatedAt
     {
         public long ActivationBlock => Activation;
+    }
+
+    /// <summary>
+    /// Compares activated items by their activation value.
+    /// </summary>
+    /// <typeparam name="T">The activated item type.</typeparam>
+    /// <typeparam name="TActivation">The activation value type.</typeparam>
+    public readonly struct ActivatedAtComparer<T, TActivation> : IComparer<T>
+        where T : IActivatedAt<TActivation>
+        where TActivation : IComparable<TActivation>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(T? x, T? y) => x is not null ? y is not null ? x.Activation.CompareTo(y.Activation) : 1 : y is null ? 0 : -1;
     }
 
     internal static class ActivatedAtBlockExtensions

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Abi;
 using Nethermind.Consensus.AuRa.Config;
@@ -33,7 +32,7 @@ namespace Nethermind.Consensus.AuRa.Rewards
                 if (auRaParameters.BlockRewardContractTransitions is not null)
                 {
                     contracts.AddRange(auRaParameters.BlockRewardContractTransitions.Select(t => new RewardContract(transactionProcessor, abiEncoder, t.Value, t.Key)));
-                    CollectionsMarshal.AsSpan(contracts).Sort(default(RewardContractByActivationComparer));
+                    CollectionsMarshal.AsSpan(contracts).Sort(default(ActivatedAtComparer<IRewardContract, long>));
                 }
 
                 if (auRaParameters.BlockRewardContractAddress is not null)
@@ -103,13 +102,6 @@ namespace Nethermind.Consensus.AuRa.Rewards
             }
 
             return blockRewards;
-        }
-
-
-        private readonly struct RewardContractByActivationComparer : IComparer<IRewardContract>
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int Compare(IRewardContract a, IRewardContract b) => a.Activation.CompareTo(b.Activation);
         }
 
         public class AuRaRewardCalculatorSource(AuRaChainSpecEngineParameters auRaParameters, IAbiEncoder abiEncoder) : IRewardCalculatorSource

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Rewards/AuRaRewardCalculator.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Abi;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.Contracts;
@@ -31,7 +33,7 @@ namespace Nethermind.Consensus.AuRa.Rewards
                 if (auRaParameters.BlockRewardContractTransitions is not null)
                 {
                     contracts.AddRange(auRaParameters.BlockRewardContractTransitions.Select(t => new RewardContract(transactionProcessor, abiEncoder, t.Value, t.Key)));
-                    contracts.Sort((a, b) => a.Activation.CompareTo(b.Activation));
+                    CollectionsMarshal.AsSpan(contracts).Sort(default(RewardContractByActivationComparer));
                 }
 
                 if (auRaParameters.BlockRewardContractAddress is not null)
@@ -103,6 +105,12 @@ namespace Nethermind.Consensus.AuRa.Rewards
             return blockRewards;
         }
 
+
+        private readonly struct RewardContractByActivationComparer : IComparer<IRewardContract>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(IRewardContract a, IRewardContract b) => a.Activation.CompareTo(b.Activation);
+        }
 
         public class AuRaRewardCalculatorSource(AuRaChainSpecEngineParameters auRaParameters, IAbiEncoder abiEncoder) : IRewardCalculatorSource
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -465,7 +466,6 @@ internal sealed class BlockAccessListValidationIndex
         private readonly bool[]? _rowTouched;
         private readonly int[]? _touchedRows;
         private readonly bool[]? _rowOverflow;
-        private readonly StorageOrderComparer _orderComparer = new();
         private int[] _orderScratch = [];
         private int[] _accountScratch = [];
         private UInt256[] _keyScratch = [];
@@ -667,8 +667,7 @@ internal sealed class BlockAccessListValidationIndex
                 _orderScratch[i] = i;
             }
 
-            _orderComparer.Reset(_accountOrdinals, _keys, start);
-            Array.Sort(_orderScratch, 0, length, _orderComparer);
+            _orderScratch.AsSpan(0, length).Sort(new StorageOrderComparer(_accountOrdinals, _keys, start));
 
             for (int i = 0; i < length; i++)
             {
@@ -696,19 +695,13 @@ internal sealed class BlockAccessListValidationIndex
             _valueScratch = new EvmWord[length];
         }
 
-        private sealed class StorageOrderComparer : IComparer<int>
+        private readonly struct StorageOrderComparer(int[] accountOrdinals, UInt256[] keys, int start) : IComparer<int>
         {
-            private int[] _accountOrdinals = [];
-            private UInt256[] _keys = [];
-            private int _start;
+            private readonly int[] _accountOrdinals = accountOrdinals;
+            private readonly UInt256[] _keys = keys;
+            private readonly int _start = start;
 
-            public void Reset(int[] accountOrdinals, UInt256[] keys, int start)
-            {
-                _accountOrdinals = accountOrdinals;
-                _keys = keys;
-                _start = start;
-            }
-
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int Compare(int leftOffset, int rightOffset)
             {
                 int left = _start + leftOffset;

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -109,7 +109,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
             {
                 // Create fresh CancellationTokenSource for current block processing
                 CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(
-                            _blockProcessorCancellationTokenSource.Token,
+                            Volatile.Read(ref _blockProcessorCancellationTokenSource).Token,
                             _mainCancellationTokenSource.Token);
                 try
                 {

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -174,12 +174,10 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
 
     public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
     {
-        IActivity activity = new Activity<TReq>
-        {
-            Deadline = DateTimeOffset.UtcNow + (timeout ?? DefaultTimeout),
-            Request = request,
-            FulfillFunc = fulfillFunc,
-        };
+        Activity<TReq> activity = Activity<TReq>.Rent(
+            DateTimeOffset.UtcNow + (timeout ?? DefaultTimeout),
+            request,
+            fulfillFunc);
 
         Evm.Metrics.IncrementTotalBackgroundTasksQueued();
 
@@ -204,6 +202,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         }
         Interlocked.Decrement(ref _queueCount);
         request.TryDispose();
+        activity.Return();
         return false;
     }
 
@@ -225,39 +224,77 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         _scheduler.Dispose();
     }
 
-    private readonly struct Activity<TReq> : IActivity
+    private sealed class Activity<TReq> : IActivity
     {
-        public DateTimeOffset Deadline { get; init; }
-        public TReq Request { get; init; }
-        public Func<TReq, CancellationToken, Task> FulfillFunc { get; init; }
+        private const int MaxPooled = 1024;
+        private static readonly ConcurrentQueue<Activity<TReq>> Pool = new();
+        private static int _poolCount;
+
+        private TReq _request = default!;
+        private Func<TReq, CancellationToken, Task>? _fulfillFunc;
+
+        public DateTimeOffset Deadline { get; private set; }
+
+        public static Activity<TReq> Rent(DateTimeOffset deadline, TReq request, Func<TReq, CancellationToken, Task> fulfillFunc)
+        {
+            if (Pool.TryDequeue(out Activity<TReq>? activity))
+            {
+                Interlocked.Decrement(ref _poolCount);
+            }
+            else
+            {
+                activity = new Activity<TReq>();
+            }
+
+            activity.Deadline = deadline;
+            activity._request = request;
+            activity._fulfillFunc = fulfillFunc;
+            return activity;
+        }
+
+        public void Return()
+        {
+            Deadline = default;
+            _request = default!;
+            _fulfillFunc = null;
+
+            if (Interlocked.Increment(ref _poolCount) <= MaxPooled)
+            {
+                Pool.Enqueue(this);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _poolCount);
+            }
+        }
 
         public int CompareTo(IActivity? other) => Deadline.CompareTo(other?.Deadline ?? DateTimeOffset.MaxValue);
 
         public async Task Do(CancellationToken cancellationToken)
         {
-            TimeSpan timeToComplete = Deadline - DateTimeOffset.UtcNow;
-
             CancellationTokenSource? cts = null;
-            CancellationToken token;
-            if (timeToComplete <= TimeSpan.Zero)
-            {
-                // Cancel immediately. Got no time left.
-                token = CancellationTokenExtensions.AlreadyCancelledToken;
-            }
-            else
-            {
-                cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(timeToComplete);
-                token = cts.Token;
-            }
-
             try
             {
-                await FulfillFunc.Invoke(Request, token);
+                TimeSpan timeToComplete = Deadline - DateTimeOffset.UtcNow;
+                CancellationToken token;
+                if (timeToComplete <= TimeSpan.Zero)
+                {
+                    // Cancel immediately. Got no time left.
+                    token = CancellationTokenExtensions.AlreadyCancelledToken;
+                }
+                else
+                {
+                    cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    cts.CancelAfter(timeToComplete);
+                    token = cts.Token;
+                }
+
+                await _fulfillFunc!.Invoke(_request, token);
             }
             finally
             {
                 cts?.Dispose();
+                Return();
             }
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -221,6 +221,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         // until they observe cancellation and complete.
         await Task.WhenAll(_tasksExecutors);
         _mainCancellationTokenSource.Dispose();
+        _blockProcessorCancellationTokenSource.Dispose();
         _scheduler.Dispose();
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -63,11 +63,12 @@ public static class WitnessExtensions
         public ArrayPoolList<BlockHeader> DecodeHeaders()
         {
             IOwnedReadOnlyList<byte[]> headers = witness.Headers;
-            ArrayPoolList<BlockHeader> decodedHeaders = new(headers.Count, headers.Count);
+            ReadOnlySpan<byte[]> headersSpan = headers.AsSpan();
+            ArrayPoolList<BlockHeader> decodedHeaders = new(headersSpan.Length, headersSpan.Length);
 
-            for (int i = 0; i < headers.Count; i++)
+            for (int i = 0; i < headersSpan.Length; i++)
             {
-                Rlp.ValueDecoderContext stream = new(headers[i]);
+                Rlp.ValueDecoderContext stream = new(headersSpan[i]);
 
                 decodedHeaders[i] = _decoder.Decode(ref stream)
                     ?? throw new InvalidOperationException($"No header decoded at index {i}");

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -279,6 +280,24 @@ namespace Nethermind.Core
         }
 
         internal long GetHashCode64() => SpanExtensions.FastHash64For20Bytes(ref Unsafe.AsRef(in FirstByte));
+    }
+
+    public readonly struct AddressByEip55ChecksumOrdinalComparer : IComparer<Address>
+    {
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Address? a, Address? b)
+        {
+            if (ReferenceEquals(a, b)) return 0;
+            if (a is null) return -1;
+            if (b is null) return 1;
+
+            Span<char> aHex = stackalloc char[Address.Size * 2];
+            Span<char> bHex = stackalloc char[Address.Size * 2];
+            a.Bytes.OutputBytesToCharHexWithEip55Checksum(aHex, withZeroX: false);
+            b.Bytes.OutputBytesToCharHexWithEip55Checksum(bHex, withZeroX: false);
+            return aHex.SequenceCompareTo(bHex);
+        }
     }
 
     [JsonConverter(typeof(AddressAsKeyConverter))]

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -285,7 +285,6 @@ namespace Nethermind.Core
     public readonly struct AddressByEip55ChecksumOrdinalComparer : IComparer<Address>
     {
         [SkipLocalsInit]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(Address? a, Address? b)
         {
             if (ReferenceEquals(a, b)) return 0;

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -301,8 +301,8 @@ namespace Nethermind.Core
             ValueHash256 bChecksum = ValueKeccak.Compute(bLowerHex);
             for (int i = 0; i < aLowerHex.Length; i++)
             {
-                char aChar = ToChecksummedHexChar(aLowerHex[i], GetChecksumNibble(in aChecksum, i));
-                char bChar = ToChecksummedHexChar(bLowerHex[i], GetChecksumNibble(in bChecksum, i));
+                char aChar = Bytes.ToChecksummedHexChar(aLowerHex[i], Bytes.GetChecksumNibble(in aChecksum, i));
+                char bChar = Bytes.ToChecksummedHexChar(bLowerHex[i], Bytes.GetChecksumNibble(in bChecksum, i));
                 if (aChar != bChar)
                 {
                     return aChar - bChar;
@@ -310,19 +310,6 @@ namespace Nethermind.Core
             }
 
             return 0;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
-            lowerHexChar >= 'a' && checksumNibble > 7
-                ? (char)(lowerHexChar - ('a' - 'A'))
-                : (char)lowerHexChar;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetChecksumNibble(in ValueHash256 checksum, int index)
-        {
-            byte value = checksum.BytesAsSpan[index >> 1];
-            return (index & 1) == 0 ? value >> 4 : value & 0x0f;
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -292,11 +292,37 @@ namespace Nethermind.Core
             if (a is null) return -1;
             if (b is null) return 1;
 
-            Span<char> aHex = stackalloc char[Address.Size * 2];
-            Span<char> bHex = stackalloc char[Address.Size * 2];
-            a.Bytes.OutputBytesToCharHexWithEip55Checksum(aHex, withZeroX: false);
-            b.Bytes.OutputBytesToCharHexWithEip55Checksum(bHex, withZeroX: false);
-            return aHex.SequenceCompareTo(bHex);
+            Span<byte> aLowerHex = stackalloc byte[Address.Size * 2];
+            Span<byte> bLowerHex = stackalloc byte[Address.Size * 2];
+            a.Bytes.OutputBytesToByteHex(aLowerHex, extraNibble: false);
+            b.Bytes.OutputBytesToByteHex(bLowerHex, extraNibble: false);
+
+            ValueHash256 aChecksum = ValueKeccak.Compute(aLowerHex);
+            ValueHash256 bChecksum = ValueKeccak.Compute(bLowerHex);
+            for (int i = 0; i < aLowerHex.Length; i++)
+            {
+                char aChar = ToChecksummedHexChar(aLowerHex[i], GetChecksumNibble(in aChecksum, i));
+                char bChar = ToChecksummedHexChar(bLowerHex[i], GetChecksumNibble(in bChecksum, i));
+                if (aChar != bChar)
+                {
+                    return aChar - bChar;
+                }
+            }
+
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
+            lowerHexChar >= 'a' && checksumNibble > 7
+                ? (char)(lowerHexChar - ('a' - 'A'))
+                : (char)lowerHexChar;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetChecksumNibble(in ValueHash256 checksum, int index)
+        {
+            byte value = checksum.BytesAsSpan[index >> 1];
+            return (index & 1) == 0 ? value >> 4 : value & 0x0f;
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Collections/ByteArrayListAdapter.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ByteArrayListAdapter.cs
@@ -9,7 +9,7 @@ public sealed class ByteArrayListAdapter(IOwnedReadOnlyList<byte[]> inner) : IBy
 {
     public int Count => inner.Count;
 
-    public ReadOnlySpan<byte> this[int index] => inner.AsSpan()[index];
+    public ReadOnlySpan<byte> this[int index] => inner[index];
 
     public void Dispose() => inner.Dispose();
 }

--- a/src/Nethermind/Nethermind.Core/Collections/ByteArrayListAdapter.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ByteArrayListAdapter.cs
@@ -9,7 +9,7 @@ public sealed class ByteArrayListAdapter(IOwnedReadOnlyList<byte[]> inner) : IBy
 {
     public int Count => inner.Count;
 
-    public ReadOnlySpan<byte> this[int index] => inner[index];
+    public ReadOnlySpan<byte> this[int index] => inner.AsSpan()[index];
 
     public void Dispose() => inner.Dispose();
 }

--- a/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
@@ -56,9 +56,10 @@ public static class OwnedReadOnlyListExtensions
 
     public static void DisposeRecursive<T>(this IOwnedReadOnlyList<T> list) where T : IDisposable
     {
-        for (int i = 0; i < list.Count; i++)
+        ReadOnlySpan<T> span = list.AsSpan();
+        for (int i = 0; i < span.Length; i++)
         {
-            list[i]?.Dispose();
+            span[i]?.Dispose();
         }
 
         list.Dispose();

--- a/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
@@ -56,10 +56,13 @@ public static class OwnedReadOnlyListExtensions
 
     public static void DisposeRecursive<T>(this IOwnedReadOnlyList<T> list) where T : IDisposable
     {
-        ReadOnlySpan<T> span = list.AsSpan();
-        for (int i = 0; i < span.Length; i++)
+        if (list.Count != 0)
         {
-            span[i]?.Dispose();
+            ReadOnlySpan<T> span = list.AsSpan();
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i]?.Dispose();
+            }
         }
 
         list.Dispose();

--- a/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autofac;
+using Autofac.Builder;
 using Autofac.Core;
 
 namespace Nethermind.Core.Container;
@@ -55,7 +56,7 @@ public static class OrderedComponentsContainerBuilderExtensions
     /// <c>T[]</c> from <see cref="OrderedComponents{T}"/>. It also relaxes the ordered components
     /// safety check to allow this single <typeparamref name="T"/> registration.
     /// </summary>
-    public static ContainerBuilder AddCompositeOrderedComponents<T, TComposite>(this ContainerBuilder builder) where T : class where TComposite : class, T
+    public static ContainerBuilder AddCompositeOrderedComponents<T, TComposite>(this ContainerBuilder builder, bool singleInstance = false) where T : class where TComposite : class, T
     {
         builder.EnsureOrderedComponents<T>();
 
@@ -63,9 +64,14 @@ public static class OrderedComponentsContainerBuilderExtensions
         if (!builder.Properties.TryAdd(compositeMarker, null))
             return builder;
 
-        builder.RegisterType<TComposite>()
+        IRegistrationBuilder<TComposite, ConcreteReflectionActivatorData, SingleRegistrationStyle> registration = builder.RegisterType<TComposite>()
             .As<T>()
             .AsSelf();
+
+        if (singleInstance)
+        {
+            registration.SingleInstance();
+        }
 
         return builder;
     }

--- a/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Container/OrderedComponentsContainerBuilderExtensions.cs
@@ -70,7 +70,7 @@ public static class OrderedComponentsContainerBuilderExtensions
 
         if (singleInstance)
         {
-            registration.SingleInstance();
+            registration = registration.SingleInstance();
         }
 
         return builder;

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -817,13 +817,13 @@ namespace Nethermind.Core.Extensions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
+        internal static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
             lowerHexChar >= 'a' && checksumNibble > 7
                 ? (char)(lowerHexChar - ('a' - 'A'))
                 : (char)lowerHexChar;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetChecksumNibble(in ValueHash256 checksum, int index)
+        internal static int GetChecksumNibble(in ValueHash256 checksum, int index)
         {
             byte value = checksum.BytesAsSpan[index >> 1];
             return (index & 1) == 0 ? value >> 4 : value & 0x0f;

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -764,42 +764,74 @@ namespace Nethermind.Core.Extensions
             }
         }
 
-        private static string ByteArrayToHexViaLookup32Checksum(int length, State stateToPass) => string.Create(length, stateToPass, static (chars, state) =>
+        /// <summary>
+        /// Writes the EIP-55 checksummed hexadecimal representation of <paramref name="bytes"/> into <paramref name="chars"/>.
+        /// </summary>
+        /// <param name="bytes">The bytes to encode.</param>
+        /// <param name="chars">The destination span. Its length must match the encoded length after <paramref name="leadingZeros"/> are skipped.</param>
+        /// <param name="withZeroX">Whether to include the <c>0x</c> prefix.</param>
+        /// <param name="leadingZeros">The number of leading hex nibbles to skip in the output. The checksum is still computed over the full lowercase hex input.</param>
+        [SkipLocalsInit]
+        public static void OutputBytesToCharHexWithEip55Checksum(this ReadOnlySpan<byte> bytes, Span<char> chars, bool withZeroX, int leadingZeros = 0)
         {
-            // this path is rarely used - only in wallets
-            byte[] bytesArray = state.Bytes;
-            string hashHex = Keccak.Compute(bytesArray.ToHexString(false)).ToString(false);
-            Span<byte> bytes = bytesArray;
-
-            if (state.WithZeroX)
+            int hexLength = bytes.Length * 2;
+            int expectedLength = hexLength + (withZeroX ? 2 : 0) - leadingZeros;
+            if ((uint)leadingZeros > (uint)hexLength || chars.Length != expectedLength)
             {
-                chars[1] = 'x';
-                chars[0] = '0';
-                chars = chars[2..];
+                ThrowArgumentOutOfRangeException();
             }
 
-            bool odd = state.LeadingZeros % 2 == 1;
-            int oddity = odd ? 1 : 0;
+            byte[]? rentedHex = null;
+            Span<byte> lowerHex = hexLength <= 256
+                ? stackalloc byte[hexLength]
+                : (rentedHex = ArrayPool<byte>.Shared.Rent(hexLength)).AsSpan(0, hexLength);
 
-            uint[] lookup32 = Lookup32;
-            for (int i = 0; i < chars.Length; i += 2)
+            try
             {
-                uint val = lookup32[bytes[(i + state.LeadingZeros) / 2]];
-                if (i != 0 || !odd)
+                bytes.OutputBytesToByteHex(lowerHex, extraNibble: false);
+                ValueHash256 checksum = ValueKeccak.Compute(lowerHex);
+
+                if (withZeroX)
                 {
-                    char char1 = (char)val;
-                    chars[i - oddity] =
-                        char.IsLetter(char1) && hashHex![i] > '7'
-                            ? char.ToUpper(char1)
-                            : char1;
+                    chars[1] = 'x';
+                    chars[0] = '0';
+                    chars = chars[2..];
                 }
 
-                char char2 = (char)(val >> 16);
-                chars[i + 1 - oddity] =
-                    char.IsLetter(char2) && hashHex![i + 1] > '7'
-                        ? char.ToUpper(char2)
-                        : char2;
+                for (int i = leadingZeros; i < lowerHex.Length; i++)
+                {
+                    chars[i - leadingZeros] = ToChecksummedHexChar(lowerHex[i], GetChecksumNibble(in checksum, i));
+                }
             }
+            finally
+            {
+                if (rentedHex is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(rentedHex);
+                }
+            }
+
+            [DoesNotReturn]
+            static void ThrowArgumentOutOfRangeException() =>
+                throw new ArgumentOutOfRangeException(nameof(chars), "Output hex span has incorrect length.");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static char ToChecksummedHexChar(byte lowerHexChar, int checksumNibble) =>
+            lowerHexChar >= 'a' && checksumNibble > 7
+                ? (char)(lowerHexChar - ('a' - 'A'))
+                : (char)lowerHexChar;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetChecksumNibble(in ValueHash256 checksum, int index)
+        {
+            byte value = checksum.BytesAsSpan[index >> 1];
+            return (index & 1) == 0 ? value >> 4 : value & 0x0f;
+        }
+
+        private static string ByteArrayToHexViaLookup32Checksum(int length, State stateToPass) => string.Create(length, stateToPass, static (chars, state) =>
+        {
+            state.Bytes.AsSpan().OutputBytesToCharHexWithEip55Checksum(chars, state.WithZeroX, state.LeadingZeros);
         });
 
         internal static uint[] Lookup32 = CreateLookup32("x2");

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -13,7 +13,6 @@ using System.Runtime.Intrinsics;
 using Arm = System.Runtime.Intrinsics.Arm;
 using x64 = System.Runtime.Intrinsics.X86;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Crypto;
 
 namespace Nethermind.Core.Extensions
 {
@@ -103,64 +102,25 @@ namespace Nethermind.Core.Extensions
 
         private static string ToHexStringWithEip55Checksum(ReadOnlySpan<byte> bytes, bool withZeroX, bool skipLeadingZeros)
         {
-            string hashHex = Keccak.Compute(bytes.ToHexString(false)).ToString(false);
-
             int leadingZeros = skipLeadingZeros ? bytes.CountLeadingNibbleZeros() : 0;
             int length = bytes.Length * 2 + (withZeroX ? 2 : 0) - leadingZeros;
-            if (leadingZeros >= 2)
+            if (skipLeadingZeros && length == (withZeroX ? 2 : 0))
             {
-                bytes = bytes[(leadingZeros / 2)..];
+                return withZeroX ? Bytes.ZeroHexValue : Bytes.ZeroValue;
             }
+
             char[] charArray = ArrayPool<char>.Shared.Rent(length);
 
             Span<char> chars = charArray.AsSpan(0, length);
-
-            if (withZeroX)
+            try
             {
-                // In reverse, bounds check on [1] will elide bounds check on [0]
-                chars[1] = 'x';
-                chars[0] = '0';
-                // Trim off the two chars from the span
-                chars = chars[2..];
+                bytes.OutputBytesToCharHexWithEip55Checksum(chars, withZeroX, leadingZeros);
+                return new string(chars);
             }
-
-            uint[] lookup32 = Bytes.Lookup32;
-
-            bool odd = (leadingZeros & 1) != 0;
-            int oddity = odd ? 2 : 0;
-            if (odd)
+            finally
             {
-                // Odd number of hex chars, handle the first
-                // separately so loop can work in pairs
-                uint val = lookup32[bytes[0]];
-                char char2 = (char)(val >> 16);
-                chars[0] = char.IsLetter(char2) && hashHex[1] > '7'
-                            ? char.ToUpper(char2)
-                            : char2;
-
-                // Trim off the first byte and char from the spans
-                chars = chars[1..];
-                bytes = bytes[1..];
+                ArrayPool<char>.Shared.Return(charArray);
             }
-
-            for (int i = 0; i < chars.Length; i += 2)
-            {
-                uint val = lookup32[bytes[i / 2]];
-                char char1 = (char)val;
-                char char2 = (char)(val >> 16);
-
-                chars[i] = char.IsLetter(char1) && hashHex[i + oddity] > '7'
-                            ? char.ToUpper(char1)
-                            : char1;
-                chars[i + 1] = char.IsLetter(char2) && hashHex[i + 1 + oddity] > '7'
-                            ? char.ToUpper(char2)
-                            : char2;
-            }
-
-            string result = new(charArray.AsSpan(0, length));
-            ArrayPool<char>.Shared.Return(charArray);
-
-            return result;
         }
 
         public static ReadOnlySpan<T> TakeAndMove<T>(this ref ReadOnlySpan<T> span, int length)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -244,15 +245,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             }
         }
 
-        fileMetadataEntries.Sort((item1, item2) =>
-        {
-            // Sort them by level so that lower level get priority
-            int levelDiff = item1.metadata.FileLevel - item2.metadata.FileLevel;
-            if (levelDiff != 0) return levelDiff;
-
-            // Otherwise, we pick which file is newest.
-            return item2.creationTime.CompareTo(item1.creationTime);
-        });
+        CollectionsMarshal.AsSpan(fileMetadataEntries).Sort(default(FileMetadataByLevelThenNewestComparer));
 
         long totalSize = 0;
         fileMetadataEntries = fileMetadataEntries.TakeWhile(metadata =>
@@ -297,6 +290,18 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 _logger.Warn($"Exception warming up {fullPath} {e}");
             }
         });
+    }
+
+    private readonly struct FileMetadataByLevelThenNewestComparer : IComparer<(FileMetadata metadata, DateTime creationTime)>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(
+            (FileMetadata metadata, DateTime creationTime) item1,
+            (FileMetadata metadata, DateTime creationTime) item2)
+        {
+            int levelDiff = item1.metadata.FileLevel - item2.metadata.FileLevel;
+            return levelDiff != 0 ? levelDiff : item2.creationTime.CompareTo(item1.creationTime);
+        }
     }
 
     private void CreateMarkerIfCorrupt(RocksDbSharpException rocksDbException)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -249,8 +250,9 @@ namespace Nethermind.Evm.TransactionProcessing
                 JournalSet<Address> destroyList = substate.DestroyList;
                 if (destroyList.Count > 1)
                 {
-                    Address[] orderedDestroyList = [.. destroyList];
-                    Array.Sort(orderedDestroyList, GenericComparer.GetOptimized<Address>());
+                    Address[] orderedDestroyList = new Address[destroyList.Count];
+                    destroyList.CopyTo(orderedDestroyList, 0);
+                    orderedDestroyList.AsSpan().Sort(default(AddressByBytesComparer));
                     for (int i = 0; i < orderedDestroyList.Length; i++)
                     {
                         FinalizeDestroyedAccount(WorldState, in substate, orderedDestroyList[i]);
@@ -1449,6 +1451,14 @@ namespace Nethermind.Evm.TransactionProcessing
 
         [DoesNotReturn, StackTraceHidden]
         private static void ThrowInvalidDataException(string message) => throw new InvalidDataException(message);
+
+        // Devirtualised wrapper over Address.CompareTo (sealed -> already devirt'd inside) so the EIP-7708
+        // destroy-list sort goes through Sort<TComparer> instead of Comparer<Address>.Default's virtual call.
+        private readonly struct AddressByBytesComparer : IComparer<Address>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(Address? x, Address? y) => x!.CompareTo(y);
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1454,6 +1454,8 @@ namespace Nethermind.Evm.TransactionProcessing
 
         // Devirtualised wrapper over Address.CompareTo (sealed -> already devirt'd inside) so the EIP-7708
         // destroy-list sort goes through Sort<TComparer> instead of Comparer<Address>.Default's virtual call.
+        // The IComparer<Address> contract declares nullable parameters; the destroy-list source
+        // (JournalSet<Address>) never contains null entries, so the `!` dereference is safe here.
         private readonly struct AddressByBytesComparer : IComparer<Address>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -144,7 +144,7 @@ public class NetworkModule(IConfigProvider configProvider) : Module
 
             .AddSingleton<State.SnapServer.ISnapServer, State.IWorldStateManager>(wsm => wsm.SnapServer)
 
-            // Protocol handler factories (using clean DSL with Autofac Func auto-generation)
+            // Protocol handler factories
             .AddProtocolHandler<Subprotocols.Snap.SnapProtocolHandler>()
             .AddProtocolHandler<Subprotocols.Eth.V66.Eth66ProtocolHandler>()
             .AddProtocolHandler<Subprotocols.Eth.V67.Eth67ProtocolHandler>()

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Threading;
 using Autofac;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
@@ -42,7 +43,8 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .AddModule(new SynchronizerModule(configProvider.GetConfig<ISyncConfig>()))
             .AddSingleton<SyncedTxGossipPolicy>()
             .AddLast<ITxGossipPolicy>(ctx => ctx.Resolve<SyncedTxGossipPolicy>())
-            .AddCompositeOrderedComponents<ITxGossipPolicy, CompositeTxGossipPolicy>()
+            .AddSingleton<ITxGossipPolicySource, TxGossipPolicySource>()
+            .AddCompositeOrderedComponents<ITxGossipPolicy, CompositeTxGossipPolicy>(singleInstance: true)
             .AddSingleton<IIPResolver, IPResolver>()
             .AddSingleton<IForkInfo, ForkInfo>()
 
@@ -152,5 +154,35 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .AddProtocolHandler<Subprotocols.Eth.V71.Eth71ProtocolHandler>()
 
             ;
+    }
+
+    private sealed class TxGossipPolicySource(ILifetimeScope lifetimeScope) : ITxGossipPolicySource
+    {
+        private readonly Lock _lock = new();
+        private ITxGossipPolicy[]? _policies;
+
+        public ITxGossipPolicy[] Policies
+        {
+            get
+            {
+                ITxGossipPolicy[]? policies = Volatile.Read(ref _policies);
+                if (policies is not null)
+                {
+                    return policies;
+                }
+
+                lock (_lock)
+                {
+                    policies = _policies;
+                    if (policies is null)
+                    {
+                        policies = lifetimeScope.Resolve<ITxGossipPolicy[]>();
+                        Volatile.Write(ref _policies, policies);
+                    }
+
+                    return policies;
+                }
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
@@ -62,10 +62,23 @@ namespace Nethermind.Init.Steps
             return stepsWithMatchingApiType.FirstOrDefault();
         }
 
+        // Orders steps so the most derived comes first (taken by FirstOrDefault below).
+        // The original lambda returned `t1.IsAssignableFrom(t2) ? 1 : -1`, which violated
+        // reflexivity (Compare(x, x) = 1) and antisymmetry (for unrelated types both
+        // directions returned -1). This restored ordering uses AssemblyQualifiedName as a
+        // stable tie-break when neither type derives from the other.
         private readonly struct StepInfoByAssignabilityComparer : IComparer<StepInfo>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int Compare(StepInfo? t1, StepInfo? t2) => t1!.StepType.IsAssignableFrom(t2!.StepType) ? 1 : -1;
+            public int Compare(StepInfo? t1, StepInfo? t2)
+            {
+                if (ReferenceEquals(t1, t2)) return 0;
+                bool t1IsParent = t1!.StepType.IsAssignableFrom(t2!.StepType);
+                bool t2IsParent = t2.StepType.IsAssignableFrom(t1.StepType);
+                if (t1IsParent && !t2IsParent) return 1;   // t2 is more derived -> first
+                if (t2IsParent && !t1IsParent) return -1;  // t1 is more derived -> first
+                return string.CompareOrdinal(t1.StepType.AssemblyQualifiedName, t2.StepType.AssemblyQualifiedName);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
@@ -47,7 +48,7 @@ namespace Nethermind.Init.Steps
 
             if (stepsWithMatchingApiType.Length > 1)
             {
-                Array.Sort(stepsWithMatchingApiType, (t1, t2) => t1.StepType.IsAssignableFrom(t2.StepType) ? 1 : -1);
+                stepsWithMatchingApiType.AsSpan().Sort(default(StepInfoByAssignabilityComparer));
             }
 
             if (stepsWithMatchingApiType.Length == 0)
@@ -59,6 +60,12 @@ namespace Nethermind.Init.Steps
             }
 
             return stepsWithMatchingApiType.FirstOrDefault();
+        }
+
+        private readonly struct StepInfoByAssignabilityComparer : IComparer<StepInfo>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(StepInfo? t1, StepInfo? t2) => t1!.StepType.IsAssignableFrom(t2!.StepType) ? 1 : -1;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsLoader.cs
@@ -73,7 +73,9 @@ namespace Nethermind.Init.Steps
             public int Compare(StepInfo? t1, StepInfo? t2)
             {
                 if (ReferenceEquals(t1, t2)) return 0;
-                bool t1IsParent = t1!.StepType.IsAssignableFrom(t2!.StepType);
+                if (t1 is null) return -1;
+                if (t2 is null) return 1;
+                bool t1IsParent = t1.StepType.IsAssignableFrom(t2.StepType);
                 bool t2IsParent = t2.StepType.IsAssignableFrom(t1.StepType);
                 if (t1IsParent && !t2IsParent) return 1;   // t2 is more derived -> first
                 if (t2IsParent && !t1IsParent) return -1;  // t1 is more derived -> first

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -474,7 +474,7 @@ public class AdminModuleTests
             manualResetEvent.Set();
         }));
 
-        _existingSession1.Disconnected += Raise.EventWith(_existingSession1, disconnectEventArgs);
+        _rlpxPeer.SessionDisconnected += Raise.Event<SessionDisconnectedEventHandler>(_rlpxPeer, _existingSession1, disconnectEventArgs);
         _existingSession1.MsgDelivered += Raise.EventWith(new object(), peerEventArgs);
 
         manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().BeFalse(because: "after disconnect the session is unhooked and must not raise further notifications");

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/FeeHistory/FeeHistoryOracle.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -57,6 +59,12 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
         });
 
         private readonly record struct RewardInfo(long GasUsed, UInt256 PremiumPerGas);
+
+        private readonly struct RewardInfoByPremiumAscendingComparer : IComparer<RewardInfo>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(RewardInfo i1, RewardInfo i2) => i1.PremiumPerGas.CompareTo(i2.PremiumPerGas);
+        }
 
         private readonly record struct BlockFeeHistorySearchInfo(
             long BlockNumber,
@@ -273,7 +281,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.FeeHistory
                 rewardInfos.Add(new RewardInfo(gasUsedSpan[i], premiumPerGas));
             }
 
-            rewardInfos.Sort(static (i1, i2) => i1.PremiumPerGas.CompareTo(i2.PremiumPerGas));
+            CollectionsMarshal.AsSpan(rewardInfos).Sort(default(RewardInfoByPremiumAscendingComparer));
 
             return rewardInfos;
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/PeerEventsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/PeerEventsSubscription.cs
@@ -39,9 +39,9 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             {
                 session.MsgDelivered += OnMsgDelivered;
                 session.MsgReceived += OnMsgReceived;
-                session.Disconnected += OnSessionDisconnected;
             }
             _rlpxHost.SessionCreated += OnSessionCreated;
+            _rlpxHost.SessionDisconnected += OnSessionDisconnected;
             if (_logger.IsTrace) _logger.Trace($"admin_subscription {Id} will track PeerAdded, PeerRemoved, MsgDelivered and MsgReceived.");
         }
 
@@ -142,15 +142,12 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         {
             args.Session.MsgDelivered += OnMsgDelivered;
             args.Session.MsgReceived += OnMsgReceived;
-            args.Session.Disconnected += OnSessionDisconnected;
         }
 
-        private void OnSessionDisconnected(object sender, DisconnectEventArgs e)
+        private void OnSessionDisconnected(object sender, ISession session, DisconnectEventArgs e)
         {
-            ISession session = (ISession)sender;
             session.MsgDelivered -= OnMsgDelivered;
             session.MsgReceived -= OnMsgReceived;
-            session.Disconnected -= OnSessionDisconnected;
         }
 
         public override string Type => SubscriptionType.AdminSubscription.PeerEvents;
@@ -163,9 +160,9 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             {
                 session.MsgDelivered -= OnMsgDelivered;
                 session.MsgReceived -= OnMsgReceived;
-                session.Disconnected -= OnSessionDisconnected;
             }
             _rlpxHost.SessionCreated -= OnSessionCreated;
+            _rlpxHost.SessionDisconnected -= OnSessionDisconnected;
             base.Dispose();
             if (_logger.IsTrace) _logger.Trace($"admin_subscription.peerEvent {Id} is no longer subscribed.");
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PosForwardHeaderProvider.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -71,16 +70,23 @@ public class PosForwardHeaderProvider(
     {
         // Override PoW's RequestHeaders so that it won't request beyond PoW.
         // This fixes `Incremental Sync` hive test.
-        if (response.Count > 0)
+        ReadOnlySpan<BlockHeader> responseSpan = response.AsSpan();
+        if (responseSpan.Length > 0)
         {
-            BlockHeader lastBlockHeader = response[^1];
-            bool lastBlockIsPostMerge = poSSwitcher.GetBlockConsensusInfo(response[^1]).IsPostMerge;
+            BlockHeader lastBlockHeader = responseSpan[^1];
+            bool lastBlockIsPostMerge = poSSwitcher.GetBlockConsensusInfo(responseSpan[^1]).IsPostMerge;
             if (lastBlockIsPostMerge) // Initial check to prevent creating new array every time
             {
+                int preMergeHeadersCount = 0;
+                while (preMergeHeadersCount < responseSpan.Length && !poSSwitcher.GetBlockConsensusInfo(responseSpan[preMergeHeadersCount]).IsPostMerge)
+                {
+                    preMergeHeadersCount++;
+                }
+
                 using IOwnedReadOnlyList<BlockHeader> oldResponse = response;
-                response = response
-                    .TakeWhile(header => !poSSwitcher.GetBlockConsensusInfo(header).IsPostMerge)
-                    .ToPooledList(response.Count);
+                ArrayPoolList<BlockHeader> trimmedResponse = new(preMergeHeadersCount);
+                trimmedResponse.AddRange(responseSpan[..preMergeHeadersCount]);
+                response = trimmedResponse;
                 if (_logger.IsInfo) _logger.Info($"Last block is post merge. {lastBlockHeader.Hash}. Trimming to {response.Count} sized batch.");
             }
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,7 +65,8 @@ public class UnsafeStartingSyncPivotUpdater(
         TryGetFromPeers(blockNumber, cancellationToken, static async (peer, number, token) =>
         {
             using IOwnedReadOnlyList<BlockHeader>? x = await peer.GetBlockHeaders(number, 1, 0, token);
-            return x?.Count == 1 ? x[0] : null;
+            ReadOnlySpan<BlockHeader> headers = x?.AsSpan() ?? [];
+            return headers.Length == 1 ? headers[0] : null;
         });
 
     private Hash256? TryGetPotentialPivotBlockNumberFromBlockCache(long potentialPivotBlockNumber)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
@@ -65,7 +65,7 @@ public class UnsafeStartingSyncPivotUpdater(
         TryGetFromPeers(blockNumber, cancellationToken, static async (peer, number, token) =>
         {
             using IOwnedReadOnlyList<BlockHeader>? x = await peer.GetBlockHeaders(number, 1, 0, token);
-            ReadOnlySpan<BlockHeader> headers = x?.AsSpan() ?? [];
+            ReadOnlySpan<BlockHeader> headers = x is null ? [] : x.AsSpan();
             return headers.Length == 1 ? headers[0] : null;
         });
 

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -396,7 +396,7 @@ public class DiscoveryManager : IDiscoveryManager
     {
         if (_nodeLifecycleManagers.TryRemove(key, out INodeLifecycleManager? manager))
         {
-            manager.OnStateChanged -= ManagerOnOnStateChanged;
+            manager.OnStateChanged -= _managerOnStateChanged;
             _discoveryStorage.RemoveNode(manager.ManagedNode.Id);
             return true;
         }

--- a/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
@@ -4,20 +4,13 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
-using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Logging;
 using Nethermind.Network.P2P;
-using Nethermind.Network.P2P.Messages;
-using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
-using Nethermind.Network.Rlpx;
-using Nethermind.Stats;
-using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 using GetBlockHeadersMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage;
@@ -34,7 +27,7 @@ public class MessageDictionaryTests
     public void Setup()
     {
         _recordedRequests.Clear();
-        _testMessageDictionary = new(CreateHandler(_recordedRequests));
+        _testMessageDictionary = new(RecordingProtocolHandler.Create(_recordedRequests));
     }
 
     [Test]
@@ -122,7 +115,7 @@ public class MessageDictionaryTests
     [Test]
     public void Handle_disposes_tuple_disposable_component_on_unmatched_request()
     {
-        MessageDictionary<Eth66Message<GetBlockHeadersMessage>, (IDisposable, long)> dictionary = new(CreateHandler<Eth66Message<GetBlockHeadersMessage>>());
+        MessageDictionary<Eth66Message<GetBlockHeadersMessage>, (IDisposable, long)> dictionary = new(RecordingProtocolHandler.Create<Eth66Message<GetBlockHeadersMessage>>());
         IDisposable inner = Substitute.For<IDisposable>();
 
         dictionary.Invoking(d => d.Handle(9999, (inner, 100L), 100))
@@ -138,33 +131,5 @@ public class MessageDictionaryTests
             new(new Network.P2P.Subprotocols.Eth.V66.Messages.GetBlockHeadersMessage(requestId,
                 new GetBlockHeadersMessage()));
         return request;
-    }
-
-    private static TestProtocolHandler CreateHandler<TMessage>(List<TMessage>? recordedSends = null)
-        where TMessage : P2PMessage
-    {
-        ISession session = Substitute.For<ISession>();
-        session.When(s => s.DeliverMessage(Arg.Any<TMessage>()))
-            .Do(c => recordedSends?.Add(c.Arg<TMessage>()));
-        return new TestProtocolHandler(session);
-    }
-
-    private sealed class TestProtocolHandler(ISession session)
-        : ProtocolHandlerBase(
-            session,
-            Substitute.For<INodeStatsManager>(),
-            Substitute.For<IMessageSerializationService>(),
-            Substitute.For<IBackgroundTaskScheduler>(),
-            LimboLogs.Instance)
-    {
-        public override string Name => "test";
-        protected override TimeSpan InitTimeout => TimeSpan.Zero;
-        public override byte ProtocolVersion => 0;
-        public override string ProtocolCode => "test";
-        public override int MessageIdSpaceSize => 0;
-        public override void Init() { }
-        public override void HandleMessage(Packet message) { }
-        public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
-        public override void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
@@ -4,13 +4,20 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
+using Nethermind.Network.Rlpx;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 using GetBlockHeadersMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage;
@@ -27,7 +34,7 @@ public class MessageDictionaryTests
     public void Setup()
     {
         _recordedRequests.Clear();
-        _testMessageDictionary = new((message) => _recordedRequests.Add(message));
+        _testMessageDictionary = new(CreateHandler(_recordedRequests));
     }
 
     [Test]
@@ -115,7 +122,7 @@ public class MessageDictionaryTests
     [Test]
     public void Handle_disposes_tuple_disposable_component_on_unmatched_request()
     {
-        MessageDictionary<Eth66Message<GetBlockHeadersMessage>, (IDisposable, long)> dictionary = new(_ => { });
+        MessageDictionary<Eth66Message<GetBlockHeadersMessage>, (IDisposable, long)> dictionary = new(CreateHandler<Eth66Message<GetBlockHeadersMessage>>());
         IDisposable inner = Substitute.For<IDisposable>();
 
         dictionary.Invoking(d => d.Handle(9999, (inner, 100L), 100))
@@ -131,5 +138,33 @@ public class MessageDictionaryTests
             new(new Network.P2P.Subprotocols.Eth.V66.Messages.GetBlockHeadersMessage(requestId,
                 new GetBlockHeadersMessage()));
         return request;
+    }
+
+    private static TestProtocolHandler CreateHandler<TMessage>(List<TMessage>? recordedSends = null)
+        where TMessage : P2PMessage
+    {
+        ISession session = Substitute.For<ISession>();
+        session.When(s => s.DeliverMessage(Arg.Any<TMessage>()))
+            .Do(c => recordedSends?.Add(c.Arg<TMessage>()));
+        return new TestProtocolHandler(session);
+    }
+
+    private sealed class TestProtocolHandler(ISession session)
+        : ProtocolHandlerBase(
+            session,
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IMessageSerializationService>(),
+            Substitute.For<IBackgroundTaskScheduler>(),
+            LimboLogs.Instance)
+    {
+        public override string Name => "test";
+        protected override TimeSpan InitTimeout => TimeSpan.Zero;
+        public override byte ProtocolVersion => 0;
+        public override string ProtocolCode => "test";
+        public override int MessageIdSpaceSize => 0;
+        public override void Init() { }
+        public override void HandleMessage(Packet message) { }
+        public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
+        public override void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
@@ -4,20 +4,13 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
-using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Logging;
 using Nethermind.Network.P2P;
-using Nethermind.Network.P2P.Messages;
-using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
-using Nethermind.Network.Rlpx;
-using Nethermind.Stats;
-using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -32,7 +25,7 @@ public class MessageQueueTests
     public void Setup()
     {
         _recordedSends.Clear();
-        _queue = new(CreateHandler(_recordedSends));
+        _queue = new(RecordingProtocolHandler.Create(_recordedSends));
     }
 
     [Test]
@@ -214,7 +207,7 @@ public class MessageQueueTests
     [Test]
     public void Handle_disposes_tuple_disposable_component_when_no_current_request()
     {
-        MessageQueue<GetBlockHeadersMessage, (IDisposable, long)> queue = new(CreateHandler<GetBlockHeadersMessage>());
+        MessageQueue<GetBlockHeadersMessage, (IDisposable, long)> queue = new(RecordingProtocolHandler.Create<GetBlockHeadersMessage>());
         IDisposable inner = Substitute.For<IDisposable>();
 
         queue.Invoking(q => q.Handle((inner, 100L), 100))
@@ -225,32 +218,4 @@ public class MessageQueueTests
     }
 
     private static Request<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> CreateRequest() => new(new GetBlockHeadersMessage());
-
-    private static TestProtocolHandler CreateHandler<TMessage>(List<TMessage>? recordedSends = null)
-        where TMessage : P2PMessage
-    {
-        ISession session = Substitute.For<ISession>();
-        session.When(s => s.DeliverMessage(Arg.Any<TMessage>()))
-            .Do(c => recordedSends?.Add(c.Arg<TMessage>()));
-        return new TestProtocolHandler(session);
-    }
-
-    private sealed class TestProtocolHandler(ISession session)
-        : ProtocolHandlerBase(
-            session,
-            Substitute.For<INodeStatsManager>(),
-            Substitute.For<IMessageSerializationService>(),
-            Substitute.For<IBackgroundTaskScheduler>(),
-            LimboLogs.Instance)
-    {
-        public override string Name => "test";
-        protected override TimeSpan InitTimeout => TimeSpan.Zero;
-        public override byte ProtocolVersion => 0;
-        public override string ProtocolCode => "test";
-        public override int MessageIdSpaceSize => 0;
-        public override void Init() { }
-        public override void HandleMessage(Packet message) { }
-        public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
-        public override void Dispose() { }
-    }
 }

--- a/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageQueueTests.cs
@@ -4,13 +4,20 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
+using Nethermind.Network.Rlpx;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -25,7 +32,7 @@ public class MessageQueueTests
     public void Setup()
     {
         _recordedSends.Clear();
-        _queue = new((message) => _recordedSends.Add(message));
+        _queue = new(CreateHandler(_recordedSends));
     }
 
     [Test]
@@ -207,7 +214,7 @@ public class MessageQueueTests
     [Test]
     public void Handle_disposes_tuple_disposable_component_when_no_current_request()
     {
-        MessageQueue<GetBlockHeadersMessage, (IDisposable, long)> queue = new(_ => { });
+        MessageQueue<GetBlockHeadersMessage, (IDisposable, long)> queue = new(CreateHandler<GetBlockHeadersMessage>());
         IDisposable inner = Substitute.For<IDisposable>();
 
         queue.Invoking(q => q.Handle((inner, 100L), 100))
@@ -218,4 +225,32 @@ public class MessageQueueTests
     }
 
     private static Request<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> CreateRequest() => new(new GetBlockHeadersMessage());
+
+    private static TestProtocolHandler CreateHandler<TMessage>(List<TMessage>? recordedSends = null)
+        where TMessage : P2PMessage
+    {
+        ISession session = Substitute.For<ISession>();
+        session.When(s => s.DeliverMessage(Arg.Any<TMessage>()))
+            .Do(c => recordedSends?.Add(c.Arg<TMessage>()));
+        return new TestProtocolHandler(session);
+    }
+
+    private sealed class TestProtocolHandler(ISession session)
+        : ProtocolHandlerBase(
+            session,
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IMessageSerializationService>(),
+            Substitute.For<IBackgroundTaskScheduler>(),
+            LimboLogs.Instance)
+    {
+        public override string Name => "test";
+        protected override TimeSpan InitTimeout => TimeSpan.Zero;
+        public override byte ProtocolVersion => 0;
+        public override string ProtocolCode => "test";
+        public override int MessageIdSpaceSize => 0;
+        public override void Init() { }
+        public override void HandleMessage(Packet message) { }
+        public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
+        public override void Dispose() { }
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Consensus.Scheduler;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Rlpx.Handshake;
@@ -21,6 +22,12 @@ namespace Nethermind.Network.Test.P2P.ProtocolHandlers;
 [Parallelizable(ParallelScope.Self)]
 public class ProtocolHandlerBaseTests
 {
+    private static readonly Func<TestRequestMessage, CancellationToken, Task<TestResponseMessage>> SyncServeTaskHandler =
+        static (_, _) => Task.FromResult(new TestResponseMessage());
+
+    private static readonly Func<TestRequestMessage, CancellationToken, ValueTask<TestResponseMessage>> SyncServeValueTaskHandler =
+        static (_, _) => ValueTask.FromResult(new TestResponseMessage());
+
     private class TestProtocolHandler(ISession session, TimeSpan initTimeout, IBackgroundTaskScheduler? backgroundTaskScheduler = null)
         : ProtocolHandlerBase(session, Substitute.For<INodeStatsManager>(), Substitute.For<IMessageSerializationService>(), backgroundTaskScheduler ?? Substitute.For<IBackgroundTaskScheduler>(), LimboLogs.Instance)
     {
@@ -35,6 +42,10 @@ public class ProtocolHandlerBaseTests
         public void SimulateLateInitMessage() => ReceivedProtocolInitMsg(new AckMessage());
         public void ScheduleBackgroundTask(Func<int, CancellationToken, ValueTask> backgroundTask) =>
             BackgroundTaskScheduler.TryScheduleBackgroundTask(1, backgroundTask, "test");
+        public void ScheduleSyncServeTask(TestRequestMessage request, Func<TestRequestMessage, CancellationToken, Task<TestResponseMessage>> syncServe) =>
+            BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
+        public void ScheduleSyncServeValueTask(TestRequestMessage request, Func<TestRequestMessage, CancellationToken, ValueTask<TestResponseMessage>> syncServe) =>
+            BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
         public override void Init() { }
         public override void Dispose() { }
         public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
@@ -50,6 +61,23 @@ public class ProtocolHandlerBaseTests
             ScheduledTask = fulfillFunc(request, cancellationToken);
             return true;
         }
+    }
+
+    private sealed class NoopBackgroundTaskScheduler : IBackgroundTaskScheduler
+    {
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null) => true;
+    }
+
+    private sealed class TestRequestMessage : P2PMessage
+    {
+        public override int PacketType => 1;
+        public override string Protocol => "test";
+    }
+
+    private sealed class TestResponseMessage : P2PMessage
+    {
+        public override int PacketType => 2;
+        public override string Protocol => "test";
     }
 
     [Test]
@@ -89,5 +117,37 @@ public class ProtocolHandlerBaseTests
         {
             session.Received().InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, Arg.Any<string>());
         }
+    }
+
+    [Test]
+    public void Sync_serve_task_scheduling_does_not_allocate_wrapper_delegate()
+    {
+        TestProtocolHandler handler = new(Substitute.For<ISession>(), TimeSpan.FromMilliseconds(50), new NoopBackgroundTaskScheduler());
+        TestRequestMessage request = new();
+
+        handler.ScheduleSyncServeTask(request, SyncServeTaskHandler);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+
+        handler.ScheduleSyncServeTask(request, SyncServeTaskHandler);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.That(allocated, Is.Zero);
+    }
+
+    [Test]
+    public void Sync_serve_value_task_scheduling_does_not_allocate_wrapper_delegate()
+    {
+        TestProtocolHandler handler = new(Substitute.For<ISession>(), TimeSpan.FromMilliseconds(50), new NoopBackgroundTaskScheduler());
+        TestRequestMessage request = new();
+
+        handler.ScheduleSyncServeValueTask(request, SyncServeValueTaskHandler);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+
+        handler.ScheduleSyncServeValueTask(request, SyncServeValueTaskHandler);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.That(allocated, Is.Zero);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -447,6 +447,32 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _transactionPool.Received(canGossipTransactions ? 3 : 0).SubmitTx(Arg.Any<Transaction>(), TxHandlingOptions.None);
         }
 
+        [Test]
+        public void Should_schedule_transactions_without_value_tuple_request()
+        {
+            RecordingBackgroundTaskScheduler taskScheduler = new();
+            _handler.Dispose();
+            _handler = new Eth62ProtocolHandler(
+                _session,
+                _svc,
+                new NodeStatsManager(Substitute.For<ITimerFactory>(), LimboLogs.Instance),
+                _syncManager,
+                taskScheduler,
+                _transactionPool,
+                _gossipPolicy,
+                LimboLogs.Instance,
+                _txGossipPolicy);
+            _handler.Init();
+
+            using TransactionsMessage msg = new(Build.A.Transaction.SignedAndResolved().TestObjectNTimes(3).ToPooledList());
+
+            HandleIncomingStatusMessage();
+            HandleZeroMessage(msg, Eth62MessageCode.Transactions);
+
+            Assert.That(taskScheduler.RequestTypes, Has.Count.EqualTo(1));
+            Assert.That(ContainsValueTuple(taskScheduler.RequestTypes[0]), Is.False);
+        }
+
         /// <summary>
         /// Calls <see cref="ZeroNettyP2PHandler.ExceptionCaught"/> with <see cref="RlpException"/> directly
         /// (without testing the whole pipeline) and verifies disconnect was triggered.
@@ -480,6 +506,38 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 ScheduledTasks++;
                 return true;
             }
+        }
+
+        private sealed class RecordingBackgroundTaskScheduler : IBackgroundTaskScheduler
+        {
+            public List<Type> RequestTypes { get; } = new();
+
+            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc,
+                TimeSpan? timeout = null, string? source = null)
+            {
+                RequestTypes.Add(typeof(TReq));
+                fulfillFunc(request, CancellationToken.None).GetAwaiter().GetResult();
+                return true;
+            }
+        }
+
+        private static bool ContainsValueTuple(Type type)
+        {
+            if (type.FullName?.StartsWith("System.ValueTuple", StringComparison.Ordinal) is true)
+            {
+                return true;
+            }
+
+            Type[] genericArguments = type.IsGenericType ? type.GetGenericArguments() : Type.EmptyTypes;
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                if (ContainsValueTuple(genericArguments[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -224,7 +224,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         }
 
         [Test]
-        public void Should_reuse_GetPooledTransactions_background_handler_delegate()
+        public void Should_schedule_GetPooledTransactions_without_request_handler_delegate()
         {
             _handler.Dispose();
             RecordingBackgroundTaskScheduler backgroundTaskScheduler = new();
@@ -240,6 +240,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
 
             Assert.That(backgroundTaskScheduler.ScheduledFulfillFuncs.Count, Is.EqualTo(2));
             Assert.That(backgroundTaskScheduler.ScheduledFulfillFuncs[1], Is.SameAs(backgroundTaskScheduler.ScheduledFulfillFuncs[0]));
+            Assert.That(backgroundTaskScheduler.ScheduledRequestsHaveDelegateFields, Is.EqualTo(new[] { false, false }));
         }
 
         [Test]
@@ -406,15 +407,17 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         private sealed class RecordingBackgroundTaskScheduler : IBackgroundTaskScheduler
         {
             public List<Delegate> ScheduledFulfillFuncs { get; } = new();
+            public List<bool> ScheduledRequestsHaveDelegateFields { get; } = new();
 
             public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
             {
-                ScheduledFulfillFuncs.Add(GetFulfillFunc(request));
+                ScheduledRequestsHaveDelegateFields.Add(HasDelegateField<TReq>());
+                ScheduledFulfillFuncs.Add(fulfillFunc);
                 fulfillFunc(request, CancellationToken.None).GetAwaiter().GetResult();
                 return true;
             }
 
-            private static Delegate GetFulfillFunc<TReq>(TReq request)
+            private static bool HasDelegateField<TReq>()
             {
                 FieldInfo[] fields = typeof(TReq).GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
                 for (int i = 0; i < fields.Length; i++)
@@ -422,11 +425,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
                     FieldInfo field = fields[i];
                     if (typeof(Delegate).IsAssignableFrom(field.FieldType))
                     {
-                        return (Delegate)field.GetValue(request)!;
+                        return true;
                     }
                 }
 
-                throw new InvalidOperationException($"No delegate field found in scheduled request {typeof(TReq)}.");
+                return false;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
+using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -37,6 +40,7 @@ using BlockBodiesMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.
 using BlockHeadersMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.BlockHeadersMessage;
 using GetBlockBodiesMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockBodiesMessage;
 using GetBlockHeadersMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage;
+using GetPooledTransactionsMessage66 = Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages.GetPooledTransactionsMessage;
 using GetNodeDataMessage = Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages.GetNodeDataMessage;
 using GetReceiptsMessage = Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages.GetReceiptsMessage;
 using NodeDataMessage = Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages.NodeDataMessage;
@@ -79,18 +83,21 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             _syncManager.Head.Returns(_genesisBlock.Header);
             _syncManager.Genesis.Returns(_genesisBlock.Header);
             _timerFactory = Substitute.For<ITimerFactory>();
-            _handler = new Eth66ProtocolHandler(
+            _handler = CreateHandler(RunImmediatelyScheduler.Instance);
+            _handler.Init();
+        }
+
+        private Eth66ProtocolHandler CreateHandler(IBackgroundTaskScheduler backgroundTaskScheduler) =>
+            new(
                 _session,
                 _svc,
                 new NodeStatsManager(_timerFactory, LimboLogs.Instance),
                 _syncManager,
-                RunImmediatelyScheduler.Instance,
+                backgroundTaskScheduler,
                 _transactionPool,
                 _gossipPolicy,
                 new ForkInfo(_specProvider, _syncManager),
                 LimboLogs.Instance);
-            _handler.Init();
-        }
 
         [TearDown]
         public void TearDown()
@@ -214,6 +221,25 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             HandleIncomingStatusMessage();
             HandleZeroMessage(msg66, Eth66MessageCode.GetPooledTransactions);
             _session.Received().DeliverMessage(Arg.Any<Network.P2P.Subprotocols.Eth.V66.Messages.PooledTransactionsMessage>());
+        }
+
+        [Test]
+        public void Should_reuse_GetPooledTransactions_background_handler_delegate()
+        {
+            _handler.Dispose();
+            RecordingBackgroundTaskScheduler backgroundTaskScheduler = new();
+            _handler = CreateHandler(backgroundTaskScheduler);
+            _handler.Init();
+
+            using GetPooledTransactionsMessage66 firstMessage = new(new[] { Keccak.Zero }.ToPooledList());
+            using GetPooledTransactionsMessage66 secondMessage = new(new[] { TestItem.KeccakA }.ToPooledList());
+
+            HandleIncomingStatusMessage();
+            HandleZeroMessage(firstMessage, Eth66MessageCode.GetPooledTransactions);
+            HandleZeroMessage(secondMessage, Eth66MessageCode.GetPooledTransactions);
+
+            Assert.That(backgroundTaskScheduler.ScheduledFulfillFuncs.Count, Is.EqualTo(2));
+            Assert.That(backgroundTaskScheduler.ScheduledFulfillFuncs[1], Is.SameAs(backgroundTaskScheduler.ScheduledFulfillFuncs[0]));
         }
 
         [Test]
@@ -375,6 +401,33 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             using DisposableByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg).AsDisposable();
             statusPacket.ReadByte();
             _handler.HandleMessage(new ZeroPacket(statusPacket) { PacketType = 0 });
+        }
+
+        private sealed class RecordingBackgroundTaskScheduler : IBackgroundTaskScheduler
+        {
+            public List<Delegate> ScheduledFulfillFuncs { get; } = new();
+
+            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+            {
+                ScheduledFulfillFuncs.Add(GetFulfillFunc(request));
+                fulfillFunc(request, CancellationToken.None).GetAwaiter().GetResult();
+                return true;
+            }
+
+            private static Delegate GetFulfillFunc<TReq>(TReq request)
+            {
+                FieldInfo[] fields = typeof(TReq).GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    FieldInfo field = fields[i];
+                    if (typeof(Delegate).IsAssignableFrom(field.FieldType))
+                    {
+                        return (Delegate)field.GetValue(request)!;
+                    }
+                }
+
+                throw new InvalidOperationException($"No delegate field found in scheduled request {typeof(TReq)}.");
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
@@ -204,6 +204,7 @@ public class PeerManagerFilteringIntegrationTests
         public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
         public int LocalPort => 30303;
         public event EventHandler<SessionEventArgs>? SessionCreated;
+        public event SessionDisconnectedEventHandler? SessionDisconnected { add { } remove { } }
         public ISessionMonitor SessionMonitor => Substitute.For<ISessionMonitor>();
     }
 
@@ -229,6 +230,7 @@ public class PeerManagerFilteringIntegrationTests
         public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
         public int LocalPort => 30303;
         public event EventHandler<SessionEventArgs>? SessionCreated { add { } remove { } }
+        public event SessionDisconnectedEventHandler? SessionDisconnected { add { } remove { } }
         public ISessionMonitor SessionMonitor => Substitute.For<ISessionMonitor>();
     }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -845,6 +845,7 @@ namespace Nethermind.Network.Test
 
                 Session session = new(30313, node, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance,
                     LimboLogs.Instance);
+                Track(session);
                 lock (_sessions)
                 {
                     _sessions.Add(session);
@@ -857,6 +858,7 @@ namespace Nethermind.Network.Test
             public void CreateRandomIncoming()
             {
                 Session session = new(30313, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
+                Track(session);
                 lock (_sessions)
                 {
                     _sessions.Add(session);
@@ -875,6 +877,7 @@ namespace Nethermind.Network.Test
             public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
             public int LocalPort => 0;
             public event EventHandler<SessionEventArgs> SessionCreated;
+            public event SessionDisconnectedEventHandler SessionDisconnected;
 
             public void CreateIncoming(params Session[] sessions)
             {
@@ -884,6 +887,7 @@ namespace Nethermind.Network.Test
                     Session sessionIn = new(30313, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
                     sessionIn.RemoteHost = session.RemoteHost;
                     sessionIn.RemotePort = session.RemotePort;
+                    Track(sessionIn);
                     SessionCreated?.Invoke(this, new SessionEventArgs(sessionIn));
                     sessionIn.Handshake(session.RemoteNodeId);
                     incomingSessions.Add(sessionIn);
@@ -900,6 +904,15 @@ namespace Nethermind.Network.Test
             public void MakeItFail() => _isFailing = true;
 
             public bool ShouldContact(IPAddress ip, bool exactOnly = false) => true;
+
+            private void Track(Session session) => session.Disconnected += OnSessionDisconnected;
+
+            private void OnSessionDisconnected(object? sender, DisconnectEventArgs args)
+            {
+                ISession session = (ISession)sender!;
+                session.Disconnected -= OnSessionDisconnected;
+                SessionDisconnected?.Invoke(this, session, args);
+            }
         }
 
         private class InMemoryStorage : INetworkStorage

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -53,7 +53,7 @@ public class ProtocolsManagerTests
     public static Context When => new();
 
     [Test]
-    public void Reuses_session_event_handlers_when_unsubscribing_on_disconnect()
+    public void Uses_host_disconnected_event_when_unsubscribing_on_disconnect()
     {
         IRlpxHost rlpxHost = Substitute.For<IRlpxHost>();
         TrackingSession session = new();
@@ -71,14 +71,16 @@ public class ProtocolsManagerTests
         rlpxHost.SessionCreated += Raise.EventWith(new object(), new SessionEventArgs(session));
 
         EventHandler<EventArgs>? initializedHandler = session.AddedInitializedHandler;
-        EventHandler<DisconnectEventArgs>? disconnectedHandler = session.AddedDisconnectedHandler;
 
-        session.RaiseDisconnected();
+        rlpxHost.SessionDisconnected += Raise.Event<SessionDisconnectedEventHandler>(
+            new object(),
+            session,
+            new DisconnectEventArgs(DisconnectReason.Other, DisconnectType.Remote, "test"));
 
         Assert.That(initializedHandler, Is.Not.Null);
-        Assert.That(disconnectedHandler, Is.Not.Null);
+        Assert.That(session.AddedDisconnectedHandler, Is.Null);
         Assert.That(session.RemovedInitializedHandler, Is.SameAs(initializedHandler));
-        Assert.That(session.RemovedDisconnectedHandler, Is.SameAs(disconnectedHandler));
+        Assert.That(session.RemovedDisconnectedHandler, Is.Null);
     }
 
     public class Context
@@ -272,6 +274,10 @@ public class ProtocolsManagerTests
         public Context Disconnect()
         {
             _currentSession.MarkDisconnected(DisconnectReason.TooManyPeers, DisconnectType.Local, "test");
+            _rlpxHost.SessionDisconnected += Raise.Event<SessionDisconnectedEventHandler>(
+                new object(),
+                _currentSession,
+                new DisconnectEventArgs(DisconnectReason.TooManyPeers, DisconnectType.Local, "test"));
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Numerics;
 using DotNetty.Transport.Channels;
 using Nethermind.Blockchain;
@@ -18,6 +19,7 @@ using Nethermind.Network.Config;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Analyzers;
+using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62;
@@ -49,6 +51,35 @@ public class ProtocolsManagerTests
     }
 
     public static Context When => new();
+
+    [Test]
+    public void Reuses_session_event_handlers_when_unsubscribing_on_disconnect()
+    {
+        IRlpxHost rlpxHost = Substitute.For<IRlpxHost>();
+        TrackingSession session = new();
+        _ = new ProtocolsManager(
+            Substitute.For<ISyncPeerPool>(),
+            Substitute.For<ITxPool>(),
+            Substitute.For<IDiscoveryApp>(),
+            rlpxHost,
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IProtocolValidator>(),
+            Substitute.For<INetworkStorage>(),
+            [],
+            LimboLogs.Instance);
+
+        rlpxHost.SessionCreated += Raise.EventWith(new object(), new SessionEventArgs(session));
+
+        EventHandler<EventArgs>? initializedHandler = session.AddedInitializedHandler;
+        EventHandler<DisconnectEventArgs>? disconnectedHandler = session.AddedDisconnectedHandler;
+
+        session.RaiseDisconnected();
+
+        Assert.That(initializedHandler, Is.Not.Null);
+        Assert.That(disconnectedHandler, Is.Not.Null);
+        Assert.That(session.RemovedInitializedHandler, Is.SameAs(initializedHandler));
+        Assert.That(session.RemovedDisconnectedHandler, Is.SameAs(disconnectedHandler));
+    }
 
     public class Context
     {
@@ -486,4 +517,63 @@ public class ProtocolsManagerTests
             .Handshake()
             .Init()
             .VerifyProtocolVersion(Protocol.Eth, 68);
+
+    private sealed class TrackingSession : ISession
+    {
+        public EventHandler<EventArgs>? AddedInitializedHandler { get; private set; }
+        public EventHandler<EventArgs>? RemovedInitializedHandler { get; private set; }
+        public EventHandler<DisconnectEventArgs>? AddedDisconnectedHandler { get; private set; }
+        public EventHandler<DisconnectEventArgs>? RemovedDisconnectedHandler { get; private set; }
+
+        public byte P2PVersion => 5;
+        public SessionState State => SessionState.Disconnected;
+        public SessionState BestStateReached => SessionState.Disconnected;
+        public bool IsClosing => true;
+        public PublicKey RemoteNodeId => null!;
+        public PublicKey ObsoleteRemoteNodeId => null!;
+        public string RemoteHost { get; set; } = string.Empty;
+        public int RemotePort { get; set; }
+        public int LocalPort => 0;
+        public bool IsNetworkIdMatched { get; set; }
+        public ConnectionDirection Direction => ConnectionDirection.In;
+        public Guid SessionId { get; } = Guid.NewGuid();
+        public Node Node => null!;
+        public DateTime LastPingUtc { get; set; }
+        public DateTime LastPongUtc { get; set; }
+        public IPingSender PingSender { get; set; } = null!;
+
+        public event EventHandler<DisconnectEventArgs> Disconnecting { add { } remove { } }
+        public event EventHandler<DisconnectEventArgs> Disconnected
+        {
+            add => AddedDisconnectedHandler = value;
+            remove => RemovedDisconnectedHandler = value;
+        }
+        public event EventHandler<EventArgs> Initialized
+        {
+            add => AddedInitializedHandler = value;
+            remove => RemovedInitializedHandler = value;
+        }
+        public event EventHandler<EventArgs> HandshakeComplete { add { } remove { } }
+        public event EventHandler<PeerEventArgs> MsgReceived { add { } remove { } }
+        public event EventHandler<PeerEventArgs> MsgDelivered { add { } remove { } }
+
+        public void RaiseDisconnected() => AddedDisconnectedHandler?.Invoke(
+            this,
+            new DisconnectEventArgs(DisconnectReason.Other, DisconnectType.Local, "test"));
+
+        public void Dispose() { }
+        public void ReceiveMessage(ZeroPacket zeroPacket) => throw new NotSupportedException();
+        public int DeliverMessage<T>(T message) where T : P2PMessage => throw new NotSupportedException();
+        public void EnableSnappy() => throw new NotSupportedException();
+        public void AddSupportedCapability(Capability capability) => throw new NotSupportedException();
+        public bool HasAvailableCapability(Capability capability) => throw new NotSupportedException();
+        public bool HasAgreedCapability(Capability capability) => throw new NotSupportedException();
+        public void AddProtocolHandler(IProtocolHandler handler) => throw new NotSupportedException();
+        public bool TryGetProtocolHandler(string protocolCode, out IProtocolHandler handler) => throw new NotSupportedException();
+        public void Init(byte p2PVersion, IChannelHandlerContext context, IPacketSender packetSender) => throw new NotSupportedException();
+        public void InitiateDisconnect(DisconnectReason disconnectReason, string details) => throw new NotSupportedException();
+        public void MarkDisconnected(DisconnectReason disconnectReason, DisconnectType disconnectType, string details) => throw new NotSupportedException();
+        public void Handshake(PublicKey handshakeRemoteNodeId) => throw new NotSupportedException();
+        public void StartTrackingSession() => throw new NotSupportedException();
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Test/RecordingProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Test/RecordingProtocolHandler.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Network.Rlpx;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+using NSubstitute;
+
+namespace Nethermind.Network.Test;
+
+internal sealed class RecordingProtocolHandler(ISession session)
+    : ProtocolHandlerBase(
+        session,
+        Substitute.For<INodeStatsManager>(),
+        Substitute.For<IMessageSerializationService>(),
+        Substitute.For<IBackgroundTaskScheduler>(),
+        LimboLogs.Instance)
+{
+    public static RecordingProtocolHandler Create<TMessage>(List<TMessage>? recordedSends = null)
+        where TMessage : P2PMessage
+    {
+        ISession session = Substitute.For<ISession>();
+        session.When(s => s.DeliverMessage(Arg.Any<TMessage>()))
+            .Do(c => recordedSends?.Add(c.Arg<TMessage>()));
+        return new RecordingProtocolHandler(session);
+    }
+
+    public override string Name => "test";
+    protected override TimeSpan InitTimeout => TimeSpan.Zero;
+    public override byte ProtocolVersion => 0;
+    public override string ProtocolCode => "test";
+    public override int MessageIdSpaceSize => 0;
+    public override void Init() { }
+    public override void HandleMessage(Packet message) { }
+    public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
+    public override void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -36,12 +36,14 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Will_unregister_on_disconnect()
+        public void Can_remove_session()
         {
             ISession session = CreateSession();
             SessionMonitor sessionMonitor = new(new NetworkConfig(), LimboLogs.Instance);
             sessionMonitor.AddSession(session);
-            session.MarkDisconnected(DisconnectReason.Other, DisconnectType.Remote, "test");
+            sessionMonitor.RemoveSession(session);
+
+            sessionMonitor.Sessions.Should().BeEmpty();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -11,7 +11,6 @@ using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Analyzers;
-using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
@@ -14,6 +14,14 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 
 namespace Nethermind.Network;
 
+/// <summary>
+/// Creates protocol handlers with a cached constructor activator.
+/// </summary>
+/// <remarks>
+/// Non-<see cref="ISession"/> constructor dependencies of <typeparamref name="THandler"/>
+/// are resolved once and reused across all sessions; protocol handlers registered through this
+/// factory must only depend on singleton-safe services outside the session parameter.
+/// </remarks>
 internal sealed class AutofacProtocolHandlerFactory<THandler>(
     ILifetimeScope lifetimeScope,
     string protocolCode,
@@ -42,11 +50,6 @@ internal sealed class AutofacProtocolHandlerFactory<THandler>(
         return true;
     }
 
-    /// <remarks>
-    /// Non-<see cref="ISession"/> constructor dependencies of <typeparamref name="THandler"/>
-    /// are resolved once and reused across all sessions; per-dependency or per-scope lifetimes
-    /// are silently promoted to singleton semantics.
-    /// </remarks>
     private object?[] GetDependencies()
     {
         object?[]? dependencies = Volatile.Read(ref _dependencies);

--- a/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using Autofac;
+using Autofac.Core;
+using Autofac.Features.AttributeFilters;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.ProtocolHandlers;
+
+namespace Nethermind.Network;
+
+internal sealed class AutofacProtocolHandlerFactory<THandler>(
+    ILifetimeScope lifetimeScope,
+    string protocolCode,
+    int? expectedVersion = null) : IProtocolHandlerFactory
+    where THandler : IProtocolHandler
+{
+    private static readonly ConstructorInfo Constructor = SelectConstructor();
+    private static readonly ParameterInfo[] ConstructorParameters = Constructor.GetParameters();
+    private static readonly Func<ISession, object?[], THandler> Activator = CompileActivator();
+    private static readonly int DependencyCount = CountDependencies();
+
+    private readonly Lock _lock = new();
+    private object?[]? _dependencies;
+
+    public string ProtocolCode => protocolCode;
+
+    public bool TryCreate(ISession session, int version, [NotNullWhen(true)] out IProtocolHandler? handler)
+    {
+        if (expectedVersion is not null && version != expectedVersion)
+        {
+            handler = null;
+            return false;
+        }
+
+        handler = Activator(session, GetDependencies());
+        return true;
+    }
+
+    private object?[] GetDependencies()
+    {
+        object?[]? dependencies = Volatile.Read(ref _dependencies);
+        if (dependencies is not null)
+        {
+            return dependencies;
+        }
+
+        lock (_lock)
+        {
+            dependencies = _dependencies;
+            if (dependencies is null)
+            {
+                dependencies = ResolveDependencies(lifetimeScope);
+                Volatile.Write(ref _dependencies, dependencies);
+            }
+
+            return dependencies;
+        }
+    }
+
+    private static object?[] ResolveDependencies(IComponentContext context)
+    {
+        object?[] dependencies = new object?[DependencyCount];
+        int dependencyIndex = 0;
+        for (int i = 0; i < ConstructorParameters.Length; i++)
+        {
+            ParameterInfo parameter = ConstructorParameters[i];
+            if (parameter.ParameterType == typeof(ISession))
+            {
+                continue;
+            }
+
+            dependencies[dependencyIndex++] = ResolveDependency(context, parameter);
+        }
+
+        return dependencies;
+    }
+
+    private static object? ResolveDependency(IComponentContext context, ParameterInfo parameter)
+    {
+        Type parameterType = parameter.ParameterType;
+        if (parameter.GetCustomAttribute<KeyFilterAttribute>() is { } keyFilter)
+        {
+            KeyedService keyedService = new(keyFilter.Key, parameterType);
+            if (context.ComponentRegistry.IsRegistered(keyedService))
+            {
+                return context.ResolveKeyed(keyFilter.Key, parameterType);
+            }
+        }
+        else if (context.ComponentRegistry.IsRegistered(new TypedService(parameterType)))
+        {
+            return context.Resolve(parameterType);
+        }
+
+        if (parameter.HasDefaultValue)
+        {
+            return parameter.DefaultValue;
+        }
+
+        return context.Resolve(parameterType);
+    }
+
+    private static Func<ISession, object?[], THandler> CompileActivator()
+    {
+        ParameterExpression sessionParameter = Expression.Parameter(typeof(ISession), "session");
+        ParameterExpression dependenciesParameter = Expression.Parameter(typeof(object[]), "dependencies");
+
+        Expression[] arguments = new Expression[ConstructorParameters.Length];
+        int dependencyIndex = 0;
+        for (int i = 0; i < ConstructorParameters.Length; i++)
+        {
+            Type parameterType = ConstructorParameters[i].ParameterType;
+            arguments[i] = parameterType == typeof(ISession)
+                ? sessionParameter
+                : Expression.Convert(
+                    Expression.ArrayIndex(dependenciesParameter, Expression.Constant(dependencyIndex++)),
+                    parameterType);
+        }
+
+        NewExpression constructorCall = Expression.New(Constructor, arguments);
+        return Expression.Lambda<Func<ISession, object?[], THandler>>(
+                constructorCall,
+                sessionParameter,
+                dependenciesParameter)
+            .Compile();
+    }
+
+    private static ConstructorInfo SelectConstructor()
+    {
+        ConstructorInfo? selected = null;
+        int selectedParameterCount = -1;
+        foreach (ConstructorInfo constructor in typeof(THandler).GetConstructors(
+                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (constructor.IsPrivate || CountSessionParameters(constructor) != 1)
+            {
+                continue;
+            }
+
+            int parameterCount = constructor.GetParameters().Length;
+            if (parameterCount > selectedParameterCount)
+            {
+                selected = constructor;
+                selectedParameterCount = parameterCount;
+            }
+        }
+
+        return selected ?? throw new InvalidOperationException(
+            $"{typeof(THandler).Name} must have a constructor with exactly one {nameof(ISession)} parameter.");
+    }
+
+    private static int CountSessionParameters(ConstructorInfo constructor)
+    {
+        int count = 0;
+        ParameterInfo[] parameters = constructor.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i].ParameterType == typeof(ISession))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountDependencies()
+    {
+        int count = 0;
+        for (int i = 0; i < ConstructorParameters.Length; i++)
+        {
+            if (ConstructorParameters[i].ParameterType != typeof(ISession))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
@@ -42,6 +42,11 @@ internal sealed class AutofacProtocolHandlerFactory<THandler>(
         return true;
     }
 
+    /// <remarks>
+    /// Non-<see cref="ISession"/> constructor dependencies of <typeparamref name="THandler"/>
+    /// are resolved once and reused across all sessions; per-dependency or per-scope lifetimes
+    /// are silently promoted to singleton semantics.
+    /// </remarks>
     private object?[] GetDependencies()
     {
         object?[]? dependencies = Volatile.Read(ref _dependencies);

--- a/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/AutofacProtocolHandlerFactory.cs
@@ -91,6 +91,10 @@ internal sealed class AutofacProtocolHandlerFactory<THandler>(
             {
                 return context.ResolveKeyed(keyFilter.Key, parameterType);
             }
+
+            throw new InvalidOperationException(
+                $"Missing keyed registration for {parameterType.Name} with key '{keyFilter.Key}' " +
+                $"required by {typeof(THandler).Name}.{Constructor.Name} parameter '{parameter.Name}'.");
         }
         else if (context.ComponentRegistry.IsRegistered(new TypedService(parameterType)))
         {

--- a/src/Nethermind/Nethermind.Network/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Network/ContainerBuilderExtensions.cs
@@ -19,13 +19,13 @@ public static class ContainerBuilderExtensions
     /// <summary>
     /// Registers a protocol handler type and its corresponding <see cref="IProtocolHandlerFactory"/>.
     /// Handler lifetime is owned by <see cref="ISession"/>: the session disposes its handlers
-    /// on disconnect, so the DI container must not track them.
+    /// on disconnect, so the DI container must not track them. The factory uses a cached
+    /// constructor activator to avoid Autofac reflection binding on every session.
     /// </summary>
     public static ContainerBuilder AddProtocolHandler<THandler>(
         this ContainerBuilder builder) where THandler : class, IProtocolHandler, IStaticProtocolInfo => builder
-            .Add<THandler>(externallyOwned: true)
             .AddLast<IProtocolHandlerFactory>(ctx =>
-                new ReusableProtocolHandlerFactory<THandler>(ctx.Resolve<Func<ISession, THandler>>(), THandler.Code, THandler.Version));
+                new AutofacProtocolHandlerFactory<THandler>(ctx.Resolve<ILifetimeScope>(), THandler.Code, THandler.Version));
 
     /// <summary>
     /// Registers a protocol handler that accepts any version (version validation happens
@@ -34,7 +34,6 @@ public static class ContainerBuilderExtensions
     /// </summary>
     public static ContainerBuilder AddProtocolHandler<THandler>(
         this ContainerBuilder builder, string protocolCode) where THandler : class, IProtocolHandler => builder
-            .Add<THandler>(externallyOwned: true)
             .AddLast<IProtocolHandlerFactory>(ctx =>
-                new ReusableProtocolHandlerFactory<THandler>(ctx.Resolve<Func<ISession, THandler>>(), protocolCode));
+                new AutofacProtocolHandlerFactory<THandler>(ctx.Resolve<ILifetimeScope>(), protocolCode));
 }

--- a/src/Nethermind/Nethermind.Network/ContainerBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Network/ContainerBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Container;

--- a/src/Nethermind/Nethermind.Network/ISessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/ISessionMonitor.cs
@@ -11,6 +11,12 @@ namespace Nethermind.Network
         void Start();
         void Stop();
         void AddSession(ISession session);
+
+        /// <summary>
+        /// Removes a session from ping monitoring.
+        /// </summary>
+        /// <param name="session">The session to remove.</param>
+        void RemoveSession(ISession session);
         public IEnumerable<ISession> Sessions { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
@@ -10,13 +10,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 using TaskExtensions = Nethermind.Core.Extensions.TaskExtensions;
 
 namespace Nethermind.Network.P2P;
 
-public class MessageDictionary<T66Msg, TData>(Action<T66Msg> send, TimeSpan? oldRequestThreshold = null, CancellationToken cancellationToken = default) where T66Msg : IEth66Message
+public class MessageDictionary<T66Msg, TData>(ProtocolHandlerBase handler, TimeSpan? oldRequestThreshold = null, CancellationToken cancellationToken = default)
+    where T66Msg : P2PMessage, IEth66Message
 {
     // The limit is largely to prevent unexpected OOM.
     // But the side effect is that if the peer did not respond with the message, eventually it will throw
@@ -50,7 +53,7 @@ public class MessageDictionary<T66Msg, TData>(Action<T66Msg> send, TimeSpan? old
         {
             Interlocked.Increment(ref _requestCount);
             request.StartMeasuringTime();
-            send(request.Message);
+            handler.Send(request.Message);
 
             if (_cleanOldRequestTask.IsCompleted)
             {

--- a/src/Nethermind/Nethermind.Network/P2P/MessageQueue.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/MessageQueue.cs
@@ -1,16 +1,17 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Core.Extensions;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols;
 
 namespace Nethermind.Network.P2P
 {
-    public class MessageQueue<TMsg, TData>(Action<TMsg> send)
-        where TMsg : MessageBase
+    public class MessageQueue<TMsg, TData>(ProtocolHandlerBase handler)
+        where TMsg : P2PMessage
     {
         private bool _isClosed;
         private Request<TMsg, TData>? _currentRequest;
@@ -33,7 +34,7 @@ namespace Nethermind.Network.P2P
                 {
                     _currentRequest = request;
                     _currentRequest.StartMeasuringTime();
-                    send(_currentRequest.Message);
+                    handler.Send(_currentRequest.Message);
                 }
                 else
                 {
@@ -60,7 +61,7 @@ namespace Nethermind.Network.P2P
                 if (_requestQueue.TryDequeue(out _currentRequest))
                 {
                     _currentRequest!.StartMeasuringTime();
-                    send(_currentRequest.Message);
+                    handler.Send(_currentRequest.Message);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Network.P2P.Messages
             stream.Encode(msg.P2PVersion);
             stream.Encode(msg.ClientId);
             stream.StartSequence(innerLength);
-            foreach (Capability? capability in msg.Capabilities)
+            foreach (Capability? capability in msg.Capabilities.AsSpan())
             {
                 string protocolCode = capability.ProtocolCode.ToLowerInvariant();
                 int capabilityLength = Rlp.LengthOf(protocolCode);
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P.Messages
             contentLength += Rlp.LengthOf(msg.P2PVersion);
             contentLength += Rlp.LengthOf(msg.ClientId);
             int innerContentLength = 0;
-            foreach (Capability? capability in msg.Capabilities)
+            foreach (Capability? capability in msg.Capabilities.AsSpan())
             {
                 int capabilityLength = Rlp.LengthOf(capability.ProtocolCode.ToLowerInvariant());
                 capabilityLength += Rlp.LengthOf(capability.Version);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/IProtocolRegistrar.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/IProtocolRegistrar.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Network.P2P.EventArg;
 
 namespace Nethermind.Network.P2P.ProtocolHandlers;
 
@@ -25,4 +26,8 @@ public interface IProtocolRegistrar
     /// Registers a sync peer protocol (e.g., ETH) — wires into sync pool, tx pool, and peer storage.
     /// </summary>
     void Register(ISession session, SyncPeerProtocolHandlerBase handler);
+
+    void OnProtocolInitialized(ISession session, ProtocolHandlerBase handler, ProtocolInitializedEventArgs args);
+
+    void OnSubprotocolRequested(ISession session, ProtocolHandlerBase handler, string protocolCode, int version);
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -255,9 +255,11 @@ public class P2PProtocolHandler(
         _protocolVersion = hello.P2PVersion;
 
         IOwnedReadOnlyList<Capability>? capabilities = hello.Capabilities;
-        _availableCapabilities = new List<Capability>(capabilities);
-        foreach (Capability theirCapability in capabilities)
+        ReadOnlySpan<Capability> capabilitiesSpan = capabilities.AsSpan();
+        _availableCapabilities = new List<Capability>(capabilitiesSpan.Length);
+        foreach (Capability theirCapability in capabilitiesSpan)
         {
+            _availableCapabilities.Add(theirCapability);
             if (_supportedCapabilities.Contains(theirCapability))
             {
                 if (Logger.IsTrace) TraceAgreedCapability(theirCapability);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,9 +112,10 @@ public class P2PProtocolHandler(
                     // which should be constant for the whole session. Some protocols (like Eth) are sending messages
                     // on initialization and we need to avoid changing theirs AdaptiveId by initializing protocols,
                     // which are alphabetically before already initialized ones.
-                    foreach (Capability capability in
-                        _agreedCapabilities.GroupBy(static c => c.ProtocolCode).Select(static c => c.OrderBy(static v => v.Version).Last()).OrderBy(static c => c.ProtocolCode))
+                    string? previousProtocolCode = null;
+                    while (TryGetNextAgreedCapability(previousProtocolCode, out Capability? capability))
                     {
+                        previousProtocolCode = capability.ProtocolCode;
                         if (Logger.IsTrace) TraceStartingProtocolHandler(capability);
                         NotifySubprotocolRequested(capability.ProtocolCode, capability.Version);
                     }
@@ -224,6 +225,34 @@ public class P2PProtocolHandler(
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceUnhandledPacket(int packetType)
             => Logger.Trace($"{Session.RemoteNodeId} Unhandled packet type: {packetType}");
+    }
+
+    private bool TryGetNextAgreedCapability(string? previousProtocolCode, [NotNullWhen(true)] out Capability? nextCapability)
+    {
+        nextCapability = null;
+        for (int i = 0; i < _agreedCapabilities.Count; i++)
+        {
+            Capability candidate = _agreedCapabilities[i];
+            string candidateProtocolCode = candidate.ProtocolCode;
+            if (previousProtocolCode is not null && string.CompareOrdinal(candidateProtocolCode, previousProtocolCode) <= 0)
+            {
+                continue;
+            }
+
+            if (nextCapability is null)
+            {
+                nextCapability = candidate;
+                continue;
+            }
+
+            int protocolComparison = string.CompareOrdinal(candidateProtocolCode, nextCapability.ProtocolCode);
+            if (protocolComparison < 0 || (protocolComparison == 0 && candidate.Version > nextCapability.Version))
+            {
+                nextCapability = candidate;
+            }
+        }
+
+        return nextCapability is not null;
     }
 
     private void HandleHello(HelloMessage hello)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -63,10 +63,6 @@ public class P2PProtocolHandler(
     public PublicKey LocalNodeId { get; } = localNodeId;
     private string RemoteClientId { get; set; }
 
-    public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
-
-    public override event EventHandler<ProtocolEventArgs>? SubprotocolRequested;
-
     public bool HasAvailableCapability(Capability capability) => _availableCapabilities.Contains(capability);
     public bool HasAgreedCapability(Capability capability) => _agreedCapabilities.Contains(capability);
     public void AddSupportedCapability(Capability capability)
@@ -79,7 +75,11 @@ public class P2PProtocolHandler(
         _supportedCapabilities.Add(capability);
     }
 
-    public override void RegisterWith(ISession session, IProtocolRegistrar registrar) => registrar.Register(session, this);
+    public override void RegisterWith(ISession session, IProtocolRegistrar registrar)
+    {
+        SetProtocolRegistrar(registrar);
+        registrar.Register(session, this);
+    }
 
     public override void Init()
     {
@@ -116,7 +116,7 @@ public class P2PProtocolHandler(
                         _agreedCapabilities.GroupBy(static c => c.ProtocolCode).Select(static c => c.OrderBy(static v => v.Version).Last()).OrderBy(static c => c.ProtocolCode))
                     {
                         if (Logger.IsTrace) TraceStartingProtocolHandler(capability);
-                        SubprotocolRequested?.Invoke(this, new ProtocolEventArgs(capability.ProtocolCode, capability.Version));
+                        NotifySubprotocolRequested(capability.ProtocolCode, capability.Version);
                     }
 
                     break;
@@ -175,7 +175,7 @@ public class P2PProtocolHandler(
 
                     _agreedCapabilities.Add(capability);
                     if (Logger.IsTrace) TraceStartingHandler(capability);
-                    SubprotocolRequested?.Invoke(this, new ProtocolEventArgs(capability.ProtocolCode, capability.Version));
+                    NotifySubprotocolRequested(capability.ProtocolCode, capability.Version);
                     break;
                 }
             default:
@@ -287,7 +287,7 @@ public class P2PProtocolHandler(
             ListenPort = hello.ListenPort
         };
 
-        ProtocolInitialized?.Invoke(this, eventArgs);
+        NotifyProtocolInitialized(eventArgs);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceReceivedHello()
@@ -459,12 +459,7 @@ public class P2PProtocolHandler(
             => Logger.Trace($"{Session} sending P2P pong");
     }
 
-    public override void Dispose()
-    {
-        // Clear Events if set
-        ProtocolInitialized = null;
-        SubprotocolRequested = null;
-    }
+    public override void Dispose() => ClearProtocolEvents();
 
     public IReadOnlyList<Capability> GetCapabilities() =>
         _agreedCapabilities.Count > 0 ? _agreedCapabilities : _supportedCapabilities;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -187,13 +187,12 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, Task<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>
             BackgroundTaskScheduler.TryScheduleSyncServe(DeserializeAndReport<TReq>(message), handle);
 
-        protected void HandleInBackground<THandler, TReq, TRes>(
-            ZeroPacket message,
-            Func<THandler, TReq, CancellationToken, Task<TRes>> handle)
+        protected void HandleInBackground<THandler, TReq, TRes, TRequestHandler>(ZeroPacket message)
             where THandler : ProtocolHandlerBase
             where TReq : P2PMessage
-            where TRes : P2PMessage =>
-            BackgroundTaskScheduler.TryScheduleSyncServe((THandler)this, DeserializeAndReport<TReq>(message), handle);
+            where TRes : P2PMessage
+            where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes> =>
+            BackgroundTaskScheduler.TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>((THandler)this, DeserializeAndReport<TReq>(message));
 
         /// <inheritdoc cref="HandleInBackground{TReq, TRes}(ZeroPacket, Func{TReq, CancellationToken, Task{TRes}})"/>
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, ValueTask<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -187,12 +187,13 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, Task<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>
             BackgroundTaskScheduler.TryScheduleSyncServe(DeserializeAndReport<TReq>(message), handle);
 
-        protected void HandleInBackground<THandler, TReq, TRes, TRequestHandler>(ZeroPacket message)
+        protected void HandleInBackground<THandler, TReq, TRes>(
+            ZeroPacket message,
+            Func<THandler, TReq, CancellationToken, Task<TRes>> handle)
             where THandler : ProtocolHandlerBase
             where TReq : P2PMessage
-            where TRes : P2PMessage
-            where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes> =>
-            BackgroundTaskScheduler.TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>((THandler)this, DeserializeAndReport<TReq>(message));
+            where TRes : P2PMessage =>
+            BackgroundTaskScheduler.TryScheduleSyncServe((THandler)this, DeserializeAndReport<TReq>(message), handle);
 
         /// <inheritdoc cref="HandleInBackground{TReq, TRes}(ZeroPacket, Func{TReq, CancellationToken, Task{TRes}})"/>
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, ValueTask<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -187,7 +187,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, Task<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>
             BackgroundTaskScheduler.TryScheduleSyncServe(DeserializeAndReport<TReq>(message), handle);
 
-        private protected void HandleInBackground<THandler, TReq, TRes, TRequestHandler>(ZeroPacket message)
+        protected void HandleInBackground<THandler, TReq, TRes, TRequestHandler>(ZeroPacket message)
             where THandler : ProtocolHandlerBase
             where TReq : P2PMessage
             where TRes : P2PMessage

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -187,6 +187,13 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, Task<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>
             BackgroundTaskScheduler.TryScheduleSyncServe(DeserializeAndReport<TReq>(message), handle);
 
+        private protected void HandleInBackground<THandler, TReq, TRes, TRequestHandler>(ZeroPacket message)
+            where THandler : ProtocolHandlerBase
+            where TReq : P2PMessage
+            where TRes : P2PMessage
+            where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes> =>
+            BackgroundTaskScheduler.TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>((THandler)this, DeserializeAndReport<TReq>(message));
+
         /// <inheritdoc cref="HandleInBackground{TReq, TRes}(ZeroPacket, Func{TReq, CancellationToken, Task{TRes}})"/>
         protected void HandleInBackground<TReq, TRes>(ZeroPacket message, Func<TReq, CancellationToken, ValueTask<TRes>> handle) where TReq : P2PMessage where TRes : P2PMessage =>
             BackgroundTaskScheduler.TryScheduleSyncServe(DeserializeAndReport<TReq>(message), handle);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -27,6 +27,9 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         private readonly IMessageSerializationService _serializer;
         protected internal ISession Session { get; }
         protected long Counter;
+        private IProtocolRegistrar? _protocolRegistrar;
+        private EventHandler<ProtocolInitializedEventArgs>? _protocolInitialized;
+        private EventHandler<ProtocolEventArgs>? _subprotocolRequested;
 
         private readonly TaskCompletionSource<MessageBase> _initCompletionSource = new();
 
@@ -199,7 +202,32 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             return messageObject;
         }
 
-        public virtual void RegisterWith(ISession session, IProtocolRegistrar registrar) => registrar.Register(session, this);
+        public virtual void RegisterWith(ISession session, IProtocolRegistrar registrar)
+        {
+            SetProtocolRegistrar(registrar);
+            registrar.Register(session, this);
+        }
+
+        protected void SetProtocolRegistrar(IProtocolRegistrar registrar) =>
+            _protocolRegistrar = registrar ?? throw new ArgumentNullException(nameof(registrar));
+
+        protected void NotifyProtocolInitialized(ProtocolInitializedEventArgs args)
+        {
+            _protocolInitialized?.Invoke(this, args);
+            _protocolRegistrar?.OnProtocolInitialized(Session, this, args);
+        }
+
+        protected void NotifySubprotocolRequested(string protocolCode, int version)
+        {
+            _subprotocolRequested?.Invoke(this, new ProtocolEventArgs(protocolCode, version));
+            _protocolRegistrar?.OnSubprotocolRequested(Session, this, protocolCode, version);
+        }
+
+        protected void ClearProtocolEvents()
+        {
+            _protocolInitialized = null;
+            _subprotocolRequested = null;
+        }
 
         public abstract void Dispose();
 
@@ -215,9 +243,17 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         public abstract void DisconnectProtocol(DisconnectReason disconnectReason, string details);
 
-        public abstract event EventHandler<ProtocolInitializedEventArgs> ProtocolInitialized;
+        public virtual event EventHandler<ProtocolInitializedEventArgs> ProtocolInitialized
+        {
+            add => _protocolInitialized += value;
+            remove => _protocolInitialized -= value;
+        }
 
-        public abstract event EventHandler<ProtocolEventArgs> SubprotocolRequested;
+        public virtual event EventHandler<ProtocolEventArgs> SubprotocolRequested
+        {
+            add => _subprotocolRequested += value;
+            remove => _subprotocolRequested -= value;
+        }
     }
 
     public class IncompleteDeserializationException(string msg) : Exception(msg);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -66,8 +66,8 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             SyncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));
             _timestamper = Timestamper.Default;
-            _headersRequests = new MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
-            _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
+            _headersRequests = new MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(this);
+            _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(this);
         }
 
         public override void RegisterWith(ISession session, IProtocolRegistrar registrar)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -153,7 +153,8 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             msg.Skip = 0;
 
             using IOwnedReadOnlyList<BlockHeader> headers = await SendRequest(msg, token);
-            return headers.Count > 0 ? headers[0] : null;
+            ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
+            return headersSpan.Length > 0 ? headersSpan[0] : null;
         }
 
         async Task<IOwnedReadOnlyList<BlockHeader>> ISyncPeer.GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token)
@@ -366,17 +367,18 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         protected Task<ReceiptsMessage> FulfillReceiptsRequest(GetReceiptsMessage getReceiptsMessage, CancellationToken cancellationToken)
         {
-            ArrayPoolList<TxReceipt[]> txReceipts = new(getReceiptsMessage.Hashes.Count);
+            ReadOnlySpan<Hash256> hashes = getReceiptsMessage.Hashes.AsSpan();
+            ArrayPoolList<TxReceipt[]> txReceipts = new(hashes.Length);
 
             ulong sizeEstimate = 0;
-            for (int i = 0; i < getReceiptsMessage.Hashes.Count; i++)
+            for (int i = 0; i < hashes.Length; i++)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }
 
-                Hash256 blockHash = getReceiptsMessage.Hashes[i];
+                Hash256 blockHash = hashes[i];
                 if (SyncServer.FindHeader(blockHash) is null)
                 {
                     break;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -399,9 +399,10 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         private static IOwnedReadOnlyList<BlockHeader> FixHeadersForGeth(IOwnedReadOnlyList<BlockHeader> headers)
         {
             int emptyBlocksAtTheEnd = 0;
-            for (int i = 0; i < headers.Count; i++)
+            ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
+            for (int i = 0; i < headersSpan.Length; i++)
             {
-                if (headers[headers.Count - 1 - i] is null)
+                if (headersSpan[headersSpan.Length - 1 - i] is null)
                 {
                     emptyBlocksAtTheEnd++;
                 }
@@ -413,14 +414,15 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
             if (emptyBlocksAtTheEnd != 0)
             {
-                int toTake = headers.Count - emptyBlocksAtTheEnd;
+                int toTake = headersSpan.Length - emptyBlocksAtTheEnd;
                 if (headers is ArrayPoolList<BlockHeader> asArrayPoolList)
                 {
                     asArrayPoolList.Truncate(toTake);
                     return headers;
                 }
 
-                ArrayPoolList<BlockHeader> newList = new(toTake, headers.Take(toTake));
+                ArrayPoolList<BlockHeader> newList = new(toTake);
+                newList.AddRange(headersSpan[..toTake]);
                 headers.Dispose();
                 return newList;
             }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -70,7 +70,11 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
         }
 
-        public override void RegisterWith(ISession session, IProtocolRegistrar registrar) => registrar.Register(session, this);
+        public override void RegisterWith(ISession session, IProtocolRegistrar registrar)
+        {
+            SetProtocolRegistrar(registrar);
+            registrar.Register(session, this);
+        }
 
         public void Disconnect(DisconnectReason reason, string details)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -8,6 +8,7 @@ using DotNetty.Common.Utilities;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 
@@ -52,7 +53,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             TransferSpeedType speedType,
             Func<TRequest, string> describeRequestFunc,
             CancellationToken token
-        ) where TRequest : MessageBase
+        ) where TRequest : P2PMessage
         {
             Request<TRequest, TResponse> request = new(message);
             messageQueue.Send(request);

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -25,6 +25,11 @@ using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.P2P
 {
+    internal interface ISessionActivityObserver
+    {
+        void OnSessionActivity(Session session);
+    }
+
     public class Session : ISession
     {
         private static readonly ConcurrentDictionary<string, AdaptiveCodeResolver> _resolvers = new();
@@ -38,6 +43,7 @@ namespace Nethermind.Network.P2P
         private readonly IChannel _channel;
         private readonly IDisconnectsAnalyzer _disconnectsAnalyzer;
         private IChannelHandlerContext? _context;
+        private ISessionActivityObserver? _activityObserver;
         private volatile bool _isChannelClosed;
 
         public Session(
@@ -191,6 +197,7 @@ namespace Nethermind.Network.P2P
             (string? protocol, int messageId) = _resolver.ResolveProtocol(zeroPacket.PacketType);
             zeroPacket.Protocol = protocol;
 
+            _activityObserver?.OnSessionActivity(this);
             MsgReceived?.Invoke(this, new PeerEventArgs(_node, zeroPacket.Protocol, zeroPacket.PacketType, zeroPacket.Content.ReadableBytes));
 
             RecordIncomingMessageMetric(zeroPacket.Protocol, messageId, zeroPacket.Content.ReadableBytes);
@@ -249,6 +256,7 @@ namespace Nethermind.Network.P2P
                 message.AdaptivePacketType = _resolver.ResolveAdaptiveId(message.Protocol, message.PacketType);
                 int size = _packetSender.Enqueue(message);
 
+                _activityObserver?.OnSessionActivity(this);
                 MsgDelivered?.Invoke(this, new PeerEventArgs(_node, message.Protocol, message.PacketType, size));
 
                 RecordOutgoingMessageMetric(message, size);
@@ -590,6 +598,8 @@ namespace Nethermind.Network.P2P
         public event EventHandler<EventArgs> Initialized;
         public event EventHandler<PeerEventArgs> MsgReceived;
         public event EventHandler<PeerEventArgs> MsgDelivered;
+
+        internal void SetActivityObserver(ISessionActivityObserver? activityObserver) => _activityObserver = activityObserver;
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -28,6 +28,8 @@ namespace Nethermind.Network.P2P
     internal interface ISessionActivityObserver
     {
         void OnSessionActivity(Session session);
+
+        void OnSessionDisconnected(Session session, DisconnectEventArgs args);
     }
 
     public class Session : ISession
@@ -515,15 +517,18 @@ namespace Nethermind.Network.P2P
                 State = SessionState.Disconnected;
             }
 
+            ISessionActivityObserver? activityObserver = _activityObserver;
             if (_disconnectedHandlers.HasHandlers)
             {
                 if (_logger.IsTrace) TraceDisconnectedEvent(disconnectReason, disconnectType);
                 _disconnectedHandlers.Invoke(this, disconnectEventArgs);
             }
-            else if (_logger.IsDebug)
+            else if (_logger.IsDebug && activityObserver is null)
             {
                 DebugNoDisconnectedSubscriptions();
             }
+
+            activityObserver?.OnSessionDisconnected(this, disconnectEventArgs);
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void TraceAlreadyDisconnected(DisconnectReason reason, DisconnectType type)

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P
         private readonly IChannel _channel;
         private readonly IDisconnectsAnalyzer _disconnectsAnalyzer;
         private IChannelHandlerContext? _context;
-        private ISessionActivityObserver? _activityObserver;
+        private volatile ISessionActivityObserver? _activityObserver;
         private volatile bool _isChannelClosed;
 
         public Session(

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
+using System;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -28,10 +29,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);
-            int count = message.Hashes.Count;
-            for (int i = 0; i < count; i++)
+            ReadOnlySpan<Hash256> hashes = message.Hashes.AsSpan();
+            for (int i = 0; i < hashes.Length; i++)
             {
-                rlpStream.Encode(message.Hashes[i]);
+                rlpStream.Encode(hashes[i]);
             }
         }
 
@@ -39,9 +40,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
         public int GetLength(T message, out int contentLength)
         {
             contentLength = 0;
-            for (int i = 0; i < message.Hashes.Count; i++)
+            ReadOnlySpan<Hash256> hashes = message.Hashes.AsSpan();
+            for (int i = 0; i < hashes.Length; i++)
             {
-                contentLength += Rlp.LengthOf(message.Hashes[i]);
+                contentLength += Rlp.LengthOf(hashes[i]);
             }
 
             return Rlp.LengthOfSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -33,7 +33,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private readonly ITxGossipPolicy _txGossipPolicy;
         private LruKeyCache<Hash256AsKey>? _lastBlockNotificationCache;
         private LruKeyCache<Hash256AsKey> LastBlockNotificationCache => _lastBlockNotificationCache ??= new(10, "LastBlockNotificationCache");
-        private readonly Func<(IOwnedReadOnlyList<Transaction> txs, int startIndex), CancellationToken, ValueTask> _handleSlow;
+        private readonly Func<TransactionsRequest, CancellationToken, ValueTask> _handleSlow;
+
+        protected readonly record struct TransactionsRequest(IOwnedReadOnlyList<Transaction> Transactions, int StartIndex);
 
         public Eth62ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
@@ -239,19 +241,19 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         protected void Handle(TransactionsMessage msg)
         {
             IOwnedReadOnlyList<Transaction> iList = msg.Transactions;
-            if (!BackgroundTaskScheduler.TryScheduleBackgroundTask((iList, 0), _handleSlow, "Transactions"))
+            if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(iList, 0), _handleSlow, "Transactions"))
             {
                 iList.Dispose();
             }
         }
 
-        protected virtual ValueTask HandleSlow((IOwnedReadOnlyList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
+        protected virtual ValueTask HandleSlow(TransactionsRequest request, CancellationToken cancellationToken)
         {
-            IOwnedReadOnlyList<Transaction> transactions = request.txs;
+            IOwnedReadOnlyList<Transaction> transactions = request.Transactions;
             ReadOnlySpan<Transaction> transactionsSpan = transactions.AsSpan();
             try
             {
-                int startIdx = request.startIndex;
+                int startIdx = request.StartIndex;
                 bool isTrace = Logger.IsTrace;
 
                 for (int i = startIdx; i < transactionsSpan.Length; i++)
@@ -267,7 +269,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                         }
 
                         // Reschedule remaining transactions with a different start index
-                        if (!BackgroundTaskScheduler.TryScheduleBackgroundTask((transactions, i), _handleSlow, "Transactions"))
+                        if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(transactions, i), _handleSlow, "Transactions"))
                         {
                             transactions.Dispose();
                         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -67,14 +67,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
         protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossipedTransactions;
 
-        public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
-
-        public override event EventHandler<ProtocolEventArgs>? SubprotocolRequested
-        {
-            add { }
-            remove { }
-        }
-
         protected virtual void EnrichStatusMessage(StatusMessage statusMessage) { }
 
         public override void Init()
@@ -235,7 +227,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             Session.IsNetworkIdMatched = SyncServer.NetworkId == (ulong)status.NetworkId;
             HeadHash = status.BestHash;
             TotalDifficulty = status.TotalDifficulty;
-            ProtocolInitialized?.Invoke(this, eventArgs);
+            NotifyProtocolInitialized(eventArgs);
         }
 
         protected void Handle(TransactionsMessage msg)
@@ -395,8 +387,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             Send(msg);
         }
 
-        protected override void OnDisposed() =>
-            // Clear Events
-            ProtocolInitialized = null;
+        protected override void OnDisposed() => ClearProtocolEvents();
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockHeadersMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockHeadersMessageSerializer.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
+using System;
+using Nethermind.Core;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.SyncLimits;
 
@@ -19,9 +21,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);
-            for (int i = 0; i < message.BlockHeaders.Count; i++)
+            ReadOnlySpan<BlockHeader> blockHeaders = message.BlockHeaders.AsSpan();
+            for (int i = 0; i < blockHeaders.Length; i++)
             {
-                _headerDecoder.Encode(rlpStream, message.BlockHeaders[i]);
+                _headerDecoder.Encode(rlpStream, blockHeaders[i]);
             }
         }
 
@@ -31,9 +34,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public int GetLength(BlockHeadersMessage message, out int contentLength)
         {
             contentLength = 0;
-            for (int i = 0; i < message.BlockHeaders.Count; i++)
+            ReadOnlySpan<BlockHeader> blockHeaders = message.BlockHeaders.AsSpan();
+            for (int i = 0; i < blockHeaders.Length; i++)
             {
-                contentLength += _headerDecoder.GetLength(message.BlockHeaders[i], RlpBehaviors.None);
+                contentLength += _headerDecoder.GetLength(blockHeaders[i], RlpBehaviors.None);
             }
 
             return Rlp.LengthOfSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -39,8 +39,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             ITxGossipPolicy? transactionsGossipPolicy = null)
             : base(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, logManager, transactionsGossipPolicy)
         {
-            _nodeDataRequests = new MessageQueue<GetNodeDataMessage, IByteArrayList>(Send);
-            _receiptsRequests = new MessageQueue<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
+            _nodeDataRequests = new MessageQueue<GetNodeDataMessage, IByteArrayList>(this);
+            _receiptsRequests = new MessageQueue<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(this);
         }
 
         public override byte ProtocolVersion => EthVersions.Eth63;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
             long lastBlockNumber = -1;
             RlpBehaviors behaviors = RlpBehaviors.None;
 
-            foreach (TxReceipt?[]? txReceipts in message.TxReceipts)
+            foreach (TxReceipt?[]? txReceipts in message.TxReceipts.AsSpan())
             {
                 if (txReceipts is null)
                 {
@@ -102,9 +102,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         {
             contentLength = 0;
 
-            for (int i = 0; i < message.TxReceipts.Count; i++)
+            ReadOnlySpan<TxReceipt[]?> txReceiptsSpan = message.TxReceipts.AsSpan();
+            for (int i = 0; i < txReceiptsSpan.Length; i++)
             {
-                TxReceipt?[]? txReceipts = message.TxReceipts[i];
+                TxReceipt?[]? txReceipts = txReceiptsSpan[i];
                 if (txReceipts is null)
                 {
                     contentLength += Rlp.OfEmptyList.Length;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -91,10 +91,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         protected virtual void Handle(NewPooledTransactionHashesMessage msg) => RequestPooledTransactions<GetPooledTransactionsMessage>(msg.Hashes);
 
-        protected void AddNotifiedTransactions(IReadOnlyList<Hash256> hashes)
+        protected void AddNotifiedTransactions(ReadOnlySpan<Hash256> hashes)
         {
-            foreach (Hash256 hash in hashes)
+            for (int i = 0; i < hashes.Length; i++)
             {
+                Hash256 hash = hashes[i];
                 if (hash is not null)
                 {
                     NotifiedTransactions.Set(hash.ValueHash256);
@@ -179,7 +180,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
         protected void RequestPooledTransactions<TMessage>(IOwnedReadOnlyList<Hash256> hashes)
             where TMessage : P2PMessage, INew<IOwnedReadOnlyList<Hash256>, TMessage>
         {
-            AddNotifiedTransactions(hashes);
+            AddNotifiedTransactions(hashes.AsSpan());
 
             long startTime = Stopwatch.GetTimestamp();
             TxPool.Metrics.PendingTransactionsHashesReceived += hashes.Count;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -13,6 +13,7 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
+using Nethermind.Network.P2P.Utils;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
@@ -34,11 +35,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
         private readonly MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests66;
         private readonly MessageDictionary<GetNodeDataMessage, IByteArrayList> _nodeDataRequests66;
         private readonly MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)> _receiptsRequests66;
-        private readonly Func<GetBlockHeadersMessage, CancellationToken, Task<BlockHeadersMessage>> _handleGetBlockHeaders;
-        private readonly Func<GetBlockBodiesMessage, CancellationToken, Task<BlockBodiesMessage>> _handleGetBlockBodies;
-        private readonly Func<GetPooledTransactionsMessage, CancellationToken, Task<PooledTransactionsMessage>> _handleGetPooledTransactions;
-        private readonly Func<GetReceiptsMessage, CancellationToken, Task<ReceiptsMessage>> _handleGetReceipts;
-        private readonly Func<GetNodeDataMessage, CancellationToken, Task<NodeDataMessage>> _handleGetNodeData;
 
         public Eth66ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
@@ -56,11 +52,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
             _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, IByteArrayList>(Send);
             _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
-            _handleGetBlockHeaders = Handle;
-            _handleGetBlockBodies = Handle;
-            _handleGetPooledTransactions = Handle;
-            _handleGetReceipts = Handle;
-            _handleGetNodeData = Handle;
         }
 
         public override string Name => "eth66";
@@ -75,7 +66,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             switch (message.PacketType)
             {
                 case Eth66MessageCode.GetBlockHeaders:
-                    HandleInBackground<GetBlockHeadersMessage, BlockHeadersMessage>(message, _handleGetBlockHeaders);
+                    HandleInBackground<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage, GetBlockHeadersHandler>(message);
                     break;
                 case Eth66MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -83,7 +74,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(headersMsg, size);
                     break;
                 case Eth66MessageCode.GetBlockBodies:
-                    HandleInBackground<GetBlockBodiesMessage, BlockBodiesMessage>(message, _handleGetBlockBodies);
+                    HandleInBackground<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage, GetBlockBodiesHandler>(message);
                     break;
                 case Eth66MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -91,7 +82,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     HandleBodies(bodiesMsg, size);
                     break;
                 case Eth66MessageCode.GetPooledTransactions:
-                    HandleInBackground<GetPooledTransactionsMessage, PooledTransactionsMessage>(message, _handleGetPooledTransactions);
+                    HandleInBackground<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage, GetPooledTransactionsHandler>(message);
                     break;
                 case Eth66MessageCode.PooledTransactions:
                     if (CanReceiveTransactions)
@@ -108,7 +99,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
                     break;
                 case Eth66MessageCode.GetReceipts:
-                    HandleInBackground<GetReceiptsMessage, ReceiptsMessage>(message, _handleGetReceipts);
+                    HandleInBackground<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage, GetReceiptsHandler>(message);
                     break;
                 case Eth66MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -116,7 +107,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(receiptsMessage, size);
                     break;
                 case Eth66MessageCode.GetNodeData:
-                    HandleInBackground<GetNodeDataMessage, NodeDataMessage>(message, _handleGetNodeData);
+                    HandleInBackground<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage, GetNodeDataHandler>(message);
                     break;
                 case Eth66MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);
@@ -271,6 +262,51 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
         {
             using ArrayPoolList<Hash256> hashesToRetry = new(1) { new Hash256(message.TxHash) };
             RequestPooledTransactions<GetPooledTransactionsMessage>(hashesToRetry);
+        }
+
+        private readonly struct GetBlockHeadersHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>
+        {
+            static Task<BlockHeadersMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>.Execute(
+                Eth66ProtocolHandler handler,
+                GetBlockHeadersMessage request,
+                CancellationToken cancellationToken) =>
+                handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetBlockBodiesHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage>
+        {
+            static Task<BlockBodiesMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage>.Execute(
+                Eth66ProtocolHandler handler,
+                GetBlockBodiesMessage request,
+                CancellationToken cancellationToken) =>
+                handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetPooledTransactionsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage>
+        {
+            static Task<PooledTransactionsMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage>.Execute(
+                Eth66ProtocolHandler handler,
+                GetPooledTransactionsMessage request,
+                CancellationToken cancellationToken) =>
+                handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetReceiptsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage>
+        {
+            static Task<ReceiptsMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage>.Execute(
+                Eth66ProtocolHandler handler,
+                GetReceiptsMessage request,
+                CancellationToken cancellationToken) =>
+                handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetNodeDataHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage>
+        {
+            static Task<NodeDataMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage>.Execute(
+                Eth66ProtocolHandler handler,
+                GetNodeDataMessage request,
+                CancellationToken cancellationToken) =>
+                handler.Handle(request, cancellationToken);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -14,6 +14,7 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
+using Nethermind.Network.P2P.Utils;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
@@ -66,7 +67,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             switch (message.PacketType)
             {
                 case Eth66MessageCode.GetBlockHeaders:
-                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetBlockHeadersMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
+                    HandleInBackground<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage, GetBlockHeadersHandler>(message);
                     break;
                 case Eth66MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -74,7 +75,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(headersMsg, size);
                     break;
                 case Eth66MessageCode.GetBlockBodies:
-                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetBlockBodiesMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
+                    HandleInBackground<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage, GetBlockBodiesHandler>(message);
                     break;
                 case Eth66MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -82,7 +83,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     HandleBodies(bodiesMsg, size);
                     break;
                 case Eth66MessageCode.GetPooledTransactions:
-                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetPooledTransactionsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
+                    HandleInBackground<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage, GetPooledTransactionsHandler>(message);
                     break;
                 case Eth66MessageCode.PooledTransactions:
                     if (CanReceiveTransactions)
@@ -99,7 +100,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
                     break;
                 case Eth66MessageCode.GetReceipts:
-                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetReceiptsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
+                    HandleInBackground<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage, GetReceiptsHandler>(message);
                     break;
                 case Eth66MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -107,7 +108,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(receiptsMessage, size);
                     break;
                 case Eth66MessageCode.GetNodeData:
-                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetNodeDataMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
+                    HandleInBackground<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage, GetNodeDataHandler>(message);
                     break;
                 case Eth66MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);
@@ -264,5 +265,29 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             RequestPooledTransactions<GetPooledTransactionsMessage>(hashesToRetry);
         }
 
+        private readonly struct GetBlockHeadersHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>
+        {
+            public static Task<BlockHeadersMessage> Execute(Eth66ProtocolHandler handler, GetBlockHeadersMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetBlockBodiesHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage>
+        {
+            public static Task<BlockBodiesMessage> Execute(Eth66ProtocolHandler handler, GetBlockBodiesMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetPooledTransactionsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage>
+        {
+            public static Task<PooledTransactionsMessage> Execute(Eth66ProtocolHandler handler, GetPooledTransactionsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetReceiptsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage>
+        {
+            public static Task<ReceiptsMessage> Execute(Eth66ProtocolHandler handler, GetReceiptsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken);
+        }
+
+        private readonly struct GetNodeDataHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage>
+        {
+            public static Task<NodeDataMessage> Execute(Eth66ProtocolHandler handler, GetNodeDataMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.Messages;
 using Nethermind.Network.Contract.P2P;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
@@ -48,10 +49,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             ITxGossipPolicy? transactionsGossipPolicy = null)
             : base(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy)
         {
-            _headersRequests66 = new MessageDictionary<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
-            _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
-            _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, IByteArrayList>(Send);
-            _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
+            _headersRequests66 = new MessageDictionary<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(this);
+            _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(this);
+            _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, IByteArrayList>(this);
+            _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(this);
         }
 
         public override string Name => "eth66";
@@ -250,7 +251,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             Func<T66, string> describeRequestFunc,
             CancellationToken token
         )
-            where T66 : IEth66Message
+            where T66 : P2PMessage, IEth66Message
         {
             Request<T66, TResponse> request = new(message);
             messageQueue.Send(request);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -34,7 +34,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
         private readonly MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests66;
         private readonly MessageDictionary<GetNodeDataMessage, IByteArrayList> _nodeDataRequests66;
         private readonly MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)> _receiptsRequests66;
-
+        private readonly Func<GetBlockHeadersMessage, CancellationToken, Task<BlockHeadersMessage>> _handleGetBlockHeaders;
+        private readonly Func<GetBlockBodiesMessage, CancellationToken, Task<BlockBodiesMessage>> _handleGetBlockBodies;
+        private readonly Func<GetPooledTransactionsMessage, CancellationToken, Task<PooledTransactionsMessage>> _handleGetPooledTransactions;
+        private readonly Func<GetReceiptsMessage, CancellationToken, Task<ReceiptsMessage>> _handleGetReceipts;
+        private readonly Func<GetNodeDataMessage, CancellationToken, Task<NodeDataMessage>> _handleGetNodeData;
 
         public Eth66ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
@@ -52,6 +56,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
             _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, IByteArrayList>(Send);
             _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
+            _handleGetBlockHeaders = Handle;
+            _handleGetBlockBodies = Handle;
+            _handleGetPooledTransactions = Handle;
+            _handleGetReceipts = Handle;
+            _handleGetNodeData = Handle;
         }
 
         public override string Name => "eth66";
@@ -66,7 +75,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             switch (message.PacketType)
             {
                 case Eth66MessageCode.GetBlockHeaders:
-                    HandleInBackground<GetBlockHeadersMessage, BlockHeadersMessage>(message, Handle);
+                    HandleInBackground<GetBlockHeadersMessage, BlockHeadersMessage>(message, _handleGetBlockHeaders);
                     break;
                 case Eth66MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -74,7 +83,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(headersMsg, size);
                     break;
                 case Eth66MessageCode.GetBlockBodies:
-                    HandleInBackground<GetBlockBodiesMessage, BlockBodiesMessage>(message, Handle);
+                    HandleInBackground<GetBlockBodiesMessage, BlockBodiesMessage>(message, _handleGetBlockBodies);
                     break;
                 case Eth66MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -82,7 +91,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     HandleBodies(bodiesMsg, size);
                     break;
                 case Eth66MessageCode.GetPooledTransactions:
-                    HandleInBackground<GetPooledTransactionsMessage, PooledTransactionsMessage>(message, Handle);
+                    HandleInBackground<GetPooledTransactionsMessage, PooledTransactionsMessage>(message, _handleGetPooledTransactions);
                     break;
                 case Eth66MessageCode.PooledTransactions:
                     if (CanReceiveTransactions)
@@ -99,7 +108,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
                     break;
                 case Eth66MessageCode.GetReceipts:
-                    HandleInBackground<GetReceiptsMessage, ReceiptsMessage>(message, Handle);
+                    HandleInBackground<GetReceiptsMessage, ReceiptsMessage>(message, _handleGetReceipts);
                     break;
                 case Eth66MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -107,7 +116,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(receiptsMessage, size);
                     break;
                 case Eth66MessageCode.GetNodeData:
-                    HandleInBackground<GetNodeDataMessage, NodeDataMessage>(message, Handle);
+                    HandleInBackground<GetNodeDataMessage, NodeDataMessage>(message, _handleGetNodeData);
                     break;
                 case Eth66MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -265,6 +265,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             RequestPooledTransactions<GetPooledTransactionsMessage>(hashesToRetry);
         }
 
+        // Intentionally explicit: each closed generic handler keeps scheduling delegate-free
+        // and lets the JIT specialize request execution for this hot path.
         private readonly struct GetBlockHeadersHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>
         {
             static Task<BlockHeadersMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>.Execute(

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -14,7 +14,6 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
-using Nethermind.Network.P2P.Utils;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
@@ -67,7 +66,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             switch (message.PacketType)
             {
                 case Eth66MessageCode.GetBlockHeaders:
-                    HandleInBackground<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage, GetBlockHeadersHandler>(message);
+                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetBlockHeadersMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
                     break;
                 case Eth66MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -75,7 +74,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(headersMsg, size);
                     break;
                 case Eth66MessageCode.GetBlockBodies:
-                    HandleInBackground<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage, GetBlockBodiesHandler>(message);
+                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetBlockBodiesMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
                     break;
                 case Eth66MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -83,7 +82,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     HandleBodies(bodiesMsg, size);
                     break;
                 case Eth66MessageCode.GetPooledTransactions:
-                    HandleInBackground<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage, GetPooledTransactionsHandler>(message);
+                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetPooledTransactionsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
                     break;
                 case Eth66MessageCode.PooledTransactions:
                     if (CanReceiveTransactions)
@@ -100,7 +99,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
                     break;
                 case Eth66MessageCode.GetReceipts:
-                    HandleInBackground<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage, GetReceiptsHandler>(message);
+                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetReceiptsMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
                     break;
                 case Eth66MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -108,7 +107,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     Handle(receiptsMessage, size);
                     break;
                 case Eth66MessageCode.GetNodeData:
-                    HandleInBackground<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage, GetNodeDataHandler>(message);
+                    HandleInBackground(message, static (Eth66ProtocolHandler handler, GetNodeDataMessage request, CancellationToken cancellationToken) => handler.Handle(request, cancellationToken));
                     break;
                 case Eth66MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);
@@ -265,51 +264,5 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             RequestPooledTransactions<GetPooledTransactionsMessage>(hashesToRetry);
         }
 
-        // Intentionally explicit: each closed generic handler keeps scheduling delegate-free
-        // and lets the JIT specialize request execution for this hot path.
-        private readonly struct GetBlockHeadersHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>
-        {
-            static Task<BlockHeadersMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockHeadersMessage, BlockHeadersMessage>.Execute(
-                Eth66ProtocolHandler handler,
-                GetBlockHeadersMessage request,
-                CancellationToken cancellationToken) =>
-                handler.Handle(request, cancellationToken);
-        }
-
-        private readonly struct GetBlockBodiesHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage>
-        {
-            static Task<BlockBodiesMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetBlockBodiesMessage, BlockBodiesMessage>.Execute(
-                Eth66ProtocolHandler handler,
-                GetBlockBodiesMessage request,
-                CancellationToken cancellationToken) =>
-                handler.Handle(request, cancellationToken);
-        }
-
-        private readonly struct GetPooledTransactionsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage>
-        {
-            static Task<PooledTransactionsMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetPooledTransactionsMessage, PooledTransactionsMessage>.Execute(
-                Eth66ProtocolHandler handler,
-                GetPooledTransactionsMessage request,
-                CancellationToken cancellationToken) =>
-                handler.Handle(request, cancellationToken);
-        }
-
-        private readonly struct GetReceiptsHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage>
-        {
-            static Task<ReceiptsMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetReceiptsMessage, ReceiptsMessage>.Execute(
-                Eth66ProtocolHandler handler,
-                GetReceiptsMessage request,
-                CancellationToken cancellationToken) =>
-                handler.Handle(request, cancellationToken);
-        }
-
-        private readonly struct GetNodeDataHandler : ISyncServeRequestHandler<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage>
-        {
-            static Task<NodeDataMessage> ISyncServeRequestHandler<Eth66ProtocolHandler, GetNodeDataMessage, NodeDataMessage>.Execute(
-                Eth66ProtocolHandler handler,
-                GetNodeDataMessage request,
-                CancellationToken cancellationToken) =>
-                handler.Handle(request, cancellationToken);
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -248,14 +248,16 @@ public class Eth68ProtocolHandler(ISession session,
         Send(message);
     }
 
-    protected override ValueTask HandleSlow((IOwnedReadOnlyList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
+    protected override ValueTask HandleSlow(TransactionsRequest request, CancellationToken cancellationToken)
     {
-        int startIdx = request.startIndex;
-        for (int i = startIdx; i < request.txs.Count; i++)
+        IOwnedReadOnlyList<Transaction> transactions = request.Transactions;
+        ReadOnlySpan<Transaction> transactionsSpan = transactions.AsSpan();
+        int startIdx = request.StartIndex;
+        for (int i = startIdx; i < transactionsSpan.Length; i++)
         {
-            if (!ValidateSizeAndType(request.txs[i]))
+            if (!ValidateSizeAndType(transactionsSpan[i]))
             {
-                request.txs.Dispose();
+                transactions.Dispose();
                 throw new SubprotocolException("invalid pooled tx type or size");
             }
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -110,7 +110,11 @@ public class Eth68ProtocolHandler(ISession session,
 
     protected void RequestPooledTransactions(IOwnedReadOnlyList<Hash256> hashes, IOwnedReadOnlyList<int> sizes, IOwnedReadOnlyList<byte> types)
     {
-        using ArrayPoolListRef<int> newTxHashesIndexes = AddMarkUnknownHashes(hashes.AsSpan());
+        ReadOnlySpan<Hash256> hashesSpan = hashes.AsSpan();
+        ReadOnlySpan<int> sizesSpan = sizes.AsSpan();
+        ReadOnlySpan<byte> typesSpan = types.AsSpan();
+
+        using ArrayPoolListRef<int> newTxHashesIndexes = AddMarkUnknownHashes(hashesSpan);
 
         if (newTxHashesIndexes.Count == 0)
         {
@@ -129,9 +133,9 @@ public class Eth68ProtocolHandler(ISession session,
 
         foreach (int index in newTxHashesIndexes.AsSpan())
         {
-            Hash256 hash = hashes[index];
-            int txSize = sizes[index];
-            TxType txType = (TxType)types[index];
+            Hash256 hash = hashesSpan[index];
+            int txSize = sizesSpan[index];
+            TxType txType = (TxType)typesSpan[index];
             TxShapeAnnouncements.Set(hash, (txSize, txType));
 
             long maxTxSize = txType.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -99,7 +99,7 @@ public class Eth68ProtocolHandler(ISession session,
 
         TxPool.Metrics.PendingTransactionsHashesReceived += message.Hashes.Count;
 
-        AddNotifiedTransactions(message.Hashes);
+        AddNotifiedTransactions(message.Hashes.AsSpan());
 
         long startTime = Logger.IsTrace ? Stopwatch.GetTimestamp() : 0;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
@@ -58,8 +58,6 @@ public class Eth69ProtocolHandler(
         set { }
     }
 
-    public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
-
     protected override void HandleMessageCore(ZeroPacket message)
     {
         int size = message.Content.ReadableBytes;
@@ -114,7 +112,7 @@ public class Eth69ProtocolHandler(
         Session.IsNetworkIdMatched = SyncServer.NetworkId == (ulong)status.NetworkId;
         HeadNumber = status.LatestBlock;
         HeadHash = status.LatestBlockHash;
-        ProtocolInitialized?.Invoke(this, eventArgs);
+        NotifyProtocolInitialized(eventArgs);
     }
 
     private void Handle(BlockRangeUpdateMessage blockRangeUpdate)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -91,20 +91,21 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
     private ReceiptsResponse FulfillReceiptsRequest(GetReceiptsMessage70 getReceiptsMessage, CancellationToken cancellationToken)
     {
-        ArrayPoolList<TxReceipt[]> txReceipts = new(getReceiptsMessage.Hashes.Count);
+        ReadOnlySpan<Hash256> hashes = getReceiptsMessage.Hashes.AsSpan();
+        ArrayPoolList<TxReceipt[]> txReceipts = new(hashes.Length);
         bool lastBlockIncomplete = false;
 
         try
         {
             ulong responseReceiptsContentSize = 0;
-            for (int blockIndex = 0; blockIndex < getReceiptsMessage.Hashes.Count; blockIndex++)
+            for (int blockIndex = 0; blockIndex < hashes.Length; blockIndex++)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }
 
-                Hash256 blockHash = getReceiptsMessage.Hashes[blockIndex];
+                Hash256 blockHash = hashes[blockIndex];
                 if (SyncServer.FindHeader(blockHash) is null)
                 {
                     break;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -53,7 +53,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             gossipPolicy, forkInfo, logManager, txPoolConfig, specProvider, transactionsGossipPolicy)
     {
         _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
-        _receiptsRequests70 = new MessageDictionary<GetReceiptsMessage70, ReceiptsMessage70>(Send);
+        _receiptsRequests70 = new MessageDictionary<GetReceiptsMessage70, ReceiptsMessage70>(this);
     }
 
     public override string Name => "eth70";

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -243,28 +243,32 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         using ArrayPoolList<bool> validateReceiptGasUpperBoundAgainstHeader = new(blockHashes.Count);
         using ArrayPoolList<bool> validateReceiptGasEqualToHeader = new(blockHashes.Count);
 
-        for (int i = 0; i < blockHashes.Count; i++)
         {
-            BlockHeader? header = SyncServer.FindHeader(blockHashes[i]);
-            if (header is null)
+            ReadOnlySpan<Hash256> blockHashesSpan = blockHashes.AsSpan();
+            for (int i = 0; i < blockHashesSpan.Length; i++)
             {
-                expectedGasUsed.Add(0);
-                blockGasLimits.Add(0);
-                blockTransactions.Add(null);
-                receiptRlpBehaviors.Add(RlpBehaviors.None);
-                validateReceiptGasUpperBoundAgainstHeader.Add(false);
-                validateReceiptGasEqualToHeader.Add(false);
-                continue;
-            }
+                Hash256 blockHash = blockHashesSpan[i];
+                BlockHeader? header = SyncServer.FindHeader(blockHash);
+                if (header is null)
+                {
+                    expectedGasUsed.Add(0);
+                    blockGasLimits.Add(0);
+                    blockTransactions.Add(null);
+                    receiptRlpBehaviors.Add(RlpBehaviors.None);
+                    validateReceiptGasUpperBoundAgainstHeader.Add(false);
+                    validateReceiptGasEqualToHeader.Add(false);
+                    continue;
+                }
 
-            IReleaseSpec spec = _specProvider.GetSpec(header);
-            Block? block = SyncServer.Find(blockHashes[i]);
-            expectedGasUsed.Add(header.GasUsed);
-            blockGasLimits.Add(header.GasLimit);
-            blockTransactions.Add(GetTransactionsForReceiptValidation(block));
-            receiptRlpBehaviors.Add(spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None);
-            validateReceiptGasUpperBoundAgainstHeader.Add(!spec.IsEip8037Enabled);
-            validateReceiptGasEqualToHeader.Add(!spec.IsEip7778Enabled && !spec.IsEip8037Enabled);
+                IReleaseSpec spec = _specProvider.GetSpec(header);
+                Block? block = SyncServer.Find(blockHash);
+                expectedGasUsed.Add(header.GasUsed);
+                blockGasLimits.Add(header.GasLimit);
+                blockTransactions.Add(GetTransactionsForReceiptValidation(block));
+                receiptRlpBehaviors.Add(spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None);
+                validateReceiptGasUpperBoundAgainstHeader.Add(!spec.IsEip8037Enabled);
+                validateReceiptGasEqualToHeader.Add(!spec.IsEip7778Enabled && !spec.IsEip8037Enabled);
+            }
         }
 
         try
@@ -303,12 +307,12 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                         throw new SubprotocolException($"Received partial receipts response below minimum size ({size} bytes < {SoftOutgoingMessageSizeLimit / 4} bytes)");
                     }
 
-                    IOwnedReadOnlyList<TxReceipt[]?> txReceipts = response.TxReceipts;
+                    ReadOnlySpan<TxReceipt[]?> txReceipts = response.TxReceipts.AsSpan();
 
-                    for (int i = 0; i < txReceipts.Count; i++)
+                    for (int i = 0; i < txReceipts.Length; i++)
                     {
                         bool isFirst = i == 0;
-                        bool isLast = i == txReceipts.Count - 1;
+                        bool isLast = i == txReceipts.Length - 1;
                         TxReceipt[] blockReceipts = txReceipts[i] ?? throw new SubprotocolException("Unexpected null receipt block payload");
                         long blockExpectedGasUsed = expectedGasUsed[blockIndex];
                         long blockGasLimit = blockGasLimits[blockIndex];

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Messages/GetReceiptsMessageSerializer70.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Messages/GetReceiptsMessageSerializer70.cs
@@ -49,9 +49,9 @@ public class GetReceiptsMessageSerializer70 : Eth66SerializerBase<GetReceiptsMes
     private static int GetHashesContentLength(IOwnedReadOnlyList<Hash256> hashes)
     {
         int contentLength = 0;
-        for (int i = 0; i < hashes.Count; i++)
+        foreach (Hash256 hash in hashes.AsSpan())
         {
-            contentLength += Rlp.LengthOf(hashes[i]);
+            contentLength += Rlp.LengthOf(hash);
         }
 
         return contentLength;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
@@ -90,21 +90,22 @@ public class Eth71ProtocolHandler : Eth70ProtocolHandler, ISyncPeer, IStaticProt
     {
         using GetBlockAccessListsMessage req = request;
         IOwnedReadOnlyList<Hash256> hashes = req.Hashes;
+        ReadOnlySpan<Hash256> hashesSpan = hashes.AsSpan();
         long totalSize = 0;
         RlpByteArrayList results;
 
-        using (DeferredRlpItemList.Builder builder = new(entryCapacity: hashes.Count))
+        using (DeferredRlpItemList.Builder builder = new(entryCapacity: hashesSpan.Length))
         {
             using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
             {
-                for (int i = 0; i < hashes.Count; i++)
+                for (int i = 0; i < hashesSpan.Length; i++)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
                         break;
                     }
 
-                    using MemoryManager<byte>? balRlp = SyncServer.GetBlockAccessListRlp(hashes[i]);
+                    using MemoryManager<byte>? balRlp = SyncServer.GetBlockAccessListRlp(hashesSpan[i]);
                     ReadOnlySpan<byte> balRlpSpan = balRlp is null ? ReadOnlySpan<byte>.Empty : balRlp.Memory.Span;
                     writer.WriteValue(balRlpSpan);
                     totalSize += Rlp.LengthOf(balRlpSpan);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
@@ -53,7 +53,7 @@ public class Eth71ProtocolHandler : Eth70ProtocolHandler, ISyncPeer, IStaticProt
         ITxGossipPolicy? transactionsGossipPolicy = null)
         : base(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool,
             gossipPolicy, forkInfo, logManager, txPoolConfig, specProvider, transactionsGossipPolicy) =>
-        _balRequests = new MessageDictionary<GetBlockAccessListsMessage, BlockAccessListsMessage>(Send);
+        _balRequests = new MessageDictionary<GetBlockAccessListsMessage, BlockAccessListsMessage>(this);
 
     public override string Name => "eth71";
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/GetBlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/GetBlockAccessListsMessageSerializer.cs
@@ -42,9 +42,9 @@ public class GetBlockAccessListsMessageSerializer : Eth66SerializerBase<GetBlock
     {
         int contentLength = 0;
 
-        for (int i = 0; i < hashes.Count; i++)
+        foreach (Hash256 hash in hashes.AsSpan())
         {
-            contentLength += Rlp.LengthOf(hashes[i]);
+            contentLength += Rlp.LengthOf(hash);
         }
 
         return contentLength;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
+using System;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
 using Nethermind.Serialization.Rlp;
@@ -29,10 +30,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             }
             else
             {
+                ReadOnlySpan<PathWithAccount> pathsWithAccounts = message.PathsWithAccounts.AsSpan();
                 stream.StartSequence(pwasLength);
-                for (int i = 0; i < message.PathsWithAccounts.Count; i++)
+                for (int i = 0; i < pathsWithAccounts.Length; i++)
                 {
-                    PathWithAccount pwa = message.PathsWithAccounts[i];
+                    PathWithAccount pwa = pathsWithAccounts[i];
 
                     int accountContentLength = _decoder.GetContentLength(pwa.Account);
                     int pwaLength = Rlp.LengthOf(pwa.Path) + Rlp.LengthOfSequence(accountContentLength);
@@ -96,9 +98,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             int pwasLength = 0;
             if (message.PathsWithAccounts is not null && message.PathsWithAccounts.Count > 0)
             {
-                for (int i = 0; i < message.PathsWithAccounts.Count; i++)
+                ReadOnlySpan<PathWithAccount> pathsWithAccounts = message.PathsWithAccounts.AsSpan();
+                for (int i = 0; i < pathsWithAccounts.Length; i++)
                 {
-                    PathWithAccount pwa = message.PathsWithAccounts[i];
+                    PathWithAccount pwa = pathsWithAccounts[i];
                     int itemLength = Rlp.LengthOf(pwa.Path);
                     itemLength += _decoder.GetLength(pwa.Account);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
+using System;
 using Nethermind.Core.Collections;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
@@ -3,7 +3,6 @@
 
 using DotNetty.Buffers;
 using System;
-using Nethermind.Core.Collections;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetStorageRangesMessageSerializer.cs
@@ -16,8 +16,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
 
             rlpStream.Encode(message.RequestId);
             rlpStream.Encode(message.StorageRange.RootHash);
-            IOwnedReadOnlyList<PathWithAccount> accounts = message.StorageRange.Accounts;
-            int accountsCount = accounts.Count;
+            ReadOnlySpan<PathWithAccount> accounts = message.StorageRange.Accounts.AsSpan();
+            int accountsCount = accounts.Length;
             int accountsPathsContentLength = accountsCount * Rlp.LengthOfKeccakRlp;
             rlpStream.StartSequence(accountsPathsContentLength);
             for (int i = 0; i < accountsCount; i++)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using DotNetty.Buffers;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using DotNetty.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -60,12 +62,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             stream.Encode(message.Bytes);
         }
 
-        private static int GetPathsRlpLength(IReadOnlyList<PathGroup> paths)
+        private static int GetPathsRlpLength(IOwnedReadOnlyList<PathGroup> paths)
         {
             int contentLength = 0;
-            for (int i = 0; i < paths.Count; i++)
+            ReadOnlySpan<PathGroup> pathsSpan = paths.AsSpan();
+            for (int i = 0; i < pathsSpan.Length; i++)
             {
-                byte[][] group = paths[i].Group;
+                byte[][] group = pathsSpan[i].Group;
                 int groupContentLength = 0;
                 for (int j = 0; j < group.Length; j++)
                 {
@@ -76,12 +79,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             return Rlp.LengthOfSequence(contentLength);
         }
 
-        private static void EncodePaths(RlpStream stream, IReadOnlyList<PathGroup> paths)
+        private static void EncodePaths(RlpStream stream, IOwnedReadOnlyList<PathGroup> paths)
         {
             int contentLength = 0;
-            for (int i = 0; i < paths.Count; i++)
+            ReadOnlySpan<PathGroup> pathsSpan = paths.AsSpan();
+            for (int i = 0; i < pathsSpan.Length; i++)
             {
-                byte[][] group = paths[i].Group;
+                byte[][] group = pathsSpan[i].Group;
                 int groupContentLength = 0;
                 for (int j = 0; j < group.Length; j++)
                 {
@@ -91,9 +95,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             }
 
             stream.StartSequence(contentLength);
-            for (int i = 0; i < paths.Count; i++)
+            for (int i = 0; i < pathsSpan.Length; i++)
             {
-                byte[][] group = paths[i].Group;
+                byte[][] group = pathsSpan[i].Group;
                 int groupContentLength = 0;
                 for (int j = 0; j < group.Length; j++)
                 {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -33,14 +33,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             else
             {
                 stream.StartSequence(allSlotsLength);
+                ReadOnlySpan<IOwnedReadOnlyList<PathWithStorageSlot>> slotsSpan = message.Slots.AsSpan();
 
-                for (int i = 0; i < message.Slots.Count; i++)
+                for (int i = 0; i < slotsSpan.Length; i++)
                 {
                     stream.StartSequence(accountSlotsLengths[i]);
 
-                    IOwnedReadOnlyList<PathWithStorageSlot> accountSlots = message.Slots[i];
+                    ReadOnlySpan<PathWithStorageSlot> accountSlots = slotsSpan[i].AsSpan();
 
-                    for (int j = 0; j < accountSlots.Count; j++)
+                    for (int j = 0; j < accountSlots.Length; j++)
                     {
                         PathWithStorageSlot slot = accountSlots[j];
 
@@ -106,12 +107,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             {
                 if (slots is not null && slotsCount != 0)
                 {
-                    for (int i = 0; i < slotsCount; i++)
+                    ReadOnlySpan<IOwnedReadOnlyList<PathWithStorageSlot>> slotsSpan = slots.AsSpan();
+                    for (int i = 0; i < slotsSpan.Length; i++)
                     {
                         int accountSlotsLength = 0;
 
-                        IOwnedReadOnlyList<PathWithStorageSlot> accountSlots = slots[i];
-                        foreach (ref readonly PathWithStorageSlot slot in accountSlots.AsSpan())
+                        foreach (ref readonly PathWithStorageSlot slot in slotsSpan[i].AsSpan())
                         {
                             int slotLength = Rlp.LengthOf(slot.Path) + Rlp.LengthOf(slot.SlotRlpValue);
                             accountSlotsLength += Rlp.LengthOfSequence(slotLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using DotNetty.Buffers;
+using System;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -112,8 +113,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                     {
                         int accountSlotsLength = 0;
 
-                        foreach (ref readonly PathWithStorageSlot slot in slotsSpan[i].AsSpan())
+                        ReadOnlySpan<PathWithStorageSlot> accountSlots = slotsSpan[i].AsSpan();
+                        for (int j = 0; j < accountSlots.Length; j++)
                         {
+                            PathWithStorageSlot slot = accountSlots[j];
                             int slotLength = Rlp.LengthOf(slot.Path) + Rlp.LengthOf(slot.SlotRlpValue);
                             accountSlotsLength += Rlp.LengthOfSequence(slotLength);
                         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -64,18 +64,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             SnapMessageLimits.GetTrieNodesPathsPerGroupRlpLimit = RlpLimit.For<PathGroup>(syncConfig.SnapServingMaxPathsPerGroup, nameof(PathGroup.Group));
         }
 
-        public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
-        public override event EventHandler<ProtocolEventArgs>? SubprotocolRequested
-        {
-            add { }
-            remove { }
-        }
+        public override void Init() => NotifyProtocolInitialized(new ProtocolInitializedEventArgs(this));
 
-        public override void Init() => ProtocolInitialized?.Invoke(this, new ProtocolInitializedEventArgs(this));
-
-        public override void Dispose() =>
-            // Clear Events if set
-            ProtocolInitialized = null;
+        public override void Dispose() => ClearProtocolEvents();
 
         protected override void HandleMessageCore(ZeroPacket message)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -55,10 +55,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             ISnapServer snapServer)
             : base(session, nodeStats, serializer, backgroundTaskScheduler, logManager)
         {
-            _getAccountRangeRequests = new(Send);
-            _getStorageRangeRequests = new(Send);
-            _getByteCodesRequests = new(Send);
-            _getTrieNodesRequests = new(Send);
+            _getAccountRangeRequests = new(this);
+            _getStorageRangeRequests = new(this);
+            _getByteCodesRequests = new(this);
+            _getTrieNodesRequests = new(this);
             SyncServer = snapServer;
             CanServe = snapServer.CanServe;
             SnapMessageLimits.GetTrieNodesPathsPerGroupRlpLimit = RlpLimit.For<PathGroup>(syncConfig.SnapServingMaxPathsPerGroup, nameof(PathGroup.Group));

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -267,9 +267,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
         {
             using DeferredRlpItemList.Builder builder = new();
             DeferredRlpItemList.Builder.Writer rootWriter = builder.BeginRootContainer();
-            for (int i = 0; i < request.Paths.Count; i++)
+            ReadOnlySpan<AccountWithStorageStartingHash> paths = request.Paths.AsSpan();
+            for (int i = 0; i < paths.Length; i++)
             {
-                AccountWithStorageStartingHash path = request.Paths[i];
+                AccountWithStorageStartingHash path = paths[i];
                 using DeferredRlpItemList.Builder.Writer groupWriter = rootWriter.BeginContainer();
                 groupWriter.WriteValue(path.PathAndAccount.Path.Bytes);
                 groupWriter.WriteValue(_emptyBytes);

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -25,7 +25,6 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     {
         if (!TryScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSender, typeof(TReq).Name))
         {
-            request.TryDispose();
             return false;
         }
         return true;
@@ -35,14 +34,24 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     {
         if (!TryScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSenderValueTask, typeof(TReq).Name))
         {
-            request.TryDispose();
             return false;
         }
         return true;
     }
 
     internal bool TryScheduleBackgroundTask<TReq>(TReq request, Func<TReq, CancellationToken, ValueTask> fulfillFunc, string? source = null) =>
-        backgroundTaskScheduler.TryScheduleTask((request, fulfillFunc), BackgroundTaskFailureHandlerValueTask, source: source);
+        TryScheduleBackgroundTask(new BackgroundTaskRequest<TReq>(handler, request, fulfillFunc), request, source);
+
+    private bool TryScheduleBackgroundTask<TReq>(BackgroundTaskRequest<TReq> backgroundTaskRequest, TReq request, string? source)
+    {
+        if (backgroundTaskScheduler.TryScheduleTask(backgroundTaskRequest, BackgroundTaskRequestRunner<TReq>.Run, source: source))
+        {
+            return true;
+        }
+
+        request.TryDispose();
+        return false;
+    }
 
     // I just don't want to create a closure... so this happens.
     private async ValueTask BackgroundSyncSender<TReq, TRes>(
@@ -59,29 +68,41 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         handler.Send(response);
     }
 
-    private async Task BackgroundTaskFailureHandlerValueTask<TReq>((TReq Request, Func<TReq, CancellationToken, ValueTask> BackgroundTask) input, CancellationToken cancellationToken)
+    private readonly struct BackgroundTaskRequest<TReq>(
+        ProtocolHandlerBase handler,
+        TReq request,
+        Func<TReq, CancellationToken, ValueTask> fulfillFunc)
     {
-        try
+        public async Task Execute(CancellationToken cancellationToken)
         {
-            await input.BackgroundTask(input.Request, cancellationToken);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
-        {
-            // Session shutdown or disconnect canceled the task; do not treat it as a background task failure.
-            return;
-        }
-        catch (Exception e)
-        {
-            DisconnectReason disconnectReason = e switch
+            try
             {
-                EthSyncException => DisconnectReason.EthSyncException,
-                RlpLimitException => DisconnectReason.MessageLimitsBreached,
-                RlpException => DisconnectReason.BreachOfProtocol,
-                _ => DisconnectReason.BackgroundTaskFailure
-            };
+                await fulfillFunc(request, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
+            {
+                // Session shutdown or disconnect canceled the task; do not treat it as a background task failure.
+                return;
+            }
+            catch (Exception e)
+            {
+                DisconnectReason disconnectReason = e switch
+                {
+                    EthSyncException => DisconnectReason.EthSyncException,
+                    RlpLimitException => DisconnectReason.MessageLimitsBreached,
+                    RlpException => DisconnectReason.BreachOfProtocol,
+                    _ => DisconnectReason.BackgroundTaskFailure
+                };
 
-            handler.Session.InitiateDisconnect(disconnectReason, e.Message);
-            if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
+                handler.Session.InitiateDisconnect(disconnectReason, e.Message);
+                if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
+            }
         }
+    }
+
+    private static class BackgroundTaskRequestRunner<TReq>
+    {
+        public static readonly Func<BackgroundTaskRequest<TReq>, CancellationToken, Task> Run =
+            static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -23,19 +23,25 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
 {
     internal bool TryScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, Task<TRes>> fulfillFunc) where TRes : P2PMessage
     {
-        if (!TryScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSender, typeof(TReq).Name))
+        SyncServeTaskRequest<TReq, TRes> syncServeRequest = new(handler, request, fulfillFunc);
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeTaskRequestRunner<TReq, TRes>.Run, source: RequestSource<TReq>.Name))
         {
+            request.TryDispose();
             return false;
         }
+
         return true;
     }
 
     internal bool TryScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc) where TRes : P2PMessage
     {
-        if (!TryScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSenderValueTask, typeof(TReq).Name))
+        SyncServeValueTaskRequest<TReq, TRes> syncServeRequest = new(handler, request, fulfillFunc);
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeValueTaskRequestRunner<TReq, TRes>.Run, source: RequestSource<TReq>.Name))
         {
+            request.TryDispose();
             return false;
         }
+
         return true;
     }
 
@@ -53,19 +59,68 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         return false;
     }
 
-    // I just don't want to create a closure... so this happens.
-    private async ValueTask BackgroundSyncSender<TReq, TRes>(
-        (TReq Request, Func<TReq, CancellationToken, Task<TRes>> FulfillFunc) input, CancellationToken cancellationToken) where TRes : P2PMessage
+    private static void HandleBackgroundTaskFailure(ProtocolHandlerBase handler, Exception e)
     {
-        TRes response = await input.FulfillFunc(input.Request, cancellationToken);
-        handler.Send(response);
+        DisconnectReason disconnectReason = e switch
+        {
+            EthSyncException => DisconnectReason.EthSyncException,
+            RlpLimitException => DisconnectReason.MessageLimitsBreached,
+            RlpException => DisconnectReason.BreachOfProtocol,
+            _ => DisconnectReason.BackgroundTaskFailure
+        };
+
+        handler.Session.InitiateDisconnect(disconnectReason, e.Message);
+        if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
     }
 
-    private async ValueTask BackgroundSyncSenderValueTask<TReq, TRes>(
-        (TReq Request, Func<TReq, CancellationToken, ValueTask<TRes>> FulfillFunc) input, CancellationToken cancellationToken) where TRes : P2PMessage
+    private readonly struct SyncServeTaskRequest<TReq, TRes>(
+        ProtocolHandlerBase handler,
+        TReq request,
+        Func<TReq, CancellationToken, Task<TRes>> fulfillFunc)
+        where TRes : P2PMessage
     {
-        TRes response = await input.FulfillFunc(input.Request, cancellationToken);
-        handler.Send(response);
+        public async Task Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                TRes response = await fulfillFunc(request, cancellationToken);
+                handler.Send(response);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
+            {
+                // Session shutdown or disconnect canceled the task; do not treat it as a background task failure.
+                return;
+            }
+            catch (Exception e)
+            {
+                HandleBackgroundTaskFailure(handler, e);
+            }
+        }
+    }
+
+    private readonly struct SyncServeValueTaskRequest<TReq, TRes>(
+        ProtocolHandlerBase handler,
+        TReq request,
+        Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc)
+        where TRes : P2PMessage
+    {
+        public async Task Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                TRes response = await fulfillFunc(request, cancellationToken);
+                handler.Send(response);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
+            {
+                // Session shutdown or disconnect canceled the task; do not treat it as a background task failure.
+                return;
+            }
+            catch (Exception e)
+            {
+                HandleBackgroundTaskFailure(handler, e);
+            }
+        }
     }
 
     private readonly struct BackgroundTaskRequest<TReq>(
@@ -86,23 +141,33 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
             }
             catch (Exception e)
             {
-                DisconnectReason disconnectReason = e switch
-                {
-                    EthSyncException => DisconnectReason.EthSyncException,
-                    RlpLimitException => DisconnectReason.MessageLimitsBreached,
-                    RlpException => DisconnectReason.BreachOfProtocol,
-                    _ => DisconnectReason.BackgroundTaskFailure
-                };
-
-                handler.Session.InitiateDisconnect(disconnectReason, e.Message);
-                if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
+                HandleBackgroundTaskFailure(handler, e);
             }
         }
+    }
+
+    private static class SyncServeTaskRequestRunner<TReq, TRes>
+        where TRes : P2PMessage
+    {
+        public static readonly Func<SyncServeTaskRequest<TReq, TRes>, CancellationToken, Task> Run =
+            static (request, cancellationToken) => request.Execute(cancellationToken);
+    }
+
+    private static class SyncServeValueTaskRequestRunner<TReq, TRes>
+        where TRes : P2PMessage
+    {
+        public static readonly Func<SyncServeValueTaskRequest<TReq, TRes>, CancellationToken, Task> Run =
+            static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 
     private static class BackgroundTaskRequestRunner<TReq>
     {
         public static readonly Func<BackgroundTaskRequest<TReq>, CancellationToken, Task> Run =
             static (request, cancellationToken) => request.Execute(cancellationToken);
+    }
+
+    private static class RequestSource<TReq>
+    {
+        public static readonly string Name = typeof(TReq).Name;
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -15,26 +15,6 @@ using Nethermind.Synchronization;
 namespace Nethermind.Network.P2P.Utils;
 
 /// <summary>
-/// Executes a typed sync request for a protocol handler without allocating a delegate per handler instance.
-/// </summary>
-/// <typeparam name="THandler">The protocol handler type that owns the request logic.</typeparam>
-/// <typeparam name="TReq">The request message type.</typeparam>
-/// <typeparam name="TRes">The response message type.</typeparam>
-public interface ISyncServeRequestHandler<THandler, TReq, TRes>
-    where THandler : ProtocolHandlerBase
-    where TRes : P2PMessage
-{
-    /// <summary>
-    /// Executes the request and returns the response message to send back to the peer.
-    /// </summary>
-    /// <param name="handler">The protocol handler instance.</param>
-    /// <param name="request">The request message. The implementation owns and must dispose it.</param>
-    /// <param name="cancellationToken">The cancellation token for scheduler shutdown or session closing.</param>
-    /// <returns>The response message.</returns>
-    static abstract Task<TRes> Execute(THandler handler, TReq request, CancellationToken cancellationToken);
-}
-
-/// <summary>
 /// Some utility function for interacting with BackgroundTaskScheduler. Notably, disconnect and/or log on failure.
 /// </summary>
 /// <param name="handler"></param>
@@ -53,13 +33,15 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         return true;
     }
 
-    internal bool TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>(THandler requestHandler, TReq request)
+    internal bool TryScheduleSyncServe<THandler, TReq, TRes>(
+        THandler requestHandler,
+        TReq request,
+        Func<THandler, TReq, CancellationToken, Task<TRes>> fulfillFunc)
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
-        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
-        HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler> syncServeRequest = new(requestHandler, request);
-        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>.Run, source: RequestSource<TReq>.Name))
+        HandlerSyncServeTaskRequest<THandler, TReq, TRes> syncServeRequest = new(requestHandler, request, fulfillFunc);
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes>.Run, source: RequestSource<TReq>.Name))
         {
             request.TryDispose();
             return false;
@@ -133,18 +115,18 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         }
     }
 
-    private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>(
+    private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes>(
         THandler handler,
-        TReq request)
+        TReq request,
+        Func<THandler, TReq, CancellationToken, Task<TRes>> fulfillFunc)
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
-        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
             {
-                TRes response = await TRequestHandler.Execute(handler, request, cancellationToken);
+                TRes response = await fulfillFunc(handler, request, cancellationToken);
                 handler.Send(response);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
@@ -214,12 +196,11 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
             static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 
-    private static class HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>
+    private static class HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes>
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
-        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
-        public static readonly Func<HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>, CancellationToken, Task> Run =
+        public static readonly Func<HandlerSyncServeTaskRequest<THandler, TReq, TRes>, CancellationToken, Task> Run =
             static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -15,6 +15,26 @@ using Nethermind.Synchronization;
 namespace Nethermind.Network.P2P.Utils;
 
 /// <summary>
+/// Executes a typed sync request for a protocol handler without storing a delegate in each scheduled request.
+/// </summary>
+/// <typeparam name="THandler">The protocol handler type that owns the request logic.</typeparam>
+/// <typeparam name="TReq">The request message type.</typeparam>
+/// <typeparam name="TRes">The response message type.</typeparam>
+public interface ISyncServeRequestHandler<THandler, TReq, TRes>
+    where THandler : ProtocolHandlerBase
+    where TRes : P2PMessage
+{
+    /// <summary>
+    /// Executes the request and returns the response message to send back to the peer.
+    /// </summary>
+    /// <param name="handler">The protocol handler instance.</param>
+    /// <param name="request">The request message. The implementation owns and must dispose it.</param>
+    /// <param name="cancellationToken">The cancellation token for scheduler shutdown or session closing.</param>
+    /// <returns>The response message.</returns>
+    static abstract Task<TRes> Execute(THandler handler, TReq request, CancellationToken cancellationToken);
+}
+
+/// <summary>
 /// Some utility function for interacting with BackgroundTaskScheduler. Notably, disconnect and/or log on failure.
 /// </summary>
 /// <param name="handler"></param>
@@ -33,15 +53,13 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         return true;
     }
 
-    internal bool TryScheduleSyncServe<THandler, TReq, TRes>(
-        THandler requestHandler,
-        TReq request,
-        Func<THandler, TReq, CancellationToken, Task<TRes>> fulfillFunc)
+    internal bool TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>(THandler requestHandler, TReq request)
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
-        HandlerSyncServeTaskRequest<THandler, TReq, TRes> syncServeRequest = new(requestHandler, request, fulfillFunc);
-        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes>.Run, source: RequestSource<TReq>.Name))
+        HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler> syncServeRequest = new(requestHandler, request);
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>.Run, source: RequestSource<TReq>.Name))
         {
             request.TryDispose();
             return false;
@@ -115,18 +133,18 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         }
     }
 
-    private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes>(
+    private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>(
         THandler handler,
-        TReq request,
-        Func<THandler, TReq, CancellationToken, Task<TRes>> fulfillFunc)
+        TReq request)
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
             {
-                TRes response = await fulfillFunc(handler, request, cancellationToken);
+                TRes response = await TRequestHandler.Execute(handler, request, cancellationToken);
                 handler.Send(response);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
@@ -196,11 +214,12 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
             static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 
-    private static class HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes>
+    private static class HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
-        public static readonly Func<HandlerSyncServeTaskRequest<THandler, TReq, TRes>, CancellationToken, Task> Run =
+        public static readonly Func<HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>, CancellationToken, Task> Run =
             static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -14,6 +14,13 @@ using Nethermind.Synchronization;
 
 namespace Nethermind.Network.P2P.Utils;
 
+internal interface ISyncServeRequestHandler<THandler, TReq, TRes>
+    where THandler : ProtocolHandlerBase
+    where TRes : P2PMessage
+{
+    static abstract Task<TRes> Execute(THandler handler, TReq request, CancellationToken cancellationToken);
+}
+
 /// <summary>
 /// Some utility function for interacting with BackgroundTaskScheduler. Notably, disconnect and/or log on failure.
 /// </summary>
@@ -25,6 +32,21 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     {
         SyncServeTaskRequest<TReq, TRes> syncServeRequest = new(handler, request, fulfillFunc);
         if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeTaskRequestRunner<TReq, TRes>.Run, source: RequestSource<TReq>.Name))
+        {
+            request.TryDispose();
+            return false;
+        }
+
+        return true;
+    }
+
+    internal bool TryScheduleSyncServe<THandler, TReq, TRes, TRequestHandler>(THandler requestHandler, TReq request)
+        where THandler : ProtocolHandlerBase
+        where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
+    {
+        HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler> syncServeRequest = new(requestHandler, request);
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>.Run, source: RequestSource<TReq>.Name))
         {
             request.TryDispose();
             return false;
@@ -98,6 +120,32 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         }
     }
 
+    private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>(
+        THandler handler,
+        TReq request)
+        where THandler : ProtocolHandlerBase
+        where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
+    {
+        public async Task Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                TRes response = await TRequestHandler.Execute(handler, request, cancellationToken);
+                handler.Send(response);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && handler.Session.IsClosing)
+            {
+                // Session shutdown or disconnect canceled the task; do not treat it as a background task failure.
+                return;
+            }
+            catch (Exception e)
+            {
+                HandleBackgroundTaskFailure(handler, e);
+            }
+        }
+    }
+
     private readonly struct SyncServeValueTaskRequest<TReq, TRes>(
         ProtocolHandlerBase handler,
         TReq request,
@@ -150,6 +198,15 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         where TRes : P2PMessage
     {
         public static readonly Func<SyncServeTaskRequest<TReq, TRes>, CancellationToken, Task> Run =
+            static (request, cancellationToken) => request.Execute(cancellationToken);
+    }
+
+    private static class HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>
+        where THandler : ProtocolHandlerBase
+        where TRes : P2PMessage
+        where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
+    {
+        public static readonly Func<HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>, CancellationToken, Task> Run =
             static (request, cancellationToken) => request.Execute(cancellationToken);
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -14,10 +14,23 @@ using Nethermind.Synchronization;
 
 namespace Nethermind.Network.P2P.Utils;
 
-internal interface ISyncServeRequestHandler<THandler, TReq, TRes>
+/// <summary>
+/// Executes a typed sync request for a protocol handler without allocating a delegate per handler instance.
+/// </summary>
+/// <typeparam name="THandler">The protocol handler type that owns the request logic.</typeparam>
+/// <typeparam name="TReq">The request message type.</typeparam>
+/// <typeparam name="TRes">The response message type.</typeparam>
+public interface ISyncServeRequestHandler<THandler, TReq, TRes>
     where THandler : ProtocolHandlerBase
     where TRes : P2PMessage
 {
+    /// <summary>
+    /// Executes the request and returns the response message to send back to the peer.
+    /// </summary>
+    /// <param name="handler">The protocol handler instance.</param>
+    /// <param name="request">The request message. The implementation owns and must dispose it.</param>
+    /// <param name="cancellationToken">The cancellation token for scheduler shutdown or session closing.</param>
+    /// <returns>The response message.</returns>
     static abstract Task<TRes> Execute(THandler handler, TReq request, CancellationToken cancellationToken);
 }
 

--- a/src/Nethermind/Nethermind.Network/PeerComparer.cs
+++ b/src/Nethermind/Nethermind.Network/PeerComparer.cs
@@ -2,31 +2,22 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Network
 {
-    internal class PeerComparer : IComparer<Peer>
+    internal readonly struct PeerComparer : IComparer<Peer>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(Peer x, Peer y)
         {
-            if (x is null)
-            {
-                return y is null ? 0 : 1;
-            }
+            if (x is null) return y is null ? 0 : 1;
+            if (y is null) return -1;
 
-            if (y is null)
-            {
-                return -1;
-            }
-
-            int staticValue = -x.Node.IsStatic.CompareTo(y.Node.IsStatic);
-            if (staticValue != 0)
-            {
-                return staticValue;
-            }
-
-            int reputation = -x.Node.CurrentReputation.CompareTo(y.Node.CurrentReputation);
-            return reputation;
+            int staticCompare = y.Node.IsStatic.CompareTo(x.Node.IsStatic);
+            return staticCompare != 0
+                ? staticCompare
+                : y.Node.CurrentReputation.CompareTo(x.Node.CurrentReputation);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Network
         private readonly ConcurrentDictionary<Guid, ISession> _sessions = new();
         private readonly int _outgoingConnectParallelism;
         private readonly EventHandler<EventArgs> _onHandshakeComplete;
-        private readonly EventHandler<DisconnectEventArgs> _onDisconnected;
+        private readonly SessionDisconnectedEventHandler _onSessionDisconnected;
 
         public PeerManager(
             IRlpxHost rlpxHost,
@@ -83,7 +83,7 @@ namespace Nethermind.Network
             _stats = stats;
             _networkConfig = networkConfig;
             _onHandshakeComplete = OnHandshakeComplete;
-            _onDisconnected = OnDisconnected;
+            _onSessionDisconnected = OnDisconnected;
             _outgoingConnectParallelism = networkConfig.NumConcurrentOutgoingConnects;
             if (_outgoingConnectParallelism == 0)
             {
@@ -181,6 +181,7 @@ namespace Nethermind.Network
                 _peerPool.PeerAdded += PeerPoolOnPeerAdded;
                 _peerPool.PeerRemoved += PeerPoolOnPeerRemoved;
                 _rlpxHost.SessionCreated += RlpxHostOnSessionCreated;
+                _rlpxHost.SessionDisconnected += _onSessionDisconnected;
             }
 
             StartPeerUpdateLoop();
@@ -218,6 +219,7 @@ namespace Nethermind.Network
                 _peerPool.PeerAdded -= PeerPoolOnPeerAdded;
                 _peerPool.PeerRemoved -= PeerPoolOnPeerRemoved;
                 _rlpxHost.SessionCreated -= RlpxHostOnSessionCreated;
+                _rlpxHost.SessionDisconnected -= _onSessionDisconnected;
                 foreach (KeyValuePair<Guid, ISession> kvp in _sessions)
                 {
                     ToggleSessionEventListeners(kvp.Value, false);
@@ -1137,9 +1139,8 @@ namespace Nethermind.Network
         private static bool IsConnected(Peer peer)
             => HasOpenSession(peer.InSession) || HasOpenSession(peer.OutSession);
 
-        private void OnDisconnected(object sender, DisconnectEventArgs e)
+        private void OnDisconnected(object sender, ISession session, DisconnectEventArgs e)
         {
-            ISession session = (ISession)sender;
             lock (_sessionLock)
             {
                 ToggleSessionEventListeners(session, false);
@@ -1204,12 +1205,10 @@ namespace Nethermind.Network
             if (shouldListen)
             {
                 session.HandshakeComplete += _onHandshakeComplete;
-                session.Disconnected += _onDisconnected;
             }
             else
             {
                 session.HandshakeComplete -= _onHandshakeComplete;
-                session.Disconnected -= _onDisconnected;
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -38,7 +39,6 @@ namespace Nethermind.Network
         private readonly IRlpxHost _rlpxHost;
         private readonly INodeStatsManager _stats;
         private readonly SemaphoreSlim _peerUpdateRequested = new(0, 1);
-        private readonly PeerComparer _peerComparer = new();
         private Task? _peerUpdateLoopTask;
         private readonly IPeerPool _peerPool;
         private readonly Lock _sessionLock = new();
@@ -605,7 +605,7 @@ namespace Nethermind.Network
                 node.CurrentReputation = peer.Stats.CurrentNodeReputation(nowUTC);
             }
 
-            _currentSelection.Candidates.Sort(_peerComparer);
+            CollectionsMarshal.AsSpan(_currentSelection.Candidates).Sort(default(PeerComparer));
 
             foreach (KeyValuePair<string, int> currentSelectionCounter in _currentSelection.Counters)
             {
@@ -713,7 +713,7 @@ namespace Nethermind.Network
                     }
                 }
 
-                _candidates.Sort(static (x, y) => PeerStatsComparer.Instance.Compare(x, y));
+                CollectionsMarshal.AsSpan(_candidates).Sort(default(PeerStatsComparer));
 
                 int countToRemove = _candidates.Count - _networkConfig.MaxCandidatePeerCount;
                 if (countToRemove > 0)
@@ -755,10 +755,9 @@ namespace Nethermind.Network
             public long CurrentReputation { get; } = currentReputation;
         }
 
-        private class PeerStatsComparer : IComparer<PeerStats>
+        private readonly struct PeerStatsComparer : IComparer<PeerStats>
         {
-            public static readonly PeerStatsComparer Instance = new();
-
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int Compare(PeerStats x, PeerStats y)
             {
                 int failedValidationCompare = y.FailedValidation.CompareTo(x.FailedValidation);

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -154,58 +154,13 @@ namespace Nethermind.Network
 
         private void InitHandler(ISession session, IProtocolHandler handler)
         {
-            handler.SubprotocolRequested += (s, e) => InitProtocol(session, e.ProtocolCode, e.Version);
             session.AddProtocolHandler(handler);
             handler.RegisterWith(session, this);
             handler.Init();
         }
 
-        void IProtocolRegistrar.Register(ISession session, ProtocolHandlerBase handler)
-        {
+        void IProtocolRegistrar.Register(ISession session, ProtocolHandlerBase handler) =>
             session.Node.EthDetails = handler.Name;
-            handler.ProtocolInitialized += (_, args) =>
-            {
-                if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
-                // SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
-                // _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
-                // {
-                //     NetworkId = typedArgs.NetworkId,
-                //     BestHash = typedArgs.BestHash,
-                //     GenesisHash = typedArgs.GenesisHash,
-                //     ProtocolVersion = typedArgs.ProtocolVersion,
-                //     TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
-                // });
-                bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
-                if (isValid)
-                {
-                    PeerInfo? peer = _syncPool.GetPeer(session.Node);
-                    if (peer is not null)
-                    {
-                        peer.SyncPeer.RegisterSatelliteProtocol(handler.ProtocolCode, handler);
-                        if (handler.IsPriority) _syncPool.SetPeerPriority(session.Node.Id);
-                        if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
-                    }
-                    else
-                    {
-                        _hangingSatelliteProtocols.AddOrUpdate(session.Node,
-                            _ => new ConcurrentDictionary<Guid, ProtocolHandlerBase> { [session.SessionId] = handler },
-                            (_, dict) =>
-                            {
-                                dict[session.SessionId] = handler;
-                                return dict;
-                            });
-
-                        if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol sync peer {session} not found.");
-                    }
-
-                    if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
-                }
-                else
-                {
-                    if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
-                }
-            };
-        }
 
         void IProtocolRegistrar.Register(ISession session, P2PProtocolHandler handler)
         {
@@ -215,88 +170,140 @@ namespace Nethermind.Network
             {
                 session.AddSupportedCapability(capability);
             }
-
-            handler.ProtocolInitialized += (_, args) =>
-            {
-                P2PProtocolInitializedEventArgs typedArgs = (P2PProtocolInitializedEventArgs)args;
-                if (!RunBasicChecks(session, Protocol.P2P, handler.ProtocolVersion)) return;
-
-                if (handler.ProtocolVersion >= 5)
-                {
-                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - enabling snappy");
-                    session.EnableSnappy();
-                }
-                else
-                {
-                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - disabling snappy");
-                }
-
-                _stats.ReportP2PInitializationEvent(session.Node, new P2PNodeDetails
-                {
-                    ClientId = typedArgs.ClientId,
-                    Capabilities = typedArgs.Capabilities,
-                    P2PVersion = typedArgs.P2PVersion,
-                    ListenPort = typedArgs.ListenPort
-                });
-
-                AddNodeToDiscovery(session, typedArgs);
-
-                _protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, args);
-
-                if (_logger.IsTrace) _logger.Trace($"Finalized P2P protocol initialization on {session}");
-            };
         }
 
-        void IProtocolRegistrar.Register(ISession session, SyncPeerProtocolHandlerBase handler)
-        {
+        void IProtocolRegistrar.Register(ISession session, SyncPeerProtocolHandlerBase handler) =>
             session.Node.EthDetails = handler.Name;
-            handler.ProtocolInitialized += (_, args) =>
+
+        void IProtocolRegistrar.OnProtocolInitialized(ISession session, ProtocolHandlerBase handler, ProtocolInitializedEventArgs args)
+        {
+            switch (handler)
             {
-                if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
-                SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
-                _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
+                case P2PProtocolHandler p2pProtocolHandler:
+                    OnP2PProtocolInitialized(session, p2pProtocolHandler, (P2PProtocolInitializedEventArgs)args);
+                    break;
+                case SyncPeerProtocolHandlerBase syncPeerProtocolHandler:
+                    OnSyncPeerProtocolInitialized(session, syncPeerProtocolHandler, (SyncPeerProtocolInitializedEventArgs)args);
+                    break;
+                default:
+                    OnSatelliteProtocolInitialized(session, handler, args);
+                    break;
+            }
+        }
+
+        void IProtocolRegistrar.OnSubprotocolRequested(ISession session, ProtocolHandlerBase handler, string protocolCode, int version) =>
+            InitProtocol(session, protocolCode, version);
+
+        private void OnSatelliteProtocolInitialized(ISession session, ProtocolHandlerBase handler, ProtocolInitializedEventArgs args)
+        {
+            if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
+
+            bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
+            if (isValid)
+            {
+                PeerInfo? peer = _syncPool.GetPeer(session.Node);
+                if (peer is not null)
                 {
-                    NetworkId = typedArgs.NetworkId,
-                    BestHash = typedArgs.BestHash,
-                    GenesisHash = typedArgs.GenesisHash,
-                    ProtocolVersion = typedArgs.ProtocolVersion,
-                    TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
-                });
-                bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
-                if (isValid)
-                {
-                    if (_syncPeers.TryAdd(session.SessionId, handler))
-                    {
-                        if (_hangingSatelliteProtocols.TryGetValue(handler.Node, out ConcurrentDictionary<Guid, ProtocolHandlerBase> handlerDictionary))
-                        {
-                            foreach (KeyValuePair<Guid, ProtocolHandlerBase> registration in handlerDictionary)
-                            {
-                                handler.RegisterSatelliteProtocol(registration.Value);
-                                if (registration.Value.IsPriority) handler.IsPriority = true;
-                                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}. Sync peer has priority: {handler.IsPriority}");
-                            }
-                        }
-
-                        _syncPool.AddPeer(handler);
-                        if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
-                        if (_logger.IsTrace) _logger.Trace($"{handler.ClientId} sync peer {session} created.");
-                    }
-                    else
-                    {
-                        if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
-                        session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
-                    }
-
-                    if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
-
-                    //Add/Update peer to the storage and to sync manager
-                    _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation(DateTime.UtcNow)));
+                    peer.SyncPeer.RegisterSatelliteProtocol(handler.ProtocolCode, handler);
+                    if (handler.IsPriority) _syncPool.SetPeerPriority(session.Node.Id);
+                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
                 }
                 else
                 {
-                    if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
+                    _hangingSatelliteProtocols.AddOrUpdate(session.Node,
+                        _ => new ConcurrentDictionary<Guid, ProtocolHandlerBase> { [session.SessionId] = handler },
+                        (_, dict) =>
+                        {
+                            dict[session.SessionId] = handler;
+                            return dict;
+                        });
+
+                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol sync peer {session} not found.");
                 }
-            };
+
+                if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
+            }
+        }
+
+        private void OnP2PProtocolInitialized(ISession session, P2PProtocolHandler handler, P2PProtocolInitializedEventArgs args)
+        {
+            if (!RunBasicChecks(session, Protocol.P2P, handler.ProtocolVersion)) return;
+
+            if (handler.ProtocolVersion >= 5)
+            {
+                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - enabling snappy");
+                session.EnableSnappy();
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - disabling snappy");
+            }
+
+            _stats.ReportP2PInitializationEvent(session.Node, new P2PNodeDetails
+            {
+                ClientId = args.ClientId,
+                Capabilities = args.Capabilities,
+                P2PVersion = args.P2PVersion,
+                ListenPort = args.ListenPort
+            });
+
+            AddNodeToDiscovery(session, args);
+
+            _protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, args);
+
+            if (_logger.IsTrace) _logger.Trace($"Finalized P2P protocol initialization on {session}");
+        }
+
+        private void OnSyncPeerProtocolInitialized(ISession session, SyncPeerProtocolHandlerBase handler, SyncPeerProtocolInitializedEventArgs args)
+        {
+            if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
+
+            _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
+            {
+                NetworkId = args.NetworkId,
+                BestHash = args.BestHash,
+                GenesisHash = args.GenesisHash,
+                ProtocolVersion = args.ProtocolVersion,
+                TotalDifficulty = (BigInteger)args.TotalDifficulty
+            });
+            bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
+            if (isValid)
+            {
+                if (_syncPeers.TryAdd(session.SessionId, handler))
+                {
+                    if (_hangingSatelliteProtocols.TryGetValue(handler.Node, out ConcurrentDictionary<Guid, ProtocolHandlerBase> handlerDictionary))
+                    {
+                        foreach (KeyValuePair<Guid, ProtocolHandlerBase> registration in handlerDictionary)
+                        {
+                            handler.RegisterSatelliteProtocol(registration.Value);
+                            if (registration.Value.IsPriority) handler.IsPriority = true;
+                            if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}. Sync peer has priority: {handler.IsPriority}");
+                        }
+                    }
+
+                    _syncPool.AddPeer(handler);
+                    if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
+                    if (_logger.IsTrace) _logger.Trace($"{handler.ClientId} sync peer {session} created.");
+                }
+                else
+                {
+                    if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
+                    session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
+                }
+
+                if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
+
+                //Add/Update peer to the storage and to sync manager
+                _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation(DateTime.UtcNow)));
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
+            }
         }
 
         private bool RunBasicChecks(ISession session, string protocolCode, int protocolVersion)

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -311,7 +311,7 @@ namespace Nethermind.Network
         {
             if (session.IsClosing)
             {
-                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} skipping init, session closing: {session}");
                 return false;
             }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -159,8 +159,9 @@ namespace Nethermind.Network
             handler.Init();
         }
 
-        void IProtocolRegistrar.Register(ISession session, ProtocolHandlerBase handler) =>
-            session.Node.EthDetails = handler.Name;
+        void IProtocolRegistrar.Register(ISession session, ProtocolHandlerBase handler)
+        {
+        }
 
         void IProtocolRegistrar.Register(ISession session, P2PProtocolHandler handler)
         {

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -42,6 +42,9 @@ namespace Nethermind.Network
         private readonly ILogger _logger;
         private readonly IProtocolHandlerFactory[] _factories;
         private readonly HashSet<Capability> _capabilities = DefaultCapabilities.ToHashSet();
+        private readonly EventHandler<SessionEventArgs> _onSessionCreated;
+        private readonly EventHandler<EventArgs> _onSessionInitialized;
+        private readonly EventHandler<DisconnectEventArgs> _onSessionDisconnected;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -64,21 +67,24 @@ namespace Nethermind.Network
 
             // Order is already set by OrderedComponents<T> (AddFirst/AddLast)
             _factories = factories;
-            rlpxHost.SessionCreated += SessionCreated;
+            _onSessionCreated = SessionCreated;
+            _onSessionInitialized = SessionInitialized;
+            _onSessionDisconnected = SessionDisconnected;
+            rlpxHost.SessionCreated += _onSessionCreated;
         }
 
         private void SessionCreated(object sender, SessionEventArgs e)
         {
             _sessions.TryAdd(e.Session.SessionId, e.Session);
-            e.Session.Initialized += SessionInitialized;
-            e.Session.Disconnected += SessionDisconnected;
+            e.Session.Initialized += _onSessionInitialized;
+            e.Session.Disconnected += _onSessionDisconnected;
         }
 
         private void SessionDisconnected(object sender, DisconnectEventArgs e)
         {
             ISession session = (ISession)sender;
-            session.Initialized -= SessionInitialized;
-            session.Disconnected -= SessionDisconnected;
+            session.Initialized -= _onSessionInitialized;
+            session.Disconnected -= _onSessionDisconnected;
             _sessions.TryRemove(session.SessionId, out _);
 
             if (_logger.IsDebug && session.BestStateReached == SessionState.Initialized)

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network
         private readonly HashSet<Capability> _capabilities = DefaultCapabilities.ToHashSet();
         private readonly EventHandler<SessionEventArgs> _onSessionCreated;
         private readonly EventHandler<EventArgs> _onSessionInitialized;
-        private readonly EventHandler<DisconnectEventArgs> _onSessionDisconnected;
+        private readonly SessionDisconnectedEventHandler _onSessionDisconnected;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -71,20 +71,18 @@ namespace Nethermind.Network
             _onSessionInitialized = SessionInitialized;
             _onSessionDisconnected = SessionDisconnected;
             rlpxHost.SessionCreated += _onSessionCreated;
+            rlpxHost.SessionDisconnected += _onSessionDisconnected;
         }
 
         private void SessionCreated(object sender, SessionEventArgs e)
         {
             _sessions.TryAdd(e.Session.SessionId, e.Session);
             e.Session.Initialized += _onSessionInitialized;
-            e.Session.Disconnected += _onSessionDisconnected;
         }
 
-        private void SessionDisconnected(object sender, DisconnectEventArgs e)
+        private void SessionDisconnected(object sender, ISession session, DisconnectEventArgs e)
         {
-            ISession session = (ISession)sender;
             session.Initialized -= _onSessionInitialized;
-            session.Disconnected -= _onSessionDisconnected;
             _sessions.TryRemove(session.SessionId, out _);
 
             if (_logger.IsDebug && session.BestStateReached == SessionState.Initialized)

--- a/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
@@ -5,10 +5,20 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Nethermind.Core.Crypto;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.EventArg;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Rlpx
 {
+    /// <summary>
+    /// Handles a disconnected RLPx session.
+    /// </summary>
+    /// <param name="sender">The host that observed the disconnect.</param>
+    /// <param name="session">The disconnected session.</param>
+    /// <param name="args">The disconnect details.</param>
+    public delegate void SessionDisconnectedEventHandler(object sender, ISession session, DisconnectEventArgs args);
+
     public interface IRlpxHost
     {
         Task Init();
@@ -33,6 +43,11 @@ namespace Nethermind.Network.Rlpx
         bool ShouldContact(IPAddress ip, bool exactOnly = false);
 
         event EventHandler<SessionEventArgs> SessionCreated;
+
+        /// <summary>
+        /// Raised when a tracked session disconnects.
+        /// </summary>
+        event SessionDisconnectedEventHandler SessionDisconnected;
 
         ISessionMonitor SessionMonitor { get; }
     }

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -139,8 +139,6 @@ namespace Nethermind.Network.Rlpx
                     .Option(ChannelOption.Allocator, NethermindBuffers.RlpxAllocator)
                     .Option(ChannelOption.SoBacklog, 100)
                     .ChildOption(ChannelOption.Allocator, NethermindBuffers.RlpxAllocator)
-                    .ChildOption(ChannelOption.TcpNodelay, true)
-                    .ChildOption(ChannelOption.SoKeepalive, true)
                     .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)3.MB)
                     .ChildOption(ChannelOption.WriteBufferLowWaterMark, (int)1.MB)
                     .Handler(new LoggingHandler("BOSS", LogLevel.TRACE))
@@ -204,8 +202,6 @@ namespace Nethermind.Network.Rlpx
                 .Group(_workerGroup)
                 .ChannelFactory(_createClientChannel)
                 .Option(ChannelOption.Allocator, NethermindBuffers.RlpxAllocator)
-                .Option(ChannelOption.TcpNodelay, true)
-                .Option(ChannelOption.SoKeepalive, true)
                 .Option(ChannelOption.WriteBufferHighWaterMark, (int)3.MB)
                 .Option(ChannelOption.WriteBufferLowWaterMark, (int)1.MB)
                 .Option(ChannelOption.MessageSizeEstimator, DefaultMessageSizeEstimator.Default)
@@ -299,6 +295,8 @@ namespace Nethermind.Network.Rlpx
                 return;
             }
 
+            SetTcpSocketOptions(channel);
+
             SessionActivitySubscription sessionActivitySubscription = TrackSessionActivity(session);
             _sessionMonitor.AddSession(session);
             sessionActivitySubscription.AttachDisconnected();
@@ -318,6 +316,27 @@ namespace Nethermind.Network.Rlpx
                 CancellationToken.None,
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
+        }
+
+        private void SetTcpSocketOptions(IChannel channel)
+        {
+            SetChannelOption(channel, ChannelOption.TcpNodelay, true);
+            SetChannelOption(channel, ChannelOption.SoKeepalive, true);
+        }
+
+        private void SetChannelOption<T>(IChannel channel, ChannelOption<T> option, T value)
+        {
+            try
+            {
+                if (!channel.Configuration.SetOption(option, value) && _logger.IsWarn)
+                {
+                    _logger.Warn($"Failed to set channel option {option}");
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Failed to set channel option {option}: {ex.Message}");
+            }
         }
 
         private void DisconnectConnectedChannel(Task<IChannel> connectTask, object? _)

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -243,6 +243,7 @@ namespace Nethermind.Network.Rlpx
         }
 
         public event EventHandler<SessionEventArgs> SessionCreated;
+        public event SessionDisconnectedEventHandler SessionDisconnected;
 
         internal SessionActivitySubscription TrackSessionActivity(ISession session)
         {
@@ -297,9 +298,8 @@ namespace Nethermind.Network.Rlpx
 
             SetTcpSocketOptions(channel);
 
-            SessionActivitySubscription sessionActivitySubscription = TrackSessionActivity(session);
+            TrackSessionActivity(session);
             _sessionMonitor.AddSession(session);
-            sessionActivitySubscription.AttachDisconnected();
             SessionCreated?.Invoke(this, new SessionEventArgs(session));
 
             HandshakeRole role = session.Direction == ConnectionDirection.In ? HandshakeRole.Recipient : HandshakeRole.Initiator;
@@ -410,7 +410,7 @@ namespace Nethermind.Network.Rlpx
             // Sessions whose Disconnected event fired are already disposed via OnDisconnected.
             foreach (KeyValuePair<Guid, SessionActivitySubscription> kvp in _sessionActivitySubscriptions)
             {
-                kvp.Value.DetachAndDispose();
+                kvp.Value.DisconnectAndDispose();
             }
 
             _sessionActivitySubscriptions.Clear();
@@ -423,7 +423,7 @@ namespace Nethermind.Network.Rlpx
             private readonly RlpxHost _rlpxHost;
             private readonly ISession _session;
             private readonly Session? _concreteSession;
-            private readonly EventHandler<DisconnectEventArgs> _onDisconnected;
+            private readonly EventHandler<DisconnectEventArgs>? _onDisconnected;
             private readonly EventHandler<PeerEventArgs>? _refreshNodeFilter;
 
             public SessionActivitySubscription(RlpxHost rlpxHost, ISession session)
@@ -431,10 +431,10 @@ namespace Nethermind.Network.Rlpx
                 _rlpxHost = rlpxHost;
                 _session = session;
                 _concreteSession = session as Session;
-                _onDisconnected = OnDisconnected;
                 if (_concreteSession is null)
                 {
                     _refreshNodeFilter = RefreshNodeFilter;
+                    _onDisconnected = OnDisconnected;
                 }
             }
 
@@ -448,11 +448,16 @@ namespace Nethermind.Network.Rlpx
 
                 _session.MsgReceived += _refreshNodeFilter!;
                 _session.MsgDelivered += _refreshNodeFilter!;
+                _session.Disconnected += _onDisconnected!;
             }
 
-            public void AttachDisconnected() => _session.Disconnected += _onDisconnected;
-
             public void Detach()
+            {
+                DetachSession();
+                _rlpxHost._sessionActivitySubscriptions.TryRemove(_session.SessionId, out _);
+            }
+
+            public void DetachSession()
             {
                 if (_concreteSession is not null)
                 {
@@ -462,19 +467,20 @@ namespace Nethermind.Network.Rlpx
                 {
                     _session.MsgReceived -= _refreshNodeFilter!;
                     _session.MsgDelivered -= _refreshNodeFilter!;
+                    _session.Disconnected -= _onDisconnected!;
                 }
-
-                _session.Disconnected -= _onDisconnected;
-                _rlpxHost._sessionActivitySubscriptions.TryRemove(_session.SessionId, out _);
             }
 
-            public void DetachAndDispose()
+            public void DisconnectAndDispose()
             {
-                Detach();
                 try
                 {
-                    _session.MarkDisconnected(DisconnectReason.AppClosing, DisconnectType.Local, "shutdown");
-                    _session.Dispose();
+                    const string details = "shutdown";
+                    _session.MarkDisconnected(DisconnectReason.AppClosing, DisconnectType.Local, details);
+                    if (_rlpxHost._sessionActivitySubscriptions.ContainsKey(_session.SessionId))
+                    {
+                        _rlpxHost.OnSessionDisconnected(_session, new DisconnectEventArgs(DisconnectReason.AppClosing, DisconnectType.Local, details));
+                    }
                 }
                 catch (InvalidOperationException)
                 {
@@ -488,17 +494,35 @@ namespace Nethermind.Network.Rlpx
                 _rlpxHost._nodeFilter.Touch(remoteNode.Address.Address, remoteNode.IsStatic || remoteNode.IsBootnode);
             }
 
-            public void OnDisconnected(object? _, DisconnectEventArgs __)
-            {
-                Detach();
-                _session.Dispose();
-            }
+            private void OnDisconnected(object? _, DisconnectEventArgs args) => _rlpxHost.OnSessionDisconnected(_session, args);
         }
 
         void ISessionActivityObserver.OnSessionActivity(Session session)
         {
             Node remoteNode = session.Node;
             _nodeFilter.Touch(remoteNode.Address.Address, remoteNode.IsStatic || remoteNode.IsBootnode);
+        }
+
+        void ISessionActivityObserver.OnSessionDisconnected(Session session, DisconnectEventArgs args) =>
+            OnSessionDisconnected(session, args);
+
+        private void OnSessionDisconnected(ISession session, DisconnectEventArgs args)
+        {
+            if (!_sessionActivitySubscriptions.TryRemove(session.SessionId, out SessionActivitySubscription? subscription))
+            {
+                return;
+            }
+
+            subscription.DetachSession();
+            _sessionMonitor.RemoveSession(session);
+            try
+            {
+                SessionDisconnected?.Invoke(this, session, args);
+            }
+            finally
+            {
+                session.Dispose();
+            }
         }
 
         private sealed class InboundChannelInitializer(RlpxHost rlpxHost) : ChannelInitializer<IChannel>

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -30,7 +30,7 @@ using LogLevel = DotNetty.Handlers.Logging.LogLevel;
 
 namespace Nethermind.Network.Rlpx
 {
-    public class RlpxHost : IRlpxHost
+    public class RlpxHost : IRlpxHost, ISessionActivityObserver
     {
         private IChannel? _bootstrapChannel;
         private IEventLoopGroup? _bossGroup;
@@ -422,29 +422,48 @@ namespace Nethermind.Network.Rlpx
         {
             private readonly RlpxHost _rlpxHost;
             private readonly ISession _session;
+            private readonly Session? _concreteSession;
             private readonly EventHandler<DisconnectEventArgs> _onDisconnected;
-            private readonly EventHandler<PeerEventArgs> _refreshNodeFilter;
+            private readonly EventHandler<PeerEventArgs>? _refreshNodeFilter;
 
             public SessionActivitySubscription(RlpxHost rlpxHost, ISession session)
             {
                 _rlpxHost = rlpxHost;
                 _session = session;
+                _concreteSession = session as Session;
                 _onDisconnected = OnDisconnected;
-                _refreshNodeFilter = RefreshNodeFilter;
+                if (_concreteSession is null)
+                {
+                    _refreshNodeFilter = RefreshNodeFilter;
+                }
             }
 
             public void Attach()
             {
-                _session.MsgReceived += _refreshNodeFilter;
-                _session.MsgDelivered += _refreshNodeFilter;
+                if (_concreteSession is not null)
+                {
+                    _concreteSession.SetActivityObserver(_rlpxHost);
+                    return;
+                }
+
+                _session.MsgReceived += _refreshNodeFilter!;
+                _session.MsgDelivered += _refreshNodeFilter!;
             }
 
             public void AttachDisconnected() => _session.Disconnected += _onDisconnected;
 
             public void Detach()
             {
-                _session.MsgReceived -= _refreshNodeFilter;
-                _session.MsgDelivered -= _refreshNodeFilter;
+                if (_concreteSession is not null)
+                {
+                    _concreteSession.SetActivityObserver(null);
+                }
+                else
+                {
+                    _session.MsgReceived -= _refreshNodeFilter!;
+                    _session.MsgDelivered -= _refreshNodeFilter!;
+                }
+
                 _session.Disconnected -= _onDisconnected;
                 _rlpxHost._sessionActivitySubscriptions.TryRemove(_session.SessionId, out _);
             }
@@ -474,6 +493,12 @@ namespace Nethermind.Network.Rlpx
                 Detach();
                 _session.Dispose();
             }
+        }
+
+        void ISessionActivityObserver.OnSessionActivity(Session session)
+        {
+            Node remoteNode = session.Node;
+            _nodeFilter.Touch(remoteNode.Address.Address, remoteNode.IsStatic || remoteNode.IsBootnode);
         }
 
         private sealed class InboundChannelInitializer(RlpxHost rlpxHost) : ChannelInitializer<IChannel>

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -12,7 +12,6 @@ using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
-using Nethermind.Network.P2P.EventArg;
 
 namespace Nethermind.Network
 {
@@ -22,7 +21,6 @@ namespace Nethermind.Network
         private Task _pingTimerTask;
         private readonly INetworkConfig _networkConfig;
         private readonly ILogger _logger;
-        private readonly EventHandler<DisconnectEventArgs> _onDisconnected;
 
         private readonly TimeSpan _pingInterval;
         private readonly List<Task<bool>> _pingTasks = new();
@@ -35,7 +33,6 @@ namespace Nethermind.Network
             _networkConfig = config ?? throw new ArgumentNullException(nameof(config));
 
             _pingInterval = TimeSpan.FromMilliseconds(_networkConfig.P2PPingInterval);
-            _onDisconnected = OnDisconnected;
         }
 
         public void Start() => StartPingTimer();
@@ -47,7 +44,6 @@ namespace Nethermind.Network
 
         public void AddSession(ISession session)
         {
-            session.Disconnected += _onDisconnected;
             if (session.State < SessionState.DisconnectingProtocols)
             {
                 // Stagger ping times so sessions added around the same time don't all ping on the same tick.
@@ -58,12 +54,8 @@ namespace Nethermind.Network
             }
         }
 
-        private void OnDisconnected(object sender, DisconnectEventArgs e)
-        {
-            ISession session = (ISession)sender;
-            session.Disconnected -= _onDisconnected;
+        public void RemoveSession(ISession session) =>
             _sessions.TryRemove(session.SessionId, out session);
-        }
 
         private async Task SendPingMessagesAsync()
         {

--- a/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
@@ -44,11 +44,11 @@ namespace Nethermind.Runner.Test.Module;
 public class NetworkModuleTest
 {
     /// <summary>
-    /// Protocol handlers are IDisposable transients resolved via Autofac Func factories — one
+    /// Protocol handlers are IDisposable transients created by protocol handler factories — one
     /// per peer connection. Their lifetime is owned by Session.Dispose(), not the container.
-    /// If the container tracks them (missing ExternallyOwned), they accumulate on Autofac's
-    /// internal dispose stack for the application lifetime, leaking memory proportional to
-    /// peer churn.
+    /// If handler creation routes through a tracked container registration, they accumulate
+    /// on Autofac's internal dispose stack for the application lifetime, leaking memory
+    /// proportional to peer churn.
     ///
     /// This test resolves every registered handler factory, creates a handler, disposes it,
     /// and verifies the GC can collect it — proving the container does not retain a reference.

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -115,7 +115,7 @@ public class ShutterTxLoader(
         }
 
         using ArrayPoolList<SequencedTransaction> sortedIndexes = sequencedTransactions.ToPooledList();
-        sortedIndexes.Sort((a, b) => Bytes.BytesComparer.Compare(a.IdentityPreimage, b.IdentityPreimage));
+        sortedIndexes.Sort<SequencedTransactionByIdentityPreimageComparer>(default);
 
         using ArrayPoolList<int> sortedKeyIndexes = new(txCount, txCount);
         int keyIndex = 0;
@@ -265,6 +265,13 @@ public class ShutterTxLoader(
         public UInt256 GasLimit;
         public byte[] Identity;
         public byte[] IdentityPreimage;
+    }
+
+    private readonly struct SequencedTransactionByIdentityPreimageComparer : IComparer<SequencedTransaction>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(SequencedTransaction a, SequencedTransaction b) =>
+            Bytes.BytesComparer.Compare(a.IdentityPreimage, b.IdentityPreimage);
     }
 
     private readonly struct DecryptedTransactions : IDisposable

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -267,7 +267,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                     if (account is null)
                     {
                         if (storageRoot == Keccak.EmptyTreeHash) continue;
-                        using IWorldStateScopeProvider.IStorageWriteBatch wb = CreateStorageWriteBatch(entry.Item1, 0);
+                        using IWorldStateScopeProvider.IStorageWriteBatch wb = CreateStorageWriteBatch(key.Value, 0);
                         wb.Clear();
                         continue;
                     }
@@ -276,8 +276,9 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
                     scope._snapshotBundle.SetAccount(key, account);
 
-                    OnAccountUpdated?.Invoke(key, new IWorldStateScopeProvider.AccountUpdated(key, account));
-                    if (logger.IsTrace) Trace(key, storageRoot, account);
+                    Address address = key.Value;
+                    OnAccountUpdated?.Invoke(address, new IWorldStateScopeProvider.AccountUpdated(address, account));
+                    if (logger.IsTrace) Trace(address, storageRoot, account);
                 }
 
                 using StateTree.StateTreeBulkSetter stateSetter = scope._stateTree.BeginSet(_dirtyAccounts.Count);

--- a/src/Nethermind/Nethermind.State/Snap/StorageRange.cs
+++ b/src/Nethermind/Nethermind.State/Snap/StorageRange.cs
@@ -36,7 +36,7 @@ namespace Nethermind.State.Snap
         {
             BlockNumber = BlockNumber,
             RootHash = RootHash,
-            Accounts = Accounts.ToPooledList(Accounts.Count),
+            Accounts = Accounts.AsSpan().ToPooledList(),
             StartingHash = StartingHash,
             LimitHash = LimitHash,
         };

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -156,8 +156,9 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                 if (account is null) continue;
                 account = account.WithChangedStorageRoot(storageRoot);
                 _dirtyAccounts[key] = account;
-                OnAccountUpdated?.Invoke(key, new IWorldStateScopeProvider.AccountUpdated(key, account));
-                if (logger.IsTrace) Trace(key, storageRoot, account);
+                Address address = key.Value;
+                OnAccountUpdated?.Invoke(address, new IWorldStateScopeProvider.AccountUpdated(address, account));
+                if (logger.IsTrace) Trace(address, storageRoot, account);
             }
 
             using (StateTree.StateTreeBulkSetter stateSetter = scope._backingStateTree.BeginSet(_dirtyAccounts.Count))

--- a/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
+++ b/src/Nethermind/Nethermind.StateComposition.Test/Visitors/VisitorCountersTests.cs
@@ -13,9 +13,10 @@ namespace Nethermind.StateComposition.Test.Visitors;
 [TestFixture]
 public class VisitorCountersTests
 {
-    // Mirrors TopNTracker.EntryComparer (which is internal — exposing it through a
-    // public test method signature triggers CS0051). Defined here so TestCaseSource
-    // can dispatch the three CompareBy* method groups through a single typed handle.
+    // Mirrors TopNTracker.IEntryComparer's in-ref signature (the interface itself is
+    // internal — exposing it through a public test method signature triggers CS0051).
+    // Defined here so TestCaseSource can dispatch the four strategy structs through a
+    // single typed handle.
     public delegate int EntryComparer(in TopContractEntry a, in TopContractEntry b);
 
     [Test]
@@ -137,19 +138,19 @@ public class VisitorCountersTests
         yield return new TestCaseData(
             new TopContractEntry { MaxDepth = 10, TotalNodes = 100, ValueNodes = 50 },
             new TopContractEntry { MaxDepth = 10, TotalNodes = 200, ValueNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByDepth)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByDepth).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByDepth");
 
         yield return new TestCaseData(
             new TopContractEntry { TotalNodes = 200, MaxDepth = 5, ValueNodes = 50 },
             new TopContractEntry { TotalNodes = 200, MaxDepth = 10, ValueNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByTotalNodes)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByTotalNodes).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByTotalNodes");
 
         yield return new TestCaseData(
             new TopContractEntry { ValueNodes = 100, MaxDepth = 5, TotalNodes = 50 },
             new TopContractEntry { ValueNodes = 100, MaxDepth = 10, TotalNodes = 50 },
-            (EntryComparer)TopNTracker.CompareByValueNodes)
+            (EntryComparer)((in TopContractEntry a, in TopContractEntry b) => default(TopNTracker.ByValueNodes).Compare(in a, in b)))
             .SetName(nameof(Comparator_DeterministicTiebreaking) + "_ByValueNodes");
     }
 

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -225,10 +225,10 @@ internal sealed class StateCompositionVisitor(
             EmptyAccounts = agg.EmptyAccounts,
             CodeBytesTotal = agg.CodeBytes,
             SlotCountHistogram = ImmutableArray.Create<long>(agg.SlotCountHistogram[..]),
-            TopContractsByDepth = BuildSortedTopN(agg.TopN.TopByDepth, agg.TopN.TopByDepthCount, TopNTracker.CompareByDepth),
-            TopContractsByNodes = BuildSortedTopN(agg.TopN.TopByNodes, agg.TopN.TopByNodesCount, TopNTracker.CompareByTotalNodes),
-            TopContractsByValueNodes = BuildSortedTopN(agg.TopN.TopByValueNodes, agg.TopN.TopByValueNodesCount, TopNTracker.CompareByValueNodes),
-            TopContractsBySize = BuildSortedTopN(agg.TopN.TopBySize, agg.TopN.TopBySizeCount, TopNTracker.CompareBySize),
+            TopContractsByDepth = BuildSortedTopN<TopNTracker.ByDepth>(agg.TopN.TopByDepth, agg.TopN.TopByDepthCount),
+            TopContractsByNodes = BuildSortedTopN<TopNTracker.ByTotalNodes>(agg.TopN.TopByNodes, agg.TopN.TopByNodesCount),
+            TopContractsByValueNodes = BuildSortedTopN<TopNTracker.ByValueNodes>(agg.TopN.TopByValueNodes, agg.TopN.TopByValueNodesCount),
+            TopContractsBySize = BuildSortedTopN<TopNTracker.BySize>(agg.TopN.TopBySize, agg.TopN.TopBySizeCount),
             SlotCountByAddress = agg.SlotCountsByOwner,
             CodeHashSizes = new Dictionary<ValueHash256, int>(_codeHashSizes),
             CodeHashRefcounts = agg.CodeHashRefcounts,
@@ -300,23 +300,19 @@ internal sealed class StateCompositionVisitor(
         return agg;
     }
 
-    private static ImmutableArray<TopContractEntry> BuildSortedTopN(
-        TopContractEntry[] entries, int count, TopNTracker.EntryComparer comparer)
+    // Generic over TComparer so Sort<TComparer> specialises and inlines Compare with no
+    // residual delegate dispatch. Sorts descending directly via Reverse<TComparer> so the
+    // display tier (highest-first) gets the array in one pass.
+    private static ImmutableArray<TopContractEntry> BuildSortedTopN<TComparer>(
+        TopContractEntry[] entries, int count)
+        where TComparer : struct, TopNTracker.IEntryComparer
     {
         if (count == 0)
             return [];
 
         TopContractEntry[] sorted = entries.AsSpan(0, count).ToArray();
-        sorted.AsSpan(0, count).Sort(new ReverseEntryComparer(comparer));
+        sorted.AsSpan().Sort(default(TopNTracker.Reverse<TComparer>));
         return ImmutableCollectionsMarshal.AsImmutableArray(sorted);
-    }
-
-    private readonly struct ReverseEntryComparer(TopNTracker.EntryComparer comparer) : IComparer<TopContractEntry>
-    {
-        private readonly TopNTracker.EntryComparer _comparer = comparer;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Compare(TopContractEntry a, TopContractEntry b) => _comparer(in b, in a);
     }
 
     private static double CalcAvgDepth(ReadOnlySpan<DepthCounter> depths)

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
@@ -306,8 +307,16 @@ internal sealed class StateCompositionVisitor(
             return [];
 
         TopContractEntry[] sorted = entries.AsSpan(0, count).ToArray();
-        Array.Sort(sorted, 0, count, Comparer<TopContractEntry>.Create((a, b) => comparer(b, a)));
-        return System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray(sorted);
+        sorted.AsSpan(0, count).Sort(new ReverseEntryComparer(comparer));
+        return ImmutableCollectionsMarshal.AsImmutableArray(sorted);
+    }
+
+    private readonly struct ReverseEntryComparer(TopNTracker.EntryComparer comparer) : IComparer<TopContractEntry>
+    {
+        private readonly TopNTracker.EntryComparer _comparer = comparer;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => _comparer(in b, in a);
     }
 
     private static double CalcAvgDepth(ReadOnlySpan<DepthCounter> depths)

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/StateCompositionVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.StateComposition/Visitors/TopNTracker.cs
+++ b/src/Nethermind/Nethermind.StateComposition/Visitors/TopNTracker.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Nethermind.Core.Crypto;
 using Nethermind.StateComposition.Data;
 
@@ -18,19 +20,30 @@ internal sealed class TopNTracker(int topN)
     public int TopByValueNodesCount;
     public int TopBySizeCount;
 
-    internal delegate int EntryComparer(in TopContractEntry a, in TopContractEntry b);
+    internal interface IEntryComparer : IComparer<TopContractEntry>
+    {
+        int Compare(in TopContractEntry a, in TopContractEntry b);
+    }
+
+    /// <summary>Reverses the order of an inner strategy. Used to sort top-N display-first.</summary>
+    internal readonly struct Reverse<TInner> : IComparer<TopContractEntry>
+        where TInner : struct, IEntryComparer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => default(TInner).Compare(in b, in a);
+    }
 
     public bool TryInsertDepth(in TopContractEntry entry) =>
-        TryInsert(TopByDepth, ref TopByDepthCount, entry, CompareByDepth);
+        TryInsert<ByDepth>(TopByDepth, ref TopByDepthCount, in entry);
 
     public bool TryInsertNodes(in TopContractEntry entry) =>
-        TryInsert(TopByNodes, ref TopByNodesCount, entry, CompareByTotalNodes);
+        TryInsert<ByTotalNodes>(TopByNodes, ref TopByNodesCount, in entry);
 
     public bool TryInsertValueNodes(in TopContractEntry entry) =>
-        TryInsert(TopByValueNodes, ref TopByValueNodesCount, entry, CompareByValueNodes);
+        TryInsert<ByValueNodes>(TopByValueNodes, ref TopByValueNodesCount, in entry);
 
     public bool TryInsertSize(in TopContractEntry entry) =>
-        TryInsert(TopBySize, ref TopBySizeCount, entry, CompareBySize);
+        TryInsert<BySize>(TopBySize, ref TopBySizeCount, in entry);
 
     public void SetLevelsForOwner(in ValueHash256 owner, ImmutableArray<TrieLevelStat> levels)
     {
@@ -51,68 +64,98 @@ internal sealed class TopNTracker(int topN)
 
     public void MergeFrom(TopNTracker other)
     {
-        MergeTopN(TopByDepth, ref TopByDepthCount, other.TopByDepth, other.TopByDepthCount, CompareByDepth);
-        MergeTopN(TopByNodes, ref TopByNodesCount, other.TopByNodes, other.TopByNodesCount, CompareByTotalNodes);
-        MergeTopN(TopByValueNodes, ref TopByValueNodesCount, other.TopByValueNodes, other.TopByValueNodesCount, CompareByValueNodes);
-        MergeTopN(TopBySize, ref TopBySizeCount, other.TopBySize, other.TopBySizeCount, CompareBySize);
+        MergeTopN<ByDepth>(TopByDepth, ref TopByDepthCount, other.TopByDepth, other.TopByDepthCount);
+        MergeTopN<ByTotalNodes>(TopByNodes, ref TopByNodesCount, other.TopByNodes, other.TopByNodesCount);
+        MergeTopN<ByValueNodes>(TopByValueNodes, ref TopByValueNodesCount, other.TopByValueNodes, other.TopByValueNodesCount);
+        MergeTopN<BySize>(TopBySize, ref TopBySizeCount, other.TopBySize, other.TopBySizeCount);
     }
 
-    private void MergeTopN(TopContractEntry[] target, ref int targetCount,
-        TopContractEntry[] source, int sourceCount, EntryComparer comparer)
+    private void MergeTopN<TComparer>(TopContractEntry[] target, ref int targetCount,
+        TopContractEntry[] source, int sourceCount)
+        where TComparer : struct, IEntryComparer
     {
         for (int i = 0; i < sourceCount; i++)
-            TryInsert(target, ref targetCount, source[i], comparer);
+            TryInsert<TComparer>(target, ref targetCount, in source[i]);
     }
 
     /// <summary>MaxDepth DESC → TotalNodes DESC → ValueNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByDepth(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByDepth : IEntryComparer
     {
-        int c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>TotalNodes DESC → MaxDepth DESC → ValueNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByTotalNodes(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByTotalNodes : IEntryComparer
     {
-        int c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>ValueNodes DESC → MaxDepth DESC → TotalNodes DESC → Owner bytes ASC</summary>
-    internal static int CompareByValueNodes(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct ByValueNodes : IEntryComparer
     {
-        int c = a.ValueNodes.CompareTo(b.ValueNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.ValueNodes.CompareTo(b.ValueNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
     /// <summary>TotalSize DESC → TotalNodes DESC → MaxDepth DESC → Owner bytes ASC</summary>
-    internal static int CompareBySize(in TopContractEntry a, in TopContractEntry b)
+    internal readonly struct BySize : IEntryComparer
     {
-        int c = a.TotalSize.CompareTo(b.TotalSize);
-        if (c != 0) return c;
-        c = a.TotalNodes.CompareTo(b.TotalNodes);
-        if (c != 0) return c;
-        c = a.MaxDepth.CompareTo(b.MaxDepth);
-        if (c != 0) return c;
-        return a.Owner.CompareTo(b.Owner);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(in TopContractEntry a, in TopContractEntry b)
+        {
+            int c = a.TotalSize.CompareTo(b.TotalSize);
+            if (c != 0) return c;
+            c = a.TotalNodes.CompareTo(b.TotalNodes);
+            if (c != 0) return c;
+            c = a.MaxDepth.CompareTo(b.MaxDepth);
+            if (c != 0) return c;
+            return a.Owner.CompareTo(b.Owner);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(TopContractEntry a, TopContractEntry b) => Compare(in a, in b);
     }
 
-    private bool TryInsert(TopContractEntry[] heap, ref int count, in TopContractEntry entry, EntryComparer comparer)
+    private bool TryInsert<TComparer>(TopContractEntry[] heap, ref int count, in TopContractEntry entry)
+        where TComparer : struct, IEntryComparer
     {
         if (count < topN)
         {
@@ -120,14 +163,15 @@ internal sealed class TopNTracker(int topN)
             return true;
         }
 
+        TComparer comparer = default;
         int minIdx = 0;
         for (int i = 1; i < topN; i++)
         {
-            if (comparer(heap[i], heap[minIdx]) < 0)
+            if (comparer.Compare(in heap[i], in heap[minIdx]) < 0)
                 minIdx = i;
         }
 
-        if (comparer(entry, heap[minIdx]) > 0)
+        if (comparer.Compare(in entry, in heap[minIdx]) > 0)
         {
             heap[minIdx] = entry;
             return true;

--- a/src/Nethermind/Nethermind.Stateless.Executor/InputSerializer.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/InputSerializer.cs
@@ -153,15 +153,17 @@ public static class InputSerializer
         if (value.Count == 0)
             return;
 
-        WriteInt32(value.Count, destination, ref offset);
+        ReadOnlySpan<byte[]> valueSpan = value.AsSpan();
+        WriteInt32(valueSpan.Length, destination, ref offset);
 
-        for (int i = 0; i < value.Count; i++)
+        for (int i = 0; i < valueSpan.Length; i++)
         {
-            int len = value[i].Length;
+            byte[] item = valueSpan[i];
+            int len = item.Length;
 
             WriteInt32(len, destination, ref offset);
 
-            value[i].CopyTo(destination.Slice(offset, len));
+            item.CopyTo(destination.Slice(offset, len));
             offset += len;
         }
     }
@@ -172,9 +174,10 @@ public static class InputSerializer
             return 0;
 
         int len = sizeof(int);
+        ReadOnlySpan<byte[]> valueSpan = value.AsSpan();
 
-        for (int i = 0; i < value.Count; i++)
-            len += sizeof(int) + value[i].Length;
+        for (int i = 0; i < valueSpan.Length; i++)
+            len += sizeof(int) + valueSpan[i].Length;
 
         return len;
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -54,7 +54,7 @@ public class SyncedTxGossipPolicyTests
     {
         MutableSelector selector = new(SyncMode.FastSync);
         SyncedTxGossipPolicy syncPolicy = new(selector);
-        CompositeTxGossipPolicy composite = new(new Lazy<ITxGossipPolicy[]>([syncPolicy]));
+        CompositeTxGossipPolicy composite = new(new FixedTxGossipPolicySource([syncPolicy]));
 
         // During sync: gossip disabled
         Assert.That(composite.ShouldListenToGossipedTransactions, Is.False);
@@ -90,5 +90,10 @@ public class SyncedTxGossipPolicyTests
         public Task StopAsync() => Task.CompletedTask;
         public void Update() { }
         public void Dispose() { }
+    }
+
+    private class FixedTxGossipPolicySource(ITxGossipPolicy[] policies) : ITxGossipPolicySource
+    {
+        public ITxGossipPolicy[] Policies => policies;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -259,7 +259,13 @@ namespace Nethermind.Synchronization.Blocks
 
         private void PruneRequestMap(IOwnedReadOnlyList<BlockHeader> currentHeaders)
         {
-            HashSet<Hash256> currentHeaderHashes = currentHeaders.Select(h => h.Hash).ToHashSet();
+            ReadOnlySpan<BlockHeader> currentHeadersSpan = currentHeaders.AsSpan();
+            HashSet<Hash256> currentHeaderHashes = new(currentHeadersSpan.Length);
+            foreach (BlockHeader header in currentHeadersSpan)
+            {
+                currentHeaderHashes.Add(header.Hash);
+            }
+
             foreach (KeyValuePair<Hash256, BlockEntry> kv in _downloadRequests)
             {
                 if (!currentHeaderHashes.Contains(kv.Key))
@@ -285,9 +291,10 @@ namespace Nethermind.Synchronization.Blocks
                 (await _syncPeerPool.EstimateRequestLimit(RequestType.Receipts, EstimatedAllocationStrategy, AllocationContexts.Blocks, cancellation))
                 ?? GethSyncLimits.MaxReceiptFetch;
 
-            BlockHeader parentHeader = headers[0];
-            foreach (BlockHeader blockHeader in headers.Skip(1))
+            BlockHeader parentHeader = headers.AsSpan()[0];
+            for (int i = 1; i < headers.Count; i++)
             {
+                BlockHeader blockHeader = headers.AsSpan()[i];
                 if (parentHeader.Hash != blockHeader.ParentHash)
                 {
                     // Precaution for weird consensus
@@ -378,8 +385,10 @@ namespace Nethermind.Synchronization.Blocks
             try
             {
                 satisfiedEntry = new ArrayPoolList<BlockEntry>(headers.Count);
-                foreach (BlockHeader blockHeader in headers.Skip(1))
+                ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+                for (int i = 1; i < headersSpan.Length; i++)
                 {
+                    BlockHeader? blockHeader = headersSpan[i];
                     if (blockHeader is null) break;
                     if (!_downloadRequests.TryGetValue(blockHeader.Hash, out BlockEntry blockEntry)) break;
                     if (blockEntry.Block is null) break;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -155,38 +155,43 @@ namespace Nethermind.Synchronization.Blocks
 
                 using IOwnedReadOnlyList<BlockHeader?>? headers = await _forwardHeaderProvider.GetBlockHeaders(fastSyncLag, HeaderLookupSize + 1, cancellation);
                 if (cancellation.IsCancellationRequested) return null; // check before every heavy operation
-                if (headers is null || headers.Count <= 1) return null;
-
-                if (_logger.IsTrace) _logger.Trace($"Prepared request from block {headers[0].Number} to {headers[^1].Number}");
-
-                if (previousStartingHeaderNumber == headers[0].Number)
+                bool shouldProcess;
+                bool downloadReceipts;
                 {
-                    // When the block is suggested right between a `NewPayload` and `ForkChoiceUpdatedHandler` the block is not added because it was added already
-                    // by NP, but it still a beacon block because `FCU` has not happened yet. Causing this situation.
-                    if (_logger.IsDebug) _logger.Debug($"Forward header starting block number did not changed from {previousStartingHeaderNumber}.");
-                    return null;
-                }
+                    ReadOnlySpan<BlockHeader?> headersSpan = headers is null ? [] : headers.AsSpan();
+                    if (headersSpan.Length <= 1) return null;
 
-                for (int i = 1; i < headers.Count; i++)
-                {
-                    if (headers[i].Number - 1 != headers[i - 1].Number)
+                    if (_logger.IsTrace) _logger.Trace($"Prepared request from block {headersSpan[0].Number} to {headersSpan[^1].Number}");
+
+                    if (previousStartingHeaderNumber == headersSpan[0].Number)
                     {
-                        if (_logger.IsWarn) _logger.Warn($"Non consecutive header sequence from forward header provider. {headers[i].Number} vs {headers[i - 1].Number + 1}");
+                        // When the block is suggested right between a `NewPayload` and `ForkChoiceUpdatedHandler` the block is not added because it was added already
+                        // by NP, but it still a beacon block because `FCU` has not happened yet. Causing this situation.
+                        if (_logger.IsDebug) _logger.Debug($"Forward header starting block number did not changed from {previousStartingHeaderNumber}.");
                         return null;
                     }
 
-                    if (headers[i].ParentHash != headers[i - 1].Hash)
+                    for (int i = 1; i < headersSpan.Length; i++)
                     {
-                        if (_logger.IsWarn) _logger.Warn($"Unexpected parent hash from forward header provider {headers[i].ParentHash} vs {headers[i - 1].Hash}");
-                        return null;
+                        if (headersSpan[i].Number - 1 != headersSpan[i - 1].Number)
+                        {
+                            if (_logger.IsWarn) _logger.Warn($"Non consecutive header sequence from forward header provider. {headersSpan[i].Number} vs {headersSpan[i - 1].Number + 1}");
+                            return null;
+                        }
+
+                        if (headersSpan[i].ParentHash != headersSpan[i - 1].Hash)
+                        {
+                            if (_logger.IsWarn) _logger.Warn($"Unexpected parent hash from forward header provider {headersSpan[i].ParentHash} vs {headersSpan[i - 1].Hash}");
+                            return null;
+                        }
                     }
+
+                    previousStartingHeaderNumber = headersSpan[0].Number;
+
+                    (shouldProcess, downloadReceipts) = ReceiptEdgeCase(bestProcessedBlock, headersSpan[1].Number, originalShouldProcess, originalDownloadReceiptOpts);
                 }
 
-                previousStartingHeaderNumber = headers[0].Number;
-
-                (bool shouldProcess, bool downloadReceipts) = ReceiptEdgeCase(bestProcessedBlock, headers[1].Number, originalShouldProcess, originalDownloadReceiptOpts);
-
-                using ArrayPoolList<BlockEntry> satisfiedEntry = AssembleSatisfiedEntries(headers, shouldProcess, downloadReceipts);
+                using ArrayPoolList<BlockEntry> satisfiedEntry = AssembleSatisfiedEntries(headers!, shouldProcess, downloadReceipts);
 
                 if (satisfiedEntry.Count == 0)
                 {
@@ -238,7 +243,7 @@ namespace Nethermind.Synchronization.Blocks
                 // or if the `HeaderLookupSize` become smaller significantly.
                 if (_downloadRequests.Count > headers.Count * 2)
                 {
-                    PruneRequestMap(headers);
+                    PruneRequestMap(headers!);
                 }
 
                 if (blocksSynced > 0)
@@ -250,7 +255,7 @@ namespace Nethermind.Synchronization.Blocks
 
                 if (satisfiedEntry.Count == 0) // Nothing left to process
                 {
-                    return await AssembleRequest(headers, shouldProcess, downloadReceipts, cancellation);
+                    return await AssembleRequest(headers!, shouldProcess, downloadReceipts, cancellation);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -296,10 +295,11 @@ namespace Nethermind.Synchronization.Blocks
                 (await _syncPeerPool.EstimateRequestLimit(RequestType.Receipts, EstimatedAllocationStrategy, AllocationContexts.Blocks, cancellation))
                 ?? GethSyncLimits.MaxReceiptFetch;
 
-            BlockHeader parentHeader = headers.AsSpan()[0];
-            for (int i = 1; i < headers.Count; i++)
+            int headersCount = headers.Count;
+            BlockHeader parentHeader = headers[0];
+            for (int i = 1; i < headersCount; i++)
             {
-                BlockHeader blockHeader = headers.AsSpan()[i];
+                BlockHeader blockHeader = headers[i];
                 if (parentHeader.Hash != blockHeader.ParentHash)
                 {
                     // Precaution for weird consensus

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/MultiBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/MultiBlockDownloader.cs
@@ -50,10 +50,11 @@ public class MultiBlockDownloader : ISyncDownloader<BlocksRequest>
 
     private static ArrayPoolList<Hash256> BuildHashList(IOwnedReadOnlyList<BlockHeader> headers)
     {
-        ArrayPoolList<Hash256> hashes = new(headers.Count);
-        for (int i = 0; i < headers.Count; i++)
+        ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
+        ArrayPoolList<Hash256> hashes = new(headersSpan.Length);
+        for (int i = 0; i < headersSpan.Length; i++)
         {
-            hashes.Add(headers[i].Hash!);
+            hashes.Add(headersSpan[i].Hash!);
         }
 
         return hashes;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/MultiBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/MultiBlockDownloader.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -71,14 +71,16 @@ public class PowForwardHeaderProvider(
         IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
         if (headers is not null)
         {
-            if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headers[0].ToString(BlockHeader.Format.Short)} to {headers[^1].ToString(BlockHeader.Format.Short)}");
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
             return headers;
         }
 
         headers = await GetBlockHeaders(peerInfo, skipLastN, maxHeaders, cancellation);
         if (headers is not null)
         {
-            if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headers.Count} header from {headers[0].ToString(BlockHeader.Format.Short)} to {headers[^1].ToString(BlockHeader.Format.Short)}");
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headersSpan.Length} header from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
         }
         else
         {
@@ -86,24 +88,26 @@ public class PowForwardHeaderProvider(
             _currentBestPeer = null;
         }
 
-        if (headers is not null && headers?.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.ToPooledList(headers.Count);
+        if (headers is not null && headers.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.AsSpan().ToPooledList();
         return headers;
     }, _bestPeerAllocationStrategy, AllocationContexts.ForwardHeader, cancellation);
 
     private IOwnedReadOnlyList<BlockHeader>? AssembleResponseFromLastResponseBatch()
     {
-        if (LastResponseBatch is null) return null;
+        IOwnedReadOnlyList<BlockHeader>? lastResponseBatch = LastResponseBatch;
+        if (lastResponseBatch is null) return null;
 
         long currentNumber = _currentNumber;
         bool sameFound = false;
         ArrayPoolList<BlockHeader>? newResponse = null;
-        for (int i = 0; i < LastResponseBatch.Count; i++)
+        ReadOnlySpan<BlockHeader> lastResponseBatchSpan = lastResponseBatch.AsSpan();
+        for (int i = 0; i < lastResponseBatchSpan.Length; i++)
         {
-            if (!sameFound && LastResponseBatch[i].Number != currentNumber) continue;
+            if (!sameFound && lastResponseBatchSpan[i].Number != currentNumber) continue;
             sameFound = true;
 
-            newResponse ??= new ArrayPoolList<BlockHeader>(LastResponseBatch.Count - i);
-            newResponse.Add(LastResponseBatch[i]);
+            newResponse ??= new ArrayPoolList<BlockHeader>(lastResponseBatchSpan.Length - i);
+            newResponse.Add(lastResponseBatchSpan[i]);
         }
 
         if (newResponse is null || newResponse.Count <= MinCachedHeaderBatchSize)
@@ -114,7 +118,7 @@ public class PowForwardHeaderProvider(
         }
 
         LastResponseBatch = newResponse;
-        return newResponse.ToPooledList(newResponse.Count);
+        return newResponse.AsSpan().ToPooledList();
     }
 
     private void OnNewBestPeer(PeerInfo newBestPeer)
@@ -156,15 +160,19 @@ public class PowForwardHeaderProvider(
             {
                 IOwnedReadOnlyList<BlockHeader>? headers =
                     await RequestHeaders(bestPeer, cancellation, _currentNumber, headersToRequest);
-                if (headers.Count < 2)
-                {
-                    // Peer doesn't have a new header
-                    headers.Dispose();
-                    return null;
-                }
 
-                // Remember, we start downloading from currentNumber+1
-                if (!CheckAncestorJump(bestPeer, headers[0], ref _currentNumber)) continue;
+                {
+                    ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
+                    if (headersSpan.Length < 2)
+                    {
+                        // Peer doesn't have a new header
+                        headers.Dispose();
+                        return null;
+                    }
+
+                    // Remember, we start downloading from currentNumber+1
+                    if (!CheckAncestorJump(bestPeer, headersSpan[0], ref _currentNumber)) continue;
+                }
 
                 return headers;
             }
@@ -221,15 +229,15 @@ public class PowForwardHeaderProvider(
         headers = FilterPosHeader(headers);
 
         ValidateSeals(headers, cancellation);
-        ValidateBatchConsistency(peer, headers);
+        ValidateBatchConsistency(peer, headers.AsSpan());
         return headers;
     }
 
-    private void ValidateBatchConsistency(PeerInfo bestPeer, IReadOnlyList<BlockHeader?> headers)
+    private void ValidateBatchConsistency(PeerInfo bestPeer, ReadOnlySpan<BlockHeader> headers)
     {
         // in the past (version 1.11) and possibly now too Parity was sending non canonical blocks in responses
         // so we need to confirm that the blocks form a valid subchain
-        for (int i = 1; i < headers.Count; i++)
+        for (int i = 1; i < headers.Length; i++)
         {
             if (headers[i] is not null && headers[i]?.ParentHash != headers[i - 1]?.Hash)
             {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncFeed.cs
@@ -533,10 +533,9 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncBatch dependentBatch = new();
             dependentBatch.StartNumber = addedEarliest;
             int count = (int)(addedLast - addedEarliest + 1);
+            ReadOnlySpan<BlockHeader?> response = batch.Response!.AsSpan();
             dependentBatch.RequestSize = count;
-            dependentBatch.Response = batch.Response!
-                .Skip((int)(addedEarliest - batch.StartNumber))
-                .Take(count).ToPooledList(count);
+            dependentBatch.Response = response.Slice((int)(addedEarliest - batch.StartNumber), count).ToPooledList();
             dependentBatch.ResponseSourcePeer = batch.ResponseSourcePeer;
             return dependentBatch;
         }
@@ -570,9 +569,10 @@ namespace Nethermind.Synchronization.FastBlocks
             if (headers.Count == 0) return batch;
 
             int newRequestSize = batch.RequestSize - headers.Count;
+            ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
             using HeadersSyncBatch newBatchToProcess = new();
-            newBatchToProcess.StartNumber = headers[0].Number;
-            newBatchToProcess.RequestSize = headers.Count;
+            newBatchToProcess.StartNumber = headersSpan[0].Number;
+            newBatchToProcess.RequestSize = headersSpan.Length;
             newBatchToProcess.Response = headers;
             if (_logger.IsDebug) _logger.Debug($"Handling header portion {newBatchToProcess.StartNumber} to {newBatchToProcess.EndNumber} with persisted headers.");
             InsertHeaders(newBatchToProcess);
@@ -593,32 +593,33 @@ namespace Nethermind.Synchronization.FastBlocks
                 return 0;
             }
 
-            if (batch.Response.Count > batch.RequestSize)
+            ReadOnlySpan<BlockHeader?> response = batch.Response.AsSpan();
+            if (response.Length > batch.RequestSize)
             {
                 if (_logger.IsDebug)
-                    _logger.Debug($"Peer sent too long response ({batch.Response.Count}) to {batch}");
+                    _logger.Debug($"Peer sent too long response ({response.Length}) to {batch}");
                 if (batch.ResponseSourcePeer is not null)
                 {
                     _syncPeerPool.ReportBreachOfProtocol(
                         batch.ResponseSourcePeer,
                         DisconnectReason.HeaderResponseTooLong,
-                        $"response too long ({batch.Response.Count})");
+                        $"response too long ({response.Length})");
                 }
 
                 EnqueueBatch(batch);
                 return 0;
             }
 
-            using ArrayPoolList<BlockHeader> headersToAdd = new(batch.Response.Count);
+            using ArrayPoolList<BlockHeader> headersToAdd = new(response.Length);
             (Hash256 nextHeaderHash, UInt256? nextHeaderTotalDifficulty) = _expectedNextHeader;
 
             long addedLast = batch.StartNumber - 1;
             long addedEarliest = batch.EndNumber + 1;
             BlockHeader? lowestInsertedHeader = null;
             int skippedAtTheEnd = 0;
-            for (int i = batch.Response.Count - 1; i >= 0; i--)
+            for (int i = response.Length - 1; i >= 0; i--)
             {
-                BlockHeader? header = batch.Response[i];
+                BlockHeader? header = response[i];
                 if (header is null)
                 {
                     skippedAtTheEnd++;
@@ -638,14 +639,14 @@ namespace Nethermind.Synchronization.FastBlocks
                     break;
                 }
 
-                bool isFirst = i == batch.Response.Count - 1 - skippedAtTheEnd;
+                bool isFirst = i == response.Length - 1 - skippedAtTheEnd;
                 if (isFirst)
                 {
-                    if (!ValidateFirstHeader(header)) break;
+                    if (!ValidateFirstHeader(header, response)) break;
                 }
                 else
                 {
-                    if (header.Hash != batch.Response[i + 1]?.ParentHash)
+                    if (header.Hash != response[i + 1]?.ParentHash)
                     {
                         if (batch.ResponseSourcePeer is not null)
                         {
@@ -740,7 +741,7 @@ namespace Nethermind.Synchronization.FastBlocks
             return added;
 
             // Well, its the last in the batch, but first processed.
-            bool ValidateFirstHeader(BlockHeader header)
+            bool ValidateFirstHeader(BlockHeader header, ReadOnlySpan<BlockHeader?> response)
             {
                 BlockHeader lowestInserted = LowestInsertedBlockHeader;
                 // response does not carry expected data
@@ -806,9 +807,9 @@ namespace Nethermind.Synchronization.FastBlocks
                         return false;
                     }
                     long lastNumber = -1;
-                    for (int j = 0; j < batch.Response.Count; j++)
+                    for (int j = 0; j < response.Length; j++)
                     {
-                        BlockHeader? current = batch.Response[j];
+                        BlockHeader? current = response[j];
                         if (current is not null)
                         {
                             if (lastNumber != -1 && lastNumber < current.Number - 1)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -186,7 +186,8 @@ namespace Nethermind.Synchronization.Peers
                     AllocationContexts.Headers,
                     token);
 
-                return headers?.Count == 1 ? headers[0] : null;
+                ReadOnlySpan<BlockHeader> headersSpan = headers?.AsSpan() ?? [];
+                return headersSpan.Length == 1 ? headersSpan[0] : null;
             }
 
             static async Task<BlockHeader?> FetchHeader(PeerInfo peer, Hash256 headerHash, CancellationToken token)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -186,7 +186,7 @@ namespace Nethermind.Synchronization.Peers
                     AllocationContexts.Headers,
                     token);
 
-                ReadOnlySpan<BlockHeader> headersSpan = headers?.AsSpan() ?? [];
+                ReadOnlySpan<BlockHeader> headersSpan = headers is null ? [] : headers.AsSpan();
                 return headersSpan.Length == 1 ? headersSpan[0] : null;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -310,7 +310,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             if (accountsToRefreshRequest is not null)
             {
-                foreach (AccountWithStorageStartingHash path in accountsToRefreshRequest.Paths)
+                foreach (AccountWithStorageStartingHash path in accountsToRefreshRequest.Paths.AsSpan())
                 {
                     AccountsToRefresh.Enqueue(path);
                 }
@@ -340,6 +340,16 @@ namespace Nethermind.Synchronization.SnapSync
             Interlocked.Add(ref _activeStorageRequests, -originalStorageCount);
         }
 
+        public void ReportFullStorageRequestFinished(int originalStorageCount, ReadOnlySpan<PathWithAccount> storages)
+        {
+            foreach (PathWithAccount pathWithAccount in storages)
+            {
+                EnqueueAccountStorage(pathWithAccount);
+            }
+
+            Interlocked.Add(ref _activeStorageRequests, -originalStorageCount);
+        }
+
         public void EnqueueNextSlot(StorageRange? storageRange)
         {
             if (storageRange is not null)
@@ -355,7 +365,7 @@ namespace Nethermind.Synchronization.SnapSync
                 return;
 
             ValueHash256? startingHash = parentRequest.StartingHash;
-            PathWithAccount account = parentRequest.Accounts[accountIndex];
+            PathWithAccount account = parentRequest.Accounts.AsSpan()[accountIndex];
             UInt256 limit = new(limitHash.Bytes, true);
             UInt256 lastProcessed = new(lastProcessedHash.Bytes, true);
             UInt256 start = startingHash.HasValue ? new UInt256(startingHash.Value.Bytes, true) : UInt256.Zero;
@@ -412,7 +422,7 @@ namespace Nethermind.Synchronization.SnapSync
             }
             else
             {
-                foreach (PathWithAccount account in storageRange.Accounts)
+                foreach (PathWithAccount account in storageRange.Accounts.AsSpan())
                 {
                     EnqueueAccountStorage(account);
                 }
@@ -580,7 +590,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             if (item.Accounts.Count == 1)
             {
-                _largeStorageProgress.AddOrUpdate(item.Accounts[0].Path,
+                _largeStorageProgress.AddOrUpdate(item.Accounts.AsSpan()[0].Path,
                     (key, progress) => new LargeProgressStatus().UpdateProgress(progress),
                     (key, progress, range) => progress.UpdateProgress(range),
                     item

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -126,8 +126,8 @@ namespace Nethermind.Synchronization.SnapSync
         {
             AddRangeResult result = AddRangeResult.OK;
 
-            IReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> responses = response.PathsAndSlots;
-            if (responses.Count == 0 && response.Proofs.Count == 0)
+            ReadOnlySpan<IOwnedReadOnlyList<PathWithStorageSlot>> responses = response.PathsAndSlots.AsSpan();
+            if (responses.Length == 0 && response.Proofs.Count == 0)
             {
                 _logger.Trace($"SNAP - GetStorageRange - expired BlockNumber:{request.BlockNumber}, RootHash:{request.RootHash}, (Accounts:{request.Accounts.Count}), {request.StartingHash}");
 
@@ -142,11 +142,11 @@ namespace Nethermind.Synchronization.SnapSync
 
                 int requestLength = request.Accounts.Count;
 
-                for (int i = 0; i < responses.Count; i++)
+                for (int i = 0; i < responses.Length; i++)
                 {
                     // only the last can have proofs
                     IByteArrayList proofs = null;
-                    if (i == responses.Count - 1)
+                    if (i == responses.Length - 1)
                     {
                         proofs = response.Proofs;
                     }
@@ -157,9 +157,9 @@ namespace Nethermind.Synchronization.SnapSync
                     slotCount += responses[i].Count;
                 }
 
-                if (requestLength > responses.Count)
+                if (requestLength > responses.Length)
                 {
-                    _progressTracker.ReportFullStorageRequestFinished(requestLength, request.Accounts.Skip(responses.Count));
+                    _progressTracker.ReportFullStorageRequestFinished(requestLength, request.Accounts.AsSpan()[responses.Length..]);
                 }
                 else
                 {
@@ -178,7 +178,8 @@ namespace Nethermind.Synchronization.SnapSync
 
         public AddRangeResult AddStorageRangeForAccount(StorageRange request, int accountIndex, IReadOnlyList<PathWithStorageSlot> slots, IByteArrayList? proofs = null)
         {
-            PathWithAccount pathWithAccount = request.Accounts[accountIndex];
+            ReadOnlySpan<PathWithAccount> accounts = request.Accounts.AsSpan();
+            PathWithAccount pathWithAccount = accounts[accountIndex];
 
             try
             {
@@ -199,7 +200,7 @@ namespace Nethermind.Synchronization.SnapSync
                         // Sometimes the stitching does not work. Likely because part of the storage is using different
                         // pivot, sometimes the proof is in a form that we cannot cleanly verify if it should persist or not,
                         // but also because of stitching bug. So we just force trigger healing and continue on with our lives.
-                        _progressTracker.TrackAccountToHeal(request.Accounts[accountIndex].Path);
+                        _progressTracker.TrackAccountToHeal(accounts[accountIndex].Path);
                     }
 
                     return result;
@@ -236,9 +237,10 @@ namespace Nethermind.Synchronization.SnapSync
         public void RefreshAccounts(AccountsToRefreshRequest request, IByteArrayList response)
         {
             int respLength = response.Count;
-            for (int reqIndex = 0; reqIndex < request.Paths.Count; reqIndex++)
+            ReadOnlySpan<AccountWithStorageStartingHash> paths = request.Paths.AsSpan();
+            for (int reqIndex = 0; reqIndex < paths.Length; reqIndex++)
             {
-                AccountWithStorageStartingHash requestedPath = request.Paths[reqIndex];
+                AccountWithStorageStartingHash requestedPath = paths[reqIndex];
 
                 if (reqIndex < respLength)
                 {

--- a/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
@@ -117,12 +117,13 @@ public class SnapRangeRecovery(ISyncPeerPool peerPool, ILogManager logManager) :
                 return null;
             }
 
+            ReadOnlySpan<PathWithAccount> pathAndAccounts = acc.PathAndAccounts.AsSpan();
             byte[] accountRlp = [];
             ValueHash256 slotPath = default;
-            if (acc.PathAndAccounts.Count > 0)
+            if (pathAndAccounts.Length > 0)
             {
-                accountRlp = _accountDecoder.Encode(acc.PathAndAccounts[0].Account).Bytes;
-                slotPath = acc.PathAndAccounts[0].Path;
+                accountRlp = _accountDecoder.Encode(pathAndAccounts[0].Account).Bytes;
+                slotPath = pathAndAccounts[0].Path;
             }
 
             return AssembleResponse(startingNodeHash, startingPath, slotPath, accountRlp, acc.Proofs);
@@ -144,7 +145,9 @@ public class SnapRangeRecovery(ISyncPeerPool peerPool, ILogManager logManager) :
             };
 
             SlotsAndProofs res = await snapProtocol.GetStorageRange(storageRange, cancellationToken);
-            if ((res.PathsAndSlots.Count == 0 || res.PathsAndSlots[0].Count == 0) && res.Proofs.Count == 0)
+            ReadOnlySpan<IOwnedReadOnlyList<PathWithStorageSlot>> pathsAndSlots = res.PathsAndSlots.AsSpan();
+            ReadOnlySpan<PathWithStorageSlot> firstSlots = pathsAndSlots.Length == 0 ? [] : pathsAndSlots[0].AsSpan();
+            if ((pathsAndSlots.Length == 0 || firstSlots.Length == 0) && res.Proofs.Count == 0)
             {
                 if (_logger.IsWarn) _logger.Warn($"Did not receive any path from {peer}. {res.Proofs.Count}");
                 return null;
@@ -152,10 +155,10 @@ public class SnapRangeRecovery(ISyncPeerPool peerPool, ILogManager logManager) :
 
             byte[] slotRlp = [];
             ValueHash256 slotPath = default;
-            if (res.PathsAndSlots.Count > 0 && res.PathsAndSlots[0].Count > 0)
+            if (firstSlots.Length > 0)
             {
-                slotRlp = res.PathsAndSlots[0][0].SlotRlpValue;
-                slotPath = res.PathsAndSlots[0][0].Path;
+                slotRlp = firstSlots[0].SlotRlpValue;
+                slotPath = firstSlots[0].Path;
             }
 
             return AssembleResponse(startingNodeHash, startingPath, slotPath, slotRlp, res.Proofs);

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -232,7 +233,7 @@ public class BatchedTrieVisitor<TNodeContext>
             // Sort by level
             if (_activeJobs > _targetCurrentItems)
             {
-                preSort.AsSpan().Sort(static (item1, item2) => item1.Context.Level.CompareTo(item2.Context.Level) * -1);
+                preSort.Sort<JobByLevelDescendingComparer>(default);
             }
 
             int endIdx = Math.Min(_maxBatchSize, preSort.Count);
@@ -331,9 +332,7 @@ public class BatchedTrieVisitor<TNodeContext>
                     // This innocent looking sort is surprisingly effective when batch size is large enough. The sort itself
                     // take about 0.1% of the time, so not very cpu intensive in this case.
                     resolveOrdering
-                        .AsSpan()
-                        .Sort((item1, item2) =>
-                            currentBatch[item1].Item1.Keccak.CompareTo(currentBatch[item2].Item1.Keccak));
+                        .Sort(new BatchKeccakAscendingComparer(currentBatch.UnsafeGetInternalArray()));
 
                     ReadFlags flags = ReadFlags.None;
                     if (resolveOrdering.Count > _readAheadThreshold)
@@ -490,6 +489,22 @@ public class BatchedTrieVisitor<TNodeContext>
         public readonly ValueHash256 Key = key;
         public readonly TNodeContext NodeContext = nodeContext;
         public readonly SmallTrieVisitContext Context = context;
+    }
+
+    private readonly struct JobByLevelDescendingComparer : IComparer<Job>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(Job item1, Job item2) => item2.Context.Level.CompareTo(item1.Context.Level);
+    }
+
+    private readonly struct BatchKeccakAscendingComparer(
+        (TrieNode, TNodeContext, SmallTrieVisitContext)[] items) : IComparer<int>
+    {
+        private readonly (TrieNode, TNodeContext, SmallTrieVisitContext)[] _items = items;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(int item1, int item2) =>
+            _items[item1].Item1.Keccak.CompareTo(_items[item2].Item1.Keccak);
     }
 }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -331,6 +331,9 @@ public class BatchedTrieVisitor<TNodeContext>
 
                     // This innocent looking sort is surprisingly effective when batch size is large enough. The sort itself
                     // take about 0.1% of the time, so not very cpu intensive in this case.
+                    // Safe: resolveOrdering only contains indices in [0, currentBatch.Count) (populated in the loop
+                    // above), and currentBatch is not mutated for the duration of the sort, so the backing array
+                    // reference is stable and every lookup stays in-bounds.
                     resolveOrdering
                         .Sort(new BatchKeccakAscendingComparer(currentBatch.UnsafeGetInternalArray()));
 

--- a/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Logging;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -205,7 +206,7 @@ public class RetryCacheTests
         TestHandler staleHandler = new();
 
         bag.TryAdd(handler1, 8);
-        Assert.That(bag.Drain(), Has.Length.EqualTo(1));
+        Assert.That(DrainToList(bag), Has.Count.EqualTo(1));
 
         // Bag is now inactive (drained). Simulate pool return + reuse.
         bag.Reset();
@@ -221,8 +222,8 @@ public class RetryCacheTests
         bool addedAfterReactivation = bag.TryAdd(staleHandler, 8);
         Assert.That(addedAfterReactivation, Is.True);
 
-        IMessageHandler<ResourceRequestMessage>[] handlers = bag.Drain();
-        Assert.That(handlers, Has.Length.EqualTo(1));
+        List<IMessageHandler<ResourceRequestMessage>> handlers = DrainToList(bag);
+        Assert.That(handlers, Has.Count.EqualTo(1));
         Assert.That(handlers[0], Is.SameAs(staleHandler));
     }
 
@@ -233,7 +234,7 @@ public class RetryCacheTests
         bag.Activate();
 
         bag.TryAdd(new TestHandler(), 8);
-        bag.Drain();
+        DrainToList(bag);
 
         // Bag is inactive after drain — TryAdd must be rejected
         bool added = bag.TryAdd(new TestHandler(), 8);
@@ -264,8 +265,8 @@ public class RetryCacheTests
         Assert.That(bag.TryAdd(handler, 8), Is.True);
         Assert.That(bag.TryAdd(handler, 8), Is.False);
 
-        IMessageHandler<ResourceRequestMessage>[] handlers = bag.Drain();
-        Assert.That(handlers, Has.Length.EqualTo(1));
+        List<IMessageHandler<ResourceRequestMessage>> handlers = DrainToList(bag);
+        Assert.That(handlers, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -278,5 +279,18 @@ public class RetryCacheTests
         _cache.Announced(42, retryHandler);
 
         Assert.That(() => receivedResourceId, Is.EqualTo(42).After(AssertTimeoutMs, 100));
+    }
+
+    private static List<IMessageHandler<ResourceRequestMessage>> DrainToList(HandlerBag<ResourceRequestMessage> bag)
+    {
+        List<IMessageHandler<ResourceRequestMessage>> handlers = new();
+        HandlerCollector collector = new(handlers);
+        bag.Drain(ref collector);
+        return handlers;
+    }
+
+    private readonly struct HandlerCollector(List<IMessageHandler<ResourceRequestMessage>> handlers) : IHandlerBagDrainProcessor<ResourceRequestMessage>
+    {
+        public void Process(IMessageHandler<ResourceRequestMessage> handler) => handlers.Add(handler);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core.Collections;
@@ -138,12 +137,18 @@ namespace Nethermind.TxPool.Collections
         {
             using McsLock.Disposable lockRelease = Lock.Acquire();
 
-            IEnumerable<KeyValuePair<TGroupKey, EnhancedSortedSet<TValue>>> buckets = _buckets;
-            if (where is not null)
+            Dictionary<TGroupKey, TValue[]> snapshots = new(_buckets.Count);
+            foreach ((TGroupKey key, EnhancedSortedSet<TValue> bucket) in _buckets)
             {
-                buckets = buckets.Where(kvp => kvp.Value.Count > 0 && where.Invoke((kvp.Key, kvp.Value.Min!)));
+                if (where is not null && (bucket.Count == 0 || !where.Invoke((key, bucket.Min!))))
+                {
+                    continue;
+                }
+
+                snapshots[key] = CopyBucketToArray(bucket);
             }
-            return buckets.ToDictionary(g => g.Key, g => g.Value.ToArray());
+
+            return snapshots;
         }
 
         /// <summary>
@@ -154,7 +159,19 @@ namespace Nethermind.TxPool.Collections
             using McsLock.Disposable lockRelease = Lock.Acquire();
 
             ArgumentNullException.ThrowIfNull(group);
-            return _buckets.TryGetValue(group, out EnhancedSortedSet<TValue>? bucket) ? bucket.ToArray() : [];
+            return _buckets.TryGetValue(group, out EnhancedSortedSet<TValue>? bucket) ? CopyBucketToArray(bucket) : [];
+        }
+
+        private static TValue[] CopyBucketToArray(EnhancedSortedSet<TValue> bucket)
+        {
+            TValue[] snapshot = new TValue[bucket.Count];
+            int index = 0;
+            foreach (TValue value in bucket)
+            {
+                snapshot[index++] = value;
+            }
+
+            return snapshot;
         }
 
         /// <summary>
@@ -310,8 +327,12 @@ namespace Nethermind.TxPool.Collections
                     list.Add(enumerator.Current);
                 }
 
-                return list ?? Enumerable.Empty<TValue>();
+                if (list is not null)
+                {
+                    return list;
+                }
             }
+
             return [];
         }
 
@@ -505,7 +526,7 @@ namespace Nethermind.TxPool.Collections
 
             if (_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
             {
-                items = bucket.ToArray();
+                items = CopyBucketToArray(bucket);
                 return true;
             }
 
@@ -530,8 +551,20 @@ namespace Nethermind.TxPool.Collections
         public bool BucketAny(TGroupKey groupKey, Func<TValue, bool> predicate)
         {
             using McsLock.Disposable lockRelease = Lock.Acquire();
-            return _buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket)
-                && bucket.Any(predicate);
+            if (!_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
+            {
+                return false;
+            }
+
+            foreach (TValue value in bucket)
+            {
+                if (predicate(value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         protected void EnsureCapacity(int? expectedCapacity = null)

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -126,7 +126,7 @@ namespace Nethermind.TxPool.Collections
                 }
             }
 
-            _snapshot = snapshot;
+            Volatile.Write(ref _snapshot, snapshot);
             return snapshot;
         }
 
@@ -287,7 +287,7 @@ namespace Nethermind.TxPool.Collections
                         UpdateSortedValues(bucketSet, last);
                     }
 
-                    _snapshot = null;
+                    Volatile.Write(ref _snapshot, null);
                     return true;
                 }
             }
@@ -463,7 +463,7 @@ namespace Nethermind.TxPool.Collections
                 _cacheMap[key] = value;
                 UpdateIsFull();
                 UpdateSortedValues(bucket, last);
-                _snapshot = null;
+                Volatile.Write(ref _snapshot, null);
                 Inserted?.Invoke(this, new SortedPoolEventArgs(key, value));
                 return true;
             }
@@ -499,7 +499,7 @@ namespace Nethermind.TxPool.Collections
             if (_cacheMap.Remove(key, out value))
             {
                 UpdateIsFull();
-                _snapshot = null;
+                Volatile.Write(ref _snapshot, null);
                 return true;
             }
 

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 
 namespace Nethermind.TxPool;
@@ -13,16 +12,21 @@ public interface ITxGossipPolicy
     bool ShouldGossipTransaction(Transaction tx) => true;
 }
 
-// Lazy: resolving ITxGossipPolicy[] eagerly pulls in the sync infrastructure
-// (SyncedTxGossipPolicy → ISyncModeSelector → ...) which depends on services
-// not yet available during init step construction.
-public class CompositeTxGossipPolicy(Lazy<ITxGossipPolicy[]> policies) : ITxGossipPolicy
+public interface ITxGossipPolicySource
+{
+    ITxGossipPolicy[] Policies { get; }
+}
+
+// The source is deliberately lazy: resolving ITxGossipPolicy[] eagerly pulls in the sync infrastructure
+// (SyncedTxGossipPolicy -> ISyncModeSelector -> ...) which depends on services not yet available during
+// init step construction.
+public class CompositeTxGossipPolicy(ITxGossipPolicySource policySource) : ITxGossipPolicy
 {
     public bool ShouldListenToGossipedTransactions
     {
         get
         {
-            ITxGossipPolicy[] policy = policies.Value;
+            ITxGossipPolicy[] policy = policySource.Policies;
             for (int i = 0; i < policy.Length; i++)
             {
                 if (!policy[i].ShouldListenToGossipedTransactions)
@@ -36,7 +40,7 @@ public class CompositeTxGossipPolicy(Lazy<ITxGossipPolicy[]> policies) : ITxGoss
     {
         get
         {
-            ITxGossipPolicy[] policy = policies.Value;
+            ITxGossipPolicy[] policy = policySource.Policies;
             for (int i = 0; i < policy.Length; i++)
             {
                 if (!policy[i].CanGossipTransactions)
@@ -48,7 +52,7 @@ public class CompositeTxGossipPolicy(Lazy<ITxGossipPolicy[]> policies) : ITxGoss
 
     public bool ShouldGossipTransaction(Transaction tx)
     {
-        ITxGossipPolicy[] policy = policies.Value;
+        ITxGossipPolicy[] policy = policySource.Policies;
         for (int i = 0; i < policy.Length; i++)
         {
             if (!policy[i].ShouldGossipTransaction(tx))

--- a/src/Nethermind/Nethermind.TxPool/RetryCache.cs
+++ b/src/Nethermind/Nethermind.TxPool/RetryCache.cs
@@ -61,27 +61,8 @@ public sealed class RetryCache<TMessage, TResourceId> : IAsyncDisposable
                             {
                                 try
                                 {
-                                    bool set = false;
-
-                                    foreach (IMessageHandler<TMessage> retryHandler in bag.Drain())
-                                    {
-                                        if (!set)
-                                        {
-                                            _requestingResources.Set(item.ResourceId);
-                                            set = true;
-
-                                            if (_logger.IsTrace) _logger.Trace($"Sending retry requests for {item.ResourceId} after timeout");
-                                        }
-
-                                        try
-                                        {
-                                            retryHandler.HandleMessage(TMessage.New(item.ResourceId));
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            _logger.TraceError($"Failed to send retry request to {retryHandler} for {item.ResourceId}", ex);
-                                        }
-                                    }
+                                    RetryRequestSender sender = new(this, item.ResourceId);
+                                    bag.Drain(ref sender);
                                 }
                                 finally
                                 {
@@ -199,6 +180,31 @@ public sealed class RetryCache<TMessage, TResourceId> : IAsyncDisposable
 
         Clear();
     }
+
+    private struct RetryRequestSender(RetryCache<TMessage, TResourceId> cache, TResourceId resourceId) : IHandlerBagDrainProcessor<TMessage>
+    {
+        private bool _requestingResourceSet;
+
+        public void Process(IMessageHandler<TMessage> retryHandler)
+        {
+            if (!_requestingResourceSet)
+            {
+                cache._requestingResources.Set(resourceId);
+                _requestingResourceSet = true;
+
+                if (cache._logger.IsTrace) cache._logger.Trace($"Sending retry requests for {resourceId} after timeout");
+            }
+
+            try
+            {
+                retryHandler.HandleMessage(TMessage.New(resourceId));
+            }
+            catch (Exception ex)
+            {
+                cache._logger.TraceError($"Failed to send retry request to {retryHandler} for {resourceId}", ex);
+            }
+        }
+    }
 }
 
 public enum AnnounceResult
@@ -270,21 +276,27 @@ internal sealed class HandlerBag<TMessage>
     }
 
     /// <summary>
-    /// Snapshot the handlers, clear the set, and deactivate. After this call,
+    /// Process the handlers, clear the set, and deactivate. After this call,
     /// any in-flight TryAdd will be rejected.
     /// </summary>
-    public IMessageHandler<TMessage>[] Drain()
+    public void Drain<TProcessor>(ref TProcessor processor)
+        where TProcessor : struct, IHandlerBagDrainProcessor<TMessage>
     {
         lock (_lock)
         {
             _active = false;
+        }
 
-            if (_handlers.Count == 0)
-                return [];
-
-            IMessageHandler<TMessage>[] snapshot = [.. _handlers];
+        try
+        {
+            foreach (IMessageHandler<TMessage> handler in _handlers)
+            {
+                processor.Process(handler);
+            }
+        }
+        finally
+        {
             _handlers.Clear();
-            return snapshot;
         }
     }
 
@@ -300,6 +312,11 @@ internal sealed class HandlerBag<TMessage>
             _handlers.Clear();
         }
     }
+}
+
+internal interface IHandlerBagDrainProcessor<TMessage>
+{
+    void Process(IMessageHandler<TMessage> handler);
 }
 
 internal sealed class HandlerBagPolicy<TMessage> : IPooledObjectPolicy<HandlerBag<TMessage>>

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Int256;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
-using System;
-using System.Collections.Generic;
 
 namespace Nethermind.Xdc.Spec;
 
@@ -43,9 +45,10 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         get => _v2Configs;
         set
         {
-            _v2Configs = value ?? new();
-            _v2Configs.Sort((a, b) => a.SwitchRound.CompareTo(b.SwitchRound));
-            CheckConfig(_v2Configs);
+            Span<V2ConfigParams> v2Configs = CollectionsMarshal.AsSpan(value);
+            v2Configs.Sort(default(V2ConfigBySwitchRoundComparer));
+            CheckConfig(v2Configs);
+            _v2Configs = value;
         }
     }
     public long? TipTrc21Fee { get; set; }
@@ -62,11 +65,17 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
     public long TIPXDCXMinerDisable { get; set; }
     public long? DynamicGasLimitBlock { get; set; }
 
-    private static void CheckConfig(List<V2ConfigParams> list)
+    private readonly struct V2ConfigBySwitchRoundComparer : IComparer<V2ConfigParams>
     {
-        if (list.Count == 0 || list[0].SwitchRound != 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(V2ConfigParams a, V2ConfigParams b) => a.SwitchRound.CompareTo(b.SwitchRound);
+    }
+
+    private static void CheckConfig(ReadOnlySpan<V2ConfigParams> list)
+    {
+        if (list.Length == 0 || list[0].SwitchRound != 0)
             throw new InvalidOperationException("There should be a default configuration with switchRound = 0");
-        for (int i = 1; i < list.Count; i++)
+        for (int i = 1; i < list.Length; i++)
         {
             if (list[i].SwitchRound == list[i - 1].SwitchRound)
                 throw new InvalidOperationException($"Duplicate config for round {list[i].SwitchRound}.");

--- a/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
@@ -96,14 +96,11 @@ internal class SubnetPenaltyHandler(IBlockTree tree, ISpecProvider specProvider,
                     penalties.Remove(fromSigner);
             }
         }
-        // TODO Optimize
-        // Must use EIP-55 checksummed hex to match XDC Go node ordering (addr.Hex()).
-        // Plain lowercase comparison gives wrong order: e.g. "0xAb..." < "0xaa..." but "0xab..." > "0xaa..."
+        // EIP-55 checksummed hex is required: lowercase byte comparison reorders
+        // (e.g. "0xAb..." < "0xaa..." vs "0xab..." > "0xaa...").
         Address[] result = new Address[penalties.Count];
         penalties.CopyTo(result);
-        Array.Sort(result, (a, b) => string.CompareOrdinal(
-            a.ToString(withEip55Checksum: true),
-            b.ToString(withEip55Checksum: true)));
+        result.AsSpan().Sort(default(AddressByEip55ChecksumOrdinalComparer));
         return result;
     }
 }


### PR DESCRIPTION
## Changes

Allocation-reduction sweep across networking, sync, snap, BAL, receipts, headers, serialization, and indirect-dispatch sort hot paths. Behavior preserved end-to-end; almost every commit is mechanical and individually reviewable.

### Span replacements for `IOwnedReadOnlyList<T>` / pooled collections

Replace pooled-list enumeration and disposal with `ReadOnlySpan<T>` on per-message paths so we skip the pooled-list rental, the wrapping `IEnumerator`, and the `IDisposable` shrouds.

- **Eth message serialization**: `HelloMessage`, `HashesMessage` (Eth), `BlockHeadersMessage` (V62), `ReceiptsMessage` (V63), `GetReceiptsMessage70` (V70), `GetBlockAccessListsMessage` (V71).
- **Eth protocol handlers**: V62/V63/V65/V66/V68/V69/V70/V71 - pooled transaction notifications (V65/V68), receipt fulfillment + paging (V70), BAL request/response handling (V71).
- **Snap protocol**: `AccountRangeMessageSerializer`, `GetStorageRangesMessageSerializer`, `GetTrieNodesMessageSerializer`, `StorageRangesMessageSerializer`, plus `SnapProtocolHandler` request paths.
- **Sync paths**: `BlockDownloader` header loops + validation + request-hash construction, `MultiBlockDownloader`, `PosForwardHeaderProvider`, `PowForwardHeaderProvider`, `HeadersSyncFeed`, `SyncPeerProtocolHandlerBase`, `ISyncPeerPool` single-header fetches, `UnsafeStartingSyncPivotUpdater`.
- **Snap sync state**: `ProgressTracker`, `SnapProvider`, `SnapRangeRecovery`, snap path grouping/tracking.
- **State / storage**: `FlatWorldStateScope`, `TrieStoreScopeProvider`, `StorageRange`, `BlockTree` level updates, `Witness` decoding, `InputSerializer`, `ByteArrayListAdapter`.
- **Disposal**: recursive owned-list disposal now walks a span so we no longer allocate an enumerator just to drop pooled refs.

### Delegate / event-handler allocation reduction

Cache the delegate, share one instance across peers, or rewrite the call site so the delegate is not allocated per session/message/event.

- **`BackgroundTaskScheduler`**: pool the `Activity` objects, cache scheduler delegates, and avoid the captured-state tuple on the transaction scheduling path. New `BackgroundTaskSchedulerWrapper` indirection (~200 lines) lets sync-serve / Eth66 handlers reuse one cached handler delegate per scheduler instance instead of binding one per peer.
- **`Eth66ProtocolHandler`**: removed per-instance handler delegate fields; routes through cached background-scheduler handlers.
- **`ProtocolsManager`**: cached session-event handlers (`OnSessionCreated`, lifecycle events) instead of allocating delegates on every `Session` registration.
- **`P2PProtocolHandler` / `ProtocolHandlerBase`**: protocol events now flow through a shared `IProtocolRegistrar` registrar path rather than per-peer subscriptions; eliminates one delegate per peer per event.
- **`RlpxHost` / `Session`**: drop per-session activity-event subscriptions where the runtime can poll the existing field, and reuse a single discovery state-change delegate.
- **`RetryCache`**: avoid the snapshot allocation in the retry handler hot path.
- **`MessageQueue` / `MessageDictionary`**: avoid request-queue send delegate allocations.

### LINQ / snapshot / boxing removal

- **`SortedPool` snapshots**: replace LINQ projection with a manual loop; follow-up commit switches to volatile writes so the snapshot reference is published safely without a lock.
- **P2P capability negotiation** (`P2PProtocolHandler`): drop the LINQ intersect; iterate locally.
- **`ITxGossipPolicy`**: reuse a single composite-policy instance instead of re-composing per call.
- **Autofac protocol handler binding**: new `AutofacProtocolHandlerFactory` (+189 lines) + `OrderedComponentsContainerBuilderExtensions` change avoid per-bind allocations when wiring protocol handlers through DI.
- **`RlpxHost`**: avoid boxing `SocketOptionLevel` / `SocketOptionName` enums on `SetSocketOption` calls.
- **`AddressAsKey` event sender**: eliminate the struct boxing when raising events keyed by sender address.

### Devirtualised `Sort` hot paths

Replace lambdas, `Comparison<T>` delegates, and boxed `IComparer<T>` wrappers with readonly struct comparers routed through the generic `Sort<TComparer>` overloads. The JIT specialises the sort body and inlines `Compare` at the call site; capturing-lambda allocations and per-call `Comparer<T>.Create` wrappers disappear.

- **`Nethermind.Trie.BatchedTrieVisitor`** - `preSort` by `Level` desc; per-batch `resolveOrdering` by keccak (previously allocated a closure per visitor batch during sync).
- **`Nethermind.Network.PeerComparer` + `PeerManager.PeerStatsComparer`** - `class` -> `readonly struct`; both sort sites now go through `CollectionsMarshal.AsSpan(list).Sort`.
- **`Nethermind.JsonRpc.FeeHistoryOracle`** - `rewardInfos` by `PremiumPerGas`.
- **`Nethermind.Consensus.BlockAccessListValidationIndex`** - `StorageOrderComparer` drops the mutable `Reset()` in favour of a readonly struct constructed per-sort over `(accountOrdinals, keys, start)`.
- **`Nethermind.StateComposition.TopNTracker` + `StateCompositionVisitor`** - **full chain devirt**. The `EntryComparer` delegate type and four `CompareByXxx` static methods are replaced by four zero-state strategy structs (`ByDepth`, `ByTotalNodes`, `ByValueNodes`, `BySize`) implementing both `Compare(in T, in T)` (used by the heap insert/merge loops, where the 92+ byte `TopContractEntry` makes in-ref worthwhile) and `Compare(T, T)` (required by `Span<T>.Sort`). `TryInsert<TComparer>`, `MergeTopN<TComparer>` and `BuildSortedTopN<TComparer>` are now generic-constrained so each instantiation specialises and inlines. A generic `Reverse<TInner>` wrapper replaces the previous `Sort + Array.Reverse` two-pass with a single descending-sort call, putting the display ordering directly in the type signature.
- **`Nethermind.Shutter.ShutterTxLoader`** - sort by `IdentityPreimage`.
- **`Nethermind.Api.PluginLoader`** - `PluginPriorityComparer` struct captures the priority dictionary by reference.
- **`Nethermind.Consensus.AuRa.AuRaRewardCalculator`** - by `Activation`.
- **`Nethermind.Xdc.XdcChainSpecEngineParameters`** - by `SwitchRound`.
- **`Nethermind.Xdc.SubnetPenaltyHandler`** - EIP-55-checksum ordinal sort, rewritten as a stackalloc-based comparer that derives the checksum in-place without allocating two strings per `Compare` call.
- **`Nethermind.Db.Rocks.DbOnTheRocks`** - file metadata by level then newest.
- **`Nethermind.Init.EthereumStepsLoader`** - by `IsAssignableFrom`. Also fixes a pre-existing invalid-total-order bug now made more visible by the named struct: the original `t1.IsAssignableFrom(t2) ? 1 : -1` violated reflexivity (`Compare(x, x) = 1`) and antisymmetry (unrelated types both returned -1). New body adds a reflexivity guard via `ReferenceEquals` and falls back to a stable `AssemblyQualifiedName` ordinal compare for unrelated types.
- **`Nethermind.Evm.TransactionProcessor`** - EIP-7708 destroy-list sort. Replaces `Array.Sort(arr, GenericComparer.GetOptimized<Address>())` with `arr.AsSpan().Sort(default(AddressByBytesComparer))`. `GenericComparer.GetOptimized` is the ZK-EVM allocation-avoidance layer (bflat AOT cannot reify `Comparer<T>.Default`), unnecessary on the regular CLR path - the struct wrapper forwards to the sealed `Address.IComparable<Address>.CompareTo`, so both the outer `Sort<TComparer>` dispatch and the inner `Address.CompareTo` devirtualise.

Form chosen per receiver:
- `ArrayPoolList<T>.Sort<TComparer>(default)` - single-method generic, no ambiguity.
- `CollectionsMarshal.AsSpan(list).Sort(default(TComparer))` / `array.AsSpan().Sort(default(TComparer))` - dual-method generic ambiguates with `Sort<TKey, TValue>(Span<TKey>, Span<TValue>)`, so the value-level `default(TComparer)` disambiguates via type inference.
- Stateful comparers pass a constructed instance: `Sort(new MyComparer(...))`.
- `TopNTracker`: heap routines are generic methods `TryInsert<TComparer>` / `MergeTopN<TComparer>` constrained on `struct, IEntryComparer`, so the call site supplies the type arg (`TryInsert<ByDepth>(...)`) and the body constructs `default(TComparer)` for free.

Intentionally not converted: natural-ordering `Sort()` and `Sort<TKey, TValue>(Span<TKey>, Span<TValue>)` call sites (already specialised by the JIT via `Comparer<T>.Default`); `StringComparer.Ordinal`-based `Array.Sort` sites in cold startup paths; test, benchmark, and codegen projects.

### Tests

Targeted unit tests added for the new factory / registrar surfaces and the cached-delegate behaviour:

- `AutofacProtocolHandlerFactory` exercised via `NetworkModuleTest`, `ProtocolHandlerBaseTests`, `ProtocolsManagerTests`, `Eth62ProtocolHandlerTests`, `Eth66ProtocolHandlerTests`.
- `MessageDictionaryTests` / `MessageQueueTests` extended for the rewired send delegate paths.
- `RetryCacheTests` / `SyncedTxGossipPolicyTests` cover the snapshot + composite-policy changes.
- `VisitorCountersTests` updates the tiebreak determinism cases to dispatch through the new `By*` strategy structs.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Covered by the targeted unit tests listed above plus the existing networking / sync / snap / state-composition test suites. Almost every commit is an allocation-only rewrite (span iteration, cached delegates, pooled scheduler activities, removed boxing, devirtualised sort comparers) that preserves the existing wire-level, DI, and ordering behaviour; the new `AutofacProtocolHandlerFactory` + `IProtocolRegistrar` plumbing and the `TopNTracker` strategy structs are exercised end-to-end through the protocol handler and visitor test fixtures.

## Remarks

Supersedes #11633 - the five commits from that branch (`Devirtualise indirect-dispatch Sort calls across production paths`, `Devirtualise EIP-7708 destroy-list sort`, `Feedback`, `Complete TopNTracker devirtualisation via per-strategy struct comparers`, `lint`) are cherry-picked here and #11633 can be closed.

Note on `List<T>.Sort`: cannot be expressed as a `List<T>.Sort<TComparer>` extension method - C# overload resolution always prefers the BCL `List<T>.Sort(IComparer<T>)` instance method over any extension with the same name, silently boxing the struct comparer back through the `IComparer<T>` interface. Hence the explicit `CollectionsMarshal.AsSpan(list).Sort(...)` chain at every `List<T>` site.
