### PR TITLE
feat(FlatDB): stagger compaction per-instance with random offset

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -17,7 +17,6 @@ public class FlatDbConfig : IFlatDbConfig
     public int CompactSize { get; set; } = 32;
     public int MaxInFlightCompactJob { get; set; } = 32;
     public int MaxReorgDepth { get; set; } = 256;
-    public int MinCompactSize { get; set; } = 2;
     public int MinReorgDepth { get; set; } = 128;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public long BlockCacheSizeBudget { get; set; } = 1.GiB;

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -11,6 +11,7 @@ public class FlatDbConfig : IFlatDbConfig
     public bool EnablePreimageRecording { get; set; } = false;
     public bool ImportFromPruningTrieState { get; set; } = false;
     public bool InlineCompaction { get; set; } = false;
+    public bool RegenerateCompactionOffset { get; set; } = false;
     public bool VerifyWithTrie { get; set; } = false;
     public FlatLayout Layout { get; set; } = FlatLayout.Flat;
     public int CompactSize { get; set; } = 32;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -34,9 +34,6 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Max reorg depth", DefaultValue = "256")]
     int MaxReorgDepth { get; set; }
 
-    [ConfigItem(Description = "Minimum compact size (power of 2, floor for hierarchical compaction)", DefaultValue = "2")]
-    int MinCompactSize { get; set; }
-
     [ConfigItem(Description = "Minimum reorg depth", DefaultValue = "128")]
     int MinReorgDepth { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -40,6 +40,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Minimum reorg depth", DefaultValue = "128")]
     int MinReorgDepth { get; set; }
 
+    [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]
+    bool RegenerateCompactionOffset { get; set; }
+
     [ConfigItem(Description = "Trie cache memory target", DefaultValue = "536870912")]
     long TrieCacheMemoryBudget { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
+++ b/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
@@ -22,5 +22,6 @@ namespace Nethermind.Db
         public const int LowestInsertedBodyNumber = 15;
         public const int LowestInsertedBlockAccessListBlockNumber = 16;
         public const int BlockAccessListPruningDeletePointer = 17;
+        public const int FlatDbCompactionOffset = 18;
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -52,6 +52,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 ctx.Resolve<IMetricsConfig>().EnableDetailedMetric))
             .AddSingleton<IResourcePool, ResourcePool>()
             .AddSingleton<ITrieNodeCache, TrieNodeCache>()
+            .AddSingleton<ICompactionSchedule, CompactionSchedule>()
             .AddSingleton<ISnapshotCompactor, SnapshotCompactor>()
             .AddSingleton<IPersistenceManager, PersistenceManager>()
             .AddSingleton<ISnapshotRepository, SnapshotRepository>()

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -90,7 +90,7 @@ public class CompactionScheduleTests
     public void Constructor_CompactSizeDisabled_OffsetIsZeroAndDbUntouched()
     {
         MemDb metadataDb = new();
-        FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
+        FlatDbConfig config = new() { CompactSize = 1 };
 
         CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
 
@@ -98,6 +98,7 @@ public class CompactionScheduleTests
         Assert.That(metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset), Is.Null);
     }
 
+    [TestCase(1, 1)]    // odd block: 1 & -1 = 1
     [TestCase(2, 2)]
     [TestCase(4, 4)]
     [TestCase(6, 2)]
@@ -109,7 +110,7 @@ public class CompactionScheduleTests
     [TestCase(32, 16)]   // capped at CompactSize=16
     public void GetCompactSize_OffsetZero_MatchesBitTrick(long blockNumber, int expected)
     {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        FlatDbConfig config = new() { CompactSize = 16 };
         CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 0);
 
         Assert.That(schedule.GetCompactSize(blockNumber), Is.EqualTo(expected));
@@ -117,12 +118,12 @@ public class CompactionScheduleTests
 
     [TestCase(0, 1)]    // block 0 always 1
     [TestCase(13, 16)]  // 13+3 = 16 -> full
-    [TestCase(16, 1)]   // 16+3 = 19 -> 19 & -19 = 1 (below min)
+    [TestCase(16, 1)]   // 16+3 = 19 -> 19 & -19 = 1 (caller treats as no compaction)
     [TestCase(5, 8)]    // 5+3 = 8
     [TestCase(29, 16)]  // 29+3 = 32 -> 32 & -32 = 32, capped at 16
     public void GetCompactSize_WithOffset3_ShiftsBoundaries(long blockNumber, int expected)
     {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        FlatDbConfig config = new() { CompactSize = 16 };
         CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 3);
 
         Assert.That(schedule.GetCompactSize(blockNumber), Is.EqualTo(expected));
@@ -133,7 +134,7 @@ public class CompactionScheduleTests
     [TestCase(7L, 1_000_007L)] // large offsets work modulo CompactSize
     public void GetCompactSize_OffsetLargerThanCompactSize_EquivalentToOffsetModCompactSize(long smallOffset, long largeOffset)
     {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        FlatDbConfig config = new() { CompactSize = 16 };
         CompactionSchedule small = ScheduleHelper.CreateWithOffset(config, smallOffset);
         CompactionSchedule large = ScheduleHelper.CreateWithOffset(config, largeOffset);
 
@@ -144,18 +145,6 @@ public class CompactionScheduleTests
             Assert.That(large.NextFullCompactionAfter(block), Is.EqualTo(small.NextFullCompactionAfter(block)),
                 $"Next boundary mismatch from block {block} between offset {smallOffset} and {largeOffset}");
         }
-    }
-
-    [Test]
-    public void GetCompactSize_BelowMinCompactSize_ReturnsOne()
-    {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 4 };
-        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 0);
-
-        // block 2 -> (2 & -2) = 2 < min 4
-        Assert.That(schedule.GetCompactSize(2), Is.EqualTo(1));
-        // block 4 -> (4 & -4) = 4 == min, allowed
-        Assert.That(schedule.GetCompactSize(4), Is.EqualTo(4));
     }
 
     [TestCase(0, 0, 16)]    // from 0, offset 0 -> next full at 16
