### PR TITLE
refactor: take ReadOnlySpan<byte> rlp on IPersistence trie writes

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 using Nethermind.State.Flat.Persistence;
+using Nethermind.Trie;
 using NSubstitute;
 
 namespace Nethermind.State.Flat.Test;
@@ -29,4 +34,55 @@ internal static class FlatTestHelpers
     /// </summary>
     public static ReadOnlySnapshotBundle MakeBundle(ResourcePool pool, Action<SnapshotContent>? populate = null) =>
         new(SnapshotList(MakeSnapshot(pool, populate)), Substitute.For<IPersistence.IPersistenceReader>(), recordDetailedMetrics: false);
+}
+
+/// <summary>
+/// Hand-rolled fake for <see cref="IPersistence.IWriteBatch"/> that records every call into public lists.
+/// Used in tests in place of <c>Substitute.For&lt;IPersistence.IWriteBatch&gt;()</c> because Castle DynamicProxy
+/// (NSubstitute's backing) throws <c>InvalidProgramException</c> when proxying methods with ref-struct parameters
+/// such as <c>scoped ReadOnlySpan&lt;byte&gt;</c>.
+/// </summary>
+internal sealed class FakeWriteBatch : IPersistence.IWriteBatch
+{
+    public List<Address> SelfDestructCalls { get; } = [];
+    public List<(Address Addr, Account? Account)> SetAccountCalls { get; } = [];
+    public List<(Address Addr, UInt256 Slot, SlotValue? Value)> SetStorageCalls { get; } = [];
+    public List<(TreePath Path, byte[] Rlp)> SetStateTrieNodeCalls { get; } = [];
+    public List<(Hash256 Address, TreePath Path, byte[] Rlp)> SetStorageTrieNodeCalls { get; } = [];
+    public List<(ValueHash256 AddrHash, ValueHash256 SlotHash, SlotValue? Value)> SetStorageRawCalls { get; } = [];
+    public List<(ValueHash256 AddrHash, Account Account)> SetAccountRawCalls { get; } = [];
+    public List<(ValueHash256 FromPath, ValueHash256 ToPath)> DeleteAccountRangeCalls { get; } = [];
+    public List<(ValueHash256 AddressHash, ValueHash256 FromPath, ValueHash256 ToPath)> DeleteStorageRangeCalls { get; } = [];
+    public List<(TreePath FromPath, TreePath ToPath)> DeleteStateTrieNodeRangeCalls { get; } = [];
+    public List<(ValueHash256 AddressHash, TreePath FromPath, TreePath ToPath)> DeleteStorageTrieNodeRangeCalls { get; } = [];
+    public int DisposeCount { get; private set; }
+
+    public void SelfDestruct(Address addr) => SelfDestructCalls.Add(addr);
+    public void SetAccount(Address addr, Account? account) => SetAccountCalls.Add((addr, account));
+    public void SetStorage(Address addr, in UInt256 slot, in SlotValue? value) => SetStorageCalls.Add((addr, slot, value));
+
+    public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp) =>
+        SetStateTrieNodeCalls.Add((path, rlp.ToArray()));
+
+    public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp) =>
+        SetStorageTrieNodeCalls.Add((address, path, rlp.ToArray()));
+
+    public void SetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? value) =>
+        SetStorageRawCalls.Add((addrHash, slotHash, value));
+
+    public void SetAccountRaw(in ValueHash256 addrHash, Account account) => SetAccountRawCalls.Add((addrHash, account));
+
+    public void DeleteAccountRange(in ValueHash256 fromPath, in ValueHash256 toPath) =>
+        DeleteAccountRangeCalls.Add((fromPath, toPath));
+
+    public void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath) =>
+        DeleteStorageRangeCalls.Add((addressHash, fromPath, toPath));
+
+    public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) =>
+        DeleteStateTrieNodeRangeCalls.Add((fromPath, toPath));
+
+    public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) =>
+        DeleteStorageTrieNodeRangeCalls.Add((addressHash, fromPath, toPath));
+
+    public void Dispose() => DisposeCount++;
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
@@ -95,11 +95,14 @@ public class PreimageRecordingPersistenceTests
     {
         StateId from = StateId.PreGenesis;
         StateId to = new(1, TestItem.KeccakA);
-        IPersistence.IWriteBatch innerBatch = Substitute.For<IPersistence.IWriteBatch>();
+        // Hand-rolled capturing fake — NSubstitute proxies fail at runtime on methods with
+        // scoped ReadOnlySpan<byte> parameters (Castle DynamicProxy can't proxy ref structs).
+        FakeWriteBatch innerBatch = new();
         _innerPersistence.CreateWriteBatch(from, to, WriteFlags.None).Returns(innerBatch);
 
         TreePath path = TreePath.FromHexString("1234");
-        TrieNode node = new(NodeType.Leaf, [0xc1, 0x01]);
+        byte[] rlp = [0xc1, 0x01];
+        TrieNode node = new(NodeType.Leaf, rlp);
         Hash256 addrHash = TestItem.KeccakA;
         Hash256 slotHash = TestItem.KeccakB;
         Account account = TestItem.GenerateIndexedAccount(0);
@@ -107,19 +110,24 @@ public class PreimageRecordingPersistenceTests
 
         using (IPersistence.IWriteBatch batch = _sut.CreateWriteBatch(from, to, WriteFlags.None))
         {
-            batch.SetStateTrieNode(path, node);
-            batch.SetStorageTrieNode(addrHash, path, node);
+            batch.SetStateTrieNode(path, node.FullRlp.AsSpan());
+            batch.SetStorageTrieNode(addrHash, path, node.FullRlp.AsSpan());
             batch.SetStorageRaw(addrHash, slotHash, value);
             batch.SetAccountRaw(addrHash, account);
         }
 
         // Verify trie operations delegated
-        innerBatch.Received(1).SetStateTrieNode(path, node);
-        innerBatch.Received(1).SetStorageTrieNode(addrHash, path, node);
+        innerBatch.SetStateTrieNodeCalls.Should().ContainSingle().Which.Should().BeEquivalentTo((path, rlp));
+        innerBatch.SetStorageTrieNodeCalls.Should().ContainSingle().Which.Should().BeEquivalentTo((addrHash, path, rlp));
 
         // Without preimage, raw operations stay raw
-        innerBatch.Received(1).SetStorageRaw(addrHash, slotHash, Arg.Is<SlotValue?>(v => v != null));
-        innerBatch.Received(1).SetAccountRaw(addrHash, account);
+        ValueHash256 addrHashValue = addrHash.ValueHash256;
+        ValueHash256 slotHashValue = slotHash.ValueHash256;
+        innerBatch.SetStorageRawCalls.Should().ContainSingle()
+            .Which.Should().Match<(ValueHash256 Addr, ValueHash256 Slot, SlotValue? Value)>(c =>
+                c.Addr == addrHashValue && c.Slot == slotHashValue && c.Value != null);
+        innerBatch.SetAccountRawCalls.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo((addrHashValue, account));
 
         // No preimages should be recorded for trie/raw operations
         _preimageDb.Keys.Should().BeEmpty();

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageRecordingPersistenceTests.cs
@@ -95,8 +95,6 @@ public class PreimageRecordingPersistenceTests
     {
         StateId from = StateId.PreGenesis;
         StateId to = new(1, TestItem.KeccakA);
-        // Hand-rolled capturing fake — NSubstitute proxies fail at runtime on methods with
-        // scoped ReadOnlySpan<byte> parameters (Castle DynamicProxy can't proxy ref structs).
         FakeWriteBatch innerBatch = new();
         _innerPersistence.CreateWriteBatch(from, to, WriteFlags.None).Returns(innerBatch);
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -303,8 +303,6 @@ public class PersistenceManagerTests
         TrieNode node = new(NodeType.Leaf, Keccak.Zero);
         snapshot.Content.StateNodes[path] = node;
 
-        // Hand-rolled fake — NSubstitute proxies fail at runtime when SetStateTrieNode is invoked
-        // (Castle DynamicProxy can't proxy methods with scoped ReadOnlySpan<byte> parameters).
         FakeWriteBatch writeBatch = new();
         _persistence.CreateWriteBatch(from, to).Returns(writeBatch);
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -302,18 +303,20 @@ public class PersistenceManagerTests
         TrieNode node = new(NodeType.Leaf, Keccak.Zero);
         snapshot.Content.StateNodes[path] = node;
 
-        IPersistence.IWriteBatch writeBatch = Substitute.For<IPersistence.IWriteBatch>();
+        // Hand-rolled fake — NSubstitute proxies fail at runtime when SetStateTrieNode is invoked
+        // (Castle DynamicProxy can't proxy methods with scoped ReadOnlySpan<byte> parameters).
+        FakeWriteBatch writeBatch = new();
         _persistence.CreateWriteBatch(from, to).Returns(writeBatch);
 
         // Act
         _persistenceManager.PersistSnapshot(snapshot);
 
         // Assert
-        writeBatch.Received().SetAccount(TestItem.AddressA, Arg.Any<Account?>());
-        writeBatch.Received().SetAccount(TestItem.AddressB, Arg.Any<Account?>());
-        writeBatch.Received().SetStorage(TestItem.AddressA, (UInt256)1, Arg.Any<SlotValue?>());
-        writeBatch.Received().SetStorage(TestItem.AddressA, (UInt256)2, Arg.Any<SlotValue?>());
-        writeBatch.Received().SetStateTrieNode(Arg.Any<TreePath>(), Arg.Any<TrieNode>());
+        writeBatch.SetAccountCalls.Should().Contain(c => c.Addr == TestItem.AddressA);
+        writeBatch.SetAccountCalls.Should().Contain(c => c.Addr == TestItem.AddressB);
+        writeBatch.SetStorageCalls.Should().Contain(c => c.Addr == TestItem.AddressA && c.Slot == (UInt256)1);
+        writeBatch.SetStorageCalls.Should().Contain(c => c.Addr == TestItem.AddressA && c.Slot == (UInt256)2);
+        writeBatch.SetStateTrieNodeCalls.Should().NotBeEmpty();
         Assert.That(node.IsPersisted, Is.True);
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -460,14 +460,14 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
             // State trie nodes (address=null)
-            writer.SetStateTrieNode(in stateShortPath, new TrieNode(NodeType.Leaf, stateShortRlp));
-            writer.SetStateTrieNode(in stateMediumPath, new TrieNode(NodeType.Leaf, stateMediumRlp));
-            writer.SetStateTrieNode(in stateLongPath, new TrieNode(NodeType.Leaf, stateLongRlp));
+            writer.SetStateTrieNode(in stateShortPath, stateShortRlp);
+            writer.SetStateTrieNode(in stateMediumPath, stateMediumRlp);
+            writer.SetStateTrieNode(in stateLongPath, stateLongRlp);
 
             // Storage trie nodes (with account address)
-            writer.SetStorageTrieNode(account1, in storageShortPath, new TrieNode(NodeType.Leaf, storage1ShortRlp));
-            writer.SetStorageTrieNode(account1, in storageLongPath, new TrieNode(NodeType.Leaf, storage1LongRlp));
-            writer.SetStorageTrieNode(account2, in storageShortPath, new TrieNode(NodeType.Leaf, storage2ShortRlp));
+            writer.SetStorageTrieNode(account1, in storageShortPath, storage1ShortRlp);
+            writer.SetStorageTrieNode(account1, in storageLongPath, storage1LongRlp);
+            writer.SetStorageTrieNode(account2, in storageShortPath, storage2ShortRlp);
         }
 
         // Verify all nodes
@@ -499,19 +499,19 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStateTrieNode(in path, new TrieNode(NodeType.Leaf, rlpData1));
+            writer.SetStateTrieNode(in path, rlpData1);
         }
         using IPersistence.IPersistenceReader reader1 = _persistence.CreateReader();
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStateTrieNode(in path, new TrieNode(NodeType.Leaf, rlpData2));
+            writer.SetStateTrieNode(in path, rlpData2);
         }
         using IPersistence.IPersistenceReader reader2 = _persistence.CreateReader();
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStateTrieNode(in path, new TrieNode(NodeType.Leaf, rlpData3));
+            writer.SetStateTrieNode(in path, rlpData3);
         }
         using IPersistence.IPersistenceReader reader3 = _persistence.CreateReader();
 
