### PR TITLE
Simplify pruning cutoff & separate for BALs

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -18,6 +18,7 @@ namespace Nethermind.Core.Specs
         long MaxCodeSize { get; }
         long MinGasLimit { get; }
         long MinHistoryRetentionEpochs { get; }
+        long MinBalRetentionEpochs { get; }
         long GasLimitBoundDivisor { get; }
         UInt256 BlockReward { get; }
         long DifficultyBombDelay { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -14,6 +14,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual long MaxCodeSize => spec.MaxCodeSize;
     public virtual long MinGasLimit => spec.MinGasLimit;
     public virtual long MinHistoryRetentionEpochs => spec.MinHistoryRetentionEpochs;
+    public virtual long MinBalRetentionEpochs => spec.MinBalRetentionEpochs;
     public virtual long GasLimitBoundDivisor => spec.GasLimitBoundDivisor;
     public virtual UInt256 BlockReward => spec.BlockReward;
     public virtual long DifficultyBombDelay => spec.DifficultyBombDelay;

--- a/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
+++ b/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
@@ -21,5 +21,6 @@ namespace Nethermind.Db
         public const int BlockAccessListsBarrierWhenStarted = 14;
         public const int LowestInsertedBodyNumber = 15;
         public const int LowestInsertedBlockAccessListBlockNumber = 16;
+        public const int BlockAccessListPruningDeletePointer = 17;
     }
 }

--- a/src/Nethermind/Nethermind.Ethash.Test/ChainSpecTest.cs
+++ b/src/Nethermind/Nethermind.Ethash.Test/ChainSpecTest.cs
@@ -80,6 +80,7 @@ public class ChainSpecTest
                 Registrar = Address.Zero,
                 MinGasLimit = 11,
                 MinHistoryRetentionEpochs = 11,
+                MinBalRetentionEpochs = 7,
                 GasLimitBoundDivisor = 13,
                 MaximumExtraDataSize = 17,
                 Eip140Transition = 1400L,
@@ -155,6 +156,7 @@ public class ChainSpecTest
             r.DifficultyBoundDivisor = 0x800;
             r.MinGasLimit = 11L;
             r.MinHistoryRetentionEpochs = 11L;
+            r.MinBalRetentionEpochs = 7L;
             r.GasLimitBoundDivisor = 13L;
             r.MaximumExtraDataSize = 17L;
             r.MaxCodeSize = long.MaxValue;

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -125,6 +125,7 @@ public class HistoryPrunerTests
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(historyPruner.OldestBlockHeader, Is.Not.Null);
             Assert.That(historyPruner.OldestBlockHeader?.Number, Is.EqualTo(expectedBlocksPointer));
             Assert.That(historyPruner.BalsDeletePointer, Is.EqualTo(expectedBalsPointer));
         }
@@ -144,7 +145,7 @@ public class HistoryPrunerTests
         };
 
         using BasicTestBlockchain testBlockchain = await CreateBlockchainWithBlocks(historyConfig, (int)head, syncPivot: head);
-        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
+        IHistoryPruner historyPruner = testBlockchain.Container.Resolve<IHistoryPruner>();
 
         Assert.That(historyPruner.BalCutoffBlockNumber, Is.EqualTo(expectedCutoff));
     }

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -365,7 +365,8 @@ public class HistoryPrunerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(historyPruner.CutoffBlockNumber, Is.EqualTo(cutoff));
-            Assert.That(historyPruner.OldestBlockHeader.Number, Is.EqualTo(oldest));
+            Assert.That(historyPruner.OldestBlockHeader, Is.Not.Null, "OldestBlockHeader should not be null");
+            Assert.That(historyPruner.OldestBlockHeader?.Number, Is.EqualTo(oldest));
         }
     }
 

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -82,6 +82,73 @@ public class HistoryPrunerTests
         ).SetName("Prunes_up_to_sync_pivot");
     }
 
+    private static IEnumerable<TestCaseData> BalPruningCases()
+    {
+        // head=100, SlotsPerEpoch=32 → cutoff = 100 - retentionEpochs*32 (clamped at 0)
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 2, BalRetentionEpochs = 1, PruningInterval = 0 },
+            /*expectedBlocksPointer:*/ 36L,
+            /*expectedBalsPointer:*/ 68L
+        ).SetName("Bals_pruned_past_block_cutoff_when_bal_retention_is_shorter");
+
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 2, BalRetentionEpochs = 2, PruningInterval = 0 },
+            /*expectedBlocksPointer:*/ 36L,
+            /*expectedBalsPointer:*/ 36L
+        ).SetName("Bals_pruned_alongside_blocks_when_retentions_equal");
+
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 1, BalRetentionEpochs = 2, PruningInterval = 0 },
+            /*expectedBlocksPointer:*/ 68L,
+            /*expectedBalsPointer:*/ 68L
+        ).SetName("Bals_forced_forward_when_block_retention_is_shorter");
+
+        yield return new TestCaseData(
+            new HistoryConfig { Pruning = PruningModes.UseAncientBarriers, BalRetentionEpochs = 1, PruningInterval = 0 },
+            /*expectedBlocksPointer:*/ BeaconGenesisBlockNumber,
+            /*expectedBalsPointer:*/ 68L
+        ).SetName("Bals_use_separate_rolling_cutoff_in_ancient_barriers_mode");
+    }
+
+    [TestCaseSource(nameof(BalPruningCases))]
+    public async Task Bal_pruning_uses_separate_cutoff(
+        IHistoryConfig historyConfig,
+        long expectedBlocksPointer,
+        long expectedBalsPointer)
+    {
+        const int blocks = 100;
+
+        using BasicTestBlockchain testBlockchain = await CreateBlockchainWithBlocks(historyConfig, blocks, syncPivot: blocks);
+
+        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
+        historyPruner.TryPruneHistory(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(historyPruner.OldestBlockHeader?.Number, Is.EqualTo(expectedBlocksPointer));
+            Assert.That(historyPruner.BalsDeletePointer, Is.EqualTo(expectedBalsPointer));
+        }
+    }
+
+    [TestCase(100L, 1u, 68L)]
+    [TestCase(100L, 4u, 0L)] // negative pre-clamp
+    [TestCase(100L, 0u, 100L)]
+    public async Task Bal_cutoff_block_number_uses_separate_retention(long head, uint balRetentionEpochs, long expectedCutoff)
+    {
+        IHistoryConfig historyConfig = new HistoryConfig
+        {
+            Pruning = PruningModes.Rolling,
+            RetentionEpochs = 1, // intentionally differs from balRetentionEpochs
+            BalRetentionEpochs = balRetentionEpochs,
+            PruningInterval = 0
+        };
+
+        using BasicTestBlockchain testBlockchain = await CreateBlockchainWithBlocks(historyConfig, (int)head, syncPivot: head);
+        HistoryPruner historyPruner = (HistoryPruner)testBlockchain.Container.Resolve<IHistoryPruner>();
+
+        Assert.That(historyPruner.BalCutoffBlockNumber, Is.EqualTo(expectedCutoff));
+    }
+
     [TestCaseSource(nameof(PruningCases))]
     public async Task Prunes_history(
         IHistoryConfig historyConfig,

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -125,7 +125,7 @@ public class HistoryPrunerTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(historyPruner.OldestBlockHeader, Is.Not.Null);
+            Assert.That(historyPruner.OldestBlockHeader, Is.Not.Null, "OldestBlockHeader should not be null");
             Assert.That(historyPruner.OldestBlockHeader?.Number, Is.EqualTo(expectedBlocksPointer));
             Assert.That(historyPruner.BalsDeletePointer, Is.EqualTo(expectedBalsPointer));
         }

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -235,16 +235,23 @@ public class HistoryPrunerTests
         CheckHeadPreserved(testBlockchain, blocks);
     }
 