@@ -175,7 +164,7 @@ public class CompactionScheduleTests
     [Test]
     public void NextFullCompactionAfter_CompactSizeDisabled_ReturnsLongMaxValue()
     {
-        FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
+        FlatDbConfig config = new() { CompactSize = 1 };
         CompactionSchedule schedule = new(new MemDb(), config, LimboLogs.Instance);
 
         Assert.That(schedule.NextFullCompactionAfter(0), Is.EqualTo(long.MaxValue));
@@ -185,14 +174,4 @@ public class CompactionScheduleTests
     public void Constructor_NonPowerOf2CompactSize_Throws() =>
         Assert.Throws<ArgumentException>(() =>
             new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 10 }, LimboLogs.Instance));
-
-    [Test]
-    public void Constructor_NonPowerOf2MinCompactSize_Throws() =>
-        Assert.Throws<ArgumentException>(() =>
-            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 16, MinCompactSize = 3 }, LimboLogs.Instance));
-
-    [Test]
-    public void Constructor_MinCompactSizeGreaterThanCompactSize_Throws() =>
-        Assert.Throws<ArgumentException>(() =>
-            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 8, MinCompactSize = 16 }, LimboLogs.Instance));
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class CompactionScheduleTests
+{
+    private static byte[] EncodedOffset(int value) => Rlp.Encode(value).Bytes;
+
+    [Test]
+    public void Constructor_NoStoredValue_GeneratesPersistsAndReturnsValueInRange()
+    {
+        MemDb metadataDb = new();
+        FlatDbConfig config = new() { CompactSize = 32 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.InRange(0, 31));
+        byte[]? stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset);
+        Assert.That(stored, Is.Not.Null);
+        Assert.That(stored.AsRlpValueContext().DecodeInt(), Is.EqualTo(schedule.Offset));
+    }
+
+    [Test]
+    public void Constructor_StoredValidValue_ReturnsItWithoutOverwriting()
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(7));
+        byte[] before = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!;
+        FlatDbConfig config = new() { CompactSize = 32 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.EqualTo(7));
+        byte[] after = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!;
+        Assert.That(after, Is.EqualTo(before));
+    }
+
+    [Test]
+    public void Constructor_RegenerateFlagTrue_OverwritesStoredOffset()
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(7));
+        FlatDbConfig config = new() { CompactSize = 32, RegenerateCompactionOffset = true };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.InRange(0, 31));
+        int stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeInt();
+        Assert.That(stored, Is.EqualTo(schedule.Offset));
+    }
+
+    [TestCase(-1)]
+    [TestCase(32)]
+    [TestCase(100)]
+    public void Constructor_StoredOutOfRange_Regenerates(int badStored)
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(badStored));
+        FlatDbConfig config = new() { CompactSize = 32 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.InRange(0, 31));
+        int stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeInt();
+        Assert.That(stored, Is.EqualTo(schedule.Offset));
+    }
+
+    [Test]
+    public void Constructor_CompactSizeDisabled_OffsetIsZeroAndDbUntouched()
+    {
+        MemDb metadataDb = new();
+        FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.EqualTo(0));
+        Assert.That(metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset), Is.Null);
+    }
+
+    [TestCase(2, 2)]
+    [TestCase(4, 4)]
+    [TestCase(6, 2)]
+    [TestCase(8, 8)]
+    [TestCase(10, 2)]
+    [TestCase(12, 4)]
+    [TestCase(14, 2)]
+    [TestCase(16, 16)]
+    [TestCase(32, 16)]   // capped at CompactSize=16
+    public void GetCompactSize_OffsetZero_MatchesBitTrick(long blockNumber, int expected)
+    {
+        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 0);
+
+        Assert.That(schedule.GetCompactSize(blockNumber), Is.EqualTo(expected));
+    }
+
+    [TestCase(0, 1)]    // block 0 always 1
+    [TestCase(13, 16)]  // 13+3 = 16 -> full
+    [TestCase(16, 1)]   // 16+3 = 19 -> 19 & -19 = 1 (below min)
+    [TestCase(5, 8)]    // 5+3 = 8
+    [TestCase(29, 16)]  // 29+3 = 32 -> 32 & -32 = 32, capped at 16
+    public void GetCompactSize_WithOffset3_ShiftsBoundaries(long blockNumber, int expected)
+    {
+        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 3);
+
+        Assert.That(schedule.GetCompactSize(blockNumber), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetCompactSize_BelowMinCompactSize_ReturnsOne()
+    {
+        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 4 };
+        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 0);
+
+        // block 2 -> (2 & -2) = 2 < min 4
+        Assert.That(schedule.GetCompactSize(2), Is.EqualTo(1));
+        // block 4 -> (4 & -4) = 4 == min, allowed
+        Assert.That(schedule.GetCompactSize(4), Is.EqualTo(4));
+    }
+
+    [TestCase(0, 0, 16)]    // from 0, offset 0 -> next full at 16
+    [TestCase(16, 0, 32)]   // from boundary, advance by CompactSize
+    [TestCase(15, 0, 16)]
+    [TestCase(0, 3, 13)]    // from 0, offset 3 -> 0+(16-3) = 13
+    [TestCase(13, 3, 29)]   // from boundary 13, advance by 16
+    [TestCase(7, 5, 11)]    // from 7, offset 5 -> (7+5)%16=12, next at 7+(16-12)=11
+    public void NextFullCompactionAfter_VariousOffsets(long from, int offset, long expected)
+    {
+        FlatDbConfig config = new() { CompactSize = 16 };
+        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, offset);
+
+        Assert.That(schedule.NextFullCompactionAfter(from), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void NextFullCompactionAfter_CompactSizeDisabled_ReturnsLongMaxValue()
+    {
+        FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
+        CompactionSchedule schedule = new(new MemDb(), config, LimboLogs.Instance);
+
+        Assert.That(schedule.NextFullCompactionAfter(0), Is.EqualTo(long.MaxValue));
+    }
+
+    [Test]
+    public void Constructor_NonPowerOf2CompactSize_Throws() =>
+        Assert.Throws<ArgumentException>(() =>
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 10 }, LimboLogs.Instance));
+
+    [Test]
+    public void Constructor_NonPowerOf2MinCompactSize_Throws() =>
+        Assert.Throws<ArgumentException>(() =>
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 16, MinCompactSize = 3 }, LimboLogs.Instance));
+
+    [Test]
+    public void Constructor_MinCompactSizeGreaterThanCompactSize_Throws() =>
+        Assert.Throws<ArgumentException>(() =>
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 8, MinCompactSize = 16 }, LimboLogs.Instance));
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -13,7 +13,7 @@ namespace Nethermind.State.Flat.Test;
 [TestFixture]
 public class CompactionScheduleTests
 {
-    private static byte[] EncodedOffset(int value) => Rlp.Encode(value).Bytes;
+    private static byte[] EncodedOffset(long value) => Rlp.Encode(value).Bytes;
 
     [Test]
     public void Constructor_NoStoredValue_GeneratesPersistsAndReturnsValueInRange()
@@ -23,10 +23,10 @@ public class CompactionScheduleTests
 
         CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
 
-        Assert.That(schedule.Offset, Is.InRange(0, 31));
+        Assert.That(schedule.Offset, Is.InRange(0L, (long)int.MaxValue - 1));
         byte[]? stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset);
         Assert.That(stored, Is.Not.Null);
