### PR TITLE
perf(bal): fuse Build() walks into a single pass

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -75,15 +74,10 @@ internal sealed class BlockAccessListValidationIndex
         uint lastIndex = GetLastIndex(txCount);
         int rowCount = checked((int)lastIndex + 1);
         // BAL Manager hands Build a fresh AddressIndex per call, so GetOrAdd hands out
-        // ordinals 0..accountCount-1 densely; pre-sizing avoids log2(N) Array.Resize calls.
+        // ordinals 0..accountCount-1 densely; pre-sizing the bitmap lets the fused
+        // Fill walk OR bits in without a bounds-check/resize per account.
         int accountCount = blockAccessList.AccountChanges.Count;
         ulong[] hasAccountWords = new ulong[(accountCount + 63) >> 6];
-
-        foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
-        {
-            int accountOrdinal = addressIndex.GetOrAdd(accountChanges.Address);
-            MarkAccount(ref hasAccountWords, accountOrdinal);
-        }
 
         // Per-row counts were precomputed during BAL decode; the BAL may have indices past
         // lastIndex (silently dropped here, matching the prior Count() pass that skipped them).
@@ -93,7 +87,7 @@ internal sealed class BlockAccessListValidationIndex
         Lane<ValueHash256> code = Lane<ValueHash256>.CreateImmutable(CopyCounts(cached.Code, rowCount));
         StorageLane storage = StorageLane.CreateImmutable(CopyCounts(cached.Storage, rowCount));
 
-        Fill(blockAccessList, addressIndex, lastIndex, balance, nonce, code, storage);
+        FillAndMark(blockAccessList, addressIndex, lastIndex, balance, nonce, code, storage, hasAccountWords);
 
         balance.SortAllRows();
         nonce.SortAllRows();
@@ -176,14 +170,20 @@ internal sealed class BlockAccessListValidationIndex
                _storage.ChangesEqual(other._storage, row);
     }
 
-    private static void Fill(
+    // Single walk over AccountChanges: assigns the dense ordinal, sets the presence bit, and
+    // populates the four lanes via independent per-row cursors. The lanes are pre-sized from
+    // cached row counts (rowStarts is immutable) and writes go through cursors[row], so the
+    // fill order across accounts does not matter; SortAllRows runs after to put each row in
+    // (accountOrdinal, key) order.
+    private static void FillAndMark(
         ReadOnlyBlockAccessList blockAccessList,
         AddressIndex addressIndex,
         uint lastIndex,
         Lane<UInt256> balance,
         Lane<ulong> nonce,
         Lane<ValueHash256> code,
-        StorageLane storage)
+        StorageLane storage,
+        ulong[] hasAccountWords)
     {
         int[] balanceCursors = balance.CreateFillCursors();
         int[] nonceCursors = nonce.CreateFillCursors();
@@ -192,8 +192,8 @@ internal sealed class BlockAccessListValidationIndex
 
         foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
         {
-            bool found = addressIndex.TryGet(accountChanges.Address, out int accountOrdinal);
-            Debug.Assert(found);
+            int accountOrdinal = addressIndex.GetOrAdd(accountChanges.Address);
+            hasAccountWords[accountOrdinal >> 6] |= 1UL << (accountOrdinal & 63);
 
             foreach (BalanceChange change in accountChanges.BalanceChanges)
             {
@@ -225,14 +225,6 @@ internal sealed class BlockAccessListValidationIndex
         int word = accountOrdinal >> 6;
         return (uint)word < (uint)_hasAccountWords.Length
             && (_hasAccountWords[word] & (1UL << (accountOrdinal & 63))) != 0;
-    }
-
-    private static void MarkAccount(ref ulong[] words, int accountOrdinal)
-    {
-        int word = accountOrdinal >> 6;
-        if ((uint)word >= (uint)words.Length)
-            Array.Resize(ref words, Math.Max(word + 1, words.Length == 0 ? 1 : words.Length * 2));
-        words[word] |= 1UL << (accountOrdinal & 63);
     }
 
     // No callers read `row` on the false return; cheaper to set unconditionally and skip the branch.

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -104,8 +104,6 @@ internal sealed class BlockAccessListValidationIndex
         Lane<ValueHash256> code = Lane<ValueHash256>.CreateImmutable(counts.Code);
         StorageLane storage = StorageLane.CreateImmutable(counts.Storage);
 
-        // AddressIndex is fresh per Build, so GetOrAdd yields ordinals 0..accountCount-1 densely
-        // and the bitmap sizes exactly — FillAndMark OR's in without a resize.
         int accountCount = blockAccessList.AccountChanges.Count;
         ulong[] hasAccountWords = new ulong[(accountCount + 63) >> 6];
 
@@ -482,8 +480,6 @@ internal sealed class BlockAccessListValidationIndex
         }
     }
 
