### PR TITLE
Fix shutdown race in SnapProvider PLINQ (closes #11806)

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Synchronization.SnapSync
 
                     _progressTracker.EnqueueCodeHashes(filteredCodeHashes.AsSpan());
                 }
-                catch (AggregateException ae) when (ae.Flatten() is { InnerExceptions: var inners }
+                catch (AggregateException ae) when (ae.Flatten().InnerExceptions is { Count: > 0 } inners
                     && inners.All(e => e is ObjectDisposedException))
                 {
                     ExceptionDispatchInfo.Capture(inners[0]).Throw();

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
@@ -101,14 +102,10 @@ namespace Nethermind.Synchronization.SnapSync
 
                     _progressTracker.EnqueueCodeHashes(filteredCodeHashes.AsSpan());
                 }
-                catch (AggregateException ae) when (ae.Flatten().InnerExceptions.All(ie => ie is ObjectDisposedException))
+                catch (AggregateException ae) when (ae.Flatten() is { InnerExceptions: var inners }
+                    && inners.All(e => e is ObjectDisposedException))
                 {
-                    // PLINQ wraps ObjectDisposedException from `_codeDb.KeyExists` (when the
-                    // DB is being disposed during shutdown) in AggregateException. Re-throw
-                    // the bare form so the dispatcher's existing
-                    // `catch (ObjectDisposedException) → Info("Ignoring sync response as the
-                    // DB has already closed.")` handles it uniformly without a noisy ERROR.
-                    throw (ObjectDisposedException)ae.Flatten().InnerExceptions[0];
+                    ExceptionDispatchInfo.Capture(inners[0]).Throw();
                 }
 
                 ValueHash256 nextPath = accounts[^1].Path.IncrementPath();

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -88,16 +88,28 @@ namespace Nethermind.Synchronization.SnapSync
                     _progressTracker.EnqueueAccountStorage(item);
                 }
 
-                using ArrayPoolListRef<ValueHash256> filteredCodeHashes = codeHashes.AsParallel().Where((code) =>
+                try
                 {
-                    if (_codeExistKeyCache.Get(code)) return false;
+                    using ArrayPoolListRef<ValueHash256> filteredCodeHashes = codeHashes.AsParallel().Where((code) =>
+                    {
+                        if (_codeExistKeyCache.Get(code)) return false;
 
-                    bool exist = _codeDb.KeyExists(code.Bytes);
-                    if (exist) _codeExistKeyCache.Set(code);
-                    return !exist;
-                }).ToPooledListRef(codeHashes.Count);
+                        bool exist = _codeDb.KeyExists(code.Bytes);
+                        if (exist) _codeExistKeyCache.Set(code);
+                        return !exist;
+                    }).ToPooledListRef(codeHashes.Count);
 
-                _progressTracker.EnqueueCodeHashes(filteredCodeHashes.AsSpan());
+                    _progressTracker.EnqueueCodeHashes(filteredCodeHashes.AsSpan());
+                }
+                catch (AggregateException ae) when (ae.Flatten().InnerExceptions.All(ie => ie is ObjectDisposedException))
+                {
+                    // PLINQ wraps ObjectDisposedException from `_codeDb.KeyExists` (when the
+                    // DB is being disposed during shutdown) in AggregateException. Re-throw
+                    // the bare form so the dispatcher's existing
+                    // `catch (ObjectDisposedException) → Info("Ignoring sync response as the
+                    // DB has already closed.")` handles it uniformly without a noisy ERROR.
+                    throw (ObjectDisposedException)ae.Flatten().InnerExceptions[0];
+                }
 
                 ValueHash256 nextPath = accounts[^1].Path.IncrementPath();
                 _progressTracker.UpdateAccountRangePartitionProgress(effectiveHashLimit, nextPath, moreChildrenToRight);


### PR DESCRIPTION
## Summary

- Fixes #11806 — `SnapProvider.AddAccountRange` PLINQ accesses `_codeDb` (RocksDB) on shutdown after the DB has been disposed; PLINQ wraps the resulting `ObjectDisposedException` in `AggregateException`, bypassing the snap dispatcher's existing `catch (ObjectDisposedException) → Info(...)` guard and landing on the generic `catch (Exception) → Error("Error when handling response", e)` path.
- Wraps the `AsParallel().Where(...).ToPooledListRef(...)` call in a `try/catch (AggregateException) when (… all inner == ObjectDisposedException)` that re-throws the bare `ObjectDisposedException`, so the dispatcher's already-existing benign log path handles it.
- Sync correctness is unaffected — node recovers cleanly on restart; this PR only stops the misleading `ERROR` line that's currently turning post-merge fuzz tests red across hoodi/gnosis/sepolia/mainnet/chiado/OP networks in the 1.38 release smoke run (see #11806 for the production log artifact reference).

## Where it was introduced

The PLINQ `AsParallel + _codeDb.KeyExists` pattern landed in #6873 ("Perf/dont redownload downloaded code", commit `7059b455`, 2024-03-28). The same race exists in `release/1.37.x` and `release/1.38.x` — it's long-standing latent log noise, not a 1.38 regression. Visibility increased now because the fuzz `StabilityVerification` watchdog scans EL logs on every kill/restart cycle and reliably catches the race under heavy parallel snap workload.

## Why the dispatcher's existing guard didn't catch it

Both `SimpleDispatcher.HandleResponse` (1.38+) and `SyncDispatcher.DoHandleResponse` (≤1.37.x) already do:

```csharp
catch (ObjectDisposedException)
{
    if (_logger.IsInfo) _logger.Info("Ignoring sync response as the DB has already closed.");
}
```

…but PLINQ aggregates per-partition exceptions into `AggregateException` when surfacing from `ToPooledListRef(...)`. The wrapped form is matched by `catch (Exception)` rather than `catch (ObjectDisposedException)`. Re-throwing the bare `ObjectDisposedException` at the SnapProvider site keeps the change minimal and avoids duplicating the unwrap logic across two dispatchers.

## Test plan

- [ ] Add a regression test injecting an `IDb` stub whose `KeyExists` throws `ObjectDisposedException` and asserting that `AddAccountRange` propagates a **bare** `ObjectDisposedException` (not `AggregateException`). Pattern: Autofac `.AddKeyedSingleton<IDb>(DbNames.Code, _ => new ThrowingCodeDbStub())` over `TestSynchronizerModule` (see `StateSyncFeedTestsBase.cs:123`).
- [x] Local Docker build verified against `nethermindeth/nethermind:fix-snap-shutdown-disposal-race`.
- [ ] Post-merge fuzz smoke run on `fix/snap-shutdown-disposal-race`. **Blocked**: NethermindEth/post-merge-smoke-tests `receive-push-notification.yml` has been failing at `capture_tests_for_branch` for all branches (master canary included) since ~04:08Z 2026-05-28; logs return `BlobNotFound` from the Azure log blob store. Three FuzzHL/HLo/HP dispatches on this branch (runs 26555857938 / 26555861955 / 26555866079) and a fresh master canary (26559037988) all hit the same infrastructure failure. Will re-run once the smoke-tests workflow recovers.
- [x] Test-harness allowlist workaround landed at [`nethermind-node-tests@195d2c1`](https://github.com/NethermindEth/nethermind-node-tests/commit/195d2c1) so the 1.38 release isn't blocked while this PR is in review. The allowlist entry can be removed once this PR ships.
