### PR TITLE
test: fix flaky KademliaNodeSource ping assertions

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
@@ -103,8 +103,6 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             IAsyncEnumerator<Node> enumerator = discoveryEnumerable.GetAsyncEnumerator(token);
             await enumerator.MoveNextAsync();
 
-            // Each of the concurrent discovery jobs pings the node once. The node can be yielded before
-            // the other job has pinged it, so poll for the count instead of asserting it immediately.
             Assert.That(() => Volatile.Read(ref pingCount), Is.GreaterThanOrEqualTo(2).After(5000, 50));
         }
 
@@ -163,9 +161,6 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             await enumerator.MoveNextAsync();
             Assert.That(enumerator.Current, Is.EqualTo(node2));
 
-            // Each of the concurrent discovery jobs pings node1 once; the ping timeout must not stop
-            // discovery. node2 can be yielded before the other job has pinged node1, so poll for the
-            // count instead of asserting it immediately (the immediate check is racy).
             Assert.That(() => Volatile.Read(ref node1PingCount), Is.GreaterThanOrEqualTo(2).After(5000, 50));
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
@@ -92,6 +92,10 @@ namespace Nethermind.Network.Discovery.Test.Discv4
         public async Task DiscoverNodes_should_ping_nodes_that_have_not_received_pong(CancellationToken token)
         {
             Node node = new(TestItem.PublicKeyA, "192.168.1.1", 30303);
+            int pingCount = 0;
+            _discv4Adapter.Ping(node, token)
+                .Returns(Task.CompletedTask)
+                .AndDoes(_ => Interlocked.Increment(ref pingCount));
             _lookup.Lookup(Arg.Any<PublicKey>(), token)
                 .Returns(CreateAsyncEnumerable(node));
 
@@ -99,10 +103,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             IAsyncEnumerator<Node> enumerator = discoveryEnumerable.GetAsyncEnumerator(token);
             await enumerator.MoveNextAsync();
 
-            // Assert - Verify that ping was called
-            await _discv4Adapter.Received(2).Ping(
-                Arg.Is<Node>(n => n == node),
-                token);
+            // Each of the concurrent discovery jobs pings the node once. The node can be yielded before
+            // the other job has pinged it, so poll for the count instead of asserting it immediately.
+            Assert.That(() => Volatile.Read(ref pingCount), Is.GreaterThanOrEqualTo(2).After(5000, 50));
         }
 
         [Test]
@@ -144,8 +147,10 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             Node node1 = new(TestItem.PublicKeyA, "192.168.1.1", 30303);
             Node node2 = new(TestItem.PublicKeyB, "192.168.1.2", 30303);
 
+            int node1PingCount = 0;
             _discv4Adapter.Ping(node1, token)
-                .Returns(Task.FromException(new OperationCanceledException()));
+                .Returns(Task.FromException(new OperationCanceledException()))
+                .AndDoes(_ => Interlocked.Increment(ref node1PingCount));
             _discv4Adapter.Ping(node2, token)
                 .Returns(Task.CompletedTask);
 
@@ -158,9 +163,10 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             await enumerator.MoveNextAsync();
             Assert.That(enumerator.Current, Is.EqualTo(node2));
 
-            await _discv4Adapter.Received(2).Ping(
-                Arg.Is<Node>(n => n == node1),
-                token);
+            // Each of the concurrent discovery jobs pings node1 once; the ping timeout must not stop
+            // discovery. node2 can be yielded before the other job has pinged node1, so poll for the
+            // count instead of asserting it immediately (the immediate check is racy).
+            Assert.That(() => Volatile.Read(ref node1PingCount), Is.GreaterThanOrEqualTo(2).After(5000, 50));
         }
 
         [Test]


### PR DESCRIPTION
## Changes

- `DiscoverNodes_should_handle_ping_timeout` and `DiscoverNodes_should_ping_nodes_that_have_not_received_pong` asserted an exact ping count immediately after the first `MoveNextAsync()`. With `ConcurrentDiscoveryJob = 2`, each of the two background discovery jobs pings the node once, but a node can be yielded as soon as *one* job writes it to the channel — before the other job has pinged. The immediate `Received(2)` check therefore races and intermittently observes only 1 call (seen failing on CI).
- Replaced the immediate assertion with polling via NUnit's `Is.GreaterThanOrEqualTo(2).After(5000, 50)`, counting pings through an `AndDoes` callback. This captures the real intent (both concurrent jobs ping the node; a ping timeout does not stop discovery) without the timing race.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Ran the two affected tests across repeated runs with no failures; the full `KademliaNodeSourceTests` fixture passes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No