-        Assert.That(stored.AsRlpValueContext().DecodeInt(), Is.EqualTo(schedule.Offset));
+        Assert.That(stored.AsRlpValueContext().DecodeLong(), Is.EqualTo(schedule.Offset));
     }
 
     [Test]
@@ -44,6 +44,19 @@ public class CompactionScheduleTests
         Assert.That(after, Is.EqualTo(before));
     }
 
+    [TestCase(1_000_000L)]
+    [TestCase(int.MaxValue - 1L)]
+    public void Constructor_StoredLargePositiveValue_KeptAsIs(long stored)
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(stored));
+        FlatDbConfig config = new() { CompactSize = 32 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.EqualTo(stored));
+    }
+
     [Test]
     public void Constructor_RegenerateFlagTrue_OverwritesStoredOffset()
     {
@@ -53,15 +66,14 @@ public class CompactionScheduleTests
 
         CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
 
-        Assert.That(schedule.Offset, Is.InRange(0, 31));
-        int stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeInt();
+        Assert.That(schedule.Offset, Is.InRange(0L, (long)int.MaxValue - 1));
+        long stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeLong();
         Assert.That(stored, Is.EqualTo(schedule.Offset));
     }
 
-    [TestCase(-1)]
-    [TestCase(32)]
-    [TestCase(100)]
-    public void Constructor_StoredOutOfRange_Regenerates(int badStored)
+    [TestCase(-1L)]
+    [TestCase(-100L)]
+    public void Constructor_StoredNegative_Regenerates(long badStored)
     {
         MemDb metadataDb = new();
         metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(badStored));
@@ -69,8 +81,8 @@ public class CompactionScheduleTests
 
         CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
 
-        Assert.That(schedule.Offset, Is.InRange(0, 31));
-        int stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeInt();
+        Assert.That(schedule.Offset, Is.InRange(0L, (long)int.MaxValue - 1));
+        long stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeLong();
         Assert.That(stored, Is.EqualTo(schedule.Offset));
     }
 
@@ -114,6 +126,24 @@ public class CompactionScheduleTests
         CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, 3);
 
         Assert.That(schedule.GetCompactSize(blockNumber), Is.EqualTo(expected));
