### PR TITLE
fix(rpc): emit spec message for eth_simulateV1 -38020

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -239,43 +239,6 @@ public class EthSimulateTestsBlocksAndTransactions
     }
 
     /// <summary>
-    /// The execution-apis spec (error -38020) mandates the verbatim message
-    /// "Block number in sequence did not increase". Asserts both the error code and
-    /// the canonical message so it cannot regress to a verbose, value-interpolated string.
-    /// </summary>
-    [Test]
-    public async Task Test_eth_simulate_returns_spec_message_when_block_numbers_not_increasing()
-    {
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
-
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
-                {
-                    BlockOverrides = new BlockOverride { Number = 10 },
-                    Calls = []
-                },
-                new()
-                {
-                    // Strictly less than the previous BlockStateCall.
-                    BlockOverrides = new BlockOverride { Number = 9 },
-                    Calls = []
-                }
-            ]
-        };
-
-        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
-
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            executor.Execute(payload, BlockParameter.Latest);
-
-        result.ErrorCode.Should().Be(ErrorCodes.InvalidInputBlocksOutOfOrder);
-        result.Result!.Error.Should().Be(SimulateErrorMessages.BlockNumberNotIncreasing);
-    }
-
-    /// <summary>
     ///     This test verifies that a temporary forked blockchain can make transactions, blocks and report on them
     /// </summary>
     [Test]
@@ -619,210 +582,174 @@ public class EthSimulateTestsBlocksAndTransactions
             $"Expected block.timestamp = {futureTimestamp} (overridden), got {returnedTimestamp}");
     }
 
-    /// <summary>
-    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11217.
-    /// eth_simulateV1 must return -38014 with the spec-mandated message when the sender has
-    /// insufficient funds, regardless of the <c>validation</c> flag.
-    /// </summary>
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task eth_simulateV1_insufficient_funds_returns_spec_error_code_and_message(bool validation)
+    private static SimulatePayload<TransactionForRpc> BlockNumberNotIncreasingPayload() => new()
     {
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new() { Calls = [new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 1_000_000.Ether }] }
-            ],
-            Validation = validation
-        };
+        BlockStateCalls =
+        [
+            new() { BlockOverrides = new BlockOverride { Number = 10 }, Calls = [] },
+            // Strictly less than the previous BlockStateCall.
+            new() { BlockOverrides = new BlockOverride { Number = 9 }, Calls = [] }
+        ]
+    };
 
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
-
-        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.InsufficientFunds));
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.InsufficientFunds));
-    }
-
-    /// <summary>
-    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11215
-    /// eth_simulateV1 with validation:true and maxFeePerGas below block baseFee must return
-    /// code -38012 with message "max fee per gas less than block base fee".
-    /// </summary>
-    [Test]
-    public async Task eth_simulateV1_fee_cap_below_base_fee_returns_spec_error_code_and_message()
+    private static SimulatePayload<TransactionForRpc> InsufficientFundsPayload(bool validation) => new()
     {
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+        BlockStateCalls =
+        [
+            new() { Calls = [new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 1_000_000.Ether }] }
+        ],
+        Validation = validation
+    };
 
