### PR TITLE
ci: skip Claude review autorun on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,11 +2,11 @@
 #
 # This workflow has two modes:
 #
-#   1. Review path — triggered automatically on PR open / ready-for-review, and manually when
-#      someone comments a variant of "@claude review". Runs Claude with a fixed review prompt,
-#      captures a structured `mergeable` verdict via --json-schema, and posts a
-#      `claude-review/reviewed` commit status (success/failure) that branch protection uses
-#      to gate merging.
+#   1. Review path — triggered automatically on same-repository PR open / ready-for-review,
+#      and manually when a trusted maintainer comments a variant of "@claude review". Runs
+#      Claude with a fixed review prompt, captures a structured `mergeable` verdict via
+#      --json-schema, and posts a `claude-review/reviewed` commit status (success/failure)
+#      that branch protection uses to gate merging.
 #
 #   2. Mention path — triggered by any other `@claude ...` comment/mention (e.g.
 #      `@claude explain X`, `@claude fix Y`). Runs Claude with the comment body as its prompt,
@@ -34,7 +34,7 @@ on:
 jobs:
   claude:
     # Gate the job on either:
-    #  - a pull_request event that is NOT a WIP PR (label/title filter), OR
+    #  - a same-repository pull_request event that is NOT a WIP PR (label/title filter), OR
     #  - an unlabeled event where the removed label was specifically `wip`, OR
     #  - an `@claude` mention on comments/reviews/issues from a trusted author.
     #
@@ -42,17 +42,22 @@ jobs:
     # and related events always run in the base-repo context with full secret access, even
     # for comments on fork PRs, so without this guard an external contributor could trigger
     # a Claude run (consuming the OAuth token) by commenting `@claude ...` on their own PR.
-    # The `pull_request` auto-trigger path doesn't need this guard because GitHub strips
-    # secrets from fork-PR `pull_request` events, so the action would fail without auth anyway.
+    # Auto-triggered reviews are limited to same-repository PRs. Fork PRs run with a
+    # read-only token and no secrets, so the Claude action cannot mint an OIDC token or
+    # post the required `claude-review/reviewed` status. Maintainers can still trigger a
+    # review manually with `@claude review`, which runs in the base-repo context.
     if: |
       (github.event_name == 'pull_request' && (
-        (github.event.action == 'unlabeled' && github.event.label.name == 'wip') ||
+        github.event.pull_request.head.repo.full_name == github.repository &&
         (
-          (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
-          !contains(github.event.pull_request.labels.*.name, 'wip') &&
-          !startsWith(github.event.pull_request.title, 'WIP') &&
-          !contains(github.event.pull_request.title, '[WIP]') &&
-          !contains(github.event.pull_request.title, '[wip]')
+          (github.event.action == 'unlabeled' && github.event.label.name == 'wip') ||
+          (
+            (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
+            !contains(github.event.pull_request.labels.*.name, 'wip') &&
+            !startsWith(github.event.pull_request.title, 'WIP') &&
+            !contains(github.event.pull_request.title, '[WIP]') &&
+            !contains(github.event.pull_request.title, '[wip]')
+          )
         )
       )) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&


### PR DESCRIPTION
## Changes

- skip the automatic `pull_request` Claude review path for fork PRs
- keep trusted maintainer `@claude review` comments as the supported fork-PR entrypoint
- align the workflow comments with the documented external-contributor behavior in `CONTRIBUTING.md`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Infrastructure
- [ ] Documentation

## Testing

- inspected failed run `https://github.com/NethermindEth/nethermind/actions/runs/26491393963`
- confirmed the review job failed while requesting an OIDC token:
  - `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`
  - `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`
- confirmed the follow-up status post failed with fork-token permissions:
  - `Resource not accessible by integration (HTTP 403)`
- verified the workflow diff only narrows the `pull_request` auto-trigger predicate and does not change the manual mention / review paths

## Documentation

- [x] No documentation changes required