### PR TITLE
XDC thread-safe round advancement

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
@@ -167,6 +167,39 @@ public class TimeoutCertificateManagerTests
         Assert.That(tcManager.VerifyTimeoutCertificate(timeoutCertificate, out _), Is.EqualTo(expected));
     }
 
+    [Test]
+    public async Task HandleTimeoutVote_ThresholdReachedMultipleTimes_BuildsTcOnlyOnce()
+    {
+        PrivateKeyGenerator keyBuilder = new();
+        PrivateKey[] keys = keyBuilder.Generate(3).ToArray();
+        Address[] masternodes = keys.Select(k => k.Address).ToArray();
+
+        IEpochSwitchManager epochSwitchManager = Substitute.For<IEpochSwitchManager>();
+        EpochSwitchInfo epochSwitchInfo = new(masternodes, [], [], new BlockRoundInfo(Hash256.Zero, 1, 0));
+        epochSwitchManager.GetEpochSwitchInfo(Arg.Any<XdcBlockHeader>()).Returns(epochSwitchInfo);
+
+        IXdcReleaseSpec xdcSpec = Substitute.For<IXdcReleaseSpec>();
+        xdcSpec.CertificateThreshold.Returns(0.667);
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(xdcSpec);
+
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        XdcBlockHeader header = Build.A.XdcBlockHeader().TestObject;
+        blockTree.Head.Returns(new Block(header, new BlockBody()));
+
+        XdcConsensusContext ctx = new() { CurrentRound = 1 };
+        TimeoutCertificateManager tcManager = new(ctx, Substitute.For<ITimeoutTimer>(),
+            Substitute.For<ISyncPeerPool>(), Substitute.For<ISnapshotManager>(),
+            epochSwitchManager, specProvider, blockTree, Substitute.For<ISigner>());
+
+        Timeout[] timeouts = keys.Select(k => XdcTestHelper.BuildSignedTimeout(k, 1, 0)).ToArray();
+
+        await Task.WhenAll(timeouts.Select(t => tcManager.HandleTimeoutVote(t)));
+
+        // ProcessTimeoutCertificate calls SetNewRound(2) — must happen exactly once
+        Assert.That(ctx.CurrentRound, Is.EqualTo(2));
+    }
+
     [TestCase(4UL)]
     [TestCase(6UL)]
     public async Task HandleTimeoutVote_RoundDoesNotMatchCurrentRound_ShouldReturnEarly(ulong round)

--- a/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
@@ -167,39 +167,6 @@ public class TimeoutCertificateManagerTests
         Assert.That(tcManager.VerifyTimeoutCertificate(timeoutCertificate, out _), Is.EqualTo(expected));
     }
 