@@ -547,12 +547,12 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStateTrieNode(in statePath5, new TrieNode(NodeType.Leaf, rlp5));
-            writer.SetStateTrieNode(in statePath6, new TrieNode(NodeType.Leaf, rlp6));
-            writer.SetStateTrieNode(in statePath15, new TrieNode(NodeType.Leaf, rlp15));
-            writer.SetStateTrieNode(in statePath16, new TrieNode(NodeType.Leaf, rlp16));
-            writer.SetStorageTrieNode(account, in storagePath15, new TrieNode(NodeType.Leaf, storageRlp15));
-            writer.SetStorageTrieNode(account, in storagePath16, new TrieNode(NodeType.Leaf, storageRlp16));
+            writer.SetStateTrieNode(in statePath5, rlp5);
+            writer.SetStateTrieNode(in statePath6, rlp6);
+            writer.SetStateTrieNode(in statePath15, rlp15);
+            writer.SetStateTrieNode(in statePath16, rlp16);
+            writer.SetStorageTrieNode(account, in storagePath15, storageRlp15);
+            writer.SetStorageTrieNode(account, in storagePath16, storageRlp16);
         }
 
         using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
@@ -591,14 +591,14 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
             // Account 1 storage trie nodes
-            writer.SetStorageTrieNode(account1Hash, in shortPath, new TrieNode(NodeType.Leaf, rlpShort));
-            writer.SetStorageTrieNode(account1Hash, in mediumPath, new TrieNode(NodeType.Leaf, rlpMedium));
-            writer.SetStorageTrieNode(account1Hash, in longPath, new TrieNode(NodeType.Leaf, rlpLong));
+            writer.SetStorageTrieNode(account1Hash, in shortPath, rlpShort);
+            writer.SetStorageTrieNode(account1Hash, in mediumPath, rlpMedium);
+            writer.SetStorageTrieNode(account1Hash, in longPath, rlpLong);
 
             // Account 2 storage trie nodes (same paths, different account)
