### PR TITLE
fix: zk-gas validation

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasBlockTracerTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasBlockTracerTests.cs
@@ -267,4 +267,51 @@ public class ZkGasBlockTracerTests
         Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True,
             "Intrinsic that exceeds the block budget must set IsLimitExceeded");
     }
+
+    // ── validation regression: IsLimitExceeded must survive EndTxTrace ────────
+
+    [Test]
+    public void EndTxTrace_PreservesLimitExceeded_WhenChargeFailedMidTx()
+    {
+        IBlockTracer inner = Substitute.For<IBlockTracer>();
+        inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
+        ZkGasBlockTracer blockTracer = new(inner, blockZkGasLimit: 1000, txIntrinsicZkGas: 0);
+
+        blockTracer.StartNewBlockTrace(MakeBlock());
+        blockTracer.StartNewTxTrace(MakeTx());
+
+        blockTracer.Meter.ChargeOpcode(0xf0, 800); // succeeds: 800 in-flight
+        blockTracer.Meter.ChargeOpcode(0xf0, 300); // fails: 800+300 > 1000, _txZkGasUsed stays at 800
+        Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True);
+
+        // EndTxTrace must not commit the partial 800-unit total and clear the flag.
+        blockTracer.EndTxTrace();
+
+        Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True);
+        Assert.That(blockTracer.Meter.BlockZkGasUsed, Is.EqualTo(0UL));
+    }
+
+    [Test]
+    public void EndTxTrace_PreservesLimitExceeded_WhenIntrinsicFailed()
+    {
+        IBlockTracer inner = Substitute.For<IBlockTracer>();
+        inner.StartNewTxTrace(Arg.Any<Transaction?>()).Returns(NullTxTracer.Instance);
+        // Limit=800, intrinsic=500. Pre-fill 600 units so only 200 budget remains.
+        ZkGasBlockTracer blockTracer = new(inner, blockZkGasLimit: 800, txIntrinsicZkGas: 500);
+
+        blockTracer.StartNewBlockTrace(MakeBlock());
+
+        // Pre-fill block to 600 via direct meter manipulation (bypasses intrinsic charge).
+        blockTracer.Meter.ChargeOpcode(0xf0, 600);
+        blockTracer.Meter.CommitTransaction(); // blockZkGasUsed = 600; 200 budget left
+
+        // Second tx: intrinsic (500) > remaining budget (200) → StartNewTxTrace sets the flag.
+        blockTracer.StartNewTxTrace(MakeTx());
+        Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True);
+
+        blockTracer.EndTxTrace();
+
+        Assert.That(blockTracer.Meter.IsLimitExceeded, Is.True);
+        Assert.That(blockTracer.Meter.BlockZkGasUsed, Is.EqualTo(600UL));
+    }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/ZkGas/ZkGasMeterTests.cs
@@ -247,4 +247,20 @@ public class ZkGasMeterTests
         Assert.That(result, Is.False);
         Assert.That(meter.IsLimitExceeded, Is.True);
     }
+
+    [Test]
+    public void CommitTransaction_PreservesLimitExceeded_WhenChargeFailedMidTx()
+    {
+        ZkGasMeter meter = new(blockZkGasLimit: 1000, txIntrinsicZkGas: 0);
+
+        meter.ChargeOpcode(0xf0, 800); // succeeds: 800 in-flight
+        meter.ChargeOpcode(0xf0, 300); // fails: 800+300 > 1000, _txZkGasUsed stays at 800
+        Assert.That(meter.IsLimitExceeded, Is.True);
+
+        // Must not commit the undercounted partial total and clear the flag.
+        bool committed = meter.CommitTransaction();
+        Assert.That(committed, Is.False);
+        Assert.That(meter.IsLimitExceeded, Is.True);
+        Assert.That(meter.BlockZkGasUsed, Is.EqualTo(0UL));
+    }
 }

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
@@ -50,10 +50,10 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
 
     /// <summary>
     /// Promotes the current transaction's ZK gas into the finalized block total.
