### PR TITLE
fix(zkevm): Revise G2 decoding check

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/Eip2537.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/Eip2537.zkevm.cs
@@ -74,7 +74,10 @@ internal static partial class Eip2537
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TryDecodeG2(ReadOnlySpan<byte> source, Span<byte> destination)
     {
-        if (source[..16].ContainsAnyExcept((byte)0) || source[64..80].ContainsAnyExcept((byte)0))
+        if (source[..16].ContainsAnyExcept((byte)0) ||
+            source[64..80].ContainsAnyExcept((byte)0) ||
+            source[128..144].ContainsAnyExcept((byte)0) ||
+            source[192..208].ContainsAnyExcept((byte)0))
             return false;
 
         source[16..64].CopyTo(destination);


### PR DESCRIPTION
## Changes

Revised EIP-2537 G2 point check before decoding to be on par with the standard one.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

zkEVM tests to be added later