-    [TestCase(0, 100000u, false)]
-    [TestCase(100, 10u, true)]
-    public void Validates_config(int minHistoryRetentionEpochs, uint retentionEpochs, bool shouldThrow)
+    [TestCase(0, 100000u, 0L, 3533u, false)]
+    [TestCase(100, 10u, 0L, 3533u, true)]      // block retention below min
+    [TestCase(0, 100000u, 3533L, 3000u, true)] // BAL retention below min
+    [TestCase(0, 100000u, 3533L, 3533u, false)] // BAL retention exactly at min
+    public void Validates_config(int minHistoryRetentionEpochs, uint retentionEpochs, long minBalRetentionEpochs, uint balRetentionEpochs, bool shouldThrow)
     {
         IHistoryConfig historyConfig = new HistoryConfig
         {
             Pruning = PruningModes.Rolling,
             RetentionEpochs = retentionEpochs,
+            BalRetentionEpochs = balRetentionEpochs,
         };
-        ISpecProvider specProvider = new TestSpecProvider(new ReleaseSpec { MinHistoryRetentionEpochs = minHistoryRetentionEpochs });
+        ISpecProvider specProvider = new TestSpecProvider(new ReleaseSpec
+        {
+            MinHistoryRetentionEpochs = minHistoryRetentionEpochs,
+            MinBalRetentionEpochs = minBalRetentionEpochs,
+        });
         IDbProvider dbProvider = Substitute.For<IDbProvider>();
         dbProvider.MetadataDb.Returns(new TestMemDb());
 

--- a/src/Nethermind/Nethermind.History/HistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/HistoryConfig.cs
@@ -7,6 +7,7 @@ public class HistoryConfig : IHistoryConfig
 {
     public PruningModes Pruning { get; set; } = PruningModes.Disabled;
     public uint RetentionEpochs { get; set; } = 82125;
+    public uint BalRetentionEpochs { get; set; } = 3533;
     public uint PruningInterval { get; set; } = 8;
     public uint PruningTimeoutSeconds { get; set; } = 2;
 }

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -42,6 +42,7 @@ public class HistoryPruner : IHistoryPruner
     private readonly bool _enabled;
     private readonly long _pruningInterval;
     private readonly long _minHistoryRetentionEpochs;
+    private readonly long _minBalRetentionEpochs;
     private readonly int _deletionProgressLoggingInterval;
     private readonly long _ancientBarrier;
     private readonly long _minDeletableBlockNumber;
@@ -86,6 +87,7 @@ public class HistoryPruner : IHistoryPruner
         _enabled = historyConfig.Enabled();
         _pruningInterval = historyConfig.PruningInterval * SlotsPerEpoch;
         _minHistoryRetentionEpochs = specProvider.GenesisSpec.MinHistoryRetentionEpochs;
+        _minBalRetentionEpochs = specProvider.GenesisSpec.MinBalRetentionEpochs;
         _minDeletableBlockNumber = (_blockTree.Genesis?.Number ?? 0) + 1; // do not remove genesis
 
         CheckConfig();
@@ -328,6 +330,10 @@ public class HistoryPruner : IHistoryPruner
         {
             throw new HistoryPrunerException($"HistoryRetentionEpochs must be at least {_minHistoryRetentionEpochs}.");
         }
+        if (_historyConfig.BalRetentionEpochs < _minBalRetentionEpochs)
+        {
+            throw new HistoryPrunerException($"BalRetentionEpochs must be at least {_minBalRetentionEpochs}.");
+        }
     }
 
     private bool ShouldPruneHistory()
@@ -359,10 +365,10 @@ public class HistoryPruner : IHistoryPruner
                     break;
                 }
 
-                if (number < _minDeletableBlockNumber)
+                // defensive guards against deleting genesis or anything past the (possibly moving) sync pivot
+                if (number < _minDeletableBlockNumber || number >= _blockTree.SyncPivot.BlockNumber)
                 {
-                    // defensive guard against deleting genesis
-                    if (_logger.IsWarn) _logger.Warn($"Encountered unexpected block #{number} while pruning history, this block will not be deleted. Should be in range [{_minDeletableBlockNumber}, {upperExclusive}).");
+                    if (_logger.IsWarn) _logger.Warn($"Encountered unexpected block #{number} while pruning history, this block will not be deleted. Should be in range [{_minDeletableBlockNumber}, {_blockTree.SyncPivot.BlockNumber}).");
                     continue;
                 }
 
@@ -431,7 +437,7 @@ public class HistoryPruner : IHistoryPruner
                     break;
                 }
 
