### PR TITLE
fix(FlatDB): prune orphaned non-canonical snapshots on persist

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -170,14 +170,14 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void TryLeaseState_MultipleLeases_AllSucceed()
+    public void TryLeaseState_MultipleLeases_AllSucceed([Values] bool compacted)
     {
-        AddSnapshotToRepository(0, 1);
+        AddSnapshotToRepository(0, 1, compacted: compacted);
 
         StateId to = CreateStateId(1);
-        bool leased1 = _repository.TryLeaseState(to, out Snapshot? snapshot1);
-        bool leased2 = _repository.TryLeaseState(to, out Snapshot? snapshot2);
-        bool leased3 = _repository.TryLeaseState(to, out Snapshot? snapshot3);
+        bool leased1 = TryLease(to, compacted, out Snapshot? snapshot1);
+        bool leased2 = TryLease(to, compacted, out Snapshot? snapshot2);
+        bool leased3 = TryLease(to, compacted, out Snapshot? snapshot3);
 
         Assert.That(leased1, Is.True);
         Assert.That(leased2, Is.True);
@@ -189,22 +189,6 @@ public class SnapshotRepositoryTests
         snapshot1!.Dispose();
         snapshot2!.Dispose();
         snapshot3!.Dispose();
-    }
-
-    [Test]
-    public void TryLeaseCompactedState_MultipleLeases_AllSucceed()
-    {
-        AddSnapshotToRepository(0, 1, compacted: true);
-
-        StateId to = CreateStateId(1);
-        bool leased1 = _repository.TryLeaseCompactedState(to, out Snapshot? snapshot1);
-        bool leased2 = _repository.TryLeaseCompactedState(to, out Snapshot? snapshot2);
-
-        Assert.That(leased1, Is.True);
-        Assert.That(leased2, Is.True);
-
-        snapshot1!.Dispose();
-        snapshot2!.Dispose();
     }
 
     #endregion

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -45,16 +45,17 @@ public class SnapshotRepositoryTests
     }
 
     private Snapshot AddSnapshotToRepository(long fromBlock, long toBlock, bool compacted = false, bool withData = false)
