### PR TITLE
Avoid bucket snapshot allocation in BalanceTooLowFilter

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
@@ -106,62 +106,29 @@ namespace Nethermind.TxPool.Test.Collections
             _sortedPool.TryGetBucket(tx.SenderAddress, out _).Should().BeFalse();
         }
 
-        [Test]
-        public void VisitBucket_missing_group_does_not_invoke_visitor()
+        private static IEnumerable<TestCaseData> VisitBucketCases()
         {
-            int visited = 0;
-            _sortedPool.VisitBucket(TestItem.AddressA, ref visited, static (Transaction _, ref int count) =>
-            {
-                count++;
-                return true;
-            });
-
-            visited.Should().Be(0);
+            yield return new TestCaseData(Array.Empty<int>(), int.MaxValue, Array.Empty<int>())
+                .SetName("VisitBucket_missing_group_visits_nothing");
+            yield return new TestCaseData(new[] { 0, 1, 2, 3 }, int.MaxValue, new[] { 0, 1, 2, 3 })
+                .SetName("VisitBucket_iterates_all_items_in_ascending_nonce_order");
+            yield return new TestCaseData(new[] { 0, 1, 2, 3 }, 2, new[] { 0, 1, 2 })
+                .SetName("VisitBucket_stops_after_visitor_returns_false");
         }
 
