### PR TITLE
Optimize guards

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
@@ -20,11 +20,9 @@ public class SlicedReadOnlyList<T> : IReadOnlyList<T>
     public SlicedReadOnlyList(IReadOnlyList<T> list, int start, int count)
     {
         ArgumentNullException.ThrowIfNull(list);
-        // Unsigned compares fold the implicit `< 0` check into the upper bound. The
-        // `count` check avoids overflow on `start + count` by reading the remaining
-        // capacity (which is non-negative once `start` is in range) instead.
         if ((uint)start > (uint)list.Count)
             throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of range.");
+        // Compare against remaining capacity to avoid start + count overflow.
         if ((uint)count > (uint)(list.Count - start))
             throw new ArgumentOutOfRangeException(nameof(count), "Count is out of range.");
 

--- a/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
@@ -20,10 +20,11 @@ public class SlicedReadOnlyList<T> : IReadOnlyList<T>
     public SlicedReadOnlyList(IReadOnlyList<T> list, int start, int count)
     {
         ArgumentNullException.ThrowIfNull(list);
-        if ((uint)start > (uint)list.Count)
+        int listCount = list.Count;
+        if ((uint)start > (uint)listCount)
             throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of range.");
         // Compare against remaining capacity to avoid start + count overflow.
-        if ((uint)count > (uint)(list.Count - start))
+        if ((uint)count > (uint)(listCount - start))
             throw new ArgumentOutOfRangeException(nameof(count), "Count is out of range.");
 
         _list = list;
@@ -64,9 +65,10 @@ public static class ReadOnlyListExtensions
     public static IReadOnlyList<T> Slice<T>(this IReadOnlyList<T> list, int start)
     {
         ArgumentNullException.ThrowIfNull(list);
-        if ((uint)start > (uint)list.Count)
+        int listCount = list.Count;
+        if ((uint)start > (uint)listCount)
             throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of range.");
 
-        return new SlicedReadOnlyList<T>(list, start, list.Count - start);
+        return new SlicedReadOnlyList<T>(list, start, listCount - start);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SlicedReadOnlyList.cs
@@ -20,9 +20,12 @@ public class SlicedReadOnlyList<T> : IReadOnlyList<T>
     public SlicedReadOnlyList(IReadOnlyList<T> list, int start, int count)
     {
         ArgumentNullException.ThrowIfNull(list);
-        if (start < 0 || start > list.Count)
+        // Unsigned compares fold the implicit `< 0` check into the upper bound. The
+        // `count` check avoids overflow on `start + count` by reading the remaining
+        // capacity (which is non-negative once `start` is in range) instead.
+        if ((uint)start > (uint)list.Count)
             throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of range.");
-        if (count < 0 || start + count > list.Count)
+        if ((uint)count > (uint)(list.Count - start))
             throw new ArgumentOutOfRangeException(nameof(count), "Count is out of range.");
 
         _list = list;
@@ -34,7 +37,7 @@ public class SlicedReadOnlyList<T> : IReadOnlyList<T>
     {
         get
         {
-            if (index < 0 || index >= _count)
+            if ((uint)index >= (uint)_count)
                 throw new ArgumentOutOfRangeException(nameof(index));
             return _list[_start + index];
         }
@@ -63,7 +66,7 @@ public static class ReadOnlyListExtensions
     public static IReadOnlyList<T> Slice<T>(this IReadOnlyList<T> list, int start)
     {
         ArgumentNullException.ThrowIfNull(list);
-        if (start < 0 || start > list.Count)
+        if ((uint)start > (uint)list.Count)
             throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of range.");
 
         return new SlicedReadOnlyList<T>(list, start, list.Count - start);

--- a/src/Nethermind/Nethermind.Era1/AccumulatorCalculator.cs
+++ b/src/Nethermind/Nethermind.Era1/AccumulatorCalculator.cs
@@ -39,7 +39,7 @@ public class AccumulatorCalculator : IDisposable
 
     public ValueHash256[] GetProof(int blockIndex)
     {
-        if (blockIndex < 0 || blockIndex >= _roots.Count)
+        if ((uint)blockIndex >= (uint)_roots.Count)
             throw new ArgumentOutOfRangeException(nameof(blockIndex), $"Block index {blockIndex} is out of range [0, {_roots.Count - 1}].");
 
         int count = _roots.Count;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -113,9 +113,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
                 TxReceipt[] receipts = SyncServer.GetReceipts(blockHash);
                 long requestedStartIndex = blockIndex == 0 ? getReceiptsMessage.FirstBlockReceiptIndex : 0;
-                // Promote both sides to ulong so the unsigned compare also catches a negative
-                // `requestedStartIndex` arriving from an adversarial peer without truncating
-                // the long to a uint first (which would silently drop the high bits).
+                // ulong (not uint) so an adversarial negative long isn't truncated.
                 if ((ulong)requestedStartIndex > (uint)receipts.Length)
                 {
                     throw new SubprotocolException($"Invalid firstBlockReceiptIndex {requestedStartIndex} for block receipts length {receipts.Length}");

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -114,7 +114,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 TxReceipt[] receipts = SyncServer.GetReceipts(blockHash);
                 long requestedStartIndex = blockIndex == 0 ? getReceiptsMessage.FirstBlockReceiptIndex : 0;
                 // ulong (not uint) so an adversarial negative long isn't truncated.
-                if ((ulong)requestedStartIndex > (uint)receipts.Length)
+                if ((ulong)requestedStartIndex > (ulong)(uint)receipts.Length)
                 {
                     throw new SubprotocolException($"Invalid firstBlockReceiptIndex {requestedStartIndex} for block receipts length {receipts.Length}");
                 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -113,7 +113,10 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
                 TxReceipt[] receipts = SyncServer.GetReceipts(blockHash);
                 long requestedStartIndex = blockIndex == 0 ? getReceiptsMessage.FirstBlockReceiptIndex : 0;
-                if (requestedStartIndex < 0 || requestedStartIndex > receipts.Length)
+                // Promote both sides to ulong so the unsigned compare also catches a negative
+                // `requestedStartIndex` arriving from an adversarial peer without truncating
+                // the long to a uint first (which would silently drop the high bits).
+                if ((ulong)requestedStartIndex > (uint)receipts.Length)
                 {
                     throw new SubprotocolException($"Invalid firstBlockReceiptIndex {requestedStartIndex} for block receipts length {receipts.Length}");
                 }

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
@@ -210,9 +210,6 @@ public class OptimismEthRpcModule(
         }
 
         Block block = searchResult.Object;
-        // positionIndex is UInt256 so `< 0` is dead; the previous `> Length - 1` shape also
-        // underflowed to -1 on empty transaction lists, accidentally rejecting via signed
-        // wrap. Match the base class form which compares directly against Length.
         if (positionIndex >= block!.Transactions.Length)
         {
             return ResultWrapper<TransactionForRpc?>.Success(null);

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
@@ -210,7 +210,10 @@ public class OptimismEthRpcModule(
         }
 
         Block block = searchResult.Object;
-        if (positionIndex < 0 || positionIndex > block!.Transactions.Length - 1)
+        // positionIndex is UInt256 so `< 0` is dead; the previous `> Length - 1` shape also
+        // underflowed to -1 on empty transaction lists, accidentally rejecting via signed
+        // wrap. Match the base class form which compares directly against Length.
+        if (positionIndex >= block!.Transactions.Length)
         {
             return ResultWrapper<TransactionForRpc?>.Success(null);
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -707,21 +707,31 @@ namespace Nethermind.Serialization.Rlp
                 return data;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly void Check(int nextCheck)
             {
                 if (Position != nextCheck)
                 {
-                    throw new RlpException($"Data checkpoint failed. Expected {nextCheck} and is {Position}");
+                    ThrowCheckpointFailed(nextCheck, Position);
                 }
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly void CheckEnd()
             {
                 if (Position != Length)
                 {
-                    throw new RlpException($"Data checkpoint failed. Expected to reach the end of the sequence, but is at {Position}");
+                    ThrowCheckEndFailed(Position);
                 }
             }
+
+            [DoesNotReturn, StackTraceHidden]
+            private static void ThrowCheckpointFailed(int expected, int position) =>
+                throw new RlpException($"Data checkpoint failed. Expected {expected} and is {position}");
+
+            [DoesNotReturn, StackTraceHidden]
+            private static void ThrowCheckEndFailed(int position) =>
+                throw new RlpException($"Data checkpoint failed. Expected to reach the end of the sequence, but is at {position}");
 
             // This class was introduce to reduce allocations when deserializing receipts. In order to deserialize receipts we first try to deserialize it in new format and then in old format.
             // If someone didn't do migration this will result in excessive allocations and GC of the not needed strings.
@@ -1535,11 +1545,13 @@ namespace Nethermind.Serialization.Rlp
                 => throw new DecodeKeccakRlpException(prefix, Position, Data.Length);
 
             [StackTraceHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly void GuardLimit(int count, RlpLimit? limit = null) =>
                 Rlp.GuardLimit(count, Length - Position, limit);
 
             // ReSharper disable once MemberHidesStaticFromOuterClass
             [StackTraceHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void GuardSize(int actual, int expected) =>
                 Rlp.GuardSize(actual, expected);
         }
@@ -1804,18 +1816,26 @@ namespace Nethermind.Serialization.Rlp
         private static ILogger _logger = Static.LogManager.GetClassLogger<Rlp>();
 
         [StackTraceHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GuardLimit(int count, int bytesLeft, RlpLimit? limit = null)
         {
             RlpLimit l = limit ?? RlpLimit.DefaultLimit;
-            if (count < 0 || count > bytesLeft || count > l.Limit)
+            // Unsigned compares fold the `count < 0` guard into the upper-bound checks: a
+            // negative count reinterprets above int.MaxValue and so exceeds any non-negative
+            // bytesLeft or limit. bytesLeft is Length - Position and limit.Limit is positive
+            // (see RlpLimit defaults), so both bounds are safe to treat as unsigned.
+            if ((uint)count > (uint)bytesLeft || (uint)count > (uint)l.Limit)
             {
                 ThrowCountOverLimit((uint)count, bytesLeft, l);
             }
         }
 
         [StackTraceHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GuardSize(int actual, int expected)
         {
+            // Most callers pass the sentinel expected = -1 (no constraint), so checking the
+            // sentinel first short-circuits the common case in one branch.
             if (expected >= 0 && actual != expected)
             {
                 ThrowUnexpectedCount(actual, expected);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1820,7 +1820,8 @@ namespace Nethermind.Serialization.Rlp
         public static void GuardLimit(int count, int bytesLeft, RlpLimit? limit = null)
         {
             RlpLimit l = limit ?? RlpLimit.DefaultLimit;
-            if ((uint)count > (uint)bytesLeft || (uint)count > (uint)l.Limit)
+            // First test rejects either bound being negative.
+            if ((bytesLeft | l.Limit) < 0 || (uint)count > (uint)bytesLeft || (uint)count > (uint)l.Limit)
             {
                 ThrowCountOverLimit((uint)count, bytesLeft, l);
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1820,10 +1820,6 @@ namespace Nethermind.Serialization.Rlp
         public static void GuardLimit(int count, int bytesLeft, RlpLimit? limit = null)
         {
             RlpLimit l = limit ?? RlpLimit.DefaultLimit;
-            // Unsigned compares fold the `count < 0` guard into the upper-bound checks: a
-            // negative count reinterprets above int.MaxValue and so exceeds any non-negative
-            // bytesLeft or limit. bytesLeft is Length - Position and limit.Limit is positive
-            // (see RlpLimit defaults), so both bounds are safe to treat as unsigned.
             if ((uint)count > (uint)bytesLeft || (uint)count > (uint)l.Limit)
             {
                 ThrowCountOverLimit((uint)count, bytesLeft, l);
@@ -1834,8 +1830,7 @@ namespace Nethermind.Serialization.Rlp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GuardSize(int actual, int expected)
         {
-            // Most callers pass the sentinel expected = -1 (no constraint), so checking the
-            // sentinel first short-circuits the common case in one branch.
+            // expected == -1 is the sentinel for "no constraint".
             if (expected >= 0 && actual != expected)
             {
                 ThrowUnexpectedCount(actual, expected);


### PR DESCRIPTION
## Changes

Tighten signed bound checks that show up on hot decode paths and a few hot indexers / validators. The same shape - `if (x < 0 || x > bound)` or `(x < 0 || x >= bound)` - appears in several places where both bounds are non-negative under invariants. Each one collapses to a single unsigned compare: a negative input reinterprets above `int.MaxValue` under the `(uint)` cast and so exceeds any non-negative bound, dropping a branch from the hot path. A few related cleanups landed alongside.

### RLP guards (`Nethermind.Serialization.Rlp/Rlp.cs`)

- `Rlp.GuardLimit` collapses `count < 0 || count > bytesLeft || count > l.Limit` into two unsigned compares (`(uint)count > (uint)bytesLeft || (uint)count > (uint)l.Limit`). `bytesLeft = Length - Position` and every `RlpLimit` variant has a positive `Limit`, so both bounds are safe to treat as unsigned.
- `ValueDecoderContext.GuardLimit` and `Rlp.GuardSize` annotated `AggressiveInlining` so the JIT can collapse the now two-branch bodies into per-decoder callers.
- `Check` / `CheckEnd` extract their `throw new RlpException($"...")` bodies into `[DoesNotReturn, StackTraceHidden]` helpers (`ThrowCheckpointFailed`, `ThrowCheckEndFailed`). The string-interpolation code no longer lives on the success path, so the methods become inlinable at decoder array-loop call sites.

### Collection and indexer guards

- `Nethermind.Core/Collections/SlicedReadOnlyList.cs`:
  - The `this[int]` indexer's `index < 0 || index >= _count` becomes `(uint)index >= (uint)_count` - a per-access saving on every consumer of `IReadOnlyList<T>.Slice(...)`.
  - The constructor's `count < 0 || start + count > list.Count` becomes `(uint)count > (uint)(list.Count - start)`, which both folds the sign guard and removes the latent `start + count` overflow risk for two near-`int.MaxValue` inputs.
  - Both `Slice` extension overloads adopt `(uint)start > (uint)list.Count` for consistency.
- `Nethermind.Era1/AccumulatorCalculator.GetProof`: `(uint)blockIndex >= (uint)_roots.Count`. Called once per block during Era1 import/export.

### Latent off-by-one fix in Optimism RPC

- `Nethermind.Optimism/Rpc/OptimismEthRpcModule.GetTransactionByBlockAndIndex` had `positionIndex < 0 || positionIndex > block!.Transactions.Length - 1`. `positionIndex` is `UInt256`, so the `< 0` half was dead code, and the `> Length - 1` half *underflowed to -1* on empty transaction lists - the bound check rejected such cases only by signed wrap-around accident. The override now matches the base class form (`positionIndex >= block.Transactions.Length`), which is functionally equivalent for populated blocks and behaves correctly for empty ones.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

- Existing Rlp / Core / Era1 / Network / Optimism test suites pass against the changed files (`Ethereum.Rlp.Test`, `Nethermind.Era1.Test`, `Nethermind.Core.Test`). No behaviour change is intended; all bounds reject the same set of inputs they did before. The Optimism off-by-one fix narrows the accept-set on empty transaction lists (previously accepted everything via signed wrap, now correctly rejects), but the downstream path returned the same "null" response in both cases.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The Optimism off-by-one are worth a second look during review: relied on accident of signed wrap-around for correctness, and the optimization pass surfaced them by forcing the invariants to be re-derived. Wire behaviour is unchanged for non-pathological inputs in both cases.
