### PR TITLE
fix(engine): add regression coverage for NewPayloadHandler task cleanup

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -11,7 +11,6 @@ using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -14,7 +14,6 @@ using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
@@ -37,8 +36,8 @@ namespace Nethermind.Merge.Plugin.Test;
 [TestFixture]
 public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
 {
-    private static readonly FieldInfo BlockValidationTasksField =
-        typeof(NewPayloadHandler).GetField("_blockValidationTasks", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo? BlockValidationTasksField =
+        typeof(NewPayloadHandler).GetField("_blockValidationTasks", BindingFlags.Instance | BindingFlags.NonPublic);
 
     [Test]
     public async Task NewPayloadV1_RaceCondition_EventHandling_Should_Not_Throw_When_Multiple_Completions()
@@ -212,7 +211,7 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
             .TestObject;
         block.Header.IsPostMerge = true;
 
-        NewPayloadHandler handler = CreateHandler(
+        using NewPayloadHandler handler = CreateHandler(
             block,
             suggestBlockResult: AddBlockResult.InvalidBlock,
             wasProcessed: false,
@@ -241,13 +240,13 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
             .Enqueue(Arg.Any<Block>(), Arg.Any<ProcessingOptions>())
             .Returns(_ => ValueTask.CompletedTask);
 
-        NewPayloadHandler handler = CreateHandler(
+        using NewPayloadHandler handler = CreateHandler(
             block,
             suggestBlockResult: AddBlockResult.Added,
             wasProcessed: false,
             validateSuggestedBlock: true,
             processingQueue: processingQueue,
-            timeoutMs: 25);
+            timeoutMs: 100);
 
         ResultWrapper<PayloadStatusV1> result = await handler.HandleAsync(ExecutionPayload.Create(block));
 
@@ -256,10 +255,14 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
             "timed out requests must not leave stale entries behind when BlockRemoved never arrives");
     }
 
-    private static int GetPendingValidationTaskCount(NewPayloadHandler handler) =>
-        (int)BlockValidationTasksField.FieldType
+    private static int GetPendingValidationTaskCount(NewPayloadHandler handler)
+    {
+        Assert.That(BlockValidationTasksField, Is.Not.Null, "_blockValidationTasks field not found - was it renamed?");
+
+        return (int)BlockValidationTasksField!.FieldType
             .GetProperty("Count", BindingFlags.Instance | BindingFlags.Public)!
             .GetValue(BlockValidationTasksField.GetValue(handler)!)!;
+    }
 
     private static NewPayloadHandler CreateHandler(
         Block block,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -3,12 +3,30 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Threading;
+using Nethermind.Crypto;
+using Nethermind.Int256;
 using Nethermind.JsonRpc;
+using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Merge.Plugin.InvalidChainTracker;
+using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
+using Nethermind.Synchronization;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Merge.Plugin.Test;
@@ -19,6 +37,9 @@ namespace Nethermind.Merge.Plugin.Test;
 [TestFixture]
 public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
 {
+    private static readonly FieldInfo BlockValidationTasksField =
+        typeof(NewPayloadHandler).GetField("_blockValidationTasks", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     [Test]
     public async Task NewPayloadV1_RaceCondition_EventHandling_Should_Not_Throw_When_Multiple_Completions()
     {
@@ -76,11 +97,11 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
 
         // All tasks should complete successfully without throwing exceptions
         Assert.That(results.Length, Is.EqualTo(concurrentCalls));
-        Assert.That(results.All(r => r != null), Is.True);
+        Assert.That(Array.TrueForAll(results, static r => r is not null), Is.True);
 
         // The results should be consistent (all should have the same status)
         ResultWrapper<PayloadStatusV1> firstResult = results[0];
-        Assert.That(results.All(r => r.Data.Status == firstResult.Data.Status), Is.True);
+        Assert.That(Array.TrueForAll(results, r => r.Data.Status == firstResult.Data.Status), Is.True);
     }
 
     [Test]
@@ -178,5 +199,136 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
 
         // If we reach here, the TrySetResult/TrySetException fix is working correctly
         Assert.Pass("TaskCompletionSource race condition handling works correctly");
+    }
+
+    [Test]
+    public async Task ValidateBlockAndProcess_cleans_up_completion_when_block_tree_rejects_before_enqueue()
+    {
+        Block block = Build.A.Block
+            .WithParentHash(TestItem.KeccakB)
+            .WithNumber(1)
+            .WithDifficulty(0)
+            .WithNonce(0)
+            .TestObject;
+        block.Header.IsPostMerge = true;
+
+        NewPayloadHandler handler = CreateHandler(
+            block,
+            suggestBlockResult: AddBlockResult.InvalidBlock,
+            wasProcessed: false,
+            validateSuggestedBlock: true);
+
+        ResultWrapper<PayloadStatusV1> result = await handler.HandleAsync(ExecutionPayload.Create(block));
+
+        Assert.That(result.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
+        Assert.That(GetPendingValidationTaskCount(handler), Is.EqualTo(0),
+            "the completion source must be removed even when SuggestBlockAsync rejects the block before enqueue");
+    }
+
+    [Test]
+    public async Task ValidateBlockAndProcess_cleans_up_completion_when_timeout_happens_before_block_removed()
+    {
+        Block block = Build.A.Block
+            .WithParentHash(TestItem.KeccakC)
+            .WithNumber(1)
+            .WithDifficulty(0)
+            .WithNonce(0)
+            .TestObject;
+        block.Header.IsPostMerge = true;
+
+        IBlockProcessingQueue processingQueue = Substitute.For<IBlockProcessingQueue>();
+        processingQueue
+            .Enqueue(Arg.Any<Block>(), Arg.Any<ProcessingOptions>())
+            .Returns(_ => ValueTask.CompletedTask);
+
+        NewPayloadHandler handler = CreateHandler(
+            block,
+            suggestBlockResult: AddBlockResult.Added,
+            wasProcessed: false,
+            validateSuggestedBlock: true,
+            processingQueue: processingQueue,
+            timeoutMs: 25);
+
+        ResultWrapper<PayloadStatusV1> result = await handler.HandleAsync(ExecutionPayload.Create(block));
+
+        Assert.That(result.Data.Status, Is.EqualTo(PayloadStatus.Syncing));
+        Assert.That(GetPendingValidationTaskCount(handler), Is.EqualTo(0),
+            "timed out requests must not leave stale entries behind when BlockRemoved never arrives");
+    }
+
+    private static int GetPendingValidationTaskCount(NewPayloadHandler handler) =>
+        (int)BlockValidationTasksField.FieldType
+            .GetProperty("Count", BindingFlags.Instance | BindingFlags.Public)!
+            .GetValue(BlockValidationTasksField.GetValue(handler)!)!;
+
+    private static NewPayloadHandler CreateHandler(
+        Block block,
+        AddBlockResult suggestBlockResult,
+        bool wasProcessed,
+        bool validateSuggestedBlock,
+        IBlockProcessingQueue? processingQueue = null,
+        int timeoutMs = 50)
+    {
+        IPayloadPreparationService payloadPreparationService = Substitute.For<IPayloadPreparationService>();
+        IBlockValidator blockValidator = Substitute.For<IBlockValidator>();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
+        IBeaconSyncStrategy beaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
+        IBeaconPivot beaconPivot = Substitute.For<IBeaconPivot>();
+        IBlockCacheService blockCacheService = Substitute.For<IBlockCacheService>();
+        IBlockProcessingQueue effectiveProcessingQueue = processingQueue ?? Substitute.For<IBlockProcessingQueue>();
+        IInvalidChainTracker invalidChainTracker = new NoopInvalidChainTracker();
+        IMergeSyncController mergeSyncController = Substitute.For<IMergeSyncController>();
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        IMergeConfig mergeConfig = new MergeConfig { TerminalTotalDifficulty = "0", NewPayloadBlockProcessingTimeout = timeoutMs };
+        IReceiptConfig receiptConfig = new ReceiptConfig();
+
+        BlockHeader parent = Build.A.BlockHeader
+            .WithHash(block.ParentHash!)
+            .WithNumber(block.Number - 1)
+            .WithDifficulty(UInt256.Zero)
+            .TestObject;
+        parent.TotalDifficulty = UInt256.Zero;
+
+        Block head = Build.A.Block.WithHeader(parent).TestObject;
+        blockTree.Head.Returns(head);
+        blockTree.SyncPivot.Returns((0L, Keccak.Zero));
+        blockTree.FindHeader(block.ParentHash!, Arg.Any<BlockTreeLookupOptions>(), Arg.Any<long?>()).Returns(parent);
+        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(false);
+        blockTree.GetInfo(parent.Number, parent.GetOrCalculateHash()).Returns((new BlockInfo(parent.Hash!, UInt256.Zero) { WasProcessed = true, BlockNumber = parent.Number }, null));
+        blockTree.SuggestBlockAsync(Arg.Any<Block>(), Arg.Any<BlockTreeSuggestOptions>())
+            .Returns(ValueTask.FromResult(suggestBlockResult));
+        blockTree.WasProcessed(block.Number, block.Hash!).Returns(wasProcessed);
+
+        blockValidator.ValidateSuggestedBlock(Arg.Any<Block>(), Arg.Any<BlockHeader>(), out Arg.Any<string?>(), false)
+            .Returns(callInfo =>
+            {
+                callInfo[2] = validateSuggestedBlock ? null : "invalid";
+                return validateSuggestedBlock;
+            });
+
+        poSSwitcher.FinalTotalDifficulty.Returns((UInt256?)UInt256.Zero);
+        poSSwitcher.TerminalTotalDifficulty.Returns((UInt256?)UInt256.Zero);
+        poSSwitcher.TransitionFinished.Returns(true);
+        beaconSyncStrategy.IsBeaconSyncFinished(Arg.Any<BlockHeader?>()).Returns(true);
+        stateReader.HasStateForBlock(parent).Returns(true);
+        effectiveProcessingQueue.Count.Returns(0);
+        effectiveProcessingQueue.Enqueue(Arg.Any<Block>(), Arg.Any<ProcessingOptions>()).Returns(_ => ValueTask.CompletedTask);
+
+        return new NewPayloadHandler(
+            payloadPreparationService,
+            blockValidator,
+            blockTree,
+            poSSwitcher,
+            beaconSyncStrategy,
+            beaconPivot,
+            blockCacheService,
+            effectiveProcessingQueue,
+            invalidChainTracker,
+            mergeSyncController,
+            mergeConfig,
+            receiptConfig,
+            stateReader,
+            LimboLogs.Instance);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -395,6 +395,12 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             // we timed out while processing the block, result will be null and we will return SYNCING below, no need to do anything
             if (_logger.IsDebug) _logger.Debug($"Block {block.ToString(Block.Format.FullHashAndNumber)} timed out when processing. Assume Syncing.");
         }
+        finally
+        {
+            // Blocks that exit before the processing queue publishes BlockRemoved would otherwise
+            // leave their completion source pinned in _blockValidationTasks forever.
+            _blockValidationTasks.TryRemove(block.Hash!, out _);
+        }
 
         return (TryCacheResult(result ?? ValidationResult.Syncing, validationMessage), validationMessage);
     }


### PR DESCRIPTION
This supersedes #10916.

The cleanup fix in #10916 is directionally correct, but it leaves the regression gap open. This draft keeps the same cleanup strategy in `NewPayloadHandler.ValidateBlockAndProcess(...)` and adds targeted coverage for the leaked exit paths.

Failure mechanism

`_blockValidationTasks` gets its entry before `SuggestBlockAsync(...)` completes. Cleanup originally depended on `BlockRemoved`, which only happens after the block reaches the processing queue. That leaves stale entries behind when the request exits early.

Semantic change

Add a `finally` cleanup in `ValidateBlockAndProcess(...)` so the handler always attempts `_blockValidationTasks.TryRemove(block.Hash!, out _)` before returning.

Preserved invariant

The normal path is unchanged. `GetProcessingQueueOnBlockRemoved(...)` already uses `TryRemove`, so the new `finally` is idempotent when the event handler removed the entry first.

Regression coverage

This draft adds focused tests for two leaked paths:

1. `SuggestBlockAsync(...)` returns `InvalidBlock` after the completion source is created but before enqueue.
2. `Enqueue(...)` returns, but `BlockRemoved` never arrives, so the request times out to `SYNCING` and still has to clean up the dictionary entry.

Testing

`dotnet test --project src/Nethermind/Nethermind.Merge.Plugin.Test/Nethermind.Merge.Plugin.Test.csproj --filter "FullyQualifiedName\~NewPayloadHandlerRaceConditionTests"`

Result: `5 passed, 0 failed`

Fixes NethermindEth/nethermind#10915
