### PR TITLE
fix: satisfy IDE0028 in FakeRecordedBalStore

### DIFF
--- a/src/Nethermind/Nethermind.BalRecorder.Test/FakeRecordedBalStore.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/FakeRecordedBalStore.cs
@@ -10,7 +10,7 @@ namespace Nethermind.BalRecorder.Test;
 /// <summary>In-memory <see cref="IRecordedBalStore"/> for decorator tests.</summary>
 internal sealed class FakeRecordedBalStore : IRecordedBalStore
 {
-    private readonly Dictionary<long, ReadOnlyBlockAccessList> _seeded = new();
+    private readonly Dictionary<long, ReadOnlyBlockAccessList> _seeded = [];
 
     public bool ReplayEnabled { get; init; }
     public bool RecordingEnabled { get; init; }


### PR DESCRIPTION
## Summary

- Master currently fails to build: #11708 enabled IDE0028 enforcement, and the dictionary initializer added by #11700 (`FakeRecordedBalStore._seeded = new()`) trips the new rule.
- Switch the initializer to the collection-expression form `[]` to match the surrounding code (the adjacent `Inserted` list already uses `[]`).

## Changes

- `nuget` packages or dependencies addition / removal / version change
- New JSON-RPC method
- New configuration option
- Breaking config change
- Breaking DB change (requires resync)
- Breaking API change
- New metric
- Optimization
- Refactoring
- Bug fix ✔
- New feature

## Testing

- [x] `dotnet build -c release Nethermind.BalRecorder.Test/Nethermind.BalRecorder.Test.csproj` — passes (previously failed with IDE0028)

🤖 Generated with [Claude Code](https://claude.com/claude-code)