+    }
+
+    [TestCase(3L, 19L)]      // offset 3 and 3+16=19 should be equivalent
+    [TestCase(3L, 35L)]      // offset 3 and 3+32=35 should be equivalent
+    [TestCase(7L, 1_000_007L)] // large offsets work modulo CompactSize
+    public void GetCompactSize_OffsetLargerThanCompactSize_EquivalentToOffsetModCompactSize(long smallOffset, long largeOffset)
+    {
+        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        CompactionSchedule small = ScheduleHelper.CreateWithOffset(config, smallOffset);
+        CompactionSchedule large = ScheduleHelper.CreateWithOffset(config, largeOffset);
+
+        for (long block = 1; block <= 64; block++)
+        {
+            Assert.That(large.GetCompactSize(block), Is.EqualTo(small.GetCompactSize(block)),
+                $"Tier mismatch at block {block} between offset {smallOffset} and {largeOffset}");
+            Assert.That(large.NextFullCompactionAfter(block), Is.EqualTo(small.NextFullCompactionAfter(block)),
+                $"Next boundary mismatch from block {block} between offset {smallOffset} and {largeOffset}");
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -8,7 +8,6 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -48,6 +49,7 @@ public class PersistenceManagerTests
 
         _persistenceManager = new PersistenceManager(
             _config,
+            ScheduleHelper.CreateWithOffset(_config, 0),
             _finalizedStateProvider,
             _persistence,
             _snapshotRepository,
@@ -383,6 +385,39 @@ public class PersistenceManagerTests
 
         // Verify current persisted state was updated
         Assert.That(_persistenceManager.GetCurrentPersistedStateId(), Is.EqualTo(to));
+    }
+
+    #endregion
+
+    #region Offset Behavior
+
+    [TestCase(3, 13)]
+    [TestCase(5, 11)]
+    [TestCase(0, 16)]
+    public void DetermineSnapshotToPersist_WithOffset_FirstBoundaryShifted(int offset, int expectedTargetBlock)
+    {
+        // Fresh DB: currentPersistedState = Block0 (block 0).
+        // With CompactSize=16 and offset=N, the next full compaction boundary is at block 16-N.
+        PersistenceManager pm = new(
+            _config,
+            ScheduleHelper.CreateWithOffset(_config, offset),
+            _finalizedStateProvider,
+            _persistence,
+            _snapshotRepository,
+            LimboLogs.Instance);
+
+        StateId target = CreateStateId(expectedTargetBlock);
+        StateId latest = CreateStateId(200);
+        _finalizedStateProvider.SetFinalizedBlockNumber(200);
+        _finalizedStateProvider.SetFinalizedStateRootAt(expectedTargetBlock, new Hash256(target.StateRoot.Bytes));
+
+        using Snapshot expected = CreateSnapshot(Block0, target, compacted: true);
+
+        Snapshot? result = pm.DetermineSnapshotToPersist(latest);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.To, Is.EqualTo(target));
+        result.Dispose();
     }
 
     #endregion

--- a/src/Nethermind/Nethermind.State.Flat.Test/ScheduleHelper.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ScheduleHelper.cs
@@ -10,7 +10,7 @@ namespace Nethermind.State.Flat.Test;
 
 internal static class ScheduleHelper
 {
-    public static CompactionSchedule CreateWithOffset(IFlatDbConfig config, int offset)
+    public static CompactionSchedule CreateWithOffset(IFlatDbConfig config, long offset)
     {
         MemDb metadataDb = new();
         metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, Rlp.Encode(offset).Bytes);

--- a/src/Nethermind/Nethermind.State.Flat.Test/ScheduleHelper.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ScheduleHelper.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.State.Flat.Test;
+
+internal static class ScheduleHelper
+{
+    public static CompactionSchedule CreateWithOffset(IFlatDbConfig config, int offset)
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, Rlp.Encode(offset).Bytes);
+        return new CompactionSchedule(metadataDb, config, LimboLogs.Instance);
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
@@ -28,7 +28,7 @@ public class SnapshotCompactorTests
         _config = new FlatDbConfig { CompactSize = 16 };
         _resourcePool = new ResourcePool(_config);
         _snapshotRepository = new SnapshotRepository(LimboLogs.Instance);
-        _compactor = new SnapshotCompactor(_config, _resourcePool, _snapshotRepository, LimboLogs.Instance);
+        _compactor = new SnapshotCompactor(_config, ScheduleHelper.CreateWithOffset(_config, 0), _resourcePool, _snapshotRepository, LimboLogs.Instance);
     }
 
     private static StateId CreateStateId(long blockNumber, byte rootByte = 0)
@@ -361,7 +361,7 @@ public class SnapshotCompactorTests
     public void GetSnapshotsToCompact_CompactSizeDisabled_ReturnsEmpty()
     {
         FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
-        SnapshotCompactor compactor = new(config, _resourcePool, _snapshotRepository, LimboLogs.Instance);
+        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, _snapshotRepository, LimboLogs.Instance);
 
         StateId from = new(0, Keccak.Zero);
         StateId to = new(16, Keccak.Zero);
@@ -437,7 +437,7 @@ public class SnapshotCompactorTests
     {
         FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 4 };
         SnapshotRepository repo = new(LimboLogs.Instance);
-        SnapshotCompactor compactor = new(config, _resourcePool, repo, LimboLogs.Instance);
+        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, repo, LimboLogs.Instance);
 
         for (long i = 0; i < blockNumber; i++)
         {
@@ -517,24 +517,24 @@ public class SnapshotCompactorTests
     [Test]
     public void Constructor_NonPowerOf2CompactSize_Throws() =>
         Assert.Throws<ArgumentException>(() =>
-            new SnapshotCompactor(new FlatDbConfig { CompactSize = 10 }, _resourcePool, _snapshotRepository, LimboLogs.Instance));
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 10 }, LimboLogs.Instance));
 
     [Test]
     public void Constructor_NonPowerOf2MinCompactSize_Throws() =>
         Assert.Throws<ArgumentException>(() =>
-            new SnapshotCompactor(new FlatDbConfig { CompactSize = 16, MinCompactSize = 3 }, _resourcePool, _snapshotRepository, LimboLogs.Instance));
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 16, MinCompactSize = 3 }, LimboLogs.Instance));
 
     [Test]
     public void Constructor_MinCompactSizeGreaterThanCompactSize_Throws() =>
         Assert.Throws<ArgumentException>(() =>
-            new SnapshotCompactor(new FlatDbConfig { CompactSize = 8, MinCompactSize = 16 }, _resourcePool, _snapshotRepository, LimboLogs.Instance));
+            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 8, MinCompactSize = 16 }, LimboLogs.Instance));
 
     [Test]
     public void GetSnapshotsToCompact_MinCompactSize2_AllowsSize2Compaction()
     {
         FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
         SnapshotRepository repo = new(LimboLogs.Instance);
-        SnapshotCompactor compactor = new(config, _resourcePool, repo, LimboLogs.Instance);
+        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, repo, LimboLogs.Instance);
 
         for (long i = 0; i < 2; i++)
         {
@@ -584,5 +584,57 @@ public class SnapshotCompactorTests
     {
         int actualCompactSize = (int)Math.Min(blockNumber & -blockNumber, 16);
         Assert.That(actualCompactSize, Is.EqualTo(expectedCompactSize));
+    }
+
+    [Test]
+    public void GetSnapshotsToCompact_WithOffset_FullCompactionShiftedFromBoundary()
+    {
+        // CompactSize=16, offset=3 -> full compaction triggers when (block+3) % 16 == 0,
+        // i.e. at blocks 13, 29, 45, ... Build a chain to block 29 (second full boundary).
+        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        SnapshotRepository repo = new(LimboLogs.Instance);
+        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 3), _resourcePool, repo, LimboLogs.Instance);
+
+        for (long i = 0; i < 29; i++)
+        {
+            StateId from = CreateStateId(i);
+            StateId to = CreateStateId(i + 1);
+            Snapshot s = _resourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
+            repo.TryAddSnapshot(s);
+            repo.AddStateId(to);
+        }
+
+        // Block 29: (29+3) & -(29+3) = 32 & -32 = 32, capped at CompactSize=16 -> full compaction
+        StateId target29 = CreateStateId(29);
+        repo.TryLeaseState(target29, out Snapshot? targetSnapshot);
+        using SnapshotPooledList snapshots29 = compactor.GetSnapshotsToCompact(targetSnapshot!);
+        Assert.That(snapshots29.Count, Is.EqualTo(16), "Block 29 should trigger full compaction with offset=3");
+        targetSnapshot!.Dispose();
+
+        // Block 16: (16+3) & -(16+3) = 19 & -19 = 1 < MinCompactSize=2 -> no compaction
+        StateId target16 = CreateStateId(16);
+        repo.TryLeaseState(target16, out targetSnapshot);
+        using SnapshotPooledList snapshots16 = compactor.GetSnapshotsToCompact(targetSnapshot!);
+        Assert.That(snapshots16.Count, Is.EqualTo(0), "Block 16 should NOT trigger compaction with offset=3");
+        targetSnapshot!.Dispose();
+    }
+
+    [Test]
+    public void CompactSnapshotBundle_WithOffset_UsesCorrectUsageTier()
+    {
+        // CompactSize=16, offset=3. At block 13 the bit trick yields 16 -> Compact16 tier.
+        FlatDbConfig config = new() { CompactSize = 16 };
+        SnapshotRepository repo = new(LimboLogs.Instance);
+        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 3), _resourcePool, repo, LimboLogs.Instance);
+
+        StateId from = new(0, Keccak.Zero);
+        StateId to = new(13, Keccak.Zero);
+        using Snapshot snapshot = _resourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
+
+        SnapshotPooledList snapshots = new(1) { snapshot };
+
+        using Snapshot compacted = compactor.CompactSnapshotBundle(snapshots);
+
+        Assert.That(compacted.Usage, Is.EqualTo(ResourcePool.Usage.Compact16));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
@@ -360,7 +360,7 @@ public class SnapshotCompactorTests
     [Test]
     public void GetSnapshotsToCompact_CompactSizeDisabled_ReturnsEmpty()
     {
-        FlatDbConfig config = new() { CompactSize = 1, MinCompactSize = 0 };
+        FlatDbConfig config = new() { CompactSize = 1 };
         SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, _snapshotRepository, LimboLogs.Instance);
 
         StateId from = new(0, Keccak.Zero);
