### PR TITLE
refactor(state): replace BeginScope with TryBeginScope to surface state-missing cleanly

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -23,6 +23,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/ValidatorContractTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/ValidatorContractTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -41,10 +42,16 @@ namespace Nethermind.AuRa.Test.Contract
             _transactionProcessor = Substitute.For<ITransactionProcessor>();
             _stateProvider = Substitute.For<IWorldState>();
             _readOnlyTxProcessorSource = Substitute.For<IReadOnlyTxProcessorSource>();
-            _readOnlyTxProcessorSource.Build(_block.Header).Returns(new ReadOnlyTxProcessingScope(
-                _transactionProcessor,
-                new Reactive.AnonymousDisposable(() => { }),
-                _stateProvider));
+            _readOnlyTxProcessorSource
+                .TryBuild(_block.Header, out Arg.Any<IReadOnlyTxProcessingScope?>())
+                .Returns(callInfo =>
+                {
+                    callInfo[1] = new ReadOnlyTxProcessingScope(
+                        _transactionProcessor,
+                        new Reactive.AnonymousDisposable(() => { }),
+                        _stateProvider);
+                    return true;
+                });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractBasedValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractBasedValidatorTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs.Forks;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Evm.Tracing;
@@ -78,10 +79,16 @@ public class ContractBasedValidatorTests
         _stateProvider.IsContract(_contractAddress).Returns(true);
 
         _readOnlyTxProcessorSource = Substitute.For<IReadOnlyTxProcessorSource>();
-        _readOnlyTxProcessorSource.Build(Arg.Any<BlockHeader>()).Returns(new ReadOnlyTxProcessingScope(
-            _transactionProcessor,
-            new Reactive.AnonymousDisposable(() => { }),
-            _stateProvider));
+        _readOnlyTxProcessorSource
+            .TryBuild(Arg.Any<BlockHeader>(), out Arg.Any<IReadOnlyTxProcessingScope?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = new ReadOnlyTxProcessingScope(
+                    _transactionProcessor,
+                    new Reactive.AnonymousDisposable(() => { }),
+                    _stateProvider);
+                return true;
+            });
         _blockTree.Head.Returns(_block);
 
         _abiEncoder

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.JsonRpc.Test.Modules;
@@ -1223,12 +1224,13 @@ public class BlockProcessorTests
             TrackingReadOnlyTxProcessingEnvFactory factory,
             ITransactionProcessor transactionProcessor) : IReadOnlyTxProcessorSource
         {
-            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock)
+            public bool TryBuild(BlockHeader? baseBlock, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope)
             {
                 IWorldState worldState = Substitute.For<IWorldState>();
                 factory.BuiltHeaders.Add(baseBlock);
                 factory.BuiltWorldStates.Add(worldState);
-                return new Scope(factory, transactionProcessor, worldState);
+                scope = new Scope(factory, transactionProcessor, worldState);
+                return true;
             }
 
             public void Dispose() { }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;

--- a/src/Nethermind/Nethermind.Blockchain.Test/GenesisBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/GenesisBuilderTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Container;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Evm;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Evm.Tracing;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -444,8 +445,20 @@ namespace Nethermind.Blockchain.Test
     }
 
     public class WorldStateStab()