-                if (number < _minDeletableBlockNumber)
+                if (number < _minDeletableBlockNumber || number >= _blockTree.SyncPivot.BlockNumber)
                 {
                     continue;
                 }

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -51,8 +51,8 @@ public class HistoryPruner : IHistoryPruner
     private long _lastSavedBlocksDeletePointer = 1;
     private long _lastSavedBalsDeletePointer = 1;
     private BlockHeader? _oldestBlockHeader;
-    private bool _hasLoadedDeletePointers = false;
-    private int _currentlyPruning = 0;
+    private bool _hasLoadedDeletePointers;
+    private int _currentlyPruning;
 
     public event EventHandler<OnNewOldestBlockArgs>? NewOldestBlock;
 
@@ -380,11 +380,14 @@ public class HistoryPruner : IHistoryPruner
                         if (_logger.IsDebug) _logger.Debug($"Deleting old block {number} with hash {blockInfo.BlockHash}.");
                         _blockTree.DeleteOldBlock(number, blockInfo.BlockHash);
                         _receiptStorage.RemoveReceipts(block);
-                        // BAL is pruned alongside the block so we never leave orphaned BAL entries when block deletion is the more aggressive boundary.
-                        _blockAccessListStore.Delete(blockInfo.BlockHash);
+                        // Only delete the BAL if the BAL-only pass hasn't already covered this block; otherwise the delete is a no-op and the counter would over-report.
+                        if (number >= _balsDeletePointer)
+                        {
+                            _blockAccessListStore.Delete(blockInfo.BlockHash);
+                            Metrics.BlockAccessListsPruned++;
+                        }
                         deletedBlocks++;
                         Metrics.BlocksPruned++;
-                        Metrics.BlockAccessListsPruned++;
                     }
                 }
 

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,9 +13,7 @@ using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -29,15 +26,11 @@ namespace Nethermind.History;
 
 public class HistoryPruner : IHistoryPruner
 {
-    private const int MaxOptimisticSearchAttempts = 3;
     private const int LockWaitTimeoutMs = 100;
     private const int SlotsPerEpoch = 32;
 
-    // only one pruning and one searching thread at a time
     private readonly object _pruneLock = new();
-    private readonly object _searchLock = new();
 
-    private ulong? _lastPrunedTimestamp;
     private readonly ILogger _logger;
     private readonly IBlockTree _blockTree;
     private readonly IReceiptStorage _receiptStorage;
@@ -48,18 +41,18 @@ public class HistoryPruner : IHistoryPruner
     private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
     private readonly IHistoryConfig _historyConfig;
     private readonly bool _enabled;
-    private readonly long _epochLength;
     private readonly long _pruningInterval;
     private readonly long _minHistoryRetentionEpochs;
     private readonly int _deletionProgressLoggingInterval;
     private readonly long _ancientBarrier;
-    private long _deletePointer = 1;
     private readonly long _minDeletableBlockNumber;
-    private BlockHeader? _deletePointerHeader;
-    private long _lastSavedDeletePointer = 1;
-    private long? _cutoffPointer;
-    private ulong? _cutoffTimestamp;
-    private bool _hasLoadedDeletePointer = false;
+
+    private long _blocksDeletePointer = 1;
+    private long _balsDeletePointer = 1;
+    private long _lastSavedBlocksDeletePointer = 1;
+    private long _lastSavedBalsDeletePointer = 1;
+    private BlockHeader? _oldestBlockHeader;
+    private bool _hasLoadedDeletePointers = false;
     private int _currentlyPruning = 0;
 
     public event EventHandler<OnNewOldestBlockArgs>? NewOldestBlock;
@@ -92,10 +85,9 @@ public class HistoryPruner : IHistoryPruner
         _backgroundTaskScheduler = backgroundTaskScheduler;
         _historyConfig = historyConfig;
         _enabled = historyConfig.Enabled();
-        _epochLength = (long)blocksConfig.SecondsPerSlot * SlotsPerEpoch; // must be changed if slot length changes
         _pruningInterval = historyConfig.PruningInterval * SlotsPerEpoch;
         _minHistoryRetentionEpochs = specProvider.GenesisSpec.MinHistoryRetentionEpochs;
-        _minDeletableBlockNumber = (_blockTree.Genesis?.Number ?? 0) + 1; //not not remove genesis
+        _minDeletableBlockNumber = (_blockTree.Genesis?.Number ?? 0) + 1; // do not remove genesis
 
         CheckConfig();
 
@@ -104,9 +96,9 @@ public class HistoryPruner : IHistoryPruner
             if (historyConfig.Pruning == PruningModes.UseAncientBarriers)
             {
                 _ancientBarrier = long.Min(syncConfig.AncientBodiesBarrierCalc, syncConfig.AncientReceiptsBarrierCalc);
-                Metrics.PruningCutoffBlocknumber = _ancientBarrier;
-                Metrics.PruningCutoffTimestamp = null;
             }
+            Metrics.PruningCutoffBlocknumber = CutoffBlockNumber;
+            Metrics.BlockAccessListPruningCutoffBlocknumber = BalCutoffBlockNumber;
 
             blockProcessingQueue.ProcessingQueueEmpty += OnBlockProcessorQueueEmpty;
         }
@@ -121,104 +113,21 @@ public class HistoryPruner : IHistoryPruner
                 return null;
             }
 
