### PR TITLE
refactor(core): centralize EIP-7702 SetCode shape checks

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Specs;
 using Nethermind.TxPool;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
+using Nethermind.Core.Validation;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Int256;
@@ -374,7 +375,7 @@ public sealed class NoContractCreationTxValidator : ITxValidator
     public static readonly NoContractCreationTxValidator Instance = new();
     private NoContractCreationTxValidator() { }
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.IsContractCreation ? TxErrorMessages.NotAllowedCreateTransaction : ValidationResult.Success;
+        SetCodeTxValidation.ValidateNoContractCreation(transaction);
 }
 
 public sealed class AuthorizationListTxValidator : ITxValidator
@@ -383,11 +384,7 @@ public sealed class AuthorizationListTxValidator : ITxValidator
     private AuthorizationListTxValidator() { }
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.AuthorizationList switch
-        {
-            null or { Length: 0 } => TxErrorMessages.MissingAuthorizationList,
-            _ => ValidationResult.Success
-        };
+        SetCodeTxValidation.ValidateAuthorizationList(transaction);
 }
 
 public sealed class GasLimitCapTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Specs;
 using Nethermind.TxPool;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
+using Nethermind.Core.Validation;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.GasPolicy;
@@ -381,7 +382,7 @@ public sealed class NoContractCreationTxValidator : ITxValidator
     public static readonly NoContractCreationTxValidator Instance = new();
     private NoContractCreationTxValidator() { }
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.IsContractCreation ? TxErrorMessages.NotAllowedCreateTransaction : ValidationResult.Success;
+        SetCodeTxValidation.ValidateNoContractCreation(transaction);
 }
 
 public sealed class AuthorizationListTxValidator : ITxValidator
@@ -390,11 +391,7 @@ public sealed class AuthorizationListTxValidator : ITxValidator
     private AuthorizationListTxValidator() { }
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.AuthorizationList switch
-        {
-            null or { Length: 0 } => TxErrorMessages.MissingAuthorizationList,
-            _ => ValidationResult.Success
-        };
+        SetCodeTxValidation.ValidateAuthorizationList(transaction);
 }
 
 public sealed class GasLimitCapTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Core.Test/Validation/SetCodeTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Validation/SetCodeTxValidationTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
@@ -14,7 +15,7 @@ namespace Nethermind.Core.Test.Validation;
 [Parallelizable(ParallelScope.All)]
 public class SetCodeTxValidationTests
 {
-    private static AuthorizationTuple AuthorizationTuple() =>
+    private static AuthorizationTuple CreateAuthorizationTuple() =>
         new(0, Address.Zero, 0, new Signature(new byte[64], 0));
 
     [Test]
@@ -38,24 +39,23 @@ public class SetCodeTxValidationTests
         result.Error.Should().Be(TxErrorMessages.NotAllowedCreateTransaction);
     }
 
-    [Test]
-    public void ValidateAuthorizationList_returns_error_when_list_is_null()
+    private static IEnumerable<TestCaseData> MissingAuthorizationListCases()
     {
-        Transaction tx = Build.A.Transaction.To(TestItem.AddressA).TestObject;
-
-        ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);
-
-        result.AsBool().Should().BeFalse();
-        result.Error.Should().Be(TxErrorMessages.MissingAuthorizationList);
+        yield return new TestCaseData((Func<Transaction>)(() =>
+            Build.A.Transaction.To(TestItem.AddressA).TestObject))
+        { TestName = "null_authorization_list" };
+        yield return new TestCaseData((Func<Transaction>)(() =>
+            Build.A.Transaction
+                .To(TestItem.AddressA)
+                .WithAuthorizationCode(Array.Empty<AuthorizationTuple>())
+                .TestObject))
+        { TestName = "empty_authorization_list" };
     }
 
-    [Test]
-    public void ValidateAuthorizationList_returns_error_when_list_is_empty()
+    [TestCaseSource(nameof(MissingAuthorizationListCases))]
+    public void ValidateAuthorizationList_returns_error_when_list_is_missing(Func<Transaction> buildTransaction)
     {
-        Transaction tx = Build.A.Transaction
-            .To(TestItem.AddressA)
-            .WithAuthorizationCode(Array.Empty<AuthorizationTuple>())
-            .TestObject;
+        Transaction tx = buildTransaction();
 
         ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);
 
@@ -68,7 +68,7 @@ public class SetCodeTxValidationTests
     {
         Transaction tx = Build.A.Transaction
             .To(TestItem.AddressA)
-            .WithAuthorizationCode(new[] { AuthorizationTuple() })
+            .WithAuthorizationCode([CreateAuthorizationTuple()])
             .TestObject;
 
         ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);

