### PR TITLE
BlockTree: fall back to HeadAddressInDb when the reorg-boundary block is missing

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -331,9 +331,16 @@ public partial class BlockTree
             if (Logger.IsInfo) Logger.Info(
                 $"Start block loaded from reorg boundary - {persistedNumber} - {startBlock?.ToString(Block.Format.Short)}");
         }
-        else
+
+        // Fall back to the explicitly persisted head hash whenever the reorg
+        // boundary did not yield a block — either no boundary was stored, or it
+        // points one past the highest stored block (a persisted-state pointer
+        // written ahead of the block body). HeadAddressInDb is written by
+        // UpdateHeadBlock for every committed block and still holds a valid head;
+        // discarding it here would silently reset the node to genesis on restart.
+        if (startBlock is null)
         {
-            byte[] data = _blockInfoDb.Get(HeadAddressInDb);
+            byte[]? data = _blockInfoDb.Get(HeadAddressInDb);
             if (data is not null)
             {
                 startBlock = FindBlock(new Hash256(data), BlockTreeLookupOptions.None);


### PR DESCRIPTION
## Changes

- `BlockTree.LoadStartBlock` selected the startup head from `BestPersistedState` (the reorg-boundary block number) and, when that number resolved to no block, gave up — silently leaving `Head` unset so the node fell back to genesis on restart.
- The reorg-boundary number can legitimately sit one block past the highest stored block (a persisted-state pointer written ahead of the block body). In that case the node restarted at genesis instead of its real head.
- Fall back to the explicitly persisted head hash (`HeadAddressInDb`, written by `UpdateHeadBlock` for every committed block) whenever the reorg-boundary lookup yields no block. The valid head is no longer discarded.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No

#### Notes on testing

Verified on a live node: a datadir whose persisted reorg boundary was one block past the highest stored block previously restarted at genesis; with this fallback it restores the correct head. A unit test for `LoadStartBlock` should be added before this leaves draft.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