-            writer.SetStorageTrieNode(account2Hash, in shortPath, new TrieNode(NodeType.Leaf, rlpShort));
-            writer.SetStorageTrieNode(account2Hash, in mediumPath, new TrieNode(NodeType.Leaf, rlpMedium));
-            writer.SetStorageTrieNode(account2Hash, in longPath, new TrieNode(NodeType.Leaf, rlpLong));
+            writer.SetStorageTrieNode(account2Hash, in shortPath, rlpShort);
+            writer.SetStorageTrieNode(account2Hash, in mediumPath, rlpMedium);
+            writer.SetStorageTrieNode(account2Hash, in longPath, rlpLong);
         }
 
         // Verify all nodes exist
@@ -664,10 +664,10 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         // Write trie nodes using the hashes directly
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStorageTrieNode(account1Hash, in shortPath, new TrieNode(NodeType.Leaf, rlp1));
-            writer.SetStorageTrieNode(account1Hash, in longPath, new TrieNode(NodeType.Leaf, rlp1));
-            writer.SetStorageTrieNode(account2Hash, in shortPath, new TrieNode(NodeType.Leaf, rlp2));
-            writer.SetStorageTrieNode(account2Hash, in longPath, new TrieNode(NodeType.Leaf, rlp2));
+            writer.SetStorageTrieNode(account1Hash, in shortPath, rlp1);
+            writer.SetStorageTrieNode(account1Hash, in longPath, rlp1);
+            writer.SetStorageTrieNode(account2Hash, in shortPath, rlp2);
+            writer.SetStorageTrieNode(account2Hash, in longPath, rlp2);
         }
 
         // Verify all nodes exist before SelfDestruct