-    // Fill order across accounts is irrelevant: writes go through per-row cursors over
-    // pre-sized rowStarts, and SortAllRows reorders each row by (accountOrdinal, key) after.
     private static void FillAndMark(
         ReadOnlyBlockAccessList blockAccessList,
         AddressIndex addressIndex,

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -97,14 +97,6 @@ internal sealed class BlockAccessListValidationIndex
         uint lastIndex = GetLastIndex(txCount);
         int rowCount = checked((int)lastIndex + 1);
         Counts counts = new(rowCount);
-        ulong[] hasAccountWords = [];
-
-        foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
-        {
-            int accountOrdinal = addressIndex.GetOrAdd(accountChanges.Address);
-            MarkAccount(ref hasAccountWords, accountOrdinal);
-        }
-
         Count(blockAccessList, counts, lastIndex);
 
         Lane<UInt256> balance = Lane<UInt256>.CreateImmutable(counts.Balance);
@@ -112,7 +104,12 @@ internal sealed class BlockAccessListValidationIndex
         Lane<ValueHash256> code = Lane<ValueHash256>.CreateImmutable(counts.Code);
         StorageLane storage = StorageLane.CreateImmutable(counts.Storage);
 
-        Fill(blockAccessList, addressIndex, lastIndex, balance, nonce, code, storage);
+        // AddressIndex is fresh per Build, so GetOrAdd yields ordinals 0..accountCount-1 densely
+        // and the bitmap sizes exactly — FillAndMark OR's in without a resize.
+        int accountCount = blockAccessList.AccountChanges.Count;
+        ulong[] hasAccountWords = new ulong[(accountCount + 63) >> 6];
+
+        FillAndMark(blockAccessList, addressIndex, lastIndex, balance, nonce, code, storage, hasAccountWords);
 
         balance.SortAllRows();
         nonce.SortAllRows();
@@ -485,14 +482,17 @@ internal sealed class BlockAccessListValidationIndex
         }
     }
 
