### PR TITLE
EraE - fixes

### DIFF
--- a/src/Nethermind/Nethermind.EraE.Test/Store/HttpRemoteEraClientTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Store/HttpRemoteEraClientTests.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Nethermind.EraE.Store;
+using NUnit.Framework;
+
+namespace Nethermind.EraE.Test.Store;
+
+public class HttpRemoteEraClientTests
+{
+    private const string BaseUrl = "https://example.test/erae/sepolia/";
+    private const string ManifestFilename = "checksums_sha256.txt";
+    private const string ValidHash = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    [Test]
+    public async Task FetchManifestAsync_WithValidEntry_ParsesEpoch()
+    {
+        IReadOnlyDictionary<int, RemoteEraEntry> manifest =
+            await FetchManifest($"{ValidHash}  sepolia-00000-deadbeef.erae");
+
+        manifest.Should().ContainKey(0);
+        manifest[0].Filename.Should().Be("sepolia-00000-deadbeef.erae");
+    }
+
+    [TestCase("../sepolia-00000-deadbeef.erae", TestName = "RelativeParentTraversal")]
+    [TestCase("subdir/sepolia-00000-deadbeef.erae", TestName = "NestedDirectory")]
+    [TestCase("/etc/sepolia-00000-deadbeef.erae", TestName = "RootedPath")]
+    public async Task FetchManifestAsync_WhenFilenameContainsPath_SkipsEntry(string hostileFilename)
+    {
+        IReadOnlyDictionary<int, RemoteEraEntry> manifest =
+            await FetchManifest($"{ValidHash}  {hostileFilename}");
+
+        manifest.Should().BeEmpty();
+    }
+
+    private static async Task<IReadOnlyDictionary<int, RemoteEraEntry>> FetchManifest(string manifestBody)
+    {
+        StubHttpMessageHandler handler = new(manifestBody);
+        using HttpClient httpClient = new(handler);
+        using HttpRemoteEraClient client = new(new Uri(BaseUrl), ManifestFilename, httpClient);
+        return await client.FetchManifestAsync();
+    }
+
+    private sealed class StubHttpMessageHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "text/plain")
+            });
+    }
+}

--- a/src/Nethermind/Nethermind.EraE.Test/Store/RemoteEraStoreDecoratorTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Store/RemoteEraStoreDecoratorTests.cs
@@ -116,6 +116,26 @@ public class RemoteEraStoreDecoratorTests
         File.Exists(expectedFilePath).Should().BeFalse();
     }
 
+    [Test]
+    public async Task FindBlockAndReceipts_WhenManifestFilenameEscapesDownloadDir_ThrowsAndWritesNothing()
+    {
+        string filename = $"..{Path.DirectorySeparatorChar}escape-00000-deadbeef.erae";
+        byte[] sha256 = new byte[32];
+
+        _client.FetchManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, RemoteEraEntry> { [0] = new(filename, sha256) });
+
+        string escapedPath = Path.GetFullPath(Path.Join(_downloadDir.Path, filename));
+        using RemoteEraStoreDecorator sut = new(localStore: null, _client, _downloadDir.Path, maxEraSize: 16);
+
+        await sut.Invoking(s => s.FindBlockAndReceipts(0, ensureValidated: false))
+            .Should().ThrowAsync<EraException>()
+            .WithMessage("*escapes the download directory*");
+
+        await _client.DidNotReceive().DownloadFileAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        File.Exists(escapedPath).Should().BeFalse();
+    }
+
     private static int ParseEpoch(string filename)
     {
         string[] parts = Path.GetFileNameWithoutExtension(filename).Split('-');

--- a/src/Nethermind/Nethermind.EraE/Store/HttpRemoteEraClient.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/HttpRemoteEraClient.cs
@@ -53,6 +53,7 @@ public sealed class HttpRemoteEraClient : IRemoteEraClient, IDisposable
             string hashHex = line[..separatorIdx].Trim();
             string filename = line[(separatorIdx + 2)..].Trim();
 
+            if (!IsPlainFilename(filename)) continue;
             if (!TryParseEpoch(filename, out int epoch)) continue;
             if (!TryParseHex(hashHex, out byte[] sha256)) continue;
 
@@ -98,6 +99,11 @@ public sealed class HttpRemoteEraClient : IRemoteEraClient, IDisposable
 
         File.Move(tmpPath, destinationPath, overwrite: true);
     }
+
+    // Manifest filenames must be plain names — no directory separators and not rooted —
+    // so that joining them onto the download directory cannot escape it (path traversal).
+    private static bool IsPlainFilename(string filename) =>
+        filename == Path.GetFileName(filename) && !Path.IsPathRooted(filename);
 
     private static bool TryParseEpoch(string filename, out int epoch)
     {

--- a/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
@@ -215,7 +215,8 @@ public sealed class RemoteEraStoreDecorator : IEraStore
     {
         string root = Path.GetFullPath(_downloadDir);
         string destinationPath = Path.GetFullPath(Path.Join(root, filename));
-        if (!destinationPath.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        string boundary = Path.TrimEndingDirectorySeparator(root) + Path.DirectorySeparatorChar;
+        if (!destinationPath.StartsWith(boundary, StringComparison.Ordinal))
             throw new EraException($"Remote eraE manifest filename '{filename}' escapes the download directory.");
 
         return destinationPath;

--- a/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
+++ b/src/Nethermind/Nethermind.EraE/Store/RemoteEraStoreDecorator.cs
@@ -182,7 +182,7 @@ public sealed class RemoteEraStoreDecorator : IEraStore
         if (!manifest.TryGetValue(epoch, out RemoteEraEntry entry))
             throw new EraException($"Epoch {epoch} is not available in the remote eraE manifest.");
 
-        string destinationPath = Path.Join(_downloadDir, entry.Filename);
+        string destinationPath = ResolveDestinationPath(entry.Filename);
 
         SemaphoreSlim epochLock = _epochLocks.GetOrAddDisposable(epoch, static _ => new SemaphoreSlim(1, 1));
         await epochLock.WaitAsync(cancellation).ConfigureAwait(false);
@@ -209,6 +209,16 @@ public sealed class RemoteEraStoreDecorator : IEraStore
         {
             epochLock.Release();
         }
+    }
+
+    private string ResolveDestinationPath(string filename)
+    {
+        string root = Path.GetFullPath(_downloadDir);
+        string destinationPath = Path.GetFullPath(Path.Join(root, filename));
+        if (!destinationPath.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new EraException($"Remote eraE manifest filename '{filename}' escapes the download directory.");
+
+        return destinationPath;
     }
 
     private static void VerifySha256(string filePath, byte[] expectedHash)


### PR DESCRIPTION
## Changes

Hostile remote-manifest filenames can no longer write outside the download directory. `HttpRemoteEraClient.FetchManifestAsync` now skips any manifest entry whose filename isn't a plain name (contains a separator or is rooted), and `RemoteEraStoreDecorator` resolves the destination with `Path.GetFullPath` and rejects (throws `EraException`) anything that escapes the download root before any file is opened for writing. Two layers: filter at the source, hard guard at the write point.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added regression test