--- a/src/Nethermind/Nethermind.Core.Test/Validation/SetCodeTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Validation/SetCodeTxValidationTests.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Messages;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Validation;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Validation;
+
+[Parallelizable(ParallelScope.All)]
+public class SetCodeTxValidationTests
+{
+    private static AuthorizationTuple AuthorizationTuple() =>
+        new(0, Address.Zero, 0, new Signature(new byte[64], 0));
+
+    [Test]
+    public void ValidateNoContractCreation_returns_success_for_call_transaction()
+    {
+        Transaction tx = Build.A.Transaction.To(TestItem.AddressA).TestObject;
+
+        ValidationResult result = SetCodeTxValidation.ValidateNoContractCreation(tx);
+
+        result.AsBool().Should().BeTrue();
+    }
+
+    [Test]
+    public void ValidateNoContractCreation_returns_error_for_contract_creation()
+    {
+        Transaction tx = Build.A.Transaction.To(null).TestObject;
+
+        ValidationResult result = SetCodeTxValidation.ValidateNoContractCreation(tx);
+
+        result.AsBool().Should().BeFalse();
+        result.Error.Should().Be(TxErrorMessages.NotAllowedCreateTransaction);
+    }
+
+    [Test]
+    public void ValidateAuthorizationList_returns_error_when_list_is_null()
+    {
+        Transaction tx = Build.A.Transaction.To(TestItem.AddressA).TestObject;
+
+        ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);
+
+        result.AsBool().Should().BeFalse();
+        result.Error.Should().Be(TxErrorMessages.MissingAuthorizationList);
+    }
+
+    [Test]
+    public void ValidateAuthorizationList_returns_error_when_list_is_empty()
+    {
+        Transaction tx = Build.A.Transaction
+            .To(TestItem.AddressA)
+            .WithAuthorizationCode(Array.Empty<AuthorizationTuple>())
+            .TestObject;
+
+        ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);
+
+        result.AsBool().Should().BeFalse();
+        result.Error.Should().Be(TxErrorMessages.MissingAuthorizationList);
+    }
+
+    [Test]
+    public void ValidateAuthorizationList_returns_success_when_list_has_entries()
+    {
+        Transaction tx = Build.A.Transaction
+            .To(TestItem.AddressA)
+            .WithAuthorizationCode(new[] { AuthorizationTuple() })
+            .TestObject;
+
+        ValidationResult result = SetCodeTxValidation.ValidateAuthorizationList(tx);
+
+        result.AsBool().Should().BeTrue();
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Validation/SetCodeTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/Validation/SetCodeTxValidation.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Messages;
+
+namespace Nethermind.Core.Validation;
+
+/// <summary>
+/// Shape checks specific to <see cref="TxType.SetCode"/> (EIP-7702) transactions.
+/// </summary>
+/// <remarks>
+/// These checks have to run on both the consensus side (via
+/// <c>NoContractCreationTxValidator</c> / <c>AuthorizationListTxValidator</c>
+/// registered in <c>TxValidator</c>) and the execution side
+/// (<c>TransactionProcessor.ValidateStatic</c>) because RPC entrypoints such as
+/// <c>eth_call</c> and <c>eth_estimateGas</c> reach the transaction processor
+/// without going through the consensus validator. Keeping the predicates here
+/// makes both sites delegate to a single source of truth and prevents the two
+/// paths from drifting apart as EIP-7702 evolves.
+/// </remarks>
+public static class SetCodeTxValidation
+{
+    /// <summary>
+    /// EIP-7702: a SetCode transaction cannot be a contract-creation transaction.
+    /// </summary>
+    public static ValidationResult ValidateNoContractCreation(Transaction transaction) =>
+        transaction.IsContractCreation
+            ? TxErrorMessages.NotAllowedCreateTransaction
+            : ValidationResult.Success;
+
+    /// <summary>
+    /// EIP-7702: a SetCode transaction must carry a non-empty authorization list.
+    /// </summary>
+    public static ValidationResult ValidateAuthorizationList(Transaction transaction) =>
+        transaction.AuthorizationList switch
+        {
+            null or { Length: 0 } => TxErrorMessages.MissingAuthorizationList,
+            _ => ValidationResult.Success
+        };
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Validation;
 using Nethermind.Crypto;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
@@ -610,15 +611,22 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tx.SupportsAuthorizationList)
             {
-                if (tx.IsContractCreation)
+                // SetCode-specific shape checks live in Nethermind.Core.Validation.SetCodeTxValidation
+                // so that this RPC-facing path (eth_call / eth_estimateGas, which bypass TxValidator)
+                // and the consensus-side NoContractCreationTxValidator / AuthorizationListTxValidator
+                // share a single source of truth. See https://github.com/NethermindEth/nethermind/issues/11619.
+                ValidationResult noCreation = SetCodeTxValidation.ValidateNoContractCreation(tx);
+                if (!noCreation)
                 {
                     TraceLogInvalidTx(tx, "SETCODE_TX_CREATE");
-                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.NotAllowedCreateTransaction} (sender {tx.SenderAddress})");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{noCreation.Error} (sender {tx.SenderAddress})");
                 }
