### PR TITLE
feat(Core): introduce NativeMemoryList<T> / NativeMemoryListRef<T> and public ValueAddress

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections;
+using System.Linq;
+using FluentAssertions;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Collections;
+
+[Parallelizable(ParallelScope.All)]
+public class NativeMemoryListTests
+{
+    [Test]
+    public void Empty_list_and_zero_capacity_growth()
+    {
+        using NativeMemoryList<int> list = new(1024);
+        list.Count.Should().Be(0);
+        list.Capacity.Should().Be(1024);
+
+        using NativeMemoryList<int> empty = new(0);
+        empty.Should().BeEmpty();
+        empty.Add(1);
+        empty.Count.Should().Be(1);
+        empty.Remove(1).Should().BeTrue();
+        empty.Count.Should().Be(0);
+        empty.Add(2);
+        empty[0].Should().Be(2);
+    }
+
+    [Test]
+    public void Add_AddRange_and_growth()
+    {
+        using NativeMemoryList<int> list = new(4);
+        list.AddRange(Enumerable.Range(0, 50).ToArray());
+        list.Should().BeEquivalentTo(Enumerable.Range(0, 50));
+        list.Count.Should().Be(50);
+        list.Capacity.Should().BeGreaterThanOrEqualTo(50);
+
+        list.Add(123);
+        list[50].Should().Be(123);
+    }
+
+    [Test]
+    public void Clear_resets_count_only()
+    {
+        using NativeMemoryList<int> list = new(8);
+        list.AddRange(stackalloc int[] { 1, 2, 3 });
+        int before = list.Capacity;
+        list.Clear();
+        list.Count.Should().Be(0);
+        list.Capacity.Should().Be(before);
+        list.Add(99);
+        list[0].Should().Be(99);
+    }
+
+    [TestCase(0)]
+    [TestCase(2)]
+    [TestCase(4)]
+    public void Insert_RemoveAt_at_various_indices(int index)
+    {
+        using NativeMemoryList<int> list = new(8);
+        list.AddRange(stackalloc int[] { 0, 1, 2, 3, 4 });
+        list.Insert(index, 99);
+        list[index].Should().Be(99);
+        list.Count.Should().Be(6);
+
+        list.RemoveAt(index);
+        list.Should().BeEquivalentTo(new[] { 0, 1, 2, 3, 4 });
+    }
+
+    [Test]
+    public void IndexOf_Contains_Remove_work()
+    {
+        using NativeMemoryList<int> list = new(4, [10, 20, 30]);
+        list.IndexOf(20).Should().Be(1);
+        list.Contains(30).Should().BeTrue();
+        list.Contains(99).Should().BeFalse();
+        list.Remove(20).Should().BeTrue();
+        list.Should().BeEquivalentTo(new[] { 10, 30 });
+        list.Remove(99).Should().BeFalse();
+    }
+
+    [Test]
+    public void GetRef_returns_writable_reference()
+    {
+        using NativeMemoryList<int> list = new(2, 2);
+        ref int slot = ref list.GetRef(1);
+        slot = 42;
+        list[1].Should().Be(42);
+    }
+
+    [Test]
+    public void AsSpan_reflects_count()
+    {
+        using NativeMemoryList<int> list = new(4);
+        list.AddRange(stackalloc int[] { 1, 2, 3 });
+        list.AsSpan().Length.Should().Be(3);
+        list.AsSpan()[1].Should().Be(2);
+    }
+
+    [Test]
+    public void Sort_and_Reverse()
+    {
+        using NativeMemoryList<int> list = new(4, [3, 1, 4, 1, 5, 9, 2, 6]);
+        list.Sort((a, b) => a.CompareTo(b));
+        list.Should().BeEquivalentTo(new[] { 1, 1, 2, 3, 4, 5, 6, 9 }, o => o.WithStrictOrdering());
+        list.Reverse();
+        list.Should().BeEquivalentTo(new[] { 9, 6, 5, 4, 3, 2, 1, 1 }, o => o.WithStrictOrdering());
+    }
+
+    [Test]
+    public void Truncate_and_ReduceCount()
+    {
+        using NativeMemoryList<int> list = new(64);
+        list.AddRange(Enumerable.Range(0, 50).ToArray());
+
+        list.Truncate(10);
+        list.Count.Should().Be(10);
+
+        list.ReduceCount(2);
+        list.Count.Should().Be(2);
+        list.Should().BeEquivalentTo(new[] { 0, 1 }, o => o.WithStrictOrdering());
+    }
+
+    [Test]
+    public void CopyTo_writes_into_destination_array()
+    {
+        using NativeMemoryList<int> list = new(4, [1, 2, 3]);
+        int[] dest = new int[5];
+        list.CopyTo(dest, 1);
+        dest.Should().BeEquivalentTo(new[] { 0, 1, 2, 3, 0 }, o => o.WithStrictOrdering());
+    }
+
+    [Test]
+    public void Dispose_is_idempotent_and_post_dispose_throws()
+    {
+        NativeMemoryList<int> list = new(4, [1, 2, 3]);
+        list.Dispose();
+        list.Dispose();
+        Action act = () => _ = list[0];
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public void IList_interface_compliance()
+    {
+        using NativeMemoryList<int> list = new(4);
+        IList ilist = list;
+        ilist.Add(1).Should().Be(0);
+        ilist.Add(2).Should().Be(1);
+        ilist.Contains(1).Should().BeTrue();
+        ilist.IndexOf(2).Should().Be(1);
+        ilist[0] = 99;
+        ilist[0].Should().Be(99);
+        ilist.Insert(0, 7);
+        ilist[0].Should().Be(7);
+        ilist.Remove(7);
+        ilist.Count.Should().Be(2);
+    }
+
+    [Test]
+    public void Ref_struct_round_trip()
+    {
+        NativeMemoryListRef<int> r = new(4);
+        try
+        {
+            r.AddRange(stackalloc int[] { 1, 2, 3 });
+            r.Count.Should().Be(3);
+            r[1].Should().Be(2);
+            r.AsSpan().ToArray().Should().BeEquivalentTo(new[] { 1, 2, 3 }, o => o.WithStrictOrdering());
+            r.Add(4);
+            r.AsSpan()[3].Should().Be(4);
+            r.Insert(0, 0);
+            r.AsSpan().ToArray().Should().BeEquivalentTo(new[] { 0, 1, 2, 3, 4 }, o => o.WithStrictOrdering());
+            r.RemoveAt(0);
+            r.AsSpan().ToArray().Should().BeEquivalentTo(new[] { 1, 2, 3, 4 }, o => o.WithStrictOrdering());
+            r.Clear();
+            r.Count.Should().Be(0);
+        }
+        finally
+        {
+            r.Dispose();
+            r.Dispose(); // idempotent
+        }
+    }
+
+    [Test]
+    public void Ref_struct_growth_past_initial_capacity()
+    {
+        NativeMemoryListRef<long> r = new(2);
+        try
+        {
+            for (int i = 0; i < 1000; i++) r.Add(i);
+            r.Count.Should().Be(1000);
+            r.Capacity.Should().BeGreaterThanOrEqualTo(1000);
+            r[0].Should().Be(0L);
+            r[999].Should().Be(999L);
+        }
+        finally { r.Dispose(); }
+    }
+
+    [Test]
+    public void Ref_struct_EnsureCapacity()
+    {
+        NativeMemoryListRef<byte> r = new(4);
+        try
+        {
+            r.EnsureCapacity(4096);
+            r.Capacity.Should().BeGreaterThanOrEqualTo(4096);
+        }
+        finally { r.Dispose(); }
+    }
+
+    [Test]
+    public void Empty_constructor_returns_disposable_zero_capacity()
+    {
+        using NativeMemoryList<int> empty = NativeMemoryList<int>.Empty();
+        empty.Count.Should().Be(0);
+        empty.Capacity.Should().Be(0);
+    }
+
+    // Capacity*sizeof(T) is well under the 1024-byte pool threshold here, so the underlying
+    // buffer is rented from ArrayPool<T>.Shared (pinned) rather than NativeMemory.Alloc.
+    // The list must behave identically regardless of which strategy was used; verify all
+    // mutating + read paths with a single end-to-end exercise.
+    [TestCase(8)]
+    [TestCase(32)]
+    [TestCase(64)]
+    public void Sub_threshold_capacity_round_trips(int capacity)
+    {
+        using NativeMemoryList<byte> list = new(capacity);
+        list.Count.Should().Be(0);
+        list.Capacity.Should().BeGreaterThanOrEqualTo(capacity);
+
+        list.AddRange(Bytes.FromHexString("deadbeef"));
+        list.Count.Should().Be(4);
+        list[0].Should().Be(0xde);
+        list[3].Should().Be(0xef);
+
+        list.Insert(0, 0x01);
+        list[0].Should().Be(0x01);
+        list[4].Should().Be(0xef);
+
+        list.RemoveAt(0);
+        list.AsSpan().ToArray().Should().BeEquivalentTo(Bytes.FromHexString("deadbeef"), o => o.WithStrictOrdering());
+
+        list.Reverse();
+        list[0].Should().Be(0xef);
+    }
+
+    // Cross the pool/native boundary inside one list lifetime: start in the pool (16 bytes),
+    // grow past 1 KiB so subsequent reallocations route to NativeMemory.Alloc, and confirm
+    // the data survives the strategy switch and that Dispose frees both code paths cleanly.
+    [Test]
+    public void Growth_across_pool_native_threshold_preserves_data()
+    {
+        using NativeMemoryList<byte> list = new(16);
+        byte[] payload = new byte[4096];
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i & 0xFF);
+        list.AddRange(payload);
+
+        list.Count.Should().Be(payload.Length);
+        list.Capacity.Should().BeGreaterThanOrEqualTo(payload.Length);
+        list.AsSpan().ToArray().Should().BeEquivalentTo(payload, o => o.WithStrictOrdering());
+    }
+
+    // ReduceCount shrinks below the byte threshold; the internal reallocation must route to
+    // ArrayPool and the data must remain readable.
+    [Test]
+    public void ReduceCount_downgrades_native_to_pool_when_under_threshold()
+    {
+        using NativeMemoryList<long> list = new(256);  // 256 * 8 = 2 KiB → native
+        for (int i = 0; i < 256; i++) list.Add(i);
+
+        list.ReduceCount(8);  // 8 * 8 = 64 bytes → pool
+        list.Count.Should().Be(8);
+        list[0].Should().Be(0L);
+        list[7].Should().Be(7L);
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
@@ -281,4 +281,17 @@ public class NativeMemoryListTests
         list[0].Should().Be(0L);
         list[7].Should().Be(7L);
     }
+
+    // Regression for an issue where the (capacity, count) ctor would zero-clear `count` elements
+    // against a buffer sized for `capacity` — heap overwrite when count > capacity on the native
+    // path (no pool overallocation).
+    [TestCase(-1)]
+    [TestCase(5)]
+    public void Ctor_starting_count_out_of_range_throws(int badCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => { using NativeMemoryList<int> _ = new(4, badCount); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => CtorRef(badCount));
+
+        static void CtorRef(int bad) { NativeMemoryListRef<int> _ = new(4, bad); }
+    }
 }

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -28,30 +28,24 @@ namespace Nethermind.Core
         private const int HexCharsCount = 2 * Size; // 5a4eab120fb44eb6684e5e32785702ff45ea344d
         private const int PrefixedHexCharsCount = 2 + HexCharsCount; // 0x5a4eab120fb44eb6684e5e32785702ff45ea344d
 
