### PR TITLE
Add EthStats protocol message handling

### DIFF
--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
@@ -1,8 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Core.Test.Builders;
 using Nethermind.EthStats.Integrations;
+using Nethermind.EthStats.Messages;
+using Nethermind.Facade.Eth;
+using Nethermind.JsonRpc.Modules.Eth.GasPrice;
+using Nethermind.Logging;
+using Nethermind.Network;
+using Nethermind.TxPool;
+using NSubstitute;
 using NUnit.Framework;
+using Websocket.Client;
+using CoreBlock = Nethermind.Core.Block;
+using EthStatsBlock = Nethermind.EthStats.Messages.Models.Block;
 
 namespace Nethermind.EthStats.Test;
 
@@ -12,6 +27,7 @@ public class EthStatsIntegrationTests
     [TestCase(-3, -1, false, 0, 0, TestName = "TryNormalizeHistoryRange_rejects_negative_range")]
     [TestCase(-3, 3, true, 0, 3, TestName = "TryNormalizeHistoryRange_clamps_negative_min")]
     [TestCase(0, 100, true, 37, 100, TestName = "TryNormalizeHistoryRange_limits_oversized_range")]
+    [TestCase(0, long.MaxValue, true, long.MaxValue - 63, long.MaxValue, TestName = "TryNormalizeHistoryRange_handles_max_long_without_overflow")]
     public void TryNormalizeHistoryRange_handles_edges(
         long requestMin,
         long requestMax,
@@ -30,5 +46,63 @@ public class EthStatsIntegrationTests
             Assert.That(min, Is.EqualTo(expectedMin));
             Assert.That(max, Is.EqualTo(expectedMax));
         }