@@ -689,8 +689,8 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         // Write and then delete using the real address flow
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))
         {
-            writer.SetStorageTrieNode(address1Hash, in shortPath, new TrieNode(NodeType.Leaf, rlp1));
-            writer.SetStorageTrieNode(address1Hash, in longPath, new TrieNode(NodeType.Leaf, rlp1));
+            writer.SetStorageTrieNode(address1Hash, in shortPath, rlp1);
+            writer.SetStorageTrieNode(address1Hash, in longPath, rlp1);
         }
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis, WriteFlags.None))

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTreesTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTreesTests.cs
@@ -89,7 +89,7 @@ public class FlatSnapTreesTests
     {
         IPersistence.IPersistenceReader reader = Reader();
         reader.GetAccountRaw(Arg.Any<ValueHash256>()).Returns((byte[]?)null);
-        IPersistence.IWriteBatch writer = WriteBatch();
+        FakeWriteBatch writer = new();
         using FlatSnapStateTree tree = NewStateTree(reader, writer);
 
         Account account = new(1, 100);
@@ -99,8 +99,7 @@ public class FlatSnapTreesTests
         tree.BulkSetAndUpdateRootHash([new PathWithAccount(lowPath, account), new PathWithAccount(highPath, account)]);
         tree.Commit(PathHash("55"));
 
-        writer.Received(1).SetAccountRaw(lowPath, account);
-        writer.DidNotReceive().SetAccountRaw(highPath, Arg.Any<Account>());
+        writer.SetAccountRawCalls.Should().ContainSingle().Which.Should().BeEquivalentTo((lowPath, account));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat/Importer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Importer.cs
@@ -102,11 +102,11 @@ public class Importer(
 
             if (address is null)
             {
-                writeBatch.SetStateTrieNode(path, node);
+                writeBatch.SetStateTrieNode(path, node.FullRlp.AsSpan());
             }
             else
             {
-                writeBatch.SetStorageTrieNode(address, path, node);
+                writeBatch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
             }
 
             if (node.IsLeaf)

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -231,8 +231,8 @@ public static class BasePersistence
     public interface ITrieWriteBatch
     {
         public void SelfDestruct(in ValueHash256 address);
-        public void SetStateTrieNode(in TreePath path, TrieNode tnValue);
-        public void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tnValue);
+        public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp);
+        public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp);
         public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath);
         public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath);
     }
