### PR TITLE
debug streaming: reduce allocations on per-block trace path

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
+++ b/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Collections.Pooled" />
     <PackageReference Include="Polly" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockEnvelopeStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockEnvelopeStreamingTracer.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Json;
 
 namespace Nethermind.Blockchain.Tracing.GethStyle;
@@ -26,7 +27,7 @@ public sealed class GethLikeBlockEnvelopeStreamingTracer : BlockTracerBase<GethL
     private readonly CancellationToken _cancellationToken;
     private bool _innerEnvelopeOpen;
     private Hash256? _currentTxHash;
-    private GethLikeTxDirectStreamingTracer? _currentTxTracer;
+    private GethLikeTxDirectStreamingTracer? _reusableTxTracer;
 
     public GethLikeBlockEnvelopeStreamingTracer(
         GethTraceOptions options,
@@ -52,14 +53,20 @@ public sealed class GethLikeBlockEnvelopeStreamingTracer : BlockTracerBase<GethL
         _writer.WriteStartArray();
         _innerEnvelopeOpen = true;
         _currentTxHash = tx?.Hash;
-        _currentTxTracer = new GethLikeTxDirectStreamingTracer(tx, _options, _writer, _pipeWriter, _cancellationToken);
-        return _currentTxTracer;
+        if (_reusableTxTracer is null)
+        {
+            _reusableTxTracer = new GethLikeTxDirectStreamingTracer(tx, _options, _writer, _pipeWriter, _cancellationToken);
+        }
+        else
+        {
+            _reusableTxTracer.ResetForNextTx(tx);
+        }
+        return _reusableTxTracer;
     }
 
     protected override GethLikeTxTrace OnEnd(GethLikeTxDirectStreamingTracer txTracer)
     {
         GethLikeTxTrace trace = txTracer.BuildResult();
-        _currentTxTracer = null;
 
         _writer.WriteEndArray();
         ForcedNumberConversion.WriteRawLong(_writer, "gas"u8, trace.Gas);
@@ -75,16 +82,21 @@ public sealed class GethLikeBlockEnvelopeStreamingTracer : BlockTracerBase<GethL
         _innerEnvelopeOpen = false;
         _currentTxHash = null;
 
-        FlushPerTxEnvelope();
         return trace;
     }
 
     protected override void AddTrace(GethLikeTxTrace trace) { }
 
