### PR TITLE
Fast transfer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -774,19 +774,19 @@ public class TransactionProcessorTests(bool eip155Enabled)
         Block block = Build.A.Block.WithNumber(1).WithTransactions(tx).TestObject;
         IReleaseSpec spec = _specProvider.GetSpec(block.Header);
 
-        tx.To.Should().Be(recipient);
-        tx.AuthorizationList.Should().BeNull();
-        spec.IsPrecompile(recipient).Should().BeFalse();
+        Assert.That(tx.To, Is.EqualTo(recipient));
+        Assert.That(tx.AuthorizationList, Is.Null);
+        Assert.That(spec.IsPrecompile(recipient), Is.False);
         CodeInfo codeInfo = codeInfoRepository.GetCachedCodeInfo(recipient, followDelegation: true, spec, out Address? delegationAddress);
-        ReferenceEquals(codeInfo, CodeInfo.Empty).Should().BeTrue();
-        codeInfo.IsEmpty.Should().BeTrue();
-        delegationAddress.Should().BeNull();
+        Assert.That(ReferenceEquals(codeInfo, CodeInfo.Empty), Is.True);
+        Assert.That(codeInfo.IsEmpty, Is.True);
+        Assert.That(delegationAddress, Is.Null);
 
         TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
 
-        result.TransactionExecuted.Should().BeTrue();
-        virtualMachine.ExecuteTransactionCalls.Should().Be(0);
-        _stateProvider.GetBalance(recipient).Should().Be(1.Wei);
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+        Assert.That(_stateProvider.GetBalance(recipient), Is.EqualTo((UInt256)1.Wei));
     }
 
     [TestCaseSource(nameof(SimpleTransferFastPathCases))]
@@ -823,12 +823,12 @@ public class TransactionProcessorTests(bool eip155Enabled)
 
         TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
 
-        result.TransactionExecuted.Should().BeTrue();
-        virtualMachine.ExecuteTransactionCalls.Should().Be(testCase.ExpectedVmCalls);
-        _stateProvider.GetNonce(TestItem.AddressA).Should().Be(1);
-        tx.SpentGas.Should().Be(testCase.ExpectedSpentGas);
-        _stateProvider.GetBalance(TestItem.AddressA).Should().Be(senderBalanceBefore - testCase.ExpectedSenderDebit);
-        _stateProvider.GetBalance(recipient).Should().Be(recipientBalanceBefore + testCase.Value);
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(testCase.ExpectedVmCalls));
+        Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo((UInt256)1));
+        Assert.That(tx.SpentGas, Is.EqualTo(testCase.ExpectedSpentGas));
+        Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(senderBalanceBefore - testCase.ExpectedSenderDebit));
+        Assert.That(_stateProvider.GetBalance(recipient), Is.EqualTo(recipientBalanceBefore + testCase.Value));
     }
 
     [TestCase(false, 1ul, true, true)]
@@ -841,7 +841,7 @@ public class TransactionProcessorTests(bool eip155Enabled)
         bool isTracingLogs,
         bool expectTransferLog)
     {
-        Address recipient = senderIsRecipient ? TestItem.AddressA : Address.FromNumber(1300);
+        Address recipient = senderIsRecipient ? TestItem.AddressA : Address.FromNumber((UInt256)1300);
         IReleaseSpec spec = Amsterdam.Instance;
         ISpecProvider specProvider = new TestSpecProvider(spec);
         _stateProvider.Commit(spec);
@@ -869,16 +869,16 @@ public class TransactionProcessorTests(bool eip155Enabled)
 
         TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), tracer);
 
-        result.TransactionExecuted.Should().BeTrue();
-        virtualMachine.ExecuteTransactionCalls.Should().Be(0);
-        tracer.ReceiptLogs.Should().HaveCount(expectTransferLog ? 1 : 0);
-        tracer.ReportLogCalls.Should().Be(expectTransferLog && isTracingLogs ? 1 : 0);
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+        Assert.That(tracer.ReceiptLogs, Has.Length.EqualTo(expectTransferLog ? 1 : 0));
+        Assert.That(tracer.ReportLogCalls, Is.EqualTo(expectTransferLog && isTracingLogs ? 1 : 0));
         if (expectTransferLog)
         {
-            tracer.ReceiptLogs[0].Should().BeEquivalentTo(ExpectedTransferLog(TestItem.AddressA, recipient, value));
+            AssertLog(tracer.ReceiptLogs[0], ExpectedTransferLog(TestItem.AddressA, recipient, value));
             if (isTracingLogs)
             {
-                tracer.ReportedLogs[0].Should().BeEquivalentTo(ExpectedTransferLog(TestItem.AddressA, recipient, value));
+                AssertLog(tracer.ReportedLogs[0], ExpectedTransferLog(TestItem.AddressA, recipient, value));
             }
         }
     }
@@ -964,6 +964,13 @@ public class TransactionProcessorTests(bool eip155Enabled)
 
     private static LogEntry ExpectedTransferLog(Address sender, Address recipient, UInt256 value) =>
         new(TransferLog.Sender, value.ToBigEndian(), [TransferLog.TransferSignature, sender.ToHash().ToHash256(), recipient.ToHash().ToHash256()]);
+
+    private static void AssertLog(LogEntry actual, LogEntry expected)
+    {
+        Assert.That(actual.Address, Is.EqualTo(expected.Address));
+        Assert.That(actual.Data, Is.EqualTo(expected.Data));
+        Assert.That(actual.Topics, Is.EqualTo(expected.Topics));
+    }
 
     private sealed class SimpleTransferLogTracer(bool isTracingLogs) : TxTracer
     {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.Tracing;
 using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Evm.TransactionProcessing;
@@ -785,6 +786,127 @@ public class TransactionProcessorTests(bool eip155Enabled)
         result.TransactionExecuted.Should().BeTrue();
         virtualMachine.ExecuteTransactionCalls.Should().Be(0);
         _stateProvider.GetBalance(recipient).Should().Be(1.Wei);
+    }
+
+    [TestCaseSource(nameof(SimpleTransferFastPathCases))]
+    public void Simple_transfer_fast_path_predicate_enters_vm_when_expected(SimpleTransferFastPathCase testCase)
+    {
+        Address recipient = testCase.Kind == SimpleTransferRecipientKind.Precompile
+            ? IdentityPrecompile.Address
+            : Address.FromNumber((UInt256)(uint)(1100 + (int)testCase.Kind));
+        IReleaseSpec spec = Prague.Instance;
+        PrepareSimpleTransferRecipient(testCase.Kind, recipient, spec);
+        _stateProvider.Commit(spec);
+        _stateProvider.CommitTree(0);
+
+        CountingVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+            BlobBaseFeeCalculator.Instance,
+            _specProvider,
+            _stateProvider,
+            virtualMachine,
+            codeInfoRepository,
+            LimboLogs.Instance);
+
+        Transaction tx = BuildSimpleTransfer(recipient, testCase.Value, testCase.WithAuthorizationList);
+        Block block = Build.A.Block
+            .WithNumber(MainnetSpecProvider.PragueActivation.BlockNumber)
+            .WithTimestamp(MainnetSpecProvider.PragueBlockTimestamp)
+            .WithTransactions(tx)
+            .WithGasLimit(1_000_000)
+            .TestObject;
+
+        UInt256 senderBalanceBefore = _stateProvider.GetBalance(TestItem.AddressA);
+        UInt256 recipientBalanceBefore = _stateProvider.GetBalance(recipient);
+
+        TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
+
+        result.TransactionExecuted.Should().BeTrue();
+        virtualMachine.ExecuteTransactionCalls.Should().Be(testCase.ExpectedVmCalls);
+        _stateProvider.GetNonce(TestItem.AddressA).Should().Be(1);
+        tx.SpentGas.Should().Be(testCase.ExpectedSpentGas);
+        _stateProvider.GetBalance(TestItem.AddressA).Should().Be(senderBalanceBefore - testCase.ExpectedSenderDebit);
+        _stateProvider.GetBalance(recipient).Should().Be(recipientBalanceBefore + testCase.Value);
+    }
+
+    public static IEnumerable<TestCaseData> SimpleTransferFastPathCases()
+    {
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Empty, 1.Wei, false, 0, GasCostOf.Transaction, 1.Wei + GasCostOf.Transaction))
+            .SetName("Empty-code recipient with value uses fast path");
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Empty, UInt256.Zero, false, 0, GasCostOf.Transaction, GasCostOf.Transaction))
+            .SetName("Empty-code recipient with zero value uses fast path");
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Contract, 1.Wei, false, 1, GasCostOf.Transaction, 1.Wei + GasCostOf.Transaction))
+            .SetName("Contract recipient enters VM");
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Precompile, 1.Wei, false, 1, GasCostOf.Transaction + 15, 1.Wei + GasCostOf.Transaction + 15))
+            .SetName("Precompile recipient enters VM");
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Empty, 1.Wei, true, 1, GasCostOf.Transaction + 25_000, 1.Wei))
+            .SetName("Authorization-list transaction enters VM");
+        yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.DelegatedToContract, 1.Wei, false, 1, GasCostOf.Transaction, 1.Wei + GasCostOf.Transaction))
+            .SetName("Delegated recipient with executable target enters VM");
+    }
+
+    private Transaction BuildSimpleTransfer(Address recipient, UInt256 value, bool withAuthorizationList)
+    {
+        TransactionBuilder<Transaction> builder = Build.A.Transaction
+            .WithTo(recipient)
+            .WithValue(value)
+            .WithGasPrice(1)
+            .WithGasLimit(100_000);
+
+        if (withAuthorizationList)
+        {
+            builder
+                .WithType(TxType.SetCode)
+                .WithAuthorizationCode(_ethereumEcdsa.Sign(TestItem.PrivateKeyB, _specProvider.ChainId, Address.Zero, 0));
+        }
+
+        return builder
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled)
+            .TestObject;
+    }
+
+    private void PrepareSimpleTransferRecipient(SimpleTransferRecipientKind kind, Address recipient, IReleaseSpec spec)
+    {
+        if (kind == SimpleTransferRecipientKind.Precompile)
+        {
+            return;
+        }
+
+        _stateProvider.CreateAccount(recipient, UInt256.Zero);
+        switch (kind)
+        {
+            case SimpleTransferRecipientKind.Empty:
+                CodeInfoRepository.InsertCode(_stateProvider, Array.Empty<byte>(), recipient, spec, out _);
+                break;
+            case SimpleTransferRecipientKind.Contract:
+                CodeInfoRepository.InsertCode(_stateProvider, new byte[] { (byte)Instruction.STOP }, recipient, spec, out _);
+                break;
+            case SimpleTransferRecipientKind.DelegatedToContract:
+                Address codeSource = Address.FromNumber(1200);
+                _stateProvider.CreateAccount(codeSource, UInt256.Zero);
+                CodeInfoRepository.InsertCode(_stateProvider, new byte[] { (byte)Instruction.STOP }, codeSource, spec, out _);
+                CodeInfoRepository.SetDelegation(_stateProvider, codeSource, recipient, spec, out _, out _);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
+        }
+    }
+
+    public readonly record struct SimpleTransferFastPathCase(
+        SimpleTransferRecipientKind Kind,
+        UInt256 Value,
+        bool WithAuthorizationList,
+        int ExpectedVmCalls,
+        long ExpectedSpentGas,
+        UInt256 ExpectedSenderDebit);
+
+    public enum SimpleTransferRecipientKind
+    {
+        Empty,
+        Contract,
+        Precompile,
+        DelegatedToContract
     }
 
     private sealed class CountingVirtualMachine(

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -830,6 +831,58 @@ public class TransactionProcessorTests(bool eip155Enabled)
         _stateProvider.GetBalance(recipient).Should().Be(recipientBalanceBefore + testCase.Value);
     }
 