-            if (_historyConfig.Pruning == PruningModes.UseAncientBarriers)
-            {
-                return _ancientBarrier;
-            }
-
-            ulong? cutoffTimestamp = CalculateCutoffTimestamp();
-
-            if (cutoffTimestamp is null)
-            {
-                return null;
-            }
-
-            long? cutoffBlockNumber = null;
-            long to = _blockTree.Head?.Number ?? _blockTree.SyncPivot.BlockNumber;
-
-            // cutoff is unchanged, can reuse
-            if (_cutoffTimestamp is not null && cutoffTimestamp == _cutoffTimestamp)
-            {
-                return _cutoffPointer;
-            }
-
-            bool lockTaken = false;
-            try
-            {
-                Monitor.TryEnter(_searchLock, LockWaitTimeoutMs, ref lockTaken);
-                if (lockTaken)
-                {
-                    // optimistically search a few blocks from an old pointer
-                    if (_cutoffPointer is not null)
-                    {
-                        int attempts = 0;
-                        long from = _cutoffPointer.Value;
-                        using ArrayPoolListRef<Block> x = GetBlocksByNumber(from, to, b =>
-                        {
-                            if (attempts >= MaxOptimisticSearchAttempts)
-                            {
-                                return true;
-                            }
-
-                            bool afterCutoff = b.Timestamp >= cutoffTimestamp;
-                            if (afterCutoff)
-                            {
-                                cutoffBlockNumber = b.Number;
-                            }
-                            attempts++;
-                            return afterCutoff;
-                        }).ToPooledListRef((int)(to - from + 1));
-                    }
-
-                    // if linear search fails, fallback to binary search
-                    cutoffBlockNumber ??= BlockTree.BinarySearchBlockNumber(_deletePointer, to, (n, _) =>
-                    {
-                        BlockInfo[]? blockInfos = _chainLevelInfoRepository.LoadLevel(n)?.BlockInfos;
-
-                        if (blockInfos is null)
-                        {
-                            return false;
-                        }
-
-                        foreach (BlockInfo blockInfo in blockInfos)
-                        {
-                            Block? b = _blockTree.FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, n);
-                            if (b is not null && b.Timestamp >= cutoffTimestamp)
-                            {
-                                return true;
-                            }
-                        }
-
-                        return false;
-                    }, BlockTree.BinarySearchDirection.Down);
-
-                    _cutoffTimestamp = cutoffTimestamp;
-                    _cutoffPointer = cutoffBlockNumber ?? _cutoffPointer;
-                    Metrics.PruningCutoffTimestamp = cutoffTimestamp;
-                    Metrics.PruningCutoffBlocknumber = _cutoffPointer;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            finally
-            {
-                if (lockTaken)
-                {
-                    Monitor.Exit(_searchLock);
-                }
-            }
-
-            return cutoffBlockNumber;
+            return _historyConfig.Pruning == PruningModes.UseAncientBarriers
+                ? _ancientBarrier
+                : CalculateRollingCutoff(_historyConfig.RetentionEpochs);
         }
     }
+
+    public long? BalCutoffBlockNumber => _enabled ? CalculateRollingCutoff(_historyConfig.BalRetentionEpochs) : null;
+
+    internal long BalsDeletePointer => _balsDeletePointer;
 
     public BlockHeader? OldestBlockHeader
     {
         get
         {
-            if (!_hasLoadedDeletePointer)
+            if (!_hasLoadedDeletePointers)
             {
                 bool lockTaken = false;
                 // take lock before updating delete pointer
@@ -228,7 +137,7 @@ public class HistoryPruner : IHistoryPruner
                     Monitor.TryEnter(_pruneLock, LockWaitTimeoutMs, ref lockTaken);
                     if (lockTaken)
                     {
-                        if (!TryLoadDeletePointer())
+                        if (!TryLoadDeletePointers())
                         {
                             return null;
                         }
@@ -247,8 +156,20 @@ public class HistoryPruner : IHistoryPruner
                 }
             }
 
-            return _deletePointerHeader;
+            return _oldestBlockHeader;
         }
+    }
+
+    private long? CalculateRollingCutoff(uint retentionEpochs)
+    {
+        long? head = _blockTree.Head?.Number;
+        if (head is null)
+        {
+            return null;
+        }
+
+        long blocksToRetain = (long)retentionEpochs * SlotsPerEpoch;
+        return long.Max(head.Value - blocksToRetain, 0);
     }
 
     private void OnBlockProcessorQueueEmpty(object? sender, EventArgs e)
@@ -308,7 +229,7 @@ public class HistoryPruner : IHistoryPruner
     {
         if (_blockTree.Head is null ||
             _blockTree.SyncPivot.BlockNumber == 0 ||
-            !ShouldPruneHistory(out ulong? cutoffTimestamp))
+            !ShouldPruneHistory())
         {
             SkipLocalPruning();
             return;
@@ -320,28 +241,33 @@ public class HistoryPruner : IHistoryPruner
         {
             if (lockTaken)
             {
-                if (!TryLoadDeletePointer() ||
-                    !ShouldPruneHistory(out cutoffTimestamp))
+                if (!TryLoadDeletePointers() || !ShouldPruneHistory())
                 {
                     SkipLocalPruning();
                     return;
                 }
 
+                long? blockCutoff = CutoffBlockNumber;
+                long? balCutoff = BalCutoffBlockNumber;
+                Metrics.PruningCutoffBlocknumber = blockCutoff;
+                Metrics.BlockAccessListPruningCutoffBlocknumber = balCutoff;
+
+                long syncPivot = _blockTree.SyncPivot.BlockNumber;
+                long blockUpper = blockCutoff is null ? _blocksDeletePointer : long.Min(blockCutoff.Value, syncPivot);
+                long balUpper = balCutoff is null ? _balsDeletePointer : long.Min(balCutoff.Value, syncPivot);
+
                 if (_logger.IsInfo)
                 {
-                    long? cutoffBlockNumber = CutoffBlockNumber;
-                    long? cutoff = cutoffBlockNumber is null ? null : long.Min(cutoffBlockNumber.Value, _blockTree.SyncPivot.BlockNumber);
-                    long? toDelete = cutoff - _deletePointer;
-
-                    string cutoffString = cutoffTimestamp is null
-                        ? $"#{FormatNumberOrUnknown(cutoff)}"
-                        : $"timestamp {cutoffTimestamp} (#{FormatNumberOrUnknown(cutoff)})";
-                    _logger.Info($"Pruning historical blocks up to {cutoffString}. Estimated {FormatNumberOrUnknown(toDelete)} blocks will be deleted.");
-
-                    static string FormatNumberOrUnknown(long? l) => l?.ToString() ?? "unknown";
+                    long blocksRemaining = long.Max(0, blockUpper - _blocksDeletePointer);
+                    long balsRemaining = long.Max(0, balUpper - _balsDeletePointer);
+                    _logger.Info($"Pruning historical blocks up to #{blockUpper} ({blocksRemaining} estimated) and block access lists up to #{balUpper} ({balsRemaining} estimated).");
                 }
 
-                PruneBlocksAndReceipts(cutoffTimestamp, cancellationToken);
+                PruneBlocksAndReceipts(blockUpper, cancellationToken);
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    PruneBlockAccessLists(balUpper, cancellationToken);
+                }
             }
             else if (_logger.IsDebug)
             {
@@ -368,8 +294,8 @@ public class HistoryPruner : IHistoryPruner
 
         if (oldestBlockNumber is not null)
         {
-            UpdateDeletePointer(oldestBlockNumber.Value);
-            SaveDeletePointer();
+            UpdateBlocksDeletePointer(oldestBlockNumber.Value);
+            SaveDeletePointers();
             return true;
         }
 
@@ -405,189 +331,208 @@ public class HistoryPruner : IHistoryPruner
         }
     }
 
