### PR TITLE
perf(evm): pool destroy-list buffer in TransactionProcessor

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -76,6 +76,7 @@ namespace Nethermind.Evm.TransactionProcessing
         private long _blockCumulativeReceiptGas;
         private long _blockCumulativeRegularGas;
         private long _blockCumulativeStateGas;
+        private Address[]? _destroyListBuffer;
 
         protected TransactionProcessorBase(
             ITransactionProcessor.IBlobBaseFeeCalculator? blobBaseFeeCalculator,
@@ -248,14 +249,19 @@ namespace Nethermind.Evm.TransactionProcessing
             if (spec.IsEip8037Enabled && spec.IsEip7708Enabled && statusCode == StatusCode.Success)
             {
                 JournalSet<Address> destroyList = substate.DestroyList;
-                if (destroyList.Count > 1)
+                int count = destroyList.Count;
+                if (count > 1)
                 {
-                    Address[] orderedDestroyList = new Address[destroyList.Count];
-                    destroyList.CopyTo(orderedDestroyList, 0);
-                    orderedDestroyList.AsSpan().Sort(default(AddressByBytesComparer));
-                    for (int i = 0; i < orderedDestroyList.Length; i++)
+                    Address[] buffer = _destroyListBuffer;
+                    if (buffer is null || buffer.Length < count)
                     {
-                        FinalizeDestroyedAccount(WorldState, in substate, orderedDestroyList[i]);
+                        buffer = _destroyListBuffer = new Address[count];
+                    }
+                    destroyList.CopyTo(buffer, 0);
+                    buffer.AsSpan(0, count).Sort(default(AddressByBytesComparer));
+                    for (int i = 0; i < count; i++)
+                    {
+                        FinalizeDestroyedAccount(WorldState, in substate, buffer[i]);
                     }
                 }
                 else

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Evm.TransactionProcessing
         private long _blockCumulativeReceiptGas;
         private long _blockCumulativeRegularGas;
         private long _blockCumulativeStateGas;
-        private Address[]? _destroyListBuffer;
 
         protected TransactionProcessorBase(
             ITransactionProcessor.IBlobBaseFeeCalculator? blobBaseFeeCalculator,
@@ -252,16 +251,19 @@ namespace Nethermind.Evm.TransactionProcessing
                 int count = destroyList.Count;
                 if (count > 1)
                 {
-                    Address[] buffer = _destroyListBuffer;
-                    if (buffer is null || buffer.Length < count)
+                    Address[] buffer = SafeArrayPool<Address>.Shared.Rent(count);
+                    try
                     {
-                        buffer = _destroyListBuffer = new Address[count];
+                        destroyList.CopyTo(buffer, 0);
+                        buffer.AsSpan(0, count).Sort(default(AddressByBytesComparer));
+                        for (int i = 0; i < count; i++)
+                        {
+                            FinalizeDestroyedAccount(WorldState, in substate, buffer[i]);
+                        }
                     }
-                    destroyList.CopyTo(buffer, 0);
-                    buffer.AsSpan(0, count).Sort(default(AddressByBytesComparer));
-                    for (int i = 0; i < count; i++)
+                    finally
                     {
-                        FinalizeDestroyedAccount(WorldState, in substate, buffer[i]);
+                        SafeArrayPool<Address>.Shared.Return(buffer);
                     }
                 }
                 else


### PR DESCRIPTION
## Changes

EIP-8037 + EIP-7708 destroy-list sorting allocated a fresh `Address[]` of size `destroyList.Count` on every multi-destroy tx in `TransactionProcessor`:

```csharp
Address[] orderedDestroyList = new Address[destroyList.Count];
destroyList.CopyTo(orderedDestroyList, 0);
orderedDestroyList.AsSpan().Sort(default(AddressByBytesComparer));
```

`TransactionProcessor` instances are themselves pooled per worker for parallel block validation, so the buffer can be kept as instance state and grown lazily to fit the largest destroy-list seen on this processor — no per-tx allocation after warm-up.

```csharp
Address[] buffer = _destroyListBuffer;
if (buffer is null || buffer.Length < count)
{
    buffer = _destroyListBuffer = new Address[count];
}
destroyList.CopyTo(buffer, 0);
buffer.AsSpan(0, count).Sort(default(AddressByBytesComparer));
```

Self-contained — no API change, no behavioural change.

This corresponds to idea 14 from [my BAL prioritization comment on #11573](https://github.com/NethermindEth/nethermind/pull/11573#issuecomment-4478874335).

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No — covered by existing `Eip7708Tests` and other EVM tests that exercise the multi-destroy path.

#### Notes on testing

`Nethermind.Evm.Test` clean (3650 passed, 10 skipped, 0 failed). Full solution build clean; `dotnet format --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [x] No