### PR TITLE
Move BAL spec-switch and BAL attachment to the branch processor for BalRecorder plugin

### DIFF
--- a/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBlockProcessorTests.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using FluentAssertions;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.Tracing;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.BalRecorder.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class BalRecordingBlockProcessorTests
+{
+    [TestCase(true, TestName = "Records the generated BAL when recording is enabled")]
+    [TestCase(false, TestName = "Does not record when recording is disabled")]
+    public void Records_each_processed_block_when_recording_enabled(bool recordingEnabled)
+    {
+        FakeRecordedBalStore store = new() { RecordingEnabled = recordingEnabled };
+        GeneratedBlockAccessList generated = new();
+        IBlockAccessListManager balManager = Substitute.For<IBlockAccessListManager>();
+        balManager.GeneratedBlockAccessList.Returns(generated);
+
+        Block processed = Build.A.Block.WithNumber(9).TestObject;
+        StubBlockProcessor inner = new() { ProcessedBlock = processed };
+        BalRecordingBlockProcessor sut = new(inner, store, balManager);
+
+        (Block block, _) = sut.ProcessOne(processed, ProcessingOptions.None, NullBlockTracer.Instance, Substitute.For<IReleaseSpec>(), CancellationToken.None);
+
+        block.Should().BeSameAs(processed);
+        if (recordingEnabled)
+            store.Inserted.Should().ContainSingle().Which.Should().Be((9L, generated));
+        else
+            store.Inserted.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Forwards_the_TransactionsExecuted_event_to_the_inner_processor()
+    {
+        StubBlockProcessor inner = new();
+        BalRecordingBlockProcessor sut = new(inner, new FakeRecordedBalStore(), Substitute.For<IBlockAccessListManager>());
+
+        int count = 0;
+        sut.TransactionsExecuted += () => count++;
+        inner.RaiseTransactionsExecuted();
+
+        count.Should().Be(1);
+    }
+
+    private sealed class StubBlockProcessor : IBlockProcessor
+    {
+        public Block? ProcessedBlock { get; set; }
+
+        public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
+            => (ProcessedBlock ?? suggestedBlock, []);
+
+        public event Action? TransactionsExecuted;
+
+        public void RaiseTransactionsExecuted() => TransactionsExecuted?.Invoke();
+    }
+}

--- a/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBlockProcessorTests.cs
@@ -36,6 +36,7 @@ public class BalRecordingBlockProcessorTests
         (Block block, _) = sut.ProcessOne(processed, ProcessingOptions.None, NullBlockTracer.Instance, Substitute.For<IReleaseSpec>(), CancellationToken.None);
 
         block.Should().BeSameAs(processed);
+        balManager.Received(1).ForceConstructGeneratedBlockAccessList = recordingEnabled;
         if (recordingEnabled)
             store.Inserted.Should().ContainSingle().Which.Should().Be((9L, generated));
         else

--- a/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBranchProcessorTests.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/BalRecordingBranchProcessorTests.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.Tracing;
+using NUnit.Framework;
+
+namespace Nethermind.BalRecorder.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class BalRecordingBranchProcessorTests
+{
+    [TestCase(true, false, true, true, TestName = "Replay attaches the stored BAL and flips the switch before delegating")]
+    [TestCase(true, false, false, false, TestName = "Replay without a stored BAL leaves the block untouched and the switch off")]
+    [TestCase(false, true, false, true, TestName = "Recording flips the switch before delegating")]
+    public void Interception_is_applied_before_delegating(bool replay, bool recording, bool seedBal, bool expectedSwitchDuringProcess)
+    {
+        ReadOnlyBlockAccessList seeded = new();
+        FakeRecordedBalStore store = new() { ReplayEnabled = replay, RecordingEnabled = recording };
+        if (seedBal) store.Seed(1, seeded);
+
+        BalRecorderSpecSwitch balSwitch = new();
+        StubBranchProcessor inner = new();
+        bool switchDuringProcess = false;
+        Block? observedBlock = null;
+        inner.OnProcess = blocks =>
+        {
+            observedBlock = blocks[0];
+            switchDuringProcess = balSwitch.Enabled;
+        };
+
+        BalRecordingBranchProcessor sut = new(inner, store, balSwitch);
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+
+        Block[] result = sut.Process(null, [block], ProcessingOptions.None, NullBlockTracer.Instance);
+
+        switchDuringProcess.Should().Be(expectedSwitchDuringProcess, "the prewarmer reads the spec switch inside inner.Process");
+        balSwitch.Enabled.Should().BeFalse("the switch must be reset once the branch is processed");
+        observedBlock.Should().BeSameAs(block);
+        if (seedBal)
+            block.BlockAccessList.Should().BeSameAs(seeded, "the replayed BAL must be attached before the prewarmer runs");
+        else
+            block.BlockAccessList.Should().BeNull();
+        result.Should().ContainSingle().Which.Should().BeSameAs(block);
+    }
+
+    [Test]
+    public void Forwards_branch_processor_events_to_the_inner_processor()
+    {
+        StubBranchProcessor inner = new();
+        BalRecordingBranchProcessor sut = new(inner, new FakeRecordedBalStore(), new BalRecorderSpecSwitch());
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+
+        Block? processed = null;
+        Block? processing = null;
+        IReadOnlyList<Block>? batch = null;
+        sut.BlockProcessed += (_, e) => processed = e.Block;
+        sut.BlocksProcessing += (_, e) => batch = e.Blocks;
+        sut.BlockProcessing += (_, e) => processing = e.Block;
+
+        inner.RaiseBlockProcessed(block);
+        inner.RaiseBlocksProcessing([block]);
+        inner.RaiseBlockProcessing(block);
+
+        processed.Should().BeSameAs(block);
+        processing.Should().BeSameAs(block);
+        batch.Should().Equal(block);
+    }
+
+    private sealed class StubBranchProcessor : IBranchProcessor
+    {
+        public Action<IReadOnlyList<Block>>? OnProcess { get; set; }
+
+        public Block[] Process(BlockHeader? baseBlock, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions processingOptions, IBlockTracer blockTracer, CancellationToken token = default)
+        {
+            OnProcess?.Invoke(suggestedBlocks);
+            return [.. suggestedBlocks];
+        }
+
+        public event EventHandler<BlockProcessedEventArgs>? BlockProcessed;
+        public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing;
+        public event EventHandler<BlockEventArgs>? BlockProcessing;
+
+        public void RaiseBlockProcessed(Block block) => BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(block, []));
+        public void RaiseBlocksProcessing(IReadOnlyList<Block> blocks) => BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(blocks));
+        public void RaiseBlockProcessing(Block block) => BlockProcessing?.Invoke(this, new BlockEventArgs(block));
+    }
+}