-    /// Returns <c>false</c> and leaves state unchanged when either
-    /// <see cref="IsLimitExceeded"/> is already set (a prior charge failed mid-tx,
-    /// leaving <c>_txZkGasUsed</c> underestimated) or the commit would overflow the
-    /// block limit.
+    /// Returns <c>false</c> and leaves block state (<see cref="BlockZkGasUsed"/>,
+    /// <see cref="IsLimitExceeded"/>) unchanged when either <see cref="IsLimitExceeded"/>
+    /// is already set (a prior charge failed mid-tx, leaving <c>_txZkGasUsed</c>
+    /// underestimated) or the commit would overflow the block limit.
     /// </summary>
     public bool CommitTransaction()
     {

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
@@ -57,6 +57,15 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
     /// </summary>
     public bool CommitTransaction()
     {
+        // A failed charge leaves _txZkGasUsed undercounted. Committing would understate
+        // the block total and clear the flag, letting TaikoBlockProcessor accept an
+        // over-limit block. Bail out without touching the flag.
+        if (IsLimitExceeded)
+        {
+            _txZkGasUsed = 0;
+            return false;
+        }
+
         ulong next = _blockZkGasUsed + _txZkGasUsed;
         if (next < _blockZkGasUsed) // overflow
         {
@@ -74,7 +83,6 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
 
         _blockZkGasUsed = next;
         _txZkGasUsed = 0;
-        IsLimitExceeded = false; // successful commit – clear any temporary projection spike
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
+++ b/src/Nethermind/Nethermind.Taiko/ZkGas/ZkGasMeter.cs
@@ -50,16 +50,13 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
 
     /// <summary>
     /// Promotes the current transaction's ZK gas into the finalized block total.
-    /// Returns false if the commit would exceed the block limit.
-    /// When the commit succeeds, <see cref="IsLimitExceeded"/> is reset to <c>false</c>
-    /// so that a temporary projection spike during opcode charging does not bleed into
-    /// subsequent transactions.
+    /// Returns <c>false</c> and leaves state unchanged when either
+    /// <see cref="IsLimitExceeded"/> is already set (a prior charge failed mid-tx,
+    /// leaving <c>_txZkGasUsed</c> underestimated) or the commit would overflow the
+    /// block limit.
     /// </summary>
     public bool CommitTransaction()
     {
-        // A failed charge leaves _txZkGasUsed undercounted. Committing would understate
-        // the block total and clear the flag, letting TaikoBlockProcessor accept an
-        // over-limit block. Bail out without touching the flag.
         if (IsLimitExceeded)
         {
             _txZkGasUsed = 0;
@@ -127,15 +124,12 @@ public class ZkGasMeter(ulong blockZkGasLimit = ZkGasSchedule.BlockZkGasLimit, u
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <strong>Invariant – do not call <see cref="CommitTransaction"/> while
-    /// <see cref="IsLimitExceeded"/> is <c>true</c>.</strong>
     /// When this method returns <c>false</c>, <c>_txZkGasUsed</c> is intentionally <em>not</em>
     /// updated. The opcode has already executed inside the EVM (the tracer charges after
     /// execution), so its ZK cost was consumed but is not reflected in the tracked total.
-    /// At that point <c>_txZkGasUsed</c> understates the true ZK cost of the transaction.
-    /// Committing an under-counted transaction would produce a block that exceeds the ZK
-    /// prover budget and cannot be proven. The caller must cancel the transaction instead
-    /// (via <see cref="CancelTransaction"/>).
+    /// <see cref="CommitTransaction"/> enforces this by refusing to commit when
+    /// <see cref="IsLimitExceeded"/> is set. Call <see cref="CancelTransaction"/> to discard
+    /// the in-flight total and reset the flag.
     /// </para>
     /// </remarks>
     private bool ChargeAmount(ulong rawGas, ulong multiplier)


### PR DESCRIPTION
## Changes

* Fix `ZkGasMeter.CommitTransaction`: a failed charge leaves `_txZkGasUsed` undercounted; committing the partial total and clearing `IsLimitExceeded` allowed over-limit blocks to pass validation with a wrong `Header.Difficulty`. The fix bails out immediately when `IsLimitExceeded` is already set



## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

* `ZkGasMeterTests.CommitTransaction_PreservesLimitExceeded_WhenChargeFailedMidTx` — unit regression for the commit/clear bug
* `ZkGasBlockTracerTests.EndTxTrace_PreservesLimitExceeded_WhenChargeFailedMidTx` — exercises the bug path through EndTxTrace when an opcode charge fails mid-tx
* `ZkGasBlockTracerTests.EndTxTrace_PreservesLimitExceeded_WhenIntrinsicFailed` — same path triggered by an intrinsic charge failure on a near-full block


## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
