### PR TITLE
test(rpc): cover default module baseline

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
@@ -3,15 +3,18 @@
 
 using System;
 using System.IO.Abstractions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Autofac;
 using FluentAssertions;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Era1.JsonRpc;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.JsonRpc.Modules.Net;
+using Nethermind.JsonRpc.Modules.Personal;
 using Nethermind.JsonRpc.Modules.Proof;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -61,6 +64,53 @@ public class RpcModuleProviderTests
         _moduleProvider.Check("net_Version", _context).Should().Be(ModuleResolution.Unknown);
         _moduleProvider.Check("Net_Version", _context).Should().Be(ModuleResolution.Unknown);
         _moduleProvider.Check("net_version", _context).Should().Be(ModuleResolution.Enabled);
+    }
+
+    [Test]
+    public void Default_modules_match_safe_baseline()
+    {
+        string[] expectedDefaultModules =
+        [
+            ModuleType.Eth,
+            ModuleType.Subscribe,
+            ModuleType.Trace,
+            ModuleType.TxPool,
+            ModuleType.Web3,
+            ModuleType.Proof,
+            ModuleType.Net,
+            ModuleType.Parity,
+            ModuleType.Health,
+            ModuleType.Rpc
+        ];
+
+        Assert.That(ModuleType.DefaultModules, Is.EqualTo(expectedDefaultModules));
+        Assert.That(new JsonRpcConfig().EnabledModules, Is.EqualTo(expectedDefaultModules));
+        Assert.That(GetDocumentedDefaultModules(), Is.EqualTo(expectedDefaultModules));
+    }
+
+    [Test]
+    public void Personal_module_is_disabled_by_default()
+    {
+        SingletonModulePool<IPersonalRpcModule> pool = new(Substitute.For<IPersonalRpcModule>(), true);
+        _moduleProvider.Register(pool);
+
+        ModuleResolution resolution = _moduleProvider.Check(nameof(IPersonalRpcModule.personal_listAccounts), _context);
+
+        Assert.That(resolution, Is.EqualTo(ModuleResolution.Disabled));
+    }
+
+    [Test]
+    public void Personal_module_can_be_enabled_explicitly()
+    {
+        JsonRpcConfig jsonRpcConfig = new() { EnabledModules = [ModuleType.Personal] };
+        _moduleProvider = new RpcModuleProvider(new RealFileSystem(), jsonRpcConfig, new EthereumJsonSerializer(), LimboLogs.Instance);
+
+        SingletonModulePool<IPersonalRpcModule> pool = new(Substitute.For<IPersonalRpcModule>(), true);
+        _moduleProvider.Register(pool);
+
+        ModuleResolution resolution = _moduleProvider.Check(nameof(IPersonalRpcModule.personal_listAccounts), _context);
+
+        Assert.That(resolution, Is.EqualTo(ModuleResolution.Enabled));
     }
 
     [TestCase("eth_.*", ModuleResolution.Unknown)]
@@ -191,5 +241,16 @@ public class RpcModuleProviderTests
     private class TestRpcModule : ITestRpcModule
     {
         public TestRpcModule(TestRpcModuleDependencies dependencies) => dependencies.WasRequested = true;
+    }
+
+    private static string[] GetDocumentedDefaultModules()
+    {
+        ConfigItemAttribute configItem = typeof(IJsonRpcConfig)
+            .GetProperty(nameof(IJsonRpcConfig.EnabledModules))!
+            .GetCustomAttribute<ConfigItemAttribute>()!;
+
+        return configItem.DefaultValue!
+            .Trim('[', ']')
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Consensus;
 using Nethermind.Db;
 using Nethermind.EthStats;
 using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules;
 using Nethermind.Monitoring.Config;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery;
@@ -151,6 +152,18 @@ public class ConfigFilesTests : ConfigFileTestsBase
         Test<IJsonRpcConfig, bool>(configWildcard, static c => c.Enabled, jsonEnabled);
         Test<IJsonRpcConfig, int>(configWildcard, static c => c.Port, 8545);
         Test<IJsonRpcConfig, string>(configWildcard, static c => c.Host, "127.0.0.1");
+    }
+
+    [TestCase("^spaceneth")]
+    public void Non_dev_configs_keep_default_rpc_module_baseline(string configWildcard)
+    {
+        string[] expectedDefaultModules = ModuleType.DefaultModules.ToArray();
+
+        foreach (TestConfigProvider configProvider in GetConfigProviders(configWildcard))
+        {
+            IJsonRpcConfig jsonRpcConfig = configProvider.GetConfig<IJsonRpcConfig>();
+            Assert.That(jsonRpcConfig.EnabledModules, Is.EqualTo(expectedDefaultModules), configProvider.FileName);
+        }
     }
 
     [TestCase("sepolia", DiscoveryVersion.V4)]


### PR DESCRIPTION
## Changes

- Add regression coverage for the default JSON-RPC module baseline across `ModuleType.DefaultModules`, `JsonRpcConfig.EnabledModules`, and the documented `IJsonRpcConfig.EnabledModules` default.
- Verify the `Personal` module is disabled by default and can still be enabled explicitly.
- Assert non-dev runner configs keep using the default JSON-RPC module set.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test coverage

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `git diff --check -- src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs` passes.
- `dotnet build src/Nethermind/Nethermind.JsonRpc.Test/Nethermind.JsonRpc.Test.csproj -c release --no-restore --no-dependencies -m:1 -v:normal -p:CustomAfterMicrosoftCommonTargets=/private/tmp/nethermind-remove-repo-analyzer-items.targets` passes.
- `dotnet test --project src/Nethermind/Nethermind.JsonRpc.Test/Nethermind.JsonRpc.Test.csproj -c release --no-build -v:minimal --filter "FullyQualifiedName~Default_modules_match_safe_baseline|FullyQualifiedName~Personal_module"` passes.
- Runner.Test restore passes outside the sandbox. Runner.Test build remains blocked locally because required dependency reference assemblies are missing unless the full dependency chain is built, while full dependency build hits the local Roslyn analyzer version mismatch for `Nethermind.Serialization.SszGenerator`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No