+    public override void EndBlockTrace()
+    {
+        _reusableTxTracer?.ReleaseResources();
+        base.EndBlockTrace();
+    }
+
     public void Dispose()
     {
-        _currentTxTracer?.Dispose();
-        _currentTxTracer = null;
+        _reusableTxTracer?.ReleaseResources();
+        DisposableExtensions.DisposeAndNull(ref _reusableTxTracer);
 
         if (!_innerEnvelopeOpen) return;
 
@@ -101,12 +113,5 @@ public sealed class GethLikeBlockEnvelopeStreamingTracer : BlockTracerBase<GethL
         _writer.WriteEndObject();
         _innerEnvelopeOpen = false;
         _currentTxHash = null;
-    }
-
-    private void FlushPerTxEnvelope()
-    {
-        if (_pipeWriter is null) return;
-        _writer.Flush();
-        _pipeWriter.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockStreamingMemoryTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockStreamingMemoryTracer.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Text.Json;
 using System.Threading;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Blockchain.Tracing.GethStyle;
 
@@ -22,23 +23,32 @@ public sealed class GethLikeBlockStreamingMemoryTracer(
     CancellationToken cancellationToken)
     : BlockTracerBase<GethLikeTxTrace, GethLikeTxDirectStreamingTracer>(options.TxHash), IDisposable
 {
-    private GethLikeTxDirectStreamingTracer? _currentTxTracer;
+    private GethLikeTxDirectStreamingTracer? _reusableTxTracer;
 
     protected override GethLikeTxDirectStreamingTracer OnStart(Transaction? tx)
     {
-        _currentTxTracer = new GethLikeTxDirectStreamingTracer(tx, options, writer, pipeWriter, cancellationToken);
-        return _currentTxTracer;
+        if (_reusableTxTracer is null)
+        {
+            _reusableTxTracer = new GethLikeTxDirectStreamingTracer(tx, options, writer, pipeWriter, cancellationToken);
+        }
+        else
+        {
+            _reusableTxTracer.ResetForNextTx(tx);
+        }
+        return _reusableTxTracer;
     }
 
-    protected override GethLikeTxTrace OnEnd(GethLikeTxDirectStreamingTracer txTracer)
+    protected override GethLikeTxTrace OnEnd(GethLikeTxDirectStreamingTracer txTracer) => txTracer.BuildResult();
+
+    public override void EndBlockTrace()
     {
-        try { return txTracer.BuildResult(); }
-        finally { _currentTxTracer = null; }
+        _reusableTxTracer?.ReleaseResources();
+        base.EndBlockTrace();
     }
 
     public void Dispose()
     {
-        _currentTxTracer?.Dispose();
-        _currentTxTracer = null;
+        _reusableTxTracer?.ReleaseResources();
+        DisposableExtensions.DisposeAndNull(ref _reusableTxTracer);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -7,7 +7,9 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Text.Json;
 using System.Threading;
+using Collections.Pooled;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm;
@@ -28,12 +30,12 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     private const int EvmWordSize = 32;
     private static readonly JsonEncodedText ZeroMemoryWord = JsonEncodedText.Encode(new string('0', EvmWordSize * 2));
     private const int InitialStorageMapCapacity = 8;
-    private const int InitialDepthStackCapacity = 4;
+    private const int InitialDepthStackCapacity = 8;
 
     private readonly Utf8JsonWriter _writer;
     private readonly PipeWriter? _pipeWriter;
     private readonly CancellationToken _cancellationToken;
-    private readonly Transaction? _transaction;
+    private Transaction? _transaction;
     private readonly int _flushIntervalEntries;
 
     private bool _hasPendingOpcode;
@@ -51,7 +53,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     private byte[]? _memoryBuffer;
     private int _memoryByteCount;
 
-    private readonly Stack<Dictionary<UInt256, UInt256>> _storageByDepth = new(InitialDepthStackCapacity);
+    private ArrayPoolList<PooledDictionary<UInt256, UInt256>>? _storageByDepth;
+    private int _activeStorageDepth;
 
     private int _entriesSinceLastFlush;
     private bool _disposed;
@@ -74,6 +77,29 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _cancellationToken = cancellationToken;
         _flushIntervalEntries = flushIntervalEntries;
         IsTracingMemory = IsTracingFullMemory;
+    }
+
+    internal void ResetForNextTx(Transaction? transaction)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _transaction = transaction;
+        _hasPendingOpcode = false;
+        _pendingPc = 0;
+        _pendingOpcode = default;
+        _pendingGas = 0;
+        _pendingGasCost = 0;
+        _pendingDepth = 0;
+        _pendingError = null;
+        _gasCostAlreadySet = false;
+        _stackByteCount = 0;
+        _memoryByteCount = 0;
+        if (_storageByDepth is not null)
+        {
+            for (int i = 0; i < _activeStorageDepth; i++) _storageByDepth[i].Clear();
+        }
+        _activeStorageDepth = 0;
+        _entriesSinceLastFlush = 0;
+        ResetTrace();
     }
 
     public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
@@ -153,33 +179,48 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
 
     public override void SetOperationStorage(Address address, UInt256 storageIndex, ReadOnlySpan<byte> newValue, ReadOnlySpan<byte> currentValue)
     {
-        if (!IsTracingOpLevelStorage || _storageByDepth.Count == 0) return;
-        Dictionary<UInt256, UInt256> top = _storageByDepth.Peek();
+        if (!IsTracingOpLevelStorage || _activeStorageDepth == 0) return;
+        PooledDictionary<UInt256, UInt256> top = _storageByDepth![_activeStorageDepth - 1];
         top[storageIndex] = new UInt256(newValue, isBigEndian: true);
     }
 
     public override GethLikeTxTrace BuildResult()
     {
         FinalizePendingOpcode();
-        ReturnPooledBuffers();
         GethLikeTxTrace result = base.BuildResult();
         result.TxHash = _transaction?.Hash;
         return result;
     }
 
-    public override void Dispose()
+    // Dispose is left as a no-op: the per-tx `using` in TransactionProcessorAdapterExtensions
+    // would otherwise release the pooled buffers between txs and defeat reuse. The owning
+    // block tracer drives the real cleanup via ReleaseResources from EndBlockTrace/Dispose.
+
+    internal void ReleaseResources()
     {
         if (_disposed) return;
         ReturnPooledBuffers();
         _disposed = true;
-        base.Dispose();
     }
 
     private void AdjustStorageStackForDepth(int newDepth)
     {
         if (!IsTracingOpLevelStorage) return;
-        while (_storageByDepth.Count > newDepth) _storageByDepth.Pop();
-        while (_storageByDepth.Count < newDepth) _storageByDepth.Push(new Dictionary<UInt256, UInt256>(InitialStorageMapCapacity));
+
+        if (newDepth < _activeStorageDepth)
+        {
+            for (int i = newDepth; i < _activeStorageDepth; i++) _storageByDepth![i].Clear();
+        }
+        else if (newDepth > _activeStorageDepth)
+        {
+            _storageByDepth ??= new ArrayPoolList<PooledDictionary<UInt256, UInt256>>(InitialDepthStackCapacity);
+            while (_storageByDepth.Count < newDepth)
+            {
+                _storageByDepth.Add(new PooledDictionary<UInt256, UInt256>(InitialStorageMapCapacity));
+            }
+        }
+
+        _activeStorageDepth = newDepth;
     }
 
     private void EnsureBuffer(ref byte[]? buffer, int requiredLength)
@@ -193,6 +234,12 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     {
         if (_stackBuffer is not null) { ArrayPool<byte>.Shared.Return(_stackBuffer); _stackBuffer = null; }
         if (_memoryBuffer is not null) { ArrayPool<byte>.Shared.Return(_memoryBuffer); _memoryBuffer = null; }
+        if (_storageByDepth is not null)
+        {
+            for (int i = 0; i < _storageByDepth.Count; i++) _storageByDepth[i].Dispose();
+            _storageByDepth.Dispose();
+            _storageByDepth = null;
+        }
     }
 
     private void FinalizePendingOpcode()
@@ -262,8 +309,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
 
     private void WriteStorageObjectIfPresent()
     {
-        if (_storageByDepth.Count == 0) return;
-        Dictionary<UInt256, UInt256> top = _storageByDepth.Peek();
+        if (_activeStorageDepth == 0) return;
+        PooledDictionary<UInt256, UInt256> top = _storageByDepth![_activeStorageDepth - 1];
 
         _writer.WriteStartObject("storage"u8);
         Span<byte> keyBytes = stackalloc byte[EvmWordSize];

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -25,6 +25,8 @@ public abstract class GethLikeTxTracer : TxTracer
     private GethLikeTxTrace? _trace;
     protected GethLikeTxTrace Trace => _trace ??= CreateTrace();
     protected virtual GethLikeTxTrace CreateTrace() => new();
+
+    protected void ResetTrace() => _trace = null;
     public override bool IsTracingReceipt => true;
     public sealed override bool IsTracingOpLevelStorage { get; protected set; }
     public sealed override bool IsTracingMemory { get; protected set; }

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingAllocsBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingAllocsBenchmarks.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Core;
+using Nethermind.Evm;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Int256;
+
+namespace Nethermind.JsonRpc.Benchmark;
+
+[MemoryDiagnoser]
+public class DebugTraceStreamingAllocsBenchmarks
+{
+    [Params(20)] public int TxsPerBlock { get; set; }
+    [Params(100)] public int OpcodesPerTx { get; set; }
+
+    private GethTraceOptions _options = null!;
+    private ExecutionEnvironment[] _envByDepth = null!;
+    private byte[] _valueBuffer = null!;
+    private static readonly Action<GethLikeTxDirectStreamingTracer, Transaction?> _resetForNextTx =
+        (Action<GethLikeTxDirectStreamingTracer, Transaction?>)Delegate.CreateDelegate(
+            typeof(Action<GethLikeTxDirectStreamingTracer, Transaction?>),
+            typeof(GethLikeTxDirectStreamingTracer).GetMethod("ResetForNextTx", BindingFlags.Instance | BindingFlags.NonPublic)!);
+    private static readonly Action<GethLikeTxDirectStreamingTracer> _releaseResources =
+        (Action<GethLikeTxDirectStreamingTracer>)Delegate.CreateDelegate(
+            typeof(Action<GethLikeTxDirectStreamingTracer>),
+            typeof(GethLikeTxDirectStreamingTracer).GetMethod("ReleaseResources", BindingFlags.Instance | BindingFlags.NonPublic)!);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = new GethTraceOptions { DisableStack = true, EnableMemory = false };
+        _envByDepth = new ExecutionEnvironment[5];
+        for (int d = 0; d < 5; d++)
+        {
+            _envByDepth[d] = ExecutionEnvironment.Rent(
+                CodeInfo.Empty, Address.Zero, Address.Zero, null, d, default, default, default);
+        }
+        _valueBuffer = new byte[32];
+    }
+
+    [Benchmark(Baseline = true, Description = "Per-tx tracer: original behavior, allocate+release per tx")]
+    public int PerTxTracer()
+    {
+        ArrayBufferWriter<byte> sink = new();
+        using Utf8JsonWriter writer = new(sink, new JsonWriterOptions { SkipValidation = true });
+        for (int txIdx = 0; txIdx < TxsPerBlock; txIdx++)
+        {
+            GethLikeTxDirectStreamingTracer tracer = new(null, _options, writer, null, CancellationToken.None);
+            RunTx(tracer);
+            _releaseResources(tracer);
+        }
+        return sink.WrittenCount;
+    }
+
+    [Benchmark(Description = "Reused tracer: one instance, reset between txs, release at end")]
+    public int ReusedTracer()
+    {
+        ArrayBufferWriter<byte> sink = new();
+        using Utf8JsonWriter writer = new(sink, new JsonWriterOptions { SkipValidation = true });
+        GethLikeTxDirectStreamingTracer tracer = new(null, _options, writer, null, CancellationToken.None);
+        try
+        {
+            for (int txIdx = 0; txIdx < TxsPerBlock; txIdx++)
+            {
+                if (txIdx > 0) _resetForNextTx(tracer, null);
+                RunTx(tracer);
+            }
+        }
+        finally
+        {
+            _releaseResources(tracer);
+        }
+        return sink.WrittenCount;
+    }
+
+    private void RunTx(GethLikeTxDirectStreamingTracer tracer)
+    {
+        ReadOnlySpan<byte> valueSpan = _valueBuffer;
+        for (int op = 0; op < OpcodesPerTx; op++)
+        {
+            int depth = (op % 4) + 1;
+            tracer.StartOperation(op, Instruction.SSTORE, 1_000_000 - op, _envByDepth[depth - 1]);
+            tracer.SetOperationStorage(Address.Zero, new UInt256((ulong)op), valueSpan, valueSpan);
+            tracer.ReportOperationRemainingGas(900_000 - op);
+        }
+        tracer.BuildResult();
+    }
+}


### PR DESCRIPTION
Targets #11693's branch (`debug-streaming`).

## Summary

- Drop per-tx `PipeWriter` flush in `GethLikeBlockEnvelopeStreamingTracer` — `StreamingResultBase.WriteToAsync` already flushes once at the end, and the inner `GethLikeTxDirectStreamingTracer` flushes periodically mid-tx, so the envelope-level flush was redundant.
- Reuse a single `GethLikeTxDirectStreamingTracer` across all txs in a block (both in the envelope and memory block tracers) via a new `ResetForNextTx(tx)` method. Added a protected `ResetTrace()` on `GethLikeTxTracer` so the cached `GethLikeTxTrace` is dropped per tx.
- Back the per-frame storage view with `ArrayPoolList<PooledDictionary<UInt256, UInt256>>`. Both the outer depth stack and each frame's slot map are pool-backed; `Clear()` on a popped frame keeps the rented arrays alive for the next push at that depth or the next tx; `Dispose()` returns everything to the pool. Replaces the `Stack<Dictionary>` that allocated a fresh `Dictionary` on every depth push.
- Switch the two block tracers' `Dispose()` to `DisposableExtensions.DisposeAndNull` (from #11725, now on master).

After the warmup of the first tx, no per-frame and no per-tx allocations remain on the storage path; tracer object and buffers all survive across the whole block.

The diff is wider than five files because this branch had to merge `master` to pick up `DisposeAndNull` — the actual touched files are:

- `src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj` (adds `Collections.Pooled` package ref)
- `src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockEnvelopeStreamingTracer.cs`
- `src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeBlockStreamingMemoryTracer.cs`
- `src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs`
- `src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs`

## Test plan

- [x] `dotnet test --project src/Nethermind/Nethermind.JsonRpc.Test --filter FullyQualifiedName~DebugRpcModuleTests` → 120/120
- [x] `dotnet test --project src/Nethermind/Nethermind.Blockchain.Test --filter FullyQualifiedName~GethLikeTxDirectStreamingTracerHex` → 9/9
- [x] `dotnet build src/Nethermind/Nethermind.Blockchain` clean (0 warnings, 0 errors)
- [ ] CI on the PR