+    private static SimulatePayload<TransactionForRpc> FeeCapBelowBaseFeePayload() => new()
+    {
         // baseFeePerGas = 100 gwei, maxFeePerGas = 1 gwei → fee cap is below base fee
-        UInt256 baseFee = 100.GWei;
-        UInt256 feeCap = 1.GWei;
-
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
+        BlockStateCalls =
+        [
+            new()
+            {
+                BlockOverrides = new BlockOverride { BaseFeePerGas = 100.GWei },
+                StateOverrides = new Dictionary<Address, AccountOverride>
                 {
-                    BlockOverrides = new BlockOverride { BaseFeePerGas = baseFee },
-                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    { TestItem.AddressA, new AccountOverride { Balance = 100.Ether } }
+                },
+                Calls =
+                [
+                    new EIP1559TransactionForRpc
                     {
-                        { TestItem.AddressA, new AccountOverride { Balance = 100.Ether } }
-                    },
-                    Calls =
-                    [
-                        new EIP1559TransactionForRpc
-                        {
-                            From = TestItem.AddressA,
-                            To = TestItem.AddressB,
-                            Value = UInt256.Zero,
-                            Gas = 21_000,
-                            MaxFeePerGas = feeCap,
-                            MaxPriorityFeePerGas = UInt256.Zero
-                        }
-                    ]
-                }
-            ],
-            Validation = true
-        };
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressB,
+                        Value = UInt256.Zero,
+                        Gas = 21_000,
+                        MaxFeePerGas = 1.GWei,
+                        MaxPriorityFeePerGas = UInt256.Zero
+                    }
+                ]
+            }
+        ],
+        Validation = true
+    };
 
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
-
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.FeeCapBelowBaseFee));
-        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.FeeCapBelowBaseFee));
-    }
-
-    /// <summary>
-    /// Regression test for https://github.com/NethermindEth/nethermind/issues/11218.
-    /// eth_simulateV1 must return -38013 with the spec-mandated message when the transaction
-    /// gas limit is below the intrinsic gas cost.
-    /// </summary>
-    [Test]
-    public async Task eth_simulateV1_intrinsic_gas_returns_spec_error_code_and_message()
+    private static SimulatePayload<TransactionForRpc> IntrinsicGasPayload() => new()
     {
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
-
         // Gas = 1 is below the intrinsic gas cost of 21_000 for a basic transfer.
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
+        BlockStateCalls =
+        [
+            new()
+            {
+                BlockOverrides = new BlockOverride { BaseFeePerGas = UInt256.Zero },
+                StateOverrides = new Dictionary<Address, AccountOverride>
                 {
-                    BlockOverrides = new BlockOverride { BaseFeePerGas = UInt256.Zero },
-                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } }
+                },
+                Calls =
+                [
+                    new LegacyTransactionForRpc
                     {
-                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } }
-                    },
-                    Calls =
-                    [
-                        new LegacyTransactionForRpc
-                        {
-                            From = TestItem.AddressA,
-                            To = TestItem.AddressB,
-                            Value = UInt256.Zero,
-                            Gas = 1,
-                            GasPrice = UInt256.Zero
-                        }
-                    ]
-                }
-            ],
-            Validation = true
-        };
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressB,
+                        Value = UInt256.Zero,
+                        Gas = 1,
+                        GasPrice = UInt256.Zero
+                    }
+                ]
+            }
+        ],
+        Validation = true
+    };
 
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+    private static SimulatePayload<TransactionForRpc> NoncePayload(UInt256 accountNonce, UInt256 txNonce) => new()
+    {
+        BlockStateCalls =
+        [
+            new()
+            {
+                StateOverrides = new Dictionary<Address, AccountOverride>
+                {
+                    { TestItem.AddressA, new AccountOverride { Balance = 1.Ether, Nonce = accountNonce } }
+                },
+                Calls =
+                [
+                    new LegacyTransactionForRpc
+                    {
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressB,
+                        Value = UInt256.Zero,
+                        Nonce = txNonce,
+                        GasPrice = UInt256.Zero,
+                        Gas = 21_000
+                    }
+                ]
+            }
+        ],
+        Validation = true
+    };
 
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.IntrinsicGas));
-        Assert.That(result.Result!.Error, Is.EqualTo(SimulateErrorMessages.IntrinsicGas));
+    private static IEnumerable<TestCaseData> SpecErrorCases()
+    {
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)BlockNumberNotIncreasingPayload,
+            ErrorCodes.InvalidInputBlocksOutOfOrder,
+            SimulateErrorMessages.BlockNumberNotIncreasing)
+            .SetName("BlockNumberNotIncreasing_38020");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)(static () => InsufficientFundsPayload(validation: true)),
+            ErrorCodes.InsufficientFunds,
+            SimulateErrorMessages.InsufficientFunds)
+            .SetName("InsufficientFunds_validation_true_38014");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)(static () => InsufficientFundsPayload(validation: false)),
+            ErrorCodes.InsufficientFunds,
+            SimulateErrorMessages.InsufficientFunds)
+            .SetName("InsufficientFunds_validation_false_38014");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)FeeCapBelowBaseFeePayload,
+            ErrorCodes.FeeCapBelowBaseFee,
+            SimulateErrorMessages.FeeCapBelowBaseFee)
+            .SetName("FeeCapBelowBaseFee_38012");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)IntrinsicGasPayload,
+            ErrorCodes.IntrinsicGas,
+            SimulateErrorMessages.IntrinsicGas)
+            .SetName("IntrinsicGas_38013");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)(static () => NoncePayload(accountNonce: 10, txNonce: 0)),
+            ErrorCodes.NonceTooLow,
+            null)
+            .SetName("NonceTooLow_38010");
+
+        yield return new TestCaseData(
+            (Func<SimulatePayload<TransactionForRpc>>)(static () => NoncePayload(accountNonce: 0, txNonce: 100)),
+            ErrorCodes.NonceTooHigh,
+            null)
+            .SetName("NonceTooHigh_38011");
     }
 
     /// <summary>