-    [Test]
-    public async Task HandleTimeoutVote_ThresholdReachedMultipleTimes_BuildsTcOnlyOnce()
-    {
-        PrivateKeyGenerator keyBuilder = new();
-        PrivateKey[] keys = keyBuilder.Generate(3).ToArray();
-        Address[] masternodes = keys.Select(k => k.Address).ToArray();
-
-        IEpochSwitchManager epochSwitchManager = Substitute.For<IEpochSwitchManager>();
-        EpochSwitchInfo epochSwitchInfo = new(masternodes, [], [], new BlockRoundInfo(Hash256.Zero, 1, 0));
-        epochSwitchManager.GetEpochSwitchInfo(Arg.Any<XdcBlockHeader>()).Returns(epochSwitchInfo);
-
-        IXdcReleaseSpec xdcSpec = Substitute.For<IXdcReleaseSpec>();
-        xdcSpec.CertificateThreshold.Returns(0.667);
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(xdcSpec);
-
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        XdcBlockHeader header = Build.A.XdcBlockHeader().TestObject;
-        blockTree.Head.Returns(new Block(header, new BlockBody()));
-
-        XdcConsensusContext ctx = new() { CurrentRound = 1 };
-        TimeoutCertificateManager tcManager = new(ctx, Substitute.For<ITimeoutTimer>(),
-            Substitute.For<ISyncPeerPool>(), Substitute.For<ISnapshotManager>(),
-            epochSwitchManager, specProvider, blockTree, Substitute.For<ISigner>());
-
-        Timeout[] timeouts = keys.Select(k => XdcTestHelper.BuildSignedTimeout(k, 1, 0)).ToArray();
-
-        await Task.WhenAll(timeouts.Select(t => tcManager.HandleTimeoutVote(t)));
-
-        // ProcessTimeoutCertificate calls SetNewRound(2) — must happen exactly once
-        Assert.That(ctx.CurrentRound, Is.EqualTo(2));
-    }
-
     [TestCase(4UL)]
     [TestCase(6UL)]
     public async Task HandleTimeoutVote_RoundDoesNotMatchCurrentRound_ShouldReturnEarly(ulong round)

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcConsensusContextTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcConsensusContextTests.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Xdc.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class XdcConsensusContextTests
+{
+    [TestCase(3UL)] // less than current
+    [TestCase(5UL)] // equal to current
+    public void SetNewRound_RoundNotHigherThanCurrent_IsIgnored(ulong round)
+    {
+        XdcConsensusContext ctx = new() { CurrentRound = 5 };
+        ctx.SetNewRound(round);
+        Assert.That(ctx.CurrentRound, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void SetNewRound_HigherRound_AdvancesRoundAndFiresEvent()
+    {
+        XdcConsensusContext ctx = new() { CurrentRound = 1, TimeoutCounter = 3 };
+        NewRoundEventArgs? receivedArgs = null;
+        ctx.NewRoundSetEvent += (_, args) => receivedArgs = args;
+
+        ctx.SetNewRound(5);
+
+        Assert.That(ctx.CurrentRound, Is.EqualTo(5));
+        Assert.That(ctx.TimeoutCounter, Is.EqualTo(0));
+        Assert.That(receivedArgs, Is.Not.Null);
+        Assert.That(receivedArgs!.NewRound, Is.EqualTo(5));
+        Assert.That(receivedArgs.PreviousRound, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void SetNewRound_SameRoundCalledConcurrently_AdvancesExactlyOnce()
+    {
+        XdcConsensusContext ctx = new() { CurrentRound = 0 };
+        int eventCount = 0;
+        ctx.NewRoundSetEvent += (_, _) => Interlocked.Increment(ref eventCount);
+
+        Parallel.For(0, 10, _ => ctx.SetNewRound(1));
+
+        Assert.That(ctx.CurrentRound, Is.EqualTo(1));
+        Assert.That(eventCount, Is.EqualTo(1));
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -107,8 +107,6 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         TimeoutCertificate timeoutCertificate = new(timeout.Round, signatures, timeout.GapNumber);
 
         ProcessTimeoutCertificate(timeoutCertificate);
-
-        CleanupTimeouts(timeoutCertificate.Round);
     }
 
     public void ProcessTimeoutCertificate(TimeoutCertificate timeoutCertificate)
@@ -122,6 +120,8 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         {
             _consensusContext.SetNewRound(timeoutCertificate.Round + 1);
         }
+
+        CleanupTimeouts(timeoutCertificate.Round);
     }
 
     private void CleanupTimeouts(ulong round)

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -15,6 +15,7 @@ using Nethermind.Xdc.RLP;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -35,6 +36,7 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
     private readonly IBlockTree _blockTree;
     private readonly ISigner _signer;
     private readonly XdcPool<Timeout> _timeouts = new();
+    private readonly ConcurrentDictionary<ulong, byte> _tcBuildStartedByRound = new();
 
     public TimeoutCertificateManager(
         IXdcConsensusContext context,
@@ -80,7 +82,8 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeout.Round);
         double CertificateThreshold = spec.CertificateThreshold;
-        if (collectedTimeouts.Count >= epochSwitchInfo.Masternodes.Length * CertificateThreshold)
+        if (collectedTimeouts.Count >= epochSwitchInfo.Masternodes.Length * CertificateThreshold
+            && _tcBuildStartedByRound.TryAdd(timeout.Round, 0))
         {
             OnTimeoutPoolThresholdReached(collectedTimeouts, timeout);
         }
@@ -103,6 +106,8 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         TimeoutCertificate timeoutCertificate = new(timeout.Round, signatures, timeout.GapNumber);
 
         ProcessTimeoutCertificate(timeoutCertificate);
+
+        CleanupTimeouts(timeoutCertificate.Round);
     }
 
     public void ProcessTimeoutCertificate(TimeoutCertificate timeoutCertificate)
@@ -114,9 +119,16 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
         if (timeoutCertificate.Round >= _consensusContext.CurrentRound)
         {
-            _timeouts.EndRound(timeoutCertificate.Round);
             _consensusContext.SetNewRound(timeoutCertificate.Round + 1);
         }
+    }
+
+    private void CleanupTimeouts(ulong round)
+    {
+        _timeouts.EndRound(round);
+
+        foreach (KeyValuePair<ulong, byte> kvp in _tcBuildStartedByRound)
+            if (kvp.Key <= round) _tcBuildStartedByRound.TryRemove(kvp.Key, out _);
     }
 
     public bool VerifyTimeoutCertificate(TimeoutCertificate timeoutCertificate, [NotNullWhen(false)] out string? errorMessage)

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -81,12 +81,13 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         BroadcastTimeout(timeout);
 
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeout.Round);
-        double CertificateThreshold = spec.CertificateThreshold;
-        if (collectedTimeouts.Count >= epochSwitchInfo.Masternodes.Length * CertificateThreshold
-            && _tcBuildStartedByRound.TryAdd(timeout.Round, 0))
-        {
-            OnTimeoutPoolThresholdReached(collectedTimeouts, timeout);
-        }
+        if (collectedTimeouts.Count < epochSwitchInfo.Masternodes.Length * spec.CertificateThreshold)
+            return Task.CompletedTask;
+
+        if (!_tcBuildStartedByRound.TryAdd(timeout.Round, 0))
+            return Task.CompletedTask;
+
+        OnTimeoutPoolThresholdReached(collectedTimeouts, timeout);
         return Task.CompletedTask;
     }
 