-        public static Address Zero { get; } = new(default(AddressBytes));
+        public static Address Zero { get; } = new(default(ValueAddress));
         public static Address MaxValue { get; } = new("0xffffffffffffffffffffffffffffffffffffffff");
 
         public const string SystemUserHex = "0xfffffffffffffffffffffffffffffffffffffffe";
         public static Address SystemUser { get; } = new(SystemUserHex);
 
-        private AddressBytes _bytes;
+        private readonly ValueAddress _bytes;
 
         public ReadOnlySpan<byte> Bytes
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in FirstByte), Size);
-        }
-
-        [InlineArray(Size)]
-        internal struct AddressBytes
-        {
-            private byte _element0;
+            get => _bytes.AsSpan;
         }
 
         private ref readonly byte FirstByte
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref Unsafe.As<AddressBytes, byte>(ref Unsafe.AsRef(in _bytes));
+            get => ref MemoryMarshal.GetReference(_bytes.AsSpan);
         }
 
         public Address(Hash256 hash) : this(hash.Bytes.Slice(12, Size)) { }
@@ -152,10 +146,10 @@ namespace Nethermind.Core
                     nameof(bytes));
             }
 
-            bytes.CopyTo(MemoryMarshal.CreateSpan(ref Unsafe.As<AddressBytes, byte>(ref _bytes), Size));
+            _bytes = new ValueAddress(bytes);
         }
 