-    /// Regression test: eth_simulateV1 with validation:true and a nonce below the account's current
-    /// nonce must return -38010 (NonceTooLow).
+    /// Regression test covering the execution-apis spec error codes/messages eth_simulateV1 must
+    /// return for well-known input/validation failures. See linked issues per case:
+    /// 11217 (insufficient funds), 11215 (fee cap below base fee), 11218 (intrinsic gas), 11219
+    /// (block number not increasing), nonce too low/high.
     /// </summary>
-    [Test]
-    public async Task eth_simulateV1_nonce_too_low_returns_spec_error_code()
+    [TestCaseSource(nameof(SpecErrorCases))]
+    public async Task eth_simulateV1_returns_spec_error(
+        Func<SimulatePayload<TransactionForRpc>> payloadFactory,
+        int expectedErrorCode,
+        string? expectedMessage)
     {
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
 
-        // Set the account's nonce to 10, then send a tx with nonce 0 (below current).
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
-                {
-                    StateOverrides = new Dictionary<Address, AccountOverride>
-                    {
-                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether, Nonce = 10 } }
-                    },
-                    Calls =
-                    [
-                        new LegacyTransactionForRpc
-                        {
-                            From = TestItem.AddressA,
-                            To = TestItem.AddressB,
-                            Value = UInt256.Zero,
-                            Nonce = 0,
-                            GasPrice = UInt256.Zero,
-                            Gas = 21_000
-                        }
-                    ]
-                }
-            ],
-            Validation = true
-        };
-
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+            chain.EthRpcModule.eth_simulateV1(payloadFactory(), BlockParameter.Latest);
 
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.NonceTooLow));
-    }
-
-    /// <summary>
-    /// Regression test: eth_simulateV1 with validation:true and a nonce above the account's current
-    /// nonce must return -38011 (NonceTooHigh).
-    /// </summary>
-    [Test]
-    public async Task eth_simulateV1_nonce_too_high_returns_spec_error_code()
-    {
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
-
-        // Account nonce is 0; send a tx with nonce 100 (way above current).
-        SimulatePayload<TransactionForRpc> payload = new()
-        {
-            BlockStateCalls =
-            [
-                new()
-                {
-                    StateOverrides = new Dictionary<Address, AccountOverride>
-                    {
-                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } }
-                    },
-                    Calls =
-                    [
-                        new LegacyTransactionForRpc
-                        {
-                            From = TestItem.AddressA,
-                            To = TestItem.AddressB,
-                            Value = UInt256.Zero,
-                            Nonce = 100,
-                            GasPrice = UInt256.Zero,
-                            Gas = 21_000
-                        }
-                    ]
-                }
-            ],
-            Validation = true
-        };
-
-        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
-            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
-
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.NonceTooHigh));
+        result.ErrorCode.Should().Be(expectedErrorCode);
+        if (expectedMessage is not null)
+            result.Result!.Error.Should().Be(expectedMessage);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -239,6 +239,43 @@ public class EthSimulateTestsBlocksAndTransactions
     }
 
     /// <summary>