@@ -401,11 +401,11 @@ public static class BasePersistence
         public void SetStorage(Address addr, in UInt256 slot, in SlotValue? value) =>
             _flatWriter.SetStorage(addr, slot, value);
 
-        public void SetStateTrieNode(in TreePath path, TrieNode tnValue) =>
-            _trieWriteBatch.SetStateTrieNode(path, tnValue);
+        public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp) =>
+            _trieWriteBatch.SetStateTrieNode(path, rlp);
 
-        public void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tnValue) =>
-            _trieWriteBatch.SetStorageTrieNode(address, path, tnValue);
+        public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp) =>
+            _trieWriteBatch.SetStorageTrieNode(address, path, rlp);
 
         public void SetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? value) =>
             _flatWriter.SetStorageRaw(addrHash, slotHash, value);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
@@ -164,31 +164,31 @@ public static class BaseTriePersistence
                 1 + StoragePrefixPortion + FullPathLength + PathLengthLength, addressSuffix);
         }
 
-        public void SetStateTrieNode(in TreePath path, TrieNode tn)
+        public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp)
         {
             switch (path.Length)
             {
                 case <= StateNodesTopThreshold:
-                    stateTopNodes.PutSpan(EncodeStateTopNodeKey(stackalloc byte[StateNodesTopPathLength], path), tn.FullRlp.AsSpan(), flags);
+                    stateTopNodes.PutSpan(EncodeStateTopNodeKey(stackalloc byte[StateNodesTopPathLength], path), rlp, flags);
                     break;
                 case <= ShortenedPathThreshold:
-                    stateNodes.PutSpan(EncodeShortenedStateNodeKey(stackalloc byte[ShortenedPathLength], path), tn.FullRlp.AsSpan(), flags);
+                    stateNodes.PutSpan(EncodeShortenedStateNodeKey(stackalloc byte[ShortenedPathLength], path), rlp, flags);
                     break;
                 default:
-                    fallbackNodes.PutSpan(EncodeFullStateNodeKey(stackalloc byte[FullStateNodesKeyLength], in path), tn.FullRlp.AsSpan(), flags);
+                    fallbackNodes.PutSpan(EncodeFullStateNodeKey(stackalloc byte[FullStateNodesKeyLength], in path), rlp, flags);
                     break;
             }
         }
 
-        public void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tn)
+        public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp)
         {
             switch (path.Length)
             {
                 case <= ShortenedPathThreshold:
-                    storageNodes.PutSpan(EncodeShortenedStorageNodeKey(stackalloc byte[ShortenedStorageNodesKeyLength], address, path), tn.FullRlp.AsSpan(), flags);
+                    storageNodes.PutSpan(EncodeShortenedStorageNodeKey(stackalloc byte[ShortenedStorageNodesKeyLength], address, path), rlp, flags);
                     break;
                 default:
-                    fallbackNodes.PutSpan(EncodeFullStorageNodeKey(stackalloc byte[FullStorageNodesKeyLength], address, in path), tn.FullRlp.AsSpan(), flags);
+                    fallbackNodes.PutSpan(EncodeFullStorageNodeKey(stackalloc byte[FullStorageNodesKeyLength], address, in path), rlp, flags);
                     break;
             }
         }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
