### PR TITLE
test(evm): un-ignore Trace_invalid_jump{,i}_exception

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -78,7 +78,6 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
-    [Ignore("// https://github.com/NethermindEth/nethermind/issues/140")]
     public void Trace_invalid_jump_exception()
     {
         byte[] code = Prepare.EvmCode
@@ -92,7 +91,6 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
-    [Ignore("// https://github.com/NethermindEth/nethermind/issues/140")]
     public void Trace_invalid_jumpi_exception()
     {
         byte[] code = Prepare.EvmCode


### PR DESCRIPTION
## Changes

- `Trace_invalid_jump_exception` and `Trace_invalid_jumpi_exception` in `Nethermind.Evm.Test.VirtualMachineTests` were `[Ignore]`d with the reason `"// https://github.com/NethermindEth/nethermind/issues/140"`. Issue #140 (*Review and refactor JUMP validation code*) has been closed for years and the refactor landed — but the tests stayed skipped, so we have had zero coverage of the `Geth`-trace `error` field on invalid `JUMP` / `JUMPI` instructions.
- Drop the `[Ignore]` attribute so the tests run again.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Re-enable previously skipped tests

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

PR _is_ the test re-enablement; no new test added. Verified locally with 15 consecutive standalone runs (all pass) and the full `VirtualMachineTests` fixture (35 tests) green. CI on this branch will exercise the same.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