--- a/src/Nethermind/Nethermind.BalRecorder.Test/FakeRecordedBalStore.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/FakeRecordedBalStore.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+
+namespace Nethermind.BalRecorder.Test;
+
+/// <summary>In-memory <see cref="IRecordedBalStore"/> for decorator tests.</summary>
+internal sealed class FakeRecordedBalStore : IRecordedBalStore
+{
+    private readonly Dictionary<long, ReadOnlyBlockAccessList> _seeded = new();
+
+    public bool ReplayEnabled { get; init; }
+    public bool RecordingEnabled { get; init; }
+    public List<(long Number, GeneratedBlockAccessList Bal)> Inserted { get; } = [];
+
+    public void Seed(long number, ReadOnlyBlockAccessList bal) => _seeded[number] = bal;
+    public void Insert(Block block, GeneratedBlockAccessList bal) => Inserted.Add((block.Number, bal));
+    public ReadOnlyBlockAccessList? Get(long blockNumber) => _seeded.GetValueOrDefault(blockNumber);
+    public void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.BalRecorder.Test/Nethermind.BalRecorder.Test.csproj
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/Nethermind.BalRecorder.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.BalRecorder/BalRecorderPlugin.cs
+++ b/src/Nethermind/Nethermind.BalRecorder/BalRecorderPlugin.cs
@@ -21,9 +21,10 @@ public class BalRecorderPlugin(IBalRecorderConfig config) : INethermindPlugin
 }
 
 /// <remarks>
-/// DEVELOPMENT / BENCHMARK USE ONLY. The decorators wrap every registered <see cref="IBlockProcessor"/>,
-/// <see cref="IBlockValidator"/>, and <see cref="ISpecProvider"/> — including those used for simulation,
-/// eth_call, and the producer pipeline — so this plugin must not be enabled on production nodes.
+/// DEVELOPMENT / BENCHMARK USE ONLY. The decorators wrap every registered <see cref="IBranchProcessor"/>,
+/// <see cref="IBlockProcessor"/>, <see cref="IBlockValidator"/>, and <see cref="ISpecProvider"/> — including
+/// those used for simulation, eth_call, and the producer pipeline — so this plugin must not be enabled on
+/// production nodes.
 /// </remarks>
 public class BalRecorderModule : Module
 {
@@ -33,5 +34,6 @@ public class BalRecorderModule : Module
             .AddSingleton<BalRecorderSpecSwitch>()
             .AddDecorator<ISpecProvider, BalRecorderSpecProvider>()
             .AddDecorator<IBlockValidator, BalRecordingBlockValidator>()
+            .AddDecorator<IBranchProcessor, BalRecordingBranchProcessor>()
             .AddDecorator<IBlockProcessor, BalRecordingBlockProcessor>();
 }