@@ -127,8 +127,8 @@ public class CachedReaderPersistence : IPersistence, IAsyncDisposable
         public void SelfDestruct(Address addr) => inner.SelfDestruct(addr);
         public void SetAccount(Address addr, Account? account) => inner.SetAccount(addr, account);
         public void SetStorage(Address addr, in UInt256 slot, in SlotValue? value) => inner.SetStorage(addr, slot, value);
-        public void SetStateTrieNode(in TreePath path, TrieNode tnValue) => inner.SetStateTrieNode(path, tnValue);
-        public void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tnValue) => inner.SetStorageTrieNode(address, path, tnValue);
+        public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStateTrieNode(path, rlp);
+        public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStorageTrieNode(address, path, rlp);
         public void SetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? value) => inner.SetStorageRaw(addrHash, slotHash, value);
         public void SetAccountRaw(in ValueHash256 addrHash, Account account) => inner.SetAccountRaw(addrHash, account);
         public void DeleteAccountRange(in ValueHash256 fromPath, in ValueHash256 toPath) => inner.DeleteAccountRange(fromPath, toPath);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -51,8 +51,8 @@ public interface IPersistence
         void SelfDestruct(Address addr);
         void SetAccount(Address addr, Account? account);
         void SetStorage(Address addr, in UInt256 slot, in SlotValue? value);
-        void SetStateTrieNode(in TreePath path, TrieNode tnValue);
-        void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tnValue);
+        void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp);
+        void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp);
 
         void SetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? value);
         void SetAccountRaw(in ValueHash256 addrHash, Account account);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
@@ -61,9 +61,9 @@ public class PreimageRecordingPersistence(IPersistence inner, IDb preimageDb) : 
             inner.SetStorage(addr, slot, value);
         }
 
-        public void SetStateTrieNode(in TreePath path, TrieNode tnValue) => inner.SetStateTrieNode(path, tnValue);
+        public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStateTrieNode(path, rlp);
 
