### PR TITLE
perf(kute): compile JSON-RPC method filter regex once

### DIFF
--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
@@ -11,8 +11,6 @@ public sealed class RegexJsonRpcMethodFilter : IJsonRpcMethodFilter
 
     public RegexJsonRpcMethodFilter(string pattern)
     {
-        // The filter is constructed once and reused for every JSON-RPC method name; compile the
-        // pattern up-front so the hot path skips the interpreter on every IsMatch call.
         _pattern = new Regex(pattern, RegexOptions.Compiled);
     }
 

--- a/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
+++ b/tools/Kute/Nethermind.Tools.Kute/JsonRpcMethodFilter/RegexJsonRpcMethodFilter.cs
@@ -11,7 +11,9 @@ public sealed class RegexJsonRpcMethodFilter : IJsonRpcMethodFilter
 
     public RegexJsonRpcMethodFilter(string pattern)
     {
-        _pattern = new Regex(pattern);
+        // The filter is constructed once and reused for every JSON-RPC method name; compile the
+        // pattern up-front so the hot path skips the interpreter on every IsMatch call.
+        _pattern = new Regex(pattern, RegexOptions.Compiled);
     }
 
     public bool ShouldSubmit(string methodName) => _pattern.IsMatch(methodName);


### PR DESCRIPTION
Closes #9234

## Changes

- `RegexJsonRpcMethodFilter` constructed its `Regex` without `RegexOptions.Compiled`. The filter is built once and reused for every JSON-RPC method name, so each `IsMatch` call paid interpreter overhead on the hot path.
- Pass `RegexOptions.Compiled` so the pattern is emitted as IL up front.
- The pattern is supplied at runtime from the CLI (`--methods-filter`), so `[GeneratedRegex]` is not applicable — `RegexOptions.Compiled` is the right knob here.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Behavior of `RegexJsonRpcMethodFilter` is unchanged — `RegexOptions.Compiled` only affects code-generation. Existing `JsonRpcFilterTests` (12/12) still pass and cover both literal and regex method filters.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