@@ -430,33 +430,6 @@ public class SnapshotCompactorTests
         targetSnapshot!.Dispose();
     }
 
-    [TestCase(2)]  // 2 & -2 = 2 < MinCompactSize(4)
-    [TestCase(6)]  // 6 & -6 = 2 < MinCompactSize(4)
-    [TestCase(10)] // 10 & -10 = 2 < MinCompactSize(4)
-    public void GetSnapshotsToCompact_BelowMinCompactSize_ReturnsEmpty(long blockNumber)
-    {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 4 };
-        SnapshotRepository repo = new(LimboLogs.Instance);
-        SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, repo, LimboLogs.Instance);
-
-        for (long i = 0; i < blockNumber; i++)
-        {
-            StateId from = CreateStateId(i);
-            StateId to = CreateStateId(i + 1);
-            Snapshot snapshot = _resourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
-            repo.TryAddSnapshot(snapshot);
-            repo.AddStateId(to);
-        }
-
-        StateId targetTo = CreateStateId(blockNumber);
-        repo.TryLeaseState(targetTo, out Snapshot? targetSnapshot);
-
-        using SnapshotPooledList snapshots = compactor.GetSnapshotsToCompact(targetSnapshot!);
-
-        Assert.That(snapshots.Count, Is.EqualTo(0));
-        targetSnapshot!.Dispose();
-    }
-
     [Test]
     public void GetSnapshotsToCompact_SingleSnapshot_ReturnsEmpty()
     {
@@ -520,19 +493,9 @@ public class SnapshotCompactorTests
             new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 10 }, LimboLogs.Instance));
 
     [Test]
-    public void Constructor_NonPowerOf2MinCompactSize_Throws() =>
-        Assert.Throws<ArgumentException>(() =>
-            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 16, MinCompactSize = 3 }, LimboLogs.Instance));
-
-    [Test]
-    public void Constructor_MinCompactSizeGreaterThanCompactSize_Throws() =>
-        Assert.Throws<ArgumentException>(() =>
-            new CompactionSchedule(new MemDb(), new FlatDbConfig { CompactSize = 8, MinCompactSize = 16 }, LimboLogs.Instance));
-
-    [Test]
-    public void GetSnapshotsToCompact_MinCompactSize2_AllowsSize2Compaction()
+    public void GetSnapshotsToCompact_Size2Compaction_AllowedByDefault()
     {
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        FlatDbConfig config = new() { CompactSize = 16 };
         SnapshotRepository repo = new(LimboLogs.Instance);
         SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 0), _resourcePool, repo, LimboLogs.Instance);
 
