### PR TITLE
Fix FlatSnapServer trie node response limit

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.Sync.Snap;
 using Nethermind.State.Snap;
@@ -82,6 +83,35 @@ public class FlatSnapServerTests
         Assert.That(result.Count, Is.LessThan(RequestCount));
     }
 
+    [Test]
+    public void GetTrieNodes_RespectsHardResponseByteLimitInStorageLoop()
+    {
+        // Rebuild state with a single account whose storage root is persisted, so the
+        // storage inner loop is actually reached (state-tree navigation needs the leaf, not
+        // just the root).
+        Hash256 addressHash = Keccak.Compute(TestItem.AddressA.Bytes);
+        Hash256 storageRoot = BuildAndPersistStorageRoot(addressHash, out byte[] storageRootRlp);
+        byte[] stateRootRlp = BuildSingleAccountStateRoot(addressHash, storageRoot, out _rootHash);
+        _stateId = new StateId(0, _rootHash.ValueHash256);
+
+        _flatDbManager.GatherReadOnlySnapshotBundle(_stateId)
+            .Returns(_ => new ReadOnlySnapshotBundle(new SnapshotPooledList(0), _persistence.CreateReader(), recordDetailedMetrics: false));
+
+        WriteState(stateRootRlp, addressHash, storageRootRlp);
+
+        // Single PathGroup with one account path followed by RequestCount empty storage paths.
+        // Each iteration returns the (non-empty) storage root, so the inner reqStorage loop
+        // must hit the byte limit before completing.
+        byte[][] group = new byte[RequestCount + 1][];
+        group[0] = addressHash.Bytes.ToArray();
+        for (int i = 1; i <= RequestCount; i++) group[i] = [];
+
+        using RlpPathGroupList pathSet = PathGroup.EncodeToRlpPathGroupList([new PathGroup { Group = group }]);
+        using IByteArrayList result = _server.GetTrieNodes(pathSet, _rootHash, CancellationToken.None)!;
+
+        Assert.That(result.Count, Is.LessThan(RequestCount));
+    }
+
     private static byte[] BuildRootRlp(out Hash256 rootHash)
     {
         using MemDb trieDb = new();
@@ -98,6 +128,38 @@ public class FlatSnapServerTests
         return tree.GetNodeByPath([], rootHash)!;
     }
 
