### PR TITLE
feat(engine/ssz): add target_gas_limit to PayloadAttributesV4 wire

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -533,6 +533,7 @@ public class SszCodecTests
     public void DecodeFcuV4Request_spec_layout_roundtrips_parent_beacon_block_root_and_slot_number()
     {
         ulong expectedSlot = 0xAABBCCDD_11223344UL;
+        ulong expectedTargetGasLimit = 60_000_000UL;
 
         ForkchoiceUpdatedRequestWire wire = new()
         {
@@ -552,6 +553,7 @@ public class SszCodecTests
                     Withdrawals = [],
                     ParentBeaconBlockRoot = TestItem.KeccakE,
                     SlotNumber = expectedSlot,
+                    TargetGasLimit = expectedTargetGasLimit,
                 }
             ]
         };
@@ -569,6 +571,8 @@ public class SszCodecTests
             "parent_beacon_block_root must round-trip in V4 as a fixed Bytes32");
         attrs.SlotNumber.Should().Be(expectedSlot,
             "slot_number must be decoded from the fixed uint64 that follows parent_beacon_block_root");
+        attrs.TargetGasLimit.Should().Be((long)expectedTargetGasLimit,
+            "target_gas_limit must be decoded from the fixed uint64 that follows slot_number");
         attrs.SuggestedFeeRecipient.Should().Be(TestItem.AddressB);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -288,7 +288,8 @@ public static class SszCodec
         BuildPayloadAttributes(pa.Timestamp, pa.PrevRandao, pa.SuggestedFeeRecipient,
             withdrawals: pa.Withdrawals.ToDomain(),
             parentBeaconBlockRoot: pa.ParentBeaconBlockRoot,
-            slotNumber: pa.SlotNumber);
+            slotNumber: pa.SlotNumber,
+            targetGasLimit: (long)pa.TargetGasLimit);
 
     private static PayloadAttributes BuildPayloadAttributes(
         ulong timestamp,
@@ -296,14 +297,16 @@ public static class SszCodec
         Address suggestedFeeRecipient,
         Withdrawal[]? withdrawals = null,
         Hash256? parentBeaconBlockRoot = null,
-        ulong? slotNumber = null) => new()
+        ulong? slotNumber = null,
+        long? targetGasLimit = null) => new()
         {
             Timestamp = timestamp,
             PrevRandao = prevRandao,
             SuggestedFeeRecipient = suggestedFeeRecipient,
             Withdrawals = withdrawals,
             ParentBeaconBlockRoot = parentBeaconBlockRoot,
-            SlotNumber = slotNumber
+            SlotNumber = slotNumber,
+            TargetGasLimit = targetGasLimit
         };
 
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -80,6 +80,7 @@ public partial struct PayloadAttributesWire
     [SszList(16)] public SszWithdrawal[]? Withdrawals { get; set; }
     public Hash256 ParentBeaconBlockRoot { get; set; }
     public ulong SlotNumber { get; set; }
+    public ulong TargetGasLimit { get; set; }
 }
 
 [SszContainer]


### PR DESCRIPTION
## Summary
- Adds `target_gas_limit: uint64` to the SSZ `PayloadAttributesWire` (V4) and plumbs it through `SszCodec.PayloadAttributesFromWire` into the existing `PayloadAttributes.TargetGasLimit` domain field.
- Extends the `DecodeFcuV4Request` round-trip test to assert the new field survives encode/decode.

## Context
JSON-RPC support for `targetGasLimit` landed in 4e226fd (`feat(engine): support targetGasLimit in PayloadAttributesV4`). The SSZ wire schema lagged behind, so CLs that include the alpha-8 `targetGasLimit` over the SSZ-REST transport (`POST /engine/v4/forkchoice`) get rejected as **Malformed SSZ body** — the 8 trailing bytes shift the inner `withdrawals` offset inside `PayloadAttributesV4`.

execution-apis PR #796 added `targetGasLimit` to the JSON spec (commit a22fbd4). The matching SSZ-encoding spec change was just submitted in https://github.com/ethereum/execution-apis/pull/764 (commit 949d6a8 on the `bbusa/ssz` branch). This PR aligns Nethermind's SSZ decoder with that schema so it accepts the field on the wire.

## Hit in practice
Consensoor on Gloas devnet hits this every fcU at slot transition:
```
Engine API error 400: Malformed SSZ body
  at forkchoice_updated_v4 -> POST /engine/v4/forkchoice
```
After this fix the EL decodes `PayloadAttributesV4` with 7 fields (`target_gas_limit` last) and forwards the value to `PayloadAttributes.TargetGasLimit`.

## Test plan
- [x] `DecodeFcuV4Request_spec_layout_roundtrips_parent_beacon_block_root_and_slot_number` now also asserts `target_gas_limit` round-trips
- [ ] CI green
- [ ] Manual: consensoor ↔ nethermind on glamsterdam devnet — fcU v4 over SSZ no longer rejected