### PR TITLE
test(sync): un-ignore Can_cancel_seal_validation

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
@@ -284,7 +284,6 @@ public partial class ForwardHeaderProviderTests
     }
 
     [Test, MaxTime(7000)]
-    [Ignore("Fails OneLoggerLogManager Travis only")]
     public async Task Can_cancel_seal_validation()
     {
         await using IContainer node = CreateNode(builder => builder.AddSingleton<ISealValidator>(new SlowSealValidator()));


### PR DESCRIPTION
## Changes

- `Nethermind.Synchronization.Test.ForwardHeaderProviderTests.Can_cancel_seal_validation` has been `[Ignore]`d since the Travis CI days with the comment `"Fails OneLoggerLogManager Travis only"`. Travis was retired years ago and the test has been silently skipped ever since — meaning we have had zero real coverage of `IForwardHeaderProvider.GetBlockHeaders` cancellation when seal validation is slow.
- Locally on `release/net10.0`, the test passes cleanly: 20 consecutive standalone runs and the full `ForwardHeaderProvider*` fixture (39 tests) all green.
- Drop the attribute so the test runs in normal CI again.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Re-enable a previously skipped test

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The PR _is_ the test re-enablement; no new test added. Verified locally with 20x stress runs (all pass) plus the surrounding 39-test fixture (all pass). Will be visible in CI on this branch.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
