### PR TITLE
Test EIP-8037 code-deposit halt state gas unwind

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -472,6 +472,49 @@ public class Eip8037Tests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Code_deposit_halt_removes_merged_child_state_usage_without_refunding_reservoir_twice()
+    {
+        long parentStateGasUsed = GasCostOf.CreateState;
+        long childStateGasUsed = GasCostOf.NewAccountState + GasCostOf.SSetState;
+        long childRemainingStateReservoir = 123;
+        EthereumGasPolicy parent = new()
+        {
+            Value = 1_000,
+            StateReservoir = parentStateGasUsed + childStateGasUsed + childRemainingStateReservoir,
+            StateGasSpill = 77,
+            StateGasSpillRefunded = 33,
+            StateGasSpillBurned = 22,
+            StateGasSpillReclassified = 11,
+        };
+
+        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref parent, parentStateGasUsed), Is.True);
+        EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 500);
+        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, childStateGasUsed), Is.True);
+        EthereumGasPolicy.Refund(ref parent, in child);
+
+        EthereumGasPolicy.RevertRefundToHalt(ref parent, in child);
+
+        Assert.That(
+            (
+                parent.StateReservoir,
+                parent.StateGasUsed,
+                parent.StateGasSpill,
+                parent.StateGasSpillRefunded,
+                parent.StateGasSpillBurned,
+                parent.StateGasSpillReclassified
+            ),
+            Is.EqualTo(
+                (
+                    childRemainingStateReservoir + childStateGasUsed,
+                    parentStateGasUsed,
+                    77L,
+                    33L,
+                    22L,
+                    11L
+                )));
+    }
+
+    [Test]
     public void ResetForHalt_snaps_state_gas_to_tx_start_shape()
     {
         // Architectural invariant: ResetForHalt resets the policy struct to its tx-start

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -474,12 +474,14 @@ public class Eip8037Tests : VirtualMachineTestsBase
     [Test]
     public void Code_deposit_halt_removes_merged_child_state_usage_without_refunding_reservoir_twice()
     {
+        long parentRegularGas = 1_000;
+        long childRegularGas = 500;
         long parentStateGasUsed = GasCostOf.CreateState;
         long childStateGasUsed = GasCostOf.NewAccountState + GasCostOf.SSetState;
         long childRemainingStateReservoir = 123;
         EthereumGasPolicy parent = new()
         {
-            Value = 1_000,
+            Value = parentRegularGas,
             StateReservoir = parentStateGasUsed + childStateGasUsed + childRemainingStateReservoir,
             StateGasSpill = 77,
             StateGasSpillRefunded = 33,
@@ -488,7 +490,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         };
 
         Assert.That(EthereumGasPolicy.ConsumeStateGas(ref parent, parentStateGasUsed), Is.True);
-        EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 500);
+        EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, childRegularGas);
         Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, childStateGasUsed), Is.True);
         EthereumGasPolicy.Refund(ref parent, in child);
 
@@ -496,6 +498,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
 
         Assert.That(
             (
+                parent.Value,
                 parent.StateReservoir,
                 parent.StateGasUsed,
                 parent.StateGasSpill,
@@ -505,6 +508,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
             ),
             Is.EqualTo(
                 (
+                    parentRegularGas + childRegularGas,
                     childRemainingStateReservoir + childStateGasUsed,
                     parentStateGasUsed,
                     77L,


### PR DESCRIPTION
## Changes

- Add targeted regression coverage for `EthereumGasPolicy.RevertRefundToHalt`, the helper used by CREATE code-deposit failure handling after the child frame has already been merged back into the parent.
- Cover the previously untested non-zero child `StateGasUsed` case. The existing direct test exercises the fully refunded child path (`StateGasUsed == 0`), but it does not prove that merged child state usage is removed from parent block-state accounting on halt.
- Assert the behavior that would regress consensus gas accounting: reverted child state usage must move back to the parent reservoir, the parent `StateGasUsed` must retain only its own CREATE state charge, and spill accounting fields must not be mutated by the halt unwind.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test coverage

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `git diff --check`
- `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes --include src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs`
- `dotnet restore src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj`
- Local `dotnet build` / targeted `dotnet test` attempts did not complete in this sandbox before the test runner stage; rerun `dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release --filter FullyQualifiedName~Code_deposit_halt_removes_merged_child_state_usage_without_refunding_reservoir_twice` in CI or a full local build environment.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No