### PR TITLE
XDC Small optmizations

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestHelper.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestHelper.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
@@ -8,9 +12,6 @@ using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.RLP;
 using Nethermind.Xdc.Types;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nethermind.Xdc.Test.Helpers;
 
@@ -34,14 +35,12 @@ internal static class XdcTestHelper
 
     public static Signature[] CreateVoteSignatures(BlockRoundInfo roundInfo, ulong gapNumber, PrivateKey[] keys)
     {
-        VoteDecoder encoder = new();
-        IEnumerable<Signature> signatures = keys.Select(k =>
-        {
-            KeccakRlpStream stream = new();
-            encoder.Encode(stream, new Vote(roundInfo, gapNumber), RlpBehaviors.ForSealing);
-            return ecdsa.Sign(k, stream.GetValueHash());
-        }).ToArray();
-        return signatures.ToArray();
+        KeccakRlpStream stream = new();
+        decoder.Encode(stream, new Vote(roundInfo, gapNumber), RlpBehaviors.ForSealing);
+        ValueHash256 hash = stream.GetValueHash();
+        Signature[] signatures = new Signature[keys.Length];
+        Parallel.For(0, keys.Length, i => signatures[i] = ecdsa.Sign(keys[i], hash));
+        return signatures;
     }
 
     public static Timeout BuildSignedTimeout(PrivateKey key, ulong round, ulong gap)

--- a/src/Nethermind/Nethermind.Xdc/BaseEpochSwitchManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/BaseEpochSwitchManager.cs
@@ -38,6 +38,12 @@ internal abstract class BaseEpochSwitchManager(ISpecProvider xdcSpecProvider, IB
 
         while (!IsEpochSwitchAtBlock(header))
         {
+            if (EpochSwitches.TryGet(header.ParentHash!, out EpochSwitchInfo cached))
+            {
+                EpochSwitches.Set(headerHash, cached);
+                return cached;
+            }
+
             header = (XdcBlockHeader)(Tree.FindHeader(header.ParentHash!) ?? throw new InvalidOperationException($"Parent block {header.ParentHash} not found while walking to epoch switch"));
         }
 


### PR DESCRIPTION
## Changes
  
  - **Epoch switch cache shortcut** - Before this change, every new block to walked all the way back to the epoch-switch block, which is ~450 ancestor lookups. This cuts lookups to 0 in the common case. Significantly faster

- **Test helper: parallel signature creation** - It now hashes once and signs all keys in parallel. 

## Types of changes

  - [x] Optimization