@@ -591,7 +554,7 @@ public class SnapshotCompactorTests
     {
         // CompactSize=16, offset=3 -> full compaction triggers when (block+3) % 16 == 0,
         // i.e. at blocks 13, 29, 45, ... Build a chain to block 29 (second full boundary).
-        FlatDbConfig config = new() { CompactSize = 16, MinCompactSize = 2 };
+        FlatDbConfig config = new() { CompactSize = 16 };
         SnapshotRepository repo = new(LimboLogs.Instance);
         SnapshotCompactor compactor = new(config, ScheduleHelper.CreateWithOffset(config, 3), _resourcePool, repo, LimboLogs.Instance);
 
@@ -611,7 +574,7 @@ public class SnapshotCompactorTests
         Assert.That(snapshots29.Count, Is.EqualTo(16), "Block 29 should trigger full compaction with offset=3");
         targetSnapshot!.Dispose();
 
-        // Block 16: (16+3) & -(16+3) = 19 & -19 = 1 < MinCompactSize=2 -> no compaction
+        // Block 16: (16+3) & -(16+3) = 19 & -19 = 1 -> caller sees compactSize<=1, no compaction
         StateId target16 = CreateStateId(16);
         repo.TryLeaseState(target16, out targetSnapshot);
         using SnapshotPooledList snapshots16 = compactor.GetSnapshotsToCompact(targetSnapshot!);

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Db;

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac.Features.AttributeFilters;
+using Nethermind.Core;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.State.Flat;
+
+public sealed class CompactionSchedule : ICompactionSchedule
+{
+    private readonly int _compactSize;
+    private readonly int _minCompactSize;
+    private readonly int _offset;
+
+    public CompactionSchedule(
+        [KeyFilter(DbNames.Metadata)] IDb metadataDb,
+        IFlatDbConfig config,
+        ILogManager logManager)
+    {
+        if (config.CompactSize > 1 && (config.CompactSize & (config.CompactSize - 1)) != 0)
+            throw new ArgumentException("Compact size must be a power of 2");
+        if (config.MinCompactSize > 1 && (config.MinCompactSize & (config.MinCompactSize - 1)) != 0)
+            throw new ArgumentException("Min compact size must be a power of 2");
+        if (config.MinCompactSize > config.CompactSize)
+            throw new ArgumentException("Min compact size must be <= compact size");
+
+        _compactSize = config.CompactSize;
+        _minCompactSize = Math.Max(config.MinCompactSize, 2);
+
+        ILogger logger = logManager.GetClassLogger<CompactionSchedule>();
+        _offset = ResolveOffset(metadataDb, config, logger);
+    }
+
+    public int Offset => _offset;
+
+    public int GetCompactSize(long blockNumber)
+    {
+        if (_compactSize <= 1 || blockNumber == 0) return 1;
+        long shifted = blockNumber + _offset;
+        int compactSize = (int)Math.Min(shifted & -shifted, _compactSize);
+        return compactSize < _minCompactSize ? 1 : compactSize;
+    }
+
+    public long NextFullCompactionAfter(long from)
+    {
+        if (_compactSize <= 1) return long.MaxValue;
+        long mod = (from + _offset) % _compactSize;
+        long distance = mod == 0 ? _compactSize : _compactSize - mod;
+        return from + distance;
+    }
+
+    private int ResolveOffset(IDb metadataDb, IFlatDbConfig config, ILogger logger)
+    {
+        if (_compactSize <= 1) return 0;
+
+        if (config.RegenerateCompactionOffset)
+        {
+            int regenerated = GenerateAndPersist(metadataDb);
+            if (logger.IsInfo) logger.Info($"Regenerated FlatDb compaction offset {regenerated} (RegenerateCompactionOffset=true)");
+            return regenerated;
+        }
+
+        byte[]? stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset);
+        if (stored is null)
+        {
+            int generated = GenerateAndPersist(metadataDb);
+            if (logger.IsInfo) logger.Info($"Generated new FlatDb compaction offset {generated}");
+            return generated;
+        }
+
+        int decoded = stored.AsRlpValueContext().DecodeInt();
+        if (decoded < 0 || decoded >= _compactSize)
+        {
+            if (logger.IsWarn) logger.Warn($"Stored FlatDb compaction offset {decoded} is out of range for CompactSize {_compactSize}; regenerating");
+            return GenerateAndPersist(metadataDb);
+        }
+
+        if (logger.IsInfo) logger.Info($"Loaded FlatDb compaction offset {decoded}");
+        return decoded;
+    }
+
+    private int GenerateAndPersist(IDb metadataDb)
+    {
+        int offset = Random.Shared.Next(0, _compactSize);
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, Rlp.Encode(offset).Bytes);
+        return offset;
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -14,7 +14,7 @@ public sealed class CompactionSchedule : ICompactionSchedule
 {
     private readonly int _compactSize;
     private readonly int _minCompactSize;
-    private readonly int _offset;
+    private readonly long _offset;
 
     public CompactionSchedule(
         [KeyFilter(DbNames.Metadata)] IDb metadataDb,
@@ -35,7 +35,7 @@ public sealed class CompactionSchedule : ICompactionSchedule
         _offset = ResolveOffset(metadataDb, config, logger);
     }
 
-    public int Offset => _offset;
+    public long Offset => _offset;
 
     public int GetCompactSize(long blockNumber)
     {
@@ -53,13 +53,13 @@ public sealed class CompactionSchedule : ICompactionSchedule
         return from + distance;
     }
 
-    private int ResolveOffset(IDb metadataDb, IFlatDbConfig config, ILogger logger)
+    private long ResolveOffset(IDb metadataDb, IFlatDbConfig config, ILogger logger)
     {
         if (_compactSize <= 1) return 0;
 
         if (config.RegenerateCompactionOffset)
         {
-            int regenerated = GenerateAndPersist(metadataDb);
+            long regenerated = GenerateAndPersist(metadataDb);
             if (logger.IsInfo) logger.Info($"Regenerated FlatDb compaction offset {regenerated} (RegenerateCompactionOffset=true)");
             return regenerated;
         }
@@ -67,15 +67,15 @@ public sealed class CompactionSchedule : ICompactionSchedule
         byte[]? stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset);
         if (stored is null)
         {
-            int generated = GenerateAndPersist(metadataDb);
+            long generated = GenerateAndPersist(metadataDb);
             if (logger.IsInfo) logger.Info($"Generated new FlatDb compaction offset {generated}");
             return generated;
         }
 
-        int decoded = stored.AsRlpValueContext().DecodeInt();
-        if (decoded < 0 || decoded >= _compactSize)
+        long decoded = stored.AsRlpValueContext().DecodeLong();
+        if (decoded < 0)
         {
-            if (logger.IsWarn) logger.Warn($"Stored FlatDb compaction offset {decoded} is out of range for CompactSize {_compactSize}; regenerating");
+            if (logger.IsWarn) logger.Warn($"Stored FlatDb compaction offset {decoded} is negative; regenerating");
             return GenerateAndPersist(metadataDb);
         }
 
@@ -83,9 +83,9 @@ public sealed class CompactionSchedule : ICompactionSchedule
         return decoded;
     }
 
-    private int GenerateAndPersist(IDb metadataDb)
+    private long GenerateAndPersist(IDb metadataDb)
     {
-        int offset = Random.Shared.Next(0, _compactSize);
+        long offset = Random.Shared.NextInt64(0, int.MaxValue);
         metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, Rlp.Encode(offset).Bytes);
         return offset;
     }

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -13,7 +13,6 @@ namespace Nethermind.State.Flat;
 public sealed class CompactionSchedule : ICompactionSchedule
 {
     private readonly int _compactSize;
-    private readonly int _minCompactSize;
     private readonly long _offset;
 
     public CompactionSchedule(
@@ -23,13 +22,8 @@ public sealed class CompactionSchedule : ICompactionSchedule
     {
         if (config.CompactSize > 1 && (config.CompactSize & (config.CompactSize - 1)) != 0)
             throw new ArgumentException("Compact size must be a power of 2");
-        if (config.MinCompactSize > 1 && (config.MinCompactSize & (config.MinCompactSize - 1)) != 0)
-            throw new ArgumentException("Min compact size must be a power of 2");
-        if (config.MinCompactSize > config.CompactSize)
-            throw new ArgumentException("Min compact size must be <= compact size");
 
         _compactSize = config.CompactSize;
-        _minCompactSize = Math.Max(config.MinCompactSize, 2);
 
         ILogger logger = logManager.GetClassLogger<CompactionSchedule>();
         _offset = ResolveOffset(metadataDb, config, logger);
@@ -41,8 +35,7 @@ public sealed class CompactionSchedule : ICompactionSchedule
     {
         if (_compactSize <= 1 || blockNumber == 0) return 1;
         long shifted = blockNumber + _offset;
-        int compactSize = (int)Math.Min(shifted & -shifted, _compactSize);
-        return compactSize < _minCompactSize ? 1 : compactSize;
+        return (int)Math.Min(shifted & -shifted, _compactSize);
     }
 
     public long NextFullCompactionAfter(long from)

--- a/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
@@ -8,8 +8,8 @@ public interface ICompactionSchedule
     /// <summary>
     /// Compact-size tier (power of 2, capped at <c>CompactSize</c>) that would be triggered
     /// at <paramref name="blockNumber"/>. Considers the per-instance offset so that nodes do
-    /// not compact in lockstep. Returns 1 when no compaction should run (block 0, below
-    /// <c>MinCompactSize</c>, or compaction disabled).
+    /// not compact in lockstep. Returns 1 when no compaction should run (block 0 or compaction
+    /// disabled).
     /// </summary>
     int GetCompactSize(long blockNumber);
 

--- a/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+public interface ICompactionSchedule
+{
+    /// <summary>
+    /// Compact-size tier (power of 2, capped at <c>CompactSize</c>) that would be triggered
+    /// at <paramref name="blockNumber"/>. Considers the per-instance offset so that nodes do
+    /// not compact in lockstep. Returns 1 when no compaction should run (block 0, below
+    /// <c>MinCompactSize</c>, or compaction disabled).
+    /// </summary>
+    int GetCompactSize(long blockNumber);
+
+    /// <summary>
+    /// The next block strictly greater than <paramref name="from"/> at which a full-size
+    /// compaction (and hence a persistence boundary) will occur. Returns <see cref="long.MaxValue"/>
+    /// when compaction is disabled.
+    /// </summary>
+    long NextFullCompactionAfter(long from);
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -21,6 +21,7 @@ namespace Nethermind.State.Flat;
 
 public class PersistenceManager(
     IFlatDbConfig configuration,
+    ICompactionSchedule compactionSchedule,
     IFinalizedStateProvider finalizedStateProvider,
     IPersistence persistence,
     ISnapshotRepository snapshotRepository,
@@ -30,6 +31,7 @@ public class PersistenceManager(
     private readonly int _minReorgDepth = configuration.MinReorgDepth;
     private readonly int _maxReorgDepth = configuration.MaxReorgDepth;
     private readonly int _compactSize = configuration.CompactSize;
+    private readonly ICompactionSchedule _schedule = compactionSchedule;
     private readonly List<(Hash256, TreePath)> _trieNodesSortBuffer = []; // Presort make it faster
     private readonly Lock _persistenceLock = new();
 
@@ -122,8 +124,8 @@ public class PersistenceManager(
 
         Snapshot? snapshotToPersist;
 
-        long afterPersistPersistedBlockNumber = currentPersistedState.BlockNumber + _compactSize;
-        if (afterPersistPersistedBlockNumber > finalizedBlockNumber)
+        long nextCompactedBoundary = _schedule.NextFullCompactionAfter(currentPersistedState.BlockNumber);
+        if (nextCompactedBoundary > finalizedBlockNumber)
         {
             if (inMemoryStateDepth <= _maxReorgDepth)
             {
@@ -132,12 +134,12 @@ public class PersistenceManager(
             }
 
             if (_logger.IsWarn) _logger.Warn($"Very long unfinalized state. Force persisting to conserve memory. finalized block number is {finalizedBlockNumber}.");
-            snapshotToPersist = GetFirstSnapshotAtBlockNumber(currentPersistedState.BlockNumber + _compactSize, currentPersistedState, true) ??
+            snapshotToPersist = GetFirstSnapshotAtBlockNumber(nextCompactedBoundary, currentPersistedState, true) ??
                                 GetFirstSnapshotAtBlockNumber(currentPersistedState.BlockNumber + 1, currentPersistedState, false);
         }
         else
         {
-            snapshotToPersist = GetFinalizedSnapshotAtBlockNumber(currentPersistedState.BlockNumber + _compactSize, currentPersistedState, true) ??
+            snapshotToPersist = GetFinalizedSnapshotAtBlockNumber(nextCompactedBoundary, currentPersistedState, true) ??
                                 GetFinalizedSnapshotAtBlockNumber(currentPersistedState.BlockNumber + 1, currentPersistedState, false);
         }
 
@@ -185,9 +187,11 @@ public class PersistenceManager(
         // Persist all snapshots from current persisted state to latest
         while (currentPersistedState.BlockNumber < latestStateId.Value.BlockNumber)
         {
+            long nextCompactedBoundary = _schedule.NextFullCompactionAfter(currentPersistedState.BlockNumber);
+
             // Try finalized snapshots first (compacted, then non-compacted)
             Snapshot? snapshotToPersist = GetFinalizedSnapshotAtBlockNumber(
-                currentPersistedState.BlockNumber + _compactSize,
+                nextCompactedBoundary,
                 currentPersistedState,
                 compactedSnapshot: true);
 
@@ -198,7 +202,7 @@ public class PersistenceManager(
 
             // Fall back to the first available snapshot if finalized not available
             snapshotToPersist ??= GetFirstSnapshotAtBlockNumber(
-                currentPersistedState.BlockNumber + _compactSize,
+                nextCompactedBoundary,
                 currentPersistedState,
                 compactedSnapshot: true);
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
@@ -14,32 +14,18 @@ using Nethermind.Trie;
 
 namespace Nethermind.State.Flat;
 
-public class SnapshotCompactor : ISnapshotCompactor
+public class SnapshotCompactor(
+    IFlatDbConfig config,
+    ICompactionSchedule schedule,
+    IResourcePool resourcePool,
+    ISnapshotRepository snapshotRepository,
+    ILogManager logManager) : ISnapshotCompactor
 {
-    private readonly int _compactSize;
-    private readonly int _minCompactSize;
-    private readonly ILogger _logger;
-    private readonly IResourcePool _resourcePool;
-    private readonly ISnapshotRepository _snapshotRepository;
-
-    public SnapshotCompactor(IFlatDbConfig config,
-        IResourcePool resourcePool,
-        ISnapshotRepository snapshotRepository,
-        ILogManager logManager)
-    {
-        if (config.CompactSize > 1 && (config.CompactSize & (config.CompactSize - 1)) != 0)
-            throw new ArgumentException("Compact size must be a power of 2");
-        if (config.MinCompactSize > 1 && (config.MinCompactSize & (config.MinCompactSize - 1)) != 0)
-            throw new ArgumentException("Min compact size must be a power of 2");
-        if (config.MinCompactSize > config.CompactSize)
-            throw new ArgumentException("Min compact size must be <= compact size");
-
-        _resourcePool = resourcePool;
-        _snapshotRepository = snapshotRepository;
-        _compactSize = config.CompactSize;
-        _minCompactSize = Math.Max(config.MinCompactSize, 2);
-        _logger = logManager.GetClassLogger<SnapshotCompactor>();
-    }
+    private readonly int _compactSize = config.CompactSize;
+    private readonly ICompactionSchedule _schedule = schedule;
+    private readonly ILogger _logger = logManager.GetClassLogger<SnapshotCompactor>();
+    private readonly IResourcePool _resourcePool = resourcePool;
+    private readonly ISnapshotRepository _snapshotRepository = snapshotRepository;
 
     public bool DoCompactSnapshot(in StateId stateId)
     {
@@ -73,12 +59,9 @@ public class SnapshotCompactor : ISnapshotCompactor
 
     public SnapshotPooledList GetSnapshotsToCompact(Snapshot snapshot)
     {
-        if (_compactSize <= 1) return SnapshotPooledList.Empty(); // Disabled
         long blockNumber = snapshot.To.BlockNumber;
-        if (blockNumber == 0) return SnapshotPooledList.Empty();
-
-        int compactSize = (int)Math.Min(blockNumber & -blockNumber, _compactSize);
-        if (compactSize < _minCompactSize) return SnapshotPooledList.Empty();
+        int compactSize = _schedule.GetCompactSize(blockNumber);
+        if (compactSize <= 1) return SnapshotPooledList.Empty();
         bool isFullCompaction = compactSize == _compactSize;
 
         if (!isFullCompaction)
@@ -92,7 +75,7 @@ public class SnapshotCompactor : ISnapshotCompactor
             }
         }
 
-        long startingBlockNumber = ((blockNumber - 1) / compactSize) * compactSize;
+        long startingBlockNumber = blockNumber - compactSize;
         SnapshotPooledList snapshots = _snapshotRepository.AssembleSnapshotsUntil(snapshot.To, startingBlockNumber, compactSize);
 
         bool snapshotsOk = false;
@@ -125,7 +108,7 @@ public class SnapshotCompactor : ISnapshotCompactor
         StateId to = snapshots[^1].To;
         StateId from = snapshots[0].From;
 
-        int compactSize = (int)Math.Min(to.BlockNumber & -to.BlockNumber, _compactSize);
+        int compactSize = _schedule.GetCompactSize(to.BlockNumber);
         ResourcePool.Usage usage = ResourcePool.CompactUsage(compactSize);
 
         Snapshot snapshot = _resourcePool.CreateSnapshot(from, to, usage);


### PR DESCRIPTION
## Summary

- FlatDB's `SnapshotCompactor` uses `blockNumber & -blockNumber` (capped at `CompactSize=32`) to choose the compaction tier. Because the math depends only on the block number, every node hits the same full-compaction boundary at the same height, and the persistence it triggers fires in lockstep across the fleet. For RPC providers running many nodes this shows up as correlated latency spikes every 32 blocks.
- Introduce `ICompactionSchedule` / `CompactionSchedule` that adds a per-instance random offset to the bit-trick: `(blockNumber + offset) & -(blockNumber + offset)`. The offset is a `long` in `[0, int.MaxValue)`, persisted in the metadata DB under a new key, and resolved once at startup. `SnapshotCompactor` and `PersistenceManager` both delegate tier decisions to the schedule so the offset lives in one place.
- Add `FlatDb.RegenerateCompactionOffset` (sticky, default `false`) so that a service provider restoring one backup into many instances can force a fresh roll per instance.
- Drop `FlatDb.MinCompactSize` — its default value was effectively the floor and the caller's `compactSize <= 1` short-circuit handles size-1 (odd) blocks naturally.

## Why a long offset instead of `[0, CompactSize)`

Modular arithmetic in `GetCompactSize` and `NextFullCompactionAfter` is invariant to adding multiples of `CompactSize` to the offset, so widening the range:

1. Decouples the stored offset from the current `CompactSize` — a config change no longer invalidates the persisted offset.
2. Gives much wider entropy so nodes started in the same `Random.Shared` seed-time window get distinct schedules.

## Test plan

- [x] `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj -c release` — 347 passed, 4 skipped (unrelated preimage-mode skips), 0 failed.
- [x] Full solution build clean (`dotnet build -c release Nethermind.slnx`): 0 warnings, 0 errors.
- [ ] Manual: start a node with FlatDB enabled twice with the metadata DB persisted between runs; confirm the same offset value is loaded both times via the `Loaded FlatDb compaction offset {n}` log line. Then set `FlatDb.RegenerateCompactionOffset = true`, restart, confirm a different value is generated.
- [ ] Reproducible benchmarks (`run-expb-reproducible-benchmarks`) on `flat` layout to confirm no `Exception` / `Invalid Block` / `Unhandled` in run logs and that persistence cadence shift is invisible at the protocol level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)