+    [TestCase(false, 1ul, true, true)]
+    [TestCase(false, 1ul, false, true)]
+    [TestCase(false, 0ul, true, false)]
+    [TestCase(true, 1ul, true, false)]
+    public void Simple_transfer_fast_path_reports_eip7708_log_only_for_non_zero_transfer_to_different_account(
+        bool senderIsRecipient,
+        ulong value,
+        bool isTracingLogs,
+        bool expectTransferLog)
+    {
+        Address recipient = senderIsRecipient ? TestItem.AddressA : Address.FromNumber(1300);
+        IReleaseSpec spec = Amsterdam.Instance;
+        ISpecProvider specProvider = new TestSpecProvider(spec);
+        _stateProvider.Commit(spec);
+        _stateProvider.CommitTree(0);
+
+        CountingVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+            BlobBaseFeeCalculator.Instance,
+            specProvider,
+            _stateProvider,
+            virtualMachine,
+            codeInfoRepository,
+            LimboLogs.Instance);
+
+        Transaction tx = Build.A.Transaction
+            .WithTo(recipient)
+            .WithValue(value)
+            .WithGasPrice(1)
+            .WithGasLimit(100_000)
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(1).WithTransactions(tx).WithGasLimit(1_000_000).TestObject;
+        SimpleTransferLogTracer tracer = new(isTracingLogs);
+
+        TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), tracer);
+
+        result.TransactionExecuted.Should().BeTrue();
+        virtualMachine.ExecuteTransactionCalls.Should().Be(0);
+        tracer.ReceiptLogs.Should().HaveCount(expectTransferLog ? 1 : 0);
+        tracer.ReportLogCalls.Should().Be(expectTransferLog && isTracingLogs ? 1 : 0);
+        if (expectTransferLog)
+        {
+            tracer.ReceiptLogs[0].Should().BeEquivalentTo(ExpectedTransferLog(TestItem.AddressA, recipient, value));
+            if (isTracingLogs)
+            {
+                tracer.ReportedLogs[0].Should().BeEquivalentTo(ExpectedTransferLog(TestItem.AddressA, recipient, value));
+            }
+        }
+    }
+
     public static IEnumerable<TestCaseData> SimpleTransferFastPathCases()
     {
         yield return new TestCaseData(new SimpleTransferFastPathCase(SimpleTransferRecipientKind.Empty, 1.Wei, false, 0, GasCostOf.Transaction, 1.Wei + GasCostOf.Transaction))
@@ -907,6 +960,23 @@ public class TransactionProcessorTests(bool eip155Enabled)
         Contract,
         Precompile,
         DelegatedToContract
+    }
+
+    private static LogEntry ExpectedTransferLog(Address sender, Address recipient, UInt256 value) =>
+        new(TransferLog.Sender, value.ToBigEndian(), [TransferLog.TransferSignature, sender.ToHash().ToHash256(), recipient.ToHash().ToHash256()]);
+
+    private sealed class SimpleTransferLogTracer(bool isTracingLogs) : TxTracer
+    {
+        public override bool IsTracingReceipt { get; protected set; } = true;
+        public override bool IsTracingLogs { get; protected set; } = isTracingLogs;
+        public LogEntry[] ReceiptLogs { get; private set; } = [];
+        public List<LogEntry> ReportedLogs { get; } = [];
+        public int ReportLogCalls => ReportedLogs.Count;
+
+        public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null) =>
+            ReceiptLogs = logs;
+
+        public override void ReportLog(LogEntry log) => ReportedLogs.Add(log);
     }
 
     private sealed class CountingVirtualMachine(

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -11,6 +11,8 @@ using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Tracing;
 using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Evm.TransactionProcessing;
@@ -739,5 +741,66 @@ public class TransactionProcessorTests(bool eip155Enabled)
         _transactionProcessor.Warmup(tx, new BlockExecutionContext(block.Header, _specProvider.GetSpec(block.Header)), NullTxTracer.Instance);
 
         Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(balanceBefore), "Warmup must not deduct sender balance (should use SystemTransactionProcessor path)");
+    }
+
+    [Test]
+    public void Simple_value_transfer_to_empty_account_does_not_enter_vm()
+    {
+        Address recipient = Address.FromNumber(1000);
+        _stateProvider.CreateAccount(recipient, UInt256.Zero);
+        _stateProvider.InsertCode(recipient, Array.Empty<byte>(), _specProvider.GenesisSpec);
+        _stateProvider.Commit(_specProvider.GenesisSpec);
+        _stateProvider.CommitTree(0);
+
+        CountingVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+            BlobBaseFeeCalculator.Instance,
+            _specProvider,
+            _stateProvider,
+            virtualMachine,
+            codeInfoRepository,
+            LimboLogs.Instance);
+
+        Transaction tx = Build.A.Transaction
+            .WithTo(recipient)
+            .WithValue(1.Wei)
+            .WithGasPrice(1)
+            .WithGasLimit(GasCostOf.Transaction)
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(1).WithTransactions(tx).TestObject;
+        IReleaseSpec spec = _specProvider.GetSpec(block.Header);
+
+        tx.To.Should().Be(recipient);
+        tx.AuthorizationList.Should().BeNull();
+        spec.IsPrecompile(recipient).Should().BeFalse();
+        CodeInfo codeInfo = codeInfoRepository.GetCachedCodeInfo(recipient, followDelegation: true, spec, out Address? delegationAddress);
+        ReferenceEquals(codeInfo, CodeInfo.Empty).Should().BeTrue();
+        delegationAddress.Should().BeNull();
+
+        TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
+
+        result.TransactionExecuted.Should().BeTrue();
+        virtualMachine.ExecuteTransactionCalls.Should().Be(0);
+        _stateProvider.GetBalance(recipient).Should().Be(1.Wei);
+    }
+
+    private sealed class CountingVirtualMachine(
+        IBlockhashProvider blockHashProvider,
+        ISpecProvider specProvider,
+        ILogManager logManager)
+        : VirtualMachine<EthereumGasPolicy>(blockHashProvider, specProvider, logManager), IVirtualMachine
+    {
+        public int ExecuteTransactionCalls { get; private set; }
+
+        public override TransactionSubstate ExecuteTransaction<TTracingInst>(
+            VmState<EthereumGasPolicy> vmState,
+            IWorldState worldState,
+            ITxTracer txTracer)
+        {
+            ExecuteTransactionCalls++;
+            return base.ExecuteTransaction<TTracingInst>(vmState, worldState, txTracer);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -831,6 +831,88 @@ public class TransactionProcessorTests(bool eip155Enabled)
         Assert.That(_stateProvider.GetBalance(recipient), Is.EqualTo(recipientBalanceBefore + testCase.Value));
     }
 
+    [Test]
+    public void Simple_transfer_fast_path_reports_action_trace()
+    {
+        Address recipient = Address.FromNumber((UInt256)1400);
+        IReleaseSpec spec = Prague.Instance;
+        PrepareSimpleTransferRecipient(SimpleTransferRecipientKind.Empty, recipient, spec);
+        _stateProvider.Commit(spec);
+        _stateProvider.CommitTree(0);
+
+        CountingVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+            BlobBaseFeeCalculator.Instance,
+            _specProvider,
+            _stateProvider,
+            virtualMachine,
+            codeInfoRepository,
+            LimboLogs.Instance);
+
+        Transaction tx = BuildSimpleTransfer(recipient, 7.Wei, withAuthorizationList: false);
+        Block block = Build.A.Block
+            .WithNumber(MainnetSpecProvider.PragueActivation.BlockNumber)
+            .WithTimestamp(MainnetSpecProvider.PragueBlockTimestamp)
+            .WithTransactions(tx)
+            .WithGasLimit(1_000_000)
+            .TestObject;
+        SimpleTransferActionTracer tracer = new();
+
+        TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+        Assert.That(tracer.ActionCalls, Is.EqualTo(1));
+        Assert.That(tracer.ActionEndCalls, Is.EqualTo(1));
+        Assert.That(tracer.ActionGas, Is.EqualTo(tx.GasLimit - GasCostOf.Transaction));
+        Assert.That(tracer.ActionEndGas, Is.EqualTo(tx.GasLimit - GasCostOf.Transaction));
+        Assert.That(tracer.ActionValue, Is.EqualTo((UInt256)7.Wei));
+        Assert.That(tracer.ActionFrom, Is.EqualTo(TestItem.AddressA));
+        Assert.That(tracer.ActionTo, Is.EqualTo(recipient));
+        Assert.That(tracer.ActionInput, Is.Empty);
+        Assert.That(tracer.ActionType, Is.EqualTo(ExecutionType.TRANSACTION));
+        Assert.That(tracer.IsPrecompileCall, Is.False);
+        Assert.That(tracer.ActionOutput, Is.Empty);
+    }
+
+    [Test]
+    public void Simple_transfer_fast_path_restores_state_on_call_and_restore()
+    {
+        Address recipient = Address.FromNumber((UInt256)1401);
+        IReleaseSpec spec = Prague.Instance;
+        _stateProvider.Commit(spec);
+        _stateProvider.CommitTree(0);
+
+        CountingVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+            BlobBaseFeeCalculator.Instance,
+            _specProvider,
+            _stateProvider,
+            virtualMachine,
+            codeInfoRepository,
+            LimboLogs.Instance);
+
+        Transaction tx = BuildSimpleTransfer(recipient, 7.Wei, withAuthorizationList: false);
+        Block block = Build.A.Block
+            .WithNumber(MainnetSpecProvider.PragueActivation.BlockNumber)
+            .WithTimestamp(MainnetSpecProvider.PragueBlockTimestamp)
+            .WithTransactions(tx)
+            .WithGasLimit(1_000_000)
+            .TestObject;
+        UInt256 senderBalanceBefore = _stateProvider.GetBalance(TestItem.AddressA);
+        UInt256 senderNonceBefore = _stateProvider.GetNonce(TestItem.AddressA);
+
+        TransactionResult result = transactionProcessor.CallAndRestore(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+        Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(senderBalanceBefore));
+        Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo(senderNonceBefore));
+        Assert.That(_stateProvider.AccountExists(recipient), Is.False);
+    }
+
     [TestCase(false, 1ul, true, true)]
     [TestCase(false, 1ul, false, true)]
     [TestCase(false, 0ul, true, false)]
@@ -984,6 +1066,41 @@ public class TransactionProcessorTests(bool eip155Enabled)
             ReceiptLogs = logs;
 
         public override void ReportLog(LogEntry log) => ReportedLogs.Add(log);
+    }
+
+    private sealed class SimpleTransferActionTracer : TxTracer
+    {
+        public override bool IsTracingActions { get; protected set; } = true;
+        public int ActionCalls { get; private set; }
+        public int ActionEndCalls { get; private set; }
+        public long ActionGas { get; private set; }
+        public long ActionEndGas { get; private set; }
+        public UInt256 ActionValue { get; private set; }
+        public Address ActionFrom { get; private set; } = Address.Zero;
+        public Address ActionTo { get; private set; } = Address.Zero;
+        public byte[] ActionInput { get; private set; } = [];
+        public ExecutionType ActionType { get; private set; }
+        public bool IsPrecompileCall { get; private set; }
+        public byte[] ActionOutput { get; private set; } = [];
+
+        public override void ReportAction(long gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)
+        {
+            ActionCalls++;
+            ActionGas = gas;
+            ActionValue = value;
+            ActionFrom = from;
+            ActionTo = to;
+            ActionInput = input.ToArray();
+            ActionType = callType;
+            IsPrecompileCall = isPrecompileCall;
+        }
+
+        public override void ReportActionEnd(long gas, ReadOnlyMemory<byte> output)
+        {
+            ActionEndCalls++;
+            ActionEndGas = gas;
+            ActionOutput = output.ToArray();
+        }
     }
 
     private sealed class CountingVirtualMachine(

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -777,6 +777,7 @@ public class TransactionProcessorTests(bool eip155Enabled)
         spec.IsPrecompile(recipient).Should().BeFalse();
         CodeInfo codeInfo = codeInfoRepository.GetCachedCodeInfo(recipient, followDelegation: true, spec, out Address? delegationAddress);
         ReferenceEquals(codeInfo, CodeInfo.Empty).Should().BeTrue();
+        codeInfo.IsEmpty.Should().BeTrue();
         delegationAddress.Should().BeNull();
 
         TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -54,7 +54,6 @@ namespace Nethermind.Evm.Benchmark
                 codeInfo: new CodeInfo(ByteCode),
                 callDepth: 0,
                 value: 0,
-                transferValue: 0,
                 inputData: default
             );
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -195,7 +195,6 @@ public unsafe class EvmOpcodesBenchmark
             caller: address,
             codeSource: address,
             callDepth: 0,