--- a/src/Nethermind/Nethermind.BalRecorder/BalRecordingBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.BalRecorder/BalRecordingBlockProcessor.cs
@@ -10,11 +10,21 @@ using Nethermind.Evm.Tracing;
 
 namespace Nethermind.BalRecorder;
 
+/// <summary>
+/// Decorates <see cref="IBlockProcessor"/> to record the block access list generated for each
+/// processed block.
+/// </summary>
+/// <remarks>
+/// Recording stays at the block processor — the layer that actually produces the BAL — rather
+/// than the branch processor: <see cref="IBlockProcessor.ProcessOne"/> runs for every processed
+/// block, whereas branch-level <c>BlockProcessed</c> events are raised behind a read-only-chain
+/// guard unrelated to recording. BAL attachment and the EIP-7928 spec switch are applied earlier
+/// by <see cref="BalRecordingBranchProcessor"/>.
+/// </remarks>
 public class BalRecordingBlockProcessor(
     IBlockProcessor inner,
     IRecordedBalStore store,
-    IBlockAccessListManager balManager,
-    BalRecorderSpecSwitch balSwitch) : IBlockProcessor
+    IBlockAccessListManager balManager) : IBlockProcessor
 {
     public event Action? TransactionsExecuted
     {
@@ -24,29 +34,13 @@ public class BalRecordingBlockProcessor(
 
     public (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer, IReleaseSpec spec, CancellationToken token)
     {
-        if (store.ReplayEnabled && suggestedBlock.BlockAccessList is null)
-            suggestedBlock.BlockAccessList = store.Get(suggestedBlock.Number);
-
-        bool shouldFlip = ShouldFlip(suggestedBlock);
-        if (shouldFlip) balSwitch.Enabled = true;
+        // Force the generated BAL to be built even on the parallel/verify-only fast path so it can be recorded.
         balManager.ForceConstructGeneratedBlockAccessList = store.RecordingEnabled;
-        try
-        {
-            (Block block, TxReceipt[] receipts) = inner.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
-            if (store.RecordingEnabled)
-                store.Insert(block, balManager.GeneratedBlockAccessList);
-            return (block, receipts);
-        }
-        finally
-        {
-            if (shouldFlip) balSwitch.Enabled = false;
-        }
-    }
-
-    private bool ShouldFlip(Block suggestedBlock)
-    {
-        if (suggestedBlock.IsGenesis) return false;
-        if (store.RecordingEnabled) return true;
-        return store.ReplayEnabled && suggestedBlock.BlockAccessList is not null;
+        (Block block, TxReceipt[] receipts) = inner.ProcessOne(suggestedBlock, options, blockTracer, spec, token);
+        if (store.RecordingEnabled)
+            // GeneratedBlockAccessList is fully populated by this point:
+            // BlockProcessor calls SetBlockAccessList (which merges per-tx BALs) before returning.
+            store.Insert(block, balManager.GeneratedBlockAccessList);
+        return (block, receipts);
     }
 }

--- a/src/Nethermind/Nethermind.BalRecorder/BalRecordingBranchProcessor.cs
+++ b/src/Nethermind/Nethermind.BalRecorder/BalRecordingBranchProcessor.cs
@@ -54,11 +54,13 @@ public class BalRecordingBranchProcessor(
 
     private bool ShouldFlip(IReadOnlyList<Block> suggestedBlocks)
     {
+        bool recording = store.RecordingEnabled;
+        bool replay = store.ReplayEnabled;
         foreach (Block block in suggestedBlocks)
         {
             if (block.IsGenesis) continue;
-            if (store.RecordingEnabled) return true;
-            if (store.ReplayEnabled && block.BlockAccessList is not null) return true;
+            if (recording) return true;
+            if (replay && block.BlockAccessList is not null) return true;
         }
         return false;
     }

--- a/src/Nethermind/Nethermind.BalRecorder/BalRecordingBranchProcessor.cs
+++ b/src/Nethermind/Nethermind.BalRecorder/BalRecordingBranchProcessor.cs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Evm.Tracing;
+
+namespace Nethermind.BalRecorder;
+
+/// <summary>
+/// Decorates <see cref="IBranchProcessor"/> to attach replayed block access lists and enable the
+/// EIP-7928 spec switch before branch-level work runs.
+/// </summary>
+/// <remarks>
+/// The block cache prewarmer decides whether to perform BAL read-warming inside
+/// <see cref="IBranchProcessor.Process"/>, before any <see cref="IBlockProcessor.ProcessOne"/> is
+/// reached. Attaching the replayed BAL or flipping the spec switch any later leaves the prewarmer
+/// blind to both, so this interception must sit on the branch processor. Recording is left to
+/// <see cref="BalRecordingBlockProcessor"/>: the branch processor suppresses its
+/// <c>BlockProcessed</c> event for read-only processing (e.g. block production), so recording
+/// from here would silently miss those blocks.
+/// </remarks>
+public class BalRecordingBranchProcessor(
+    IBranchProcessor inner,
+    IRecordedBalStore store,
+    BalRecorderSpecSwitch balSwitch) : IBranchProcessor
+{
+    public Block[] Process(BlockHeader? baseBlock, IReadOnlyList<Block> suggestedBlocks, ProcessingOptions processingOptions, IBlockTracer blockTracer, CancellationToken token = default)
+    {
+        // Attach replayed BALs before delegating so the prewarmer sees them when it runs.
+        if (store.ReplayEnabled)
+        {
+            foreach (Block block in suggestedBlocks)
+            {
+                if (!block.IsGenesis && block.BlockAccessList is null)
+                    block.BlockAccessList = store.Get(block.Number);
+            }
+        }
+
+        bool shouldFlip = ShouldFlip(suggestedBlocks);
+        if (shouldFlip) balSwitch.Enabled = true;
+        try
+        {
+            return inner.Process(baseBlock, suggestedBlocks, processingOptions, blockTracer, token);
+        }
+        finally
+        {
+            if (shouldFlip) balSwitch.Enabled = false;
+        }
+    }
+
+    private bool ShouldFlip(IReadOnlyList<Block> suggestedBlocks)
+    {
+        foreach (Block block in suggestedBlocks)
+        {
+            if (block.IsGenesis) continue;
+            if (store.RecordingEnabled) return true;
+            if (store.ReplayEnabled && block.BlockAccessList is not null) return true;
+        }
+        return false;
+    }
+
+    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed
+    {
+        add => inner.BlockProcessed += value;
+        remove => inner.BlockProcessed -= value;
+    }
+
+    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
+    {
+        add => inner.BlocksProcessing += value;
+        remove => inner.BlocksProcessing -= value;
+    }
+
+    public event EventHandler<BlockEventArgs>? BlockProcessing
+    {
+        add => inner.BlockProcessing += value;
+        remove => inner.BlockProcessing -= value;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Metrics.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Metrics.cs
@@ -98,7 +98,7 @@ public static class Metrics
     public static double StateMerkleizationTime { get; set; }
 
     [DetailedMetric]
-    [ExponentialPowerHistogramMetric(Start = 10, Factor = 1.2, Count = 30)]
+    [ExponentialPowerHistogramMetric(Start = 10, Factor = 1.2, Count = 35)]
     [Description("Histogram of block MGas per second")]
     public static IMetricObserver BlockMGasPerSec { get; set; } = new NoopMetricObserver();
 


### PR DESCRIPTION
## Changes

The block cache prewarmer decides whether to do BAL read-warming inside `BranchProcessor.Process`, **before** `BlockProcessor.ProcessOne` runs. The BAL recorder previously attached the replayed BAL and flipped the EIP-7928 spec switch *inside* `ProcessOne` (`BalRecordingBlockProcessor`), so the prewarmer never saw either — `ShouldBalReadWarm` always evaluated to false and BAL read-warming never ran.

This splits the BAL recorder's interception:

- **New `BalRecordingBranchProcessor`** — decorates `IBranchProcessor`. Attaches replayed BALs to the suggested blocks and flips the EIP-7928 spec switch *before* delegating to `inner.Process`, so the prewarmer sees both. Forwards the branch processor events.
- **`BalRecordingBlockProcessor`** — slimmed to recording only. Recording is the output of `ProcessOne` and stays at the block processor, which runs for every processed block with no read-only gate. The LOAD/CONTROL logic that moved to the branch decorator is removed.
- `BalRecorderModule` now registers both decorators.
- Added unit tests for both decorators (`BalRecordingBranchProcessorTests`, `BalRecordingBlockProcessorTests`) with a shared `FakeRecordedBalStore` helper; added `NSubstitute` to the test project.

`BalRecorderSpecProvider`, `BalRecordingBlockValidator`, `BalRecorderSpecSwitch`, and `BalRecorderReleaseSpec` are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New unit tests assert that the BAL is attached and the spec switch is enabled **before** `inner.Process` (the prewarming entry point), and that recording fires on every `ProcessOne` when recording is enabled. The existing `BalRecorderE2ETests.Record_Then_Replay_RoundTrip` end-to-end test remains green. Full `Nethermind.slnx` build: 0 warnings, 0 errors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The BAL recorder is development/benchmark-only and must not be enabled on production nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)