-    private bool ShouldPruneHistory(out ulong? cutoffTimestamp)
+    private bool ShouldPruneHistory()
     {
-        cutoffTimestamp = null;
-
         if (!_enabled || !PruningIntervalHasElapsed())
         {
             return false;
         }
 
-        if (_historyConfig.Pruning == PruningModes.UseAncientBarriers)
-        {
-            return _deletePointer < _ancientBarrier;
-        }
-
-        cutoffTimestamp = CalculateCutoffTimestamp();
-        return cutoffTimestamp is not null && (_lastPrunedTimestamp is null || cutoffTimestamp > _lastPrunedTimestamp);
+        long? blockCutoff = CutoffBlockNumber;
+        long? balCutoff = BalCutoffBlockNumber;
+        return (blockCutoff is { } bc && _blocksDeletePointer < bc)
+            || (balCutoff is { } balC && _balsDeletePointer < balC);
     }
 
     private bool PruningIntervalHasElapsed()
         => _pruningInterval == 0 || _blockTree.Head!.Number % _pruningInterval == 0;
 
-    private void PruneBlocksAndReceipts(ulong? cutoffTimestamp, CancellationToken cancellationToken)
+    private void PruneBlocksAndReceipts(long upperExclusive, CancellationToken cancellationToken)
     {
         int deletedBlocks = 0;
-        ulong? lastDeletedTimestamp = null;
         try
         {
-            IEnumerable<Block> blocks = _historyConfig.Pruning == PruningModes.UseAncientBarriers ?
-                GetBlocksBeforeAncientBarrier() :
-                GetBlocksBeforeTimestamp(cutoffTimestamp!.Value);
-
-            foreach (Block block in blocks)
+            for (long number = _blocksDeletePointer; number < upperExclusive; number++)
             {
-                long number = block.Number;
-                Hash256 hash = block.Hash!;
-
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    if (_logger.IsInfo) _logger.Info($"Pruning operation timed out at timestamp {cutoffTimestamp}. Deleted {deletedBlocks} blocks.");
+                    if (_logger.IsInfo) _logger.Info($"Block pruning operation timed out at #{number}. Deleted {deletedBlocks} blocks.");
                     break;
                 }
 
-                // should never happen
-                if (number < _minDeletableBlockNumber || number >= _blockTree.SyncPivot.BlockNumber)
+                if (number < _minDeletableBlockNumber)
                 {
-                    if (_logger.IsWarn) _logger.Warn($"Encountered unexpected block #{number} while pruning history, this block will not be deleted. Should be in range [{_minDeletableBlockNumber}, {_blockTree.SyncPivot.BlockNumber}).");
+                    // defensive guard against deleting genesis
+                    if (_logger.IsWarn) _logger.Warn($"Encountered unexpected block #{number} while pruning history, this block will not be deleted. Should be in range [{_minDeletableBlockNumber}, {upperExclusive}).");
                     continue;
                 }
 
-                long? remaining = CutoffBlockNumber;
-                remaining = remaining is null ? null : long.Min(remaining!.Value, _blockTree.SyncPivot.BlockNumber) - _deletePointer;
-                if (_logger.IsInfo && deletedBlocks % _deletionProgressLoggingInterval == 0)
+                ChainLevelInfo? chainLevelInfo = _chainLevelInfoRepository.LoadLevel(number);
+                if (chainLevelInfo is not null)
                 {
-                    string suffix = remaining is null ? "could not calculate cutoff." : $"with {remaining} remaining.";
-                    _logger.Info($"Historical block pruning in progress... Deleted {deletedBlocks} blocks, " + suffix);
+                    foreach (BlockInfo blockInfo in chainLevelInfo.BlockInfos)
+                    {
+                        Block? block = _blockTree.FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, number);
+                        if (block is null)
+                        {
+                            continue;
+                        }
+
+                        if (_logger.IsDebug) _logger.Debug($"Deleting old block {number} with hash {blockInfo.BlockHash}.");
+                        _blockTree.DeleteOldBlock(number, blockInfo.BlockHash);
+                        _receiptStorage.RemoveReceipts(block);
+                        // BAL is pruned alongside the block so we never leave orphaned BAL entries when block deletion is the more aggressive boundary.
+                        _blockAccessListStore.Delete(blockInfo.BlockHash);
+                        deletedBlocks++;
+                        Metrics.BlocksPruned++;
+                        Metrics.BlockAccessListsPruned++;
+                    }
                 }
 
-                if (_logger.IsDebug) _logger.Debug($"Deleting old block {number} with hash {hash}.");
-                _blockTree.DeleteOldBlock(number, hash);
-                _receiptStorage.RemoveReceipts(block);
-                _blockAccessListStore.Delete(hash);
+                if (_logger.IsInfo && deletedBlocks > 0 && deletedBlocks % _deletionProgressLoggingInterval == 0)
+                {
+                    long remaining = long.Max(0, upperExclusive - number - 1);
+                    _logger.Info($"Historical block pruning in progress... Deleted {deletedBlocks} blocks, with {remaining} remaining.");
+                }
 
-                UpdateDeletePointer(number + 1, remaining is null || remaining == 0);
-                lastDeletedTimestamp = block.Timestamp;
-                deletedBlocks++;
-                Metrics.BlocksPruned++;
+                UpdateBlocksDeletePointer(number + 1, isFinalUpdate: number + 1 >= upperExclusive);
+                if (_balsDeletePointer < _blocksDeletePointer)
+                {
+                    _balsDeletePointer = _blocksDeletePointer;
+                    Metrics.OldestStoredBlockAccessListBlockNumber = _balsDeletePointer;
+                }
             }
         }
         finally
         {
-            if (_cutoffPointer < _deletePointer && lastDeletedTimestamp is not null)
-            {
-                _cutoffPointer = _deletePointer;
-                _cutoffTimestamp = lastDeletedTimestamp;
-                Metrics.PruningCutoffBlocknumber = _cutoffPointer;
-                Metrics.PruningCutoffTimestamp = _cutoffTimestamp;
-            }
+            SaveDeletePointers();
 
-            SaveDeletePointer();
-
-            if (!cancellationToken.IsCancellationRequested)
+            if (!cancellationToken.IsCancellationRequested && _logger.IsInfo && deletedBlocks > 0)
             {
-                if (_logger.IsInfo) _logger.Info($"Completed pruning operation up to timestamp {cutoffTimestamp}. Deleted {deletedBlocks} blocks up to #{_deletePointer}.");
-                _lastPrunedTimestamp = cutoffTimestamp;
+                _logger.Info($"Completed block pruning operation up to #{_blocksDeletePointer}. Deleted {deletedBlocks} blocks.");
             }
         }
     }
 