-            transferValue: 0,
             value: 0,
             inputData: default);
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -86,7 +86,6 @@ public class MultipleUnsignedOperations
             codeInfo: new CodeInfo(_bytecode.Concat(_bytecode).Concat(_bytecode).Concat(_bytecode).ToArray()),
             callDepth: 0,
             value: 0,
-            transferValue: 0,
             inputData: default
         );
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -96,7 +96,6 @@ namespace Nethermind.Evm.Benchmark
                 codeInfo: new CodeInfo(Bytecode),
                 callDepth: 0,
                 value: 0,
-                transferValue: 0,
                 inputData: default
             );
 

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -81,6 +81,23 @@ namespace Nethermind.Evm.Test
             Assert.That(TestState.GetBalance(target), Is.EqualTo((UInt256)expectedTargetBalance * 1.Ether));
         }
 
+        [Test]
+        public void Empty_code_staticcall_touches_existing_empty_account()
+        {
+            Address target = TestItem.AddressC;
+            TestState.CreateAccount(target, UInt256.Zero);
+            byte[] code = BuildEmptyCodeCall(Instruction.STATICCALL, target);
+            (Block block, Transaction transaction) = PrepareTx(Activation, 100_000, code, value: 0);
+
+            TransactionResult result = _processor.Execute(
+                transaction,
+                new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)),
+                NullTxTracer.Instance);
+
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(TestState.AccountExists(target), Is.False);
+        }
+
         private static byte[] BuildEmptyCodeCall(Instruction instruction, Address target) =>
             instruction switch
             {

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
 using Nethermind.Specs;
 using NUnit.Framework;
 
@@ -51,5 +61,35 @@ namespace Nethermind.Evm.Test
             TestAllTracerWithOutput result = Execute(Activation, 21020, code);
             Assert.That(result.Error, Is.EqualTo("OutOfGas"));
         }
+
+        [TestCase(Instruction.CALL, 99, 1)]
+        [TestCase(Instruction.CALLCODE, 100, 0)]
+        [TestCase(Instruction.DELEGATECALL, 100, 0)]
+        [TestCase(Instruction.STATICCALL, 100, 0)]
+        public void Empty_code_call_preserves_balance_semantics(Instruction instruction, int expectedRecipientBalance, int expectedTargetBalance)
+        {
+            Address target = TestItem.AddressC;
+            byte[] code = BuildEmptyCodeCall(instruction, target);
+            (Block block, Transaction transaction) = PrepareTx(Activation, 100_000, code, value: 0);
+
+            TransactionResult result = _processor.Execute(
+                transaction,
+                new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)),
+                NullTxTracer.Instance);
+
+            result.TransactionExecuted.Should().BeTrue();
+            TestState.GetBalance(Recipient).Should().Be((UInt256)expectedRecipientBalance * 1.Ether);
+            TestState.GetBalance(target).Should().Be((UInt256)expectedTargetBalance * 1.Ether);
+        }
+
+        private static byte[] BuildEmptyCodeCall(Instruction instruction, Address target) =>
+            instruction switch
+            {
+                Instruction.CALL => Prepare.EvmCode.CallWithValue(target, 50_000, 1.Ether).Done,
+                Instruction.CALLCODE => Prepare.EvmCode.CallCode(target, 50_000, 1.Ether).Done,
+                Instruction.DELEGATECALL => Prepare.EvmCode.DelegateCall(target, 50_000).Done,
+                Instruction.STATICCALL => Prepare.EvmCode.StaticCall(target, 50_000).Done,
+                _ => throw new ArgumentOutOfRangeException(nameof(instruction), instruction, null)
+            };
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -77,9 +76,9 @@ namespace Nethermind.Evm.Test
                 new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)),
                 NullTxTracer.Instance);
 
-            result.TransactionExecuted.Should().BeTrue();
-            TestState.GetBalance(Recipient).Should().Be((UInt256)expectedRecipientBalance * 1.Ether);
-            TestState.GetBalance(target).Should().Be((UInt256)expectedTargetBalance * 1.Ether);
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(TestState.GetBalance(Recipient), Is.EqualTo((UInt256)expectedRecipientBalance * 1.Ether));
+            Assert.That(TestState.GetBalance(target), Is.EqualTo((UInt256)expectedTargetBalance * 1.Ether));
         }
 
         private static byte[] BuildEmptyCodeCall(Instruction instruction, Address target) =>

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -299,7 +299,6 @@ public class Eip8037Tests : VirtualMachineTestsBase
             caller: Sender,
             codeSource: Recipient,
             callDepth: VirtualMachineStatics.MaxCallDepth,
-            transferValue: UInt256.Zero,
             value: UInt256.Zero,
             inputData: ReadOnlyMemory<byte>.Empty);
         EthereumGasPolicy gas = new()

--- a/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
@@ -321,7 +321,7 @@ public class EvmStackTests
         VmState<EthereumGasPolicy>.RentTopLevel(
             EthereumGasPolicy.FromLong(10_000),
             ExecutionType.CALL,
-            ExecutionEnvironment.Rent(null, null, null, null, 0, default, default, default),
+            ExecutionEnvironment.Rent(null, null, null, null, 0, default, default),
             new StackAccessTracker(),
             Snapshot.Empty);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
@@ -238,6 +238,6 @@ namespace Nethermind.Evm.Test
                     Snapshot.Empty);
 
         private static ExecutionEnvironment RentExecutionEnvironment() =>
-            ExecutionEnvironment.Rent(null, null, null, null, 0, default, default, default);
+            ExecutionEnvironment.Rent(null, null, null, null, 0, default, default);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -53,6 +53,13 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
 
     private JumpDestinationAnalyzer? _analyzer;
 
