### PR TITLE
fix(TxParser): validate chainId for replay-protected legacy transactions

### DIFF
--- a/tools/TxParser/Program.cs
+++ b/tools/TxParser/Program.cs
@@ -38,7 +38,16 @@ while (true)
             continue;
         }
 
-        if (tx.Type != TxType.Legacy)
+        bool isReplayProtectedLegacyTx =
+            tx.Type == TxType.Legacy &&
+            tx.Signature is not null &&
+            tx.Signature.V >= 35; // EIP-155: v = chainId * 2 + 35/36
+
+        bool requiresChainIdValidation =
+            tx.Type != TxType.Legacy ||
+            isReplayProtectedLegacyTx;
+
+        if (requiresChainIdValidation)
         {
             signatureValidation = expectedChainIdTxValidator.IsWellFormed(tx, spec);
             if (!signatureValidation)


### PR DESCRIPTION
Problem: TxParser tool was skipping expectedChainIdTxValidator for all Legacy transactions, including EIP-155 replay-protected ones (v >= 35).Problem: TxParser tool was skipping expectedChainIdTxValidator for all Legacy transactions, including EIP-155 replay-protected ones (v >= 35). This caused inconsistent chainId validation logic compared to the production TxValidator path.

Fix: Added explicit detection of replay-protected legacy transactions based on EIP-155 protocol boundary (v >= 35), so expectedChainIdTxValidator is now correctly applied for both typed and replay-protected legacy transactions. Production validation is not affected, LegacySignatureTxValidator already enforces EIP-155 semantics via v == chainId * 2 + 35/36 check.