-        : WorldState(Substitute.For<IWorldStateScopeProvider>(), LimboLogs.Instance), IWorldState
+        : WorldState(MakeScopeProviderStub(), LimboLogs.Instance), IWorldState
     {
+        private static IWorldStateScopeProvider MakeScopeProviderStub()
+        {
+            IWorldStateScopeProvider stub = Substitute.For<IWorldStateScopeProvider>();
+            stub.TryBeginScope(Arg.Any<BlockHeader?>(), out Arg.Any<IWorldStateScopeProvider.IScope?>())
+                .Returns(callInfo =>
+                {
+                    callInfo[1] = Substitute.For<IWorldStateScopeProvider.IScope>();
+                    return true;
+                });
+            return stub;
+        }
+
         public new UInt256 GetBalance(Address address) => UInt256.MaxValue;
 
         public static IReadOnlyStateProvider GetUntrackedReader() => TestReadOnlyStateProvider.Instance;

--- a/src/Nethermind/Nethermind.Blockchain/Contracts/Contract.ConstantContract.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Contracts/Contract.ConstantContract.cs
@@ -71,8 +71,16 @@ namespace Nethermind.Blockchain.Contracts
             {
                 lock (_readOnlyTxProcessorSource)
                 {
-                    using IReadOnlyTxProcessingScope scope = _readOnlyTxProcessorSource.Build(callInfo.ParentHeader);
-                    return CallRaw(callInfo, scope);
+                    if (!_readOnlyTxProcessorSource.TryBuild(callInfo.ParentHeader, out IReadOnlyTxProcessingScope? scope))
+                    {
+                        throw new InvalidOperationException(
+                            $"Missing state for parent {callInfo.ParentHeader?.ToString(BlockHeader.Format.Short) ?? "null"} when calling {callInfo.FunctionName}.");
+                    }
+
+                    using (scope)
+                    {
+                        return CallRaw(callInfo, scope);
+                    }
                 }
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/IReadOnlyTxProcessorSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IReadOnlyTxProcessorSource.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 
 namespace Nethermind.Blockchain;
@@ -13,5 +14,9 @@ namespace Nethermind.Blockchain;
 /// </summary>
 public interface IReadOnlyTxProcessorSource : IDisposable
 {
-    IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock);
+    /// <summary>
+    /// Attempt to build a processing scope anchored at <paramref name="baseBlock"/>. Returns <c>false</c>
+    /// when the state for that block is no longer available (e.g. pruned concurrently).
+    /// </summary>
+    bool TryBuild(BlockHeader? baseBlock, [NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope);
 }

--- a/src/Nethermind/Nethermind.Blockchain/IShareableTxProcessorSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IShareableTxProcessorSource.cs
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 
 namespace Nethermind.Blockchain;
 
 public interface IShareableTxProcessorSource : IDisposable
 {
-    IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock);
+    /// <summary>
+    /// Attempt to build a processing scope anchored at <paramref name="baseBlock"/>. Returns <c>false</c>
+    /// when the state for that block is no longer available (e.g. pruned concurrently).
+    /// </summary>
+    bool TryBuild(BlockHeader? baseBlock, [NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope);
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -475,7 +475,7 @@ public class BlockCachePreWarmerTests
             FlagCapturingPolicy owner)
             : IReadOnlyTxProcessorSource
         {
-            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock)
+            public bool TryBuild(BlockHeader? baseBlock, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope)
             {
                 if (Interlocked.CompareExchange(ref owner._captured, 1, 0) == 0)
                 {
@@ -483,7 +483,7 @@ public class BlockCachePreWarmerTests
                     owner._observed.Set();
                 }
 
-                return inner.Build(baseBlock);
+                return inner.TryBuild(baseBlock, out scope);
             }
 
             public void Dispose() => inner.Dispose();
@@ -520,8 +520,8 @@ public class BlockCachePreWarmerTests
             ConcurrentBag<IReadOnlyTxProcessorSource> disposed)
             : IReadOnlyTxProcessorSource
         {
-            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock) =>
-                inner.Build(baseBlock);
+            public bool TryBuild(BlockHeader? baseBlock, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope) =>
+                inner.TryBuild(baseBlock, out scope);
 
             public void Dispose()
             {

--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.Consensus.Test/GenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/GenesisLoaderTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -44,7 +45,13 @@ public class GenesisLoaderTests
 
         _worldState = Substitute.For<IWorldState>();
         _scopeDisposable = Substitute.For<IDisposable>();
-        _worldState.BeginScope(IWorldState.PreGenesis).Returns(_scopeDisposable);
+        _worldState
+            .TryBeginScope(IWorldState.PreGenesis, out Arg.Any<IDisposable>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = _scopeDisposable;
+                return true;
+            });
 
         _worldStateManager = Substitute.For<IWorldStateManager>();
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Core;
@@ -28,10 +29,16 @@ public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, I
 
     public class AutoReadOnlyTxProcessingEnv(ITransactionProcessor transactionProcessor, IWorldState worldState, ILifetimeScope lifetimeScope) : IReadOnlyTxProcessorSource
     {
-        public IReadOnlyTxProcessingScope Build(BlockHeader? header)
+        public bool TryBuild(BlockHeader? header, [NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope)
         {
-            IDisposable closer = worldState.BeginScope(header);
-            return new ReadOnlyTxProcessingScope(transactionProcessor, closer, worldState);
+            if (!worldState.TryBeginScope(header, out IDisposable? closer))
+            {
+                scope = null;
+                return false;
+            }
+
+            scope = new ReadOnlyTxProcessingScope(transactionProcessor, closer, worldState);
+            return true;
         }
 
         public void Dispose() => lifetimeScope.Dispose();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -257,7 +257,12 @@ public partial class BlockAccessListManager
             IReadOnlyTxProcessorSource source = _parentReaderEnvPool.Get();
             try
             {
-                return new ParentReaderLease(source, _parentReaderEnvPool, source.Build(_parentStateHeader));
+                if (!source.TryBuild(_parentStateHeader, out IReadOnlyTxProcessingScope? scope))
+                {
+                    throw new InvalidOperationException(
+                        $"Missing state for parent {_parentStateHeader.ToString(BlockHeader.Format.Short)} when leasing block-access-list reader.");
+                }
+                return new ParentReaderLease(source, _parentReaderEnvPool, scope);
             }
             catch
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -416,8 +416,9 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                         baseState.InitThreadState,
                     static (i, state) =>
                     {
+                        if (state.Scope is null) return state;
                         Transaction tx = state.Payload.Transactions[i];
-                        WarmupSender(tx.SenderAddress, tx.To, state.Scope!.WorldState);
+                        WarmupSender(tx.SenderAddress, tx.To, state.Scope.WorldState);
 
                         return state;
                     },
@@ -443,8 +444,9 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 baseState.InitThreadState,
                 static (i, state) =>
                 {
+                    if (state.Scope is null) return state;
                     ReadOnlyAccountChanges ac = state.Payload[i];
-                    IWorldState worldState = state.Scope!.WorldState;
+                    IWorldState worldState = state.Scope.WorldState;
 
                     WarmupBalAccount(ac, worldState);
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -168,8 +168,11 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                         IReadOnlyTxProcessorSource env = state.EnvPool.Get();
                         try
                         {
-                            using IReadOnlyTxProcessingScope scope = env.Build(state.Parent);
-                            scope.WorldState.WarmUp(state.Block.Withdrawals![i].Address);
+                            if (env.TryBuild(state.Parent, out IReadOnlyTxProcessingScope? scope))
+                            {
+                                using IReadOnlyTxProcessingScope _scopeDisposer = scope;
+                                scope.WorldState.WarmUp(state.Block.Withdrawals![i].Address);
+                            }
                         }
                         catch (MissingTrieNodeException)
                         {
@@ -226,7 +229,11 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                         IReadOnlyTxProcessorSource env = blockState.PreWarmer._envPool.Get();
                         try
                         {
-                            using IReadOnlyTxProcessingScope scope = env.Build(blockState.Parent);
+                            if (!env.TryBuild(blockState.Parent, out IReadOnlyTxProcessingScope? scope))
+                            {
+                                return tupleState;
+                            }
+                            using IReadOnlyTxProcessingScope _scopeDisposer = scope;
                             BlockExecutionContext context = new(blockState.Block.Header, blockState.Spec);
                             scope.TransactionProcessor.SetBlockExecutionContext(context);
 
@@ -378,11 +385,13 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                     IReadOnlyTxProcessorSource env = envPool.Get();
                     try
                     {
-                        using IReadOnlyTxProcessingScope scope = env.Build(parent);
-
-                        foreach (AccessList list in SystemTxAccessLists.AsSpan())
+                        if (env.TryBuild(parent, out IReadOnlyTxProcessingScope? scope))
                         {
-                            scope.WorldState.WarmUp(list);
+                            using IReadOnlyTxProcessingScope _scopeDisposer = scope;
+                            foreach (AccessList list in SystemTxAccessLists.AsSpan())
+                            {
+                                scope.WorldState.WarmUp(list);
+                            }
                         }
                     }
                     finally
@@ -523,7 +532,12 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         public WarmingState<TPayload> InitThreadState()
         {
             IReadOnlyTxProcessorSource env = EnvPool.Get();
-            return new(EnvPool, Payload, parent, env, scope: env.Build(parent));
+            if (!env.TryBuild(parent, out IReadOnlyTxProcessingScope? scope))
+            {
+                EnvPool.Return(env);
+                return new(EnvPool, Payload, parent);
+            }
+            return new(EnvPool, Payload, parent, env, scope: scope);
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -65,9 +65,10 @@ public class BranchProcessor(
                 throw new InvalidOperationException($"State must not be handled from outside of {nameof(IBranchProcessor)} except for genesis block.");
             }
         }
-        else
+        else if (!stateProvider.TryBeginScope(baseBlock, out worldStateCloser))
         {
-            worldStateCloser = stateProvider.BeginScope(baseBlock);
+            throw new InvalidOperationException(
+                $"Missing state for block {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} entering branch processor.");
         }
 
         CancellationTokenSource? backgroundCancellation = new();
@@ -157,7 +158,11 @@ public class BranchProcessor(
                     BlockHeader previousBranchStateRoot = suggestedBlock.Header;
 
                     worldStateCloser?.Dispose();
-                    worldStateCloser = stateProvider.BeginScope(previousBranchStateRoot);
+                    if (!stateProvider.TryBeginScope(previousBranchStateRoot, out worldStateCloser))
+                    {
+                        throw new InvalidOperationException(
+                            $"Missing state for block {previousBranchStateRoot.ToString(BlockHeader.Format.Short)} during branch processing.");
+                    }
                 }
 
                 preBlockBaseBlock = processedBlock.Header;

--- a/src/Nethermind/Nethermind.Consensus/Processing/GenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/GenesisLoader.cs
@@ -39,7 +39,12 @@ namespace Nethermind.Consensus.Processing
 
         private void DoLoad()
         {
-            using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+            if (!worldState.TryBeginScope(IWorldState.PreGenesis, out IDisposable? scopeCloser))
+            {
+                throw new InvalidOperationException("Unable to open pre-genesis world-state scope.");
+            }
+
+            using IDisposable _ = scopeCloser;
 
             Block genesis = genesisBuilder.Build();
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/ShareableTxProcessingSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ShareableTxProcessingSource.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core.Cpu;
 
 namespace Nethermind.Consensus.Processing;
@@ -25,11 +26,18 @@ public class ShareableTxProcessingSource(IReadOnlyTxProcessingEnvFactory envFact
         new DefaultObjectPoolProvider { MaximumRetained = Math.Min(RuntimeInformation.ProcessorCount * 16, MaxRetainedAbsoluteCap) }
             .Create(new EnvPoolPolicy(envFactory));
 
-    public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock)
+    public bool TryBuild(BlockHeader? baseBlock, [NotNullWhen(true)] out IReadOnlyTxProcessingScope? scope)
     {
-        IReadOnlyTxProcessorSource? source = _envPool.Get();
-        IReadOnlyTxProcessingScope? scope = source.Build(baseBlock);
-        return new ScopeWrapper(source, _envPool, scope);
+        IReadOnlyTxProcessorSource source = _envPool.Get();
+        if (!source.TryBuild(baseBlock, out IReadOnlyTxProcessingScope? inner))
+        {
+            _envPool.Return(source);
+            scope = null;
+            return false;
+        }
+
+        scope = new ScopeWrapper(source, _envPool, inner);
+        return true;
     }
 
     public void Dispose() => (_envPool as IDisposable)?.Dispose();

--- a/src/Nethermind/Nethermind.Consensus/Stateless/SingleCallWitnessCollector.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/SingleCallWitnessCollector.cs
@@ -32,7 +32,13 @@ public class SingleCallWitnessCollector(
         // Uses blockHeader (not parentHeader) intentionally: for a single call we want the
         // post-state of the target block. Block-level witness uses parentHeader because it
         // needs the pre-state to re-execute the block's transactions.
-        using IDisposable? scope = worldState.BeginScope(blockHeader);
+        if (!worldState.TryBeginScope(blockHeader, out IDisposable? scopeCloser))
+        {
+            throw new InvalidOperationException(
+                $"Single-call witness collector: missing state for {blockHeader.ToString(BlockHeader.Format.Short)}.");
+        }
+
+        using IDisposable scope = scopeCloser;
 
         // Output is intentionally discarded — we only need the witness (state access record),
         // not the call result. Even if the call reverts, the witness captures all accessed state.

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCollector.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCollector.cs
@@ -21,7 +21,13 @@ public class WitnessCollector(
 {
     public Witness GetWitnessForExistingBlock(BlockHeader parentHeader, Block block)
     {
-        using IDisposable? scope = worldState.BeginScope(parentHeader);
+        if (!worldState.TryBeginScope(parentHeader, out IDisposable? scopeCloser))
+        {
+            throw new InvalidOperationException(
+                $"Witness collector: missing state for parent {parentHeader.ToString(BlockHeader.Format.Short)}.");
+        }
+
+        using IDisposable scope = scopeCloser;
         blockProcessor.ProcessOne(block, ProcessingOptions.ReadOnlyChain, NullBlockTracer.Instance, specProvider.GetSpec(block.Header));
         return worldState.GetWitness(parentHeader);
     }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Collections.Pooled;
@@ -287,7 +288,7 @@ public class WitnessGeneratingWorldState(IWorldState inner, IStateReader stateRe
 
     public void ResetTransient() => inner.ResetTransient();
 
-    public IDisposable BeginScope(BlockHeader? baseBlock) => inner.BeginScope(baseBlock);
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IDisposable? scopeCloser) => inner.TryBeginScope(baseBlock, out scopeCloser);
 
     public void CreateEmptyAccountIfDeleted(Address address)
     {

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -97,7 +97,11 @@ public class GethStyleTracer(
         if (tx.Hash is null) throw new InvalidOperationException("Cannot trace transactions without tx hash set.");
 
         block = block.WithReplacedBodyCloned(BlockBody.WithOneTransactionOnly(tx));
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(block.Header, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(block.Header, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(block.Header);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
         IBlockTracer<GethLikeTxTrace> blockTracer = CreateOptionsTracer(block.Header, options with { TxHash = tx.Hash }, scope.Component.WorldState, specProvider);
         try
         {
@@ -137,7 +141,11 @@ public class GethStyleTracer(
 
         BlockHeader? parent = FindParent(block);
 
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(parent, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(parent);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
         IntermediateRootsBlockTracer tracer = new(scope.Component.WorldState, specProvider.GetSpec(block.Header));
         scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
         return tracer.BuildResult();
@@ -151,7 +159,11 @@ public class GethStyleTracer(
         Block block = blockTree.FindBlock(blockHash) ?? throw new InvalidOperationException($"No historical block found for {blockHash}");
         BlockHeader parent = FindParent(block);
 
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(parent, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(parent);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
         GethLikeBlockFileTracer tracer = new(block, options, fileSystem);
         scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
 
@@ -168,7 +180,11 @@ public class GethStyleTracer(
                         .FirstOrDefault(b => b.Hash == blockHash)
                     ?? throw new InvalidOperationException($"No historical block found for {blockHash}");
         BlockHeader parent = FindParent(block);
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(parent, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(parent);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
         GethLikeBlockFileTracer tracer = new(block, options, fileSystem);
         scope.Component.BlockchainProcessor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken), cancellationToken);
 
@@ -189,7 +205,11 @@ public class GethStyleTracer(
             : block.Header;
 
         options.BlockOverrides?.ApplyOverrides(block.Header);
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(baseBlockHeader, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(baseBlockHeader, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(baseBlockHeader);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
 
         GethTraceOptions filtered = options with { TxHash = txHash };
         IBlockTracer<GethLikeTxTrace> tracer = writer is null
@@ -221,7 +241,11 @@ public class GethStyleTracer(
         ArgumentNullException.ThrowIfNull(block);
 
         BlockHeader parent = FindParent(block);
-        using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
+        if (!blockProcessingEnv.TryBuildAndOverride(parent, options.StateOverrides, specOverride: null, out Scope<BlockProcessingComponents> scope))
+        {
+            throw new StateUnavailableException(parent);
+        }
+        using Scope<BlockProcessingComponents> _scopeDisposer = scope;
 
         IBlockTracer<GethLikeTxTrace> tracer = writer is null
             ? CreateOptionsTracer(block.Header, options, scope.Component.WorldState, specProvider)

--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -16,9 +16,9 @@ namespace Nethermind.Core.Test.Modules;
 /// <param name="flatDbManager"></param>
 internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbManager
 {
-    public SnapshotBundle GatherSnapshotBundle(in StateId stateId, ResourcePool.Usage usage) => flatDbManager.GatherSnapshotBundle(NormalizeState(stateId), usage);
+    public SnapshotBundle? GatherSnapshotBundle(in StateId stateId, ResourcePool.Usage usage) => flatDbManager.GatherSnapshotBundle(NormalizeState(stateId), usage);
 
-    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId));
+    public ReadOnlySnapshotBundle? GatherReadOnlySnapshotBundle(in StateId stateId) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId));
 
     public bool HasStateForBlock(in StateId stateId)
     {

--- a/src/Nethermind/Nethermind.Core.Test/Modules/ScopeProviderTestExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/ScopeProviderTestExtensions.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.State.OverridableEnv;
+
+namespace Nethermind.Core.Test.Modules;
+
+/// <summary>
+/// Test-only adapters around the production <c>TryBeginScope</c>/<c>TryBuild</c>/<c>TryBuildAndOverride</c>
+/// APIs. Production code must use the explicit <c>Try*</c> form so the "no state" outcome is handled at the
+/// call site; tests typically arrange a known-present state and just want a throwing convenience wrapper.
+/// </summary>
+public static class ScopeProviderTestExtensions
+{
+    public static IDisposable BeginScope(this IWorldState worldState, BlockHeader? baseBlock)
+    {
+        if (!worldState.TryBeginScope(baseBlock, out IDisposable? closer))
+        {
+            throw new StateUnavailableException(baseBlock);
+        }
+        return closer;
+    }
+
+    public static IWorldStateScopeProvider.IScope BeginScope(this IWorldStateScopeProvider provider, BlockHeader? baseBlock)
+    {
+        if (!provider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? scope))
+        {
+            throw new StateUnavailableException(baseBlock);
+        }
+        return scope;
+    }
+
+    public static IReadOnlyTxProcessingScope Build(this IReadOnlyTxProcessorSource source, BlockHeader? baseBlock)
+    {
+        if (!source.TryBuild(baseBlock, out IReadOnlyTxProcessingScope? scope))
+        {
+            throw new StateUnavailableException(baseBlock);
+        }
+        return scope;
+    }
+
+    public static IReadOnlyTxProcessingScope Build(this IShareableTxProcessorSource source, BlockHeader? baseBlock)
+    {
+        if (!source.TryBuild(baseBlock, out IReadOnlyTxProcessingScope? scope))
+        {
+            throw new StateUnavailableException(baseBlock);
+        }
+        return scope;
+    }
+
+    public static IDisposable BuildAndOverride(
+        this IOverridableEnv env,
+        BlockHeader? header,
+        Dictionary<Address, AccountOverride>? stateOverride = null,
+        IReleaseSpec? specOverride = null)
+    {
+        if (!env.TryBuildAndOverride(header, stateOverride, specOverride, out IDisposable? closer))
+        {
+            throw new StateUnavailableException(header);
+        }
+        return closer;
+    }
+
+    public static Scope<T> BuildAndOverride<T>(
+        this IOverridableEnv<T> env,
+        BlockHeader? header,
+        Dictionary<Address, AccountOverride>? stateOverride = null,
+        IReleaseSpec? specOverride = null)
+    {
+        if (!env.TryBuildAndOverride(header, stateOverride, specOverride, out Scope<T> scope))
+        {
+            throw new StateUnavailableException(header);
+        }
+        return scope;
+    }
+
+    public static Scope<T> BuildAndOverride<T>(
+        this IShareableOverridableEnvSource<T> source,
+        BlockHeader? header,
+        Dictionary<Address, AccountOverride>? stateOverride = null)
+    {
+        if (!source.TryBuildAndOverride(header, stateOverride, out Scope<T> scope))
+        {
+            throw new StateUnavailableException(header);
+        }
+        return scope;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -21,6 +21,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/TxProcessingBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/TxProcessingBenchmark.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/WarmupBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/WarmupBenchmark.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -7,6 +7,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Test/Helpers/EvmTestHarness.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Helpers/EvmTestHarness.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/ShareableOverridableEnvSourceTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/ShareableOverridableEnvSourceTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Modules;
 using Nethermind.State.OverridableEnv;
 using NUnit.Framework;
 
@@ -118,10 +119,11 @@ public class ShareableOverridableEnvSourceTests
     {
         public bool IsDisposed { get; private set; }
 
-        public Scope<Marker> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null)
+        public bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, IReleaseSpec? specOverride, out Scope<Marker> scope)
         {
             if (throwOnBuild) throw new InvalidOperationException("simulated build failure");
-            return new Scope<Marker>(new Marker(), new NoopDisposable());
+            scope = new Scope<Marker>(new Marker(), new NoopDisposable());
+            return true;
         }
 
         public void Dispose() => IsDisposed = true;

--- a/src/Nethermind/Nethermind.Evm.Test/StateOverridesTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/StateOverridesTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.Specs.Forks;

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Evm.Tracing;

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7623Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip7623Tests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -14,15 +15,23 @@ namespace Nethermind.Evm.State;
 
 /// <summary>
 /// Represents state that can be anchored at specific state root, snapshot, committed, reverted.
-/// <see cref="BeginScope"/> must be called before any other operation, or it will throw. The returned <see cref="IDisposable"/>
-/// must be disposed to close the <see cref="IWorldState"/>. Multiple block can be executed or saved within the same scope.
+/// <see cref="TryBeginScope"/> must be called before any other operation, or operations will throw.
+/// On success the returned <see cref="IDisposable"/> must be disposed to close the <see cref="IWorldState"/>.
+/// Multiple block can be executed or saved within the same scope.
 /// </summary>
 public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 {
     // For scope to create genesis.
     const BlockHeader? PreGenesis = null;
 
-    IDisposable BeginScope(BlockHeader? baseBlock);
+    /// <summary>
+    /// Attempt to open a world-state scope anchored at <paramref name="baseBlock"/>. Returns <c>false</c> when
+    /// the underlying state is unavailable (e.g. pruned concurrently with this call) without throwing.
+    /// </summary>
+    /// <param name="baseBlock">The block header to anchor the scope at, or <see cref="PreGenesis"/>.</param>
+    /// <param name="scopeCloser">Disposable that closes the scope; only valid when the method returns <c>true</c>.</param>
+    /// <returns><c>true</c> on success; <c>false</c> if the state for <paramref name="baseBlock"/> is unavailable.</returns>
+    bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IDisposable? scopeCloser);
     bool IsInScope { get; }
     IWorldStateScopeProvider ScopeProvider { get; }
     new ref readonly UInt256 GetBalance(Address address);

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -15,7 +16,17 @@ namespace Nethermind.Evm.State;
 public interface IWorldStateScopeProvider
 {
     bool HasRoot(BlockHeader? baseBlock);
-    IScope BeginScope(BlockHeader? baseBlock);
+
+    /// <summary>
+    /// Attempt to open a scope anchored at <paramref name="baseBlock"/>. Returns <c>false</c> when the state for
+    /// that block is unavailable (e.g. concurrently pruned between a prior <see cref="HasRoot"/> check and this call).
+    /// </summary>
+    /// <remarks>
+    /// This is the atomic replacement for a <c>HasRoot</c> + <c>BeginScope</c> sequence: implementations either
+    /// return a usable scope or report unavailability without throwing. Callers that require state to be present
+    /// (block processing, genesis loading) should throw locally when this returns <c>false</c>.
+    /// </remarks>
+    bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IScope? scope);
 
     public interface IScope : IDisposable
     {

--- a/src/Nethermind/Nethermind.Evm/State/StateUnavailableException.cs
+++ b/src/Nethermind/Nethermind.Evm/State/StateUnavailableException.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// Thrown when an operation requires a world-state scope at a specific block, but that state has
+/// been pruned or is otherwise unavailable. RPC entry points translate this into a
+/// <c>ResourceUnavailable</c> error so callers can distinguish "state gone" from execution errors.
+/// </summary>
+public sealed class StateUnavailableException(BlockHeader? header)
+    : InvalidOperationException(BuildMessage(header))
+{
+    public BlockHeader? Header { get; } = header;
+
+    private static string BuildMessage(BlockHeader? header) =>
+        $"No state available for block {header?.ToString(BlockHeader.Format.FullHashAndNumber) ?? "(null)"}";
+}

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -152,23 +152,49 @@ namespace Nethermind.Facade
             return blockHash is not null ? receiptStorage.Get(blockHash).ForTransaction(txHash) : null;
         }
 
-        public CallOutput Call(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken) =>
-            HasOverrides(stateOverride, blobBaseFeeOverride)
-                ? CallExclusive(header, tx, stateOverride, blobBaseFeeOverride, cancellationToken)
-                : CallShareable(header, tx, cancellationToken);
+        public CallOutput Call(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return HasOverrides(stateOverride, blobBaseFeeOverride)
+                    ? CallExclusive(header, tx, stateOverride, blobBaseFeeOverride, cancellationToken)
+                    : CallShareable(header, tx, cancellationToken);
+            }
+            catch (MissingTrieNodeException)
+            {
+                // Trie backends do not pin state for the lifetime of a scope; a node can be missing
+                // (e.g. mid-sync, after pruning) and surface as MissingTrieNodeException deep inside the
+                // read path. Translate to the same "no state" outcome that the Flat backend reports
+                // through TryBuild, so the RPC layer returns ResourceUnavailable rather than a generic
+                // execution error.
+                return CallOutput.NoStateForBlock(header);
+            }
+        }
 
         private CallOutput CallShareable(BlockHeader header, Transaction tx, CancellationToken cancellationToken)
         {
-            using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunCall(stateReader, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
+            if (!shareableTxProcessorSource.TryBuild(header, out IReadOnlyTxProcessingScope? scope))
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+            using (scope)
+            {
+                return RunCall(stateReader, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
+            }
         }
 
         private CallOutput CallExclusive(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
-            using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride);
-            // Dual-write: RequestState feeds the VM-time decorator; RunCall applies it during pre-VM header prep.
-            scope.Component.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunCall(scope.Component.StateReader, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
+            if (!processingEnv.TryBuildAndOverride(header, stateOverride, out Scope<BlockProcessingComponents> scope))
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+            using (scope)
+            {
+                // Dual-write: RequestState feeds the VM-time decorator; RunCall applies it during pre-VM header prep.
+                scope.Component.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
+                return RunCall(scope.Component.StateReader, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
+            }
         }
 
         private CallOutput RunCall(IStateReader nonceReader, ITransactionProcessor txProcessor, BlockHeader header, Transaction tx, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
@@ -199,23 +225,44 @@ namespace Nethermind.Facade
             return _simulateBridgeHelper.TrySimulate(header, payload, tracer, env, gasCapLimit, cancellationToken);
         }
 
-        public CallOutput EstimateGas(BlockHeader header, Transaction tx, int errorMargin, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken) =>
-            HasOverrides(stateOverride, blobBaseFeeOverride)
-                ? EstimateGasExclusive(header, tx, errorMargin, stateOverride, blobBaseFeeOverride, cancellationToken)
-                : EstimateGasShareable(header, tx, errorMargin, cancellationToken);
+        public CallOutput EstimateGas(BlockHeader header, Transaction tx, int errorMargin, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return HasOverrides(stateOverride, blobBaseFeeOverride)
+                    ? EstimateGasExclusive(header, tx, errorMargin, stateOverride, blobBaseFeeOverride, cancellationToken)
+                    : EstimateGasShareable(header, tx, errorMargin, cancellationToken);
+            }
+            catch (MissingTrieNodeException)
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+        }
 
         private CallOutput EstimateGasShareable(BlockHeader header, Transaction tx, int errorMargin, CancellationToken cancellationToken)
         {
-            using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunEstimateGas(stateReader, scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
+            if (!shareableTxProcessorSource.TryBuild(header, out IReadOnlyTxProcessingScope? scope))
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+            using (scope)
+            {
+                return RunEstimateGas(stateReader, scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
+            }
         }
 
         private CallOutput EstimateGasExclusive(BlockHeader header, Transaction tx, int errorMargin, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
-            using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride);
-            BlockProcessingComponents components = scope.Component;
-            components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunEstimateGas(components.StateReader, components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
+            if (!processingEnv.TryBuildAndOverride(header, stateOverride, out Scope<BlockProcessingComponents> scope))
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+            using (scope)
+            {
+                BlockProcessingComponents components = scope.Component;
+                components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
+                return RunEstimateGas(components.StateReader, components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
+            }
         }
 
         private CallOutput RunEstimateGas(IStateReader nonceReader, ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
@@ -267,39 +314,60 @@ namespace Nethermind.Facade
             };
         }
 
-        public CallOutput CreateAccessList(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, bool optimize, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken) =>
-            HasOverrides(stateOverride, blobBaseFeeOverride)
-                ? CreateAccessListExclusive(header, tx, stateOverride, optimize, blobBaseFeeOverride, cancellationToken)
-                : CreateAccessListShareable(header, tx, optimize, cancellationToken);
+        public CallOutput CreateAccessList(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, bool optimize, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return HasOverrides(stateOverride, blobBaseFeeOverride)
+                    ? CreateAccessListExclusive(header, tx, stateOverride, optimize, blobBaseFeeOverride, cancellationToken)
+                    : CreateAccessListShareable(header, tx, optimize, cancellationToken);
+            }
+            catch (MissingTrieNodeException)
+            {
+                return CallOutput.NoStateForBlock(header);
+            }
+        }
 
         private CallOutput CreateAccessListShareable(BlockHeader header, Transaction tx, bool optimize, CancellationToken cancellationToken)
         {
-            using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            AccessList? originalAccessList = tx.AccessList;
-            try
+            if (!shareableTxProcessorSource.TryBuild(header, out IReadOnlyTxProcessingScope? scope))
             {
-                return ConvergeAccessList(stateReader, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
+                return CallOutput.NoStateForBlock(header);
             }
-            finally
+            using (scope)
             {
-                tx.AccessList = originalAccessList;
+                AccessList? originalAccessList = tx.AccessList;
+                try
+                {
+                    return ConvergeAccessList(stateReader, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
+                }
+                finally
+                {
+                    tx.AccessList = originalAccessList;
+                }
             }
         }
 
         private CallOutput CreateAccessListExclusive(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, bool optimize, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
-            using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride);
-            BlockProcessingComponents components = scope.Component;
-            components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-
-            AccessList? originalAccessList = tx.AccessList;
-            try
+            if (!processingEnv.TryBuildAndOverride(header, stateOverride, out Scope<BlockProcessingComponents> scope))
             {
-                return ConvergeAccessList(components.StateReader, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
+                return CallOutput.NoStateForBlock(header);
             }
-            finally
+            using (scope)
             {
-                tx.AccessList = originalAccessList;
+                BlockProcessingComponents components = scope.Component;
+                components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
+
+                AccessList? originalAccessList = tx.AccessList;
+                try
+                {
+                    return ConvergeAccessList(components.StateReader, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
+                }
+                finally
+                {
+                    tx.AccessList = originalAccessList;
+                }
             }
         }
 
@@ -646,11 +714,12 @@ namespace Nethermind.Facade
             IOverridableEnv<BlockchainBridge.BlockProcessingComponents> inner,
             IDisposable scope) : IOverridableEnv<BlockchainBridge.BlockProcessingComponents>, IDisposable
         {
-            public Scope<BlockchainBridge.BlockProcessingComponents> BuildAndOverride(
+            public bool TryBuildAndOverride(
                 BlockHeader? header,
-                Dictionary<Address, AccountOverride>? stateOverride = null,
-                IReleaseSpec? specOverride = null) =>
-                inner.BuildAndOverride(header, stateOverride, specOverride);
+                Dictionary<Address, AccountOverride>? stateOverride,
+                IReleaseSpec? specOverride,
+                out Scope<BlockchainBridge.BlockProcessingComponents> built) =>
+                inner.TryBuildAndOverride(header, stateOverride, specOverride, out built);
 
             public void Dispose() => scope.Dispose();
         }

--- a/src/Nethermind/Nethermind.Facade/CallOutput.cs
+++ b/src/Nethermind/Nethermind.Facade/CallOutput.cs
@@ -30,7 +30,6 @@ public class CallOutput
     public static CallOutput NoStateForBlock(BlockHeader header) => new()
     {
         Error = $"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}",
-        InputError = true,
         StateUnavailable = true,
     };
 }

--- a/src/Nethermind/Nethermind.Facade/CallOutput.cs
+++ b/src/Nethermind/Nethermind.Facade/CallOutput.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
 using Nethermind.Core.Eip2930;
 
 namespace Nethermind.Facade;
@@ -19,4 +20,17 @@ public class CallOutput
     public bool ExecutionReverted { get; set; }
 
     public AccessList? AccessList { get; set; }
+
+    /// <summary>
+    /// Set when the state anchored at the requested block was no longer available
+    /// (e.g. concurrently pruned). RPC callers translate this into a <c>ResourceUnavailable</c> error.
+    /// </summary>
+    public bool StateUnavailable { get; set; }
+
+    public static CallOutput NoStateForBlock(BlockHeader header) => new()
+    {
+        Error = $"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}",
+        InputError = true,
+        StateUnavailable = true,
+    };
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -33,7 +33,10 @@ public class SimulateReadOnlyBlocksProcessingEnv(
     public SimulateReadOnlyBlocksProcessingScope Begin(BlockHeader? baseBlock)
     {
         blockTreeOverlay.ResetMainChain();
-        IDisposable envDisposer = overridableEnv.BuildAndOverride(baseBlock);
+        if (!overridableEnv.TryBuildAndOverride(baseBlock, stateOverride: null, specOverride: null, out IDisposable? envDisposer))
+        {
+            throw new StateUnavailableException(baseBlock);
+        }
         return new SimulateReadOnlyBlocksProcessingScope(
             worldState, specProvider, blockTree, codeInfoRepository, simulateState, blockProcessor, readOnlyDbProvider, envDisposer
         );

--- a/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/FlashbotsModuleTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Flashbots.Data;
 using Nethermind.Flashbots.Modules.Flashbots;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateSubmissionHandler.cs
@@ -193,7 +193,12 @@ public class ValidateSubmissionHandler(
             return false;
         }
 
-        using Scope<ProcessingEnv> scope = _blockProcessorEnv.BuildAndOverride(parentHeader);
+        if (!_blockProcessorEnv.TryBuildAndOverride(parentHeader, stateOverride: null, specOverride: null, out Scope<ProcessingEnv> scope))
+        {
+            error = $"No state available for parent block {parentHeader.ToString(BlockHeader.Format.FullHashAndNumber)}";
+            return false;
+        }
+        using Scope<ProcessingEnv> _scopeDisposer = scope;
         IWorldState worldState = scope.Component.WorldState;
         IBlockProcessor blockProcessor = scope.Component.BlockProcessor;
 

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Rbuilder/RbuilderRpcModule.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Rbuilder/RbuilderRpcModule.cs
@@ -30,75 +30,84 @@ public class RbuilderRpcModule(IBlockFinder blockFinder, ISpecProvider specProvi
             return ResultWrapper<Hash256>.Fail("Block not found", ErrorCodes.ResourceNotFound);
         }
 
-        using IReadOnlyTxProcessingScope worldScope = txProcessorSource.Build(blockHeader);
-        IWorldState worldState = worldScope.WorldState;
-        IReleaseSpec releaseSpec = specProvider.GetSpec(blockHeader);
-
-        foreach (KeyValuePair<Address, AccountChange> kv in accountDiff)
+        if (!txProcessorSource.TryBuild(blockHeader, out IReadOnlyTxProcessingScope? worldScope))
         {
-            Address address = kv.Key;
-            AccountChange accountChange = kv.Value;
-
-            if (accountChange.SelfDestructed)
-            {
-                worldState.DeleteAccount(address);
-            }
-
-            bool hasAccountChange = accountChange.Balance is not null
-                                    || accountChange.Nonce is not null
-                                    || accountChange.CodeHash is not null
-                                    || accountChange.ChangedSlots?.Count > 0;
-            if (!hasAccountChange) continue;
-
-            if (worldState.TryGetAccount(address, out AccountStruct account))
-            {
-                // IWorldState does not actually have set nonce or set balance.
-                // Set, its either this or changing `IWorldState` which is somewhat risky.
-                if (accountChange.Nonce is not null)
-                {
-                    worldState.SetNonce(address, accountChange.Nonce.Value);
-                }
-
-                if (accountChange.Balance is not null)
-                {
-                    UInt256 originalBalance = account.Balance;
-                    if (accountChange.Balance.Value > originalBalance)
-                    {
-                        worldState.AddToBalance(address, accountChange.Balance.Value - originalBalance, releaseSpec);
-                    }
-                    else if (accountChange.Balance.Value == originalBalance)
-                    {
-                    }
-                    else
-                    {
-                        worldState.SubtractFromBalance(address, originalBalance - accountChange.Balance.Value, releaseSpec);
-                    }
-                }
-            }
-            else
-            {
-                worldState.CreateAccountIfNotExists(address, accountChange.Balance ?? 0, accountChange.Nonce ?? 0);
-            }
-
-            if (accountChange.CodeHash is not null)
-            {
-                // Note, this also set CodeDb, but since this is a read only world state, it should do nothing.
-                worldState.InsertCode(address, accountChange.CodeHash, Array.Empty<byte>(), releaseSpec, false);
-            }
-
-            if (accountChange.ChangedSlots is not null)
-            {
-                foreach (KeyValuePair<UInt256, UInt256> changedSlot in accountChange.ChangedSlots)
-                {
-                    ReadOnlySpan<byte> bytes = changedSlot.Value.ToBigEndian().WithoutLeadingZeros();
-                    worldState.Set(new StorageCell(address, changedSlot.Key), bytes.ToArray());
-                }
-            }
+            return ResultWrapper<Hash256>.Fail(
+                $"No state available for block {blockHeader.ToString(BlockHeader.Format.FullHashAndNumber)}",
+                ErrorCodes.ResourceUnavailable);
         }
 
-        worldState.Commit(releaseSpec);
-        worldState.CommitTree(blockHeader.Number + 1);
-        return ResultWrapper<Hash256>.Success(worldState.StateRoot);
+        using (worldScope)
+        {
+            IWorldState worldState = worldScope.WorldState;
+            IReleaseSpec releaseSpec = specProvider.GetSpec(blockHeader);
+
+            foreach (KeyValuePair<Address, AccountChange> kv in accountDiff)
+            {
+                Address address = kv.Key;
+                AccountChange accountChange = kv.Value;
+
+                if (accountChange.SelfDestructed)
+                {
+                    worldState.DeleteAccount(address);
+                }
+
+                bool hasAccountChange = accountChange.Balance is not null
+                                        || accountChange.Nonce is not null
+                                        || accountChange.CodeHash is not null
+                                        || accountChange.ChangedSlots?.Count > 0;
+                if (!hasAccountChange) continue;
+
+                if (worldState.TryGetAccount(address, out AccountStruct account))
+                {
+                    // IWorldState does not actually have set nonce or set balance.
+                    // Set, its either this or changing `IWorldState` which is somewhat risky.
+                    if (accountChange.Nonce is not null)
+                    {
+                        worldState.SetNonce(address, accountChange.Nonce.Value);
+                    }
+
+                    if (accountChange.Balance is not null)
+                    {
+                        UInt256 originalBalance = account.Balance;
+                        if (accountChange.Balance.Value > originalBalance)
+                        {
+                            worldState.AddToBalance(address, accountChange.Balance.Value - originalBalance, releaseSpec);
+                        }
+                        else if (accountChange.Balance.Value == originalBalance)
+                        {
+                        }
+                        else
+                        {
+                            worldState.SubtractFromBalance(address, originalBalance - accountChange.Balance.Value, releaseSpec);
+                        }
+                    }
+                }
+                else
+                {
+                    worldState.CreateAccountIfNotExists(address, accountChange.Balance ?? 0, accountChange.Nonce ?? 0);
+                }
+
+                if (accountChange.CodeHash is not null)
+                {
+                    // Note, this also set CodeDb, but since this is a read only world state, it should do nothing.
+                    worldState.InsertCode(address, accountChange.CodeHash, Array.Empty<byte>(), releaseSpec, false);
+                }
+
+                if (accountChange.ChangedSlots is not null)
+                {
+                    foreach (KeyValuePair<UInt256, UInt256> changedSlot in accountChange.ChangedSlots)
+                    {
+                        ReadOnlySpan<byte> bytes = changedSlot.Value.ToBigEndian().WithoutLeadingZeros();
+                        worldState.Set(new StorageCell(address, changedSlot.Key), bytes.ToArray());
+                    }
+                }
+            }
+
+            worldState.Commit(releaseSpec);
+            worldState.CommitTree(blockHeader.Number + 1);
+            return ResultWrapper<Hash256>.Success(worldState.StateRoot);
+        }
     }
 
 

--- a/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
@@ -20,7 +20,11 @@ public class EvmWarmer(IOverridableEnvFactory envFactory, ILifetimeScope rootSco
     public Task Execute(CancellationToken cancellationToken)
     {
         IOverridableEnv env = envFactory.Create();
-        using IDisposable envScope = env.BuildAndOverride(null, null);
+        if (!env.TryBuildAndOverride(header: null, stateOverride: null, specOverride: null, out IDisposable? envScopeCloser))
+        {
+            throw new StateUnavailableException(null);
+        }
+        using IDisposable envScope = envScopeCloser;
 
         using ILifetimeScope childContainerScope = rootScope.BeginLifetimeScope((builder) =>
         {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.ExecutionWitness.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.ExecutionWitness.cs
@@ -17,6 +17,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Evm;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -134,6 +134,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
             {
                 CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, BlobBaseFeeOverride, token);
 
+                if (result.StateUnavailable)
+                {
+                    return ResultWrapper<HexBytes>.Fail(result.Error!, ErrorCodes.ResourceUnavailable);
+                }
+
                 if (!result.ExecutionReverted && result.Error is not null)
                 {
                     string message = result.InputError
@@ -181,6 +186,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
             {
                 CallOutput result = _blockchainBridge.EstimateGas(header, tx, _errorMargin, stateOverride, BlobBaseFeeOverride, token);
 
+                if (result.StateUnavailable)
+                {
+                    return ResultWrapper<UInt256?>.Fail(result.Error!, ErrorCodes.ResourceUnavailable);
+                }
+
                 string? errorMessage = result.Error;
                 if (!result.ExecutionReverted && !result.InputError && errorMessage is not null)
                 {
@@ -197,6 +207,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
             protected override ResultWrapper<AccessListResultForRpc?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.CreateAccessList(header, tx, stateOverride, optimize, BlobBaseFeeOverride, token);
+
+                if (result.StateUnavailable)
+                {
+                    return ResultWrapper<AccessListResultForRpc?>.Fail(result.Error!, ErrorCodes.ResourceUnavailable);
+                }
 
                 AccessListResultForRpc rpcAccessListResult = new(
                     accessList: AccessListForRpc.FromAccessList(result.AccessList ?? tx.AccessList),

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/ExecutorBase.cs
@@ -29,10 +29,9 @@ public abstract class ExecutorBase<TResult, TRequest, TProcessing>(
         if (searchResult.Value.IsError) return ResultWrapper<TResult>.Fail(searchResult.Value);
 
         BlockHeader header = searchResult.Value.Object!;
-        if (!_blockchainBridge.HasStateForBlock(header))
-        {
-            return ResultWrapper<TResult>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
-        }
+        // State availability is checked atomically inside the bridge via TryBuild / TryBuildAndOverride:
+        // a "no state" outcome is surfaced through CallOutput.StateUnavailable so we can report
+        // ResourceUnavailable consistently without a racy HasStateForBlock pre-check.
 
         using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
         Result<TProcessing> prepareResult = Prepare(call, header);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -46,7 +46,13 @@ namespace Nethermind.JsonRpc.Modules.Proof
             }
 
             BlockHeader sourceHeader = searchResult.Object;
-            using Scope<ITracer> scope = tracerEnv.BuildAndOverride(sourceHeader);
+            if (!tracerEnv.TryBuildAndOverride(sourceHeader, stateOverride: null, specOverride: null, out Scope<ITracer> scope))
+            {
+                return ResultWrapper<CallResultWithProof>.Fail(
+                    $"No state available for block {sourceHeader.ToString(BlockHeader.Format.FullHashAndNumber)}",
+                    ErrorCodes.ResourceUnavailable);
+            }
+            using Scope<ITracer> _scopeDisposer = scope;
 
             BlockHeader callHeader = new(
                 sourceHeader.Hash,
@@ -143,7 +149,14 @@ namespace Nethermind.JsonRpc.Modules.Proof
             }
 
             Block block = searchResult.Object;
-            using Scope<ITracer> scope = tracerEnv.BuildAndOverride(blockFinder.FindParentHeader(block.Header, BlockTreeLookupOptions.None));
+            BlockHeader? proofParent = blockFinder.FindParentHeader(block.Header, BlockTreeLookupOptions.None);
+            if (!tracerEnv.TryBuildAndOverride(proofParent, stateOverride: null, specOverride: null, out Scope<ITracer> scope))
+            {
+                return ResultWrapper<ReceiptWithProof>.Fail(
+                    $"No state available for parent of block {block.Header.ToString(BlockHeader.Format.FullHashAndNumber)}",
+                    ErrorCodes.ResourceUnavailable);
+            }
+            using Scope<ITracer> _scopeDisposer = scope;
 
             TxReceipt receipt = receiptFinder.Get(block).ForTransaction(txHash);
             BlockReceiptsTracer receiptsTracer = new();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -18,6 +18,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
+using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.Tracing;
 using Nethermind.Blockchain.Tracing.ParityStyle;
@@ -168,12 +169,20 @@ namespace Nethermind.JsonRpc.Modules.Trace
                     using StreamingParityLikeBlockTracer streamingTracer = new(
                         parityTypes, ParityTraceStreamMode.Replay, includeTxHash: false,
                         writer, pipeWriter, ct);
-                    using Scope<ITracer> env = tracerEnv.BuildAndOverride(header, stateOverride);
+                    if (!tracerEnv.TryBuildAndOverride(header, stateOverride, specOverride: null, out Scope<ITracer> env))
+                    {
+                        throw new StateUnavailableException(header);
+                    }
+                    using Scope<ITracer> _envDisposer = env;
                     env.Component.Trace(block, streamingTracer.WithCancellation(ct));
                 },
                 runBuffered: () =>
                 {
-                    using Scope<ITracer> env = tracerEnv.BuildAndOverride(header, stateOverride);
+                    if (!tracerEnv.TryBuildAndOverride(header, stateOverride, specOverride: null, out Scope<ITracer> env))
+                    {
+                        throw new StateUnavailableException(header);
+                    }
+                    using Scope<ITracer> _envDisposer = env;
                     IReadOnlyCollection<ParityLikeTxTrace> result = TraceBlockDirect(env.Component, block, new(parityTypes));
                     return new ParityTxTraceFromReplay(result.SingleOrDefault());
                 });
@@ -462,7 +471,11 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
         private IReadOnlyCollection<ParityLikeTxTrace> TraceBlock(Block block, ParityLikeBlockTracer tracer)
         {
-            using Scope<ITracer> env = tracerEnv.BuildAndOverride(block.Header);
+            if (!tracerEnv.TryBuildAndOverride(block.Header, stateOverride: null, specOverride: null, out Scope<ITracer> env))
+            {
+                throw new StateUnavailableException(block.Header);
+            }
+            using Scope<ITracer> _envDisposer = env;
             ITracer tracer2 = env.Component;
 
             return TraceBlockDirect(tracer2, block, tracer);
@@ -485,7 +498,11 @@ namespace Nethermind.JsonRpc.Modules.Trace
                 blockToExecute = block.WithReplacedHeader(adjustedHeader);
             }
 
-            using Scope<ITracer> env = tracerEnv.BuildAndOverride(baseBlock, specOverride: specOverride);
+            if (!tracerEnv.TryBuildAndOverride(baseBlock, stateOverride: null, specOverride: specOverride, out Scope<ITracer> env))
+            {
+                throw new StateUnavailableException(baseBlock);
+            }
+            using Scope<ITracer> _envDisposer = env;
             ITracer tracer2 = env.Component;
 
             using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
@@ -611,7 +628,11 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
         private void TraceBlockStreaming(Block block, ParityLikeBlockTracer tracer, CancellationToken ct)
         {
-            using Scope<ITracer> env = tracerEnv.BuildAndOverride(block.Header);
+            if (!tracerEnv.TryBuildAndOverride(block.Header, stateOverride: null, specOverride: null, out Scope<ITracer> env))
+            {
+                throw new StateUnavailableException(block.Header);
+            }
+            using Scope<ITracer> _envDisposer = env;
             env.Component.Trace(block, tracer.WithCancellation(ct));
         }
 
@@ -622,7 +643,11 @@ namespace Nethermind.JsonRpc.Modules.Trace
             {
                 blockToExecute = block.WithReplacedHeader(AdjustHeaderForSpec(block.Header, baseHeader, specOverride));
             }
-            using Scope<ITracer> env = tracerEnv.BuildAndOverride(baseHeader, specOverride: specOverride);
+            if (!tracerEnv.TryBuildAndOverride(baseHeader, stateOverride: null, specOverride: specOverride, out Scope<ITracer> env))
+            {
+                throw new StateUnavailableException(baseHeader);
+            }
+            using Scope<ITracer> _envDisposer = env;
             env.Component.Execute(blockToExecute, tracer.WithCancellation(ct));
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -584,7 +584,14 @@ namespace Nethermind.JsonRpc.Modules.Trace
         {
             if (!jsonRpcConfig.EnableTracingStreamMode)
             {
-                return ResultWrapper<IEnumerable<T>>.Success(runBuffered());
+                try
+                {
+                    return ResultWrapper<IEnumerable<T>>.Success(runBuffered());
+                }
+                catch (StateUnavailableException ex)
+                {
+                    return ResultWrapper<IEnumerable<T>>.Fail(ex.Message, ErrorCodes.ResourceUnavailable);
+                }
             }
 
             CancellationTokenSource timeoutCts = BuildTimeoutCancellationTokenSource();
@@ -608,7 +615,14 @@ namespace Nethermind.JsonRpc.Modules.Trace
         {
             if (!jsonRpcConfig.EnableTracingStreamMode)
             {
-                return ResultWrapper<ParityTxTraceFromReplay>.Success(runBuffered());
+                try
+                {
+                    return ResultWrapper<ParityTxTraceFromReplay>.Success(runBuffered());
+                }
+                catch (StateUnavailableException ex)
+                {
+                    return ResultWrapper<ParityTxTraceFromReplay>.Fail(ex.Message, ErrorCodes.ResourceUnavailable);
+                }
             }
 
             CancellationTokenSource timeoutCts = BuildTimeoutCancellationTokenSource();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -18,6 +18,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Merge.Plugin.Data;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin/Tracing/RetrospectiveExecutionTracer.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin/Tracing/RetrospectiveExecutionTracer.cs
@@ -196,7 +196,12 @@ public sealed class RetrospectiveExecutionTracer
         try
         {
             // Create isolated processing scope based on parent state
-            using IReadOnlyTxProcessingScope scope = txProcessorSource.Build(parentHeader);
+            if (!txProcessorSource.TryBuild(parentHeader, out IReadOnlyTxProcessingScope? scope))
+            {
+                if (_logger.IsDebug) _logger.Debug($"Skipping retrospective opcode trace: missing state for parent {parentHeader?.ToString(BlockHeader.Format.Short) ?? "null"}.");
+                return blockOpcodes;
+            }
+            using IReadOnlyTxProcessingScope _scopeDisposer = scope;
 
             // Clone the header to avoid mutating the shared cached instance from BlockTree
             BlockHeader tracingHeader = block.Header.Clone();

--- a/src/Nethermind/Nethermind.Optimism.Test/Create2DeployerContractRewriterTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Create2DeployerContractRewriterTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismWithdrawalTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismWithdrawalTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.Shutter/ShutterBlockHandler.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterBlockHandler.cs
@@ -202,7 +202,12 @@ public class ShutterBlockHandler : IShutterBlockHandler
             return;
         }
 
-        using IReadOnlyTxProcessingScope scope = _txProcessorSource.Build(parent);
+        if (!_txProcessorSource.TryBuild(parent, out IReadOnlyTxProcessingScope? scope))
+        {
+            if (_logger.IsWarn) _logger.Warn($"Cannot check Shutter validator registration: missing state for parent {parent.ToString(BlockHeader.Format.Short)}.");
+            return;
+        }
+        using IReadOnlyTxProcessingScope _scopeDisposer = scope;
         ITransactionProcessor processor = scope.TransactionProcessor;
 
         ValidatorRegistryContract validatorRegistryContract = new(processor, _abiEncoder, new(_cfg.ValidatorRegistryContractAddress!), _logManager, _chainId, _cfg.ValidatorRegistryMessageVersion!);

--- a/src/Nethermind/Nethermind.Shutter/ShutterEon.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterEon.cs
@@ -28,7 +28,13 @@ public class ShutterEon(
 
     public void Update(BlockHeader header)
     {
-        using IReadOnlyTxProcessingScope scope = txSource.Build(blockTree.Head?.Header);
+        BlockHeader? headHeader = blockTree.Head?.Header;
+        if (!txSource.TryBuild(headHeader, out IReadOnlyTxProcessingScope? scope))
+        {
+            if (_logger.IsWarn) _logger.Warn($"Cannot update Shutter eon: missing state for head {headHeader?.ToString(BlockHeader.Format.Short) ?? "null"}.");
+            return;
+        }
+        using IReadOnlyTxProcessingScope _scopeDisposer = scope;
         ITransactionProcessor processor = scope.TransactionProcessor;
 
         try

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -146,6 +146,30 @@ public class FlatDbManagerTests
     }
 
     [Test]
+    public async Task GatherReadOnlySnapshotBundle_StateGoneNoMatchingPersistedState_ReturnsNull()
+    {
+        // Regression: when `HasStateForBlock` had returned true but pruning removed the snapshot
+        // before `GatherReadOnlySnapshotBundle`, the manager used to throw
+        // `InvalidOperationException("Unable to gather snapshots ...")`. RPC layers surfaced this as
+        // a confusing internal error. After the TryBeginScope refactor we return null so callers
+        // can map this cleanly to `ResourceUnavailable`.
+        StateId requestedStateId = CreateStateId(10, rootByte: 1);
+        StateId persistedStateId = CreateStateId(5, rootByte: 2);
+
+        IPersistence.IPersistenceReader mockReader = Substitute.For<IPersistence.IPersistenceReader>();
+        mockReader.CurrentState.Returns(persistedStateId);
+        _persistenceManager.LeaseReader().Returns(mockReader);
+        _snapshotRepository.AssembleSnapshots(requestedStateId, persistedStateId, Arg.Any<int>())
+            .Returns(new SnapshotPooledList(0));
+
+        await using FlatDbManager manager = CreateManager();
+        ReadOnlySnapshotBundle? bundle = manager.GatherReadOnlySnapshotBundle(requestedStateId);
+
+        Assert.That(bundle, Is.Null);
+        mockReader.Received().Dispose();
+    }
+
+    [Test]
     public async Task GatherReadOnlySnapshotBundle_CacheClearedPeriodically()
     {
         StateId stateId = CreateStateId(10);
@@ -160,11 +184,11 @@ public class FlatDbManagerTests
         await using FlatDbManager manager = CreateManager();
 
         // First call populates the cache
-        using (ReadOnlySnapshotBundle bundle1 = manager.GatherReadOnlySnapshotBundle(stateId)) { }
+        using (ReadOnlySnapshotBundle bundle1 = manager.GatherReadOnlySnapshotBundle(stateId) ?? throw new InvalidOperationException("expected bundle")) { }
 
         // Second call should hit cache (no new LeaseReader call)
         _persistenceManager.ClearReceivedCalls();
-        using (ReadOnlySnapshotBundle bundle2 = manager.GatherReadOnlySnapshotBundle(stateId)) { }
+        using (ReadOnlySnapshotBundle bundle2 = manager.GatherReadOnlySnapshotBundle(stateId) ?? throw new InvalidOperationException("expected bundle")) { }
         _persistenceManager.DidNotReceive().LeaseReader();
 
         // Wait for periodic clear (15s + margin)
@@ -172,7 +196,7 @@ public class FlatDbManagerTests
 
         // After cache clear, next call needs a new reader
         _persistenceManager.ClearReceivedCalls();
-        using (ReadOnlySnapshotBundle bundle3 = manager.GatherReadOnlySnapshotBundle(stateId)) { }
+        using (ReadOnlySnapshotBundle bundle3 = manager.GatherReadOnlySnapshotBundle(stateId) ?? throw new InvalidOperationException("expected bundle")) { }
         _persistenceManager.Received(1).LeaseReader();
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Evm.State;
 using Nethermind.Init.Modules;

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -230,17 +230,20 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         await jobTask;
     }
 
-    public SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage)
+    public SnapshotBundle? GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage)
     {
         if (_logger.IsTrace) _logger.Trace($"Gathering {baseBlock}.");
+        ReadOnlySnapshotBundle? readOnly = GatherReadOnlySnapshotBundle(baseBlock);
+        if (readOnly is null) return null;
+
         return new SnapshotBundle(
-            GatherReadOnlySnapshotBundle(baseBlock),
+            readOnly,
             _trieNodeCache,
             _resourcePool,
             usage: usage);
     }
 
-    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock)
+    public ReadOnlySnapshotBundle? GatherReadOnlySnapshotBundle(in StateId baseBlock)
     {
         // Note to self: The current verdict on trying to use a linked list of snapshots is that it is error prone and
         // hard to pull of due to the constantly moving chain making invalidation hard.
@@ -264,7 +267,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             {
                 if (Stopwatch.GetElapsedTime(sw) > GatherGiveUpDeadline)
                 {
-                    throw new InvalidOperationException($"Unable to gather {nameof(ReadOnlySnapshotBundle)} for block {baseBlock} in {Stopwatch.GetElapsedTime(sw)}");
+                    if (_logger.IsDebug) _logger.Debug($"Unable to gather {nameof(ReadOnlySnapshotBundle)} for block {baseBlock} in {Stopwatch.GetElapsedTime(sw)}");
+                    return null;
                 }
 
                 int delayMs = Math.Min(1 << Math.Min(attempt, 30), 100);  // 1, 2, 4, 8, 16, 32, 64, 100ms max
@@ -292,7 +296,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
                 if (persistenceReader.CurrentState != baseBlock)
                 {
                     persistenceReader.Dispose();
-                    throw new InvalidOperationException($"Unable to gather snapshots for state {baseBlock}.");
+                    if (_logger.IsDebug) _logger.Debug($"Unable to gather snapshots for state {baseBlock}.");
+                    return null;
                 }
             }
             else

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -75,7 +75,8 @@ public class FlatTrieVerifier
             stateId = reader.CurrentState;
         }
 
-        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId)
+            ?? throw new InvalidOperationException($"Unable to gather snapshot bundle for {stateId} when verifying trie.");
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
 
         return VerifyCore(reader, trieStore, stateId.StateRoot.ToCommitment(), cancellationToken);

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -8,8 +8,18 @@ namespace Nethermind.State.Flat;
 public interface IFlatDbManager : IFlatCommitTarget
 {
     event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
-    SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
-    ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock);
+
+    /// <summary>
+    /// Build a write-capable snapshot bundle anchored at <paramref name="baseBlock"/>, or return <c>null</c>
+    /// when the state for that block is no longer available (e.g. pruned concurrently).
+    /// </summary>
+    SnapshotBundle? GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
+
+    /// <summary>
+    /// Build a read-only snapshot bundle anchored at <paramref name="baseBlock"/>, or return <c>null</c>
+    /// when the state for that block is no longer available (e.g. pruned concurrently).
+    /// </summary>
+    ReadOnlySnapshotBundle? GatherReadOnlySnapshotBundle(in StateId baseBlock);
     void FlushCache(CancellationToken cancellationToken);
     bool HasStateForBlock(in StateId stateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -78,7 +79,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
         _resourcePool.ReturnCachedResource(ResourcePool.Usage.ReadOnlyProcessingEnv, transientResource);
     }
 
-    private SnapshotBundle GatherSnapshotBundle(BlockHeader? baseBlock)
+    private SnapshotBundle? GatherSnapshotBundle(BlockHeader? baseBlock)
     {
         StateId currentState = new(baseBlock);
 
@@ -91,7 +92,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
         }
         snapshots.Reverse();
 
-        ReadOnlySnapshotBundle readOnlySnapshotBundle;
+        ReadOnlySnapshotBundle? readOnlySnapshotBundle;
         try
         {
             readOnlySnapshotBundle = _flatDbManager.GatherReadOnlySnapshotBundle(currentState);
@@ -100,6 +101,12 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
         {
             snapshots.Dispose();
             throw;
+        }
+
+        if (readOnlySnapshotBundle is null)
+        {
+            snapshots.Dispose();
+            return null;
         }
 
         return new SnapshotBundle(
@@ -131,12 +138,17 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
     {
         public bool HasRoot(BlockHeader? baseBlock) => flatOverrideScope.HasStateForBlock(baseBlock);
 
-        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+        public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
         {
             StateId currentState = new(baseBlock);
-            SnapshotBundle snapshotBundle = flatOverrideScope.GatherSnapshotBundle(baseBlock);
+            SnapshotBundle? snapshotBundle = flatOverrideScope.GatherSnapshotBundle(baseBlock);
+            if (snapshotBundle is null)
+            {
+                scope = null;
+                return false;
+            }
 
-            return new FlatWorldStateScope(
+            scope = new FlatWorldStateScope(
                 currentState,
                 snapshotBundle,
                 codeDb,
@@ -144,6 +156,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
                 configuration,
                 trieWarmer,
                 logManager);
+            return true;
         }
     }
 
@@ -151,7 +164,12 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
     {
         public bool TryGetAccount(BlockHeader? baseBlock, Address address, out AccountStruct account)
         {
-            using SnapshotBundle snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock);
+            using SnapshotBundle? snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock);
+            if (snapshotBundle is null)
+            {
+                account = default;
+                return false;
+            }
             if (snapshotBundle.GetAccount(address) is { } acc)
             {
                 account = acc.ToStruct();
@@ -163,7 +181,8 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
 
         public ReadOnlySpan<byte> GetStorage(BlockHeader? baseBlock, Address address, in UInt256 index)
         {
-            using SnapshotBundle snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock);
+            using SnapshotBundle? snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock);
+            if (snapshotBundle is null) return [];
             int selfDestructIdx = snapshotBundle.DetermineSelfDestructSnapshotIdx(address);
             return snapshotBundle.GetSlot(address, index, selfDestructIdx) ?? [];
         }
@@ -177,7 +196,8 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
         public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock, VisitingOptions? visitingOptions = null) where TCtx : struct, INodeContext<TCtx>
         {
             StateId stateId = new(baseBlock);
-            using SnapshotBundle snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock);
+            using SnapshotBundle snapshotBundle = overridableWorldScope.GatherSnapshotBundle(baseBlock)
+                ?? throw new InvalidOperationException($"State at {baseBlock} not found");
 
             ConcurrencyController concurrency = new(1);
             StateTrieStoreAdapter trieStoreAdapter = new(snapshotBundle, concurrency);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatScopeProvider.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Db;
@@ -26,12 +27,17 @@ public class FlatScopeProvider(
 
     public bool HasRoot(BlockHeader? baseBlock) => flatDbManager.HasStateForBlock(new StateId(baseBlock));
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
     {
         StateId currentState = new(baseBlock);
-        SnapshotBundle snapshotBundle = flatDbManager.GatherSnapshotBundle(currentState, usage: usage);
+        SnapshotBundle? snapshotBundle = flatDbManager.GatherSnapshotBundle(currentState, usage: usage);
+        if (snapshotBundle is null)
+        {
+            scope = null;
+            return false;
+        }
 
-        return new FlatWorldStateScope(
+        scope = new FlatWorldStateScope(
             currentState,
             snapshotBundle,
             _codeDb,
@@ -40,5 +46,6 @@ public class FlatScopeProvider(
             trieWarmer,
             logManager,
             isReadOnly: isReadOnly);
+        return true;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -38,7 +38,14 @@ public class FlatSnapServer(
             return false;
         }
 
-        bundle = flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        ReadOnlySnapshotBundle? maybeBundle = flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        if (maybeBundle is null)
+        {
+            bundle = null!;
+            return false;
+        }
+
+        bundle = maybeBundle;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.State.Test/BlockAccessListBasedWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/BlockAccessListBasedWorldStateTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
 using Nethermind.State;

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Specs;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.State.Test/StatsCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StatsCollectorTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Autofac;
 using FluentAssertions;
 using Nethermind.Core;
@@ -11,6 +12,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Resettables;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Specs.Forks;
 using Nethermind.Logging;
@@ -802,7 +804,18 @@ public class StorageProviderTests(bool useFlat)
 
         public bool HasRoot(BlockHeader baseBlock) => scopeProvider.HasRoot(baseBlock);
 
-        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader baseBlock) => new ScopeDecorator(scopeProvider.BeginScope(baseBlock), writtenData);
+#nullable enable
+        public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
+        {
+            if (!scopeProvider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? inner))
+            {
+                scope = null;
+                return false;
+            }
+            scope = new ScopeDecorator(inner, writtenData);
+            return true;
+        }
+#nullable disable
 
         private class ScopeDecorator(IWorldStateScopeProvider.IScope baseScope, WrittenData writtenData) : IWorldStateScopeProvider.IScope
         {

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -91,8 +91,8 @@ public class BlockAccessListBasedWorldState(IWorldState innerWorldState, ILogMan
         return !AccountExists(address);
     }
 
-    public IDisposable BeginScope(BlockHeader? baseBlock)
-        => _innerWorldState.BeginScope(baseBlock);
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IDisposable? scopeCloser)
+        => _innerWorldState.TryBeginScope(baseBlock, out scopeCloser);
 
     public ReadOnlySpan<byte> Get(in StorageCell storageCell)
     {

--- a/src/Nethermind/Nethermind.State/OverridableEnv/DisposableScopeOverridableEnv.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/DisposableScopeOverridableEnv.cs
@@ -21,10 +21,16 @@ public class DisposableScopeOverridableEnv<T>(
     T resolvedComponents
 ) : IOverridableEnv<T>
 {
-    public Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null)
+    public bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, IReleaseSpec? specOverride, out Scope<T> scope)
     {
-        IDisposable disposable = overridableEnv.BuildAndOverride(header, stateOverride, specOverride);
-        return new Scope<T>(resolvedComponents, disposable);
+        if (!overridableEnv.TryBuildAndOverride(header, stateOverride, specOverride, out IDisposable? disposable))
+        {
+            scope = default!;
+            return false;
+        }
+
+        scope = new Scope<T>(resolvedComponents, disposable);
+        return true;
     }
 }
 

--- a/src/Nethermind/Nethermind.State/OverridableEnv/IOverridableEnv.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/IOverridableEnv.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Autofac.Core;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -19,7 +20,15 @@ namespace Nethermind.State.OverridableEnv;
 /// </summary>
 public interface IOverridableEnv : IModule
 {
-    IDisposable BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null);
+    /// <summary>
+    /// Attempt to build and apply overrides on top of the state anchored at <paramref name="header"/>.
+    /// Returns <c>false</c> when the state is no longer available (e.g. concurrently pruned).
+    /// </summary>
+    bool TryBuildAndOverride(
+        BlockHeader? header,
+        Dictionary<Address, AccountOverride>? stateOverride,
+        IReleaseSpec? specOverride,
+        [NotNullWhen(true)] out IDisposable? closer);
 }
 
 /// <summary>
@@ -32,5 +41,8 @@ public interface IOverridableEnv : IModule
 /// <typeparam name="T"></typeparam>
 public interface IOverridableEnv<T>
 {
-    Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null);
+    /// <summary>
+    /// Attempt to build a typed scope; returns <c>false</c> when the underlying state is unavailable.
+    /// </summary>
+    bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, IReleaseSpec? specOverride, out Scope<T> scope);
 }

--- a/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
@@ -15,5 +15,8 @@ namespace Nethermind.State.OverridableEnv;
 /// </summary>
 public interface IShareableOverridableEnvSource<T> : IDisposable
 {
-    Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null);
+    /// <summary>
+    /// Attempt to build a typed scope; returns <c>false</c> when the underlying state is unavailable.
+    /// </summary>
+    bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, out Scope<T> scope);
 }

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -36,7 +37,7 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, ILifeti
         private readonly IOverridableCodeInfoRepository _codeInfoRepository = childLifetimeScope.Resolve<IOverridableCodeInfoRepository>();
         private readonly IWorldState _worldState = childLifetimeScope.Resolve<IWorldState>();
 
-        public IDisposable BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null)
+        public bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, IReleaseSpec? specOverride, [NotNullWhen(true)] out IDisposable? closer)
         {
             if (_worldScopeCloser is not null) throw new InvalidOperationException("Previous overridable world scope was not closed");
 
@@ -45,7 +46,12 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, ILifeti
             if (specOverride is not null)
                 overridableSpecProvider.SetOverride(specOverride);
 
-            _worldScopeCloser = _worldState.BeginScope(header);
+            if (!_worldState.TryBeginScope(header, out _worldScopeCloser))
+            {
+                Reset();
+                closer = null;
+                return false;
+            }
 
             try
             {
@@ -55,7 +61,8 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, ILifeti
                     header.StateRoot = _worldState.StateRoot;
                 }
 
-                return new Scope(this);
+                closer = new Scope(this);
+                return true;
             }
             catch
             {

--- a/src/Nethermind/Nethermind.State/OverridableEnv/ShareableOverridableEnvSource.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/ShareableOverridableEnvSource.cs
@@ -26,13 +26,14 @@ public sealed class ShareableOverridableEnvSource<T>(
     private int _activeCount;
     private volatile bool _disposed;
 
-    public Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null)
+    public bool TryBuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride, out Scope<T> scope)
     {
         IOverridableEnv<T> env = Rent();
         Scope<T> innerScope;
+        bool ok;
         try
         {
-            innerScope = env.BuildAndOverride(header, stateOverride);
+            ok = env.TryBuildAndOverride(header, stateOverride, specOverride: null, out innerScope);
         }
         catch
         {
@@ -41,7 +42,16 @@ public sealed class ShareableOverridableEnvSource<T>(
             ReleasePoisoned(env);
             throw;
         }
-        return new Scope<T>(innerScope.Component, new ReturnOnDispose(env, innerScope, this));
+
+        if (!ok)
+        {
+            Release(env);
+            scope = default!;
+            return false;
+        }
+
+        scope = new Scope<T>(innerScope.Component, new ReturnOnDispose(env, innerScope, this));
+        return true;
     }
 
     public void Dispose()

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -36,7 +37,17 @@ public class PrewarmerScopeProvider(
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, populatePreBlockCache);
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
+    {
+        if (!baseProvider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? inner))
+        {
+            scope = null;
+            return false;
+        }
+
+        scope = new ScopeWrapper(inner, preBlockCaches, populatePreBlockCache);
+        return true;
+    }
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !populatePreBlockCache;

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -80,8 +80,8 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         return res;
     }
 
-    public IDisposable BeginScope(BlockHeader? baseBlock)
-        => _innerWorldState.BeginScope(baseBlock);
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IDisposable? scopeCloser)
+        => _innerWorldState.TryBeginScope(baseBlock, out scopeCloser);
 
     public IDisposable? BeginSystemAccountReadSuppression() => new SystemAccountReadSuppressionScope(this);
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -44,13 +45,18 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
     public bool HasRoot(BlockHeader? baseBlock) => _trieStore.HasRoot(baseBlock?.StateRoot ?? Keccak.EmptyTreeHash);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
     {
+        // PruningTrieStore has no mechanism to keep the state pinned for the lifetime of a scope, so
+        // there is no point pre-checking HasRoot here: the race window the Flat backend cares about does
+        // not exist for the trie backend, and gating on HasRoot would break sync paths (healing trie)
+        // that legitimately open a scope before all nodes are present.
         IDisposable trieStoreCloser = _trieStore.BeginScope(baseBlock);
         _backingStateTree ??= CreateStateTree();
         _backingStateTree.RootHash = baseBlock?.StateRoot ?? Keccak.EmptyTreeHash;
 
-        return new TrieStoreWorldStateBackendScope(_backingStateTree, this, _codeDb, trieStoreCloser, _logManager);
+        scope = new TrieStoreWorldStateBackendScope(_backingStateTree, this, _codeDb, trieStoreCloser, _logManager);
+        return true;
     }
 
     protected virtual StorageTree CreateStorageTree(Address address, Hash256 storageRoot) => new(_trieStore.GetTrieStore(address), storageRoot, _logManager);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -218,7 +218,7 @@ namespace Nethermind.State
 
         public bool HasCode(Address address) => _stateProvider.GetAccount(address).HasCode;
 
-        public IDisposable BeginScope(BlockHeader? baseBlock)
+        public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IDisposable? scopeCloser)
         {
             if (Interlocked.CompareExchange(ref _isInScope, true, false))
             {
@@ -227,11 +227,19 @@ namespace Nethermind.State
 
             if (_logger.IsTrace) _logger.Trace($"Beginning WorldState scope with baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} with stateroot {baseBlock?.StateRoot?.ToString() ?? "null"}.");
 
-            _currentScope = ScopeProvider.BeginScope(baseBlock);
+            if (!ScopeProvider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? newScope))
+            {
+                _isInScope = false;
+                scopeCloser = null;
+                if (_logger.IsTrace) _logger.Trace($"WorldState scope for baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} unavailable.");
+                return false;
+            }
+
+            _currentScope = newScope;
             _stateProvider.SetScope(_currentScope);
             _persistentStorageProvider.SetBackendScope(_currentScope);
 
-            return new Reactive.AnonymousDisposable(() =>
+            scopeCloser = new Reactive.AnonymousDisposable(() =>
             {
                 Reset();
                 _stateProvider.SetScope(null);
@@ -240,6 +248,7 @@ namespace Nethermind.State
                 _isInScope = false;
                 if (_logger.IsTrace) _logger.Trace($"WorldState scope for baseblock {baseBlock?.ToString(BlockHeader.Format.Short) ?? "null"} closed");
             });
+            return true;
         }
 
         public bool IsInScope => _currentScope is not null;

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.State;
@@ -16,7 +17,18 @@ public class WorldStateMetricsScopeProvider(IWorldStateScopeProvider baseProvide
     private double _stateMerkleizationTime;
 
     public bool HasRoot(BlockHeader? baseBlock) => _baseProvider.HasRoot(baseBlock);
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new MetricsScope(_baseProvider.BeginScope(baseBlock), this);
+
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
+    {
+        if (!_baseProvider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? inner))
+        {
+            scope = null;
+            return false;
+        }
+
+        scope = new MetricsScope(inner, this);
+        return true;
+    }
 
     private sealed class MetricsScope(IWorldStateScopeProvider.IScope baseScope, WorldStateMetricsScopeProvider parent) : IWorldStateScopeProvider.IScope
     {

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -20,10 +21,18 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
     public bool HasRoot(BlockHeader? baseBlock) =>
         baseScopeProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public bool TryBeginScope(BlockHeader? baseBlock, [NotNullWhen(true)] out IWorldStateScopeProvider.IScope? scope)
     {
         long scopeId = Interlocked.Increment(ref _currentScopeId);
-        return new ScopeWrapper(baseScopeProvider.BeginScope(baseBlock), scopeId, _logger);
+        if (!baseScopeProvider.TryBeginScope(baseBlock, out IWorldStateScopeProvider.IScope? inner))
+        {
+            _logger.Trace($"{scopeId}: Scope begin unavailable");
+            scope = null;
+            return false;
+        }
+
+        scope = new ScopeWrapper(inner, scopeId, _logger);
+        return true;
     }
 
     private class ScopeWrapper(IWorldStateScopeProvider.IScope innerScope, long scopeId, ILogger logger) : IWorldStateScopeProvider.IScope

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -15,7 +15,7 @@ namespace Nethermind.State;
 
 public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopeProvider, ILogManager logManager) : IWorldStateScopeProvider
 {
-    private ILogger _logger = logManager.GetClassLogger<WorldStateScopeOperationLogger>();
+    private readonly ILogger _logger = logManager.GetClassLogger<WorldStateScopeOperationLogger>();
     private long _currentScopeId = 0;
 
     public bool HasRoot(BlockHeader? baseBlock) =>

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
@@ -86,7 +86,13 @@ public static class StatelessExecutor
         StatelessBlockProcessingEnv blockProcessingEnv = new(
             witness, specProvider, Always.Valid, NullLogManager.Instance);
 
-        using IDisposable scope = blockProcessingEnv.WorldState.BeginScope(parentHeader);
+        if (!blockProcessingEnv.WorldState.TryBeginScope(parentHeader, out IDisposable? scopeCloser))
+        {
+            throw new InvalidOperationException(
+                $"Stateless executor: missing state for parent {parentHeader?.ToString(BlockHeader.Format.Short) ?? "null"}.");
+        }
+
+        using IDisposable scope = scopeCloser;
 
         IBlockProcessor blockProcessor = blockProcessingEnv.BlockProcessor;
 

--- a/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Evm.Tracing;

--- a/src/Nethermind/Nethermind.Taiko.Test/TxPoolContentListsTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TxPoolContentListsTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using Nethermind.Core;
 using System.Collections.Generic;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.Tracing;
@@ -67,7 +68,13 @@ public class TxPoolContentListsTests
         scope.TransactionProcessor.Returns(transactionProcessor);
 
         IShareableTxProcessorSource shareableTxProcessor = Substitute.For<IShareableTxProcessorSource>();
-        shareableTxProcessor.Build(Arg.Any<BlockHeader?>()).Returns(scope);
+        shareableTxProcessor
+            .TryBuild(Arg.Any<BlockHeader?>(), out Arg.Any<IReadOnlyTxProcessingScope?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = scope;
+                return true;
+            });
 
         TaikoEngineRpcModule taikoAuthRpcModule = CreateRpcModule(txPool, blockFinder, shareableTxProcessor);
 
@@ -165,7 +172,13 @@ public class TxPoolContentListsTests
         scope.TransactionProcessor.Returns(transactionProcessor);
 
         IShareableTxProcessorSource shareableTxProcessor = Substitute.For<IShareableTxProcessorSource>();
-        shareableTxProcessor.Build(Arg.Any<BlockHeader?>()).Returns(scope);
+        shareableTxProcessor
+            .TryBuild(Arg.Any<BlockHeader?>(), out Arg.Any<IReadOnlyTxProcessingScope?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = scope;
+                return true;
+            });
 
         TaikoEngineRpcModule rpcModule = CreateRpcModule(txPool, blockFinder, shareableTxProcessor,
             new Config.SurgeConfig { MaxGasLimitRatio = maxGasLimitRatio });
@@ -224,7 +237,13 @@ public class TxPoolContentListsTests
         scope.TransactionProcessor.Returns(transactionProcessor);
 
         IShareableTxProcessorSource shareableTxProcessor = Substitute.For<IShareableTxProcessorSource>();
-        shareableTxProcessor.Build(Arg.Any<BlockHeader?>()).Returns(scope);
+        shareableTxProcessor
+            .TryBuild(Arg.Any<BlockHeader?>(), out Arg.Any<IReadOnlyTxProcessingScope?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = scope;
+                return true;
+            });
 
         TaikoEngineRpcModule rpcModule = CreateRpcModule(txPool, blockFinder, shareableTxProcessor,
             new Config.SurgeConfig { MaxGasLimitRatio = surgeMaxGasLimitRatio });

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoEngineRpcModule.cs
@@ -190,22 +190,30 @@ public class TaikoEngineRpcModule(IAsyncHandler<byte[], ExecutionPayload?> getPa
             return ResultWrapper<PreBuiltTxList[]?>.Success([]);
         }
 
-        using IReadOnlyTxProcessingScope scope = txProcessorSource.Build(head);
-
-        return ResultWrapper<PreBuiltTxList[]?>.Success(ProcessTransactions(scope.TransactionProcessor, scope.WorldState, new BlockHeader(
-                head.Hash!,
-                Keccak.OfAnEmptySequenceRlp,
-                beneficiary,
-                UInt256.Zero,
-                head!.Number + 1,
-                (long)blockMaxGasLimit,
-                head.Timestamp + 1,
-                [])
+        if (!txProcessorSource.TryBuild(head, out IReadOnlyTxProcessingScope? scope))
         {
-            BaseFeePerGas = baseFee,
-            StateRoot = head.StateRoot,
-            IsPostMerge = true,
-        }, txQueue, maxTransactionsLists, maxBytesPerTxList, minTip));
+            return ResultWrapper<PreBuiltTxList[]?>.Fail(
+                $"No state available for block {head.ToString(BlockHeader.Format.FullHashAndNumber)}",
+                ErrorCodes.ResourceUnavailable);
+        }
+
+        using (scope)
+        {
+            return ResultWrapper<PreBuiltTxList[]?>.Success(ProcessTransactions(scope.TransactionProcessor, scope.WorldState, new BlockHeader(
+                    head.Hash!,
+                    Keccak.OfAnEmptySequenceRlp,
+                    beneficiary,
+                    UInt256.Zero,
+                    head!.Number + 1,
+                    (long)blockMaxGasLimit,
+                    head.Timestamp + 1,
+                    [])
+            {
+                BaseFeePerGas = baseFee,
+                StateRoot = head.StateRoot,
+                IsPostMerge = true,
+            }, txQueue, maxTransactionsLists, maxBytesPerTxList, minTip));
+        }
     }
 
     private PreBuiltTxList[] ProcessTransactions(ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader blockHeader, Transaction[] txSource, int maxBatchCount, ulong maxBytesPerTxList, ulong minTip)

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.Xdc.Test/Contracts/MasternodeVotingContractTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Contracts/MasternodeVotingContractTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Evm;

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RewardTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RewardTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.State;

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;

--- a/src/Nethermind/Nethermind.Xdc/Contracts/MasternodeVotingContract.cs
+++ b/src/Nethermind/Nethermind.Xdc/Contracts/MasternodeVotingContract.cs
@@ -100,7 +100,13 @@ internal class MasternodeVotingContract(
         Span<byte> input = [(byte)variableSlot];
         UInt256 slot = new(Keccak.Compute(input).Bytes);
         IReadOnlyTxProcessorSource txProcessorSource = readOnlyTxProcessingEnvFactory.Create();
-        using IReadOnlyTxProcessingScope source = txProcessorSource.Build(header);
+        if (!txProcessorSource.TryBuild(header, out IReadOnlyTxProcessingScope? source))
+        {
+            throw new InvalidOperationException(
+                $"Missing state for block {header.ToString(BlockHeader.Format.Short)} when reading masternode candidates.");
+        }
+
+        using IReadOnlyTxProcessingScope _scopeDisposer = source;
         IWorldState worldState = source.WorldState;
         ReadOnlySpan<byte> storageCell = worldState.Get(new StorageCell(ContractAddress, slot));
         UInt256 length = new(storageCell);


### PR DESCRIPTION
## Summary

Between an RPC handler's `HasStateForBlock` check and the actual scope creation, state can be pruned concurrently. On Flat this surfaced as `Unable to gather snapshots for state ...` after a 5-second retry; on Trie it surfaced as `MissingTrieNodeException` from inside the read path. Both became confusing internal errors instead of a clean `ResourceUnavailable`.

This PR converts `BeginScope` to `TryBeginScope` on `IWorldState` / `IWorldStateScopeProvider` and threads the Try-pattern through the factory layer (`IReadOnlyTxProcessorSource`, `IShareableTxProcessorSource`, `IOverridableEnv`, `IOverridableEnv<T>`, `IShareableOverridableEnvSource<T>`) and into the RPC layer. The Flat backend's `GatherSnapshotBundle` now returns `null` on terminal failure instead of throwing.

## Changes

- `IWorldStateScopeProvider.BeginScope` → `bool TryBeginScope(BlockHeader?, out IScope?)`; same on `IWorldState`. All scope-provider implementations and decorators updated (`FlatScopeProvider`, `FlatOverridableWorldScope`, `TrieStoreScopeProvider`, `PrewarmerScopeProvider`, `WorldStateMetricsScopeProvider`, `WorldStateScopeOperationLogger`) plus `IWorldState` decorators (`WitnessGeneratingWorldState`, `BlockAccessListBasedWorldState`, `TracedAccessWorldState`).
- `FlatDbManager.GatherSnapshotBundle` / `GatherReadOnlySnapshotBundle` return `null` on both terminal failure modes (zero-snapshots + persisted-state moved; retry-deadline exhausted). The existing transient-race retry loop is preserved.
- New `Nethermind.Evm.State.StateUnavailableException` for callers that contractually require state (`BranchProcessor`, `GenesisLoader`, `StatelessExecutor`, `WitnessCollector`, `SingleCallWitnessCollector`, `EvmWarmer`, `GethStyleTracer`, AuRa contract reads, etc.) — they throw locally when the new try-pattern reports unavailability, preserving fail-fast.
- `IReadOnlyTxProcessorSource.Build` / `IShareableTxProcessorSource.Build` → `TryBuild(out IReadOnlyTxProcessingScope?)`. `IOverridableEnv(<T>).BuildAndOverride` and `IShareableOverridableEnvSource<T>.BuildAndOverride` → `TryBuildAndOverride(..., out)`. All factories, pool policies, and `Contract.ConstantContract` updated.
- `BlockchainBridge.Call` / `EstimateGas` / `CreateAccessList` surface "no state" via a new `CallOutput.StateUnavailable` flag (factory: `CallOutput.NoStateForBlock(header)`). RPC executors (`CallTxExecutor`, `EstimateGasTxExecutor`, `CreateAccessListTxExecutor`) map it to `ErrorCodes.ResourceUnavailable`. The bridge also catches `MissingTrieNodeException` from the trie read path and maps it the same way so the legacy backend keeps the existing `ResourceUnavailable` contract (covers e.g. `Eth_call_missing_state_after_fast_sync`).
- `ExecutorBase.Execute` drops the racy `_blockchainBridge.HasStateForBlock(header)` pre-check now that the downstream path reports state-missing atomically. `IStateReader`-based handlers (`eth_getBalance`, `eth_getTransactionCount`, `eth_getStorageAt`, `admin_isStateRootAvailable`, `admin_verifyTrie`) keep their direct `HasStateForBlock` checks since those paths don't enter a scope.
- `TraceRpcModule`: streaming and buffered branches of `trace_call` / `trace_replayBlockTransactions` / `trace_replayTransaction` plus the new `TraceBlockStreaming` / `ExecuteBlockStreaming` helpers from #11755 all use `TryBuildAndOverride`; buffered branches return `ResourceUnavailable`, streaming branches throw `StateUnavailableException`.
- `ProofRpcModule.proof_call` / `proof_getTransactionReceipt`, `RbuilderRpcModule.rbuilder_calculateStateRoot`, and `TaikoEngineRpcModule.taikoAuth_txPoolContent` return `ResourceUnavailable` when state is gone instead of throwing.
- Other downstream callers handled: `BranchProcessor` (throws on both entry and mid-loop scope re-open), `GethStyleTracer` (6 sites), `ValidateSubmissionHandler`, `SimulateReadOnlyBlocksProcessingEnv`, `Shutter*`, `RetrospectiveExecutionTracer`, `BlockAccessListManager.TxProcessorPool`, `BlockCachePreWarmer` (3 sites — silently skip on missing state since prewarming is best-effort), `MasternodeVotingContract`, `FlatStateReader`, `FlatSnapServer`, `FlatTrieVerifier`.

### Tests

- Production interface mocks (`NSubstitute`) updated where they previously stubbed the old `Build` / `BeginScope` / `BuildAndOverride`.
- New extension class `Nethermind.Core.Test.Modules.ScopeProviderTestExtensions` provides throwing `BeginScope` / `Build` / `BuildAndOverride` wrappers so existing test bodies that assume state is present keep compiling — added `using Nethermind.Core.Test.Modules;` to ~30 test/benchmark files.
- Regression test `FlatDbManagerTests.GatherReadOnlySnapshotBundle_StateGoneNoMatchingPersistedState_ReturnsNull` covers the new `null` terminal path.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New regression test in `FlatDbManagerTests` for the null-on-state-gone path.
- Pre-existing `Eth_call_missing_state_after_fast_sync` keeps passing via the `MissingTrieNodeException` catch in `BlockchainBridge`.
- Healing-trie sync (`HealingTreeTests`) keeps passing — `TrieStoreScopeProvider.TryBeginScope` deliberately does **not** pre-check `HasRoot` (trie backend doesn't pin state; gating would break sync paths that open a scope before all nodes are present).
- Locally verified test suites green: `Nethermind.State.Test`, `Nethermind.State.Flat.Test`, `Nethermind.JsonRpc.Test`, `Nethermind.Synchronization.Test`, `Nethermind.Blockchain.Test`, `Nethermind.Consensus.Test`, `Nethermind.Taiko.Test`, `Nethermind.AuRa.Test`.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

The cross-cutting nature of the API rename touches every site that consumed `BeginScope` / `Build` / `BuildAndOverride`, but each individual change is mechanical and the call-site behavior is preserved (except for the explicit "no state" path, which is the point of the PR). The test extension class keeps the test diff small.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)