### PR TITLE
refactor: rework AccountProofCollector to use path-based traversal

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -438,9 +438,11 @@ namespace Nethermind.Store.Test.Proofs
             IScopedTrieStore scopedTrieStore = new RawScopedTrieStore(memDb);
             StateTree tree = new(scopedTrieStore, LimboLogs.Instance);
             StorageTree storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), Keccak.EmptyTreeHash, LimboLogs.Instance);
-            storageTree.Set(Bytes.FromHexString("1000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("aa"));
-            storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("ab"));
-            storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000010"), Bytes.FromHexString("1111111111111111111111111111111111111111111111111111111111111111"));
+            // Wrap values in Rlp.Encode so the trie matches production usage (StorageTree.Set RLP-encodes by default);
+            // this lets the values stay small enough to inline while keeping the leaf payload valid RLP.
+            storageTree.Set(Bytes.FromHexString("1000000000000000000000000000000000000000000000000000000000000000"), Rlp.Encode(Bytes.FromHexString("aa")));
+            storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000000"), Rlp.Encode(Bytes.FromHexString("ab")));
+            storageTree.Set(Bytes.FromHexString("3000000000000000000000000000000000000000000000000000000000000010"), Rlp.Encode(Bytes.FromHexString("1111111111111111111111111111111111111111111111111111111111111111")));
             storageTree.Commit();
             storageTree = new(new RawScopedTrieStore(memDb, TestItem.AddressA.ToAccountPath.ToCommitment()), storageTree.RootHash, LimboLogs.Instance);
             Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -30,8 +30,6 @@ namespace Nethermind.State.Proofs
         private readonly List<byte[]> _accountProofItems = new();
         private readonly List<byte[]>[] _storageProofItems;
 
-        private readonly AccountDecoder _accountDecoder = AccountDecoder.Instance;
-
         private static ValueHash256 ToKey(byte[] index) => ValueKeccak.Compute(index);
 
         private static byte[] ToKey(UInt256 index)
@@ -110,8 +108,11 @@ namespace Nethermind.State.Proofs
         {
             if (ctx.Storage is null)
             {
-                // Account trie: follow the path leading to our target account
-                return IsPrefix(_fullAccountPath, ctx.Path);
+                // Account trie: follow the path leading to our target account. Once we've reached
+                // the target leaf, only descend further (into the storage trie) when storage slots
+                // were actually requested.
+                if (!IsPrefix(_fullAccountPath, ctx.Path)) return false;
+                return _fullStoragePaths.Length != 0 || ctx.Path.Length < _fullAccountPath.Length;
             }
 
             // Storage trie: visit nodes on the path to any requested storage slot
@@ -137,66 +138,48 @@ namespace Nethermind.State.Proofs
         {
             AddProofItem(node, ctx);
 
-            if (ctx.Storage is null)
+            // Account-leaf fields are written from VisitAccount (the visitor framework decodes
+            // the account for us, so we avoid decoding the same RLP twice).
+            if (ctx.Storage is null) return;
+
+            // Storage leaf: record the decoded value for every requested slot whose full path
+            // ends at this leaf. Storage leaf Values are always RLP-encoded in a valid trie.
+            for (int i = 0; i < _fullStoragePaths.Length; i++)
             {
-                // Decode account fields only if this leaf is our target account
-                if (IsFullPathMatch(_fullAccountPath, ctx.Path, node.Key))
-                {
-                    Rlp.ValueDecoderContext rlpCtx = new(node.Value.ToArray());
-                    Account account = _accountDecoder.Decode(ref rlpCtx);
-                    _accountProof.Nonce = account.Nonce;
-                    _accountProof.Balance = account.Balance;
-                    _accountProof.StorageRoot = account.StorageRoot;
-                    _accountProof.CodeHash = account.CodeHash;
-                }
-            }
-            else
-            {
-                // Record decoded storage values for every slot whose full path matches this leaf
-                for (int i = 0; i < _fullStoragePaths.Length; i++)
-                {
-                    if (IsFullPathMatch(_fullStoragePaths[i], ctx.Path, node.Key))
-                    {
-                        _accountProof.StorageProofs[i].Value = DecodeStorageValue(node.Value);
-                    }
-                }
+                if (IsFullPathMatch(_fullStoragePaths[i], ctx.Path, node.Key))
+                    _accountProof.StorageProofs[i].Value = new Rlp.ValueDecoderContext(node.Value.AsSpan()).DecodeByteArray();
             }
         }
 
-        public void VisitAccount(in TreePathContextWithStorage ctx, TrieNode node, in AccountStruct account) { }
+        public void VisitAccount(in TreePathContextWithStorage ctx, TrieNode node, in AccountStruct account)
+        {
+            // ctx.Path here already includes the leaf's key (it's leafContext, not nodeContext).
+            if (!IsFullPathMatch(_fullAccountPath, ctx.Path)) return;
+
+            _accountProof.Nonce = account.Nonce;
+            _accountProof.Balance = account.Balance;
+            _accountProof.StorageRoot = account.StorageRoot.ToCommitment();
+            _accountProof.CodeHash = account.CodeHash.ToCommitment();
+        }
 
         private void AddProofItem(TrieNode node, in TreePathContextWithStorage ctx)
         {
+            // Inline nodes have no standalone hash; their RLP is already embedded in the parent's
+            // RLP, so EIP-1186 / go-ethereum convention is to omit them from the proof entries.
+            if (node.Keccak is null) return;
+
+            byte[] rlp = node.FullRlp.ToArray();
             if (ctx.Storage is null)
             {
-                _accountProofItems.Add(node.FullRlp.ToArray());
+                _accountProofItems.Add(rlp);
+                return;
             }
-            else
-            {
-                // Add the node RLP to every storage proof whose path passes through this node
-                for (int i = 0; i < _fullStoragePaths.Length; i++)
-                {
-                    if (IsPrefix(_fullStoragePaths[i], ctx.Path))
-                        _storageProofItems[i].Add(node.FullRlp.ToArray());
-                }
-            }
-        }
 
-
-        /// <summary>
-        /// Decodes a storage leaf value. Handles both RLP-encoded values (standard) and raw bytes.
-        /// </summary>
-        private static ReadOnlyMemory<byte> DecodeStorageValue(ReadOnlySpan<byte> nodeValue)
-        {
-            if (nodeValue.IsEmpty) return new byte[] { 0 };
-            try
+            // Add the node RLP to every storage proof whose path passes through this node.
+            for (int i = 0; i < _fullStoragePaths.Length; i++)
             {
-                return new Rlp.ValueDecoderContext(nodeValue).DecodeByteArray();
-            }
-            catch (RlpException)
-            {
-                // Value was stored without RLP encoding; return as-is
-                return nodeValue.ToArray();
+                if (IsPrefix(_fullStoragePaths[i], ctx.Path))
+                    _storageProofItems[i].Add(rlp);
             }
         }
 
@@ -231,6 +214,20 @@ namespace Nethermind.State.Proofs
                 if (nodeKey[i] != (byte)targetPath[ctxPath.Length + i]) return false;
             }
 
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="fullPath"/> exactly equals <paramref name="targetPath"/>.
+        /// Used at the account leaf where the context path already includes the leaf's key.
+        /// </summary>
+        private static bool IsFullPathMatch(Nibble[] targetPath, TreePath fullPath)
+        {
+            if (fullPath.Length != targetPath.Length) return false;
+            for (int i = 0; i < targetPath.Length; i++)
+            {
+                if (fullPath[i] != (byte)targetPath[i]) return false;
+            }
             return true;
         }
     }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -1,10 +1,9 @@
-// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -15,11 +14,13 @@ using Nethermind.Trie;
 namespace Nethermind.State.Proofs
 {
     /// <summary>
-    /// EIP-1186 style proof collector
+    /// EIP-1186 style proof collector.
+    /// Uses path-based traversal via <see cref="TreePathContextWithStorage"/> instead of
+    /// hash-based node tracking, which correctly handles inline trie nodes (nodes smaller
+    /// than 32 bytes that have no standalone hash).
     /// </summary>
-    public class AccountProofCollector : ITreeVisitor<OldStyleTrieVisitContext>
+    public class AccountProofCollector : ITreeVisitor<TreePathContextWithStorage>
     {
-        private int _pathTraversalIndex;
         private readonly Address _address = Address.Zero;
         private readonly AccountProof _accountProof;
 
@@ -29,17 +30,7 @@ namespace Nethermind.State.Proofs
         private readonly List<byte[]> _accountProofItems = new();
         private readonly List<byte[]>[] _storageProofItems;
 
-        private readonly Dictionary<Hash256AsKey, StorageNodeInfo> _storageNodeInfos = new(Hash256AsKeyComparer.Instance);
-        private readonly Dictionary<Hash256AsKey, StorageNodeInfo>.AlternateLookup<ValueHash256> _storageNodeInfosLookup;
-        private readonly HashSet<Hash256AsKey> _nodeToVisitFilter = new(Hash256AsKeyComparer.Instance);
-        private readonly HashSet<Hash256AsKey>.AlternateLookup<ValueHash256> _nodeToVisitFilterLookup;
         private readonly AccountDecoder _accountDecoder = AccountDecoder.Instance;
-
-        private class StorageNodeInfo
-        {
-            public int PathIndex { get; set; }
-            public List<int> StorageIndices { get; } = new();
-        }
 
         private static ValueHash256 ToKey(byte[] index) => ValueKeccak.Compute(index);
 
@@ -52,9 +43,6 @@ namespace Nethermind.State.Proofs
 
         private AccountProofCollector(ReadOnlySpan<byte> hashedAddress, IEnumerable<ValueHash256>? keccakStorageKeys, int length, byte[][]? storageKeys)
         {
-            _storageNodeInfosLookup = _storageNodeInfos.GetAlternateLookup<ValueHash256>();
-            _nodeToVisitFilterLookup = _nodeToVisitFilter.GetAlternateLookup<ValueHash256>();
-
             keccakStorageKeys ??= [];
 
             _fullAccountPath = Nibbles.FromBytes(hashedAddress);
@@ -72,53 +60,36 @@ namespace Nethermind.State.Proofs
                 _storageProofItems[i] = new List<byte[]>();
             }
 
-            if (keccakStorageKeys is not null)
+            int j = 0;
+            foreach (ValueHash256 storageKey in keccakStorageKeys)
             {
-                int i = 0;
-                foreach (ValueHash256 storageKey in keccakStorageKeys)
+                _fullStoragePaths[j] = Nibbles.FromBytes(storageKey.Bytes);
+                _accountProof.StorageProofs[j] = new StorageProof
                 {
-                    _fullStoragePaths[i] = Nibbles.FromBytes(storageKey.Bytes);
-
-                    _accountProof.StorageProofs[i] = new StorageProof
-                    {
-                        // we don't know the key (index)
-                        Key = storageKeys?[i].ToHexString(true, true),
-                        Value = Bytes.ZeroByte
-                    };
-
-                    i++;
-                }
+                    Key = storageKeys?[j].ToHexString(true, true),
+                    Value = Bytes.ZeroByte
+                };
+                j++;
             }
         }
 
