### PR TITLE
fix(rlpx): drop racy OnSessionDisconnected fallback in shutdown

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -475,12 +475,15 @@ namespace Nethermind.Network.Rlpx
             {
                 try
                 {
-                    const string details = "shutdown";
-                    _session.MarkDisconnected(DisconnectReason.AppClosing, DisconnectType.Local, details);
-                    if (_rlpxHost._sessionActivitySubscriptions.ContainsKey(_session.SessionId))
-                    {
-                        _rlpxHost.OnSessionDisconnected(_session, new DisconnectEventArgs(DisconnectReason.AppClosing, DisconnectType.Local, details));
-                    }
+                    // MarkDisconnected is responsible for firing OnSessionDisconnected (via the
+                    // activity observer for concrete sessions, or via the Disconnected event for
+                    // substitutes). It does this only when it actually transitions state; if it
+                    // returns early because another thread already moved state to Disconnecting,
+                    // that other thread will fire OnSessionDisconnected from its own context
+                    // once it reaches Disconnected. Firing it again here races with that thread
+                    // and can reach PeerManager.OnDisconnected while State == Disconnecting,
+                    // which throws InvalidAsynchronousStateException.
+                    _session.MarkDisconnected(DisconnectReason.AppClosing, DisconnectType.Local, "shutdown");
                 }
                 catch (InvalidOperationException)
                 {

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -475,14 +475,6 @@ namespace Nethermind.Network.Rlpx
             {
                 try
                 {
-                    // MarkDisconnected is responsible for firing OnSessionDisconnected (via the
-                    // activity observer for concrete sessions, or via the Disconnected event for
-                    // substitutes). It does this only when it actually transitions state; if it
-                    // returns early because another thread already moved state to Disconnecting,
-                    // that other thread will fire OnSessionDisconnected from its own context
-                    // once it reaches Disconnected. Firing it again here races with that thread
-                    // and can reach PeerManager.OnDisconnected while State == Disconnecting,
-                    // which throws InvalidAsynchronousStateException.
                     _session.MarkDisconnected(DisconnectReason.AppClosing, DisconnectType.Local, "shutdown");
                 }
                 catch (InvalidOperationException)


### PR DESCRIPTION
## Changes

- Remove the explicit `OnSessionDisconnected` fallback in `RlpxHost.SessionActivitySubscription.DisconnectAndDispose`. `MarkDisconnected` already fires `OnSessionDisconnected` on the path that actually transitions state; the fallback only ever ran when `MarkDisconnected` returned early due to a concurrent in-progress disconnect, and racing the disconnecting thread is what was producing the failure.

## Why

Regression from #11639. Observed as a flake in `E2EDiscoveryTests.TestDiscovery` during container disposal (e.g. https://github.com/NethermindEth/nethermind/actions/runs/26103205685/job/76759910786):

```
System.ComponentModel.InvalidAsynchronousStateException : Invalid session state in OnDisconnected - Disconnected
   at Nethermind.Network.PeerManager.OnDisconnected(...) PeerManager.cs:1157
   at Nethermind.Network.Rlpx.RlpxHost.OnSessionDisconnected(...) RlpxHost.cs:520
   at Nethermind.Network.Rlpx.RlpxHost.SessionActivitySubscription.DisconnectAndDispose() RlpxHost.cs:482
   at Nethermind.Network.Rlpx.RlpxHost.Shutdown() RlpxHost.cs:413
   at Nethermind.Core.Test.Modules.PseudoNethermindRunner.DisposeAsync() PseudoNethermindRunner.cs:102
   ...
   at Nethermind.Network.Discovery.Test.E2EDiscoveryTests.TestDiscovery() E2EDiscoveryTests.cs:89
```

### Race

`Session.MarkDisconnected` performs two state transitions with substantial work in between, only the boundaries of which are locked:

```csharp
lock (_sessionStateLock)
{
    if (State >= SessionState.Disconnecting) return;   // early return
    State = SessionState.Disconnecting;
}

// fires Disconnecting event, kicks off DisconnectAsync, etc. — wide gap

lock (_sessionStateLock) { State = SessionState.Disconnected; }
activityObserver?.OnSessionDisconnected(this, disconnectEventArgs);
```

Scenario:

1. A netty thread (from `_group.ShutdownGracefullyAsync`) enters `MarkDisconnected`, transitions to `Disconnecting`, and starts the in-between work.
2. The shutdown thread iterates `_sessionActivitySubscriptions` and calls `DisconnectAndDispose`. Its `MarkDisconnected` call early-returns (state is already `Disconnecting`).
3. The shutdown thread's `_sessionActivitySubscriptions.ContainsKey` check passes — the netty thread hasn't reached its `activityObserver?.OnSessionDisconnected` yet, so the subscription is still registered.
4. The shutdown thread fires the fallback `OnSessionDisconnected` → `SessionDisconnected` event → `PeerManager.OnDisconnected` → assertion `session.State == Disconnected` fails (state is still `Disconnecting`) → `InvalidAsynchronousStateException`.

The `catch (InvalidOperationException)` in `DisconnectAndDispose` doesn't cover this exception type, so it bubbles up through container disposal and fails the test.

### Why dropping the fallback is safe

`MarkDisconnected` already routes the disconnect notification on its own when it transitions:
- Concrete `Session` instances: `activityObserver?.OnSessionDisconnected(this, args)` (Session.cs:531) — `activityObserver` is the `RlpxHost` itself, set via `SetActivityObserver` in `Attach()`.
- Substitute sessions: the `Disconnected` event handler attached in `Attach()` (`_session.Disconnected += _onDisconnected`) calls `_rlpxHost.OnSessionDisconnected`.

`OnSessionDisconnected` removes the subscription, so in the non-racy case the `ContainsKey` guard in the fallback would have been `false` anyway — the fallback only ever runs in the race window, where it produces the bug instead of doing useful work.

If `MarkDisconnected` was a no-op because another thread is mid-disconnect, that thread will reach the `Disconnected` state and fire `OnSessionDisconnected` from its own context — no fallback needed.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

`E2EDiscoveryTests.TestDiscovery` already exercises the shutdown path and was where the bug surfaced; it should stop flaking with this change. No new test added — the race window is narrow and hard to reproduce deterministically without instrumentation. Suggestions welcome if a targeted test is desired.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

cc @benaadams — flagging since this reverts part of the `DetachAndDispose` → `DisconnectAndDispose` change in #11639. If there was a specific scenario the fallback was meant to cover that I'm missing, happy to add a targeted alternative.