-        internal Address(AddressBytes bytes) => _bytes = bytes;
+        internal Address(in ValueAddress bytes) => _bytes = bytes;
 
         public bool Equals(Address? other)
         {

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
@@ -36,6 +36,8 @@ public sealed unsafe class NativeMemoryList<T> : IList<T>, IList, IOwnedReadOnly
 
     public NativeMemoryList(int capacity, int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, capacity);
         _ptr = NativeMemoryListCore<T>.AllocateBuffer(capacity, out _pooledArray, out _pinHandle, out _capacity);
         if (count > 0) new Span<T>(_ptr, count).Clear();
         _count = count;

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Collections;
+
+/// <summary>
+/// List backed by <see cref="NativeMemory"/> for large buffers and <see cref="System.Buffers.ArrayPool{T}"/>
+/// (pinned) for small ones — the switch is decided by byte size at allocation time. Mirrors
+/// <see cref="ArrayPoolList{T}"/> in shape but keeps storage off the managed heap whenever the
+/// requested capacity is large enough to be worth a native alloc. Constrained to
+/// <see langword="unmanaged"/> element types. Buffers expose only <see cref="Span{T}"/> —
+/// no <see cref="Memory{T}"/> projection.
+/// </summary>
+public sealed unsafe class NativeMemoryList<T> : IList<T>, IList, IOwnedReadOnlyList<T> where T : unmanaged
+{
+    private T* _ptr;
+    private T[]? _pooledArray;
+    private GCHandle _pinHandle;
+    private int _capacity;
+    private int _count;
+    private bool _disposed;
+
+    public NativeMemoryList(int capacity)
+    {
+        _ptr = NativeMemoryListCore<T>.AllocateBuffer(capacity, out _pooledArray, out _pinHandle, out _capacity);
+        _count = 0;
+    }
+
+    public NativeMemoryList(int capacity, int count)
+    {
+        _ptr = NativeMemoryListCore<T>.AllocateBuffer(capacity, out _pooledArray, out _pinHandle, out _capacity);
+        if (count > 0) new Span<T>(_ptr, count).Clear();
+        _count = count;
+    }
+
+    public NativeMemoryList(int capacity, IEnumerable<T> enumerable) : this(capacity)
+    {
+        foreach (T item in enumerable) Add(item);
+    }
+
+    public NativeMemoryList(ReadOnlySpan<T> span) : this(span.Length) => AddRange(span);
+
+    public int Count => _count;
+    public int Capacity => _capacity;
+
+    ReadOnlySpan<T> IOwnedReadOnlyList<T>.AsSpan() => AsSpan();
+
+    public Span<T> AsSpan()
+    {
+        GuardDispose();
+        return new Span<T>(_ptr, _count);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void GuardDispose()
+    {
+        if (_disposed) ThrowObjectDisposed();
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(NativeMemoryList<T>));
+    }
+
+    public Enumerator GetEnumerator()
+    {
+        GuardDispose();
+        return new Enumerator(_ptr, _count);
+    }
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Add(T item)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Add(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, item);
+    }
+
+    int IList.Add(object? value)
+    {
+        ThrowHelper.IfNullAndNullsAreIllegalThenThrow<T>(value, nameof(value));
+        Add((T)value!);
+        return _count - 1;
+    }
+
+    public void AddRange(params ReadOnlySpan<T> items)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.AddRange(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, items);
+    }
+
+    public void EnsureCapacity(int capacity)
+    {
+        GuardDispose();
+        if (capacity > _capacity)
+        {
+            NativeMemoryListCore<T>.GuardResize(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, _count, capacity - _count);
+        }
+    }
+
+    public void Clear()
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Clear(ref _count);
+    }
+
+    public bool Contains(T item)
+    {
+        GuardDispose();
+        return NativeMemoryListCore<T>.Contains(_ptr, _count, item);
+    }
+
+    bool IList.Contains(object? value) => IsCompatibleObject(value) && Contains((T)value!);
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.CopyTo(_ptr, _count, array, arrayIndex);
+    }
+
+    void ICollection.CopyTo(Array? array, int index)
+    {
+        if (array is T[] typed)
+        {
+            CopyTo(typed, index);
+            return;
+        }
+        ThrowUnsupportedArrayType();
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnsupportedArrayType() =>
+            throw new ArgumentException($"Only {typeof(T[])} arrays are supported.", nameof(array));
+    }
+
+    public void ReduceCount(int count)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.ReduceCount(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, count);
+    }
+
+    public void Sort(Comparison<T> comparison)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Sort(_ptr, _count, comparison);
+    }
+
+    public void Sort<TComparer>(TComparer comparer) where TComparer : IComparer<T>
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Sort(_ptr, _count, comparer);
+    }
+
+    public void Reverse()
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Reverse(_ptr, _count);
+    }
+
+    bool IList.IsFixedSize => false;
+    bool ICollection<T>.IsReadOnly => false;
+    bool IList.IsReadOnly => false;
+    bool ICollection.IsSynchronized => false;
+    object ICollection.SyncRoot => this;
+
+    public int IndexOf(T item)
+    {
+        GuardDispose();
+        return NativeMemoryListCore<T>.IndexOf(_ptr, _count, item);
+    }
+
+    int IList.IndexOf(object? value) => IsCompatibleObject(value) ? IndexOf((T)value!) : -1;
+
+    public void Insert(int index, T item)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Insert(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, index, item);
+    }
+
+    void IList.Insert(int index, object? value)
+    {
+        ThrowHelper.IfNullAndNullsAreIllegalThenThrow<T>(value, nameof(value));
+        Insert(index, (T)value!);
+    }
+
+    public bool Remove(T item)
+    {
+        GuardDispose();
+        return NativeMemoryListCore<T>.Remove(_ptr, ref _count, item);
+    }
+
+    void IList.Remove(object? value)
+    {
+        if (IsCompatibleObject(value)) Remove((T)value!);
+    }
+
+    public void RemoveAt(int index)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.RemoveAt(_ptr, ref _count, index, shouldThrow: true);
+    }
+
+    public void Truncate(int newLength)
+    {
+        GuardDispose();
+        NativeMemoryListCore<T>.Truncate(newLength, ref _count);
+    }
+
+    public ref T GetRef(int index)
+    {
+        GuardDispose();
+        return ref NativeMemoryListCore<T>.GetRef(_ptr, index, _count);
+    }
+
+    public T this[int index]
+    {
+        get
+        {
+            GuardDispose();
+            return NativeMemoryListCore<T>.Get(_ptr, index, _count);
+        }
+        set
+        {
+            GuardDispose();
+            NativeMemoryListCore<T>.Set(_ptr, index, _count, value);
+        }
+    }
+
+    object? IList.this[int index]
+    {
+        get => this[index];
+        set
+        {
+            ThrowHelper.IfNullAndNullsAreIllegalThenThrow<T>(value, nameof(value));
+            this[index] = (T)value!;
+        }
+    }
+
+    private static bool IsCompatibleObject(object? value) => value is T;
+
+    public static NativeMemoryList<T> Empty() => new(0);
+
+    public void Dispose()
+    {
+        NativeMemoryListCore<T>.Dispose(ref _ptr, ref _pooledArray, ref _pinHandle, ref _count, ref _capacity, ref _disposed);
+        GC.SuppressFinalize(this);
+    }
+
+#if DEBUG
+    private readonly StackTrace _creationStackTrace = new();
+#endif
+
+    ~NativeMemoryList()
+    {
+        if (_capacity != 0 && !_disposed)
+        {
+#if DEBUG
+            Console.Error.WriteLine($"Warning: {nameof(NativeMemoryList<T>)} was not disposed. Created at: {_creationStackTrace}");
+#endif
+            // Always free unmanaged memory / return pooled array in the finalizer to avoid
+            // process-lifetime native leaks or starvation of the ArrayPool.
+            NativeMemoryListCore<T>.Dispose(ref _ptr, ref _pooledArray, ref _pinHandle, ref _count, ref _capacity, ref _disposed);
+        }
+    }
+
+    public struct Enumerator(T* ptr, int count) : IEnumerator<T>
+    {
+        private int _index = -1;
+
+        public bool MoveNext() => ++_index < count;
+        public void Reset() => _index = -1;
+        public readonly T Current => ptr[_index];
+        readonly object IEnumerator.Current => Current!;
+        public readonly void Dispose() { }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListCore.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListCore.cs
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Collections;
+
+internal static unsafe class NativeMemoryListCore<T> where T : unmanaged
+{
+    // Buffers requested below this byte size route through ArrayPool<T>.Shared (pinned)
+    // instead of NativeMemory.Alloc, to avoid per-allocation malloc round-trips on hot,
+    // short-lived collections. The decision is made on the requested capacity; the pool
+    // may overshoot, but we stay on pool until a resize would push us above the threshold.
+    internal const int PoolThresholdBytes = 1024;
+
+    // When sizeof(T) is a power of two we route the native-alloc path through
+    // NativeMemory.AlignedAlloc so the returned pointer is aligned to the element
+    // size. This makes element accesses naturally aligned (SIMD loads, Interlocked
+    // ops on multi-word structs, cache-line packing for slot tables, etc.) — the
+    // common case for primitives and tightly-packed value types. Non-power-of-two
+    // sizes fall back to NativeMemory.Alloc, which only guarantees malloc-default
+    // alignment. The branch is on a `sizeof(T)`-derived constant so the JIT folds
+    // it away per generic instantiation. ArrayPool-backed allocations are pinned
+    // to a managed array and stay on the unaligned path; callers that need element
+    // alignment should size the buffer above PoolThresholdBytes.
+    //
+    // ZK_EVM omits AlignedAlloc entirely because the runtime in those environments
+    // can fault on aligned-alloc — same carve-out KeccakCache uses.
+    // A property (not a const) even in the ZK_EVM case: a compile-time-constant
+    // `false` here would make the AlignedAlloc/AlignedFree branches unreachable
+    // and trip CS0162 (warnings-as-errors). The JIT still folds the constant get
+    // body and drops the dead branch per generic instantiation.
+    private static bool UseAlignedAlloc
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if ZK_EVM
+        get => false;
+#else
+        get => BitOperations.IsPow2(sizeof(T));
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T* AllocateBuffer(int capacity, out T[]? pooledArray, out GCHandle pinHandle, out int actualCapacity)
+    {
+        if (capacity == 0)
+        {
+            pooledArray = null;
+            pinHandle = default;
+            actualCapacity = 0;
+            return null;
+        }
+
+        if ((long)capacity * sizeof(T) < PoolThresholdBytes)
+        {
+            T[] arr = ArrayPool<T>.Shared.Rent(capacity);
+            GCHandle handle = GCHandle.Alloc(arr, GCHandleType.Pinned);
+            pooledArray = arr;
+            pinHandle = handle;
+            actualCapacity = arr.Length;
+            return (T*)handle.AddrOfPinnedObject();
+        }
+
+        pooledArray = null;
+        pinHandle = default;
+        actualCapacity = capacity;
+        if (UseAlignedAlloc)
+            return (T*)NativeMemory.AlignedAlloc((nuint)((long)capacity * sizeof(T)), (nuint)sizeof(T));
+        return (T*)NativeMemory.Alloc((nuint)capacity, (nuint)sizeof(T));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void FreeBuffer(T* ptr, T[]? pooledArray, GCHandle pinHandle)
+    {
+        if (pooledArray is not null)
+        {
+            if (pinHandle.IsAllocated) pinHandle.Free();
+            ArrayPool<T>.Shared.Return(pooledArray);
+        }
+        else if (ptr is not null)
+        {
+            if (UseAlignedAlloc)
+                NativeMemory.AlignedFree(ptr);
+            else
+                NativeMemory.Free(ptr);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GuardResize(
+        ref T* ptr,
+        ref int capacity,
+        ref T[]? pooledArray,
+        ref GCHandle pinHandle,
+        int count,
+        int itemsToAdd = 1)
+    {
+        // Compute newCount as long to detect overflow past int.MaxValue. The element
+        // count itself is bounded by int.MaxValue (Count returns int); throw OOM when
+        // the caller would push past that ceiling instead of silently writing past
+        // the buffer.
+        long newCountLong = (long)count + itemsToAdd;
+        if (newCountLong <= capacity) return;
+        if (newCountLong > int.MaxValue)
+            throw new OutOfMemoryException($"NativeMemoryList<{typeof(T).Name}> exceeded int.MaxValue elements (requested {newCountLong}).");
+        int newCount = (int)newCountLong;
+
+        // Doubling growth, computed via long so the *2 step doesn't overflow int when
+        // capacity > int.MaxValue / 2. Clamp at int.MaxValue.
+        long newCapacityLong = capacity == 0 ? 1 : (long)capacity * 2;
+        while (newCount > newCapacityLong) newCapacityLong *= 2;
+        if (newCapacityLong > int.MaxValue) newCapacityLong = int.MaxValue;
+        int newCapacity = (int)newCapacityLong;
+
+        T* newPtr = AllocateBuffer(newCapacity, out T[]? newPooled, out GCHandle newPin, out int newActual);
+        if (count > 0)
+        {
+            Buffer.MemoryCopy(ptr, newPtr, (long)newActual * sizeof(T), (long)count * sizeof(T));
+        }
+        FreeBuffer(ptr, pooledArray, pinHandle);
+        ptr = newPtr;
+        pooledArray = newPooled;
+        pinHandle = newPin;
+        capacity = newActual;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Add(ref T* ptr, ref int capacity, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, T item)
+    {
+        GuardResize(ref ptr, ref capacity, ref pooledArray, ref pinHandle, count);
+        ptr[count++] = item;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void AddRange(ref T* ptr, ref int capacity, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, ReadOnlySpan<T> items)
+    {
+        if (items.IsEmpty) return;
+        GuardResize(ref ptr, ref capacity, ref pooledArray, ref pinHandle, count, items.Length);
+        items.CopyTo(new Span<T>(ptr + count, items.Length));
+        count += items.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Clear(ref int count) => count = 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ReduceCount(ref T* ptr, ref int capacity, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, int newCount)
+    {
+        if (newCount == count) return;
+        if (newCount > count) ThrowOnlyReduce(newCount, count);
+
+        count = newCount;
+
+        if (newCount < capacity / 2 && newCount > 0)
+        {
+            T* newPtr = AllocateBuffer(newCount, out T[]? newPooled, out GCHandle newPin, out int newActual);
+            Buffer.MemoryCopy(ptr, newPtr, (long)newActual * sizeof(T), (long)newCount * sizeof(T));
+            FreeBuffer(ptr, pooledArray, pinHandle);
+            ptr = newPtr;
+            pooledArray = newPooled;
+            pinHandle = newPin;
+            capacity = newActual;
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowOnlyReduce(int newCount, int oldCount) =>
+            throw new ArgumentException($"Count can only be reduced. {newCount} is larger than {oldCount}", nameof(count));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Sort(T* ptr, int count, Comparison<T> comparison)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        if (count > 1) new Span<T>(ptr, count).Sort(comparison);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Sort<TComparer>(T* ptr, int count, TComparer comparer)
+        where TComparer : IComparer<T>
+    {
+        if (count > 1) new Span<T>(ptr, count).Sort(comparer);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Reverse(T* ptr, int count) => new Span<T>(ptr, count).Reverse();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int IndexOf(T* ptr, int count, T item) =>
+        new ReadOnlySpan<T>(ptr, count).IndexOf(item);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Contains(T* ptr, int count, T item) => IndexOf(ptr, count, item) >= 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void CopyTo(T* ptr, int count, T[] destination, int index) =>
+        new ReadOnlySpan<T>(ptr, count).CopyTo(destination.AsSpan(index));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool GuardIndex(int index, int count, bool shouldThrow = true, bool allowEqualToCount = false)
+    {
+        if ((uint)index > (uint)count || (!allowEqualToCount && index == count))
+        {
+            if (shouldThrow) ThrowArgumentOutOfRangeException();
+            return false;
+        }
+        return true;
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool RemoveAt(T* ptr, ref int count, int index, bool shouldThrow)
+    {
+        bool isValid = GuardIndex(index, count, shouldThrow);
+        if (isValid)
+        {
+            int start = index + 1;
+            if (start < count)
+            {
+                new Span<T>(ptr + start, count - start).CopyTo(new Span<T>(ptr + index, count - index));
+            }
+            count--;
+        }
+        return isValid;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Remove(T* ptr, ref int count, T item) =>
+        RemoveAt(ptr, ref count, IndexOf(ptr, count, item), shouldThrow: false);
+
+    public static T? RemoveLast(T* ptr, ref int count)
+    {
+        if (count > 0)
+        {
+            int index = count - 1;
+            T item = ptr[index];
+            count--;
+            return item;
+        }
+        return default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Insert(ref T* ptr, ref int capacity, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, int index, T item)
+    {
+        GuardIndex(index, count, shouldThrow: true, allowEqualToCount: true);
+        GuardResize(ref ptr, ref capacity, ref pooledArray, ref pinHandle, count);
+        if (index < count)
+        {
+            new Span<T>(ptr + index, count - index).CopyTo(new Span<T>(ptr + index + 1, count - index));
+        }
+        ptr[index] = item;
+        count++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Truncate(int newLength, ref int count)
+    {
+        GuardIndex(newLength, count, shouldThrow: true, allowEqualToCount: true);
+        count = newLength;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref T GetRef(T* ptr, int index, int count)
+    {
+        GuardIndex(index, count);
+        return ref ptr[index];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Get(T* ptr, int index, int count)
+    {
+        GuardIndex(index, count);
+        return ptr[index];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Set(T* ptr, int index, int count, T value)
+    {
+        GuardIndex(index, count);
+        ptr[index] = value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Dispose(ref T* ptr, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, ref int capacity)
+    {
+        T* localPtr = ptr;
+        T[]? localPool = pooledArray;
+        GCHandle localPin = pinHandle;
+        ptr = null;
+        pooledArray = null;
+        pinHandle = default;
+        FreeBuffer(localPtr, localPool, localPin);
+        count = 0;
+        capacity = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Dispose(ref T* ptr, ref T[]? pooledArray, ref GCHandle pinHandle, ref int count, ref int capacity, ref bool disposed)
+    {
+        if (!disposed)
+        {
+            disposed = true;
+            Dispose(ref ptr, ref pooledArray, ref pinHandle, ref count, ref capacity);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListCore.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListCore.cs
@@ -12,6 +12,13 @@ using System.Runtime.InteropServices;
 
 namespace Nethermind.Core.Collections;
 
+// Safety invariant: after every successful public operation, count <= capacity holds, where
+// capacity is the element count of the buffer currently at ptr (returned by AllocateBuffer as
+// `actualCapacity` and tracked through GuardResize / ReduceCount). Writes go through
+// GuardResize, which grows the buffer before the write; reads go through GuardIndex, which
+// bounds-checks against count. FreeBuffer is always called with the exact (ptr, pooledArray,
+// pinHandle) triple returned by the matching AllocateBuffer call — pool-backed and
+// native-allocated buffers are never crossed, so the right free path runs in every case.
 internal static unsafe class NativeMemoryListCore<T> where T : unmanaged
 {
     // Buffers requested below this byte size route through ArrayPool<T>.Shared (pinned)
@@ -72,7 +79,12 @@ internal static unsafe class NativeMemoryListCore<T> where T : unmanaged
         pinHandle = default;
         actualCapacity = capacity;
         if (UseAlignedAlloc)
-            return (T*)NativeMemory.AlignedAlloc((nuint)((long)capacity * sizeof(T)), (nuint)sizeof(T));
+            // Floor the alignment at sizeof(nuint): POSIX `aligned_alloc` requires the alignment
+            // to be a multiple of sizeof(void*), so alignments of 1/2/4 on a 64-bit host (i.e.
+            // T = byte/short/int/float) are undefined behavior even though glibc happens to
+            // accept them. The resulting alignment is always at least the element size for
+            // power-of-two T.
+            return (T*)NativeMemory.AlignedAlloc((nuint)((long)capacity * sizeof(T)), (nuint)Math.Max(sizeof(T), sizeof(nuint)));
         return (T*)NativeMemory.Alloc((nuint)capacity, (nuint)sizeof(T));
     }
 

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Collections;
+
+/// <summary>
+/// Ref-struct list backed by <see cref="NativeMemory"/> for large buffers and
+/// <see cref="System.Buffers.ArrayPool{T}"/> (pinned) for small ones — the switch is decided by
+/// byte size at allocation time. Mirrors <see cref="ArrayPoolListRef{T}"/> in shape.
+/// Constrained to <see langword="unmanaged"/> element types. Buffers expose only
+/// <see cref="Span{T}"/> — no <see cref="Memory{T}"/> projection.
+/// </summary>
+public unsafe ref struct NativeMemoryListRef<T> where T : unmanaged
+{
+    private T* _ptr;
+    private T[]? _pooledArray;
+    private GCHandle _pinHandle;
+    private int _capacity;
+    private int _count;
+
+    public NativeMemoryListRef(int capacity, IEnumerable<T> items) : this(capacity) => AddRange(items);
+    public NativeMemoryListRef(int capacity, params ReadOnlySpan<T> items) : this(capacity) => AddRange(items);
+    public NativeMemoryListRef(ReadOnlySpan<T> span) : this(span.Length) => AddRange(span);
+
+    public NativeMemoryListRef(int capacity, int startingCount = 0)
+    {
+        _ptr = NativeMemoryListCore<T>.AllocateBuffer(capacity, out _pooledArray, out _pinHandle, out _capacity);
+        if (startingCount > 0) new Span<T>(_ptr, startingCount).Clear();
+        _count = startingCount;
+    }
+
+    public readonly int Count => _count;
+    public readonly int Capacity => _capacity;
+
+    public void Add(T item) => NativeMemoryListCore<T>.Add(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, item);
+    public void AddRange(params T[] items) => AddRange(items.AsSpan());
+    public void AddRange(params ReadOnlySpan<T> items) => NativeMemoryListCore<T>.AddRange(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, items);
+
+    public void AddRange(params IEnumerable<T> items)
+    {
+        switch (items)
+        {
+            case T[] array:
+                AddRange((ReadOnlySpan<T>)array);
+                break;
+            case List<T> listItems:
+                AddRange(CollectionsMarshal.AsSpan(listItems));
+                break;
+            default:
+                foreach (T item in items) Add(item);
+                break;
+        }
+    }
+
+    public void EnsureCapacity(int capacity)
+    {
+        if (capacity > _capacity)
+        {
+            NativeMemoryListCore<T>.GuardResize(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, _count, capacity - _count);
+        }
+    }
+
+    public void Insert(int index, T item) => NativeMemoryListCore<T>.Insert(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, index, item);
+    public bool Remove(T item) => NativeMemoryListCore<T>.Remove(_ptr, ref _count, item);
+    public T? RemoveLast() => NativeMemoryListCore<T>.RemoveLast(_ptr, ref _count);
+    public void RemoveAt(int index) => NativeMemoryListCore<T>.RemoveAt(_ptr, ref _count, index, shouldThrow: true);
+    public void Clear() => NativeMemoryListCore<T>.Clear(ref _count);
+    public void ReduceCount(int newCount) => NativeMemoryListCore<T>.ReduceCount(ref _ptr, ref _capacity, ref _pooledArray, ref _pinHandle, ref _count, newCount);
+    public void Truncate(int newLength) => NativeMemoryListCore<T>.Truncate(newLength, ref _count);
+    public readonly void Sort(Comparison<T> comparison) => NativeMemoryListCore<T>.Sort(_ptr, _count, comparison);
+    public readonly void Sort<TComparer>(TComparer comparer) where TComparer : IComparer<T> => NativeMemoryListCore<T>.Sort(_ptr, _count, comparer);
+    public readonly void Reverse() => NativeMemoryListCore<T>.Reverse(_ptr, _count);
+    public readonly ref T GetRef(int index) => ref NativeMemoryListCore<T>.GetRef(_ptr, index, _count);
+    public readonly Span<T> AsSpan() => new(_ptr, _count);
+
+    public readonly T this[int index]
+    {
+        get => NativeMemoryListCore<T>.Get(_ptr, index, _count);
+        set => NativeMemoryListCore<T>.Set(_ptr, index, _count, value);
+    }
+
+    public void Dispose() => NativeMemoryListCore<T>.Dispose(ref _ptr, ref _pooledArray, ref _pinHandle, ref _count, ref _capacity);
+
+    public readonly bool Contains(T item) => NativeMemoryListCore<T>.Contains(_ptr, _count, item);
+    public readonly int IndexOf(T item) => NativeMemoryListCore<T>.IndexOf(_ptr, _count, item);
+    public readonly void CopyTo(T[] array, int arrayIndex) => NativeMemoryListCore<T>.CopyTo(_ptr, _count, array, arrayIndex);
+    public readonly T[] ToArray() => AsSpan().ToArray();
+}

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
@@ -28,6 +28,8 @@ public unsafe ref struct NativeMemoryListRef<T> where T : unmanaged
 
     public NativeMemoryListRef(int capacity, int startingCount = 0)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(startingCount);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(startingCount, capacity);
         _ptr = NativeMemoryListCore<T>.AllocateBuffer(capacity, out _pooledArray, out _pinHandle, out _capacity);
         if (startingCount > 0) new Span<T>(_ptr, startingCount).Clear();
         _count = startingCount;

--- a/src/Nethermind/Nethermind.Core/ValueAddress.cs
+++ b/src/Nethermind/Nethermind.Core/ValueAddress.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core;
+
+// 20-byte unmanaged form of Address. Backs Address itself and is also usable directly
+// by callers that want an address-shaped key/value without a managed allocation.
+[StructLayout(LayoutKind.Sequential, Size = Address.Size)]
+public readonly struct ValueAddress
+{
+    [InlineArray(Address.Size)]
+    private struct Bytes20 { private byte _e0; }
+
+    private readonly Bytes20 _bytes;
+
+    public ValueAddress(ReadOnlySpan<byte> bytes)
+    {
+        Debug.Assert(bytes.Length == Address.Size);
+        bytes.CopyTo(MemoryMarshal.CreateSpan(ref Unsafe.As<Bytes20, byte>(ref Unsafe.AsRef(in _bytes)), Address.Size));
+    }
+
+    public ReadOnlySpan<byte> AsSpan
+        => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<Bytes20, byte>(ref Unsafe.AsRef(in _bytes)), Address.Size);
+
+    public Address ToAddress() => new(AsSpan);
+}

--- a/src/Nethermind/Nethermind.Core/ValueAddress.cs
+++ b/src/Nethermind/Nethermind.Core/ValueAddress.cs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nethermind.Core;
 
-// 20-byte unmanaged form of Address. Backs Address itself and is also usable directly
-// by callers that want an address-shaped key/value without a managed allocation.
+/// <summary>
+/// 20-byte unmanaged representation of an Ethereum address. Usable as a value-typed
+/// key/field without a managed allocation; also backs <see cref="Address"/> internally.
+/// </summary>
 [StructLayout(LayoutKind.Sequential, Size = Address.Size)]
 public readonly struct ValueAddress
 {
@@ -18,14 +19,20 @@ public readonly struct ValueAddress
 
     private readonly Bytes20 _bytes;
 
+    /// <summary>Initializes the address from an exactly-<see cref="Address.Size"/>-byte span.</summary>
+    /// <param name="bytes">Source bytes. Must be <see cref="Address.Size"/> bytes long.</param>
+    /// <exception cref="ArgumentException"><paramref name="bytes"/> is not <see cref="Address.Size"/> bytes long.</exception>
     public ValueAddress(ReadOnlySpan<byte> bytes)
     {
-        Debug.Assert(bytes.Length == Address.Size);
+        if (bytes.Length != Address.Size)
+            throw new ArgumentException($"{nameof(ValueAddress)} must be exactly {Address.Size} bytes, got {bytes.Length}.", nameof(bytes));
         bytes.CopyTo(MemoryMarshal.CreateSpan(ref Unsafe.As<Bytes20, byte>(ref Unsafe.AsRef(in _bytes)), Address.Size));
     }
 
+    /// <summary>Exposes the 20 backing bytes as a read-only span over the struct's storage.</summary>
     public ReadOnlySpan<byte> AsSpan
         => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<Bytes20, byte>(ref Unsafe.AsRef(in _bytes)), Address.Size);
 
+    /// <summary>Materializes a managed <see cref="Address"/> from this value-typed address.</summary>
     public Address ToAddress() => new(AsSpan);
 }


### PR DESCRIPTION
## Changes

Two narrowly-scoped extractions from `flat/long-finality` so the rest of that branch can shrink and so the new types become usable across the codebase ahead of the larger long-finality PR.

**1. `NativeMemoryList<T>` / `NativeMemoryListRef<T>`** (`Nethermind.Core.Collections`, `where T : unmanaged`)
- Sibling pair to `ArrayPoolList<T>` / `ArrayPoolListRef<T>`.
- Backed by `NativeMemory.*` (aligned-alloc when `sizeof(T)` is a power of two) for large buffers and by a pinned slice of `ArrayPool<T>.Shared` for small ones (threshold 1024 bytes).
- Exposes only `Span<T>` — no `Memory<T>` projection.
- Pulled verbatim from `flat/long-finality` with their existing unit tests (`Nethermind.Core.Test/Collections/NativeMemoryListTests.cs`, 23 cases).
- Flat/long-finality consumers (`PersistenceManager`, `SnapshotRepository`, `AccumulatorCalculator`, `EnumerableExtensions.ToNativeMemoryList`) are **not** part of this PR — they stay on flat/long-finality and will migrate naturally when that branch rebases.

**2. `ValueAddress` + `Address` refactor** (`Nethermind.Core`)
- New public `readonly struct ValueAddress` — 20-byte `[InlineArray]` unmanaged sibling of `ValueHash256`. Lifted from `Nethermind.State.Flat.PersistedSnapshots` (where it was `internal`) and promoted to `public` in `Nethermind.Core`.
- `Address` now stores its bytes as a `ValueAddress` field; the embedded `internal struct AddressBytes` (same shape, separate type) is deleted. `AddressBytes` had zero external references, so this is a private-internals rename.
- SIMD-`Equals` fast path (`Vector128` + `uint`) preserved via `MemoryMarshal.GetReference(_bytes.AsSpan)`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix
- [x] New feature (`NativeMemoryList<T>` / `NativeMemoryListRef<T>` / `ValueAddress` are new public API surface)
- [ ] Breaking change
- [ ] Optimization
- [x] Refactoring (`Address` internal storage consolidated onto `ValueAddress`)
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `NativeMemoryListTests` brought across with the type (23/23 pass locally on `release`).
- `Nethermind.Core.Test --filter Address` 61/61 pass locally after the `Address` refactor — covers equality, comparison, hex parsing, and the SIMD-`Equals` path.
- `Nethermind.slnx` builds clean (0 errors / 0 warnings).
- `dotnet format whitespace --verify-no-changes` exits 0.
- `grep -rn '\bAddressBytes\b' src/Nethermind/ --include='*.cs'` returns no matches.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

These are the prerequisites for follow-up branches that mechanically convert eligible `ArrayPoolList(Ref)<T-unmanaged>` call sites (notably `<byte>`, `<UInt256>`, `<ValueHash256>`, `<long>`, `<int>`) to `NativeMemoryList(Ref)`, plus future address-keyed buffers that move to `ValueAddress`.

Authored by Claude Opus 4.7 (Claude Code).