-    private static void Fill(
+    // Fill order across accounts is irrelevant: writes go through per-row cursors over
+    // pre-sized rowStarts, and SortAllRows reorders each row by (accountOrdinal, key) after.
+    private static void FillAndMark(
         ReadOnlyBlockAccessList blockAccessList,
         AddressIndex addressIndex,
         uint lastIndex,
         Lane<UInt256> balance,
         Lane<ulong> nonce,
         Lane<ValueHash256> code,
-        StorageLane storage)
+        StorageLane storage,
+        ulong[] hasAccountWords)
     {
         int[] balanceCursors = balance.CreateFillCursors();
         int[] nonceCursors = nonce.CreateFillCursors();
@@ -501,8 +501,8 @@ internal sealed class BlockAccessListValidationIndex
 
         foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
         {
-            bool found = addressIndex.TryGet(accountChanges.Address, out int accountOrdinal);
-            Debug.Assert(found);
+            int accountOrdinal = addressIndex.GetOrAdd(accountChanges.Address);
+            hasAccountWords[accountOrdinal >> 6] |= 1UL << (accountOrdinal & 63);
 
             foreach (BalanceChange change in accountChanges.BalanceChanges)
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListValidationIndex.cs
@@ -104,8 +104,7 @@ internal sealed class BlockAccessListValidationIndex
         Lane<ValueHash256> code = Lane<ValueHash256>.CreateImmutable(counts.Code);
         StorageLane storage = StorageLane.CreateImmutable(counts.Storage);
 
-        int accountCount = blockAccessList.AccountChanges.Count;
-        ulong[] hasAccountWords = new ulong[(accountCount + 63) >> 6];
+        ulong[] hasAccountWords = new ulong[WordCount(blockAccessList.AccountChanges.Count)];
 
         FillAndMark(blockAccessList, addressIndex, lastIndex, balance, nonce, code, storage, hasAccountWords);
 
@@ -445,7 +444,7 @@ internal sealed class BlockAccessListValidationIndex
             while (word != 0)
             {
                 int bitOffset = BitOperations.TrailingZeroCount(word);
-                yield return (wordIdx << 6) + bitOffset;
+                yield return (wordIdx << WordShift) + bitOffset;
                 word &= word - 1;
             }
         }
@@ -498,7 +497,7 @@ internal sealed class BlockAccessListValidationIndex
         foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
         {
             int accountOrdinal = addressIndex.GetOrAdd(accountChanges.Address);
-            hasAccountWords[accountOrdinal >> 6] |= 1UL << (accountOrdinal & 63);
+            SetBit(hasAccountWords, accountOrdinal);
 
             foreach (BalanceChange change in accountChanges.BalanceChanges)
             {
@@ -525,19 +524,31 @@ internal sealed class BlockAccessListValidationIndex
         }
     }
 
-    private bool HasAccountOrdinal(int accountOrdinal)
-    {
-        int word = accountOrdinal >> 6;
-        return (uint)word < (uint)_hasAccountWords.Length
-            && (_hasAccountWords[word] & (1UL << (accountOrdinal & 63))) != 0;
-    }
+    private bool HasAccountOrdinal(int accountOrdinal) => TestBit(_hasAccountWords, accountOrdinal);
 
     private static void MarkAccount(ref ulong[] words, int accountOrdinal)
     {
-        int word = accountOrdinal >> 6;
+        int word = accountOrdinal >> WordShift;
         if ((uint)word >= (uint)words.Length)
             Array.Resize(ref words, Math.Max(word + 1, words.Length == 0 ? 1 : words.Length * 2));
-        words[word] |= 1UL << (accountOrdinal & 63);
+        words[word] |= 1UL << (accountOrdinal & BitMask);
+    }
+
+    private const int WordShift = 6;
+    private const int BitMask = 63;
+
+    private static int WordCount(int bitCount) => (bitCount + BitMask) >> WordShift;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetBit(ulong[] words, int ordinal) =>
+        words[ordinal >> WordShift] |= 1UL << (ordinal & BitMask);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TestBit(ulong[] words, int ordinal)
+    {
+        int word = ordinal >> WordShift;
+        return (uint)word < (uint)words.Length
+            && (words[word] & (1UL << (ordinal & BitMask))) != 0;
     }
 
     // No callers read `row` on the false return; cheaper to set unconditionally and skip the branch.


### PR DESCRIPTION
## Summary

Fuses the `MarkAccount` and `Fill` walks in `BlockAccessListValidationIndex.Build()` into a single `FillAndMark` pass.

`Build()` previously walked `AccountChanges` three times:

1. **MarkAccount loop** — `addressIndex.GetOrAdd(...)` + OR a bit into the presence bitmap (with an `Array.Resize` path for growth),
2. **`Count(...)`** — populate per-row capacity arrays for each lane,
3. **`Fill(...)`** — re-look up each ordinal via `addressIndex.TryGet(...)` (with `Debug.Assert(found)`) and write each balance/nonce/code/storage entry through the per-row cursors.

The `Count` pass still has to run on its own — lane buffers are pre-sized from it before `FillAndMark` opens its cursors. Walks 1 and 3 collapse into one:

- `hasAccountWords` is pre-sized exactly from `AccountChanges.Count` (`AddressIndex` is fresh per `Build`, so `GetOrAdd` yields ordinals `0..accountCount-1` densely — no resize path needed),
- `FillAndMark` calls `GetOrAdd` directly (no `TryGet` + `Debug.Assert`) and ORs the presence bit inline next to the lane writes,
- `MarkAccount` is still used by the mutable `Add(slice)` path, so the helper stays.

This removes one full pass over `AccountChanges` plus a dictionary lookup per account, and lets the JIT keep `accountOrdinal` in a register across all four lane writes.

### Correctness

- Cursors are per-row (`int[] cursors[row]++`) and `rowStarts` is fixed once the lanes are pre-sized from `Count`, so the order accounts are visited has no bearing on what lands in each row.
- The post-walk `balance/nonce/code/storage.SortAllRows()` calls are unchanged and still run **after** all writes complete, so the final `(accountOrdinal, key)` ordering inside each row is preserved.
- `MarkAccount`'s `Array.Resize` path is unreachable from `Build` under pre-sizing (ordinals are `0..accountCount-1`); the helper stays for the mutable `Add` path which still grows the bitmap on demand.

## Test plan

- [x] `dotnet build src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj -c release` — clean
- [x] `dotnet test --project src/Nethermind/Nethermind.Consensus.Test/...` — 64/64 pass (incl. `BlockAccessListValidationIndexTests`)
- [x] `dotnet test --project src/Nethermind/Nethermind.BalRecorder.Test/...` — 17/17 pass