### PR TITLE
XDC Add Timestamper 

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -171,6 +171,7 @@ public class XdcTestBlockchain : TestBlockchain
             .AddSingleton((_) => BlockProducer)
             //.AddSingleton((_) => BlockProducerRunner)
             .AddSingleton<IRewardCalculator, ZeroRewardCalculator>()
+            .AddSingleton<ITimestamper>((_) => Timestamper)
             .AddSingleton<IBlockProducerRunner, XdcHotStuff>()
 
             .AddSingleton<ITxPool>((ctx) =>
@@ -548,6 +549,7 @@ public class XdcTestBlockchain : TestBlockchain
             //by setting the correct signer the block producer runner should trigger trying to propose a block
             Address leader = ConsensusModule.GetLeaderAddress(head, XdcContext.CurrentRound, spec);
             Signer.SetSigner(MasterNodeCandidates.First(k => k.Address == leader));
+            Timestamper.Set(DateTimeOffset.FromUnixTimeSeconds((long)(head.Timestamp + (ulong)spec.MinePeriod)).UtcDateTime);
             ConsensusModule.StartRoundTask(head, XdcContext.CurrentRound);
 
             Task waitingForHead = await Task.WhenAny(newHeadWaitHandle.Task, Task.Delay(10_000));

--- a/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
@@ -28,6 +28,7 @@ namespace Nethermind.Xdc
         IVotesManager votesManager,
         ISigner signer,
         ITimeoutTimer timeoutTimer,
+        ITimestamper timestamper,
         ILogManager logManager) : IBlockProducerRunner
     {
         private readonly IBlockTree _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -39,6 +40,7 @@ namespace Nethermind.Xdc
         private readonly IVotesManager _votesManager = votesManager ?? throw new ArgumentNullException(nameof(votesManager));
         private readonly ISigner _signer = signer ?? throw new ArgumentNullException(nameof(signer));
         private readonly ITimeoutTimer _timeoutTimer = timeoutTimer ?? throw new ArgumentNullException(nameof(timeoutTimer));
+        private readonly ITimestamper _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
         private readonly ILogger _logger = logManager?.GetClassLogger<XdcHotStuff>() ?? throw new ArgumentNullException(nameof(logManager));
 
         private readonly object _lockObject = new();
@@ -215,7 +217,7 @@ namespace Nethermind.Xdc
             if (!TryAdvance(ref _highestSelfMinedRound, (long)round)) return;
 
             // Gate 1: enforce minimum mine period since parent block was produced
-            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            long now = _timestamper.UnixTime.SecondsLong;
             long mineReadyAt = (long)proposalParent.Timestamp + proposalSpec.MinePeriod;
             if (mineReadyAt > now)
                 await Task.Delay(TimeSpan.FromSeconds(mineReadyAt - now), ct);
@@ -229,7 +231,7 @@ namespace Nethermind.Xdc
             if (!headHasQc)
             {
                 long fallbackReadyAt = (long)head.Timestamp + proposalSpec.TimeoutPeriod / 2;
-                now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                now = _timestamper.UnixTime.SecondsLong;
                 if (fallbackReadyAt > now)
                     await Task.Delay(TimeSpan.FromSeconds(fallbackReadyAt - now), ct);
             }
@@ -251,7 +253,7 @@ namespace Nethermind.Xdc
                 {
                     Round = currentRound,
                     QuorumCertificate = qc,
-                    Timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    Timestamp = _timestamper.UnixTime.Seconds
                 };
 
                 Block? proposedBlock = await _blockBuilder.BuildBlock(parent, null, payloadAttributes, IBlockProducer.Flags.None, ct);

--- a/src/Nethermind/Nethermind.Xdc/XdcPlugin.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcPlugin.cs
@@ -7,6 +7,7 @@ using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
+using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
@@ -54,6 +55,7 @@ public class XdcPlugin(ChainSpec chainSpec) : IConsensusPlugin
             _nethermindApi.Context.Resolve<IVotesManager>(),
             _nethermindApi.Context.Resolve<ISigner>(),
             _nethermindApi.Context.Resolve<ITimeoutTimer>(),
+            _nethermindApi.Context.Resolve<ITimestamper>(),
             _nethermindApi.Context.Resolve<ILogManager>()
             );
     public IBlockProducer InitBlockProducer()


### PR DESCRIPTION
## Summary

  `XdcHotStuff` was calling `DateTimeOffset.UtcNow` directly, so tests had to sleep for real between blocks (2 s per block). This PR injects `ITimestamper` so tests can control the clock and skip the wait entirely.

  ## Changes
  
  - **`XdcHotStuff`** — use `ITimestamper` instead of `DateTimeOffset.UtcNow` for timing checks and block timestamps


  ## Type of change

  - [x] Refactoring (no functional change)

  ## Testing

  Tests that produce multiple blocks no longer wait for real wall-clock time between rounds.

