### PR TITLE
feat(engine/ssz): add target_gas_limit to PayloadAttributesV4 wire

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -533,6 +533,7 @@ public class SszCodecTests
     public void DecodeFcuV4Request_spec_layout_roundtrips_parent_beacon_block_root_and_slot_number()
     {
         ulong expectedSlot = 0xAABBCCDD_11223344UL;
+        ulong expectedTargetGasLimit = 0x0123456789ABCDEFUL;
 
         ForkchoiceUpdatedRequestWire wire = new()
         {
@@ -552,6 +553,7 @@ public class SszCodecTests
                     Withdrawals = [],
                     ParentBeaconBlockRoot = TestItem.KeccakE,
                     SlotNumber = expectedSlot,
+                    TargetGasLimit = expectedTargetGasLimit,
                 }
             ]
         };
@@ -569,6 +571,8 @@ public class SszCodecTests
             "parent_beacon_block_root must round-trip in V4 as a fixed Bytes32");
         attrs.SlotNumber.Should().Be(expectedSlot,
             "slot_number must be decoded from the fixed uint64 that follows parent_beacon_block_root");
+        attrs.TargetGasLimit.Should().Be((long)expectedTargetGasLimit,
+            "target_gas_limit must be decoded from the fixed uint64 that follows slot_number");
         attrs.SuggestedFeeRecipient.Should().Be(TestItem.AddressB);
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -288,7 +288,8 @@ public static class SszCodec
         BuildPayloadAttributes(pa.Timestamp, pa.PrevRandao, pa.SuggestedFeeRecipient,
             withdrawals: pa.Withdrawals.ToDomain(),
             parentBeaconBlockRoot: pa.ParentBeaconBlockRoot,
-            slotNumber: pa.SlotNumber);
+            slotNumber: pa.SlotNumber,
+            targetGasLimit: (long)pa.TargetGasLimit);
 
     private static PayloadAttributes BuildPayloadAttributes(
         ulong timestamp,
@@ -296,14 +297,16 @@ public static class SszCodec
         Address suggestedFeeRecipient,
         Withdrawal[]? withdrawals = null,
         Hash256? parentBeaconBlockRoot = null,
-        ulong? slotNumber = null) => new()
+        ulong? slotNumber = null,
+        long? targetGasLimit = null) => new()
         {
             Timestamp = timestamp,
             PrevRandao = prevRandao,
             SuggestedFeeRecipient = suggestedFeeRecipient,
             Withdrawals = withdrawals,
             ParentBeaconBlockRoot = parentBeaconBlockRoot,
-            SlotNumber = slotNumber
+            SlotNumber = slotNumber,
+            TargetGasLimit = targetGasLimit
         };
 
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -80,6 +80,7 @@ public partial struct PayloadAttributesWire
     [SszList(16)] public SszWithdrawal[]? Withdrawals { get; set; }
     public Hash256 ParentBeaconBlockRoot { get; set; }
     public ulong SlotNumber { get; set; }
+    public ulong TargetGasLimit { get; set; }
 }
 
 [SszContainer]


### PR DESCRIPTION
## Summary
Stacked on top of #11611. Plumbs the new \`TargetGasLimit\` field through the SSZ-REST wire schema for \`engine_forkchoiceUpdatedV4\` (introduced in #11611 for JSON-RPC).

- \`PayloadAttributesWire\` gains \`target_gas_limit: uint64\` at the end of the container (matches execution-apis ssz-encoding.md \`PayloadAttributesV4\`).
- \`SszCodec.PayloadAttributesFromWire\` forwards the wire \`ulong\` as \`long\` to \`PayloadAttributes.TargetGasLimit\`.
- \`DecodeFcuV4Request\` round-trip test now also asserts \`target_gas_limit\` survives encode/decode, using a diverse-byte value (\`0x0123456789ABCDEF\`) rather than a plausible default.

## Why
Without the SSZ wire counterpart, CLs that send \`targetGasLimit\` over the SSZ-REST transport (\`POST /engine/v4/forkchoice\`, advertised under execution-apis PR #764) get rejected as **Malformed SSZ body** — the 8 extra trailing bytes shift the inner \`withdrawals\` offset inside \`PayloadAttributesV4\`.

Spec alignment:
- execution-apis JSON spec: \`targetGasLimit\` landed in PR #796 (a22fbd4).
- execution-apis SSZ spec: matching container update in https://github.com/ethereum/execution-apis/pull/764 (commit 949d6a8 on \`bbusa/ssz\`).

## Fail-loud guarantee
The wire \`target_gas_limit\` is a required fixed-size \`uint64\` (per ssz-encoding.md), so a missing value fails SSZ decode directly — the V4 null-guard in \`PayloadAttributes.GetInvalidPayloadAttributesMessage\` (\`Producers/PayloadAttributes.cs:232\`) remains as defense-in-depth for the JSON path. No default-value fallback anywhere.

## Sister PRs
- #11611 — JSON-RPC support for \`targetGasLimit\` (this PR stacks on its head branch)
- #11646 — same SSZ change, against \`glamsterdam-devnet-4\` (where #11611's content is already squashed in)
- https://github.com/ethpandaops/consensoor/pull/6 — CL-side temporary fallback to JSON-RPC fcU until this lands

## Test plan
- [x] \`DecodeFcuV4Request_spec_layout_roundtrips_parent_beacon_block_root_and_slot_number\` now asserts \`target_gas_limit\` round-trips
- [ ] CI green
- [ ] Manual: consensoor ↔ nethermind on glamsterdam devnet — fcU v4 over SSZ no longer rejected