-    private IEnumerable<Block> GetBlocksBeforeAncientBarrier()
-        => GetBlocksByNumber(_deletePointer, long.Min(_ancientBarrier, _blockTree.SyncPivot.BlockNumber) - 1, (_) => false);
-
-    private IEnumerable<Block> GetBlocksBeforeTimestamp(ulong cutoffTimestamp)
-        => GetBlocksByNumber(_deletePointer, _blockTree.SyncPivot.BlockNumber - 1, b => b.Timestamp >= cutoffTimestamp);
-
-    private IEnumerable<Block> GetBlocksByNumber(long from, long to, Predicate<Block> endSearch)
+    private void PruneBlockAccessLists(long upperExclusive, CancellationToken cancellationToken)
     {
-        for (long i = from; i <= to; i++)
+        // BAL-only pruning for the range past the block cutoff. Blocks (with their BALs) up to
+        // _blocksDeletePointer have already been pruned by PruneBlocksAndReceipts.
+        int deletedBals = 0;
+        try
         {
-            ChainLevelInfo? chainLevelInfo = _chainLevelInfoRepository.LoadLevel(i);
-            if (chainLevelInfo is null)
+            for (long number = _balsDeletePointer; number < upperExclusive; number++)
             {
-                continue;
-            }
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    if (_logger.IsInfo) _logger.Info($"Block access list pruning operation timed out at #{number}. Deleted {deletedBals} BALs.");
+                    break;
+                }
 
-            bool finished = false;
-            foreach (BlockInfo blockInfo in chainLevelInfo.BlockInfos)
-            {
-                Block? block = _blockTree.FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, i);
-                if (block is null)
+                if (number < _minDeletableBlockNumber)
                 {
                     continue;
                 }
 
-                // search the entire chain level before finishing
-                if (endSearch(block))
+                ChainLevelInfo? chainLevelInfo = _chainLevelInfoRepository.LoadLevel(number);
+                if (chainLevelInfo is not null)
                 {
-                    finished = true;
+                    foreach (BlockInfo blockInfo in chainLevelInfo.BlockInfos)
+                    {
+                        if (_logger.IsDebug) _logger.Debug($"Deleting old block access list at #{number} with hash {blockInfo.BlockHash}.");
+                        _blockAccessListStore.Delete(blockInfo.BlockHash);
+                        deletedBals++;
+                        Metrics.BlockAccessListsPruned++;
+                    }
                 }
-                else
+
+                _balsDeletePointer = number + 1;
+                Metrics.OldestStoredBlockAccessListBlockNumber = _balsDeletePointer;
+
+                if (_logger.IsInfo && deletedBals > 0 && deletedBals % _deletionProgressLoggingInterval == 0)
                 {
-                    yield return block;
+                    long remaining = long.Max(0, upperExclusive - number - 1);
+                    _logger.Info($"Historical block access list pruning in progress... Deleted {deletedBals} BALs, with {remaining} remaining.");
                 }
             }
+        }
+        finally
+        {
+            SaveDeletePointers();
 
-            if (finished)
+            if (!cancellationToken.IsCancellationRequested && _logger.IsInfo && deletedBals > 0)
             {
-                yield break;
+                _logger.Info($"Completed block access list pruning operation up to #{_balsDeletePointer}. Deleted {deletedBals} BALs.");
             }
         }
     }
 
-    private ulong? CalculateCutoffTimestamp()
-        => _historyConfig.Pruning == PruningModes.Rolling && _blockTree.Head is not null ?
-            _blockTree.Head!.Timestamp - (ulong)(_historyConfig.RetentionEpochs * _epochLength) :
-            null;
-
-    private bool TryLoadDeletePointer()
+    private bool TryLoadDeletePointers()
     {
-        if (_hasLoadedDeletePointer)
+        if (_hasLoadedDeletePointers)
         {
             return true;
         }
 
-        byte[]? val = _metadataDb.Get(MetadataDbKeys.HistoryPruningDeletePointer);
-        if (val is null)
+        byte[]? blocksVal = _metadataDb.Get(MetadataDbKeys.HistoryPruningDeletePointer);
+        if (blocksVal is null)
         {
-            if (SetDeletePointerToOldestBlock())
+            if (!SetDeletePointerToOldestBlock())
             {
-                _hasLoadedDeletePointer = true;
+                return false;
             }
         }
         else
         {
-            UpdateDeletePointer(Math.Max(val.AsRlpValueContext().DecodeLong(), _minDeletableBlockNumber));
-            _lastSavedDeletePointer = _deletePointer;
-            _hasLoadedDeletePointer = true;
+            UpdateBlocksDeletePointer(long.Max(blocksVal.AsRlpValueContext().DecodeLong(), _minDeletableBlockNumber));
+            _lastSavedBlocksDeletePointer = _blocksDeletePointer;
         }
 
-        if (_logger.IsDebug) _logger.Debug($"Discovered oldest block stored #{_deletePointer}.");
-        return _hasLoadedDeletePointer;
+        byte[]? balsVal = _metadataDb.Get(MetadataDbKeys.BlockAccessListPruningDeletePointer);
+        // Until BAL pruning runs once, the BAL pointer trails the blocks pointer because BALs are
+        // deleted alongside blocks in PruneBlocksAndReceipts. Default to the blocks pointer on first load.
+        _balsDeletePointer = balsVal is null
+            ? _blocksDeletePointer
+            : long.Max(balsVal.AsRlpValueContext().DecodeLong(), _blocksDeletePointer);
+        _lastSavedBalsDeletePointer = balsVal is null ? long.MinValue : _balsDeletePointer;
+        Metrics.OldestStoredBlockAccessListBlockNumber = _balsDeletePointer;
+
+        _hasLoadedDeletePointers = true;
+        if (_logger.IsDebug) _logger.Debug($"Discovered oldest block stored #{_blocksDeletePointer}, oldest BAL stored #{_balsDeletePointer}.");
+        return true;
     }
 
