### PR TITLE
Keep devp2p 8-byte capability limit; log rejected bytes for diagnosis

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
@@ -131,10 +131,10 @@ public class HelloMessageSerializerTests
     private static IEnumerable<TestCaseData> ProtocolCodeLimitCases()
     {
         yield return new TestCaseData(1, false).SetName("1 char protocol code - accepted");
-        yield return new TestCaseData(8, false).SetName("Longest known protocol code - accepted");
-        yield return new TestCaseData(13, false).SetName("13 char protocol code - accepted");
-        yield return new TestCaseData(32, false).SetName("Max protocol code length - accepted");
-        yield return new TestCaseData(33, true).SetName("Max+1 protocol code length - rejected");
+        yield return new TestCaseData(8, false).SetName("Longest spec-legal protocol code - accepted");
+        yield return new TestCaseData(9, true).SetName("9 char protocol code - rejected (over spec)");
+        yield return new TestCaseData(13, true).SetName("13 char protocol code - rejected (over spec)");
+        yield return new TestCaseData(33, true).SetName("33 char protocol code - rejected (over diagnostic read limit)");
     }
 
     [TestCaseSource(nameof(ProtocolCodeLimitCases))]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
@@ -132,7 +132,7 @@ public class HelloMessageSerializerTests
     {
         yield return new TestCaseData(1, false).SetName("1 char protocol code - accepted");
         yield return new TestCaseData(8, false).SetName("Longest known protocol code - accepted");
-        yield return new TestCaseData(13, false).SetName("Unknown protocol code beyond known set - accepted (UTF-8 fallback)");
+        yield return new TestCaseData(13, false).SetName("13 char protocol code - accepted");
         yield return new TestCaseData(32, false).SetName("Max protocol code length - accepted");
         yield return new TestCaseData(33, true).SetName("Max+1 protocol code length - rejected");
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/HelloMessageSerializerTests.cs
@@ -131,8 +131,10 @@ public class HelloMessageSerializerTests
     private static IEnumerable<TestCaseData> ProtocolCodeLimitCases()
     {
         yield return new TestCaseData(1, false).SetName("1 char protocol code - accepted");
-        yield return new TestCaseData(8, false).SetName("Max protocol code length - accepted");
-        yield return new TestCaseData(9, true).SetName("Max+1 protocol code length - rejected");
+        yield return new TestCaseData(8, false).SetName("Longest known protocol code - accepted");
+        yield return new TestCaseData(13, false).SetName("Unknown protocol code beyond known set - accepted (UTF-8 fallback)");
+        yield return new TestCaseData(32, false).SetName("Max protocol code length - accepted");
+        yield return new TestCaseData(33, true).SetName("Max+1 protocol code length - rejected");
     }
 
     [TestCaseSource(nameof(ProtocolCodeLimitCases))]

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Network.P2P.Messages
                 int length = c.ReadSequenceLength();
                 int checkPosition = c.Position + length;
 
-                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan(RlpLimit.L8);
+                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan(RlpLimit.L32);
                 if (!Contract.P2P.ProtocolParser.TryGetProtocolCode(protocolSpan, out string? protocolCode))
                 {
                     protocolCode = Encoding.UTF8.GetString(protocolSpan);

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
@@ -5,14 +5,25 @@ using System;
 using System.Text;
 using DotNetty.Buffers;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.P2P.Messages
 {
-    public class HelloMessageSerializer : IZeroMessageSerializer<HelloMessage>
+    public class HelloMessageSerializer(ILogManager? logManager = null) : IZeroMessageSerializer<HelloMessage>
     {
         private static readonly RlpLimit ClientIdRlpLimit = RlpLimit.For<HelloMessage>(1_024, nameof(HelloMessage.ClientId));
+
+        // devp2p spec: "A capability is identified by a short ASCII name (max eight
+        // characters)". Reads are bounded above by L32 so an over-spec code can still
+        // be captured for the diagnostic log; the spec-strict 8-byte rejection happens
+        // explicitly below.
+        private const int SpecMaxCapabilityCodeLength = 8;
+        private static readonly RlpLimit CapabilityCodeReadLimit = RlpLimit.L32;
+
+        private readonly ILogger _logger = (logManager ?? LimboLogs.Instance).GetClassLogger<HelloMessageSerializer>();
 
         public void Serialize(IByteBuffer byteBuffer, HelloMessage msg)
         {
@@ -58,7 +69,7 @@ namespace Nethermind.Network.P2P.Messages
         public HelloMessage Deserialize(IByteBuffer msgBytes) =>
             msgBytes.DeserializeRlp(Deserialize);
 
-        private static HelloMessage Deserialize(ref Rlp.ValueDecoderContext ctx)
+        private HelloMessage Deserialize(ref Rlp.ValueDecoderContext ctx)
         {
             ctx.ReadSequenceLength();
 
@@ -66,12 +77,26 @@ namespace Nethermind.Network.P2P.Messages
             helloMessage.P2PVersion = ctx.DecodeByte();
             helloMessage.ClientId = ctx.DecodeString(ClientIdRlpLimit);
 
-            helloMessage.Capabilities = ctx.DecodeArrayPoolList(static (ref Rlp.ValueDecoderContext c) =>
+            ILogger logger = _logger;
+            string clientId = helloMessage.ClientId;
+            helloMessage.Capabilities = ctx.DecodeArrayPoolList((ref Rlp.ValueDecoderContext c) =>
             {
                 int length = c.ReadSequenceLength();
                 int checkPosition = c.Position + length;
 
-                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan(RlpLimit.L32);
+                ReadOnlySpan<byte> protocolSpan = c.DecodeByteArraySpan(CapabilityCodeReadLimit);
+                if (protocolSpan.Length > SpecMaxCapabilityCodeLength)
+                {
+                    if (logger.IsWarn)
+                    {
+                        logger.Warn(
+                            $"Rejecting Hello capability with protocol code longer than the {SpecMaxCapabilityCodeLength}-byte devp2p spec limit. " +
+                            $"ClientId='{clientId}', length={protocolSpan.Length}, hex=0x{protocolSpan.ToHexString()}, utf8='{Encoding.UTF8.GetString(protocolSpan)}'");
+                    }
+                    throw new RlpLimitException(
+                        $"Hello capability protocol code length {protocolSpan.Length} exceeds devp2p spec limit of {SpecMaxCapabilityCodeLength}");
+                }
+
                 if (!Contract.P2P.ProtocolParser.TryGetProtocolCode(protocolSpan, out string? protocolCode))
                 {
                     protocolCode = Encoding.UTF8.GetString(protocolSpan);


### PR DESCRIPTION
## Summary

Per @LukaszRozmej's review on the original PR: the devp2p spec mandates a max 8-byte capability protocol code, so the previous L32 bump was over-permissive. This PR keeps the spec-strict 8-byte rejection and instead **adds instrumentation** that captures the offending byte span on rejection, so we can identify who is sending what.

## What it does

In `HelloMessageSerializer.Deserialize`:

- Reads up to 32 bytes per capability code (`RlpLimit.L32`) so a 9–32-byte spec violator can still reach the diagnostic log. Larger than 32 bytes is rejected by the read itself.
- Manually rejects any code longer than 8 bytes (the spec limit) with `RlpLimitException`, preserving the existing handshake-failure path (`MessageLimitsBreached` disconnect).
- Logs the **remote `ClientId`, byte length, hex, and UTF-8 decode** of the rejected span at `Warn` level before rethrowing, so Seq captures who is sending what.
- Accepts `ILogManager` via constructor; defaults to `LimboLogs` for tests.

## Why

From Seq (last 14d, ~1k rejections — see #11751): 100% of rejections involve codes of length 11–13 bytes, concentrated on chiado/gnosis/mainnet dev fleet from 27 distinct IPs. We never see the actual code strings today because `DecodeByteArraySpan(RlpLimit.L8)` throws before the UTF-8 fallback runs. After this PR lands, those rejections will surface the actual strings — at which point we can decide whether they're a benign new subprotocol or a real client bug, and the responsible client can be notified.

Closes #11751.

## Test plan

- [x] `HelloMessageSerializerTests` — 15/15 pass. `ProtocolCodeLimitCases` updated: 1 + 8 accepted, 9 / 13 / 33 rejected.
- [x] `ProtocolsManagerTests` + `P2PProtocolHandlerTests` — 28/28 pass (parameterless ctor still works).