### PR TITLE
Fix Geth genesis deposit contract fallback to use zero address

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -1142,7 +1142,7 @@ public class ChainSpecBasedSpecProviderTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(provider.GenesisSpec.IsEip6110Enabled, Is.True);
-            Assert.That(provider.GenesisSpec.DepositContractAddress, Is.EqualTo(Eip6110Constants.MainnetDepositContractAddress));
+            Assert.That(provider.GenesisSpec.DepositContractAddress, Is.EqualTo(Address.Zero));
         }
     }
 

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -376,6 +376,15 @@ public class GethGenesisLoaderTests
         chainSpec.Parameters.Eip6110TransitionTimestamp.Should().Be(1800000000);
     }
 
+    [Test]
+    public void Defaults_deposit_contract_to_zero_when_unspecified()
+    {
+        ChainSpec chainSpec = LoadStandardGethGenesis(chainId: 12345, configExtra: "\"pragueTime\": 1800000000");
+
+        chainSpec.Parameters.DepositContractAddress.Should().Be(Address.Zero);
+        chainSpec.Parameters.Eip6110TransitionTimestamp.Should().Be(1800000000);
+    }
+
     /// <summary>
     /// Returns EIP numbers newly enabled by <paramref name="fork"/> compared to its <paramref name="parent"/>.
     /// </summary>

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
@@ -157,7 +157,7 @@ public class GethGenesisLoader(IJsonSerializer serializer) : IChainSpecLoader
             // the side-effects that don't fit the bulk-label pattern stay here as conditional gates.
             Eip4788ContractAddress = config.CancunTime is null ? null : Eip4788Constants.BeaconRootsAddress,
             Eip2935ContractAddress = config.PragueTime is null ? null : Eip2935Constants.BlockHashHistoryAddress,
-            DepositContractAddress = config.PragueTime is null ? null : config.DepositContractAddress ?? Eip6110Constants.MainnetDepositContractAddress,
+            DepositContractAddress = config.PragueTime is null ? null : config.DepositContractAddress ?? Address.Zero,
             Eip7002ContractAddress = config.PragueTime is null ? null : Eip7002Constants.WithdrawalRequestPredeployAddress,
             Eip7251ContractAddress = config.PragueTime is null ? null : Eip7251Constants.ConsolidationRequestPredeployAddress,
             Eip7934MaxRlpBlockSize = Eip7934Constants.DefaultMaxRlpBlockSize,


### PR DESCRIPTION
## Changes

- `GethGenesisLoader` previously substituted `Eip6110Constants.MainnetDepositContractAddress` whenever a Geth-style genesis enabled Prague but omitted `depositContractAddress`. Geth itself defaults the field to `common.Address{}` (zero address), so `eth_config` / EIP-7910 must report `0x000…000` to match. Fall back to `Address.Zero` instead.
- Added regression test `GethGenesisLoaderTests.Defaults_deposit_contract_to_zero_when_unspecified` covering a non-mainnet chain with `pragueTime` but no `depositContractAddress`.
- Updated `ChainSpecBasedSpecProviderTests.Geth_genesis_defaults_deposit_contract_address_when_prague_is_active`, which had codified the old (buggy) mainnet fallback, to expect `Address.Zero`.

Existing Nethermind chainspecs (`foundation.json`, `sepolia.json`, `hoodi.json`, `gnosis.json`, etc.) all declare `depositContractAddress` explicitly, so this fallback change does not affect behavior on any known chain — only the Hive-style genesis path that was relying on the implicit mainnet substitution.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Verified failing Hive `eth_config` scenario:

\`\`\`
>>  {"jsonrpc":"2.0","id":1,"method":"eth_config"}
<<  ... "DEPOSIT_CONTRACT_ADDRESS":"0x00000000219ab540356cbb839cbe05303d7705fa" ...
expected: "0x0000000000000000000000000000000000000000"
\`\`\`

After the fix the loader yields `Address.Zero` for that case, and the full `Nethermind.Specs.Test` suite (277 tests) passes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No