### PR TITLE
fix(bal): defer 7702 delegation BAL entry past depth/balance check

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -1167,6 +1167,42 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         }
     }
 
+    [TestCase(Instruction.CALL, TestName = "EIP7702_call_into_delegated_eoa_with_insufficient_balance_excludes_delegation_target_from_BAL_for_CALL")]
+    [TestCase(Instruction.CALLCODE, TestName = "EIP7702_call_into_delegated_eoa_with_insufficient_balance_excludes_delegation_target_from_BAL_for_CALLCODE")]
+    public void Call_into_7702_delegated_eoa_with_insufficient_balance_does_not_record_delegation_target(Instruction callOpcode)
+    {
+        InitWorldState(TestState);
+
+        (TracedAccessWorldState tracedState, TransactionProcessor<EthereumGasPolicy> processor) = CreateTracedProcessor();
+        Block block = Build.A.Block.TestObject;
+
+        // EIP-7928 (https://github.com/ethereum/EIPs/pull/11699): when a value-transferring
+        // CALL/CALLCODE targets a 7702-delegated EOA but the sender's balance does not cover
+        // the value transfer, the delegation target MUST NOT appear in the BAL. The original
+        // call target is still recorded because it was accessed to resolve the delegation.
+        UInt256 senderBalance = 100;
+        UInt256 callValue = 1000;
+        byte[] code = callOpcode == Instruction.CALL
+            ? Prepare.EvmCode.CallWithValue(_callTargetAddress, 50_000, callValue).Done
+            : Prepare.EvmCode.CallCode(_callTargetAddress, 50_000, callValue).Done;
+
+        Transaction tx = BuildContractTx(code, executionGas: 100_000, senderBalance, block.Header);
+
+        processor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, Amsterdam.Instance));
+        CallOutputTracer tracer = new();
+        TransactionResult res = processor.Execute(tx, tracer);
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(res.TransactionExecuted);
+            Assert.That(bal.GetAccountChanges(_callTargetAddress), Is.Not.Null,
+                "EIP-7702 delegated EOA must be recorded as the CALL target (accessed to resolve delegation)");
+            Assert.That(bal.GetAccountChanges(_delegationTargetAddress), Is.Null,
+                "EIP-7702 delegation target must not be recorded when the value-transferring call fails because sender balance < value");
+        }
+    }
+
     [TestCase(120_000_000L, 30_000_000L, true, TestName = "EIP2935_system_call_records_storage_change_when_state_gas_affordable")]
     [TestCase(120_000_000L, 30_000L, false, TestName = "EIP2935_system_call_records_no_storage_access_when_state_gas_not_affordable")]
     public void Eip2935_system_call_bal_respects_eip8037_state_gas(long blockGasLimit, long systemCallGasLimit, bool shouldStoreParentHash)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -1167,8 +1167,8 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         }
     }
 
-    [TestCase(Instruction.CALL, TestName = "EIP7702_call_into_delegated_eoa_with_insufficient_balance_excludes_delegation_target_from_BAL_for_CALL")]
-    [TestCase(Instruction.CALLCODE, TestName = "EIP7702_call_into_delegated_eoa_with_insufficient_balance_excludes_delegation_target_from_BAL_for_CALLCODE")]
+    [TestCase(Instruction.CALL, TestName = "EIP7702_call_with_insufficient_balance_excludes_delegation_from_BAL_for_CALL")]
+    [TestCase(Instruction.CALLCODE, TestName = "EIP7702_call_with_insufficient_balance_excludes_delegation_from_BAL_for_CALLCODE")]
     public void Call_into_7702_delegated_eoa_with_insufficient_balance_does_not_record_delegation_target(Instruction callOpcode)
     {
         InitWorldState(TestState);
@@ -1176,17 +1176,15 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         (TracedAccessWorldState tracedState, TransactionProcessor<EthereumGasPolicy> processor) = CreateTracedProcessor();
         Block block = Build.A.Block.TestObject;
 
-        // EIP-7928 (https://github.com/ethereum/EIPs/pull/11699): when a value-transferring
-        // CALL/CALLCODE targets a 7702-delegated EOA but the sender's balance does not cover
-        // the value transfer, the delegation target MUST NOT appear in the BAL. The original
-        // call target is still recorded because it was accessed to resolve the delegation.
-        UInt256 senderBalance = 100;
+        // EIP-7928 (PR 11699): value-transferring CALL/CALLCODE with sender_balance < value
+        // must not load the delegation; only the original call target is recorded.
+        UInt256 callerBalance = 100;
         UInt256 callValue = 1000;
         byte[] code = callOpcode == Instruction.CALL
             ? Prepare.EvmCode.CallWithValue(_callTargetAddress, 50_000, callValue).Done
             : Prepare.EvmCode.CallCode(_callTargetAddress, 50_000, callValue).Done;
 
-        Transaction tx = BuildContractTx(code, executionGas: 100_000, senderBalance, block.Header);
+        Transaction tx = BuildContractTx(code, executionGas: 100_000, callerBalance, block.Header);
 
         processor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, Amsterdam.Instance));
         CallOutputTracer tracer = new();