+    }
+
+    [Test]
+    public async Task HandleIncomingMessageAsync_sends_history_in_ascending_order()
+    {
+        IMessageSender sender = Substitute.For<IMessageSender>();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        EthStatsIntegration integration = CreateIntegration(sender, blockTree);
+        CoreBlock firstBlock = Build.A.Block.WithNumber(1).TestObject;
+        CoreBlock secondBlock = Build.A.Block.WithNumber(2).TestObject;
+
+        blockTree.FindBlock(1, BlockTreeLookupOptions.RequireCanonical).Returns(firstBlock);
+        blockTree.FindBlock(2, BlockTreeLookupOptions.RequireCanonical).Returns(secondBlock);
+        sender.SendAsync(Arg.Any<IWebsocketClient>(), Arg.Any<HistoryMessage>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        await integration.HandleIncomingMessageAsync("""{"emit":["history",{"min":1,"max":2}]}""");
+
+        _ = sender.Received(1).SendAsync(
+            Arg.Any<IWebsocketClient>(),
+            Arg.Is<HistoryMessage>(message => HasHistoryBlocks(message, 1, 2)),
+            null);
+    }
+
+    private static EthStatsIntegration CreateIntegration(IMessageSender sender, IBlockTree blockTree)
+        => new(
+            "test-node",
+            "test-client",
+            30303,
+            "testnet",
+            "eth/68",
+            "No",
+            "Nethermind/v1",
+            "contact",
+            true,
+            "secret",
+            Substitute.For<IEthStatsClient>(),
+            sender,
+            Substitute.For<ITxPool>(),
+            blockTree,
+            Substitute.For<IPeerManager>(),
+            Substitute.For<IGasPriceOracle>(),
+            Substitute.For<IEthSyncingInfo>(),
+            false,
+            TimeSpan.FromSeconds(1),
+            LimboLogs.Instance);
+
+    private static bool HasHistoryBlocks(HistoryMessage message, long firstBlockNumber, long secondBlockNumber)
+    {
+        List<long> numbers = new();
+        foreach (EthStatsBlock block in message.History)
+        {
+            numbers.Add(block.Number);
+        }
+
+        return numbers.Count == 2 &&
+            numbers[0] == firstBlockNumber &&
+            numbers[1] == secondBlockNumber;
     }
 }

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.EthStats.Integrations;
+using NUnit.Framework;
+
+namespace Nethermind.EthStats.Test;
+
+public class EthStatsIntegrationTests
+{
+    [TestCase(3, 1, true, 1, 3, TestName = "TryNormalizeHistoryRange_swaps_min_and_max")]
+    [TestCase(-3, -1, false, 0, 0, TestName = "TryNormalizeHistoryRange_rejects_negative_range")]
+    [TestCase(-3, 3, true, 0, 3, TestName = "TryNormalizeHistoryRange_clamps_negative_min")]
+    [TestCase(0, 100, true, 37, 100, TestName = "TryNormalizeHistoryRange_limits_oversized_range")]
+    public void TryNormalizeHistoryRange_handles_edges(
+        long requestMin,
+        long requestMax,
+        bool expectedResult,
+        long expectedMin,
+        long expectedMax)
+    {
+        bool result = EthStatsIntegration.TryNormalizeHistoryRange(
+            new EthStatsHistoryRequest(requestMin, requestMax),
+            out long min,
+            out long max);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(expectedResult));
+            Assert.That(min, Is.EqualTo(expectedMin));
+            Assert.That(max, Is.EqualTo(expectedMax));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
@@ -1,48 +1,74 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace Nethermind.EthStats.Test
+namespace Nethermind.EthStats.Test;
+
+public class EthStatsMessageParserTests
 {
-    public class EthStatsMessageParserTests
+    private static IEnumerable<TestCaseData> ParseCases()
     {
-        [Test]
-        public void Can_parse_history_request()
-        {
-            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["history",{"min":1,"max":3}]}""", out EthStatsIncomingMessage message);
+        yield return new TestCaseData(
+            """{"emit":["history",{"min":1,"max":3}]}""",
+            (int)EthStatsIncomingMessageType.History,
+            1L,
+            3L,
+            null,
+            null)
+            .SetName("Can_parse_history_request");
 
+        yield return new TestCaseData(
+            """{"emit":["node-ping",{"clientTime":42}]}""",
+            (int)EthStatsIncomingMessageType.NodePing,
+            null,
+            null,
+            42L,
+            null)
+            .SetName("Can_parse_node_ping");
+
+        yield return new TestCaseData(
+            """{"emit":["node-pong",{"clientTime":42,"serverTime":84}]}""",
+            (int)EthStatsIncomingMessageType.NodePong,
+            null,
+            null,
+            42L,
+            84L)
+            .SetName("Can_parse_node_pong");
+    }
+
+    [TestCaseSource(nameof(ParseCases))]
+    public void Can_parse_message(
+        string json,
+        int expectedMessageType,
+        long? expectedHistoryMin,
+        long? expectedHistoryMax,
+        long? expectedClientTime,
+        long? expectedServerTime)
+    {
+        bool parsed = EthStatsMessageParser.TryParse(json, out EthStatsIncomingMessage message);
+        EthStatsHistoryRequest? expectedHistoryRequest = expectedHistoryMin is null || expectedHistoryMax is null
+            ? null
+            : new EthStatsHistoryRequest(expectedHistoryMin.Value, expectedHistoryMax.Value);
+        EthStatsNodeTiming? expectedNodeTiming = expectedClientTime is null && expectedServerTime is null
+            ? null
+            : new EthStatsNodeTiming(expectedClientTime, expectedServerTime);
+
+        using (Assert.EnterMultipleScope())
+        {
             Assert.That(parsed, Is.True);
-            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.History));
-            Assert.That(message.HistoryRequest, Is.EqualTo(new EthStatsHistoryRequest(1, 3)));
+            Assert.That(message.MessageType, Is.EqualTo((EthStatsIncomingMessageType)expectedMessageType));
+            Assert.That(message.HistoryRequest, Is.EqualTo(expectedHistoryRequest));
+            Assert.That(message.NodeTiming, Is.EqualTo(expectedNodeTiming));
         }
+    }
 
-        [Test]
-        public void Can_parse_node_ping()
-        {
-            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["node-ping",{"clientTime":42}]}""", out EthStatsIncomingMessage message);
+    [Test]
+    public void Ignores_invalid_payload()
+    {
+        bool parsed = EthStatsMessageParser.TryParse("""{"emit":["history",{"min":"bad","max":3}]}""", out _);
 
-            Assert.That(parsed, Is.True);
-            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.NodePing));
-            Assert.That(message.NodeTiming, Is.EqualTo(new EthStatsNodeTiming(42, null)));
-        }
-
-        [Test]
-        public void Can_parse_node_pong()
-        {
-            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["node-pong",{"clientTime":42,"serverTime":84}]}""", out EthStatsIncomingMessage message);
-
-            Assert.That(parsed, Is.True);
-            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.NodePong));
-            Assert.That(message.NodeTiming, Is.EqualTo(new EthStatsNodeTiming(42, 84)));
-        }
-
-        [Test]
-        public void Ignores_invalid_payload()
-        {
-            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["history",{"min":"bad","max":3}]}""", out _);
-
-            Assert.That(parsed, Is.False);
-        }
+        Assert.That(parsed, Is.False);
     }
 }

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using NUnit.Framework;
+
+namespace Nethermind.EthStats.Test
+{
+    public class EthStatsMessageParserTests
+    {
+        [Test]
+        public void Can_parse_history_request()
+        {
+            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["history",{"min":1,"max":3}]}""", out EthStatsIncomingMessage message);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.History));
+            Assert.That(message.HistoryRequest, Is.EqualTo(new EthStatsHistoryRequest(1, 3)));
+        }
+
+        [Test]
+        public void Can_parse_node_ping()
+        {
+            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["node-ping",{"clientTime":42}]}""", out EthStatsIncomingMessage message);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.NodePing));
+            Assert.That(message.NodeTiming, Is.EqualTo(new EthStatsNodeTiming(42, null)));
+        }
+
+        [Test]
+        public void Can_parse_node_pong()
+        {
+            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["node-pong",{"clientTime":42,"serverTime":84}]}""", out EthStatsIncomingMessage message);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(message.MessageType, Is.EqualTo(EthStatsIncomingMessageType.NodePong));
+            Assert.That(message.NodeTiming, Is.EqualTo(new EthStatsNodeTiming(42, 84)));
+        }
+
+        [Test]
+        public void Ignores_invalid_payload()
+        {
+            bool parsed = EthStatsMessageParser.TryParse("""{"emit":["history",{"min":"bad","max":3}]}""", out _);
+
+            Assert.That(parsed, Is.False);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsMessageParserTests.cs
@@ -15,7 +15,6 @@ public class EthStatsMessageParserTests
             (int)EthStatsIncomingMessageType.History,
             1L,
             3L,
-            null,
             null)
             .SetName("Can_parse_history_request");
 
@@ -24,8 +23,7 @@ public class EthStatsMessageParserTests
             (int)EthStatsIncomingMessageType.NodePing,
             null,
             null,
-            42L,
-            null)
+            42L)
             .SetName("Can_parse_node_ping");
 
         yield return new TestCaseData(
@@ -33,8 +31,7 @@ public class EthStatsMessageParserTests
             (int)EthStatsIncomingMessageType.NodePong,
             null,
             null,
-            42L,
-            84L)
+            42L)
             .SetName("Can_parse_node_pong");
     }
 
@@ -44,16 +41,15 @@ public class EthStatsMessageParserTests
         int expectedMessageType,
         long? expectedHistoryMin,
         long? expectedHistoryMax,
-        long? expectedClientTime,
-        long? expectedServerTime)
+        long? expectedClientTime)
     {
         bool parsed = EthStatsMessageParser.TryParse(json, out EthStatsIncomingMessage message);
         EthStatsHistoryRequest? expectedHistoryRequest = expectedHistoryMin is null || expectedHistoryMax is null
             ? null
             : new EthStatsHistoryRequest(expectedHistoryMin.Value, expectedHistoryMax.Value);
-        EthStatsNodeTiming? expectedNodeTiming = expectedClientTime is null && expectedServerTime is null
+        EthStatsNodeTiming? expectedNodeTiming = expectedClientTime is null
             ? null
-            : new EthStatsNodeTiming(expectedClientTime, expectedServerTime);
+            : new EthStatsNodeTiming(expectedClientTime);
 
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.EthStats.Test/MessageSenderTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/MessageSenderTests.cs
@@ -9,37 +9,34 @@ using NSubstitute;
 using NUnit.Framework;
 using Websocket.Client;
 
-namespace Nethermind.EthStats.Test
+namespace Nethermind.EthStats.Test;
+
+public class MessageSenderTests
 {
-    public class MessageSenderTests
+    [TestCase("node-ping", false, TestName = "Can_send_node_ping_with_ethstats_event_name")]
+    [TestCase("node-pong", true, TestName = "Can_send_node_pong_with_ethstats_event_name")]
+    public async Task Can_send_node_message_with_ethstats_event_name(string eventType, bool includeServerTime)
     {
-        [Test]
-        public async Task Can_send_node_ping_with_ethstats_event_name()
+        IWebsocketClient client = Substitute.For<IWebsocketClient>();
+        MessageSender sender = new("test-node", LimboLogs.Instance);
+        IMessage message = includeServerTime
+            ? new NodePongMessage(42, 84)
+            : new NodePingMessage(42);
+
+        await sender.SendAsync(client, message, eventType);
+
+        client.Received(1).Send(Arg.Is<string>(payload => ContainsExpectedPayload(payload, eventType, includeServerTime)));
+    }
+
+    private static bool ContainsExpectedPayload(string payload, string eventType, bool includeServerTime)
+    {
+        if (!payload.Contains($"\"{eventType}\"") ||
+            !payload.Contains("\"id\":\"test-node\"") ||
+            !payload.Contains("\"clientTime\":42"))
         {
-            IWebsocketClient client = Substitute.For<IWebsocketClient>();
-            MessageSender sender = new("test-node", LimboLogs.Instance);
-
-            await sender.SendAsync(client, new NodePingMessage(42), "node-ping");
-
-            client.Received(1).Send(Arg.Is<string>(payload =>
-                payload.Contains("\"node-ping\"") &&
-                payload.Contains("\"id\":\"test-node\"") &&
-                payload.Contains("\"clientTime\":42")));
+            return false;
         }
 
-        [Test]
-        public async Task Can_send_node_pong_with_ethstats_event_name()
-        {
-            IWebsocketClient client = Substitute.For<IWebsocketClient>();
-            MessageSender sender = new("test-node", LimboLogs.Instance);
-
-            await sender.SendAsync(client, new NodePongMessage(42, 84), "node-pong");
-
-            client.Received(1).Send(Arg.Is<string>(payload =>
-                payload.Contains("\"node-pong\"") &&
-                payload.Contains("\"id\":\"test-node\"") &&
-                payload.Contains("\"clientTime\":42") &&
-                payload.Contains("\"serverTime\":84")));
-        }
+        return !includeServerTime || payload.Contains("\"serverTime\":84");
     }
 }

--- a/src/Nethermind/Nethermind.EthStats.Test/MessageSenderTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/MessageSenderTests.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.EthStats.Messages;
+using Nethermind.EthStats.Senders;
+using Nethermind.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using Websocket.Client;
+
+namespace Nethermind.EthStats.Test
+{
+    public class MessageSenderTests
+    {
+        [Test]
+        public async Task Can_send_node_ping_with_ethstats_event_name()
+        {
+            IWebsocketClient client = Substitute.For<IWebsocketClient>();
+            MessageSender sender = new("test-node", LimboLogs.Instance);
+
+            await sender.SendAsync(client, new NodePingMessage(42), "node-ping");
+
+            client.Received(1).Send(Arg.Is<string>(payload =>
+                payload.Contains("\"node-ping\"") &&
+                payload.Contains("\"id\":\"test-node\"") &&
+                payload.Contains("\"clientTime\":42")));
+        }
+
+        [Test]
+        public async Task Can_send_node_pong_with_ethstats_event_name()
+        {
+            IWebsocketClient client = Substitute.For<IWebsocketClient>();
+            MessageSender sender = new("test-node", LimboLogs.Instance);
+
+            await sender.SendAsync(client, new NodePongMessage(42, 84), "node-pong");
+
+            client.Received(1).Send(Arg.Is<string>(payload =>
+                payload.Contains("\"node-pong\"") &&
+                payload.Contains("\"id\":\"test-node\"") &&
+                payload.Contains("\"clientTime\":42") &&
+                payload.Contains("\"serverTime\":84")));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
+++ b/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
@@ -21,6 +21,7 @@ namespace Nethermind.EthStats.Clients
         ILogManager? logManager) : IEthStatsClient, IDisposable
     {
         private const string ServerPingMessage = "primus::ping::";
+        private const int ReconnectTimeoutMultiplier = 6;
         private readonly string _urlFromConfig = urlFromConfig ?? throw new ArgumentNullException(nameof(urlFromConfig));
         private readonly int _reconnectionInterval = reconnectionInterval;
         private readonly IMessageSender _messageSender = messageSender ?? throw new ArgumentNullException(nameof(messageSender));
@@ -72,7 +73,7 @@ namespace Nethermind.EthStats.Clients
             _client = new WebsocketClient(url)
             {
                 ErrorReconnectTimeout = TimeSpan.FromMilliseconds(_reconnectionInterval),
-                ReconnectTimeout = null
+                ReconnectTimeout = TimeSpan.FromMilliseconds(_reconnectionInterval * ReconnectTimeoutMultiplier)
             };
 
             _client.MessageReceived.Subscribe(async message =>

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+
+namespace Nethermind.EthStats;
+
+internal enum EthStatsIncomingMessageType
+{
+    Unknown,
+    History,
+    NodePing,
+    NodePong
+}
+
+internal readonly record struct EthStatsHistoryRequest(long Min, long Max);
+
+internal readonly record struct EthStatsNodeTiming(long? ClientTime, long? ServerTime);
+
+internal readonly record struct EthStatsIncomingMessage(
+    string EventTypeName,
+    EthStatsIncomingMessageType MessageType,
+    EthStatsHistoryRequest? HistoryRequest,
+    EthStatsNodeTiming? NodeTiming);
+
+internal static class EthStatsMessageParser
+{
+    public static bool TryParse(string? message, out EthStatsIncomingMessage incomingMessage)
+    {
+        incomingMessage = new EthStatsIncomingMessage(string.Empty, EthStatsIncomingMessageType.Unknown, null, null);
+
+        if (string.IsNullOrWhiteSpace(message) || message[0] != '{')
+        {
+            return false;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(message);
+            JsonElement root = document.RootElement;
+
+            if (!root.TryGetProperty("emit", out JsonElement emit) ||
+                emit.ValueKind != JsonValueKind.Array ||
+                emit.GetArrayLength() == 0)
+            {
+                return false;
+            }
+
+            JsonElement eventTypeElement = emit[0];
+            if (eventTypeElement.ValueKind != JsonValueKind.String)
+            {
+                return false;
+            }
+
+            string? eventType = eventTypeElement.GetString();
+            if (string.IsNullOrWhiteSpace(eventType))
+            {
+                return false;
+            }
+
+            JsonElement payload = emit.GetArrayLength() > 1 ? emit[1] : default;
+            if (eventType == "history")
+            {
+                if (!TryReadHistoryRequest(payload, out EthStatsHistoryRequest historyRequest))
+                {
+                    return false;
+                }
+
+                incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.History, historyRequest, null);
+                return true;
+            }
+
+            incomingMessage = eventType switch
+            {
+                "node-ping" =>
+                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.NodePing, null, ReadNodeTiming(payload)),
+                "node-pong" =>
+                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.NodePong, null, ReadNodeTiming(payload)),
+                _ =>
+                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.Unknown, null, null)
+            };
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadHistoryRequest(JsonElement payload, out EthStatsHistoryRequest historyRequest)
+    {
+        historyRequest = default;
+
+        if (!TryGetInt64(payload, "min", out long min) ||
+            !TryGetInt64(payload, "max", out long max))
+        {
+            return false;
+        }
+
+        historyRequest = new EthStatsHistoryRequest(min, max);
+        return true;
+    }
+
+    private static EthStatsNodeTiming ReadNodeTiming(JsonElement payload)
+    {
+        long? clientTime = TryGetInt64(payload, "clientTime", out long parsedClientTime) ? parsedClientTime : null;
+        long? serverTime = TryGetInt64(payload, "serverTime", out long parsedServerTime) ? parsedServerTime : null;
+
+        return new EthStatsNodeTiming(clientTime, serverTime);
+    }
+
+    private static bool TryGetInt64(JsonElement payload, string propertyName, out long value)
+    {
+        value = 0;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        foreach (JsonProperty property in payload.EnumerateObject())
+        {
+            if (property.NameEquals(propertyName))
+            {
+                return TryReadInt64(property.Value, out value);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadInt64(JsonElement element, out long value)
+    {
+        value = 0;
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetInt64(out value),
+            JsonValueKind.String => long.TryParse(element.GetString(), out value),
+            _ => false
+        };
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -161,27 +161,27 @@ internal static class EthStatsMessageParser
             switch (messageType)
             {
                 case EthStatsIncomingMessageType.History:
-                {
-                    if (!TryReadHistoryRequest(ref reader, out EthStatsHistoryRequest historyRequest))
                     {
-                        return false;
-                    }
+                        if (!TryReadHistoryRequest(ref reader, out EthStatsHistoryRequest historyRequest))
+                        {
+                            return false;
+                        }
 
-                    incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.History, historyRequest, null);
-                    return true;
-                }
+                        incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.History, historyRequest, null);
+                        return true;
+                    }
                 case EthStatsIncomingMessageType.NodePing:
                 case EthStatsIncomingMessageType.NodePong:
-                {
-                    EthStatsNodeTiming timing = ReadNodeTiming(ref reader);
-                    incomingMessage = new EthStatsIncomingMessage(eventType, messageType, null, timing);
-                    return true;
-                }
+                    {
+                        EthStatsNodeTiming timing = ReadNodeTiming(ref reader);
+                        incomingMessage = new EthStatsIncomingMessage(eventType, messageType, null, timing);
+                        return true;
+                    }
                 default:
-                {
-                    incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.Unknown, null, null);
-                    return true;
-                }
+                    {
+                        incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.Unknown, null, null);
+                        return true;
+                    }
             }
         }
 

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text;
 using System.Text.Json;
 
@@ -282,16 +283,43 @@ internal static class EthStatsMessageParser
 
     private static bool TryReadInt64(ref Utf8JsonReader reader, out long value)
     {
+        value = 0;
+
         switch (reader.TokenType)
         {
             case JsonTokenType.Number:
                 return reader.TryGetInt64(out value);
             case JsonTokenType.String:
-                value = 0;
-                return long.TryParse(reader.GetString(), out value);
+                return TryParseInt64String(ref reader, out value);
             default:
-                value = 0;
                 return false;
         }
+    }
+
+    private static bool TryParseInt64String(ref Utf8JsonReader reader, out long value)
+    {
+        // A signed 64-bit integer is at most 20 ASCII bytes ("-9223372036854775808"); anything
+        // longer cannot be a valid long, so we can reject without allocating.
+        const int maxInt64Digits = 20;
+        Span<byte> sequenceBuffer = stackalloc byte[maxInt64Digits];
+        ReadOnlySpan<byte> raw;
+
+        if (reader.HasValueSequence)
+        {
+            if (reader.ValueSequence.Length > maxInt64Digits)
+            {
+                value = 0;
+                return false;
+            }
+
+            reader.ValueSequence.CopyTo(sequenceBuffer);
+            raw = sequenceBuffer[..(int)reader.ValueSequence.Length];
+        }
+        else
+        {
+            raw = reader.ValueSpan;
+        }
+
+        return Utf8Parser.TryParse(raw, out value, out int consumed) && consumed == raw.Length;
     }
 }

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Text.Json;
 
 namespace Nethermind.EthStats;
@@ -120,15 +119,7 @@ internal static class EthStatsMessageParser
             return false;
         }
 
-        foreach (JsonProperty property in payload.EnumerateObject())
-        {
-            if (property.NameEquals(propertyName))
-            {
-                return TryReadInt64(property.Value, out value);
-            }
-        }
-
-        return false;
+        return payload.TryGetProperty(propertyName, out JsonElement element) && TryReadInt64(element, out value);
     }
 
     private static bool TryReadInt64(JsonElement element, out long value)

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Buffers;
+using System.Text;
 using System.Text.Json;
 
 namespace Nethermind.EthStats;
@@ -25,6 +28,11 @@ internal readonly record struct EthStatsIncomingMessage(
 
 internal static class EthStatsMessageParser
 {
+    private const string History = "history";
+    private const string NodePing = "node-ping";
+    private const string NodePong = "node-pong";
+    private const int StackBufferThreshold = 512;
+
     public static bool TryParse(string? message, out EthStatsIncomingMessage incomingMessage)
     {
         incomingMessage = new EthStatsIncomingMessage(string.Empty, EthStatsIncomingMessageType.Unknown, null, null);
@@ -34,102 +42,256 @@ internal static class EthStatsMessageParser
             return false;
         }
 
+        int maxByteCount = Encoding.UTF8.GetMaxByteCount(message.Length);
+        byte[]? rented = null;
+        Span<byte> buffer = maxByteCount <= StackBufferThreshold
+            ? stackalloc byte[StackBufferThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(maxByteCount));
+
         try
         {
-            using JsonDocument document = JsonDocument.Parse(message);
-            JsonElement root = document.RootElement;
-
-            if (!root.TryGetProperty("emit", out JsonElement emit) ||
-                emit.ValueKind != JsonValueKind.Array ||
-                emit.GetArrayLength() == 0)
-            {
-                return false;
-            }
-
-            JsonElement eventTypeElement = emit[0];
-            if (eventTypeElement.ValueKind != JsonValueKind.String)
-            {
-                return false;
-            }
-
-            string? eventType = eventTypeElement.GetString();
-            if (string.IsNullOrWhiteSpace(eventType))
-            {
-                return false;
-            }
-
-            JsonElement payload = emit.GetArrayLength() > 1 ? emit[1] : default;
-            if (eventType == "history")
-            {
-                if (!TryReadHistoryRequest(payload, out EthStatsHistoryRequest historyRequest))
-                {
-                    return false;
-                }
-
-                incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.History, historyRequest, null);
-                return true;
-            }
-
-            incomingMessage = eventType switch
-            {
-                "node-ping" =>
-                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.NodePing, null, ReadNodeTiming(payload)),
-                "node-pong" =>
-                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.NodePong, null, ReadNodeTiming(payload)),
-                _ =>
-                    new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.Unknown, null, null)
-            };
-
-            return true;
+            int written = Encoding.UTF8.GetBytes(message, buffer);
+            return TryParseCore(buffer[..written], out incomingMessage);
         }
         catch (JsonException)
         {
             return false;
         }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
     }
 
-    private static bool TryReadHistoryRequest(JsonElement payload, out EthStatsHistoryRequest historyRequest)
+    private static bool TryParseCore(ReadOnlySpan<byte> utf8Bytes, out EthStatsIncomingMessage incomingMessage)
     {
-        historyRequest = default;
+        incomingMessage = new EthStatsIncomingMessage(string.Empty, EthStatsIncomingMessageType.Unknown, null, null);
 
-        if (!TryGetInt64(payload, "min", out long min) ||
-            !TryGetInt64(payload, "max", out long max))
+        Utf8JsonReader reader = new(utf8Bytes);
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
         {
             return false;
         }
 
-        historyRequest = new EthStatsHistoryRequest(min, max);
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return false;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                return false;
+            }
+
+            if (!reader.ValueTextEquals("emit"u8))
+            {
+                reader.Skip();
+                continue;
+            }
+
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+            {
+                return false;
+            }
+
+            if (!reader.Read() || reader.TokenType != JsonTokenType.String)
+            {
+                return false;
+            }
+
+            string eventType;
+            EthStatsIncomingMessageType messageType;
+
+            if (reader.ValueTextEquals("history"u8))
+            {
+                eventType = History;
+                messageType = EthStatsIncomingMessageType.History;
+            }
+            else if (reader.ValueTextEquals("node-ping"u8))
+            {
+                eventType = NodePing;
+                messageType = EthStatsIncomingMessageType.NodePing;
+            }
+            else if (reader.ValueTextEquals("node-pong"u8))
+            {
+                eventType = NodePong;
+                messageType = EthStatsIncomingMessageType.NodePong;
+            }
+            else
+            {
+                eventType = reader.GetString() ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(eventType))
+                {
+                    return false;
+                }
+                messageType = EthStatsIncomingMessageType.Unknown;
+            }
+
+            if (!reader.Read())
+            {
+                return false;
+            }
+
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                if (messageType == EthStatsIncomingMessageType.History)
+                {
+                    return false;
+                }
+
+                EthStatsNodeTiming? emptyTiming = messageType is EthStatsIncomingMessageType.NodePing or EthStatsIncomingMessageType.NodePong
+                    ? new EthStatsNodeTiming(null)
+                    : null;
+                incomingMessage = new EthStatsIncomingMessage(eventType, messageType, null, emptyTiming);
+                return true;
+            }
+
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                return false;
+            }
+
+            switch (messageType)
+            {
+                case EthStatsIncomingMessageType.History:
+                {
+                    if (!TryReadHistoryRequest(ref reader, out EthStatsHistoryRequest historyRequest))
+                    {
+                        return false;
+                    }
+
+                    incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.History, historyRequest, null);
+                    return true;
+                }
+                case EthStatsIncomingMessageType.NodePing:
+                case EthStatsIncomingMessageType.NodePong:
+                {
+                    EthStatsNodeTiming timing = ReadNodeTiming(ref reader);
+                    incomingMessage = new EthStatsIncomingMessage(eventType, messageType, null, timing);
+                    return true;
+                }
+                default:
+                {
+                    incomingMessage = new EthStatsIncomingMessage(eventType, EthStatsIncomingMessageType.Unknown, null, null);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadHistoryRequest(ref Utf8JsonReader reader, out EthStatsHistoryRequest historyRequest)
+    {
+        historyRequest = default;
+        long? min = null;
+        long? max = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                return false;
+            }
+
+            bool isMin = reader.ValueTextEquals("min"u8);
+            bool isMax = !isMin && reader.ValueTextEquals("max"u8);
+
+            if (!reader.Read())
+            {
+                return false;
+            }
+
+            if (isMin)
+            {
+                if (!TryReadInt64(ref reader, out long value))
+                {
+                    return false;
+                }
+                min = value;
+            }
+            else if (isMax)
+            {
+                if (!TryReadInt64(ref reader, out long value))
+                {
+                    return false;
+                }
+                max = value;
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        if (min is null || max is null)
+        {
+            return false;
+        }
+
+        historyRequest = new EthStatsHistoryRequest(min.Value, max.Value);
         return true;
     }
 
-    private static EthStatsNodeTiming ReadNodeTiming(JsonElement payload)
+    private static EthStatsNodeTiming ReadNodeTiming(ref Utf8JsonReader reader)
     {
-        long? clientTime = TryGetInt64(payload, "clientTime", out long parsedClientTime) ? parsedClientTime : null;
+        long? clientTime = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                break;
+            }
+
+            bool isClientTime = reader.ValueTextEquals("clientTime"u8);
+
+            if (!reader.Read())
+            {
+                break;
+            }
+
+            if (isClientTime && TryReadInt64(ref reader, out long value))
+            {
+                clientTime = value;
+            }
+            else if (!isClientTime)
+            {
+                reader.Skip();
+            }
+        }
 
         return new EthStatsNodeTiming(clientTime);
     }
 
-    private static bool TryGetInt64(JsonElement payload, string propertyName, out long value)
+    private static bool TryReadInt64(ref Utf8JsonReader reader, out long value)
     {
-        value = 0;
-
-        if (payload.ValueKind != JsonValueKind.Object)
+        switch (reader.TokenType)
         {
-            return false;
+            case JsonTokenType.Number:
+                return reader.TryGetInt64(out value);
+            case JsonTokenType.String:
+                value = 0;
+                return long.TryParse(reader.GetString(), out value);
+            default:
+                value = 0;
+                return false;
         }
-
-        return payload.TryGetProperty(propertyName, out JsonElement element) && TryReadInt64(element, out value);
-    }
-
-    private static bool TryReadInt64(JsonElement element, out long value)
-    {
-        value = 0;
-
-        return element.ValueKind switch
-        {
-            JsonValueKind.Number => element.TryGetInt64(out value),
-            JsonValueKind.String => long.TryParse(element.GetString(), out value),
-            _ => false
-        };
     }
 }

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -15,7 +15,7 @@ internal enum EthStatsIncomingMessageType
 
 internal readonly record struct EthStatsHistoryRequest(long Min, long Max);
 
-internal readonly record struct EthStatsNodeTiming(long? ClientTime, long? ServerTime);
+internal readonly record struct EthStatsNodeTiming(long? ClientTime);
 
 internal readonly record struct EthStatsIncomingMessage(
     string EventTypeName,
@@ -105,9 +105,8 @@ internal static class EthStatsMessageParser
     private static EthStatsNodeTiming ReadNodeTiming(JsonElement payload)
     {
         long? clientTime = TryGetInt64(payload, "clientTime", out long parsedClientTime) ? parsedClientTime : null;
-        long? serverTime = TryGetInt64(payload, "serverTime", out long parsedServerTime) ? parsedServerTime : null;
 
-        return new EthStatsNodeTiming(clientTime, serverTime);
+        return new EthStatsNodeTiming(clientTime);
     }
 
     private static bool TryGetInt64(JsonElement payload, string propertyName, out long value)

--- a/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsMessageParser.cs
@@ -301,25 +301,23 @@ internal static class EthStatsMessageParser
         // A signed 64-bit integer is at most 20 ASCII bytes ("-9223372036854775808"); anything
         // longer cannot be a valid long, so we can reject without allocating.
         const int maxInt64Digits = 20;
-        Span<byte> sequenceBuffer = stackalloc byte[maxInt64Digits];
-        ReadOnlySpan<byte> raw;
 
         if (reader.HasValueSequence)
         {
-            if (reader.ValueSequence.Length > maxInt64Digits)
+            long sequenceLength = reader.ValueSequence.Length;
+            if (sequenceLength > maxInt64Digits)
             {
                 value = 0;
                 return false;
             }
 
+            Span<byte> sequenceBuffer = stackalloc byte[maxInt64Digits];
             reader.ValueSequence.CopyTo(sequenceBuffer);
-            raw = sequenceBuffer[..(int)reader.ValueSequence.Length];
-        }
-        else
-        {
-            raw = reader.ValueSpan;
+            ReadOnlySpan<byte> sequenceRaw = sequenceBuffer[..(int)sequenceLength];
+            return Utf8Parser.TryParse(sequenceRaw, out value, out int sequenceConsumed) && sequenceConsumed == sequenceRaw.Length;
         }
 
+        ReadOnlySpan<byte> raw = reader.ValueSpan;
         return Utf8Parser.TryParse(raw, out value, out int consumed) && consumed == raw.Length;
     }
 }

--- a/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
@@ -13,7 +13,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.EthStats.Clients;
-using Nethermind.EthStats.Configs;
 using Nethermind.EthStats.Integrations;
 using Nethermind.EthStats.Senders;
 using Nethermind.Facade.Eth;

--- a/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
@@ -51,10 +51,7 @@ public class EthStatsStep(
         if (!initConfig.WebSocketsEnabled)
         {
             _logger.Warn($"{nameof(EthStatsPlugin)} disabled due to {nameof(initConfig.WebSocketsEnabled)} set to false");
-        }
-        else
-        {
-            if (_logger.IsDebug) _logger.Debug($"{nameof(EthStatsPlugin)} plugin disabled due to {nameof(EthStatsConfig)} settings set to false");
+            return;
         }
 
         string instanceId = $"{ethStatsConfig.Name}-{Keccak.Compute(enode!.Info)}";
@@ -66,7 +63,7 @@ public class EthStatsStep(
         const int reconnectionInterval = 5000;
         const string api = "no";
         const string client = "0.1.1";
-        const bool canUpdateHistory = false;
+        const bool canUpdateHistory = true;
         string node = ProductInfo.ClientId;
         int port = networkConfig.P2PPort;
         string network = specProvider!.NetworkId.ToString();

--- a/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
+++ b/src/Nethermind/Nethermind.EthStats/EthStatsStep.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
 using Nethermind.Config;
@@ -37,7 +36,6 @@ public class EthStatsStep(
     IEnode enode,
     IEthStatsConfig ethStatsConfig,
     INetworkConfig networkConfig,
-    IInitConfig initConfig,
     IMiningConfig miningConfig,
     ILogManager logManager
 ) : IStep, IAsyncDisposable
@@ -47,12 +45,6 @@ public class EthStatsStep(
     private IEthStatsIntegration _ethStatsIntegration = null!;
     public async Task Execute(CancellationToken cancellationToken)
     {
-        if (!initConfig.WebSocketsEnabled)
-        {
-            _logger.Warn($"{nameof(EthStatsPlugin)} disabled due to {nameof(initConfig.WebSocketsEnabled)} set to false");
-            return;
-        }
-
         string instanceId = $"{ethStatsConfig.Name}-{Keccak.Compute(enode!.Info)}";
         if (_logger.IsInfo)
         {

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -85,7 +85,10 @@ namespace Nethermind.EthStats.Integrations
             _timer.Elapsed += TimerOnElapsed;
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
             _websocketClient = await _ethStatsClient.InitAsync();
+
+            // Subscribe to incoming messages before the explicit initial hello; reconnect events only cover later reconnects.
             Run(_timer);
+
             if (_logger.IsInfo) _logger.Info("Initial connection, sending 'hello' message...");
             await SendHelloAsync();
             _connected = true;
@@ -99,11 +102,9 @@ namespace Nethermind.EthStats.Integrations
                 return;
             }
 
-            _websocketClient.ReconnectionHappened.Subscribe(async _ =>
+            _websocketClient.ReconnectionHappened.Subscribe(reconnectionInfo =>
             {
-                if (_logger.IsInfo) _logger.Info("ETH Stats reconnected, sending 'hello' message...");
-                await SendHelloAsync();
-                _connected = true;
+                _ = ReconnectHelloAsync();
             });
 
             _websocketClient.DisconnectionHappened.Subscribe(reason =>
@@ -149,7 +150,7 @@ namespace Nethermind.EthStats.Integrations
 
             if (_logger.IsDebug) _logger.Debug("ETH Stats sending 'block', 'pending' messages...");
             _lastBlockProcessedTimestamp = timestamp;
-            SendBlockAsync(block);
+            _ = SendBlockAsync(block);
         }
 
         public void Dispose()
@@ -178,6 +179,20 @@ namespace Nethermind.EthStats.Integrations
         private Task SendBlockAsync(CoreBlock block)
             => _sender.SendAsync(_websocketClient!, new BlockMessage(CreateBlockModel(block)));
 
+        private async Task ReconnectHelloAsync()
+        {
+            try
+            {
+                if (_logger.IsInfo) _logger.Info("ETH Stats reconnected, sending 'hello' message...");
+                await SendHelloAsync();
+                _connected = true;
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"ETH Stats hello failed after reconnect: {e}");
+            }
+        }
+
         private Task SendHistoryAsync(EthStatsHistoryRequest request)
         {
             if (!TryNormalizeHistoryRange(request, out long min, out long max))
@@ -187,12 +202,17 @@ namespace Nethermind.EthStats.Integrations
             }
 
             List<EthStatsBlock> history = new((int)(max - min + 1));
-            for (long blockNumber = max; blockNumber >= min; blockNumber--)
+            for (long blockNumber = min; blockNumber <= max; blockNumber++)
             {
                 CoreBlock? block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
                 if (block is not null)
                 {
                     history.Add(CreateBlockModel(block));
+                }
+
+                if (blockNumber == max)
+                {
+                    break;
                 }
             }
 
@@ -212,7 +232,7 @@ namespace Nethermind.EthStats.Integrations
             return _sender.SendAsync(_websocketClient, new NodePingMessage(clientTime), "node-ping");
         }
 
-        private async Task HandleIncomingMessageAsync(string? message)
+        internal async Task HandleIncomingMessageAsync(string? message)
         {
             if (!EthStatsMessageParser.TryParse(message, out EthStatsIncomingMessage incomingMessage))
             {
@@ -261,7 +281,13 @@ namespace Nethermind.EthStats.Integrations
 
             long clientTime = nodeTiming.Value.ClientTime.Value;
             long now = Timestamper.Default.UnixTime.MillisecondsLong;
-            long latency = now >= clientTime ? now - clientTime : clientTime - now;
+            if (now < clientTime)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Ignoring ETH Stats 'node-pong' latency with future clientTime {clientTime}.");
+                return Task.CompletedTask;
+            }
+
+            long latency = now - clientTime;
 
             if (_logger.IsDebug) _logger.Debug($"ETH Stats sending 'latency' message after 'node-pong': {latency} ms.");
             return _sender.SendAsync(_websocketClient, new LatencyMessage(latency));
@@ -287,8 +313,7 @@ namespace Nethermind.EthStats.Integrations
 
             min = Math.Max(0, min);
 
-            long requestedBlocks = max - min + 1;
-            if (requestedBlocks > MaxHistoryBlocks)
+            if (max - min >= MaxHistoryBlocks)
             {
                 min = max - MaxHistoryBlocks + 1;
             }

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -194,11 +194,6 @@ namespace Nethermind.EthStats.Integrations
                 {
                     history.Add(CreateBlockModel(block));
                 }
-
-                if (blockNumber == 0)
-                {
-                    break;
-                }
             }
 
             if (_logger.IsDebug) _logger.Debug($"ETH Stats sending 'history' message for range {min}-{max}.");
@@ -278,7 +273,7 @@ namespace Nethermind.EthStats.Integrations
             return Task.CompletedTask;
         }
 
-        private static bool TryNormalizeHistoryRange(EthStatsHistoryRequest request, out long min, out long max)
+        internal static bool TryNormalizeHistoryRange(EthStatsHistoryRequest request, out long min, out long max)
         {
             min = Math.Min(request.Min, request.Max);
             max = Math.Max(request.Min, request.Max);

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -102,10 +102,7 @@ namespace Nethermind.EthStats.Integrations
                 return;
             }
 
-            _websocketClient.ReconnectionHappened.Subscribe(reconnectionInfo =>
-            {
-                _ = ReconnectHelloAsync();
-            });
+            _websocketClient.ReconnectionHappened.Subscribe(_ => OnReconnectionHappened());
 
             _websocketClient.DisconnectionHappened.Subscribe(reason =>
             {
@@ -124,7 +121,7 @@ namespace Nethermind.EthStats.Integrations
             if (_logger.IsDebug) _logger.Debug("ETH Stats sending 'stats' message...");
             _ = SendStatsAsync();
             _ = SendNodePingAsync();
-            SendPendingAsync(_txPool.GetPendingTransactionsCount() + _txPool.GetPendingBlobTransactionsCount());
+            _ = SendPendingAsync(_txPool.GetPendingTransactionsCount() + _txPool.GetPendingBlobTransactionsCount());
         }
 
         private void BlockTreeOnNewHeadBlock(object? sender, BlockEventArgs e)
@@ -179,6 +176,9 @@ namespace Nethermind.EthStats.Integrations
         private Task SendBlockAsync(CoreBlock block)
             => _sender.SendAsync(_websocketClient!, new BlockMessage(CreateBlockModel(block)));
 
+        private void OnReconnectionHappened()
+            => _ = ReconnectHelloAsync();
+
         private async Task ReconnectHelloAsync()
         {
             try
@@ -210,6 +210,7 @@ namespace Nethermind.EthStats.Integrations
                     history.Add(CreateBlockModel(block));
                 }
 
+                // Prevent long.MaxValue + 1 overflow on the for-loop increment.
                 if (blockNumber == max)
                 {
                     break;

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Timers;
@@ -18,9 +18,11 @@ using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.TxPool;
 using Websocket.Client;
-using Block = Nethermind.Core.Block;
+using CoreBlock = Nethermind.Core.Block;
+using CoreTransaction = Nethermind.Core.Transaction;
 using Timer = System.Timers.Timer;
-using Transaction = Nethermind.EthStats.Messages.Models.Transaction;
+using EthStatsBlock = Nethermind.EthStats.Messages.Models.Block;
+using EthStatsTransaction = Nethermind.EthStats.Messages.Models.Transaction;
 
 namespace Nethermind.EthStats.Integrations
 {
@@ -74,6 +76,8 @@ namespace Nethermind.EthStats.Integrations
         private long _lastBlockProcessedTimestamp;
         private Timer? _timer;
         private const int ThrottlingThreshold = 250;
+        private const int MaxHistoryBlocks = 64;
+        private IDisposable? _messageSubscription;
 
         public async Task InitAsync()
         {
@@ -81,11 +85,10 @@ namespace Nethermind.EthStats.Integrations
             _timer.Elapsed += TimerOnElapsed;
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
             _websocketClient = await _ethStatsClient.InitAsync();
+            Run(_timer);
             if (_logger.IsInfo) _logger.Info("Initial connection, sending 'hello' message...");
             await SendHelloAsync();
             _connected = true;
-
-            Run(_timer);
         }
 
         private void Run(Timer timer)
@@ -109,6 +112,7 @@ namespace Nethermind.EthStats.Integrations
                 if (_logger.IsInfo) _logger.Info($"ETH Stats disconnected, reason: {reason}");
             });
 
+            _messageSubscription = _websocketClient.MessageReceived.Subscribe(message => _ = HandleIncomingMessageAsync(message.Text));
             timer.Start();
         }
 
@@ -118,12 +122,13 @@ namespace Nethermind.EthStats.Integrations
                 return;
             if (_logger.IsDebug) _logger.Debug("ETH Stats sending 'stats' message...");
             _ = SendStatsAsync();
+            _ = SendNodePingAsync();
             SendPendingAsync(_txPool.GetPendingTransactionsCount() + _txPool.GetPendingBlobTransactionsCount());
         }
 
         private void BlockTreeOnNewHeadBlock(object? sender, BlockEventArgs e)
         {
-            Block? block = e.Block;
+            CoreBlock? block = e.Block;
 
             if (!_connected)
             {
@@ -159,6 +164,7 @@ namespace Nethermind.EthStats.Integrations
                 timer.Dispose();
             }
 
+            _messageSubscription?.Dispose();
             _websocketClient?.Dispose();
         }
 
@@ -169,22 +175,161 @@ namespace Nethermind.EthStats.Integrations
                 _contact, _canUpdateHistory)));
 
         // ReSharper disable once UnusedMethodReturnValue.Local
-        private Task SendBlockAsync(Block block)
-            => _sender.SendAsync(_websocketClient!, new BlockMessage(
-                new Messages.Models.Block(
-                    block.Number,
-                    (block.Hash ?? Keccak.Zero).ToString(),
-                    (block.ParentHash ?? Keccak.Zero).ToString(),
-                    (long)block.Timestamp,
-                    (block.Author ?? block.Beneficiary ?? Address.Zero).ToString(),
-                    block.GasUsed,
-                    block.GasLimit,
-                    block.Difficulty.ToString(),
-                    (block.TotalDifficulty ?? 0).ToString(),
-                    block.Transactions.Select(static t => new Transaction((t.Hash ?? Keccak.Zero).ToString())),
-                    (block.TxRoot ?? Keccak.Zero).ToString(),
-                    (block.StateRoot ?? Keccak.Zero).ToString(),
-                    block.Uncles.Select(static _ => new Uncle()))));
+        private Task SendBlockAsync(CoreBlock block)
+            => _sender.SendAsync(_websocketClient!, new BlockMessage(CreateBlockModel(block)));
+
+        private Task SendHistoryAsync(EthStatsHistoryRequest request)
+        {
+            if (!TryNormalizeHistoryRange(request, out long min, out long max))
+            {
+                if (_logger.IsDebug) _logger.Debug($"Ignoring invalid ETH Stats history range {request.Min}-{request.Max}.");
+                return Task.CompletedTask;
+            }
+
+            List<EthStatsBlock> history = new((int)(max - min + 1));
+            for (long blockNumber = max; blockNumber >= min; blockNumber--)
+            {
+                CoreBlock? block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
+                if (block is not null)
+                {
+                    history.Add(CreateBlockModel(block));
+                }
+
+                if (blockNumber == 0)
+                {
+                    break;
+                }
+            }
+
+            if (_logger.IsDebug) _logger.Debug($"ETH Stats sending 'history' message for range {min}-{max}.");
+            return _sender.SendAsync(_websocketClient!, new HistoryMessage(history));
+        }
+
+        private Task SendNodePingAsync()
+        {
+            if (_websocketClient is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            long clientTime = Timestamper.Default.UnixTime.MillisecondsLong;
+            if (_logger.IsDebug) _logger.Debug("ETH Stats sending 'node-ping' message...");
+            return _sender.SendAsync(_websocketClient, new NodePingMessage(clientTime), "node-ping");
+        }
+
+        private async Task HandleIncomingMessageAsync(string? message)
+        {
+            if (!EthStatsMessageParser.TryParse(message, out EthStatsIncomingMessage incomingMessage))
+            {
+                return;
+            }
+
+            try
+            {
+                Task handleTask = incomingMessage.MessageType switch
+                {
+                    EthStatsIncomingMessageType.History when incomingMessage.HistoryRequest is not null =>
+                        SendHistoryAsync(incomingMessage.HistoryRequest.Value),
+                    EthStatsIncomingMessageType.NodePing =>
+                        SendNodePongAsync(incomingMessage.NodeTiming?.ClientTime),
+                    EthStatsIncomingMessageType.NodePong =>
+                        SendLatencyFromNodePongAsync(incomingMessage.NodeTiming),
+                    _ => HandleUnknownMessageAsync(incomingMessage.EventTypeName)
+                };
+
+                await handleTask;
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Failed to handle ETH Stats message '{incomingMessage.EventTypeName}': {e}");
+            }
+        }
+
+        private Task SendNodePongAsync(long? clientTime)
+        {
+            if (_websocketClient is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            long serverTime = Timestamper.Default.UnixTime.MillisecondsLong;
+            if (_logger.IsDebug) _logger.Debug("ETH Stats sending 'node-pong' message...");
+            return _sender.SendAsync(_websocketClient, new NodePongMessage(clientTime, serverTime), "node-pong");
+        }
+
+        private Task SendLatencyFromNodePongAsync(EthStatsNodeTiming? nodeTiming)
+        {
+            if (_websocketClient is null || nodeTiming?.ClientTime is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            long clientTime = nodeTiming.Value.ClientTime.Value;
+            long now = Timestamper.Default.UnixTime.MillisecondsLong;
+            long latency = now >= clientTime ? now - clientTime : clientTime - now;
+
+            if (_logger.IsDebug) _logger.Debug($"ETH Stats sending 'latency' message after 'node-pong': {latency} ms.");
+            return _sender.SendAsync(_websocketClient, new LatencyMessage(latency));
+        }
+
+        private Task HandleUnknownMessageAsync(string eventType)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Ignoring unsupported ETH Stats message '{eventType}'.");
+            return Task.CompletedTask;
+        }
+
+        private static bool TryNormalizeHistoryRange(EthStatsHistoryRequest request, out long min, out long max)
+        {
+            min = Math.Min(request.Min, request.Max);
+            max = Math.Max(request.Min, request.Max);
+
+            if (max < 0)
+            {
+                min = 0;
+                max = 0;
+                return false;
+            }
+
+            min = Math.Max(0, min);
+
+            long requestedBlocks = max - min + 1;
+            if (requestedBlocks > MaxHistoryBlocks)
+            {
+                min = max - MaxHistoryBlocks + 1;
+            }
+
+            return true;
+        }
+
+        private static EthStatsBlock CreateBlockModel(CoreBlock block)
+        {
+            List<EthStatsTransaction> transactions = new(block.Transactions.Length);
+            foreach (CoreTransaction transaction in block.Transactions)
+            {
+                transactions.Add(new EthStatsTransaction((transaction.Hash ?? Keccak.Zero).ToString()));
+            }
+
+            List<Uncle> uncles = new(block.Uncles.Length);
+            foreach (BlockHeader _ in block.Uncles)
+            {
+                uncles.Add(new Uncle());
+            }
+
+            return new EthStatsBlock(
+                block.Number,
+                (block.Hash ?? Keccak.Zero).ToString(),
+                (block.ParentHash ?? Keccak.Zero).ToString(),
+                (long)block.Timestamp,
+                (block.Author ?? block.Beneficiary ?? Address.Zero).ToString(),
+                block.GasUsed,
+                block.GasLimit,
+                block.Difficulty.ToString(),
+                (block.TotalDifficulty ?? 0).ToString(),
+                transactions,
+                (block.TxRoot ?? Keccak.Zero).ToString(),
+                (block.StateRoot ?? Keccak.Zero).ToString(),
+                uncles);
+        }
 
         // ReSharper disable once UnusedMethodReturnValue.Local
         private Task SendPendingAsync(int pending)

--- a/src/Nethermind/Nethermind.EthStats/Messages/HistoryMessage.cs
+++ b/src/Nethermind/Nethermind.EthStats/Messages/HistoryMessage.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.EthStats.Messages.Models;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Nethermind.EthStats.Messages
+{
+    public class HistoryMessage(IEnumerable<Block> history) : IMessage
+    {
+        public string? Id { get; set; }
+        public IEnumerable<Block> History { get; } = history;
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/Messages/NodePingMessage.cs
+++ b/src/Nethermind/Nethermind.EthStats/Messages/NodePingMessage.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Nethermind.EthStats.Messages
+{
+    public class NodePingMessage(long clientTime) : IMessage
+    {
+        public string? Id { get; set; }
+        public long ClientTime { get; } = clientTime;
+    }
+}

--- a/src/Nethermind/Nethermind.EthStats/Messages/NodePongMessage.cs
+++ b/src/Nethermind/Nethermind.EthStats/Messages/NodePongMessage.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Nethermind.EthStats.Messages
+{
+    public class NodePongMessage(long? clientTime, long serverTime) : IMessage
+    {
+        public string? Id { get; set; }
+        public long? ClientTime { get; } = clientTime;
+        public long ServerTime { get; } = serverTime;
+    }
+}


### PR DESCRIPTION
Resolves #1362

## Changes

- Added parsing and dispatch for EthStats `emit` messages: `history`, `node-ping`, and `node-pong`.
- Added bounded canonical block history responses, including range normalization, ascending response order, and `canUpdateHistory=true`.
- Added `node-ping` sending, `node-ping` -> `node-pong` responses, and `node-pong` -> `latency` handling while ignoring invalid future `clientTime` values.
- Re-enabled WebSocket liveness reconnects by setting a non-null `ReconnectTimeout`, and send `hello` again after reconnect with failures logged.
- Keep EthStats independent of Nethermind's inbound JSON-RPC WebSocket setting; EthStats uses its own outbound WebSocket client.
- Added regression coverage for message parsing, sender payload names, history range normalization, and incoming history dispatch/serialization.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet build "D:\GitHub\nethermind\src\Nethermind\Nethermind.EthStats\Nethermind.EthStats.csproj" -c release --no-restore`
- `dotnet build "D:\GitHub\nethermind\src\Nethermind\Nethermind.EthStats.Test\Nethermind.EthStats.Test.csproj" -c release --no-restore --no-dependencies`
- `D:\GitHub\nethermind\src\Nethermind\artifacts\bin\Nethermind.EthStats.Test\release\Nethermind.EthStats.Test.exe --no-progress` (`24/24`)

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EthStats now supports history and node ping/pong messages, restores WebSocket liveness reconnect handling, and remains independent from Nethermind's inbound JSON-RPC WebSocket setting.

## Remarks

Local investigation confirmed classic EthStats can request history even when Nethermind previously advertised `canUpdateHistory=false` if the node is synced and has peers. Nethermind's `Init.WebSocketsEnabled` controls inbound JSON-RPC WebSockets only; EthStats uses its own outbound WebSocket client.