-        /// <summary>
-        /// Only for testing
-        /// </summary>
+        /// <summary>Only for testing</summary>
         internal AccountProofCollector(ReadOnlySpan<byte> hashedAddress, Hash256[]? keccakStorageKeys)
-            : this(hashedAddress, keccakStorageKeys?.Select(static keccak => (ValueHash256)keccak).ToArray())
-        {
-        }
+            : this(hashedAddress, keccakStorageKeys?.Select(static keccak => (ValueHash256)keccak).ToArray()) { }
 
-        /// <summary>
-        /// Only for testing too
-        /// </summary>
+        /// <summary>Only for testing</summary>
         internal AccountProofCollector(ReadOnlySpan<byte> hashedAddress, ValueHash256[]? keccakStorageKeys)
-            : this(hashedAddress, keccakStorageKeys, keccakStorageKeys?.Length ?? 0, null)
-        {
-        }
+            : this(hashedAddress, keccakStorageKeys, keccakStorageKeys?.Length ?? 0, null) { }
 
         public AccountProofCollector(ReadOnlySpan<byte> hashedAddress, params byte[][]? storageKeys)
-            : this(hashedAddress, storageKeys?.Select(ToKey), storageKeys?.Length ?? 0, storageKeys)
-        {
-        }
+            : this(hashedAddress, storageKeys?.Select(ToKey), storageKeys?.Length ?? 0, storageKeys) { }
 
         public AccountProofCollector(Address? address, params byte[][] storageKeys)