+    /// The execution-apis spec (error -38020) mandates the verbatim message
+    /// "Block number in sequence did not increase". Asserts both the error code and
+    /// the canonical message so it cannot regress to a verbose, value-interpolated string.
+    /// </summary>
+    [Test]
+    public async Task Test_eth_simulate_returns_spec_message_when_block_numbers_not_increasing()
+    {
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    BlockOverrides = new BlockOverride { Number = 10 },
+                    Calls = []
+                },
+                new()
+                {
+                    // Strictly less than the previous BlockStateCall.
+                    BlockOverrides = new BlockOverride { Number = 9 },
+                    Calls = []
+                }
+            ]
+        };
+
+        SimulateTxExecutor<SimulateCallResult> executor = new(chain.Bridge, chain.BlockFinder, new JsonRpcConfig(), chain.SpecProvider, new SimulateBlockMutatorTracerFactory());
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            executor.Execute(payload, BlockParameter.Latest);
+
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidInputBlocksOutOfOrder);
+        result.Result!.Error.Should().Be(SimulateErrorMessages.BlockNumberNotIncreasing);
+    }
+
+    /// <summary>
     ///     This test verifies that a temporary forked blockchain can make transactions, blocks and report on them
     /// </summary>
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -134,7 +134,7 @@ public class SimulateTxExecutor<TTrace>(
                     return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail($"Block number too big {givenNumber}!", ErrorCodes.InvalidParams);
 
                 if (givenNumber <= (ulong)lastBlockNumber)
-                    return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail($"Block number out of order {givenNumber} is <= than previous block number of {header.Number}!", ErrorCodes.InvalidInputBlocksOutOfOrder);
+                    return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail(SimulateErrorMessages.BlockNumberNotIncreasing, ErrorCodes.InvalidInputBlocksOutOfOrder);
 
                 // if the no. of filler blocks are greater than maximum simulate blocks cap
                 if (givenNumber - (ulong)lastBlockNumber > (ulong)_blocksLimit)
@@ -314,4 +314,11 @@ internal static class SimulateErrorMessages
     /// (error code <see cref="ErrorCodes.InsufficientFunds"/>).
     /// </summary>
     public const string InsufficientFunds = "Insufficient funds to pay for gas fees and value for a transaction";
+
+    /// <summary>
+    /// Returned when a simulated block number is not strictly greater than the previous one
+    /// (error code <see cref="ErrorCodes.InvalidInputBlocksOutOfOrder"/>). Mandated verbatim by
+    /// the execution-apis spec.
+    /// </summary>
+    public const string BlockNumberNotIncreasing = "Block number in sequence did not increase";
 }


### PR DESCRIPTION
Fixes #11219

## Changes

- `SimulateTxExecutor.Execute` returned `-38020` (`InvalidInputBlocksOutOfOrder`) with a verbose, value-interpolated message: `$"Block number out of order {given} is <= than previous block number of {prev}!"`. The execution-apis spec mandates a fixed message: `"Block number in sequence did not increase"`.
- Added `SimulateErrorMessages.BlockNumberNotIncreasing` so this canonical string sits next to the other spec-mandated messages (`IntrinsicGas`, `FeeCapBelowBaseFee`, `InsufficientFunds`) already shared with the test suite.
- Use the constant at the validation site (`SimulateTxExecutor.cs:137`).
- Added regression test `Test_eth_simulate_returns_spec_message_when_block_numbers_not_increasing` in `EthSimulateTestsBlocksAndTransactions`. Builds a `SimulatePayload` with a second `BlockStateCall` whose `Number` is strictly less than the first and asserts both `ErrorCode == -38020` and `Error == SimulateErrorMessages.BlockNumberNotIncreasing`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New regression test in `EthSimulateTestsBlocksAndTransactions` exercises the error path end-to-end through `SimulateTxExecutor.Execute`.
- All 22 `EthSimulateTestsBlocksAndTransactions` tests pass.
- `dotnet format whitespace --folder` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
