### PR TITLE
fix(blockchain): defer main-chain events until write batch is flushed

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -263,7 +263,7 @@ public class BlockTreeTests
             onUpdateDbObserved = level?.HasBlockOnMainChain == true;
         };
 
-        blockTree.UpdateMainChain(new[] { block1, block2 }, wereProcessed: true);
+        blockTree.UpdateMainChain([block1, block2], wereProcessed: true);
 
         blockAddedDbObservations.Should().Equal(true, true);
         newHeadDbObserved.Should().BeTrue();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -224,6 +224,53 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public void UpdateMainChain_fires_main_chain_events_after_chain_level_repository_batch_flushed()
+    {
+        BlockTree blockTree = BuildBlockTree();
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        Block block2 = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).TestObject;
+
+        AddToMain(blockTree, block0);
+        blockTree.SuggestBlock(block1);
+        blockTree.SuggestBlock(block2);
+
+        List<bool> blockAddedDbObservations = new();
+        bool newHeadDbObserved = false;
+        bool onUpdateDbObserved = false;
+
+        // A new ChainLevelInfoRepository instance starts with an empty cache, so HasBlockOnMainChain
+        // can only be observed via the underlying IDb. Pre-fix, UpdateMainChain held its write batch
+        // open across the event invocations, so a fresh repository would miss the new canonical
+        // markers. After the fix, the batch is disposed (and therefore flushed) before any of these
+        // events fires, so each subscriber observes a fully persisted level.
+        blockTree.BlockAddedToMain += (_, e) =>
+        {
+            ChainLevelInfoRepository freshRepo = new(_blocksInfosDb);
+            ChainLevelInfo? level = freshRepo.LoadLevel(e.Block.Number);
+            blockAddedDbObservations.Add(level?.HasBlockOnMainChain == true);
+        };
+        blockTree.NewHeadBlock += (_, e) =>
+        {
+            ChainLevelInfoRepository freshRepo = new(_blocksInfosDb);
+            ChainLevelInfo? level = freshRepo.LoadLevel(e.Block.Number);
+            newHeadDbObserved = level?.HasBlockOnMainChain == true;
+        };
+        blockTree.OnUpdateMainChain += (_, e) =>
+        {
+            ChainLevelInfoRepository freshRepo = new(_blocksInfosDb);
+            ChainLevelInfo? level = freshRepo.LoadLevel(e.Blocks[^1].Number);
+            onUpdateDbObserved = level?.HasBlockOnMainChain == true;
+        };
+
+        blockTree.UpdateMainChain(new[] { block1, block2 }, wereProcessed: true);
+
+        blockAddedDbObservations.Should().Equal(true, true);
+        newHeadDbObserved.Should().BeTrue();
+        onUpdateDbObserved.Should().BeTrue();
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void Shall_notify_on_new_suggested_block_after_genesis()
     {
         bool hasNotified = false;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1003,11 +1003,7 @@ namespace Nethermind.Blockchain
             long lastNumber = ascendingOrder ? blocks[^1].Number : blocks[0].Number;
             long previousHeadNumber = Head?.Number ?? 0L;
 
-            // Events are buffered and raised after the batch is disposed so that subscribers always
-            // observe the underlying RocksDB write batch as committed. Otherwise subscribers reading
-            // ChainLevelInfo through a path that bypasses _blockInfoCache (cache eviction, a separate
-            // repository instance, or a process restart in between) would see stale state.
-            List<DeferredMainChainEvent> pendingEvents = new(blocks.Count);
+            using ArrayPoolListRef<DeferredMainChainEvent> pendingEvents = new(blocks.Count);
 
             using (BatchWrite batch = _chainLevelInfoRepository.StartBatch())
             {
@@ -1051,16 +1047,12 @@ namespace Nethermind.Blockchain
                     DeferredMainChainEvent deferred = MoveToMain(blocks[i], batch, wereProcessed, forceUpdateHeadBlock && lastProcessedBlock);
                     pendingEvents.Add(deferred);
                 }
-
-                TryUpdateSyncPivot();
             }
 
