### PR TITLE
test(merge): cover slot-1151 late-sibling FCU reorg scenario

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1521,7 +1521,7 @@ public partial class EngineModuleTests
 
         ExecutionPayload blockA = CreateBlockRequest(chain, blockX, TestItem.AddressA);
         (await rpc.engine_newPayloadV1(blockA)).Data.Status.Should().Be(PayloadStatus.Valid);
-        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockA.BlockHash, blockA.BlockHash)))
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockA.BlockHash, blockX.BlockHash)))
             .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
 
         ExecutionPayload blockB = CreateBlockRequest(chain, blockX, TestItem.AddressB);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1521,7 +1521,7 @@ public partial class EngineModuleTests
 
         ExecutionPayload blockA = CreateBlockRequest(chain, blockX, TestItem.AddressA);
         (await rpc.engine_newPayloadV1(blockA)).Data.Status.Should().Be(PayloadStatus.Valid);
-        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockA.BlockHash, blockX.BlockHash)))
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockX.BlockHash, blockX.BlockHash)))
             .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
 
         ExecutionPayload blockB = CreateBlockRequest(chain, blockX, TestItem.AddressB);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1454,6 +1454,96 @@ public partial class EngineModuleTests
     }
 
     [Test]
+    public async Task forkchoiceUpdated_reorgs_to_late_sibling_chain_after_head_was_advanced_on_sibling()
+    {
+        // Production regression (late slot-1151 envelope, EL height N):
+        //   1. Slot 1154 builds block A on parent X first; FCU sets A as canonical head at N.
+        //   2. Slot 1151's late payload arrives as block B - a sibling of A at N (same parent X).
+        //   3. Slot 1152 builds block C on B at N+1.
+        //   4. CL fork choice picks the B/C chain and sends FCU(head=C, safe=B, finalized=X).
+        // The EL must accept the FCU and reorg the main chain so block-by-number[N]=B / [N+1]=C.
+        // Observed symptom was -38002 Inconsistent ForkChoiceState - safe block hash, with the
+        // canonical marker at N still pointing at A and every follow-up FCU rejected for ~9 min.
+        using MergeTestBlockchain chain =
+            await CreateBlockchain(null, new MergeConfig() { TerminalTotalDifficulty = "0" });
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        ExecutionPayload blockX = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressA);
+        (await rpc.engine_newPayloadV1(blockX)).Data.Status.Should().Be(PayloadStatus.Valid);
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockX.BlockHash, blockX.BlockHash, blockX.BlockHash)))
+            .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
+        ExecutionPayload blockA = CreateBlockRequest(chain, blockX, TestItem.AddressA);
+        (await rpc.engine_newPayloadV1(blockA)).Data.Status.Should().Be(PayloadStatus.Valid);
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockX.BlockHash, blockX.BlockHash)))
+            .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.IsMainChain(blockA.BlockHash).Should().BeTrue("precondition: A wins the race and is canonical at height N");
+
+        ExecutionPayload blockB = CreateBlockRequest(chain, blockX, TestItem.AddressB);
+        (await rpc.engine_newPayloadV1(blockB)).Data.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.IsMainChain(blockB.BlockHash).Should().BeFalse("precondition: late sibling B is in the tree but off-canonical");
+
+        ExecutionPayload blockC = CreateBlockRequest(chain, blockB, TestItem.AddressB);
+        (await rpc.engine_newPayloadV1(blockC)).Data.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.IsMainChain(blockC.BlockHash).Should().BeFalse("precondition: C on top of B is also off-canonical pre-reorg");
+
+        ForkchoiceStateV1 reorgToC = new(headBlockHash: blockC.BlockHash, finalizedBlockHash: blockX.BlockHash, safeBlockHash: blockB.BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> reorgResult = await rpc.engine_forkchoiceUpdatedV1(reorgToC);
+        reorgResult.ErrorCode.Should().Be(0);
+        reorgResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
+        chain.BlockTree.Head!.Hash.Should().Be(blockC.BlockHash);
+        chain.BlockTree.IsMainChain(blockC.BlockHash).Should().BeTrue();
+        chain.BlockTree.IsMainChain(blockB.BlockHash).Should().BeTrue("canonical marker at height N must move from A to B after the reorg");
+        chain.BlockTree.IsMainChain(blockA.BlockHash).Should().BeFalse("A must no longer be canonical at height N after the reorg");
+
+        ForkchoiceStateV1 followUp = new(headBlockHash: blockC.BlockHash, finalizedBlockHash: blockB.BlockHash, safeBlockHash: blockB.BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> followUpResult = await rpc.engine_forkchoiceUpdatedV1(followUp);
+        followUpResult.ErrorCode.Should().Be(0);
+        followUpResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+    }
+
+    [Test]
+    public async Task forkchoiceUpdated_safe_on_sibling_chain_of_head_is_rejected_without_disturbing_canonical_markers()
+    {
+        // Models the "Prysm advances safeBlockHash to B while head is still A" path of the
+        // slot-1151 incident: an FCU whose safe lives on a sibling chain of the (still) canonical
+        // head must be rejected per Engine API spec, and the EL's canonical markers must remain
+        // untouched (so a follow-up FCU on the proper chain can still advance head/safe).
+        using MergeTestBlockchain chain =
+            await CreateBlockchain(null, new MergeConfig() { TerminalTotalDifficulty = "0" });
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        ExecutionPayload blockX = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressA);
+        (await rpc.engine_newPayloadV1(blockX)).Data.Status.Should().Be(PayloadStatus.Valid);
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockX.BlockHash, blockX.BlockHash, blockX.BlockHash)))
+            .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
+        ExecutionPayload blockA = CreateBlockRequest(chain, blockX, TestItem.AddressA);
+        (await rpc.engine_newPayloadV1(blockA)).Data.Status.Should().Be(PayloadStatus.Valid);
+        (await rpc.engine_forkchoiceUpdatedV1(new(blockA.BlockHash, blockA.BlockHash, blockA.BlockHash)))
+            .Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
+        ExecutionPayload blockB = CreateBlockRequest(chain, blockX, TestItem.AddressB);
+        (await rpc.engine_newPayloadV1(blockB)).Data.Status.Should().Be(PayloadStatus.Valid);
+
+        ForkchoiceStateV1 inconsistent = new(headBlockHash: blockA.BlockHash, finalizedBlockHash: blockX.BlockHash, safeBlockHash: blockB.BlockHash);
+        await AssertFcuRejectedAndStateUnchanged(chain, rpc, inconsistent);
+        chain.BlockTree.IsMainChain(blockA.BlockHash).Should().BeTrue("rejection must not flip canonical marker off A");
+        chain.BlockTree.IsMainChain(blockB.BlockHash).Should().BeFalse("rejection must leave the sibling B off-canonical");
+
+        ExecutionPayload blockC = CreateBlockRequest(chain, blockB, TestItem.AddressB);
+        (await rpc.engine_newPayloadV1(blockC)).Data.Status.Should().Be(PayloadStatus.Valid);
+        ForkchoiceStateV1 recover = new(headBlockHash: blockC.BlockHash, finalizedBlockHash: blockX.BlockHash, safeBlockHash: blockB.BlockHash);
+        ResultWrapper<ForkchoiceUpdatedV1Result> recovered = await rpc.engine_forkchoiceUpdatedV1(recover);
+        recovered.ErrorCode.Should().Be(0);
+        recovered.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+        chain.BlockTree.Head!.Hash.Should().Be(blockC.BlockHash);
+        chain.BlockTree.IsMainChain(blockB.BlockHash).Should().BeTrue();
+        chain.BlockTree.IsMainChain(blockA.BlockHash).Should().BeFalse();
+    }
+
+    [Test]
     public async Task forkchoiceUpdated_isInconsistent_takes_fast_path_when_candidate_is_on_main_chain()
     {
         // Coverage for the candidateIsMain/headNotMain branch of IsInconsistent: stale canonical


### PR DESCRIPTION
## Summary

Two regression tests pinning the FCU validation behaviour exercised by the recent slot-1151 production incident (late slot-1151 payload arriving after the EL had already accepted a sibling at the same height, with the CL subsequently advancing safe to the late sibling).

Investigating whether #11681 caused the incident; both new tests **pass on master**, so the reorg path and the inconsistent-FCU rejection are both behaving per spec.

### Tests

- `forkchoiceUpdated_reorgs_to_late_sibling_chain_after_head_was_advanced_on_sibling` — `head=A` canonical at N, late sibling `B` arrives via `newPayload`, child `C` built on `B` via `newPayload`, then `FCU(head=C, safe=B, finalized=X)` must reorg main chain to `B`/`C`. Asserts `IsMainChain` flips A→B at N and a follow-up `FCU(head=C, safe=B, finalized=B)` is accepted.
- `forkchoiceUpdated_safe_on_sibling_chain_of_head_is_rejected_without_disturbing_canonical_markers` — `FCU(head=A, safe=B)` where A and B are siblings must be rejected with `InvalidForkchoiceState` (Engine API §1 point 5). Asserts the rejection leaves canonical markers untouched and that a follow-up consistent `FCU(head=C, safe=B)` then recovers cleanly.

### Why this matters

The production symptom was `-38002 Inconsistent ForkChoiceState - safe block hash` repeated for ~9 min. The most plausible trigger is the CL advancing its justified pointer to the late sibling while its head pointer briefly stayed on the earlier sibling — that yields an internally inconsistent FCU which the EL must reject. The new tests lock both halves down: (a) the direct reorg case works, (b) the inconsistent FCU is rejected without corrupting state, and the EL recovers on the next consistent FCU.

The `RejectIfInconsistent` rejection itself predates #11681 (introduced in #11185/#11187). #11681 only changed *when* the rejection runs relative to `UpdateMainChain` (now before, so state is never mutated on a reject), which does not affect either scenario tested here.

## Test plan

- [x] `forkchoiceUpdated_reorgs_to_late_sibling_chain_after_head_was_advanced_on_sibling` passes locally on `origin/master`
- [x] `forkchoiceUpdated_safe_on_sibling_chain_of_head_is_rejected_without_disturbing_canonical_markers` passes locally on `origin/master`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)