### PR TITLE
fix: use enabled parameter in EthStatsPluginTests

### DIFF
--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -18,7 +18,7 @@ private INethermindPlugin _plugin = null!;
     [SetUp]
     public void Setup() => _context = Build.ContextWithMocks();
 
-public void Init_eth_stats_plugin_does_not_throw_exception([Values] bool enabled)
+    public void Init_eth_stats_plugin_does_not_throw_exception([Values] bool enabled)
     {
         _plugin = new EthStatsPlugin(new EthStatsConfig() { Enabled = enabled });
 

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -18,9 +18,7 @@ private INethermindPlugin _plugin = null!;
     [SetUp]
     public void Setup() => _context = Build.ContextWithMocks();
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public void Init_eth_stats_plugin_does_not_throw_exception(bool enabled)
+public void Init_eth_stats_plugin_does_not_throw_exception([Values] bool enabled)
     {
         _plugin = new EthStatsPlugin(new EthStatsConfig() { Enabled = enabled });
 

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.EthStats.Configs;
@@ -13,7 +12,7 @@ namespace Nethermind.EthStats.Test;
 public class EthStatsPluginTests
 {
     private NethermindApi _context = null!;
-private INethermindPlugin _plugin = null!;
+    private INethermindPlugin _plugin = null!;
 
     [SetUp]
     public void Setup() => _context = Build.ContextWithMocks();

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.EthStats.Configs;
@@ -12,21 +13,17 @@ namespace Nethermind.EthStats.Test;
 public class EthStatsPluginTests
 {
     private NethermindApi _context = null!;
-#pragma warning disable NUnit1032
-    private INethermindPlugin _plugin = null!;
-#pragma warning restore NUnit1032
+private INethermindPlugin _plugin = null!;
 
     [SetUp]
-    public void Setup()
-    {
-        _context = Build.ContextWithMocks();
-        _plugin = new EthStatsPlugin(new EthStatsConfig() { Enabled = true });
-    }
+    public void Setup() => _context = Build.ContextWithMocks();
 
     [TestCase(true)]
     [TestCase(false)]
     public void Init_eth_stats_plugin_does_not_throw_exception(bool enabled)
     {
+        _plugin = new EthStatsPlugin(new EthStatsConfig() { Enabled = enabled });
+
         Assert.DoesNotThrow(() => _plugin.InitTxTypesAndRlpDecoders(_context));
         Assert.DoesNotThrowAsync(async () => await _plugin.Init(_context));
         Assert.DoesNotThrowAsync(async () => await _plugin.InitNetworkProtocol());


### PR DESCRIPTION
Problem
The enabled parameter in Init_eth_stats_plugin_does_not_throw_exception was never used. The plugin was always initialized with Enabled = true in [SetUp], so [TestCase(false)] never actually tested the disabled state.

Fix
Removed plugin initialization from [SetUp]
Plugin is now created inside the test with the `enabled` parameter
Both [TestCase(true)] and [TestCase(false)] now test real scenarios