-    private void SaveDeletePointer()
+    private void SaveDeletePointers()
     {
-        if (!_hasLoadedDeletePointer || _deletePointer == _lastSavedDeletePointer)
+        if (!_hasLoadedDeletePointers)
         {
             return;
         }
 
-        _metadataDb.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(_deletePointer).Bytes);
-        _lastSavedDeletePointer = _deletePointer;
-        if (_logger.IsDebug) _logger.Debug($"Persisting oldest block known = #{_deletePointer} to disk.");
+        if (_blocksDeletePointer != _lastSavedBlocksDeletePointer)
+        {
+            _metadataDb.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(_blocksDeletePointer).Bytes);
+            _lastSavedBlocksDeletePointer = _blocksDeletePointer;
+            if (_logger.IsDebug) _logger.Debug($"Persisting oldest block stored = #{_blocksDeletePointer} to disk.");
+        }
+
+        if (_balsDeletePointer != _lastSavedBalsDeletePointer)
+        {
+            _metadataDb.Set(MetadataDbKeys.BlockAccessListPruningDeletePointer, Rlp.Encode(_balsDeletePointer).Bytes);
+            _lastSavedBalsDeletePointer = _balsDeletePointer;
+            if (_logger.IsDebug) _logger.Debug($"Persisting oldest BAL stored = #{_balsDeletePointer} to disk.");
+        }
     }
 
-    private void UpdateDeletePointer(long newDeletePointer, bool isFinalUpdate = true)
+    private void UpdateBlocksDeletePointer(long newDeletePointer, bool isFinalUpdate = true)
     {
-        _deletePointer = newDeletePointer;
-        Metrics.OldestStoredBlockNumber = _deletePointer;
-        _blockTree.NewOldestBlock(_deletePointer);
-        BlockHeader? oldest = _blockTree.FindBlock(_deletePointer)?.Header;
+        _blocksDeletePointer = newDeletePointer;
+        Metrics.OldestStoredBlockNumber = _blocksDeletePointer;
+        _blockTree.NewOldestBlock(_blocksDeletePointer);
+        BlockHeader? oldest = _blockTree.FindBlock(_blocksDeletePointer)?.Header;
         if (oldest is not null)
         {
-            _deletePointerHeader = oldest;
+            _oldestBlockHeader = oldest;
             NewOldestBlock?.Invoke(this, new OnNewOldestBlockArgs(oldest, isFinalUpdate));
         }
     }

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -13,7 +13,6 @@ using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.History/IHistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryConfig.cs
@@ -15,12 +15,12 @@ public interface IHistoryConfig : IConfig
 
     // For EIP-4444 should be 82125
     [ConfigItem(
-        Description = "The number of epochs to retain historical blocks and receipts when using 'Rolling' pruning mode. For mainnet this must be at least 82125. The cutoff assumes 32 blocks per epoch.",
+        Description = "The number of epochs to retain historical blocks and receipts when using 'Rolling' pruning mode. For mainnet this must be at least 82125.",
         DefaultValue = "82125")]
     uint RetentionEpochs { get; set; }
 
     [ConfigItem(
-        Description = "The number of epochs to retain block access lists (BALs). The cutoff assumes 32 blocks per epoch and is applied independently of the block/receipt retention.",
+        Description = "The number of epochs to retain block access lists (BALs).",
         DefaultValue = "3533",
         HiddenFromDocs = true)]
     uint BalRetentionEpochs { get; set; }

--- a/src/Nethermind/Nethermind.History/IHistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryConfig.cs
@@ -15,9 +15,15 @@ public interface IHistoryConfig : IConfig
 
     // For EIP-4444 should be 82125
     [ConfigItem(
-        Description = "The number of epochs to retain historical blocks and receipts when using 'Rolling' pruning mode. For mainnet this must be at least 82125.",
+        Description = "The number of epochs to retain historical blocks and receipts when using 'Rolling' pruning mode. For mainnet this must be at least 82125. The cutoff assumes 32 blocks per epoch.",
         DefaultValue = "82125")]
     uint RetentionEpochs { get; set; }
+
+    [ConfigItem(
+        Description = "The number of epochs to retain block access lists (BALs). The cutoff assumes 32 blocks per epoch and is applied independently of the block/receipt retention.",
+        DefaultValue = "3533",
+        HiddenFromDocs = true)]
+    uint BalRetentionEpochs { get; set; }
 
     // Set to 0 to prune every slot
     [ConfigItem(

--- a/src/Nethermind/Nethermind.History/IHistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryConfig.cs
@@ -19,6 +19,7 @@ public interface IHistoryConfig : IConfig
         DefaultValue = "82125")]
     uint RetentionEpochs { get; set; }
 
