### PR TITLE
Enable Zisk 0.18 support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
-    <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.1" />
+    <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />
     <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.3" />
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
     <PackageVersion Include="NJsonSchema" Version="11.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,7 +66,7 @@
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.1" />
-    <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.2" />
+    <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.3" />
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
     <PackageVersion Include="NJsonSchema" Version="11.3.2" />
     <PackageVersion Include="NLog" Version="5.5.1" />

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -42,7 +42,7 @@ build: dotnet-build
 		-w $(SRC_DIR) \
 		--mount type=bind,source="$(ARTIFACTS_DIR)/Nethermind.Stateless.ZiskGuest/release",target=$(BIN_DIR) \
 		--mount type=bind,source="$(GUEST_DIR)",target=$(SRC_DIR) \
-		nethermindeth/bflat-riscv64:036bebe11d27c3ccf50c82c2c099599ac21c5b92 \
+		nethermindeth/bflat-riscv64:e2d315d20de25edcd4ec8ef2da91647ff0671db1 \
 		bflat build --arch riscv64 --os linux --stdlib dotnet --libc zisk \
 		--no-pie \
 		--no-pthread \
@@ -58,7 +58,7 @@ build: dotnet-build
 run:
 	docker run --rm -e RUST_BACKTRACE=full \
 		--mount type=bind,source="$(GUEST_DIR)/bin",target=/n \
-		nethermindeth/zisk:0.17.0 \
+		nethermindeth/zisk:0.18.0 \
 		ziskemu -e /n/nethermind -i /n/$(INPUT)
 
 build-run: build run


### PR DESCRIPTION
## Changes

- Update ZiskOs Runtime to version that supports Zisk 0.18.
- Update bflat-riscv64 to the version with Zisk 0.18 support.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