@@ -1196,10 +1194,8 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(res.TransactionExecuted);
-            Assert.That(bal.GetAccountChanges(_callTargetAddress), Is.Not.Null,
-                "EIP-7702 delegated EOA must be recorded as the CALL target (accessed to resolve delegation)");
-            Assert.That(bal.GetAccountChanges(_delegationTargetAddress), Is.Null,
-                "EIP-7702 delegation target must not be recorded when the value-transferring call fails because sender balance < value");
+            Assert.That(bal.GetAccountChanges(_callTargetAddress), Is.Not.Null);
+            Assert.That(bal.GetAccountChanges(_delegationTargetAddress), Is.Null);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -191,18 +191,6 @@ public static partial class EvmInstructions
 
         if (newAccountOutOfGas) goto OutOfGas;
 
-        // EIP-7702: load delegated code after cold-access charge above.
-        if (delegated is not null)
-        {
-            // EIP-7928: decorator fast-path skips world-state reads; record explicitly.
-            state.AddAccountRead(delegated);
-
-            // EIP-7702: precompile MUST NOT execute via delegation; the decorator would route to the precompile CodeInfo.
-            codeInfo = spec.IsPrecompile(delegated)
-                ? CodeInfo.Empty
-                : vm.CodeInfoRepository.GetCachedCodeInfoNoDelegation(delegated, spec);
-        }
-
         long gasAvailable = TGasPolicy.GetRemainingGas(in gas);
         long gasLimitUl;
 
@@ -260,6 +248,22 @@ public static partial class EvmInstructions
                 vm.TxTracer.ReportGasUpdateForVmTrace(gasLimitUl, TGasPolicy.GetRemainingGas(in gas));
             }
             return pushResult;
+        }
+
+        // EIP-7702: load delegated code only after the preflight checks above all pass
+        // (gas for delegation access_cost, depth limit, value-transfer balance for CALL/CALLCODE).
+        // Per EIP-7928, the delegated address must NOT appear in the BAL if any of those checks
+        // fail, so both the explicit AddAccountRead and the world-state code lookup are deferred
+        // until here. See https://github.com/ethereum/EIPs/pull/11699.
+        if (delegated is not null)
+        {
+            // EIP-7928: decorator fast-path skips world-state reads; record explicitly.
+            state.AddAccountRead(delegated);
+
+            // EIP-7702: precompile MUST NOT execute via delegation; the decorator would route to the precompile CodeInfo.
+            codeInfo = spec.IsPrecompile(delegated)
+                ? CodeInfo.Empty
+                : vm.CodeInfoRepository.GetCachedCodeInfoNoDelegation(delegated, spec);
         }
 
         // Take a snapshot of the state for potential rollback.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -250,11 +250,7 @@ public static partial class EvmInstructions
             return pushResult;
         }
 
-        // EIP-7702: load delegated code only after the preflight checks above all pass
-        // (gas for delegation access_cost, depth limit, value-transfer balance for CALL/CALLCODE).
-        // Per EIP-7928, the delegated address must NOT appear in the BAL if any of those checks
-        // fail, so both the explicit AddAccountRead and the world-state code lookup are deferred
-        // until here. See https://github.com/ethereum/EIPs/pull/11699.
+        // EIP-7928 (PR 11699): defer delegated load past the depth/balance preflight so a failed check doesn't leak delegation into BAL.
         if (delegated is not null)
         {
             // EIP-7928: decorator fast-path skips world-state reads; record explicitly.


### PR DESCRIPTION
Aligns Nethermind with the EIP-7928 clarification merged in [ethereum/EIPs#11699](https://github.com/ethereum/EIPs/pull/11699): an EIP-7702 delegation target may appear in the Block Access List only when **all** of the following hold — sufficient gas for the delegated `access_cost`, `sender_balance >= value` for value-transferring `CALL`/`CALLCODE`, and the call-stack depth limit not violated. Otherwise the delegation target must not be loaded and must not appear in the BAL.

Mirrors the conformance test in [ethereum/execution-specs#2824](https://github.com/ethereum/execution-specs/pull/2824) (`test_bal_call_revert_insufficient_funds`).

## Changes

- `EvmInstructions.Call.cs` — moved the `if (delegated is not null) { state.AddAccountRead(delegated); ... GetCachedCodeInfoNoDelegation(...) }` block from before the gas-limit / depth / balance preflight to after it. The OOG-on-delegated-cold-access case was already correctly excluded (the earlier `ConsumeAccountAccessGas` failure jumps to `OutOfGas` before any BAL write); balance-insufficient and depth-1024 failures used to leak the delegation target because `AddAccountRead` is intentionally not journaled and so isn't undone on snapshot restore.
- `Eip7928Tests.cs` — added `Call_into_7702_delegated_eoa_with_insufficient_balance_does_not_record_delegation_target`, parametrized over `CALL` and `CALLCODE`. The depth-limit case shares the same `if (env.CallDepth >= MaxCallDepth || ...)` branch and is implicitly covered.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Eip7928Tests` (198 tests), `Eip7702`-named tests in `Eip7928Tests` (28), `CodeInfoRepositoryTests` (18), `VirtualMachineTests` (33), `Eip8037Tests` (115) — all pass.
- `dotnet format whitespace` clean on the modified files.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No