### PR TITLE
Fix/eth69 blockrangeupdate validation

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
@@ -279,6 +279,10 @@ public class Eth69ProtocolHandlerTests
     [Test]
     public void Should_disconnect_on_invalid_BlockRangeUpdate()
     {
+        HandleIncomingStatusMessage();
+        long headNumber = _handler.HeadNumber;
+        Hash256? headHash = _handler.HeadHash;
+
         using BlockRangeUpdateMessage msg = new()
         {
             EarliestBlock = 2,
@@ -286,15 +290,23 @@ public class Eth69ProtocolHandlerTests
             LatestBlockHash = Keccak.Compute("2")
         };
 
-        HandleIncomingStatusMessage();
         HandleZeroMessage(msg, Eth69MessageCode.BlockRangeUpdate);
 
-        _session.Received().InitiateDisconnect(DisconnectReason.InvalidBlockRangeUpdate, Arg.Any<string>());
+        using (Assert.EnterMultipleScope())
+        {
+            _session.Received().InitiateDisconnect(DisconnectReason.InvalidBlockRangeUpdate, Arg.Any<string>());
+            Assert.That(_handler.HeadNumber, Is.EqualTo(headNumber));
+            Assert.That(_handler.HeadHash, Is.EqualTo(headHash));
+        }
     }
 
     [Test]
     public void Should_disconnect_on_invalid_BlockRangeUpdate_empty_hash()
     {
+        HandleIncomingStatusMessage();
+        long headNumber = _handler.HeadNumber;
+        Hash256? headHash = _handler.HeadHash;
+
         using BlockRangeUpdateMessage msg = new()
         {
             EarliestBlock = 1,
@@ -302,10 +314,14 @@ public class Eth69ProtocolHandlerTests
             LatestBlockHash = Keccak.Zero
         };
 
-        HandleIncomingStatusMessage();
         HandleZeroMessage(msg, Eth69MessageCode.BlockRangeUpdate);
 
-        _session.Received().InitiateDisconnect(DisconnectReason.InvalidBlockRangeUpdate, Arg.Any<string>());
+        using (Assert.EnterMultipleScope())
+        {
+            _session.Received().InitiateDisconnect(DisconnectReason.InvalidBlockRangeUpdate, Arg.Any<string>());
+            Assert.That(_handler.HeadNumber, Is.EqualTo(headNumber));
+            Assert.That(_handler.HeadHash, Is.EqualTo(headHash));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandlerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -276,32 +277,14 @@ public class Eth69ProtocolHandlerTests
         }
     }
 
-    [Test]
-    public void Should_disconnect_on_invalid_BlockRangeUpdate()
+    private static IEnumerable<TestCaseData> InvalidBlockRangeUpdates()
     {
-        HandleIncomingStatusMessage();
-        long headNumber = _handler.HeadNumber;
-        Hash256? headHash = _handler.HeadHash;
-
-        using BlockRangeUpdateMessage msg = new()
-        {
-            EarliestBlock = 2,
-            LatestBlock = 1,
-            LatestBlockHash = Keccak.Compute("2")
-        };
-
-        HandleZeroMessage(msg, Eth69MessageCode.BlockRangeUpdate);
-
-        using (Assert.EnterMultipleScope())
-        {
-            _session.Received().InitiateDisconnect(DisconnectReason.InvalidBlockRangeUpdate, Arg.Any<string>());
-            Assert.That(_handler.HeadNumber, Is.EqualTo(headNumber));
-            Assert.That(_handler.HeadHash, Is.EqualTo(headHash));
-        }
+        yield return new TestCaseData(2L, 1L, Keccak.Compute("2")).SetName("earliest_after_latest");
+        yield return new TestCaseData(1L, 2L, Keccak.Zero).SetName("empty_hash");
     }
 
-    [Test]
-    public void Should_disconnect_on_invalid_BlockRangeUpdate_empty_hash()
+    [TestCaseSource(nameof(InvalidBlockRangeUpdates))]
+    public void Should_disconnect_on_invalid_BlockRangeUpdate(long earliestBlock, long latestBlock, Hash256 latestBlockHash)
     {
         HandleIncomingStatusMessage();
         long headNumber = _handler.HeadNumber;
@@ -309,9 +292,9 @@ public class Eth69ProtocolHandlerTests
 
         using BlockRangeUpdateMessage msg = new()
         {
-            EarliestBlock = 1,
-            LatestBlock = 2,
-            LatestBlockHash = Keccak.Zero
+            EarliestBlock = earliestBlock,
+            LatestBlock = latestBlock,
+            LatestBlockHash = latestBlockHash
         };
 
         HandleZeroMessage(msg, Eth69MessageCode.BlockRangeUpdate);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
@@ -122,6 +122,7 @@ public class Eth69ProtocolHandler(
                 DisconnectReason.InvalidBlockRangeUpdate,
                 $"BlockRangeUpdate with earliest ({blockRangeUpdate.EarliestBlock}) > latest ({blockRangeUpdate.LatestBlock})."
             );
+            return;
         }
 
         if (blockRangeUpdate.LatestBlockHash.IsZero)
@@ -130,6 +131,7 @@ public class Eth69ProtocolHandler(
                 DisconnectReason.InvalidBlockRangeUpdate,
                 "BlockRangeUpdate with latest block hash as zero."
             );
+            return;
         }
 
         _remoteHeadBlockHash = blockRangeUpdate.LatestBlockHash;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Eth69ProtocolHandler.cs
@@ -122,21 +122,20 @@ public class Eth69ProtocolHandler(
                 DisconnectReason.InvalidBlockRangeUpdate,
                 $"BlockRangeUpdate with earliest ({blockRangeUpdate.EarliestBlock}) > latest ({blockRangeUpdate.LatestBlock})."
             );
-            return;
         }
-
-        if (blockRangeUpdate.LatestBlockHash.IsZero)
+        else if (blockRangeUpdate.LatestBlockHash.IsZero)
         {
             Disconnect(
                 DisconnectReason.InvalidBlockRangeUpdate,
                 "BlockRangeUpdate with latest block hash as zero."
             );
-            return;
         }
-
-        _remoteHeadBlockHash = blockRangeUpdate.LatestBlockHash;
-        HeadNumber = blockRangeUpdate.LatestBlock;
-        HeadHash = blockRangeUpdate.LatestBlockHash;
+        else
+        {
+            _remoteHeadBlockHash = blockRangeUpdate.LatestBlockHash;
+            HeadNumber = blockRangeUpdate.LatestBlock;
+            HeadHash = blockRangeUpdate.LatestBlockHash;
+        }
     }
 
     private new async Task<ReceiptsMessage69> Handle(GetReceiptsMessage getReceiptsMessage, CancellationToken cancellationToken)


### PR DESCRIPTION
Reopen of https://github.com/NethermindEth/nethermind/pull/11792

## Changes

- Stop processing invalid eth/69 BlockRangeUpdate messages after scheduling disconnect.
- Extend invalid BlockRangeUpdate tests to assert peer head state is left unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- dotnet test --project src/Nethermind/Nethermind.Network.Test/Nethermind.Network.Test.csproj --filter 'FullyQualifiedName~Eth69ProtocolHandlerTests.Should_disconnect_on_invalid_BlockRangeUpdate' --output Normal

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No