-            // Batch disposed above — write batch is now flushed to the underlying IDb.
-            // Raise the per-block events in their original relative order: NewHeadBlock first
-            // (for the block whose UpdateHeadBlock path ran), then BlockAddedToMain.
-            for (int i = 0; i < pendingEvents.Count; i++)
+            TryUpdateSyncPivot();
+
+            foreach (DeferredMainChainEvent deferred in pendingEvents.AsSpan())
             {
-                DeferredMainChainEvent deferred = pendingEvents[i];
                 if (deferred.NewHead is not null)
                 {
                     NewHeadBlock?.Invoke(this, deferred.NewHead);
@@ -1071,11 +1063,7 @@ namespace Nethermind.Blockchain
             OnUpdateMainChain?.Invoke(this, new OnUpdateMainChainArgs(blocks, wereProcessed));
         }
 
-        private readonly struct DeferredMainChainEvent(BlockReplacementEventArgs blockAdded, BlockEventArgs? newHead)
-        {
-            public BlockReplacementEventArgs BlockAdded { get; } = blockAdded;
-            public BlockEventArgs? NewHead { get; } = newHead;
-        }
+        private readonly record struct DeferredMainChainEvent(BlockReplacementEventArgs BlockAdded, BlockEventArgs? NewHead);
 
 
         private void TryUpdateSyncPivot()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1002,50 +1002,79 @@ namespace Nethermind.Blockchain
 
             long lastNumber = ascendingOrder ? blocks[^1].Number : blocks[0].Number;
             long previousHeadNumber = Head?.Number ?? 0L;
-            using BatchWrite batch = _chainLevelInfoRepository.StartBatch();
-            if (previousHeadNumber > lastNumber)
-            {
-                for (long i = 0; i < previousHeadNumber - lastNumber; i++)
-                {
-                    long levelNumber = previousHeadNumber - i;
 
-                    ChainLevelInfo? level = LoadLevel(levelNumber);
-                    if (level is not null)
+            // Events are buffered and raised after the batch is disposed so that subscribers always
+            // observe the underlying RocksDB write batch as committed. Otherwise subscribers reading
+            // ChainLevelInfo through a path that bypasses _blockInfoCache (cache eviction, a separate
+            // repository instance, or a process restart in between) would see stale state.
+            List<DeferredMainChainEvent> pendingEvents = new(blocks.Count);
+
+            using (BatchWrite batch = _chainLevelInfoRepository.StartBatch())
+            {
+                if (previousHeadNumber > lastNumber)
+                {
+                    for (long i = 0; i < previousHeadNumber - lastNumber; i++)
                     {
-                        level.HasBlockOnMainChain = false;
-                        _chainLevelInfoRepository.PersistLevel(levelNumber, level, batch);
+                        long levelNumber = previousHeadNumber - i;
+
+                        ChainLevelInfo? level = LoadLevel(levelNumber);
+                        if (level is not null)
+                        {
+                            level.HasBlockOnMainChain = false;
+                            _chainLevelInfoRepository.PersistLevel(levelNumber, level, batch);
+                        }
                     }
                 }
-            }
 
-            // Clear stale canonical markers above the new head left by beacon sync.
-            // Only needed on FCU reorgs (forceUpdateHeadBlock == true). During forward sync
-            // (BlockDownloader) and forward processing (BlockchainProcessor), the markers above
-            // are either not yet set or belong to the same chain and must not be cleared.
-            if (forceUpdateHeadBlock)
-                ClearStaleMarkersAbove(Math.Max(previousHeadNumber, lastNumber), batch);
+                // Clear stale canonical markers above the new head left by beacon sync.
+                // Only needed on FCU reorgs (forceUpdateHeadBlock == true). During forward sync
+                // (BlockDownloader) and forward processing (BlockchainProcessor), the markers above
+                // are either not yet set or belong to the same chain and must not be cleared.
+                if (forceUpdateHeadBlock)
+                    ClearStaleMarkersAbove(Math.Max(previousHeadNumber, lastNumber), batch);
 
-            for (int i = 0; i < blocks.Count; i++)
-            {
-                Block block = blocks[i];
-                _balStore.InsertFromBlock(block);
-
-                if (ShouldCache(block.Number))
+                for (int i = 0; i < blocks.Count; i++)
                 {
-                    _blockStore.Cache(block);
-                    _headerStore.Cache(block.Header);
+                    Block block = blocks[i];
+                    _balStore.InsertFromBlock(block);
+
+                    if (ShouldCache(block.Number))
+                    {
+                        _blockStore.Cache(block);
+                        _headerStore.Cache(block.Header);
+                    }
+
+                    // we only force update head block for last block in processed blocks
+                    bool lastProcessedBlock = i == blocks.Count - 1;
+
+                    // Where head is set if wereProcessed is true
+                    DeferredMainChainEvent deferred = MoveToMain(blocks[i], batch, wereProcessed, forceUpdateHeadBlock && lastProcessedBlock);
+                    pendingEvents.Add(deferred);
                 }
 
-                // we only force update head block for last block in processed blocks
-                bool lastProcessedBlock = i == blocks.Count - 1;
-
-                // Where head is set if wereProcessed is true
-                MoveToMain(blocks[i], batch, wereProcessed, forceUpdateHeadBlock && lastProcessedBlock);
+                TryUpdateSyncPivot();
             }
 
-            TryUpdateSyncPivot();
+            // Batch disposed above — write batch is now flushed to the underlying IDb.
+            // Raise the per-block events in their original relative order: NewHeadBlock first
+            // (for the block whose UpdateHeadBlock path ran), then BlockAddedToMain.
+            for (int i = 0; i < pendingEvents.Count; i++)
+            {
+                DeferredMainChainEvent deferred = pendingEvents[i];
+                if (deferred.NewHead is not null)
+                {
+                    NewHeadBlock?.Invoke(this, deferred.NewHead);
+                }
+                BlockAddedToMain?.Invoke(this, deferred.BlockAdded);
+            }
 
             OnUpdateMainChain?.Invoke(this, new OnUpdateMainChainArgs(blocks, wereProcessed));
+        }
+
+        private readonly struct DeferredMainChainEvent(BlockReplacementEventArgs blockAdded, BlockEventArgs? newHead)
+        {
+            public BlockReplacementEventArgs BlockAdded { get; } = blockAdded;
+            public BlockEventArgs? NewHead { get; } = newHead;
         }
 
 
@@ -1161,7 +1190,7 @@ namespace Nethermind.Blockchain
         /// <param name="forceUpdateHeadBlock">Force updating <see cref="Head"/> to this block, even when <see cref="Block.TotalDifficulty"/> is not higher than previous head.</param>
         /// <exception cref="InvalidOperationException">Invalid block</exception>
         [Todo(Improve.MissingFunctionality, "Recalculate bloom storage on reorg.")]
-        private void MoveToMain(Block block, BatchWrite batch, bool wasProcessed, bool forceUpdateHeadBlock)
+        private DeferredMainChainEvent MoveToMain(Block block, BatchWrite batch, bool wasProcessed, bool forceUpdateHeadBlock)
         {
             if (Logger.IsTrace) Logger.Trace($"Moving {block.ToString(Block.Format.Short)} to main");
             if (block.Hash is null)
@@ -1193,6 +1222,7 @@ namespace Nethermind.Blockchain
                 ? FindBlock(hashOfThePreviousMainBlock, BlockTreeLookupOptions.TotalDifficultyNotNeeded, blockNumber: block.Number)
                 : null;
 
+            BlockEventArgs? newHeadArgs = null;
             if (forceUpdateHeadBlock || block.IsGenesis || HeadImprovementRequirementsSatisfied(block.Header))
             {
                 if (block.Number == _genesisBlockNumber)
@@ -1207,15 +1237,17 @@ namespace Nethermind.Blockchain
 
                 if (wasProcessed)
                 {
-                    UpdateHeadBlock(block);
+                    newHeadArgs = SetHeadBlock(block);
                 }
             }
 
             if (Logger.IsTrace) Logger.Trace($"Block added to main {block}, block TD {block.TotalDifficulty}");
 
-            BlockAddedToMain?.Invoke(this, new BlockReplacementEventArgs(block, previous));
+            BlockReplacementEventArgs blockAddedArgs = new(block, previous);
 
             if (Logger.IsTrace) Logger.Trace($"Block {block.ToString(Block.Format.Short)}, TD: {block.TotalDifficulty} added to main chain");
+
+            return new DeferredMainChainEvent(blockAddedArgs, newHeadArgs);
         }
 
         protected virtual bool HeadImprovementRequirementsSatisfied(BlockHeader header)
@@ -1310,6 +1342,15 @@ namespace Nethermind.Blockchain
 
         private void UpdateHeadBlock(Block block)
         {
+            BlockEventArgs args = SetHeadBlock(block);
+            NewHeadBlock?.Invoke(this, args);
+        }
+
+        // Mutates Head and writes the head hash without raising NewHeadBlock.
+        // UpdateMainChain raises the event itself after the ChainLevelInfoRepository write batch
+        // has been disposed (and therefore flushed) so subscribers always observe committed state.
+        private BlockEventArgs SetHeadBlock(Block block)
+        {
             if (block.Hash is null)
             {
                 throw new InvalidOperationException("Block suggested as the new head block has no hash set.");
@@ -1322,7 +1363,7 @@ namespace Nethermind.Blockchain
 
             Head = block;
             _blockInfoDb.Set(HeadAddressInDb, block.Hash.Bytes);
-            NewHeadBlock?.Invoke(this, new BlockEventArgs(block));
+            return new BlockEventArgs(block);
         }
 
         private ChainLevelInfo UpdateOrCreateLevel(long number, BlockInfo blockInfo, bool setAsMain = false)


### PR DESCRIPTION
Fixes #11616

## Changes

- `BlockTree.UpdateMainChain` opened a `ChainLevelInfoRepository` write batch and held it across `MoveToMain` for every block in the slice. `BlockAddedToMain`, `NewHeadBlock`, and `OnUpdateMainChain` all fired while the batch was still in scope. `PersistLevel` writes to `_blockInfoCache` _and_ the batch simultaneously, so the bug was masked for any subscriber hitting the cache; once the cache evicts (`CacheSize = 64`), a fresh repository reads through to the underlying `IDb`, or a process restarts mid-flow, subscribers observe stale `HasBlockOnMainChain` markers. `InMemoryWriteBatch` / `RocksDbWriteBatch` only commit on `Dispose()`.
- `MoveToMain` now returns a buffered `DeferredMainChainEvent` (`BlockReplacementEventArgs` + optional `BlockEventArgs` from the head-update path) instead of raising the events directly.
- `UpdateHeadBlock(Block)` is split into a pure state-mutating `SetHeadBlock` (writes `_blockInfoDb[HeadAddressInDb]`, returns the event args) and a thin wrapper that fires `NewHeadBlock`. Existing callers (`DeleteChainSlice`) are untouched and continue to fire the event after their own batch closes.
- `UpdateMainChain` wraps the batch in an inner `using` block, collects deferred events from each `MoveToMain` call, disposes the batch (flushing the underlying write batch), then raises the buffered events in their original relative order (per block: `NewHeadBlock` → `BlockAddedToMain`), and finally `OnUpdateMainChain`.
- Added regression test `UpdateMainChain_fires_main_chain_events_after_chain_level_repository_batch_flushed` in `BlockTreeTests`. Each handler constructs a fresh `ChainLevelInfoRepository` over the same underlying `_blocksInfosDb` (cache empty) and asserts `LoadLevel(...).HasBlockOnMainChain == true`. Pre-fix this fails for both per-block events because `InMemoryWriteBatch` has not yet flushed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`dotnet test --filter FullyQualifiedName~BlockTreeTests` — 245/245 in `Nethermind.Blockchain.Test`, 38/38 in `Nethermind.Merge.Plugin.Test`. The new regression test fails pre-fix and passes post-fix. Existing notification-ordering tests (`Shall_notify_new_head_block_once_and_block_added_to_main_multiple_times...`, `BlockAddedToMain_should_have_updated_Head`) still pass — relative event order and `Head` visibility from subscribers are preserved.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