-            : this(Keccak.Compute((address ?? Address.Zero).Bytes).Bytes, storageKeys) => _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
+            : this(Keccak.Compute((address ?? Address.Zero).Bytes).Bytes, storageKeys)
+            => _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
 
         public AccountProofCollector(Address? address, IEnumerable<UInt256> storageKeys)
-            : this(address, storageKeys.Select(ToKey).ToArray())
-        {
-        }
+            : this(address, storageKeys.Select(ToKey).ToArray()) { }
 
         public AccountProof BuildResult()
         {
@@ -127,7 +98,6 @@ namespace Nethermind.State.Proofs
             {
                 _accountProof.StorageProofs![i].Proof = _storageProofItems[i].ToArray();
             }
-
             return _accountProof;
         }
 
@@ -136,180 +106,132 @@ namespace Nethermind.State.Proofs
 
         public bool IsFullDbScan => false;
 
-        public bool ShouldVisit(in OldStyleTrieVisitContext _, in ValueHash256 nextNode)
+        public bool ShouldVisit(in TreePathContextWithStorage ctx, in ValueHash256 nextNode)
         {
-            if (_storageNodeInfosLookup.TryGetValue(nextNode, out StorageNodeInfo value))
+            if (ctx.Storage is null)
             {
-                _pathTraversalIndex = value.PathIndex;
+                // Account trie: follow the path leading to our target account
+                return IsPrefix(_fullAccountPath, ctx.Path);
             }
 
-            return _nodeToVisitFilterLookup.Contains(nextNode);
-        }
-
-        public void VisitTree(in OldStyleTrieVisitContext _, in ValueHash256 rootHash)
-        {
-        }
-
-        public void VisitMissingNode(in OldStyleTrieVisitContext _, in ValueHash256 nodeHash)
-        {
-        }
-
-        public void VisitBranch(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
-        {
-            AddProofItem(node, trieVisitContext);
-            _nodeToVisitFilter.Remove(node.Keccak);
-
-            if (trieVisitContext.IsStorage)
+            // Storage trie: visit nodes on the path to any requested storage slot
+            for (int i = 0; i < _fullStoragePaths.Length; i++)
             {
-                HashSet<int> bumpedIndexes = new();
-                foreach (int storageIndex in _storageNodeInfos[node.Keccak].StorageIndices)
+                if (IsPrefix(_fullStoragePaths[i], ctx.Path))
+                    return true;
+            }
+            return false;
+        }
+
+        public void VisitTree(in TreePathContextWithStorage ctx, in ValueHash256 rootHash) { }
+
+        public void VisitMissingNode(in TreePathContextWithStorage ctx, in ValueHash256 nodeHash) { }
+
+        public void VisitBranch(in TreePathContextWithStorage ctx, TrieNode node)
+            => AddProofItem(node, ctx);
+
+        public void VisitExtension(in TreePathContextWithStorage ctx, TrieNode node)
+            => AddProofItem(node, ctx);
+
+        public void VisitLeaf(in TreePathContextWithStorage ctx, TrieNode node)
+        {
+            AddProofItem(node, ctx);
+
+            if (ctx.Storage is null)
+            {
+                // Decode account fields only if this leaf is our target account
+                if (IsFullPathMatch(_fullAccountPath, ctx.Path, node.Key))
                 {
-                    Nibble childIndex = _fullStoragePaths[storageIndex][_pathTraversalIndex];
-                    byte[] child = node.GetChildHashOrInlineValue((byte)childIndex);
-
-                    if (child?.Length == Hash256.Size)
-                    {
-                        // If the length is 32 it's the hash of the child
-                        Hash256 childHash = new(child);
-                        ref StorageNodeInfo? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_storageNodeInfos, childHash, out bool exists);
-                        if (!exists)
-                        {
-                            value = new StorageNodeInfo();
-                        }
-
-                        if (!bumpedIndexes.Contains((byte)childIndex))
-                        {
-                            bumpedIndexes.Add((byte)childIndex);
-                            value.PathIndex = _pathTraversalIndex + 1;
-                        }
-
-                        value.StorageIndices.Add(storageIndex);
-                        _nodeToVisitFilter.Add(childHash);
-                    }
-                    else if (child is not null)
-                    {
-                        // Child is an inline node
-                        _accountProof.StorageProofs[storageIndex].Value = child;
-                    }
-                }
-            }
-            else
-            {
-                _nodeToVisitFilter.Add(node.GetChildHash((byte)_fullAccountPath[_pathTraversalIndex]));
-            }
-
-            _pathTraversalIndex++;
-        }
-
-        public void VisitExtension(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
-        {
-            AddProofItem(node, trieVisitContext);
-            _nodeToVisitFilter.Remove(node.Keccak);
-
-            Hash256 childHash = node.GetChildHash(0);
-            if (trieVisitContext.IsStorage)
-            {
-                _storageNodeInfos[childHash] = new StorageNodeInfo();
-                _storageNodeInfos[childHash].PathIndex = _pathTraversalIndex + node.Key.Length;
-
-                foreach (int storageIndex in _storageNodeInfos[node.Keccak].StorageIndices)
-                {
-                    bool isPathMatched = IsPathMatched(node, _fullStoragePaths[storageIndex]);
-                    if (isPathMatched)
-                    {
-                        _storageNodeInfos[childHash].StorageIndices.Add(storageIndex);
-                        _nodeToVisitFilter.Add(childHash); // always accept so can optimize
-                    }
-                }
-            }
-
-            if (IsPathMatched(node, _fullAccountPath))
-            {
-                _nodeToVisitFilter.Add(childHash); // always accept so can optimize
-                _pathTraversalIndex += node.Key.Length;
-            }
-        }
-
-        private void AddProofItem(TrieNode node, OldStyleTrieVisitContext trieVisitContext)
-        {
-            if (trieVisitContext.IsStorage)
-            {
-                if (_storageNodeInfos.TryGetValue(node.Keccak, out StorageNodeInfo value))
-                {
-                    foreach (int storageIndex in value.StorageIndices)
-                    {
-                        _storageProofItems[storageIndex].Add(node.FullRlp.ToArray());
-                    }
-                }
-            }
-            else
-            {
-                _accountProofItems.Add(node.FullRlp.ToArray());
-            }
-        }
-
-        public void VisitLeaf(in OldStyleTrieVisitContext trieVisitContext, TrieNode node)
-        {
-            AddProofItem(node, trieVisitContext);
-            _nodeToVisitFilter.Remove(node.Keccak);
-
-            if (trieVisitContext.IsStorage)
-            {
-                foreach (int storageIndex in _storageNodeInfos[node.Keccak].StorageIndices)
-                {
-                    Nibble[] thisStoragePath = _fullStoragePaths[storageIndex];
-                    bool isPathMatched = IsPathMatched(node, thisStoragePath);
-                    if (isPathMatched)
-                    {
-                        _accountProof.StorageProofs[storageIndex].Value = new Rlp.ValueDecoderContext(node.Value.ToArray()).DecodeByteArray();
-                    }
-                }
-            }
-            else
-            {
-                Rlp.ValueDecoderContext ctx = new(node.Value.ToArray());
-                Account account = _accountDecoder.Decode(ref ctx);
-                bool isPathMatched = IsPathMatched(node, _fullAccountPath);
-                if (isPathMatched)
-                {
+                    Rlp.ValueDecoderContext rlpCtx = new(node.Value.ToArray());
+                    Account account = _accountDecoder.Decode(ref rlpCtx);
                     _accountProof.Nonce = account.Nonce;
                     _accountProof.Balance = account.Balance;
                     _accountProof.StorageRoot = account.StorageRoot;
                     _accountProof.CodeHash = account.CodeHash;
-
-                    if (_fullStoragePaths.Length > 0)
+                }
+            }
+            else
+            {
+                // Record decoded storage values for every slot whose full path matches this leaf
+                for (int i = 0; i < _fullStoragePaths.Length; i++)
+                {
+                    if (IsFullPathMatch(_fullStoragePaths[i], ctx.Path, node.Key))
                     {
-                        _nodeToVisitFilter.Add(_accountProof.StorageRoot);
-                        _storageNodeInfos[_accountProof.StorageRoot] = new StorageNodeInfo();
-                        _storageNodeInfos[_accountProof.StorageRoot].PathIndex = 0;
-                        for (int i = 0; i < _fullStoragePaths.Length; i++)
-                        {
-                            _storageNodeInfos[_accountProof.StorageRoot].StorageIndices.Add(i);
-                        }
+                        _accountProof.StorageProofs[i].Value = DecodeStorageValue(node.Value);
                     }
                 }
             }
-
-            _pathTraversalIndex = 0;
         }
 
-        private bool IsPathMatched(TrieNode node, Nibble[] path)
+        public void VisitAccount(in TreePathContextWithStorage ctx, TrieNode node, in AccountStruct account) { }
+
+        private void AddProofItem(TrieNode node, in TreePathContextWithStorage ctx)
         {
-            bool isPathMatched = true;
-            for (int i = _pathTraversalIndex; i < node.Key.Length + _pathTraversalIndex; i++)
+            if (ctx.Storage is null)
             {
-                if ((byte)path[i] != node.Key[i - _pathTraversalIndex])
+                _accountProofItems.Add(node.FullRlp.ToArray());
+            }
+            else
+            {
+                // Add the node RLP to every storage proof whose path passes through this node
+                for (int i = 0; i < _fullStoragePaths.Length; i++)
                 {
-                    isPathMatched = false;
-                    break;
+                    if (IsPrefix(_fullStoragePaths[i], ctx.Path))
+                        _storageProofItems[i].Add(node.FullRlp.ToArray());
                 }
             }
-
-            return isPathMatched;
         }
 
-        public void VisitAccount(in OldStyleTrieVisitContext _, TrieNode node, in AccountStruct account)
+
+        /// <summary>
+        /// Decodes a storage leaf value. Handles both RLP-encoded values (standard) and raw bytes.
+        /// </summary>
+        private static ReadOnlyMemory<byte> DecodeStorageValue(ReadOnlySpan<byte> nodeValue)
         {
+            if (nodeValue.IsEmpty) return new byte[] { 0 };
+            try
+            {
+                return new Rlp.ValueDecoderContext(nodeValue).DecodeByteArray();
+            }
+            catch (RlpException)
+            {
+                // Value was stored without RLP encoding; return as-is
+                return nodeValue.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="currentPath"/> is a prefix of <paramref name="targetPath"/>.
+        /// An empty path is a prefix of every target.
+        /// </summary>
+        private static bool IsPrefix(Nibble[] targetPath, TreePath currentPath)
+        {
+            if (currentPath.Length > targetPath.Length) return false;
+            for (int i = 0; i < currentPath.Length; i++)
+            {
+                if (currentPath[i] != (byte)targetPath[i]) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the full trie path (context path + leaf node key) exactly equals <paramref name="targetPath"/>.
+        /// </summary>
+        private static bool IsFullPathMatch(Nibble[] targetPath, TreePath ctxPath, byte[]? nodeKey)
+        {
+            if (nodeKey is null || ctxPath.Length + nodeKey.Length != targetPath.Length) return false;
+
+            for (int i = 0; i < ctxPath.Length; i++)
+            {
+                if (ctxPath[i] != (byte)targetPath[i]) return false;
+            }
+
+            for (int i = 0; i < nodeKey.Length; i++)
+            {
+                if (nodeKey[i] != (byte)targetPath[ctxPath.Length + i]) return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
Replaced hash-based node tracking in AccountProofCollector with path-based traversal via TreePathContextWithStorage.Replaced hash-based node tracking in AccountProofCollector with path-based traversal via TreePathContextWithStorage. The old approach stored nodes by Keccak hash, which silently broke for inline trie nodes (nodes < 32 bytes with no standalone hash), causing eth_getProofs to return wrong storage values. The new implementation follows the trie path directly from the traversal context, correctly handling inline nodes without any changes to the public API.

Closes #9386