### PR TITLE
fix(trie test): de-flake Will_Persist_ReCommittedPersistedNode_FromCommitBuffer

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1568,6 +1568,12 @@ namespace Nethermind.Trie.Test.Pruning
 
             await persistTask;
 
+            // The commit buffer flush is posted as a fire-and-forget Task from BeginScope's dispose
+            // and can lose the lock race against the background prune. Force a deterministic flush
+            // here so block 12's commit moves into the main queue before the next assertion phase;
+            // otherwise the follow-up commits below would land in the buffer instead.
+            fullTrieStore.FlushCommitBufferForTest();
+
             // Write a bit more
             for (int i = 13; i < 13 + pruningBoundary; i++)
             {

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1572,6 +1572,8 @@ namespace Nethermind.Trie.Test.Pruning
             // and can lose the lock race against the background prune. Force a deterministic flush
             // here so block 12's commit moves into the main queue before the next assertion phase;
             // otherwise the follow-up commits below would land in the buffer instead.
+            // Fire-and-forget TryExitCommitBufferMode (posted from BeginScope's dispose) can lose the
+            // lock race; force a blocking flush so block 12 is in the main queue before the writes below.
             fullTrieStore.FlushCommitBufferForTest();
 
             // Write a bit more

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1568,13 +1568,9 @@ namespace Nethermind.Trie.Test.Pruning
 
             await persistTask;
 
-            // The commit buffer flush is posted as a fire-and-forget Task from BeginScope's dispose
-            // and can lose the lock race against the background prune. Force a deterministic flush
-            // here so block 12's commit moves into the main queue before the next assertion phase;
-            // otherwise the follow-up commits below would land in the buffer instead.
-            // Fire-and-forget TryExitCommitBufferMode (posted from BeginScope's dispose) can lose the
-            // lock race; force a blocking flush so block 12 is in the main queue before the writes below.
-            fullTrieStore.FlushCommitBufferForTest();
+            // The fire-and-forget flush from BeginScope's dispose can lose the lock race; force it
+            // here so block 12 leaves the commit buffer before the follow-up commits.
+            fullTrieStore.FlushNonBlockingBuffer();
 
             // Write a bit more
             for (int i = 13; i < 13 + pruningBoundary; i++)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -591,10 +591,6 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         TryExitCommitBufferMode();
     }
 
-    // Testing purpose only — blocks until the commit buffer is flushed, so tests don't depend on the
-    // fire-and-forget TryExitCommitBufferMode posted from BeginScope's dispose to win the lock race.
-    internal void FlushCommitBufferForTest() => FlushNonBlockingBuffer();
-
     private void SyncPruneNonLocked()
     {
         Debug.Assert(_pruningLock.IsHeldByCurrentThread, "Pruning lock must be held to perform sync prune.");
@@ -1009,7 +1005,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         PersistOnShutdown();
     }
 
-    private void FlushNonBlockingBuffer()
+    internal void FlushNonBlockingBuffer()
     {
         using Lock.Scope _ = _scopeLock.EnterScope();
         if (_commitBuffer is null) return;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -591,6 +591,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         TryExitCommitBufferMode();
     }
 
+    // Testing purpose only — blocks until the commit buffer is flushed, so tests don't depend on the
+    // fire-and-forget TryExitCommitBufferMode posted from BeginScope's dispose to win the lock race.
+    internal void FlushCommitBufferForTest() => FlushNonBlockingBuffer();
+
     private void SyncPruneNonLocked()
     {
         Debug.Assert(_pruningLock.IsHeldByCurrentThread, "Pruning lock must be held to perform sync prune.");


### PR DESCRIPTION
## Changes

- Expose the existing blocking `FlushNonBlockingBuffer` as `internal FlushCommitBufferForTest()` on `TrieStore`.
- Call it from `Will_Persist_ReCommittedPersistedNode_FromCommitBuffer` after `await persistTask` so block 12 leaves the commit buffer deterministically before the follow-up commits and final assertion.

### Why

The test re-commits block 5's persisted root at block 12 inside a commit-buffer scope, awaits the background pruner, then writes blocks 13–16 and asserts that `LastPersistedBlockNumber == 12`.

Today the buffer-flush happens via two non-blocking paths — `TryExitCommitBufferMode` at the tail of `SyncPruneQueue` and the fire-and-forget `Task.Factory.StartNew(TryExitCommitBufferMode, …)` posted from `BeginScope`'s dispose. Both use `TryEnter` on `_scopeLock` / `_pruningLock`, so under contention both can fail to acquire and the buffer stays unflushed; the subsequent block commits then land in the buffer, the final `SaveSnapshot` can't find a commit at the finalized boundary, and the assertion sees `LastPersistedBlockNumber` stuck at `7` instead of `12`.

The flake was already flagged in passing in #11469.

### Verification

- 20/20 isolated runs of the test pass with the fix.
- Full `Nethermind.Trie.Test` suite green (433 / 0 / 4).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Test-only change plus a 4-line `internal` test helper on `TrieStore`. No production behavior change.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No