+    // Default matches the mainnet weak-subjectivity period — BALs older than that are not useful for state reconstruction during weak-subjectivity sync
     [ConfigItem(
         Description = "The number of epochs to retain block access lists (BALs).",
         DefaultValue = "3533",

--- a/src/Nethermind/Nethermind.History/IHistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryPruner.cs
@@ -10,6 +10,7 @@ namespace Nethermind.History;
 public interface IHistoryPruner
 {
     public long? CutoffBlockNumber { get; }
+    public long? BalCutoffBlockNumber { get; }
     public BlockHeader? OldestBlockHeader { get; }
 
     event EventHandler<OnNewOldestBlockArgs> NewOldestBlock;

--- a/src/Nethermind/Nethermind.History/Metrics.cs
+++ b/src/Nethermind/Nethermind.History/Metrics.cs
@@ -12,15 +12,23 @@ public static class Metrics
     [Description("The number of the oldest block stored.")]
     public static long OldestStoredBlockNumber { get; set; }
 
+    [GaugeMetric]
+    [Description("The number of the oldest block access list stored.")]
+    public static long OldestStoredBlockAccessListBlockNumber { get; set; }
+
     [CounterMetric]
     [Description("The number of the historical blocks that have been pruned (since restart).")]
     public static long BlocksPruned { get; set; }
 
-    [GaugeMetric]
-    [Description("The cutoff timestamp from which historical blocks will be pruned.")]
-    public static ulong? PruningCutoffTimestamp { get; set; }
+    [CounterMetric]
+    [Description("The number of the historical block access lists that have been pruned (since restart).")]
+    public static long BlockAccessListsPruned { get; set; }
 
     [GaugeMetric]
     [Description("The cutoff block number from which historical blocks will be pruned.")]
     public static long? PruningCutoffBlocknumber { get; set; }
+
+    [GaugeMetric]
+    [Description("The cutoff block number from which historical block access lists will be pruned.")]
+    public static long? BlockAccessListPruningCutoffBlocknumber { get; set; }
 }

--- a/src/Nethermind/Nethermind.History/Metrics.cs
+++ b/src/Nethermind/Nethermind.History/Metrics.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 20225Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.ComponentModel;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -20,6 +20,7 @@ namespace Nethermind.Specs.Test
         public long MaxCodeSize { get; set; } = spec.MaxCodeSize;
         public long MinGasLimit { get; set; } = spec.MinGasLimit;
         public long MinHistoryRetentionEpochs { get; set; } = spec.MinHistoryRetentionEpochs;
+        public long MinBalRetentionEpochs { get; set; } = spec.MinBalRetentionEpochs;
         public long GasLimitBoundDivisor { get; set; } = spec.GasLimitBoundDivisor;
         public UInt256 BlockReward { get; set; } = spec.BlockReward;
         public long DifficultyBombDelay { get; set; } = spec.DifficultyBombDelay;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -19,6 +19,7 @@ public class ChainParameters
     public long MaximumExtraDataSize { get; set; }
     public long MinGasLimit { get; set; }
     public long MinHistoryRetentionEpochs { get; set; }
+    public long MinBalRetentionEpochs { get; set; }
     public Hash256 ForkCanonHash { get; set; }
     public long? ForkBlock { get; set; }
     public long? Eip7Transition { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -224,6 +224,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.MaximumExtraDataSize = chainSpec.Parameters.MaximumExtraDataSize;
             releaseSpec.MinGasLimit = chainSpec.Parameters.MinGasLimit;
             releaseSpec.MinHistoryRetentionEpochs = chainSpec.Parameters.MinHistoryRetentionEpochs;
+            releaseSpec.MinBalRetentionEpochs = chainSpec.Parameters.MinBalRetentionEpochs;
             releaseSpec.GasLimitBoundDivisor = chainSpec.Parameters.GasLimitBoundDivisor;
             releaseSpec.IsEip170Enabled = (chainSpec.Parameters.MaxCodeSizeTransition ?? long.MaxValue) <= releaseStartBlock ||
                                           (chainSpec.Parameters.MaxCodeSizeTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -100,6 +100,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             MaximumExtraDataSize = chainSpecJson.Params.MaximumExtraDataSize ?? 32,
             MinGasLimit = chainSpecJson.Params.MinGasLimit ?? 5000,
             MinHistoryRetentionEpochs = chainSpecJson.Params.MinHistoryRetentionEpochs ?? 82125,
+            MinBalRetentionEpochs = chainSpecJson.Params.MinBalRetentionEpochs ?? 3533,
             MaxCodeSize = chainSpecJson.Params.MaxCodeSize,
             MaxCodeSizeTransition = chainSpecJson.Params.MaxCodeSizeTransition,
             MaxCodeSizeTransitionTimestamp = chainSpecJson.Params.MaxCodeSizeTransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
@@ -101,6 +101,7 @@ public class GethGenesisLoader(IJsonSerializer serializer) : IChainSpecLoader
             MaximumExtraDataSize = 32,
             MinGasLimit = 5000,
             MinHistoryRetentionEpochs = 82125,
+            MinBalRetentionEpochs = 3533,
 
             Eip7Transition = config.HomesteadBlock ?? 0,
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -30,6 +30,8 @@ public class ChainSpecParamsJson : IHasNamedForks
 
     public long? MinHistoryRetentionEpochs { get; set; }
 
+    public long? MinBalRetentionEpochs { get; set; }
+
     public long? ForkBlock { get; set; }
 
     public Hash256 ForkCanonHash { get; set; }

--- a/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
@@ -23,6 +23,7 @@ public class Olympic() : NamedReleaseSpec<Olympic>(null)
         spec.ValidateChainId = true;
         spec.ValidateReceipts = true;
         spec.MinHistoryRetentionEpochs = 82125;
+        spec.MinBalRetentionEpochs = 3533;
 
         // The below addresses are added for all forks, but the given EIPs can be enabled at a specific timestamp or block.
         spec.Eip7251ContractAddress = Eip7251Constants.ConsolidationRequestPredeployAddress;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -19,6 +19,7 @@ public class ReleaseSpec : IReleaseSpec
     public long MaxCodeSize { get; set; }
     public long MinGasLimit { get; set; }
     public long MinHistoryRetentionEpochs { get; set; }
+    public long MinBalRetentionEpochs { get; set; }
     public long GasLimitBoundDivisor { get; set; }
     public UInt256 BlockReward { get; set; }
     public long DifficultyBombDelay { get; set; }


### PR DESCRIPTION
## Changes

- Give BALs their own cutoff for pruning
- Simplify history pruning cutoff, calculate with block number instead of timestamp

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

History pruning should be tested before release.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No