--- a/src/Nethermind/Nethermind.Xdc/XdcConsensusContext.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConsensusContext.cs
@@ -44,8 +44,6 @@ public class XdcConsensusContext : IXdcConsensusContext
             RoundStarted = DateTime.UtcNow;
             eventArgs = new NewRoundEventArgs(round, last, previousTimeoutCounter, RoundStarted - lastRoundStarted);
         }
-        // Invoked outside the lock so subscribers receive the specific round that this call advanced to,
-        // rather than a potentially newer round already set by a concurrent caller.
         NewRoundSetEvent?.Invoke(this, eventArgs);
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcConsensusContext.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConsensusContext.cs
@@ -4,13 +4,13 @@
 using Nethermind.Core.Crypto;
 using Nethermind.Xdc.Types;
 using System;
-using System.Threading;
 
 namespace Nethermind.Xdc;
 
 public class XdcConsensusContext : IXdcConsensusContext
 {
     private ulong _currentRound;
+    private readonly object _gate = new();
 
     public XdcConsensusContext()
     {
@@ -26,19 +26,26 @@ public class XdcConsensusContext : IXdcConsensusContext
     public TimeoutCertificate HighestTC { get; set; }
     public BlockRoundInfo HighestCommitBlock { get; set; }
 
-    public event EventHandler<NewRoundEventArgs> NewRoundSetEvent;
+    public event EventHandler<NewRoundEventArgs>? NewRoundSetEvent;
 
-    public void SetNewRound() => SetNewRound(Interlocked.Increment(ref _currentRound));
+    public void SetNewRound() => SetNewRound(CurrentRound + 1);
     public void SetNewRound(ulong round)
     {
-        int previousTimeoutCounter = TimeoutCounter;
-        ulong last = CurrentRound;
-        CurrentRound = round;
-        TimeoutCounter = 0;
-        DateTime? lastRoundStarted = RoundStarted;
-        RoundStarted = DateTime.UtcNow;
+        NewRoundEventArgs? eventArgs = null;
+        lock (_gate)
+        {
+            if (round <= CurrentRound) return;
 
-        // timer should be reset outside
-        NewRoundSetEvent?.Invoke(this, new NewRoundEventArgs(round, last, previousTimeoutCounter, RoundStarted - lastRoundStarted));
+            int previousTimeoutCounter = TimeoutCounter;
+            ulong last = CurrentRound;
+            CurrentRound = round;
+            TimeoutCounter = 0;
+            DateTime? lastRoundStarted = RoundStarted;
+            RoundStarted = DateTime.UtcNow;
+            eventArgs = new NewRoundEventArgs(round, last, previousTimeoutCounter, RoundStarted - lastRoundStarted);
+        }
+        // Invoked outside the lock so subscribers receive the specific round that this call advanced to,
+        // rather than a potentially newer round already set by a concurrent caller.
+        NewRoundSetEvent?.Invoke(this, eventArgs);
     }
 }


### PR DESCRIPTION
 ## Changes
  
  - `XdcConsensusContext.SetNewRound`: lock-protect state update; drop stale rounds
  - `TimeoutCertificateManager`: guard TC build with `ConcurrentDictionary.TryAdd` to prevent duplicate builds; align style with `VotesManager`

  ## Types of changes
  
  - [x] Bugfix
  - [x] Refactoring

  ## Testing

  #### Requires testing
  - [x] Yes

  #### If yes, did you write tests?
  - [x] Yes