-        [Test]
-        public void VisitBucket_iterates_all_items_in_ascending_nonce_order()
+        [TestCaseSource(nameof(VisitBucketCases))]
+        public void VisitBucket_visits_expected_nonces(int[] insertNonces, int stopAfterNonce, int[] expectedVisited)
         {
-            InsertNonces(TestItem.AddressA, [0, 1, 2, 3]);
+            InsertNonces(TestItem.AddressA, insertNonces);
 
-            List<UInt256> visited = new();
-            _sortedPool.VisitBucket(TestItem.AddressA, ref visited, static (Transaction tx, ref List<UInt256> acc) =>
+            (List<int> Visited, int StopAfter) state = (new List<int>(), stopAfterNonce);
+            _sortedPool.VisitBucket(TestItem.AddressA, ref state, static (Transaction tx, ref (List<int> Visited, int StopAfter) s) =>
             {
-                acc.Add(tx.Nonce);
-                return true;
+                s.Visited.Add((int)tx.Nonce);
+                return (int)tx.Nonce < s.StopAfter;
             });
 
-            visited.Should().Equal((UInt256)0, (UInt256)1, (UInt256)2, (UInt256)3);
-        }
-
-        [Test]
-        public void VisitBucket_stops_when_visitor_returns_false()
-        {
-            InsertNonces(TestItem.AddressA, [0, 1, 2, 3]);
-
-            (int Count, UInt256 StopAt) state = (0, StopAt: (UInt256)2);
-            _sortedPool.VisitBucket(TestItem.AddressA, ref state, static (Transaction tx, ref (int Count, UInt256 StopAt) s) =>
-            {
-                s.Count++;
-                return tx.Nonce < s.StopAt;
-            });
-
-            state.Count.Should().Be(3);
-        }
-
-        [Test]
-        public void VisitBucket_propagates_state_mutations_via_ref()
-        {
-            InsertNonces(TestItem.AddressA, [0, 1, 2]);
-
-            UInt256 sum = UInt256.Zero;
-            _sortedPool.VisitBucket(TestItem.AddressA, ref sum, static (Transaction tx, ref UInt256 acc) =>
-            {
-                acc += tx.Nonce;
-                return true;
-            });
-
-            sum.Should().Be((UInt256)3);
+            state.Visited.Should().Equal(expectedVisited);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -103,6 +104,86 @@ namespace Nethermind.TxPool.Test.Collections
 
             _sortedPool.TryRemove(tx.Hash);
             _sortedPool.TryGetBucket(tx.SenderAddress, out _).Should().BeFalse();
+        }
+
+        [Test]
+        public void VisitBucket_missing_group_does_not_invoke_visitor()
+        {
+            int visited = 0;
+            _sortedPool.VisitBucket(TestItem.AddressA, ref visited, static (Transaction _, ref int count) =>
+            {
+                count++;
+                return true;
+            });
+
+            visited.Should().Be(0);
+        }
+
+        [Test]
+        public void VisitBucket_iterates_all_items_in_ascending_nonce_order()
+        {
+            InsertNonces(TestItem.AddressA, [0, 1, 2, 3]);
+
+            List<UInt256> visited = new();
+            _sortedPool.VisitBucket(TestItem.AddressA, ref visited, static (Transaction tx, ref List<UInt256> acc) =>
+            {
+                acc.Add(tx.Nonce);
+                return true;
+            });
+
+            visited.Should().Equal((UInt256)0, (UInt256)1, (UInt256)2, (UInt256)3);
+        }
+
+        [Test]
+        public void VisitBucket_stops_when_visitor_returns_false()
+        {
+            InsertNonces(TestItem.AddressA, [0, 1, 2, 3]);
+
+            (int Count, UInt256 StopAt) state = (0, StopAt: (UInt256)2);
+            _sortedPool.VisitBucket(TestItem.AddressA, ref state, static (Transaction tx, ref (int Count, UInt256 StopAt) s) =>
+            {
+                s.Count++;
+                return tx.Nonce < s.StopAt;
+            });
+
+            state.Count.Should().Be(3);
+        }
+
+        [Test]
+        public void VisitBucket_propagates_state_mutations_via_ref()
+        {
+            InsertNonces(TestItem.AddressA, [0, 1, 2]);
+
+            UInt256 sum = UInt256.Zero;
+            _sortedPool.VisitBucket(TestItem.AddressA, ref sum, static (Transaction tx, ref UInt256 acc) =>
+            {
+                acc += tx.Nonce;
+                return true;
+            });
+
+            sum.Should().Be((UInt256)3);
+        }
+
+        [Test]
+        public void VisitBucket_throws_on_null_visitor()
+        {
+            int unused = 0;
+            Action act = () => _sortedPool.VisitBucket(TestItem.AddressA, ref unused, null!);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        private void InsertNonces(Address sender, ReadOnlySpan<int> nonces)
+        {
+            foreach (int nonce in nonces)
+            {
+                Transaction tx = Build.A.Transaction
+                    .WithNonce((UInt256)nonce)
+                    .WithSenderAddress(sender)
+                    .TestObject;
+                tx.Hash = tx.CalculateHash();
+                _sortedPool.TryInsert(tx.Hash, tx);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -23,6 +23,8 @@ namespace Nethermind.TxPool.Collections
         where TKey : notnull
         where TGroupKey : notnull
     {
+        internal delegate bool BucketVisitor<TState>(TValue value, ref TState state);
+
         protected McsLock Lock { get; } = new();
 
         private readonly int _capacity;
@@ -546,6 +548,29 @@ namespace Nethermind.TxPool.Collections
 
             item = default;
             return false;
+        }
+
+        /// <summary>
+        /// Iterates over bucket items under lock until visitor returns false.
+        /// </summary>
+        internal void VisitBucket<TState>(TGroupKey groupKey, ref TState state, BucketVisitor<TState> visitor)
+        {
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+
+            ArgumentNullException.ThrowIfNull(groupKey);
+            ArgumentNullException.ThrowIfNull(visitor);
+            if (!_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
+            {
+                return;
+            }
+
+            foreach (TValue value in bucket)
+            {
+                if (!visitor(value, ref state))
+                {
+                    break;
+                }
+            }
         }
 
         public bool BucketAny(TGroupKey groupKey, Func<TValue, bool> predicate)

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -553,12 +553,17 @@ namespace Nethermind.TxPool.Collections
         /// <summary>
         /// Iterates over bucket items under lock until visitor returns false.
         /// </summary>
+        /// <remarks>
+        /// The visitor runs while the pool lock is held, so it must be short and must not call back into the pool.
+        /// Items are visited in the pool's group comparer order (ascending nonce for the tx pool).
+        /// </remarks>
         internal void VisitBucket<TState>(TGroupKey groupKey, ref TState state, BucketVisitor<TState> visitor)
         {
-            using McsLock.Disposable lockRelease = Lock.Acquire();
-
             ArgumentNullException.ThrowIfNull(groupKey);
             ArgumentNullException.ThrowIfNull(visitor);
+
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+
             if (!_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
             {
                 return;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -55,7 +55,7 @@ namespace Nethermind.TxPool.Filters
             });
 
             bool overflow = bucketBalanceState.Overflow;
-            overflow |= tx.IsOverflowWhenAddingTxCostToCumulative(bucketBalanceState.CumulativeCost, out UInt256 cumulativeCost);
+            overflow |= tx.IsOverflowWhenAddingTxCostToCumulative(bucketBalanceState.CumulativeCost, out bucketBalanceState.CumulativeCost);
 
             if (overflow)
             {
@@ -64,7 +64,7 @@ namespace Nethermind.TxPool.Filters
                 return AcceptTxResult.Int256Overflow;
             }
 
-            if (balance < cumulativeCost)
+            if (balance < bucketBalanceState.CumulativeCost)
             {
                 Metrics.PendingTransactionsTooLowBalance++;
 
@@ -76,7 +76,7 @@ namespace Nethermind.TxPool.Filters
                 bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
                 return isNotLocal ?
                     AcceptTxResult.InsufficientFunds :
-                    AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {cumulativeCost}");
+                    AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {bucketBalanceState.CumulativeCost}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -13,6 +13,22 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal sealed class BalanceTooLowFilter(TxDistinctSortedPool txs, TxDistinctSortedPool blobTxs, ILogger logger) : IIncomingTxFilter
     {
+        private struct BucketBalanceState
+        {
+            public readonly long AccountNonce;
+            public readonly long TxNonce;
+            public UInt256 CumulativeCost;
+            public bool Overflow;
+
+            public BucketBalanceState(long accountNonce, long txNonce)
+            {
+                AccountNonce = accountNonce;
+                TxNonce = txNonce;
+                CumulativeCost = UInt256.Zero;
+                Overflow = false;
+            }
+        }
+
         private readonly TxDistinctSortedPool _txs = txs;
         private readonly TxDistinctSortedPool _blobTxs = blobTxs;
         private readonly ILogger _logger = logger;
@@ -27,32 +43,27 @@ namespace Nethermind.TxPool.Filters
             AccountStruct account = state.SenderAccount;
             UInt256 balance = account.Balance;
 
-            UInt256 cumulativeCost = UInt256.Zero;
-            bool overflow = false;
-            Transaction[] sameTypeTxs = tx.SupportsBlobs
-                ? _blobTxs.GetBucketSnapshot(tx.SenderAddress!) // it will create a snapshot of light txs (without actual blobs)
-                : _txs.GetBucketSnapshot(tx.SenderAddress!);
+            BucketBalanceState bucketBalanceState = new(account.Nonce, tx.Nonce);
+            TxDistinctSortedPool pool = tx.SupportsBlobs ? _blobTxs : _txs;
             // tx.SenderAddress! as unknownSenderFilter will run before this one
-
-            for (int i = 0; i < sameTypeTxs.Length; i++)
+            pool.VisitBucket(tx.SenderAddress!, ref bucketBalanceState, static (Transaction otherTx, ref BucketBalanceState bucketState) =>
             {
-                Transaction otherTx = sameTypeTxs[i];
-                if (otherTx.Nonce < account.Nonce)
+                if (otherTx.Nonce < bucketState.AccountNonce)
                 {
-                    continue;
+                    return true;
                 }
 
-                if (otherTx.Nonce < tx.Nonce)
+                if (otherTx.Nonce >= bucketState.TxNonce)
                 {
-                    overflow |= otherTx.IsOverflowWhenAddingTxCostToCumulative(cumulativeCost, out cumulativeCost);
+                    return false;
                 }
-                else
-                {
-                    break;
-                }
-            }
 
-            overflow |= tx.IsOverflowWhenAddingTxCostToCumulative(cumulativeCost, out cumulativeCost);
+                bucketState.Overflow |= otherTx.IsOverflowWhenAddingTxCostToCumulative(bucketState.CumulativeCost, out bucketState.CumulativeCost);
+                return true;
+            });
+
+            bool overflow = bucketBalanceState.Overflow;
+            overflow |= tx.IsOverflowWhenAddingTxCostToCumulative(bucketBalanceState.CumulativeCost, out UInt256 cumulativeCost);
 
             if (overflow)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -13,20 +13,12 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal sealed class BalanceTooLowFilter(TxDistinctSortedPool txs, TxDistinctSortedPool blobTxs, ILogger logger) : IIncomingTxFilter
     {
-        private struct BucketBalanceState
+        private struct BucketBalanceState(UInt256 accountNonce, UInt256 txNonce)
         {
-            public readonly long AccountNonce;
-            public readonly long TxNonce;
-            public UInt256 CumulativeCost;
-            public bool Overflow;
-
-            public BucketBalanceState(long accountNonce, long txNonce)
-            {
-                AccountNonce = accountNonce;
-                TxNonce = txNonce;
-                CumulativeCost = UInt256.Zero;
-                Overflow = false;
-            }
+            public readonly UInt256 AccountNonce = accountNonce;
+            public readonly UInt256 TxNonce = txNonce;
+            public UInt256 CumulativeCost = UInt256.Zero;
+            public bool Overflow = false;
         }
 
         private readonly TxDistinctSortedPool _txs = txs;


### PR DESCRIPTION
## Changes
                                                                                                                                                                                                 
  - Added VisitBucket<TState> to SortedPool to iterate bucket entries under lock with early stop, avoiding mandatory snapshot materialization.                                                   
  - Updated BalanceTooLowFilter to use VisitBucket(...) instead of GetBucketSnapshot(...) when scanning same-sender pending txs.                                                                 
  - Removed per-call Transaction[] snapshot allocation from the BalanceTooLowFilter hot path while preserving existing nonce/overflow/balance decision logic.                                    
                                                                                                                                                                                                 
  ## Types of changes                                                                                                                                                                            
                                                                                                                                                                                                 
  #### What types of changes does your code introduce?                                                                                                                                           
                                                                                                                                                                                                 
  - [ ] Bugfix (a non-breaking change that fixes an issue)                                                                                                                                       
  - [ ] New feature (a non-breaking change that adds functionality)                                                                                                                              
  - [ ] Breaking change (a change that causes existing functionality not to work as expected)                                                                                                    
  - [x] Optimization                                                                                                                                                                             
  - [ ] Refactoring                                                                                                                                                                              
  - [ ] Documentation update                                                                                                                                                                     
  - [ ] Build-related changes                                                                                                                                                                    
  - [ ] Other: Description                                                                                                                                                                       
                                                                                                                                                                                                 
  ## Testing                                                                                                                                                                                     
                                                                                                                                                                                                 
  #### Requires testing                                                                                                                                                                          
                                                                                                                                                                                                 
  - [x] Yes                                                                                                                                                                                      
  - [ ] No                                                                                                                                                                                       
                                                                                                                                                                                                 
  #### If yes, did you write tests?                                                                                                                                                              
                                                                                                                                                                                                 
  - [ ] Yes                                                                                                                                                                                      
  - [x] No                                                                                                                                                                                       
                                                                                                                                                                                                 
  #### Notes on testing                                                                                                                                                                          
                                                                                                                                                                                                 
  - Validate with Nethermind.TxPool build and targeted Nethermind.TxPool.Test runs (especially SortedPoolTests and InsufficientFunds-related TxPoolTests filters).                               
  - In this environment, dotnet is unavailable, so build/test execution could not be run locally.                                                                                                
                                                                                                                                                                                                 
  ## Documentation                                                                                                                                                                               
                                                                                                                                                                                                 
  #### Requires documentation update                                                                                                                                                             
                                                                                                                                                                                                 
  - [ ] Yes                                                                                                                                                                                      
  - [x] No                                                                                                                                                                                       
                                                                                                                                                                                                 
  #### Requires explanation in Release Notes                                                                                                                                                     
                                                                                                                                                                                                 
  - [ ] Yes                                                                                                                                                                                      
  - [x] No 