+    private static Hash256 BuildAndPersistStorageRoot(Hash256 addressHash, out byte[] rootRlp)
+    {
+        using MemDb storageDb = new();
+        RawScopedTrieStore storageStore = new(storageDb, addressHash);
+        StorageTree storageTree = new(storageStore, Keccak.EmptyTreeHash, LimboLogs.Instance);
+
+        // 32 populated slots produces a branch-heavy root well above the per-iteration size
+        // we need to push the total response past HardResponseByteLimit (2 MB / RequestCount).
+        for (int i = 0; i < 32; i++)
+        {
+            storageTree.Set(Keccak.Compute(i.ToBigEndianByteArray()).Bytes, Rlp.Encode((UInt256)i + 1));
+        }
+
+        storageTree.Commit();
+        rootRlp = storageTree.GetNodeByPath([], storageTree.RootHash)!;
+        return storageTree.RootHash;
+    }
+
+    private static byte[] BuildSingleAccountStateRoot(Hash256 addressHash, Hash256 storageRoot, out Hash256 rootHash)
+    {
+        using MemDb trieDb = new();
+        RawScopedTrieStore trieStore = new(trieDb);
+        StateTree tree = new(trieStore, LimboLogs.Instance);
+
+        Account account = Build.An.Account.WithBalance(1).WithStorageRoot(storageRoot).TestObject;
+        tree.Set(addressHash, account);
+
+        tree.Commit();
+        rootHash = tree.RootHash;
+        return tree.GetNodeByPath([], rootHash)!;
+    }
+
     private void WriteStateTrieRoot(byte[] rootRlp)
     {
         StateId currentState;
@@ -108,5 +170,18 @@ public class FlatSnapServerTests
 
         using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(currentState, _stateId, WriteFlags.DisableWAL);
         batch.SetStateTrieNode(TreePath.Empty, rootRlp);
+    }
+
+    private void WriteState(byte[] stateRootRlp, Hash256 storageAddressHash, byte[] storageRootRlp)
+    {
+        StateId currentState;
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            currentState = reader.CurrentState;
+        }
+
+        using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(currentState, _stateId, WriteFlags.DisableWAL);
+        batch.SetStateTrieNode(TreePath.Empty, stateRootRlp);
+        batch.SetStorageTrieNode(storageAddressHash, TreePath.Empty, storageRootRlp);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
@@ -10,8 +10,6 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.State;
-using Nethermind.State.Flat;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.Sync.Snap;
 using Nethermind.State.Snap;

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.State.Flat.Sync.Snap;
+using Nethermind.State.Snap;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Sync.Snap;
+
+[TestFixture]
+public class FlatSnapServerTests
+{
+    private const int RequestCount = 5000;
+
+    private SnapshotableMemColumnsDb<FlatDbColumns> _columnsDb = null!;
+    private IPersistence _persistence = null!;
+    private MemDb _codeDb = null!;
+    private IFlatDbManager _flatDbManager = null!;
+    private IFlatStateRootIndex _stateRootIndex = null!;
+    private FlatSnapServer _server = null!;
+    private Hash256 _rootHash = null!;
+    private StateId _stateId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
+        _persistence = new RocksDbPersistence(_columnsDb);
+        _codeDb = new MemDb();
+
+        byte[] rootRlp = BuildRootRlp(out _rootHash);
+        _stateId = new StateId(0, _rootHash.ValueHash256);
+        WriteStateTrieRoot(rootRlp);
+
+        _flatDbManager = Substitute.For<IFlatDbManager>();
+        _flatDbManager.GatherReadOnlySnapshotBundle(_stateId)
+            .Returns(_ => new ReadOnlySnapshotBundle(new SnapshotPooledList(0), _persistence.CreateReader(), recordDetailedMetrics: false));
+
+        _stateRootIndex = Substitute.For<IFlatStateRootIndex>();
+        _stateRootIndex.TryGetStateId(Arg.Any<Hash256>(), out Arg.Any<StateId>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = _stateId;
+                return true;
+            });
+
+        _server = new FlatSnapServer(_flatDbManager, _codeDb, _stateRootIndex, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _codeDb.Dispose();
+        _columnsDb.Dispose();
+    }
+
+    [Test]
+    public void GetTrieNodes_RespectsHardResponseByteLimit()
+    {
+        PathGroup[] groups = new PathGroup[RequestCount];
+        for (int i = 0; i < RequestCount; i++)
+        {
+            groups[i] = new PathGroup { Group = [[]] };
+        }
+
+        using RlpPathGroupList pathSet = PathGroup.EncodeToRlpPathGroupList(groups);
+        using IByteArrayList result = _server.GetTrieNodes(pathSet, _rootHash, CancellationToken.None)!;
+
+        Assert.That(result.Count, Is.LessThan(RequestCount));
+    }
+
+    private static byte[] BuildRootRlp(out Hash256 rootHash)
+    {
+        using MemDb trieDb = new();
+        RawScopedTrieStore trieStore = new(trieDb);
+        StateTree tree = new(trieStore, LimboLogs.Instance);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            tree.Set(Keccak.Compute(i.ToBigEndianByteArray()), Build.An.Account.WithBalance((UInt256)i).TestObject);
+        }
+
+        tree.Commit();
+        rootHash = tree.RootHash;
+        return tree.GetNodeByPath([], rootHash)!;
+    }
+
+    private void WriteStateTrieRoot(byte[] rootRlp)
+    {
+        StateId currentState;
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            currentState = reader.CurrentState;
+        }
+
+        using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(currentState, _stateId, WriteFlags.DisableWAL);
+        batch.SetStateTrieNode(TreePath.Empty, rootRlp);
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -70,7 +70,7 @@ public class FlatSnapServer(
                         try
                         {
                             byte[]? rlp = tree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[0]), stateId.StateRoot.ToCommitment());
-                            response.Add(rlp!);
+                            response.Add(rlp ?? []);
                             responseSize += rlp?.Length ?? 0;
                         }
                         catch (MissingTrieNodeException)
@@ -94,7 +94,7 @@ public class FlatSnapServer(
                                 for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
                                 {
                                     byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
-                                    response.Add(sRlp!);
+                                    response.Add(sRlp ?? []);
                                     responseSize += sRlp?.Length ?? 0;
                                 }
                             }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -56,8 +56,9 @@ public class FlatSnapServer(
             ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
             StateTree tree = new(trieStore, logManager);
             bool abort = false;
+            long responseSize = 0;
 
-            for (int i = 0; i < pathLength && !abort && !cancellationToken.IsCancellationRequested; i++)
+            for (int i = 0; i < pathLength && !abort && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; i++)
             {
                 byte[][]? requestedPath = pathSet[i].Group;
                 switch (requestedPath.Length)
@@ -70,6 +71,7 @@ public class FlatSnapServer(
                         {
                             byte[]? rlp = tree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[0]), stateId.StateRoot.ToCommitment());
                             response.Add(rlp!);
+                            responseSize += rlp?.Length ?? 0;
                         }
                         catch (MissingTrieNodeException)
                         {
@@ -89,10 +91,11 @@ public class FlatSnapServer(
                                 Hash256? storageRoot = account.StorageRoot;
                                 StorageTree sTree = new(trieStore.GetStorageTrieStore(storagePath), storageRoot, logManager);
 
-                                for (int reqStorage = 1; reqStorage < requestedPath.Length; reqStorage++)
+                                for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
                                 {
                                     byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
                                     response.Add(sRlp!);
+                                    responseSize += sRlp?.Length ?? 0;
                                 }
                             }
                         }


### PR DESCRIPTION
## Changes

- Enforce the hard response byte limit in `FlatSnapServer.GetTrieNodes` for account trie node requests.
- Apply the same limit inside the storage trie node loop and honor cancellation there as well.
- Add a regression test covering repeated flat snap trie-node requests stopping before the full request is returned.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet format whitespace src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj --include src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs`
- `dotnet test --project src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj -c release -- --filter FullyQualifiedName~FlatSnapServerTests`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
