### PR TITLE
ci: retry setup-dotnet up to 3 times

### DIFF
--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -1,0 +1,46 @@
+name: Setup .NET
+description: >-
+  Wraps `actions/setup-dotnet@v5` with up to 3 attempts. Transient install /
+  cache-restore failures (Windows runners are the usual offenders) would
+  otherwise fail the job; the second attempt almost always succeeds.
+
+inputs:
+  cache:
+    description: Forwarded to `actions/setup-dotnet`.
+    required: false
+    default: "false"
+  cache-dependency-path:
+    description: Forwarded to `actions/setup-dotnet`.
+    required: false
+    default: ""
+  global-json-file:
+    description: Forwarded to `actions/setup-dotnet`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - id: try1
+      uses: actions/setup-dotnet@v5
+      with:
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        global-json-file: ${{ inputs.global-json-file }}
+      continue-on-error: true
+
+    - id: try2
+      if: steps.try1.outcome == 'failure'
+      uses: actions/setup-dotnet@v5
+      with:
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        global-json-file: ${{ inputs.global-json-file }}
+      continue-on-error: true
+
+    - if: steps.try1.outcome == 'failure' && steps.try2.outcome == 'failure'
+      uses: actions/setup-dotnet@v5
+      with:
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        global-json-file: ${{ inputs.global-json-file }}

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: ${{ matrix.solution == 'EthereumTests' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Build ${{ matrix.project }}
         working-directory: tools

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Check whitespaces
         run: |

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
           packs: githubsecuritylab/codeql-csharp-queries
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Build Nethermind
         working-directory: src/Nethermind

--- a/.github/workflows/collect-pgo-profile.yml
+++ b/.github/workflows/collect-pgo-profile.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Set up .NET
         if: always()
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: false
 

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -104,7 +104,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json

--- a/.github/workflows/hive-consensus-tests.yml
+++ b/.github/workflows/hive-consensus-tests.yml
@@ -122,7 +122,7 @@ jobs:
           path: nethermind
           submodules: "recursive"
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: nethermind/global.json
       - name: Generate Hive Json For Matrix

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -99,7 +99,7 @@ jobs:
           submodules: ${{ startsWith(matrix.project, 'Ethereum.') && 'recursive' || 'false' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |
@@ -159,7 +159,7 @@ jobs:
           submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -225,7 +225,7 @@ jobs:
           submodules: ${{ startsWith(matrix.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |
@@ -182,7 +182,7 @@ jobs:
           submodules: recursive
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |
@@ -277,7 +277,7 @@ jobs:
           submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: |
@@ -330,7 +330,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Download coverage reports
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -155,7 +155,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Download Nethermind reference assemblies
         id: download

--- a/.github/workflows/run-block-processing-benchmark.yml
+++ b/.github/workflows/run-block-processing-benchmark.yml
@@ -85,7 +85,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha || 'master' }}
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           cache: true
           cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -36,7 +36,7 @@ jobs:
           path: d
           token: ${{ steps.gh-app.outputs.token }}
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: n/global.json
       - name: Build DocGen


### PR DESCRIPTION
## Changes

- Add `./.github/actions/setup-dotnet/action.yaml` — a composite action that wraps `actions/setup-dotnet@v5` with up to 3 attempts. The first two attempts use `continue-on-error: true`; only an all-three-fail case breaks the job. Forwards the only inputs any caller uses today: `cache`, `cache-dependency-path`, `global-json-file`.
- Switch all 19 call sites across 15 workflow files from `uses: actions/setup-dotnet@v5` to `uses: ./.github/actions/setup-dotnet`.

### Why

A Windows job on PR #11645 ([job 76543058556](https://github.com/NethermindEth/nethermind/actions/runs/26038462999/job/76543058556)) failed at the **Set up .NET** step despite the install scripts logging \"Installation finished\" for both the runtime and the SDK with no error in between. The step exited non-zero and the rest of the job was skipped — most likely a transient cache-restore / post-install failure. Retrying the install once or twice resolves this class of flake without any code-level change.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

CI-only change. Validated YAML parses for every modified workflow. The new composite action only exercises retry on real failure; the happy path is one `actions/setup-dotnet@v5` invocation with the same inputs as before.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No