-        public void SetStorageTrieNode(Hash256 address, in TreePath path, TrieNode tnValue) => inner.SetStorageTrieNode(address, path, tnValue);
+        public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStorageTrieNode(address, path, rlp);
 
         public void SetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? value)
         {

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -285,7 +285,7 @@ public class PersistenceManager(
 
                 stateNodesSize += node.FullRlp.Length;
                 // Note: Even if the node already marked as persisted, we still re-persist it
-                batch.SetStateTrieNode(path, node);
+                batch.SetStateTrieNode(path, node.FullRlp.AsSpan());
 
                 node.IsPersisted = true;
             }
@@ -313,7 +313,7 @@ public class PersistenceManager(
 
                 storageNodesSize += node.FullRlp.Length;
                 // Note: Even if the node already marked as persisted, we still re-persist it
-                batch.SetStorageTrieNode(address, path, node);
+                batch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
                 node.IsPersisted = true;
             }
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -52,14 +52,14 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         {
             RequestStateDeletion(writeBatch, path, node, existingNode);
 
-            writeBatch.SetStateTrieNode(path, node);
+            writeBatch.SetStateTrieNode(path, node.FullRlp.AsSpan());
             FlatEntryWriter.WriteAccountFlatEntries(writeBatch, path, node);
         }
         else
         {
             RequestStorageDeletion(writeBatch, address, path, node, existingNode);
 
-            writeBatch.SetStorageTrieNode(address, path, node);
+            writeBatch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
             FlatEntryWriter.WriteStorageFlatEntries(writeBatch, address, path, node);
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -59,7 +59,7 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         {
             RequestStorageDeletion(writeBatch, address, path, node, existingNode);
 
-            writeBatch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
+            writeBatch.SetStorageTrieNode(address, path, data);
             FlatEntryWriter.WriteStorageFlatEntries(writeBatch, address, path, node);
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -52,7 +52,7 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         {
             RequestStateDeletion(writeBatch, path, node, existingNode);
 
-            writeBatch.SetStateTrieNode(path, node.FullRlp.AsSpan());
+            writeBatch.SetStateTrieNode(path, data);
             FlatEntryWriter.WriteAccountFlatEntries(writeBatch, path, node);
         }
         else

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
@@ -104,7 +104,7 @@ public class FlatSnapStateTree : ISnapTree<PathWithAccount>
                 {
                     throw new Exception($"Double state rlp write. {path}");
                 }
-                writeBatch.SetStateTrieNode(path, node);
+                writeBatch.SetStateTrieNode(path, node.FullRlp.AsSpan());
                 return node;
             }
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStorageTree.cs
@@ -112,7 +112,7 @@ public class FlatSnapStorageTree : ISnapTree<PathWithStorageSlot>
                 {
                     throw new Exception($"Double storage rlp write. {address} {path}");
                 }
-                writeBatch.SetStorageTrieNode(address, path, node);
+                writeBatch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
                 return node;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
@@ -137,7 +137,7 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
         {
             public TrieNode CommitNode(ref TreePath path, TrieNode node)
             {
-                writeBatch.SetStateTrieNode(path, node);
+                writeBatch.SetStateTrieNode(path, node.FullRlp.AsSpan());
                 FlatEntryWriter.WriteAccountFlatEntries(writeBatch, path, node);
                 return node;
             }
@@ -169,7 +169,7 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
         {
             public TrieNode CommitNode(ref TreePath path, TrieNode node)
             {
-                writeBatch.SetStorageTrieNode(address, path, node);
+                writeBatch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
                 FlatEntryWriter.WriteStorageFlatEntries(writeBatch, address, path, node);
                 return node;
             }


### PR DESCRIPTION
> Stacked on top of #11695. The diff below is the single refactor commit (cf14cb8); the other commits belong to #11695 and will drop out once that merges.

## Changes

- `IPersistence.IWriteBatch.SetStateTrieNode` / `SetStorageTrieNode` (and the mirrored internal `BasePersistence.ITrieWriteBatch`) now take `scoped ReadOnlySpan<byte> rlp` instead of `TrieNode tnValue`. Persistence no longer depends on `Nethermind.Trie.TrieNode` on the write path.
- Every implementation already did `tn.FullRlp.AsSpan()` as its first operation, so the `AsSpan()` call moves up to the five production call sites (`Importer`, `PersistenceManager`, `FlatTreeSyncStore`, `FlatSnapStateTree`, `FlatSnapStorageTree`).
- Adds a shared `FakeWriteBatch` helper in `FlatTestHelpers.cs`. Three tests (`PreimageRecordingPersistenceTests.TrieAndRawOperations_…`, `PersistenceManagerTests.PersistSnapshot_…`, `FlatSnapTreesTests.StateTree_BulkSetThenCommit_…`) needed it because Castle DynamicProxy throws `InvalidProgramException` at runtime when proxying methods with `scoped ReadOnlySpan<byte>` parameters via NSubstitute.
- `PersistenceScenario.cs`: dropped the `new TrieNode(NodeType.Leaf, …)` wrappers that existed only to satisfy the old signature — tests now pass the raw RLP `byte[]` directly.

### Why

The `TrieNode` parameter was dead weight from the persistence layer's point of view — no implementation reads anything but `FullRlp`. Carrying it forced `IPersistence` to take a hard dependency on `Nethermind.Trie.TrieNode`, which causes churn for branches that change `TrieNode` internals (`flat/long-finality`, `perf/refcountingtrienoderlp`). Decoupling lets those branches evolve `TrieNode` without dragging persistence along.

## Types of changes

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes _(existing test coverage retained; failing tests adapted to use `FakeWriteBatch`)_

#### Notes on testing

- \`dotnet test --project src/Nethermind/Nethermind.State.Flat.Test -c release\` → 408 passed, 4 pre-existing skipped, 0 failed.
- \`dotnet test --project src/Nethermind/Nethermind.Synchronization.Test -c release\` → 2039 passed, 394 pre-existing skipped, 0 failed.
- \`dotnet build -c release src/Nethermind/Nethermind.slnx\` → clean (0 warnings, 0 errors).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No