### PR TITLE
Merge.Plugin: make testing_commitBlockV1 txRlps nullable

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/ITestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/ITestingRpcModule.cs
@@ -23,5 +23,5 @@ public interface ITestingRpcModule : IRpcModule
         Description = "Build a block from provided transactions on top of the current chain head, commit it, and wait for the BlockchainProcessor to advance the canonical head to the committed block before returning. Returns the committed block hash. Concurrent invocations are serialized inside the implementation, so callers do not need their own mutex; serialization order between simultaneous calls is unspecified.",
         IsSharable = true,
         IsImplemented = true)]
-    public Task<ResultWrapper<Hash256>> testing_commitBlockV1(PayloadAttributes payloadAttributes, IEnumerable<byte[]> txRlps, byte[]? extraData = null);
+    public Task<ResultWrapper<Hash256>> testing_commitBlockV1(PayloadAttributes payloadAttributes, IEnumerable<byte[]>? txRlps, byte[]? extraData = null);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -60,7 +60,7 @@ public class TestingRpcModule(
     }
 
     public async Task<ResultWrapper<Hash256>> testing_commitBlockV1(
-        PayloadAttributes payloadAttributes, IEnumerable<byte[]> txRlps, byte[]? extraData = null)
+        PayloadAttributes payloadAttributes, IEnumerable<byte[]>? txRlps, byte[]? extraData = null)
     {
         CancellationToken exitToken = processExitSource.Token;
         try


### PR DESCRIPTION
## Summary

The OpenRPC spec for `testing_commitBlockV1` declares `txRlps` as `oneOf [array, null]`, where `null` means the client MAY build from the local txpool. On the current master, `testing_buildBlockV1` already takes `IEnumerable<byte[]>? txRlps`, but `testing_commitBlockV1` still takes a non-nullable `IEnumerable<byte[]>`. JSON-RPC requests with `null` for that parameter fail at parameter binding with `-32602 \"Missing parameter does not have a default value\"` before ever reaching the implementation.

`ProduceBlockAsync` already handles the `txRlps is null` case correctly (it falls back to `env.TxSource.GetTransactions`). Making the entry-point parameter nullable on both `ITestingRpcModule` and `TestingRpcModule` is enough to let the spec-compliant null case dispatch.

This is a 2-character change.

## Companion PRs

- **Spec + cross-client fixtures**: ethereum/execution-apis#801
- **Original spec proposal**: ethereum/execution-apis#787
- **Original commit-block implementation**: #11385
- **go-ethereum impl**: ethereum/go-ethereum#34995
- **hive client gas-limit pinning**: ethereum/hive#1496

## Test plan

- [x] hive `rpc-compat` simulator's `testing_commitBlockV1/commit-block-z-from-mempool` test (which passes `txRlps: null`) goes from failing on Nethermind master to passing with this change
- [x] All 9 `testing_buildBlockV1` + `testing_commitBlockV1` subtests pass against patched Nethermind under hive