+    /// <summary>
+    /// Returns <c>true</c> when this instance represents non-executable empty bytecode.
+    /// </summary>
+    /// <remarks>
+    /// Empty code is represented by the shared analyzer sentinel so fast paths can test this without inspecting bytecode.
+    /// Constructors that create zero-length executable bytecode must assign the sentinel to preserve that invariant.
+    /// </remarks>
     public bool IsEmpty => ReferenceEquals(_analyzer, _emptyAnalyzer);
     public bool IsPrecompile => Precompile is not null;
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -12,10 +12,18 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
 {
     public static CodeInfo Empty { get; } = new();
     // Empty code sentinel
-    private static readonly JumpDestinationAnalyzer? _emptyAnalyzer = new(Empty, skipAnalysis: true);
+    private static readonly JumpDestinationAnalyzer _emptyAnalyzer;
+
+    static CodeInfo()
+    {
+        _emptyAnalyzer = new JumpDestinationAnalyzer(Empty, skipAnalysis: true);
+        Empty._analyzer = _emptyAnalyzer;
+    }
 
     // Empty
-    private CodeInfo() => _analyzer = null;
+    private CodeInfo()
+    {
+    }
 
     // Regular contract
     public CodeInfo(ReadOnlyMemory<byte> code)
@@ -43,7 +51,7 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
 
     public IPrecompile? Precompile { get; }
 
-    private readonly JumpDestinationAnalyzer? _analyzer;
+    private JumpDestinationAnalyzer? _analyzer;
 
     public bool IsEmpty => ReferenceEquals(_analyzer, _emptyAnalyzer);
     public bool IsPrecompile => Precompile is not null;

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -6,6 +6,7 @@ using System.Collections.Frozen;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -23,7 +24,7 @@ public class CodeInfoRepository : ICodeInfoRepository
 {
     private readonly FrozenDictionary<AddressAsKey, CodeInfo> _localPrecompiles;
     private readonly IWorldState _worldState;
-    private readonly Func<Address, ValueHash256, IReleaseSpec, CodeInfo> _codeInfoLoader;
+    private readonly Func<Address, ValueHash256, IReleaseSpec, CodeInfo>? _codeInfoLoader;
 
     public CodeInfoRepository(IWorldState worldState, IPrecompileProvider precompileProvider)
         : this(worldState, precompileProvider, codeInfoLoader: null)
@@ -34,10 +35,7 @@ public class CodeInfoRepository : ICodeInfoRepository
     {
         _localPrecompiles = precompileProvider.GetPrecompiles();
         _worldState = worldState;
-        _codeInfoLoader = codeInfoLoader ?? DefaultLoad;
-
-        CodeInfo DefaultLoad(Address address, ValueHash256 codeHash, IReleaseSpec spec) =>
-            codeHash == ValueKeccak.OfAnEmptyString ? CodeInfo.Empty : GetCodeInfo(worldState, address, in codeHash);
+        _codeInfoLoader = codeInfoLoader;
     }
 
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress)
@@ -65,8 +63,15 @@ public class CodeInfoRepository : ICodeInfoRepository
     private CodeInfo InternalGetCodeInfo(Address codeSource, IReleaseSpec vmSpec)
     {
         ValueHash256 codeHash = _worldState.GetCodeHash(codeSource);
-        return _codeInfoLoader(codeSource, codeHash, vmSpec);
+        Func<Address, ValueHash256, IReleaseSpec, CodeInfo>? codeInfoLoader = _codeInfoLoader;
+        return codeInfoLoader is not null
+            ? codeInfoLoader(codeSource, codeHash, vmSpec)
+            : LoadCodeInfoDefault(codeSource, in codeHash);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private CodeInfo LoadCodeInfoDefault(Address address, in ValueHash256 codeHash) =>
+        codeHash == ValueKeccak.OfAnEmptyString ? CodeInfo.Empty : GetCodeInfo(_worldState, address, in codeHash);
 
     internal static CodeInfo GetCodeInfo(IWorldState worldState, Address address, in ValueHash256 codeHash)
     {

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -19,7 +19,6 @@ namespace Nethermind.Evm
     {
         private static readonly ConcurrentQueue<ExecutionEnvironment> _pool = new();
         private UInt256 _value;
-        private UInt256 _transferValue;
 
         /// <summary>
         /// Parsed bytecode for the current call.
@@ -45,11 +44,6 @@ namespace Nethermind.Evm
         public int CallDepth { get; private set; }
 
         /// <summary>
-        /// ETH value transferred in this call.
-        /// </summary>
-        public ref readonly UInt256 TransferValue => ref _transferValue;
-
-        /// <summary>
         /// Value information passed (it is different from transfer value in DELEGATECALL.
         /// DELEGATECALL behaves like a library call, and it uses the value information from the caller even
         /// as no transfer happens.
@@ -72,7 +66,6 @@ namespace Nethermind.Evm
             Address caller,
             Address? codeSource,
             int callDepth,
-            in UInt256 transferValue,
             in UInt256 value,
             in ReadOnlyMemory<byte> inputData)
         {
@@ -82,7 +75,6 @@ namespace Nethermind.Evm
             env.Caller = caller;
             env.CodeSource = codeSource;
             env.CallDepth = callDepth;
-            env._transferValue = transferValue;
             env._value = value;
             env.InputData = inputData;
             return env;
@@ -100,7 +92,6 @@ namespace Nethermind.Evm
                 Caller = null!;
                 CodeSource = null;
                 CallDepth = 0;
-                _transferValue = default;
                 _value = default;
                 InputData = default;
                 _pool.Enqueue(this);

--- a/src/Nethermind/Nethermind.Evm/ExecutionType.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionType.cs
@@ -17,6 +17,14 @@ namespace Nethermind.Evm
         public static bool IsAnyCall(this ExecutionType executionType) =>
             executionType is ExecutionType.CALL or ExecutionType.STATICCALL or ExecutionType.DELEGATECALL or ExecutionType.CALLCODE;
 
+        /// <summary>
+        /// Returns <c>true</c> when entering this frame credits the executing account balance with the frame value.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ExecutionType.DELEGATECALL"/> carries the caller's value without moving ETH, while
+        /// <see cref="ExecutionType.STATICCALL"/> cannot transfer ETH. <see cref="ExecutionType.CALLCODE"/>
+        /// still credits the executing account, which is a self-transfer when caller and target are the same account.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CreditsBalance(this ExecutionType executionType) =>
             executionType is ExecutionType.TRANSACTION or ExecutionType.CALL or ExecutionType.CALLCODE or ExecutionType.CREATE or ExecutionType.CREATE2;

--- a/src/Nethermind/Nethermind.Evm/ExecutionType.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Nethermind.Int256;
 
 namespace Nethermind.Evm
 {
@@ -15,6 +16,14 @@ namespace Nethermind.Evm
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsAnyCall(this ExecutionType executionType) =>
             executionType is ExecutionType.CALL or ExecutionType.STATICCALL or ExecutionType.DELEGATECALL or ExecutionType.CALLCODE;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CreditsBalance(this ExecutionType executionType) =>
+            executionType is ExecutionType.TRANSACTION or ExecutionType.CALL or ExecutionType.CALLCODE or ExecutionType.CREATE or ExecutionType.CREATE2;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly UInt256 GetBalanceCredit(this ExecutionType executionType, in UInt256 value) =>
+            ref executionType.CreditsBalance() ? ref value : ref UInt256.Zero;
 
         public static Instruction ToInstruction(this ExecutionType executionType) =>
             executionType switch

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -28,6 +28,10 @@ public static partial class EvmInstructions
         /// </summary>
         virtual static bool IsStatic => false;
 
+        virtual static bool IsDelegateCall => false;
+
+        virtual static bool IsCallCode => false;
+
         /// <summary>
         /// Returns the specific execution type of the call.
         /// </summary>
@@ -47,6 +51,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpCallCode : IOpCall
     {
+        public static bool IsCallCode => true;
         public static ExecutionType ExecutionType => ExecutionType.CALLCODE;
     }
 
@@ -55,6 +60,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpDelegateCall : IOpCall
     {
+        public static bool IsDelegateCall => true;
         public static ExecutionType ExecutionType => ExecutionType.DELEGATECALL;
     }
 
@@ -115,12 +121,12 @@ public static partial class EvmInstructions
         ExecutionEnvironment env = vm.VmState.Env;
         // Determine the call value based on the call type.
         UInt256 callValue;
-        if (typeof(TOpCall) == typeof(OpStaticCall))
+        if (TOpCall.IsStatic)
         {
             // Static calls cannot transfer value.
             callValue = UInt256.Zero;
         }
-        else if (typeof(TOpCall) == typeof(OpDelegateCall))
+        else if (TOpCall.IsDelegateCall)
         {
             // Delegate calls use the value from the current execution context.
             callValue = env.Value;
@@ -137,19 +143,20 @@ public static partial class EvmInstructions
         }
 
         // For non-delegate calls, the transfer value is the call value.
-        UInt256 transferValue = typeof(TOpCall) == typeof(OpDelegateCall) ? UInt256.Zero : callValue;
+        UInt256 transferValue = TOpCall.IsDelegateCall ? UInt256.Zero : callValue;
+        bool hasValueTransfer = !TOpCall.IsDelegateCall && !callValue.IsZero;
         // Enforce static call restrictions: no value transfer allowed unless it's a CALLCODE.
-        if (vm.VmState.IsStatic && !transferValue.IsZero && typeof(TOpCall) != typeof(OpCallCode))
+        if (vm.VmState.IsStatic && hasValueTransfer && !TOpCall.IsCallCode)
             return EvmExceptionType.StaticCallViolation;
 
         // Determine caller and target based on the call type.
-        Address caller = typeof(TOpCall) == typeof(OpDelegateCall) ? env.Caller : env.ExecutingAccount;
-        Address target = (typeof(TOpCall) == typeof(OpCall) || typeof(TOpCall) == typeof(OpStaticCall))
+        Address caller = TOpCall.IsDelegateCall ? env.Caller : env.ExecutingAccount;
+        Address target = !TOpCall.IsDelegateCall && !TOpCall.IsCallCode
             ? codeSource
             : env.ExecutingAccount;
 
         // Add extra gas cost if value is transferred.
-        if (!transferValue.IsZero)
+        if (hasValueTransfer)
         {
             if (!TGasPolicy.ConsumeCallValueTransfer(ref gas)) goto OutOfGas;
         }
@@ -184,7 +191,7 @@ public static partial class EvmInstructions
         bool chargesNewAccount = spec.ClearEmptyAccountWhenTouched switch
         {
             false => !state.AccountExists(target),
-            true => transferValue != 0 && state.IsDeadAccount(target),
+            true => hasValueTransfer && state.IsDeadAccount(target),
         };
 
         bool newAccountOutOfGas = chargesNewAccount && !TGasPolicy.ConsumeNewAccountCreation<TEip8037>(ref gas);
@@ -224,7 +231,7 @@ public static partial class EvmInstructions
         if (!TGasPolicy.UpdateGas(ref gas, gasLimitUl)) goto OutOfGas;
 
         // Add call stipend if value is being transferred.
-        if (!transferValue.IsZero)
+        if (hasValueTransfer)
         {
             if (vm.TxTracer.IsTracingRefunds)
                 vm.TxTracer.ReportExtraGasPressure(GasCostOf.CallStipend);
@@ -233,7 +240,7 @@ public static partial class EvmInstructions
 
         // Check call depth and balance of the caller.
         if (env.CallDepth >= MaxCallDepth ||
-            (!transferValue.IsZero && state.GetBalance(env.ExecutingAccount) < transferValue))
+            (hasValueTransfer && state.GetBalance(env.ExecutingAccount) < transferValue))
         {
             // If the call cannot proceed, return an empty response and push zero on the stack.
             vm.ReturnDataBuffer = Array.Empty<byte>();
@@ -262,25 +269,70 @@ public static partial class EvmInstructions
             return pushResult;
         }
 
-        // Take a snapshot of the state for potential rollback.
-        Snapshot snapshot = state.TakeSnapshot();
-        // Subtract the transfer value from the caller's balance.
-        state.SubtractFromBalance(caller, in transferValue, spec);
-
         // Fast-path for calls to externally owned accounts (non-contracts)
-        if (codeInfo.IsEmpty && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
+        if (HasNoExecutableCode(codeInfo) && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
         {
             vm.ReturnDataBuffer = default;
             EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(StatusCode.SuccessBytes.Span);
             if (pushResult != EvmExceptionType.None) return pushResult;
             TGasPolicy.UpdateGasUp(ref gas, gasLimitUl);
-            vm.AddTransferLog<TEip7708>(caller, target, transferValue);
-            return FastCall(vm, spec, in transferValue, target);
+            if (hasValueTransfer)
+            {
+                state.SubtractFromBalance(caller, in transferValue, spec);
+                vm.AddTransferLog<TEip7708>(caller, target, transferValue);
+                state.AddToBalanceAndCreateIfNotExists(target, in transferValue, spec);
+            }
+            Metrics.IncrementEmptyCalls();
+            vm.ReturnData = null;
+            return EvmExceptionType.None;
         }
 
+        // Take a snapshot of the state for potential rollback.
+        Snapshot snapshot = state.TakeSnapshot();
+        // Subtract the transfer value from the caller's balance.
+        if (hasValueTransfer) state.SubtractFromBalance(caller, in transferValue, spec);
+
+        return SlowCall(
+            vm,
+            ref gas,
+            in dataOffset,
+            dataLength,
+            outputOffset,
+            outputLength,
+            codeInfo,
+            target,
+            caller,
+            codeSource,
+            env,
+            in callValue,
+            in transferValue,
+            gasLimitUl,
+            in snapshot);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool HasNoExecutableCode(CodeInfo codeInfo) => codeInfo.IsEmpty || ReferenceEquals(codeInfo, CodeInfo.Empty);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static EvmExceptionType SlowCall(
+            VirtualMachine<TGasPolicy> vm,
+            ref TGasPolicy gas,
+            in UInt256 dataOffset,
+            UInt256 dataLength,
+            UInt256 outputOffset,
+            UInt256 outputLength,
+            CodeInfo codeInfo,
+            Address target,
+            Address caller,
+            Address codeSource,
+            ExecutionEnvironment env,
+            in UInt256 callValue,
+            in UInt256 transferValue,
+            long gasLimitUl,
+            in Snapshot snapshot)
+        {
         // Load call data from memory.
         if (!vm.VmState.Memory.TryLoad(in dataOffset, dataLength, out ReadOnlyMemory<byte> callData))
-            goto OutOfGas;
+            return EvmExceptionType.OutOfGas;
         // Construct the execution environment for the call.
         ExecutionEnvironment callEnv = ExecutionEnvironment.Rent(
             codeInfo: codeInfo,
@@ -293,16 +345,17 @@ public static partial class EvmInstructions
             inputData: in callData);
 
         // Normalize output offset if output length is zero.
+        UInt256 normalizedOutputOffset = outputOffset;
         if (outputLength == 0)
         {
             // Output offset is inconsequential when output length is 0.
-            outputOffset = 0;
+            normalizedOutputOffset = 0;
         }
 
         // Rent a new call frame for executing the call.
         vm.ReturnData = VmState<TGasPolicy>.RentFrame(
             gas: TGasPolicy.CreateChildFrameGas(ref gas, gasLimitUl),
-            outputDestination: outputOffset.ToLong(),
+            outputDestination: normalizedOutputOffset.ToLong(),
             outputLength: outputLength.ToLong(),
             executionType: TOpCall.ExecutionType,
             isStatic: TOpCall.IsStatic || vm.VmState.IsStatic,
@@ -312,17 +365,6 @@ public static partial class EvmInstructions
             snapshot: in snapshot);
 
         return EvmExceptionType.None;
-
-        // Fast-call path for non-contract calls:
-        // Directly credit the target account and avoid constructing a full call frame.
-        static EvmExceptionType FastCall(VirtualMachine<TGasPolicy> vm, IReleaseSpec spec, in UInt256 transferValue, Address target)
-        {
-            IWorldState state = vm.WorldState;
-            state.AddToBalanceAndCreateIfNotExists(target, transferValue, spec);
-            Metrics.IncrementEmptyCalls();
-
-            vm.ReturnData = null;
-            return EvmExceptionType.None;
         }
 
         // Jump forward to be unpredicted by the branch predictor.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -273,6 +273,7 @@ public static partial class EvmInstructions
         if (HasNoExecutableCode(codeInfo) && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
         {
             vm.ReturnDataBuffer = default;
+            // Mutate balances only after the success byte is on the stack; this fast path has no snapshot to roll back a failed push.
             EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(StatusCode.SuccessBytes.Span);
             if (pushResult != EvmExceptionType.None) return pushResult;
             TGasPolicy.UpdateGasUp(ref gas, gasLimitUl);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -272,26 +272,17 @@ public static partial class EvmInstructions
             {
                 state.SubtractFromBalance(caller, in callValue, spec);
                 vm.AddTransferLog<TEip7708>(caller, target, in callValue);
-                state.AddToBalanceAndCreateIfNotExists(target, in callValue, spec);
             }
-            else
-            {
-                state.AddToBalanceAndCreateIfNotExists(target, in UInt256.Zero, spec);
-            }
+            state.AddToBalanceAndCreateIfNotExists(target, in hasValueTransfer ? ref callValue : ref UInt256.Zero, spec);
             Metrics.IncrementEmptyCalls();
             vm.ReturnData = null;
             return EvmExceptionType.None;
         }
 
-        // Take a snapshot of the state for potential rollback.
-        Snapshot snapshot = state.TakeSnapshot();
-        // Subtract the transfer value from the caller's balance.
-        if (hasValueTransfer) state.SubtractFromBalance(caller, in callValue, spec);
-
-        return SlowCall(vm, ref gas, in dataOffset, dataLength, outputOffset, outputLength, codeInfo, target, caller, codeSource, env, in callValue, gasLimitUl, in snapshot);
+        return CreateFullCallFrame(vm, ref gas, in dataOffset, dataLength, outputOffset, outputLength, codeInfo, target, caller, codeSource, env, in callValue, gasLimitUl);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static EvmExceptionType SlowCall(
+        static EvmExceptionType CreateFullCallFrame(
             VirtualMachine<TGasPolicy> vm,
             ref TGasPolicy gas,
             in UInt256 dataOffset,
@@ -304,9 +295,14 @@ public static partial class EvmInstructions
             Address codeSource,
             ExecutionEnvironment env,
             in UInt256 callValue,
-            long gasLimitUl,
-            in Snapshot snapshot)
+            long gasLimitUl)
         {
+            IWorldState state = vm.WorldState;
+            // Take a snapshot of the state for potential rollback.
+            Snapshot snapshot = state.TakeSnapshot();
+            // Subtract the transfer value from the caller's balance.
+            if (!TOpCall.IsDelegateCall && !callValue.IsZero) state.SubtractFromBalance(caller, in callValue, vm.Spec);
+
             // Load call data from memory.
             if (!vm.VmState.Memory.TryLoad(in dataOffset, dataLength, out ReadOnlyMemory<byte> callData))
                 return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -142,9 +142,7 @@ public static partial class EvmInstructions
             goto StackUnderflow;
         }
 
-        // For non-delegate calls, the transfer value is the call value.
-        UInt256 transferValue = TOpCall.IsDelegateCall ? UInt256.Zero : callValue;
-        bool hasValueTransfer = !transferValue.IsZero;
+        bool hasValueTransfer = !TOpCall.IsDelegateCall && !callValue.IsZero;
         // Enforce static call restrictions: no value transfer allowed unless it's a CALLCODE.
         if (vm.VmState.IsStatic && hasValueTransfer && !TOpCall.IsCallCode)
             return EvmExceptionType.StaticCallViolation;
@@ -156,13 +154,10 @@ public static partial class EvmInstructions
             : env.ExecutingAccount;
 
         // Add extra gas cost if value is transferred.
-        if (hasValueTransfer)
-        {
-            if (!TGasPolicy.ConsumeCallValueTransfer(ref gas)) goto OutOfGas;
-        }
+        if (hasValueTransfer && !TGasPolicy.ConsumeCallValueTransfer(ref gas))
+            goto OutOfGas;
 
         IReleaseSpec spec = vm.Spec;
-
         IWorldState state = vm.WorldState;
 
         // Update gas: call cost and memory expansion for input and output.
@@ -175,11 +170,7 @@ public static partial class EvmInstructions
         if (!TGasPolicy.ConsumeAccountAccessGas(ref gas, vm.Spec, in vm.VmState.AccessTracker,
                 vm.TxTracer.IsTracingAccess, codeSource)) goto OutOfGas;
 
-        CodeInfo codeInfo = vm.CodeInfoRepository.GetCachedCodeInfo(
-            codeSource,
-            followDelegation: false,
-            vmSpec: spec,
-            delegationAddress: out Address? delegated);
+        CodeInfo codeInfo = vm.CodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation: false, vmSpec: spec, delegationAddress: out Address? delegated);
 
         if (spec.UseHotAndColdStorage && delegated is not null)
         {
@@ -240,7 +231,7 @@ public static partial class EvmInstructions
 
         // Check call depth and balance of the caller.
         if (env.CallDepth >= MaxCallDepth ||
-            (hasValueTransfer && state.GetBalance(env.ExecutingAccount) < transferValue))
+            (hasValueTransfer && state.GetBalance(env.ExecutingAccount) < callValue))
         {
             // If the call cannot proceed, return an empty response and push zero on the stack.
             vm.ReturnDataBuffer = Array.Empty<byte>();
@@ -270,7 +261,7 @@ public static partial class EvmInstructions
         }
 
         // Fast-path for calls to externally owned accounts (non-contracts)
-        if (HasNoExecutableCode(codeInfo) && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
+        if (codeInfo.IsEmpty && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
         {
             vm.ReturnDataBuffer = default;
             // Mutate balances only after the success byte is on the stack; this fast path has no snapshot to roll back a failed push.
@@ -279,10 +270,14 @@ public static partial class EvmInstructions
             TGasPolicy.UpdateGasUp(ref gas, gasLimitUl);
             if (hasValueTransfer)
             {
-                state.SubtractFromBalance(caller, in transferValue, spec);
-                vm.AddTransferLog<TEip7708>(caller, target, transferValue);
+                state.SubtractFromBalance(caller, in callValue, spec);
+                vm.AddTransferLog<TEip7708>(caller, target, in callValue);
+                state.AddToBalanceAndCreateIfNotExists(target, in callValue, spec);
             }
-            state.AddToBalanceAndCreateIfNotExists(target, in transferValue, spec);
+            else
+            {
+                state.AddToBalanceAndCreateIfNotExists(target, in UInt256.Zero, spec);
+            }
             Metrics.IncrementEmptyCalls();
             vm.ReturnData = null;
             return EvmExceptionType.None;
@@ -291,26 +286,9 @@ public static partial class EvmInstructions
         // Take a snapshot of the state for potential rollback.
         Snapshot snapshot = state.TakeSnapshot();
         // Subtract the transfer value from the caller's balance.
-        if (hasValueTransfer) state.SubtractFromBalance(caller, in transferValue, spec);
+        if (hasValueTransfer) state.SubtractFromBalance(caller, in callValue, spec);
 
-        return SlowCall(
-            vm,
-            ref gas,
-            in dataOffset,
-            dataLength,
-            outputOffset,
-            outputLength,
-            codeInfo,
-            target,
-            caller,
-            codeSource,
-            env,
-            in callValue,
-            gasLimitUl,
-            in snapshot);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool HasNoExecutableCode(CodeInfo codeInfo) => codeInfo.IsEmpty;
+        return SlowCall(vm, ref gas, in dataOffset, dataLength, outputOffset, outputLength, codeInfo, target, caller, codeSource, env, in callValue, gasLimitUl, in snapshot);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static EvmExceptionType SlowCall(

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -310,7 +310,7 @@ public static partial class EvmInstructions
             in snapshot);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool HasNoExecutableCode(CodeInfo codeInfo) => codeInfo.IsEmpty || ReferenceEquals(codeInfo, CodeInfo.Empty);
+        static bool HasNoExecutableCode(CodeInfo codeInfo) => codeInfo.IsEmpty;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static EvmExceptionType SlowCall(

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -340,7 +340,6 @@ public static partial class EvmInstructions
             caller: caller,
             codeSource: codeSource,
             callDepth: env.CallDepth + 1,
-            transferValue: in transferValue,
             value: in callValue,
             inputData: in callData);
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -280,8 +280,8 @@ public static partial class EvmInstructions
             {
                 state.SubtractFromBalance(caller, in transferValue, spec);
                 vm.AddTransferLog<TEip7708>(caller, target, transferValue);
-                state.AddToBalanceAndCreateIfNotExists(target, in transferValue, spec);
             }
+            state.AddToBalanceAndCreateIfNotExists(target, in transferValue, spec);
             Metrics.IncrementEmptyCalls();
             vm.ReturnData = null;
             return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -330,40 +330,40 @@ public static partial class EvmInstructions
             long gasLimitUl,
             in Snapshot snapshot)
         {
-        // Load call data from memory.
-        if (!vm.VmState.Memory.TryLoad(in dataOffset, dataLength, out ReadOnlyMemory<byte> callData))
-            return EvmExceptionType.OutOfGas;
-        // Construct the execution environment for the call.
-        ExecutionEnvironment callEnv = ExecutionEnvironment.Rent(
-            codeInfo: codeInfo,
-            executingAccount: target,
-            caller: caller,
-            codeSource: codeSource,
-            callDepth: env.CallDepth + 1,
-            value: in callValue,
-            inputData: in callData);
+            // Load call data from memory.
+            if (!vm.VmState.Memory.TryLoad(in dataOffset, dataLength, out ReadOnlyMemory<byte> callData))
+                return EvmExceptionType.OutOfGas;
+            // Construct the execution environment for the call.
+            ExecutionEnvironment callEnv = ExecutionEnvironment.Rent(
+                codeInfo: codeInfo,
+                executingAccount: target,
+                caller: caller,
+                codeSource: codeSource,
+                callDepth: env.CallDepth + 1,
+                value: in callValue,
+                inputData: in callData);
 
-        // Normalize output offset if output length is zero.
-        UInt256 normalizedOutputOffset = outputOffset;
-        if (outputLength == 0)
-        {
-            // Output offset is inconsequential when output length is 0.
-            normalizedOutputOffset = 0;
-        }
+            // Normalize output offset if output length is zero.
+            UInt256 normalizedOutputOffset = outputOffset;
+            if (outputLength == 0)
+            {
+                // Output offset is inconsequential when output length is 0.
+                normalizedOutputOffset = 0;
+            }
 
-        // Rent a new call frame for executing the call.
-        vm.ReturnData = VmState<TGasPolicy>.RentFrame(
-            gas: TGasPolicy.CreateChildFrameGas(ref gas, gasLimitUl),
-            outputDestination: normalizedOutputOffset.ToLong(),
-            outputLength: outputLength.ToLong(),
-            executionType: TOpCall.ExecutionType,
-            isStatic: TOpCall.IsStatic || vm.VmState.IsStatic,
-            isCreateOnPreExistingAccount: false,
-            env: callEnv,
-            stateForAccessLists: in vm.VmState.AccessTracker,
-            snapshot: in snapshot);
+            // Rent a new call frame for executing the call.
+            vm.ReturnData = VmState<TGasPolicy>.RentFrame(
+                gas: TGasPolicy.CreateChildFrameGas(ref gas, gasLimitUl),
+                outputDestination: normalizedOutputOffset.ToLong(),
+                outputLength: outputLength.ToLong(),
+                executionType: TOpCall.ExecutionType,
+                isStatic: TOpCall.IsStatic || vm.VmState.IsStatic,
+                isCreateOnPreExistingAccount: false,
+                env: callEnv,
+                stateForAccessLists: in vm.VmState.AccessTracker,
+                snapshot: in snapshot);
 
-        return EvmExceptionType.None;
+            return EvmExceptionType.None;
         }
 
         // Jump forward to be unpredicted by the branch predictor.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -144,7 +144,7 @@ public static partial class EvmInstructions
 
         // For non-delegate calls, the transfer value is the call value.
         UInt256 transferValue = TOpCall.IsDelegateCall ? UInt256.Zero : callValue;
-        bool hasValueTransfer = !TOpCall.IsDelegateCall && !callValue.IsZero;
+        bool hasValueTransfer = !transferValue.IsZero;
         // Enforce static call restrictions: no value transfer allowed unless it's a CALLCODE.
         if (vm.VmState.IsStatic && hasValueTransfer && !TOpCall.IsCallCode)
             return EvmExceptionType.StaticCallViolation;
@@ -306,7 +306,6 @@ public static partial class EvmInstructions
             codeSource,
             env,
             in callValue,
-            in transferValue,
             gasLimitUl,
             in snapshot);
 
@@ -327,7 +326,6 @@ public static partial class EvmInstructions
             Address codeSource,
             ExecutionEnvironment env,
             in UInt256 callValue,
-            in UInt256 transferValue,
             long gasLimitUl,
             in Snapshot snapshot)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -226,7 +226,6 @@ public static partial class EvmInstructions
             caller: env.ExecutingAccount,
             codeSource: null,
             callDepth: env.CallDepth + 1,
-            transferValue: in value,
             value: in value,
             inputData: in _emptyMemory);
 

--- a/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
@@ -31,12 +31,7 @@ public static class WorldStateExtensions
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, ExecutionType executionType, in UInt256 balanceChange, IReleaseSpec spec)
-    {
-        if (executionType.CreditsBalance())
-        {
-            worldState.AddToBalanceAndCreateIfNotExists(address, balanceChange, spec, out _);
-        }
-    }
+        => worldState.AddToBalanceAndCreateIfNotExists(address, executionType.GetBalanceCredit(in balanceChange), spec, out _);
 
     public static void SubtractFromBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.SubtractFromBalance(address, balanceChange, spec, out _);

--- a/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -27,6 +28,15 @@ public static class WorldStateExtensions
 
     public static bool AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalanceAndCreateIfNotExists(address, balanceChange, spec, out _);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, ExecutionType executionType, in UInt256 balanceChange, IReleaseSpec spec)
+    {
+        if (executionType.CreditsBalance())
+        {
+            worldState.AddToBalanceAndCreateIfNotExists(address, balanceChange, spec, out _);
+        }
+    }
 
     public static void SubtractFromBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.SubtractFromBalance(address, balanceChange, spec, out _);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -285,7 +285,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool HasNoExecutableCode(CodeInfo codeInfo, Address? delegationAddress)
-            => delegationAddress is null && (codeInfo.IsEmpty || ReferenceEquals(codeInfo, CodeInfo.Empty));
+            => delegationAddress is null && codeInfo.IsEmpty;
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -413,16 +413,17 @@ namespace Nethermind.Evm.TransactionProcessing
             Metrics.IncrementEmptyCalls();
 
             ref readonly UInt256 value = ref tx.ValueRef;
+            bool hasValueTransfer = !value.IsZero;
             if (tracer.IsTracingActions)
             {
                 TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
             }
 
-            PayValue(tx, spec, opts);
-            WorldState.AddToBalanceAndCreateIfNotExists(recipient, in value, spec);
+            if (hasValueTransfer) PayValue(tx, spec, opts);
+            WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
 
             JournalCollection<LogEntry>? logs = null;
-            if (spec.IsEip7708Enabled && !value.IsZero && tx.SenderAddress != recipient)
+            if (spec.IsEip7708Enabled && hasValueTransfer && tx.SenderAddress != recipient)
             {
                 LogEntry transferLog = TransferLog.CreateTransfer(tx.SenderAddress!, recipient, in value);
                 logs = [transferLog];

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -255,10 +255,10 @@ namespace Nethermind.Evm.TransactionProcessing
             // the priority fee in the destroyed account's balance.
             if (spec.IsEip8037Enabled && spec.IsEip7708Enabled && statusCode == StatusCode.Success)
             {
-                JournalSet<Address> destroyList = substate.DestroyList;
-                int count = destroyList.Count;
+                int count = substate.DestroyListCount;
                 if (count > 1)
                 {
+                    JournalSet<Address> destroyList = substate.DestroyList;
                     Address[] buffer = SafeArrayPool<Address>.Shared.Rent(count);
                     try
                     {
@@ -274,9 +274,9 @@ namespace Nethermind.Evm.TransactionProcessing
                         SafeArrayPool<Address>.Shared.Return(buffer);
                     }
                 }
-                else
+                else if (count == 1)
                 {
-                    foreach (Address toBeDestroyed in destroyList)
+                    foreach (Address toBeDestroyed in substate.DestroyList)
                     {
                         FinalizeDestroyedAccount(WorldState, in substate, toBeDestroyed);
                     }
@@ -354,7 +354,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
                 else
                 {
-                    LogEntry[] logs = substate.Logs.Count != 0 ? substate.Logs.ToArray() : [];
+                    LogEntry[] logs = substate.Logs.Count != 0 ? substate.LogsToArray() : [];
                     tracer.MarkAsSuccess(env.ExecutingAccount, spentGas, substate.Output.ToArray(), logs, stateRoot);
                 }
             }
@@ -1025,7 +1025,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     // EIP-8037: defer destroy list processing to after PayFees so that
                     // burn logs include the priority fee in the balance.
                     bool deferFinalization = spec.IsEip7708Enabled && spec.IsEip8037Enabled;
-                    if (!deferFinalization)
+                    if (!deferFinalization && substate.DestroyListCount != 0)
                     {
                         bool eip7708Enabled = spec.IsEip7708Enabled;
                         bool tracingRefunds = tracer.IsTracingRefunds;
@@ -1268,7 +1268,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             // n.b. destroyed accounts already set to zero balance
             // EIP-8037: always pay coinbase — deferred finalization will burn the balance
-            bool gasBeneficiaryNotDestroyed = !substate.DestroyList.Contains(header.GasBeneficiary);
+            bool gasBeneficiaryNotDestroyed = !substate.DestroyListContains(header.GasBeneficiary);
             if (statusCode == StatusCode.Failure || gasBeneficiaryNotDestroyed || spec.IsEip8037Enabled)
             {
                 WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
@@ -1383,7 +1383,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             long totalToRefund = codeInsertRegularRefund;
             if (!substate.IsError && !substate.ShouldRevert)
-                totalToRefund += substate.Refund + substate.DestroyList.Count * spec.GasCosts.DestroyRefund;
+                totalToRefund += substate.Refund + substate.DestroyListCount * spec.GasCosts.DestroyRefund;
 
             return (spentGas, CalculateClaimableRefund(spentGas, totalToRefund, spec));
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -410,6 +410,8 @@ namespace Nethermind.Evm.TransactionProcessing
             in UInt256 senderReservedGasPayment,
             in UInt256 blobBaseFee)
         {
+            Metrics.IncrementEmptyCalls();
+
             ref readonly UInt256 value = ref tx.ValueRef;
             if (tracer.IsTracingActions)
             {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -77,6 +77,7 @@ namespace Nethermind.Evm.TransactionProcessing
         protected IWorldState WorldState { get; }
         protected IVirtualMachine<TGasPolicy> VirtualMachine { get; }
         private readonly ICodeInfoRepository _codeInfoRepository;
+        private readonly bool _isOverridableCodeInfoRepository;
         private SystemTransactionProcessor<TGasPolicy>? _systemTransactionProcessor;
         private readonly ITransactionProcessor.IBlobBaseFeeCalculator _blobBaseFeeCalculator;
         private readonly ILogManager _logManager;
@@ -106,6 +107,7 @@ namespace Nethermind.Evm.TransactionProcessing
             WorldState = worldState;
             VirtualMachine = virtualMachine;
             _codeInfoRepository = codeInfoRepository;
+            _isOverridableCodeInfoRepository = codeInfoRepository is IOverridableCodeInfoRepository;
             _blobBaseFeeCalculator = blobBaseFeeCalculator;
 
             Ecdsa = new EthereumEcdsa(specProvider.ChainId);
@@ -193,6 +195,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return Execute(tx, tracer, opts, header, spec, in intrinsicGas);
         }
 
+        [SkipLocalsInit]
         private TransactionResult Execute(Transaction tx, ITxTracer tracer, ExecutionOptions opts, BlockHeader header, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas)
         {
             // restore is CallAndRestore - previous call, we will restore state after the execution
@@ -226,11 +229,42 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitRoots: false);
 
+            return ExecuteEvmTransaction(
+                tx,
+                header,
+                spec,
+                tracer,
+                opts,
+                restore,
+                commit,
+                deleteCallerAccount,
+                in intrinsicGas,
+                in premiumPerGas,
+                in senderReservedGasPayment,
+                in blobBaseFee);
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private TransactionResult ExecuteEvmTransaction(
+            Transaction tx,
+            BlockHeader header,
+            IReleaseSpec spec,
+            ITxTracer tracer,
+            ExecutionOptions opts,
+            bool restore,
+            bool commit,
+            bool deleteCallerAccount,
+            in IntrinsicGas<TGasPolicy> intrinsicGas,
+            in UInt256 premiumPerGas,
+            in UInt256 senderReservedGasPayment,
+            in UInt256 blobBaseFee)
+        {
             // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method
             using StackAccessTracker accessTracker = new(tracer.IsTracingAccess);
-
             int delegationRefunds = 0;
             int delegationAuthBaseRefunds = 0;
+            TransactionResult result;
             if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
 
             if (!(result = Validate8037DelegationRefundBounds(tx, spec, in gasAvailable))) return result;
@@ -295,6 +329,39 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
+            return FinalizeTransaction(
+                tx,
+                header,
+                spec,
+                tracer,
+                opts,
+                restore,
+                commit,
+                deleteCallerAccount,
+                in senderReservedGasPayment,
+                env,
+                in substate,
+                spentGas,
+                statusCode);
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private TransactionResult FinalizeTransaction(
+            Transaction tx,
+            BlockHeader header,
+            IReleaseSpec spec,
+            ITxTracer tracer,
+            ExecutionOptions opts,
+            bool restore,
+            bool commit,
+            bool deleteCallerAccount,
+            in UInt256 senderReservedGasPayment,
+            ExecutionEnvironment env,
+            in TransactionSubstate substate,
+            GasConsumed spentGas,
+            int statusCode)
+        {
             if (!opts.HasFlag(ExecutionOptions.Warmup))
             {
                 tx.BlockGasUsed = spentGas.EffectiveBlockGas;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -210,8 +210,6 @@ namespace Nethermind.Evm.TransactionProcessing
 
             UInt256 effectiveGasPrice = CalculateEffectiveGasPrice(tx, spec.IsEip1559Enabled, header.BaseFeePerGas, out UInt256 opcodeGasPrice);
 
-            VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
-
             UpdateMetrics(opts, effectiveGasPrice);
 
             bool deleteCallerAccount = RecoverSenderIfNeeded(tx, spec, opts, effectiveGasPrice);
@@ -227,7 +225,40 @@ namespace Nethermind.Evm.TransactionProcessing
                 return result;
             }
 
-            if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitRoots: false);
+            Address? recipient = tx.To;
+            bool useSimpleTransferFastPath = false;
+            CodeInfo? preloadedCodeInfo = null;
+            Address? preloadedDelegationAddress = null;
+            if (IsSimpleTransferFastPathCandidate(tx, _isOverridableCodeInfoRepository))
+            {
+                preloadedCodeInfo = _codeInfoRepository.GetCachedCodeInfo(recipient!, followDelegation: true, spec, out preloadedDelegationAddress);
+                useSimpleTransferFastPath = HasNoExecutableCode(preloadedCodeInfo, preloadedDelegationAddress);
+            }
+
+            bool commitBeforeExecution = commit && (!useSimpleTransferFastPath || restore || tracer.IsTracingState);
+            if (commitBeforeExecution) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitRoots: false);
+
+            if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
+
+            if (useSimpleTransferFastPath)
+            {
+                return ExecuteSimpleTransfer(
+                    tx,
+                    header,
+                    spec,
+                    tracer,
+                    opts,
+                    restore,
+                    commit,
+                    deleteCallerAccount,
+                    recipient!,
+                    in intrinsicGas,
+                    gasAvailable,
+                    in opcodeGasPrice,
+                    in premiumPerGas,
+                    in senderReservedGasPayment,
+                    in blobBaseFee);
+            }
 
             return ExecuteEvmTransaction(
                 tx,
@@ -239,10 +270,22 @@ namespace Nethermind.Evm.TransactionProcessing
                 commit,
                 deleteCallerAccount,
                 in intrinsicGas,
+                gasAvailable,
+                in opcodeGasPrice,
                 in premiumPerGas,
                 in senderReservedGasPayment,
-                in blobBaseFee);
+                in blobBaseFee,
+                preloadedCodeInfo,
+                preloadedDelegationAddress);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsSimpleTransferFastPathCandidate(Transaction tx, bool isOverridableCodeInfoRepository)
+            => !isOverridableCodeInfoRepository && tx.To is not null && tx.AuthorizationList is null;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasNoExecutableCode(CodeInfo codeInfo, Address? delegationAddress)
+            => delegationAddress is null && (codeInfo.IsEmpty || ReferenceEquals(codeInfo, CodeInfo.Empty));
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -256,17 +299,20 @@ namespace Nethermind.Evm.TransactionProcessing
             bool commit,
             bool deleteCallerAccount,
             in IntrinsicGas<TGasPolicy> intrinsicGas,
+            TGasPolicy gasAvailable,
+            in UInt256 opcodeGasPrice,
             in UInt256 premiumPerGas,
             in UInt256 senderReservedGasPayment,
-            in UInt256 blobBaseFee)
+            in UInt256 blobBaseFee,
+            CodeInfo? preloadedCodeInfo,
+            Address? preloadedDelegationAddress)
         {
+            VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
             // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method
             using StackAccessTracker accessTracker = new(tracer.IsTracingAccess);
             int delegationRefunds = 0;
             int delegationAuthBaseRefunds = 0;
             TransactionResult result;
-            if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
-
             if (!(result = Validate8037DelegationRefundBounds(tx, spec, in gasAvailable))) return result;
 
             if (spec.IsEip7702Enabled && tx.HasAuthorizationList)
@@ -276,7 +322,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (!(result = Apply8037DelegationRefunds(tx, spec, in intrinsicGas, ref gasAvailable, ref delegationRefunds, ref delegationAuthBaseRefunds))) return result;
 
-            if (!(result = BuildExecutionEnvironment(tx, spec, _codeInfoRepository, accessTracker, out ExecutionEnvironment e))) return result;
+            if (!(result = BuildExecutionEnvironment(tx, spec, _codeInfoRepository, accessTracker, preloadedCodeInfo, preloadedDelegationAddress, out ExecutionEnvironment e))) return result;
             using ExecutionEnvironment env = e;
 
             int statusCode = !tracer.IsTracingInstructions ?
@@ -339,10 +385,143 @@ namespace Nethermind.Evm.TransactionProcessing
                 commit,
                 deleteCallerAccount,
                 in senderReservedGasPayment,
-                env,
+                env.ExecutingAccount,
                 in substate,
                 spentGas,
                 statusCode);
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private TransactionResult ExecuteSimpleTransfer(
+            Transaction tx,
+            BlockHeader header,
+            IReleaseSpec spec,
+            ITxTracer tracer,
+            ExecutionOptions opts,
+            bool restore,
+            bool commit,
+            bool deleteCallerAccount,
+            Address recipient,
+            in IntrinsicGas<TGasPolicy> intrinsicGas,
+            TGasPolicy gasAvailable,
+            in UInt256 opcodeGasPrice,
+            in UInt256 premiumPerGas,
+            in UInt256 senderReservedGasPayment,
+            in UInt256 blobBaseFee)
+        {
+            ref readonly UInt256 value = ref tx.ValueRef;
+            if (tracer.IsTracingActions)
+            {
+                TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
+            }
+
+            PayValue(tx, spec, opts);
+            WorldState.AddToBalanceAndCreateIfNotExists(recipient, in value, spec);
+
+            JournalCollection<LogEntry>? logs = null;
+            if (spec.IsEip7708Enabled && !value.IsZero && tx.SenderAddress != recipient)
+            {
+                LogEntry transferLog = TransferLog.CreateTransfer(tx.SenderAddress!, recipient, in value);
+                logs = [transferLog];
+                if (tracer.IsTracingLogs) tracer.ReportLog(transferLog);
+            }
+
+            TransactionSubstate substate = new(
+                bytes: default,
+                refund: 0,
+                destroyList: null,
+                logs: logs,
+                shouldRevert: false,
+                isTracerConnected: tracer.IsTracing,
+                logger: Logger);
+
+            if (tracer.IsTracingActions)
+            {
+                tracer.ReportActionEnd(TGasPolicy.GetRemainingGas(in gasAvailable), default);
+            }
+
+            TGasPolicy floorGas = intrinsicGas.FloorGas;
+            TGasPolicy standardGas = intrinsicGas.Standard;
+            long postIntrinsicStateReservoir = TGasPolicy.GetStateReservoir(in gasAvailable);
+            GasConsumed spentGas = Refund(tx, header, spec, opts, in substate, in gasAvailable, in opcodeGasPrice, codeInsertRefunds: 0, in floorGas, in standardGas, postIntrinsicStateReservoir);
+
+            const int statusCode = StatusCode.Success;
+            PayFees(tx, header, spec, tracer, in substate, spentGas.SpentGas, premiumPerGas, blobBaseFee, statusCode);
+
+            if (tracer.IsTracingAccess)
+            {
+                ReportSimpleTransferAccess(tx, spec, tracer, recipient);
+            }
+
+            if (!opts.HasFlag(ExecutionOptions.SkipValidation) && !_parallel)
+            {
+                if (spec.IsEip8037Enabled)
+                {
+                    _blockCumulativeRegularGas += spentGas.EffectiveBlockGas;
+                    _blockCumulativeStateGas += spentGas.BlockStateGas;
+                    header.GasUsed = Math.Max(_blockCumulativeRegularGas, _blockCumulativeStateGas);
+                }
+                else
+                {
+                    header.GasUsed += spentGas.EffectiveBlockGas;
+                }
+            }
+
+            return FinalizeTransaction(
+                tx,
+                header,
+                spec,
+                tracer,
+                opts,
+                restore,
+                commit,
+                deleteCallerAccount,
+                in senderReservedGasPayment,
+                recipient,
+                in substate,
+                spentGas,
+                statusCode);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void TraceSimpleTransferActionStart(Transaction tx, Address recipient, ITxTracer tracer, in UInt256 value, in TGasPolicy gasAvailable)
+        {
+            tracer.ReportAction(
+                TGasPolicy.GetRemainingGas(in gasAvailable),
+                value,
+                tx.SenderAddress!,
+                recipient,
+                tx.Data,
+                ExecutionType.TRANSACTION);
+
+            if (tracer.IsTracingCode)
+            {
+                tracer.ReportByteCode(default);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ReportSimpleTransferAccess(Transaction tx, IReleaseSpec spec, ITxTracer tracer, Address recipient)
+        {
+            using StackAccessTracker accessTracker = new(tracer.IsTracingAccess);
+            WarmUpTxAccesses(tx, spec, in accessTracker, recipient);
+            tracer.ReportAccess(accessTracker.AccessedAddresses, accessTracker.AccessedStorageCells);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WarmUpTxAccesses(Transaction tx, IReleaseSpec spec, in StackAccessTracker accessTracker, Address recipient)
+        {
+            if (!spec.UseHotAndColdStorage) return;
+
+            if (spec.UseTxAccessLists)
+                accessTracker.WarmUp(tx.AccessList); // eip-2930
+
+            if (spec.AddCoinbaseToTxAccessList)
+                accessTracker.WarmUp(VirtualMachine.BlockExecutionContext.Header.GasBeneficiary!);
+
+            accessTracker.WarmUp(recipient);
+            accessTracker.WarmUp(tx.SenderAddress!);
         }
 
         [SkipLocalsInit]
@@ -357,7 +536,7 @@ namespace Nethermind.Evm.TransactionProcessing
             bool commit,
             bool deleteCallerAccount,
             in UInt256 senderReservedGasPayment,
-            ExecutionEnvironment env,
+            Address executingAccount,
             in TransactionSubstate substate,
             GasConsumed spentGas,
             int statusCode)
@@ -417,12 +596,12 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (statusCode == StatusCode.Failure)
                 {
                     byte[] output = substate.ShouldRevert ? substate.Output.ToArray() : [];
-                    tracer.MarkAsFailed(env.ExecutingAccount, spentGas, output, substate.Error, stateRoot);
+                    tracer.MarkAsFailed(executingAccount, spentGas, output, substate.Error, stateRoot);
                 }
                 else
                 {
                     LogEntry[] logs = substate.Logs.Count != 0 ? substate.LogsToArray() : [];
-                    tracer.MarkAsSuccess(env.ExecutingAccount, spentGas, substate.Output.ToArray(), logs, stateRoot);
+                    tracer.MarkAsSuccess(executingAccount, spentGas, substate.Output.ToArray(), logs, stateRoot);
                 }
             }
 
@@ -951,6 +1130,8 @@ namespace Nethermind.Evm.TransactionProcessing
             IReleaseSpec spec,
             ICodeInfoRepository codeInfoRepository,
             in StackAccessTracker accessTracker,
+            CodeInfo? preloadedCodeInfo,
+            Address? preloadedDelegationAddress,
             out ExecutionEnvironment env)
         {
             Address recipient = tx.GetRecipient(tx.IsContractCreation ? WorldState.GetNonce(tx.SenderAddress!) : 0);
@@ -963,24 +1144,23 @@ namespace Nethermind.Evm.TransactionProcessing
             }
             else
             {
-                codeInfo = codeInfoRepository.GetCachedCodeInfo(recipient, spec, out Address? delegationAddress);
+                Address? delegationAddress;
+                if (preloadedCodeInfo is not null)
+                {
+                    codeInfo = preloadedCodeInfo;
+                    delegationAddress = preloadedDelegationAddress;
+                }
+                else
+                {
+                    codeInfo = codeInfoRepository.GetCachedCodeInfo(recipient, spec, out delegationAddress);
+                }
 
                 //We assume eip-7702 must be active if it is a delegation
                 if (delegationAddress is not null)
                     accessTracker.WarmUp(delegationAddress);
             }
 
-            if (spec.UseHotAndColdStorage)
-            {
-                if (spec.UseTxAccessLists)
-                    accessTracker.WarmUp(tx.AccessList); // eip-2930
-
-                if (spec.AddCoinbaseToTxAccessList)
-                    accessTracker.WarmUp(VirtualMachine.BlockExecutionContext.Header.GasBeneficiary!);
-
-                accessTracker.WarmUp(recipient);
-                accessTracker.WarmUp(tx.SenderAddress!);
-            }
+            WarmUpTxAccesses(tx, spec, in accessTracker, recipient);
 
             env = ExecutionEnvironment.Rent(
                 codeInfo: codeInfo,
@@ -1327,7 +1507,10 @@ namespace Nethermind.Evm.TransactionProcessing
             return true;
         }
 
-        protected virtual void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts) => WorldState.SubtractFromBalance(tx.SenderAddress!, in tx.ValueRef, spec);
+        protected virtual void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
+        {
+            if (!tx.ValueRef.IsZero) WorldState.SubtractFromBalance(tx.SenderAddress!, in tx.ValueRef, spec);
+        }
 
         protected virtual void PayFees(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, in TransactionSubstate substate, long spentGas, in UInt256 premiumPerGas, in UInt256 blobBaseFee, int statusCode)
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1168,7 +1168,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 caller: tx.SenderAddress!,
                 codeSource: recipient,
                 callDepth: 0,
-                transferValue: in tx.ValueRef,
                 value: in tx.ValueRef,
                 inputData: in inputData);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -17,7 +17,6 @@ namespace Nethermind.Evm;
 public readonly ref struct TransactionSubstate
 {
     private readonly ILogger _logger;
-    private static readonly JournalSet<Address> _emptyDestroyList = new(Address.EqualityComparer);
 
     private const string SomeError = "error";
     public const string Revert = "revert";
@@ -54,7 +53,8 @@ public readonly ref struct TransactionSubstate
     public bool ShouldRevert { get; }
     public long Refund { get; }
     public JournalCollection<LogEntry> Logs => _logs;
-    public JournalSet<Address> DestroyList => _destroyList ?? _emptyDestroyList;
+    public JournalSet<Address> DestroyList => _destroyList!;
+    public int DestroyListCount => _destroyList?.Count ?? 0;
 
     public TransactionSubstate(EvmExceptionType exceptionType, bool isTracerConnected, string? substateError = null)
     {
@@ -62,7 +62,7 @@ public readonly ref struct TransactionSubstate
         SubstateError = substateError;
         EvmExceptionType = exceptionType;
         Refund = 0;
-        _destroyList = _emptyDestroyList;
+        _destroyList = null;
         // Can be mutated by SELFDESTRUCT and BURN logs so need to initialize as empty.
         _logs = [];
         ShouldRevert = false;
@@ -70,8 +70,8 @@ public readonly ref struct TransactionSubstate
 
     public TransactionSubstate(ReadOnlyMemory<byte> bytes,
         long refund,
-        JournalSet<Address> destroyList,
-        JournalCollection<LogEntry> logs,
+        JournalSet<Address>? destroyList,
+        JournalCollection<LogEntry>? logs,
         bool shouldRevert,
         bool isTracerConnected,
         EvmExceptionType evmExceptionType = default,
@@ -81,7 +81,7 @@ public readonly ref struct TransactionSubstate
         Output = bytes;
         Refund = refund;
         _destroyList = destroyList;
-        _logs = logs;
+        _logs = logs ?? [];
         ShouldRevert = shouldRevert;
         EvmExceptionType = evmExceptionType;
 
@@ -102,6 +102,10 @@ public readonly ref struct TransactionSubstate
         ReadOnlySpan<byte> span = Output.Span;
         if (TryGetErrorMessage(span) is { } decoded) Error = decoded;
     }
+
+    public bool DestroyListContains(Address? address) => address is not null && _destroyList?.Contains(address) == true;
+
+    public LogEntry[] LogsToArray() => _logs.ToArray();
 
     public static string EncodeErrorMessage(ReadOnlySpan<byte> span)
     {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -985,7 +985,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     private CallResult RunPrecompile(VmState<TGasPolicy> state)
     {
         ReadOnlyMemory<byte> callData = state.Env.InputData;
-        UInt256 transferValue = state.Env.TransferValue;
+        ref readonly UInt256 transferValue = ref state.ExecutionType.GetBalanceCredit(in state.Env.Value);
         TGasPolicy gas = state.Gas;
 
         IPrecompile precompile = state.Env.CodeInfo.Precompile!;
@@ -1119,7 +1119,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         {
             IReleaseSpec spec = BlockExecutionContext.Spec;
             // Ensure the executing account has sufficient balance and exists in the world state.
-            _worldState.AddToBalanceAndCreateIfNotExists(env.ExecutingAccount, env.TransferValue, spec);
+            _worldState.AddToBalanceAndCreateIfNotExists(env.ExecutingAccount, vmState.ExecutionType, in env.Value, spec);
 
             // For contract creation calls, increment the nonce if the specification requires it.
             if (vmState.ExecutionType.IsAnyCreate() && spec.ClearEmptyAccountWhenTouched)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
@@ -49,7 +49,6 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
             caller: addressOne,
             codeSource: addressOne,
             callDepth: 0,
-            transferValue: 0,
             value: 0,
             inputData: default);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingAllocsBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingAllocsBenchmarks.cs
@@ -41,7 +41,7 @@ public class DebugTraceStreamingAllocsBenchmarks
         for (int d = 0; d < 5; d++)
         {
             _envByDepth[d] = ExecutionEnvironment.Rent(
-                CodeInfo.Empty, Address.Zero, Address.Zero, null, d, default, default, default);
+                CodeInfo.Empty, Address.Zero, Address.Zero, null, d, default, default);
         }
         _valueBuffer = new byte[32];
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/DebugTraceStreamingBenchmarks.cs
@@ -31,7 +31,7 @@ public class DebugTraceStreamingBenchmarks
     {
         _tx = Build.A.Transaction.WithTo(TestItem.AddressA).TestObject;
         _block = Build.A.Block.WithTransactions(_tx).TestObject;
-        _env = ExecutionEnvironment.Rent(CodeInfo.Empty, Address.Zero, Address.Zero, null, 1, default, default, default);
+        _env = ExecutionEnvironment.Rent(CodeInfo.Empty, Address.Zero, Address.Zero, null, 1, default, default);
     }
 
     [Benchmark(Baseline = true, Description = "Throughput: buffered — accumulate N entries, then serialize the full envelope")]

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/TraceStreamingAllocsBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/TraceStreamingAllocsBenchmarks.cs
@@ -40,7 +40,7 @@ public class TraceStreamingAllocsBenchmarks
         for (int d = 0; d <= CallDepthPerTx; d++)
         {
             _envByDepth[d] = ExecutionEnvironment.Rent(
-                CodeInfo.Empty, Address.Zero, Address.Zero, null, d, default, default, default);
+                CodeInfo.Empty, Address.Zero, Address.Zero, null, d, default, default);
         }
         _value32 = new byte[32];
         _jsonOptions = EthereumJsonSerializer.JsonOptions;

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/TraceStreamingBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/TraceStreamingBenchmarks.cs
@@ -34,7 +34,7 @@ public class TraceStreamingBenchmarks
     {
         _tx = Build.A.Transaction.WithTo(TestItem.AddressA).TestObject;
         _block = Build.A.Block.WithTransactions(_tx).TestObject;
-        _env = ExecutionEnvironment.Rent(CodeInfo.Empty, Address.Zero, Address.Zero, null, 1, default, default, default);
+        _env = ExecutionEnvironment.Rent(CodeInfo.Empty, Address.Zero, Address.Zero, null, 1, default, default);
         _value32 = new byte[32];
     }
 

--- a/src/Nethermind/Nethermind.Taiko/TaikoTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoTransactionProcessor.cs
@@ -51,7 +51,7 @@ public class TaikoTransactionProcessor(
         // If the account has been destroyed during the execution, the balance is already set
         // as zero. So there is no need to create the account and pay the fees to the beneficiary,
         // except for the case when a restore is required due to a failure.
-        bool gasBeneficiaryNotDestroyed = !substate.DestroyList.Contains(header.GasBeneficiary!);
+        bool gasBeneficiaryNotDestroyed = !substate.DestroyListContains(header.GasBeneficiary);
         if (statusCode == StatusCode.Failure || gasBeneficiaryNotDestroyed)
         {
             WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, tipFees, spec);


### PR DESCRIPTION
## Changes

Ports the performance wins from #11323 onto current `master` as a minimal, independently bisectable patch. Drops the bundled refactors from that PR that did not appear in the JIT'd output of the hot path. Touches 25 files (+888 / -130).

**Top-level simple-transfer fast path (`TransactionProcessor`)**

- New EOA-to-EOA value-transfer fast path in `TransactionProcessor.Execute` that skips the EVM frame entirely. Predicate: non-overridable code-info repository, `tx.AuthorizationList is null`, and `GetCachedCodeInfo(recipient, followDelegation: true, ...)` returns an empty `CodeInfo` with no delegation address.
- Slow path extracted into `[NoInlining] ExecuteEvmTransaction` and post-execution tail into `[NoInlining] FinalizeTransaction` so the fast path keeps its register / stack budget small. `[SkipLocalsInit]` applied to the hot methods, matching the rest of the EVM hot path.
- Pre-execution `WorldState.Commit` skipped on the fast path; preserved for `restore` mode and state tracing.
- `BuildExecutionEnvironment` gains `preloadedCodeInfo` / `preloadedDelegationAddress` parameters so the slow path reuses the predicate's lookup instead of re-querying.
- `WarmUpTxAccesses` extracted as an `[AggressiveInlining]` helper shared between `BuildExecutionEnvironment` and the new `ReportSimpleTransferAccess`.
- Cached `_isOverridableCodeInfoRepository` bool set in the processor ctor as the fast-path safety gate (simulation / tracing repositories always take the slow path).
- EIP-7708 transfer log emitted from the fast path when `spec.IsEip7708Enabled && !tx.ValueRef.IsZero && tx.SenderAddress != recipient`.
- Access tracing only materialises a `StackAccessTracker` when `tracer.IsTracingAccess`.
- `PayValue`: added `if (!tx.ValueRef.IsZero)` guard to skip a state write for zero-value transactions.

**Nested empty-code call fast path (`EvmInstructions.Call`)**

- Added static-abstract `IOpCall.IsDelegateCall` / `IOpCall.IsCallCode` (with overrides on `OpDelegateCall` / `OpCallCode`); replaced `typeof(TOpCall) == typeof(OpFoo)` chains with the static-abstract reads.
- Empty-code call path now skips the snapshot, `ExecutionEnvironment.Rent`, and `VmState.RentFrame` work. The slow body is hoisted into a `[NoInlining]` local function.
- Empty-code branch preserves the existing CALL / CALLCODE / DELEGATECALL / STATICCALL credit semantics and account-touch invariants.

**`TransactionSubstate` null-tolerant**

- Main constructor accepts `JournalSet<Address>? destroyList` and `JournalCollection<LogEntry>? logs`; `logs ?? []` is mapped inside the ctor so the `Logs` getter still returns a non-null collection (important for EIP-7708).
- `_destroyList` field switched from `IHashSetEnumerableCollection<Address>` to `JournalSet<Address>?`. Added `DestroyListContains(Address?)`, `DestroyListCount`, and `LogsToArray()` accessors used by the hot call sites in `PayFees` / `Refund` / receipt tracing.
- Deleted the now-dead `_emptyDestroyList` / `_emptyLogs` static sentinels.
- Deleted `IHashSetEnumerableCollection<T>` (single-implementer interface that only existed to type the field).
- Taiko's processor updated to use `substate.DestroyListContains(...)`.

**`ExecutionEnvironment._transferValue` removal**

- Removed the `_transferValue` field, `TransferValue` property, and the `transferValue` parameter on `Rent`. Saves 32 bytes per call frame.
- Added `ExecutionType.CreditsBalance()` and `ExecutionType.GetBalanceCredit(in value)` helpers (`[AggressiveInlining]`): STATICCALL / DELEGATECALL return `ref UInt256.Zero`; everything else returns `ref value`.
- Added `IWorldStateExtensions.AddToBalanceAndCreateIfNotExists(this, address, ExecutionType, in value, spec)` overload that early-returns when the execution type does not credit balance.
- `VirtualMachine.RunPrecompile` and `VirtualMachine.ExecuteCall` consumer sites updated to derive the credit from `ExecutionType + Value` at the call site instead of reading it off the frame. Warmup and benchmark `Rent` call sites updated accordingly.

**Two inlining-shape micro-opts**

- `CodeInfo.Empty._analyzer` sentinel made non-null so the JIT can drop the per-call null check on analyzer access from hot consumers.
- `CodeInfoRepository._codeInfoLoader` made nullable so the default loader path inlines through a JIT-visible `is not null` branch instead of always indirecting through a delegate.

**Explicitly NOT in this PR**

Bundled into #11323 but deferred here because they did not pull weight in the JIT'd hot path:

- `VirtualMachine.ExecuteTransaction` split into `ProcessCallFrames` / `ProcessCallFramesCore` and the `_stateToDispose` pending-dispose helper.
- `ExecuteByteCode<TTracingInst, TCancelable>` specialisation and `RunByteCode` -> `DispatchExecution` rename.
- `TxExecutionState<TGasPolicy>` argument-bundle struct.
- `TryGetDelegation` -> `HasDelegation` rename family, splitting out `GetDelegatedCodeInfo`, moving `TryGetDelegatedAddress` off the interface, removing `GetExecutableCodeHash`.
- `InstructionCreate` zero-value `SubtractFromBalance` micro-opt.
- Benchmark `using System.Linq` cleanup.

Each of the above can be its own PR if a payload benchmark or JitAsm reading later justifies it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New parameterised tests in `Nethermind.Blockchain.Test/TransactionProcessorTests.cs` cover the fast-path predicate matrix: empty-code recipient with value transfer (fast), empty-code recipient with zero value (fast), contract recipient (slow), precompile recipient (slow), EIP-7702 authorisation-list transaction (slow), EIP-7702 delegated recipient with executable target (slow), restore mode (pre-execution commit preserved), state tracing (pre-execution commit preserved).
- Regression test asserting `VirtualMachine.ExecuteTransaction` is not invoked for a simple EOA value transfer.
- EIP-7708 coverage parameterised by sender == recipient and value == 0: `TransferLog` appears in receipt logs only when value > 0 and sender != recipient; `tracer.ReportLog` is called exactly once when log tracing is enabled.
- New parameterised tests in `Nethermind.Evm.Test/CallTests.cs` cover empty-code CALL / CALLCODE / DELEGATECALL / STATICCALL balance and account-touch semantics against the pre-patch baseline.
- Targeted test commands:
  - `dotnet test --project src/Nethermind/Nethermind.Blockchain.Test/Nethermind.Blockchain.Test.csproj -c release -- --filter "FullyQualifiedName~TransactionProcessor"`
  - `dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release`
  - `dotnet test --project src/Nethermind/Nethermind.Taiko.Test/Nethermind.Taiko.Test.csproj -c release`

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

- Reference: ports the load-bearing fast-path changes from #11323 with reduced churn.
- JitAsm acceptance after the EOA fast path: `ExecuteSimpleTransfer` contains no `VirtualMachine.ExecuteTransaction` call, constructs no `StackAccessTracker` / `ExecutionEnvironment` / `VmState` on the non-tracing path, and emits no pre-execution `WorldState.Commit`. After `_transferValue` removal, `ExecutionEnvironment` is 32 bytes smaller and the two consumer sites no longer load the credit off the frame.