### PR TITLE
fix(sync test): de-flake two SynchronizerTests on Windows

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -697,7 +697,7 @@ public class SynchronizerTests(SynchronizerType synchronizerType)
             .StopAsync();
     }
 
-    [Test]
+    [Test, Retry(3)]
     public async Task Will_remove_peer_when_init_fails()
     {
         SyncPeerMock peerA = new("A", true, true);
@@ -830,7 +830,7 @@ public class SynchronizerTests(SynchronizerType synchronizerType)
             .StopAsync();
     }
 
-    [Test]
+    [Test, Retry(3)]
     public async Task Will_not_reorganize_more_than_max_reorg_length()
     {
         SyncPeerMock peerA = new("A");
@@ -842,10 +842,10 @@ public class SynchronizerTests(SynchronizerType synchronizerType)
         await When.Syncing
             .AfterProcessingGenesis()
             .AfterPeerIsAdded(peerA)
-            .BestSuggestedHeaderIs(peerA.HeadHeader)
+            .BestSuggestedHeaderIs(peerA.HeadHeader, BatchSyncDynamicTimeout)
             .AfterPeerIsAdded(peerB)
             .WaitALittle()
-            .BestSuggestedHeaderIs(peerA.HeadHeader)
+            .BestSuggestedHeaderIs(peerA.HeadHeader, BatchSyncDynamicTimeout)
             .StopAsync();
     }
 


### PR DESCRIPTION
## Changes

- Add `[Retry(3)]` to `Will_remove_peer_when_init_fails` and `Will_not_reorganize_more_than_max_reorg_length` in `SynchronizerTests`.
- Bump both `BestSuggestedHeaderIs(...)` assertions in `Will_not_reorganize_more_than_max_reorg_length` to use `BatchSyncDynamicTimeout` (60 s), matching `Can_reorg_on_add_peer`.

## Why

These are the only two assertion-bearing tests in the `[TestFixtureSource]` fixture (6 `SynchronizerType` variants) without `[Retry(3)]`. They both rely on NUnit `.After(...)` polling assertions, and recently flaked on `windows-latest` (e.g. https://github.com/NethermindEth/nethermind/actions/runs/26096948544/job/76737132841?pr=11656):

- `Will_remove_peer_when_init_fails`: peer-removal chain (`Disconnect` event → `RemovePeer`) runs on a thread-pool continuation; under parallel-fixture saturation the 5 s `PeerCountEventuallyIs(0)` polling deadline can be missed. The path is correct (`ExecuteRefreshTask` faulted-task branch → `ReportRefreshFailed` with `AggregateException` → `else` → `Disconnect`) — it's purely scheduling latency.
- `Will_not_reorganize_more_than_max_reorg_length`: largest sync in the file (`MaxReorganizationLength + 1` = 257 blocks) but uses default `DynamicTimeout` (10 s) instead of `BatchSyncDynamicTimeout` (60 s) that the comparable `Can_reorg_on_add_peer` uses.

No product behavior changes.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Test-only change. Verified locally that both tests still pass against the existing product code paths.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No