### PR TITLE
test: bump executePayloadV1_accepts_already_known_block timeout to 60s

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -458,7 +458,7 @@ public partial class EngineModuleTests
 
     [TestCase(true)]
     [TestCase(false)]
-    [CancelAfter(30000)]
+    [CancelAfter(60000)]
     public virtual async Task executePayloadV1_accepts_already_known_block(bool throttleBlockProcessor, CancellationToken cancellationToken)
     {
         using MergeTestBlockchain chain = await CreateBaseBlockchain()


### PR DESCRIPTION
## Summary

- `executePayloadV1_accepts_already_known_block(True)` is flaking again on Flat DB CI by hitting its `[CancelAfter(30000)]` budget while waiting on `bestBlockProcessed.WaitAsync` (PR #11730, run [26317272304](https://github.com/NethermindEth/nethermind/actions/runs/26317272304/job/77479028818)).
- I previously bumped this test from 10s → 30s in #11380; 30s is no longer enough on slow runners.
- Aligns the cap with the 60s `NewPayloadBlockProcessingTimeout` already set in `MergeTestBlockchain` for the same reason (Flat DB CI load — see #11402).

## Test plan

- [ ] CI green on this PR
- [ ] Spot-check `dotnet test --project src/Nethermind/Nethermind.Merge.Plugin.Test -c release -- --filter "FullyQualifiedName~executePayloadV1_accepts_already_known_block"` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)