+        => AddSnapshotToRepository(CreateStateId(fromBlock), CreateStateId(toBlock), compacted, withData);
+
+    private Snapshot AddSnapshotToRepository(StateId from, StateId to, bool compacted = false, bool withData = false)
     {
-        StateId from = CreateStateId(fromBlock);
-        StateId to = CreateStateId(toBlock);
         Snapshot snapshot = CreateSnapshot(from, to, withData);
 
         bool added = compacted
             ? _repository.TryAddCompactedSnapshot(snapshot)
             : _repository.TryAddSnapshot(snapshot);
 
-        Assert.That(added, Is.True, $"Failed to add snapshot {fromBlock}->{toBlock}");
+        Assert.That(added, Is.True, $"Failed to add snapshot {from}->{to}");
 
         if (!compacted)
         {
@@ -366,4 +367,131 @@ public class SnapshotRepositoryTests
     }
 
     #endregion
+
+    [Test]
+    public void AssembleSnapshots_LinearChain_ReturnsAscendingPathToTarget()
+    {
+        BuildSnapshotChain(0, 5);
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(5), CreateStateId(0), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(5));
+        Assert.That(assembled[0].From, Is.EqualTo(CreateStateId(0)));
+        Assert.That(assembled[^1].To, Is.EqualTo(CreateStateId(5)));
+    }
+
+    [Test]
+    public void AssembleSnapshots_CompactedSnapshot_TakesWideHop()
+    {
+        AddSnapshotToRepository(0, 5, compacted: true);
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(5), CreateStateId(0), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(1));
+        Assert.That(assembled[0].From, Is.EqualTo(CreateStateId(0)));
+        Assert.That(assembled[0].To, Is.EqualTo(CreateStateId(5)));
+    }
+
+    [Test]
+    public void AssembleSnapshots_CompactedOvershoot_FallsBackToBaseEdges()
+    {
+        BuildSnapshotChain(0, 5);
+        AddSnapshotToRepository(0, 5, compacted: true); // Compacted edge overshoots target 2
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(5), CreateStateId(2), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(3));
+        Assert.That(assembled[0].From, Is.EqualTo(CreateStateId(2)));
+        Assert.That(assembled[^1].To, Is.EqualTo(CreateStateId(5)));
+    }
+
+    [Test]
+    public void AssembleSnapshots_BaseEqualsTarget_ReturnsEmpty()
+    {
+        BuildSnapshotChain(0, 3);
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(3), CreateStateId(3), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void AssembleSnapshots_UnreachableTarget_ReturnsEmpty()
+    {
+        // Chain starts at block 1, so block 0 is not reachable.
+        for (long block = 1; block < 4; block++)
+        {
+            AddSnapshotToRepository(block, block + 1);
+        }
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(4), CreateStateId(0), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void AssembleSnapshots_SelfReferencingSnapshot_ReturnsEmptyWithoutHanging()
+    {
+        // A snapshot whose From == To must not cause an infinite walk.
+        AddSnapshotToRepository(CreateStateId(1), CreateStateId(1));
+
+        using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(1), CreateStateId(0), 10);
+
+        Assert.That(assembled.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RemoveNonCanonicalStates_LinearChain_RemovesNothing()
+    {
+        BuildSnapshotChain(0, 10);
+
+        _repository.RemoveNonCanonicalStates(CreateStateId(5));
+
+        for (long block = 1; block <= 10; block++)
+        {
+            Assert.That(_repository.HasState(CreateStateId(block)), Is.True, $"State {block} should be kept");
+        }
+    }
+
+    [Test]
+    public void RemoveNonCanonicalStates_OrphanedFork_PrunesUnreachableDescendantsAbovePersistedBlock()
+    {
+        // Common chain 0->1->2->3, then a canonical branch and a non-canonical branch both
+        // diverging at block 3. Persisting canonical block 5 orphans the non-canonical
+        // descendants above block 5 - they must be pruned so HasState stops reporting them.
+        BuildSnapshotChain(0, 3);
+        for (long block = 3; block < 7; block++)
+        {
+            AddSnapshotToRepository(CreateStateId(block), CreateStateId(block + 1));
+        }
+        for (long block = 3; block < 7; block++)
+        {
+            StateId from = block == 3 ? CreateStateId(3) : CreateStateId(block, rootByte: 1);
+            AddSnapshotToRepository(from, CreateStateId(block + 1, rootByte: 1));
+        }
+
+        _repository.RemoveNonCanonicalStates(CreateStateId(5));
+
+        Assert.That(_repository.HasState(CreateStateId(6, rootByte: 1)), Is.False, "orphan NC(6) should be pruned");
+        Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.False, "orphan NC(7) should be pruned");
+        Assert.That(_repository.HasState(CreateStateId(6)), Is.True, "canonical C(6) should be kept");
+        Assert.That(_repository.HasState(CreateStateId(7)), Is.True, "canonical C(7) should be kept");
+        Assert.That(_repository.HasState(CreateStateId(5, rootByte: 1)), Is.True, "NC(5) at the persisted block is left to RemoveStatesUntil");
+        Assert.That(_repository.HasState(CreateStateId(4, rootByte: 1)), Is.True, "NC(4) below the persisted block is left to RemoveStatesUntil");
+    }
+
+    [Test]
+    public void RemoveNonCanonicalStates_ForkAbovePersistedBlock_KeepsBothBranches()
+    {
+        // A fork that diverges above the persisted block is still reachable from the
+        // canonical state and must be kept.
+        BuildSnapshotChain(0, 6);
+        AddSnapshotToRepository(CreateStateId(6), CreateStateId(7));
+        AddSnapshotToRepository(CreateStateId(6), CreateStateId(7, rootByte: 1));
+
+        _repository.RemoveNonCanonicalStates(CreateStateId(3));
+
+        Assert.That(_repository.HasState(CreateStateId(7)), Is.True);
+        Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.True);
+    }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -441,11 +441,11 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void RemoveNonCanonicalStates_LinearChain_RemovesNothing()
+    public void RemoveSiblingAndDescendents_LinearChain_RemovesNothing()
     {
         BuildSnapshotChain(0, 10);
 
-        _repository.RemoveNonCanonicalStates(CreateStateId(5));
+        _repository.RemoveSiblingAndDescendents(CreateStateId(5));
 
         for (long block = 1; block <= 10; block++)
         {
@@ -454,7 +454,7 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void RemoveNonCanonicalStates_OrphanedFork_PrunesUnreachableDescendantsAbovePersistedBlock()
+    public void RemoveSiblingAndDescendents_OrphanedFork_PrunesUnreachableDescendantsAbovePersistedBlock()
     {
         // Common chain 0->1->2->3, then a canonical branch and a non-canonical branch both
         // diverging at block 3. Persisting canonical block 5 orphans the non-canonical
@@ -470,7 +470,7 @@ public class SnapshotRepositoryTests
             AddSnapshotToRepository(from, CreateStateId(block + 1, rootByte: 1));
         }
 
-        _repository.RemoveNonCanonicalStates(CreateStateId(5));
+        _repository.RemoveSiblingAndDescendents(CreateStateId(5));
 
         Assert.That(_repository.HasState(CreateStateId(6, rootByte: 1)), Is.False, "orphan NC(6) should be pruned");
         Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.False, "orphan NC(7) should be pruned");
@@ -481,7 +481,7 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void RemoveNonCanonicalStates_ForkAbovePersistedBlock_KeepsBothBranches()
+    public void RemoveSiblingAndDescendents_ForkAbovePersistedBlock_KeepsBothBranches()
     {
         // A fork that diverges above the persisted block is still reachable from the
         // canonical state and must be kept.
@@ -489,7 +489,7 @@ public class SnapshotRepositoryTests
         AddSnapshotToRepository(CreateStateId(6), CreateStateId(7));
         AddSnapshotToRepository(CreateStateId(6), CreateStateId(7, rootByte: 1));
 
-        _repository.RemoveNonCanonicalStates(CreateStateId(3));
+        _repository.RemoveSiblingAndDescendents(CreateStateId(3));
 
         Assert.That(_repository.HasState(CreateStateId(7)), Is.True);
         Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.True);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -75,6 +75,17 @@ public class SnapshotRepositoryTests
         return snapshots;
     }
 
+    private void BuildSnapshotChain(StateId start, long endBlock, byte rootByte = 0)
+    {
+        StateId prev = start;
+        for (long block = start.BlockNumber + 1; block <= endBlock; block++)
+        {
+            StateId next = CreateStateId(block, rootByte);
+            AddSnapshotToRepository(prev, next);
+            prev = next;
+        }
+    }
+
     #region Snapshot Addition and Removal
 
     [Test]
@@ -396,7 +407,7 @@ public class SnapshotRepositoryTests
     public void AssembleSnapshots_CompactedOvershoot_FallsBackToBaseEdges()
     {
         BuildSnapshotChain(0, 5);
-        AddSnapshotToRepository(0, 5, compacted: true); // Compacted edge overshoots target 2
+        AddSnapshotToRepository(0, 5, compacted: true);
 
         using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(5), CreateStateId(2), 10);
 
@@ -418,11 +429,7 @@ public class SnapshotRepositoryTests
     [Test]
     public void AssembleSnapshots_UnreachableTarget_ReturnsEmpty()
     {
-        // Chain starts at block 1, so block 0 is not reachable.
-        for (long block = 1; block < 4; block++)
-        {
-            AddSnapshotToRepository(block, block + 1);
-        }
+        BuildSnapshotChain(1, 4);
 
         using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(4), CreateStateId(0), 10);
 
@@ -432,7 +439,6 @@ public class SnapshotRepositoryTests
     [Test]
     public void AssembleSnapshots_SelfReferencingSnapshot_ReturnsEmptyWithoutHanging()
     {
-        // A snapshot whose From == To must not cause an infinite walk.
         AddSnapshotToRepository(CreateStateId(1), CreateStateId(1));
 
         using SnapshotPooledList assembled = _repository.AssembleSnapshots(CreateStateId(1), CreateStateId(0), 10);
@@ -456,19 +462,11 @@ public class SnapshotRepositoryTests
     [Test]
     public void RemoveSiblingAndDescendents_OrphanedFork_PrunesUnreachableDescendantsAbovePersistedBlock()
     {
-        // Common chain 0->1->2->3, then a canonical branch and a non-canonical branch both
-        // diverging at block 3. Persisting canonical block 5 orphans the non-canonical
-        // descendants above block 5 - they must be pruned so HasState stops reporting them.
+        // Common 0->3, then canonical and non-canonical branches both diverging at block 3.
+        // Persisting C(5) must prune NC descendants above block 5 (kept at/below — that's RemoveStatesUntil's job).
         BuildSnapshotChain(0, 3);
-        for (long block = 3; block < 7; block++)
-        {
-            AddSnapshotToRepository(CreateStateId(block), CreateStateId(block + 1));
-        }
-        for (long block = 3; block < 7; block++)
-        {
-            StateId from = block == 3 ? CreateStateId(3) : CreateStateId(block, rootByte: 1);
-            AddSnapshotToRepository(from, CreateStateId(block + 1, rootByte: 1));
-        }
+        BuildSnapshotChain(CreateStateId(3), 7);
+        BuildSnapshotChain(CreateStateId(3), 7, rootByte: 1);
 
         _repository.RemoveSiblingAndDescendents(CreateStateId(5));
 
@@ -483,8 +481,6 @@ public class SnapshotRepositoryTests
     [Test]
     public void RemoveSiblingAndDescendents_ForkAbovePersistedBlock_KeepsBothBranches()
     {
-        // A fork that diverges above the persisted block is still reachable from the
-        // canonical state and must be kept.
         BuildSnapshotChain(0, 6);
         AddSnapshotToRepository(CreateStateId(6), CreateStateId(7));
         AddSnapshotToRepository(CreateStateId(6), CreateStateId(7, rootByte: 1));

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -65,6 +65,11 @@ public class SnapshotRepositoryTests
         return snapshot;
     }
 
+    private bool TryLease(StateId state, bool compacted, out Snapshot? snapshot)
+        => compacted
+            ? _repository.TryLeaseCompactedState(state, out snapshot)
+            : _repository.TryLeaseState(state, out snapshot);
+
     private List<Snapshot> BuildSnapshotChain(long startBlock, long endBlock)
     {
         List<Snapshot> snapshots = [];
@@ -89,32 +94,15 @@ public class SnapshotRepositoryTests
     #region Snapshot Addition and Removal
 
     [Test]
-    public void TryAddSnapshot_NewAndDuplicate_BehavesCorrectly()
+    public void TryAddSnapshot_NewAndDuplicate_BehavesCorrectly([Values] bool compacted)
     {
         StateId from = CreateStateId(0);
         StateId to = CreateStateId(1);
         Snapshot snapshot1 = CreateSnapshot(from, to);
         Snapshot snapshot2 = CreateSnapshot(from, to);
 
-        bool added1 = _repository.TryAddSnapshot(snapshot1);
-        bool added2 = _repository.TryAddSnapshot(snapshot2);
-
-        Assert.That(added1, Is.True);
-        Assert.That(added2, Is.False);
-
-        snapshot2.Dispose();
-    }
-
-    [Test]
-    public void TryAddCompactedSnapshot_NewAndDuplicate_BehavesCorrectly()
-    {
-        StateId from = CreateStateId(0);
-        StateId to = CreateStateId(1);
-        Snapshot snapshot1 = CreateSnapshot(from, to);
-        Snapshot snapshot2 = CreateSnapshot(from, to);
-
-        bool added1 = _repository.TryAddCompactedSnapshot(snapshot1);
-        bool added2 = _repository.TryAddCompactedSnapshot(snapshot2);
+        bool added1 = compacted ? _repository.TryAddCompactedSnapshot(snapshot1) : _repository.TryAddSnapshot(snapshot1);
+        bool added2 = compacted ? _repository.TryAddCompactedSnapshot(snapshot2) : _repository.TryAddSnapshot(snapshot2);
 
         Assert.That(added1, Is.True);
         Assert.That(added2, Is.False);
@@ -167,18 +155,16 @@ public class SnapshotRepositoryTests
     #region Lease Operations
 
     [Test]
-    public void TryLeaseState_ExistingAndNonExistent()
+    public void TryLeaseState_ExistingAndNonExistent([Values] bool compacted)
     {
-        AddSnapshotToRepository(0, 1);
+        AddSnapshotToRepository(0, 1, compacted: compacted);
 
-        StateId existing = CreateStateId(1);
-        bool leasedExisting = _repository.TryLeaseState(existing, out Snapshot? snapshot);
+        bool leasedExisting = TryLease(CreateStateId(1), compacted, out Snapshot? snapshot);
         Assert.That(leasedExisting, Is.True);
         Assert.That(snapshot, Is.Not.Null);
         snapshot!.Dispose();
 
-        StateId nonExistent = CreateStateId(999);
-        bool leasedNonExistent = _repository.TryLeaseState(nonExistent, out Snapshot? nonExistentSnapshot);
+        bool leasedNonExistent = TryLease(CreateStateId(999), compacted, out Snapshot? nonExistentSnapshot);
         Assert.That(leasedNonExistent, Is.False);
         Assert.That(nonExistentSnapshot, Is.Null);
     }
@@ -203,23 +189,6 @@ public class SnapshotRepositoryTests
         snapshot1!.Dispose();
         snapshot2!.Dispose();
         snapshot3!.Dispose();
-    }
-
-    [Test]
-    public void TryLeaseCompactedState_ExistingAndNonExistent()
-    {
-        AddSnapshotToRepository(0, 1, compacted: true);
-
-        StateId existing = CreateStateId(1);
-        bool leasedExisting = _repository.TryLeaseCompactedState(existing, out Snapshot? snapshot);
-        Assert.That(leasedExisting, Is.True);
-        Assert.That(snapshot, Is.Not.Null);
-        snapshot!.Dispose();
-
-        StateId nonExistent = CreateStateId(999);
-        bool leasedNonExistent = _repository.TryLeaseCompactedState(nonExistent, out Snapshot? nonExistentSnapshot);
-        Assert.That(leasedNonExistent, Is.False);
-        Assert.That(nonExistentSnapshot, Is.Null);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -289,11 +289,19 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
             // The BFS assembly returns a non-empty list only when it reaches the persisted state
             // exactly. An empty list while the target is not already the persisted state means the
-            // chain was removed concurrently (or is not yet complete) - retry until the deadline.
+            // chain was removed concurrently (or is not yet complete) - retry until the deadline,
+            // unless `baseBlock` itself has been pruned (orphaned non-canonical state), in which
+            // case no retry will recover it.
             if (snapshots.Count == 0 && persistenceReader.CurrentState != baseBlock)
             {
                 snapshots.Dispose();
                 persistenceReader.Dispose();
+
+                if (!_snapshotRepository.HasState(baseBlock))
+                {
+                    throw new InvalidOperationException($"State {baseBlock} no longer exists; concurrently removed.");
+                }
+
                 attempt++;
                 continue;
             }

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -287,11 +287,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             }
 
 
-            // The BFS assembly returns a non-empty list only when it reaches the persisted state
-            // exactly. An empty list while the target is not already the persisted state means the
-            // chain was removed concurrently (or is not yet complete) - retry until the deadline,
-            // unless `baseBlock` itself has been pruned (orphaned non-canonical state), in which
-            // case no retry will recover it.
+            // Empty result + reader not at baseBlock means the path was removed concurrently;
+            // retry unless baseBlock itself was pruned (orphaned), which no retry can recover.
             if (snapshots.Count == 0 && persistenceReader.CurrentState != baseBlock)
             {
                 snapshots.Dispose();

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -287,25 +287,15 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             }
 
 
-            if (snapshots.Count == 0)
+            // The BFS assembly returns a non-empty list only when it reaches the persisted state
+            // exactly. An empty list while the target is not already the persisted state means the
+            // chain was removed concurrently (or is not yet complete) - retry until the deadline.
+            if (snapshots.Count == 0 && persistenceReader.CurrentState != baseBlock)
             {
-                if (persistenceReader.CurrentState != baseBlock)
-                {
-                    persistenceReader.Dispose();
-                    throw new InvalidOperationException($"Unable to gather snapshots for state {baseBlock}.");
-                }
-            }
-            else
-            {
-                if (snapshots[0].From != persistenceReader.CurrentState)
-                {
-                    // Cannot assemble snapshot that reaches the persisted state snapshot. It could be that the snapshots was removed
-                    // concurrently. We will retry.
-                    snapshots.Dispose();
-                    persistenceReader.Dispose();
-                    attempt++;
-                    continue;
-                }
+                snapshots.Dispose();
+                persistenceReader.Dispose();
+                attempt++;
+                continue;
             }
 
             if (_logger.IsTrace) _logger.Trace($"Gathered {baseBlock}. Got {snapshots.Count} known states, Reader state: {persistenceReader.CurrentState}. Persistence state: {_persistenceManager.GetCurrentPersistedStateId()}");

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -264,7 +264,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             {
                 if (Stopwatch.GetElapsedTime(sw) > GatherGiveUpDeadline)
                 {
-                    throw new InvalidOperationException($"Unable to gather {nameof(ReadOnlySnapshotBundle)} for block {baseBlock} in {Stopwatch.GetElapsedTime(sw)}");
+                    throw new InvalidOperationException($"Timed out gathering {nameof(ReadOnlySnapshotBundle)} for block {baseBlock} after {attempt} retries over {Stopwatch.GetElapsedTime(sw)}");
                 }
 
                 int delayMs = Math.Min(1 << Math.Min(attempt, 30), 100);  // 1, 2, 4, 8, 16, 32, 64, 100ms max

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -22,6 +22,7 @@ public interface ISnapshotRepository
     SnapshotPooledList AssembleSnapshotsUntil(in StateId stateId, long minBlockNumber, int estimatedSize);
     StateId? GetLastSnapshotId();
     ArrayPoolList<StateId> GetStatesAtBlockNumber(long blockNumber);
+    bool HasForkAt(long blockNumber);
     void RemoveStatesUntil(in StateId currentPersistedStateId);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -22,7 +22,6 @@ public interface ISnapshotRepository
     SnapshotPooledList AssembleSnapshotsUntil(in StateId stateId, long minBlockNumber, int estimatedSize);
     StateId? GetLastSnapshotId();
     ArrayPoolList<StateId> GetStatesAtBlockNumber(long blockNumber);
-    bool HasForkAt(long blockNumber);
     void RemoveStatesUntil(in StateId currentPersistedStateId);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -35,5 +35,5 @@ public interface ISnapshotRepository
     /// persist commits so no reader observes an advanced persisted state alongside such orphans.
     /// </remarks>
     /// <param name="canonicalStateId">The canonical state being persisted.</param>
-    void RemoveNonCanonicalStates(in StateId canonicalStateId);
+    void RemoveSiblingAndDescendents(in StateId canonicalStateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -23,4 +23,17 @@ public interface ISnapshotRepository
     StateId? GetLastSnapshotId();
     ArrayPoolList<StateId> GetStatesAtBlockNumber(long blockNumber);
     void RemoveStatesUntil(in StateId currentPersistedStateId);
+
+    /// <summary>
+    /// Removes in-memory snapshots belonging to non-canonical forks that persisting
+    /// <paramref name="canonicalStateId"/> orphans.
+    /// </summary>
+    /// <remarks>
+    /// After a reorg a non-canonical fork can have descendants above the block being persisted.
+    /// Once the fork's parent at the persisted block is dropped those descendants become
+    /// unreachable yet still satisfy <see cref="HasState"/>. This must be called before the
+    /// persist commits so no reader observes an advanced persisted state alongside such orphans.
+    /// </remarks>
+    /// <param name="canonicalStateId">The canonical state being persisted.</param>
+    void RemoveNonCanonicalStates(in StateId canonicalStateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -160,6 +160,10 @@ public class PersistenceManager(
             if (snapshotToSave is null) return;
             using Snapshot _ = snapshotToSave; // dispose
 
+            // Prune non-canonical forks orphaned by this persist before committing it, so no reader
+            // can observe an advanced persisted state alongside now-unreachable in-memory snapshots.
+            snapshotRepository.RemoveNonCanonicalStates(snapshotToSave.To);
+
             // Add the canon snapshot
             PersistSnapshot(snapshotToSave);
             _currentPersistedStateId = snapshotToSave.To;
@@ -213,6 +217,9 @@ public class PersistenceManager(
             }
 
             using Snapshot _ = snapshotToPersist;
+
+            snapshotRepository.RemoveNonCanonicalStates(snapshotToPersist.To);
+
             PersistSnapshot(snapshotToPersist);
             _currentPersistedStateId = snapshotToPersist.To;
             currentPersistedState = _currentPersistedStateId;

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -162,7 +162,7 @@ public class PersistenceManager(
 
             // Prune non-canonical forks orphaned by this persist before committing it, so no reader
             // can observe an advanced persisted state alongside now-unreachable in-memory snapshots.
-            snapshotRepository.RemoveNonCanonicalStates(snapshotToSave.To);
+            snapshotRepository.RemoveSiblingAndDescendents(snapshotToSave.To);
 
             // Add the canon snapshot
             PersistSnapshot(snapshotToSave);
@@ -218,7 +218,7 @@ public class PersistenceManager(
 
             using Snapshot _ = snapshotToPersist;
 
-            snapshotRepository.RemoveNonCanonicalStates(snapshotToPersist.To);
+            snapshotRepository.RemoveSiblingAndDescendents(snapshotToPersist.To);
 
             PersistSnapshot(snapshotToPersist);
             _currentPersistedStateId = snapshotToPersist.To;

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -160,12 +160,7 @@ public class PersistenceManager(
             if (snapshotToSave is null) return;
             using Snapshot _ = snapshotToSave; // dispose
 
-            // Prune non-canonical forks orphaned by this persist before committing it, so no reader
-            // can observe an advanced persisted state alongside now-unreachable in-memory snapshots.
-            if (snapshotRepository.HasForkAt(snapshotToSave.To.BlockNumber))
-            {
-                snapshotRepository.RemoveSiblingAndDescendents(snapshotToSave.To);
-            }
+            snapshotRepository.RemoveSiblingAndDescendents(snapshotToSave.To);
 
             // Add the canon snapshot
             PersistSnapshot(snapshotToSave);
@@ -221,10 +216,7 @@ public class PersistenceManager(
 
             using Snapshot _ = snapshotToPersist;
 
-            if (snapshotRepository.HasForkAt(snapshotToPersist.To.BlockNumber))
-            {
-                snapshotRepository.RemoveSiblingAndDescendents(snapshotToPersist.To);
-            }
+            snapshotRepository.RemoveSiblingAndDescendents(snapshotToPersist.To);
 
             PersistSnapshot(snapshotToPersist);
             _currentPersistedStateId = snapshotToPersist.To;

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -162,7 +162,10 @@ public class PersistenceManager(
 
             // Prune non-canonical forks orphaned by this persist before committing it, so no reader
             // can observe an advanced persisted state alongside now-unreachable in-memory snapshots.
-            snapshotRepository.RemoveSiblingAndDescendents(snapshotToSave.To);
+            if (snapshotRepository.HasForkAt(snapshotToSave.To.BlockNumber))
+            {
+                snapshotRepository.RemoveSiblingAndDescendents(snapshotToSave.To);
+            }
 
             // Add the canon snapshot
             PersistSnapshot(snapshotToSave);
@@ -218,7 +221,10 @@ public class PersistenceManager(
 
             using Snapshot _ = snapshotToPersist;
 
-            snapshotRepository.RemoveSiblingAndDescendents(snapshotToPersist.To);
+            if (snapshotRepository.HasForkAt(snapshotToPersist.To.BlockNumber))
+            {
+                snapshotRepository.RemoveSiblingAndDescendents(snapshotToPersist.To);
+            }
 
             PersistSnapshot(snapshotToPersist);
             _currentPersistedStateId = snapshotToPersist.To;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -343,6 +343,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         parent.TryAdd(canonicalStateId, canonicalStateId);
         StateId canonicalRoot = Find(canonicalStateId);
 
+        int pruned = 0;
         foreach (StateId stateId in aboveStates)
         {
             // A state with no entry was never unioned (its snapshot vanished mid-pass); leave it.
@@ -350,7 +351,13 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
             {
                 RemoveAndReleaseCompactedKnownState(stateId);
                 RemoveAndReleaseKnownState(stateId);
+                pruned++;
             }
+        }
+
+        if (pruned > 0 && _logger.IsInfo)
+        {
+            _logger.Info($"Pruned {pruned} orphaned non-canonical snapshot(s) above persisted state {canonicalStateId}.");
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -286,7 +286,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         }
     }
 
-    public void RemoveNonCanonicalStates(in StateId canonicalStateId)
+    public void RemoveSiblingAndDescendents(in StateId canonicalStateId)
     {
         // A consistent point-in-time set of the states above the persisted block. Sourcing it from
         // the locked `_sortedSnapshotStateIds` (rather than enumerating the lock-free `_snapshots`)

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -300,7 +300,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         // the locked `_sortedSnapshotStateIds` (rather than enumerating the lock-free `_snapshots`)
         // guarantees that whenever a state is present so is its parent - `AddStateId` runs in block
         // order - an invariant the disjoint-set below relies on.
-        using ArrayPoolList<StateId> aboveStates = GetStatesAbove(canonicalStateId.BlockNumber);
+        using ArrayPoolListRef<StateId> aboveStates = GetStatesAbove(canonicalStateId.BlockNumber);
         if (aboveStates.Count == 0) return;
 
         // Disjoint-set over those states. Only the non-compacted snapshot of each state is unioned:
@@ -354,12 +354,16 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         }
     }
 
-    private ArrayPoolList<StateId> GetStatesAbove(long blockNumber)
+    private ArrayPoolListRef<StateId> GetStatesAbove(long blockNumber)
     {
         using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
 
-        return sortedSnapshots
-            .GetViewBetween(new StateId(blockNumber + 1, Hash256.Zero), new StateId(long.MaxValue, Keccak.MaxValue))
-            .ToPooledList(0);
+        SortedSet<StateId> view = sortedSnapshots.GetViewBetween(
+            new StateId(blockNumber + 1, Hash256.Zero),
+            new StateId(long.MaxValue, Keccak.MaxValue));
+
+        ArrayPoolListRef<StateId> result = new(view.Count);
+        foreach (StateId stateId in view) result.Add(stateId);
+        return result;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -34,10 +34,9 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     {
         if (baseBlock == targetState) return SnapshotPooledList.Empty();
 
-        // BFS over the snapshot graph: each StateId node has up to 2 edges, explored widest-jump
-        // first - the in-memory compacted snapshot, then the in-memory base snapshot. Finds a path
-        // from `baseBlock` back to exactly `targetState`. `visited` owns a lease on every leased
-        // snapshot; the winning path is re-leased before the finally releases all of them.
+        // BFS from baseBlock back to targetState across both compacted (wider jump, tried first) and
+        // base snapshot edges. `visited` owns a lease on every leased snapshot for the duration of
+        // the search; the winning path is re-acquired before the finally releases them all.
         using ArrayPoolListRef<(Snapshot Snapshot, int ParentIndex)> visited = new(estimatedSize);
         using PooledQueue<(StateId Current, int ParentIndex)> queue = new();
         using PooledSet<StateId> seen = new();
@@ -86,14 +85,12 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
             if (winnerIndex < 0) return SnapshotPooledList.Empty();
 
-            // Walk winner -> root: yields ascending order directly (result[0].From == targetState,
-            // result[^1].To == baseBlock).
+            // Walk winner -> root yields ascending order: result[0].From == targetState, result[^1].To == baseBlock.
             SnapshotPooledList result = new(estimatedSize);
             for (int walk = winnerIndex; walk >= 0; walk = visited[walk].ParentIndex)
             {
-                // `visited` still holds the BFS lease, so the ref-count is at least 1 and
-                // re-acquisition cannot fail. Asserted to flag any future Snapshot lifecycle change
-                // (e.g. a "closing" sentinel) that could invalidate the invariant.
+                // `visited` still holds a lease, so re-acquire cannot fail; assert flags future
+                // Snapshot lifecycle changes that could break this invariant.
                 bool acquired = visited[walk].Snapshot.TryAcquire();
                 Debug.Assert(acquired, "TryAcquire failed despite held lease");
                 result.Add(visited[walk].Snapshot);
@@ -222,7 +219,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         return sortedSnapshots.GetViewBetween(min, max).ToPooledList(0);
     }
 
-    public bool HasForkAt(long blockNumber)
+    private bool HasForkAt(long blockNumber)
     {
         using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
 
@@ -303,12 +300,9 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
     public void RemoveSiblingAndDescendents(in StateId canonicalStateId)
     {
-        // Walk blocks above the persisted state in batches of `PruneBatchSize`. For each state
-        // probe a DFS path back to `canonicalStateId`; states with no such path are orphaned
-        // descendants of a non-canonical sibling and must be dropped. Processing ascending lets the
-        // DFS for higher states short-circuit cheaply: once a non-canonical state is removed its
-        // descendants' edges lead into an empty entry and the search returns immediately. Compacted
-        // snapshots are followed too - their wider jumps make the canonical probe terminate fast.
+        // Fast-fail when the persisted block has no sibling state: nothing above it can be orphaned.
+        if (!HasForkAt(canonicalStateId.BlockNumber)) return;
+
         StateId? lastStateId = GetLastSnapshotId();
         if (lastStateId is null || lastStateId.Value.BlockNumber <= canonicalStateId.BlockNumber) return;
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -37,7 +37,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         // first - the in-memory compacted snapshot, then the in-memory base snapshot. Finds a path
         // from `baseBlock` back to exactly `targetState`. `visited` owns a lease on every leased
         // snapshot; the winning path is re-leased before the finally releases all of them.
-        using ArrayPoolList<(Snapshot Snapshot, int ParentIndex)> visited = new(estimatedSize);
+        using ArrayPoolListRef<(Snapshot Snapshot, int ParentIndex)> visited = new(estimatedSize);
         using PooledQueue<(StateId Current, int ParentIndex)> queue = new();
         using PooledSet<StateId> seen = new();
         try
@@ -64,8 +64,6 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
                     StateId from = snapshot.From;
 
-                    // In-memory snapshots are persistence-granular, so an edge that lands below the
-                    // target cannot be part of a valid path; a cycle (incl. `from == current`) likewise.
                     if (from.BlockNumber < targetState.BlockNumber || !seen.Add(from))
                     {
                         snapshot.Dispose();
@@ -217,6 +215,16 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         StateId max = new(blockNumber, ValueKeccak.MaxValue);
 
         return sortedSnapshots.GetViewBetween(min, max).ToPooledList(0);
+    }
+
+    public bool HasForkAt(long blockNumber)
+    {
+        using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
+
+        StateId min = new(blockNumber, ValueKeccak.Zero);
+        StateId max = new(blockNumber, ValueKeccak.MaxValue);
+
+        return sortedSnapshots.GetViewBetween(min, max).Count > 1;
     }
 
     public StateId? GetLastSnapshotId()

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -294,80 +294,94 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         }
     }
 
+    private const int PruneBatchSize = 1000;
+
     public void RemoveSiblingAndDescendents(in StateId canonicalStateId)
     {
-        // A consistent point-in-time set of the states above the persisted block. Sourcing it from
-        // the locked `_sortedSnapshotStateIds` (rather than enumerating the lock-free `_snapshots`)
-        // guarantees that whenever a state is present so is its parent - `AddStateId` runs in block
-        // order - an invariant the disjoint-set below relies on.
-        using ArrayPoolListRef<StateId> aboveStates = GetStatesAbove(canonicalStateId.BlockNumber);
-        if (aboveStates.Count == 0) return;
+        // Walk blocks above the persisted state in batches of `PruneBatchSize`. For each state
+        // probe a DFS path back to `canonicalStateId`; states with no such path are orphaned
+        // descendants of a non-canonical sibling and must be dropped. Processing ascending lets the
+        // DFS for higher states short-circuit cheaply: once a non-canonical state is removed its
+        // descendants' edges lead into an empty entry and the search returns immediately. Compacted
+        // snapshots are followed too - their wider jumps make the canonical probe terminate fast.
+        StateId? lastStateId = GetLastSnapshotId();
+        if (lastStateId is null || lastStateId.Value.BlockNumber <= canonicalStateId.BlockNumber) return;
 
-        // Disjoint-set over those states. Only the non-compacted snapshot of each state is unioned:
-        // its `From` is a single block back, so no edge crosses the persisted-block boundary and
-        // each fork stays in the component anchored at its own block-`persistBlockNumber` state.
-        // Compacted snapshots are excluded because they can span the boundary and would wrongly
-        // merge the canonical and non-canonical components.
-        using PooledDictionary<StateId, StateId> parent = new();
+        long maxBlock = lastStateId.Value.BlockNumber;
+        long batchStart = canonicalStateId.BlockNumber + 1;
+        int totalPruned = 0;
 
-        StateId Find(StateId node)
+        using PooledStack<StateId> stack = new();
+        using PooledSet<StateId> seen = new();
+
+        while (batchStart <= maxBlock)
         {
-            StateId root = parent[node];
-            while (root != node)
+            long batchEnd = Math.Min(batchStart + PruneBatchSize - 1, maxBlock);
+            using ArrayPoolListRef<StateId> batch = GetStatesInRange(batchStart, batchEnd);
+            foreach (StateId stateId in batch)
             {
-                StateId grandparent = parent[root];
-                parent[node] = grandparent; // Path halving
-                node = root;
-                root = grandparent;
+                if (!CanReachState(stateId, canonicalStateId, stack, seen))
+                {
+                    RemoveAndReleaseCompactedKnownState(stateId);
+                    RemoveAndReleaseKnownState(stateId);
+                    totalPruned++;
+                }
             }
-            return root;
+            batchStart = batchEnd + 1;
         }
 
-        void Union(StateId a, StateId b)
+        if (totalPruned > 0 && _logger.IsInfo)
         {
-            parent.TryAdd(a, a);
-            parent.TryAdd(b, b);
-            StateId rootA = Find(a);
-            StateId rootB = Find(b);
-            if (rootA != rootB) parent[rootA] = rootB;
-        }
-
-        foreach (StateId stateId in aboveStates)
-        {
-            if (_snapshots.TryGetValue(stateId, out Snapshot? snapshot))
-            {
-                Union(snapshot.To, snapshot.From);
-            }
-        }
-
-        parent.TryAdd(canonicalStateId, canonicalStateId);
-        StateId canonicalRoot = Find(canonicalStateId);
-
-        int pruned = 0;
-        foreach (StateId stateId in aboveStates)
-        {
-            // A state with no entry was never unioned (its snapshot vanished mid-pass); leave it.
-            if (parent.ContainsKey(stateId) && Find(stateId) != canonicalRoot)
-            {
-                RemoveAndReleaseCompactedKnownState(stateId);
-                RemoveAndReleaseKnownState(stateId);
-                pruned++;
-            }
-        }
-
-        if (pruned > 0 && _logger.IsInfo)
-        {
-            _logger.Info($"Pruned {pruned} orphaned non-canonical snapshot(s) above persisted state {canonicalStateId}.");
+            _logger.Info($"Pruned {totalPruned} orphaned non-canonical snapshot(s) above persisted state {canonicalStateId}.");
         }
     }
 
-    private ArrayPoolListRef<StateId> GetStatesAbove(long blockNumber)
+    private bool CanReachState(in StateId from, in StateId target, PooledStack<StateId> stack, PooledSet<StateId> seen)
+    {
+        if (from == target) return true;
+        if (from.BlockNumber <= target.BlockNumber) return false;
+
+        stack.Clear();
+        seen.Clear();
+        stack.Push(from);
+        seen.Add(from);
+
+        while (stack.Count > 0)
+        {
+            StateId current = stack.Pop();
+
+            for (int edge = 0; edge < 2; edge++)
+            {
+                Snapshot? snapshot;
+                if (edge == 0)
+                {
+                    if (!TryLeaseCompactedState(current, out snapshot)) continue;
+                }
+                else
+                {
+                    if (!TryLeaseState(current, out snapshot)) continue;
+                }
+
+                StateId parent = snapshot.From;
+                snapshot.Dispose();
+
+                if (parent == target) return true;
+                if (parent.BlockNumber > target.BlockNumber && seen.Add(parent))
+                {
+                    stack.Push(parent);
+                }
+            }
+        }
+        return false;
+    }
+
+    private ArrayPoolListRef<StateId> GetStatesInRange(long blockStartInclusive, long blockEndInclusive)
     {
         using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
 
         SortedSet<StateId> view = sortedSnapshots.GetViewBetween(
-            new StateId(blockNumber + 1, Hash256.Zero),
-            new StateId(long.MaxValue, Keccak.MaxValue));
+            new StateId(blockStartInclusive, Hash256.Zero),
+            new StateId(blockEndInclusive, Keccak.MaxValue));
 
         ArrayPoolListRef<StateId> result = new(view.Count);
         foreach (StateId stateId in view) result.Add(stateId);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Collections.Pooled;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -30,16 +31,79 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
     public SnapshotPooledList AssembleSnapshots(in StateId baseBlock, in StateId targetState, int estimatedSize)
     {
-        SnapshotPooledList list = AssembleSnapshotsUntil(baseBlock, targetState.BlockNumber, estimatedSize);
-        if (list.Count > 0 && list[0].From.BlockNumber == targetState.BlockNumber && list[0].From != targetState)
+        if (baseBlock == targetState) return SnapshotPooledList.Empty();
+
+        // BFS over the snapshot graph: each StateId node has up to 2 edges, explored widest-jump
+        // first - the in-memory compacted snapshot, then the in-memory base snapshot. Finds a path
+        // from `baseBlock` back to exactly `targetState`. `visited` owns a lease on every leased
+        // snapshot; the winning path is re-leased before the finally releases all of them.
+        using ArrayPoolList<(Snapshot Snapshot, int ParentIndex)> visited = new(estimatedSize);
+        using PooledQueue<(StateId Current, int ParentIndex)> queue = new();
+        using PooledSet<StateId> seen = new();
+        try
         {
-            list.Dispose();
+            queue.Enqueue((baseBlock, -1));
+            seen.Add(baseBlock);
+            int winnerIndex = -1;
 
-            // Likely persisted a non-finalized block.
-            throw new InvalidOperationException($"Attempted to compile snapshots from {baseBlock} to {targetState} but target is not reachable from baseBlock");
+            while (queue.Count > 0 && winnerIndex < 0)
+            {
+                (StateId current, int parentIndex) = queue.Dequeue();
+
+                for (int edge = 0; edge < 2; edge++)
+                {
+                    Snapshot? snapshot;
+                    if (edge == 0)
+                    {
+                        if (!TryLeaseCompactedState(current, out snapshot)) continue;
+                    }
+                    else
+                    {
+                        if (!TryLeaseState(current, out snapshot)) continue;
+                    }
+
+                    StateId from = snapshot.From;
+
+                    // In-memory snapshots are persistence-granular, so an edge that lands below the
+                    // target cannot be part of a valid path; a cycle (incl. `from == current`) likewise.
+                    if (from.BlockNumber < targetState.BlockNumber || !seen.Add(from))
+                    {
+                        snapshot.Dispose();
+                        continue;
+                    }
+
+                    int index = visited.Count;
+                    visited.Add((snapshot, parentIndex));
+
+                    if (from == targetState)
+                    {
+                        winnerIndex = index;
+                        break;
+                    }
+
+                    queue.Enqueue((from, index));
+                }
+            }
+
+            if (winnerIndex < 0) return SnapshotPooledList.Empty();
+
+            // Walk winner -> root: yields ascending order directly (result[0].From == targetState,
+            // result[^1].To == baseBlock).
+            SnapshotPooledList result = new(estimatedSize);
+            for (int walk = winnerIndex; walk >= 0; walk = visited[walk].ParentIndex)
+            {
+                visited[walk].Snapshot.TryAcquire();
+                result.Add(visited[walk].Snapshot);
+            }
+            return result;
         }
-
-        return list;
+        finally
+        {
+            for (int i = 0; i < visited.Count; i++)
+            {
+                visited[i].Snapshot.Dispose();
+            }
+        }
     }
 
     public SnapshotPooledList AssembleSnapshotsUntil(in StateId baseBlock, long minBlockNumber, int estimatedSize)
@@ -220,5 +284,74 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
             RemoveAndReleaseCompactedKnownState(stateToRemove);
             RemoveAndReleaseKnownState(stateToRemove);
         }
+    }
+
+    public void RemoveNonCanonicalStates(in StateId canonicalStateId)
+    {
+        // A consistent point-in-time set of the states above the persisted block. Sourcing it from
+        // the locked `_sortedSnapshotStateIds` (rather than enumerating the lock-free `_snapshots`)
+        // guarantees that whenever a state is present so is its parent - `AddStateId` runs in block
+        // order - an invariant the disjoint-set below relies on.
+        using ArrayPoolList<StateId> aboveStates = GetStatesAbove(canonicalStateId.BlockNumber);
+        if (aboveStates.Count == 0) return;
+
+        // Disjoint-set over those states. Only the non-compacted snapshot of each state is unioned:
+        // its `From` is a single block back, so no edge crosses the persisted-block boundary and
+        // each fork stays in the component anchored at its own block-`persistBlockNumber` state.
+        // Compacted snapshots are excluded because they can span the boundary and would wrongly
+        // merge the canonical and non-canonical components.
+        using PooledDictionary<StateId, StateId> parent = new();
+
+        StateId Find(StateId node)
+        {
+            StateId root = parent[node];
+            while (root != node)
+            {
+                StateId grandparent = parent[root];
+                parent[node] = grandparent; // Path halving
+                node = root;
+                root = grandparent;
+            }
+            return root;
+        }
+
+        void Union(StateId a, StateId b)
+        {
+            parent.TryAdd(a, a);
+            parent.TryAdd(b, b);
+            StateId rootA = Find(a);
+            StateId rootB = Find(b);
+            if (rootA != rootB) parent[rootA] = rootB;
+        }
+
+        foreach (StateId stateId in aboveStates)
+        {
+            if (_snapshots.TryGetValue(stateId, out Snapshot? snapshot))
+            {
+                Union(snapshot.To, snapshot.From);
+            }
+        }
+
+        parent.TryAdd(canonicalStateId, canonicalStateId);
+        StateId canonicalRoot = Find(canonicalStateId);
+
+        foreach (StateId stateId in aboveStates)
+        {
+            // A state with no entry was never unioned (its snapshot vanished mid-pass); leave it.
+            if (parent.ContainsKey(stateId) && Find(stateId) != canonicalRoot)
+            {
+                RemoveAndReleaseCompactedKnownState(stateId);
+                RemoveAndReleaseKnownState(stateId);
+            }
+        }
+    }
+
+    private ArrayPoolList<StateId> GetStatesAbove(long blockNumber)
+    {
+        using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
+
+        return sortedSnapshots
+            .GetViewBetween(new StateId(blockNumber + 1, Hash256.Zero), new StateId(long.MaxValue, Keccak.MaxValue))
+            .ToPooledList(0);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Collections.Pooled;
 using Nethermind.Core.Collections;
@@ -90,7 +91,11 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
             SnapshotPooledList result = new(estimatedSize);
             for (int walk = winnerIndex; walk >= 0; walk = visited[walk].ParentIndex)
             {
-                visited[walk].Snapshot.TryAcquire();
+                // `visited` still holds the BFS lease, so the ref-count is at least 1 and
+                // re-acquisition cannot fail. Asserted to flag any future Snapshot lifecycle change
+                // (e.g. a "closing" sentinel) that could invalidate the invariant.
+                bool acquired = visited[walk].Snapshot.TryAcquire();
+                Debug.Assert(acquired, "TryAcquire failed despite held lease");
                 result.Add(visited[walk].Snapshot);
             }
             return result;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -31,12 +31,31 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     }
 
     public SnapshotPooledList AssembleSnapshots(in StateId baseBlock, in StateId targetState, int estimatedSize)
-    {
-        if (baseBlock == targetState) return SnapshotPooledList.Empty();
+        => baseBlock == targetState
+            ? SnapshotPooledList.Empty()
+            : AssembleSnapshotsBfs(baseBlock, targetState.BlockNumber, targetState, estimatedSize);
 
-        // BFS from baseBlock back to targetState across both compacted (wider jump, tried first) and
-        // base snapshot edges. `visited` owns a lease on every leased snapshot for the duration of
-        // the search; the winning path is re-acquired before the finally releases them all.
+    public SnapshotPooledList AssembleSnapshotsUntil(in StateId baseBlock, long minBlockNumber, int estimatedSize)
+        => AssembleSnapshotsBfs(baseBlock, minBlockNumber, exactTarget: null, estimatedSize);
+
+    /// <summary>
+    /// BFS over the snapshot graph from <paramref name="baseBlock"/> back toward
+    /// <paramref name="minBlockNumber"/>, returning the snapshots along the winning path in ascending
+    /// order (<c>result[0].From</c> is the terminus, <c>result[^1].To == baseBlock</c>). Returns an
+    /// empty list when no path reaches the terminus.
+    /// </summary>
+    /// <remarks>
+    /// Each StateId node has up to 2 edges, explored widest-jump first - the in-memory compacted
+    /// snapshot, then the in-memory base snapshot. Edges dropping below <paramref name="minBlockNumber"/>
+    /// are pruned, so a wide compacted jump that overshoots is discarded in favour of the narrower base
+    /// edge. The path wins at the first node reaching <paramref name="minBlockNumber"/>; when
+    /// <paramref name="exactTarget"/> is supplied that node must also equal it (used to assemble a path
+    /// to a specific state), otherwise any state at that block number qualifies (used to gather a window
+    /// for compaction). `visited` owns a lease on every leased snapshot; the winning path is re-leased
+    /// before the finally releases all of them.
+    /// </remarks>
+    private SnapshotPooledList AssembleSnapshotsBfs(in StateId baseBlock, long minBlockNumber, StateId? exactTarget, int estimatedSize)
+    {
         using ArrayPoolListRef<(Snapshot Snapshot, int ParentIndex)> visited = new(estimatedSize);
         using PooledQueue<(StateId Current, int ParentIndex)> queue = new();
         using PooledSet<StateId> seen = new();
@@ -64,7 +83,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
                     StateId from = snapshot.From;
 
-                    if (from.BlockNumber < targetState.BlockNumber || !seen.Add(from))
+                    if (from.BlockNumber < minBlockNumber || !seen.Add(from))
                     {
                         snapshot.Dispose();
                         continue;
@@ -73,7 +92,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
                     int index = visited.Count;
                     visited.Add((snapshot, parentIndex));
 
-                    if (from == targetState)
+                    if (from.BlockNumber == minBlockNumber && (exactTarget is not StateId target || from == target))
                     {
                         winnerIndex = index;
                         break;
@@ -85,7 +104,8 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
 
             if (winnerIndex < 0) return SnapshotPooledList.Empty();
 
-            // Walk winner -> root yields ascending order: result[0].From == targetState, result[^1].To == baseBlock.
+            // Walk winner -> root: yields ascending order directly (result[0].From == terminus,
+            // result[^1].To == baseBlock).
             SnapshotPooledList result = new(estimatedSize);
             for (int walk = winnerIndex; walk >= 0; walk = visited[walk].ParentIndex)
             {
@@ -104,53 +124,6 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
                 visited[i].Snapshot.Dispose();
             }
         }
-    }
-
-    public SnapshotPooledList AssembleSnapshotsUntil(in StateId baseBlock, long minBlockNumber, int estimatedSize)
-    {
-        SnapshotPooledList snapshots = new(estimatedSize);
-
-        StateId current = baseBlock;
-        while (TryLeaseCompactedState(current, out Snapshot? snapshot) || TryLeaseState(current, out snapshot))
-        {
-            if (_logger.IsTrace) _logger.Trace($"Got {snapshot.From} -> {snapshot.To}");
-
-            if (snapshot.From.BlockNumber < minBlockNumber)
-            {
-                // `snapshot` is now a compacted snapshot, we dont want to use it.
-                snapshot.Dispose();
-
-                // Try got get a non compacted one
-                if (!TryLeaseState(current, out snapshot))
-                {
-                    // Failure, exit loop.
-                    break;
-                }
-            }
-
-            if (snapshot.From.BlockNumber < minBlockNumber)
-            {
-                // Should not happen... unless someone try to add out of order snapshots
-                snapshot.Dispose();
-                break;
-            }
-
-            snapshots.Add(snapshot);
-            if (snapshot.From == current)
-            {
-                break; // Some test commit two block with the same id, so we dont know the parent anymore.
-            }
-
-            if (snapshot.From.BlockNumber == minBlockNumber)
-            {
-                break;
-            }
-
-            current = snapshot.From;
-        }
-
-        snapshots.Reverse();
-        return snapshots;
     }
 
     public bool TryLeaseCompactedState(in StateId stateId, [NotNullWhen(true)] out Snapshot? entry)


### PR DESCRIPTION
## Changes

After a reorg, `RemoveStatesUntil` drops the non-canonical state at the persisted block but leaves its descendants above that block orphaned: unreachable from the persisted state yet still reported as available by `HasState`. This PR fixes that:

- `RemoveNonCanonicalStates` now prunes orphaned forks before each persist (in `AddToPersistence`/`FlushToPersistence`, before the persisted pointer advances) via a disjoint-set over the in-memory snapshots above the persisted block, sourced from the locked sorted state-id set so the parent-present-if-child-present invariant holds.
- Replaces the linear `AssembleSnapshots` with a BFS graph-walk over the in-memory compacted/base edges.
- Adapts `GatherReadOnlySnapshotBundle` to retry on an empty assembly result.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New regression tests added in `SnapshotRepositoryTests` covering the orphaned-fork pruning behavior.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No