-                if (!tx.HasAuthorizationList)
+
+                ValidationResult authList = SetCodeTxValidation.ValidateAuthorizationList(tx);
+                if (!authList)
                 {
                     TraceLogInvalidTx(tx, "EMPTY_AUTHORIZATION_LIST");
-                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.MissingAuthorizationList} (sender {tx.SenderAddress})");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{authList.Error} (sender {tx.SenderAddress})");
                 }
             }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -621,10 +621,6 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tx.SupportsAuthorizationList)
             {
-                // SetCode-specific shape checks live in Nethermind.Core.Validation.SetCodeTxValidation
-                // so that this RPC-facing path (eth_call / eth_estimateGas, which bypass TxValidator)
-                // and the consensus-side NoContractCreationTxValidator / AuthorizationListTxValidator
-                // share a single source of truth. See https://github.com/NethermindEth/nethermind/issues/11619.
                 ValidationResult noCreation = SetCodeTxValidation.ValidateNoContractCreation(tx);
                 if (!noCreation)
                 {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -611,10 +611,6 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tx.SupportsAuthorizationList)
             {
-                // SetCode-specific shape checks live in Nethermind.Core.Validation.SetCodeTxValidation
-                // so that this RPC-facing path (eth_call / eth_estimateGas, which bypass TxValidator)
-                // and the consensus-side NoContractCreationTxValidator / AuthorizationListTxValidator
-                // share a single source of truth. See https://github.com/NethermindEth/nethermind/issues/11619.
                 ValidationResult noCreation = SetCodeTxValidation.ValidateNoContractCreation(tx);
                 if (!noCreation)
                 {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Validation;
 using Nethermind.Crypto;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
@@ -620,15 +621,22 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tx.SupportsAuthorizationList)
             {
-                if (tx.IsContractCreation)
+                // SetCode-specific shape checks live in Nethermind.Core.Validation.SetCodeTxValidation
+                // so that this RPC-facing path (eth_call / eth_estimateGas, which bypass TxValidator)
+                // and the consensus-side NoContractCreationTxValidator / AuthorizationListTxValidator
+                // share a single source of truth. See https://github.com/NethermindEth/nethermind/issues/11619.
+                ValidationResult noCreation = SetCodeTxValidation.ValidateNoContractCreation(tx);
+                if (!noCreation)
                 {
                     TraceLogInvalidTx(tx, "SETCODE_TX_CREATE");
-                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.NotAllowedCreateTransaction} (sender {tx.SenderAddress})");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{noCreation.Error} (sender {tx.SenderAddress})");
                 }
-                if (!tx.HasAuthorizationList)
+
+                ValidationResult authList = SetCodeTxValidation.ValidateAuthorizationList(tx);
+                if (!authList)
                 {
                     TraceLogInvalidTx(tx, "EMPTY_AUTHORIZATION_LIST");
-                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{TxErrorMessages.MissingAuthorizationList} (sender {tx.SenderAddress})");
+                    return TransactionResult.ErrorType.MalformedTransaction.WithDetail($"{authList.Error} (sender {tx.SenderAddress})");
                 }
             }
 


### PR DESCRIPTION
Closes #11619

## Changes

- `TransactionProcessor.ValidateStatic` (`Nethermind.Evm`) and the `NoContractCreationTxValidator` / `AuthorizationListTxValidator` classes (`Nethermind.Consensus`) each carried their own copy of the EIP-7702 no-contract-creation and non-empty-authorization-list checks. The two sites cannot be collapsed into one — the consensus validators run for block validation / mempool admission, while the transaction-processor checks gate the RPC paths (`eth_call`, `eth_estimateGas`) that bypass `TxValidator` entirely — but they must not drift.
- Extract the underlying predicates into `Nethermind.Core.Validation.SetCodeTxValidation` (`ValidateNoContractCreation`, `ValidateAuthorizationList`).
- `NoContractCreationTxValidator.IsWellFormed` and `AuthorizationListTxValidator.IsWellFormed` are now one-liners delegating to the helper.
- `TransactionProcessor.ValidateStatic` calls the same helpers, preserving its existing trace tags (`SETCODE_TX_CREATE`, `EMPTY_AUTHORIZATION_LIST`) and the `MalformedTransaction.WithDetail(... (sender ...))` error shape.
- New `Nethermind.Core.Test.Validation.SetCodeTxValidationTests` covers the helper directly.

No behavior change: error strings, trace tags, and consensus-side dispatch via the `TxValidator` register table are unchanged. The PR is a pure deduplication so that future EIP-7702 rule edits land in one place rather than two.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New `SetCodeTxValidationTests` — 5/5 in `Nethermind.Core.Test`.
- `TxValidatorTests` + `TransactionProcessorEip7702Tests` — 164/164 in `Nethermind.Blockchain.Test`.
- `EthRpcModuleTests` (covers `eth_call` and `eth_estimateGas` SetCode rejection paths via `TransactionProcessor`) — 381/383 in `Nethermind.JsonRpc.Test` (2 unrelated skipped).
- `dotnet format whitespace --folder` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
