### PR TITLE
fix: count committed system tx gas metrics

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Helpers/EvmTestHarness.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Helpers/EvmTestHarness.cs
@@ -78,6 +78,15 @@ public sealed class EvmTestHarness : IDisposable
     public void ExecuteTx(Transaction tx, Block block, ITxTracer? tracer = null) =>
         TxProcessor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer ?? NullTxTracer.Instance);
 
+    /// <summary>
+    /// Runs <paramref name="tx"/> against <paramref name="block"/>'s header with explicit execution options.
+    /// </summary>
+    public TransactionResult ProcessTx(Transaction tx, Block block, ExecutionOptions options, ITxTracer? tracer = null)
+    {
+        TxProcessor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)));
+        return TxProcessor.Process(tx, tracer ?? NullTxTracer.Instance, options);
+    }
+
     public void Dispose()
     {
         _scope.Dispose();

--- a/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
@@ -161,9 +161,9 @@ public class MetricsIntegrationTests
     }
 
     [TestCase(ExecutionOptions.Commit, false, 1, TestName = "Block gas metrics count committed transactions")]
+    [TestCase(ExecutionOptions.Commit, true, 1, TestName = "Block gas metrics count committed system transactions")]
     [TestCase(ExecutionOptions.CommitAndRestore, false, 0, TestName = "Block gas metrics skip call-and-restore transactions")]
     [TestCase(ExecutionOptions.SkipValidationAndCommit, true, 0, TestName = "Block gas metrics skip trace-style system calls")]
-    [TestCase(ExecutionOptions.SkipValidationAndCommit | ExecutionOptions.OriginalValidate, true, 1, TestName = "Block gas metrics count committed system transactions with original validate marker")]
     public void Block_gas_metrics_track_only_block_like_execution_modes(ExecutionOptions options, bool useSystemCall, long expectedTransactions)
     {
         Metrics.ResetBlockStats();

--- a/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
@@ -8,6 +8,8 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Test.Helpers;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using Nethermind.Specs.Forks;
 using NUnit.Framework;
 using DbMetrics = Nethermind.Db.Metrics;
@@ -157,4 +159,41 @@ public class MetricsIntegrationTests
 
         Assert.That(Metrics.MainThreadEip7702DelegationsCleared - startCleared, Is.EqualTo(1));
     }
+
+    [TestCase(ExecutionOptions.Commit, false, 1, TestName = "Block gas metrics count committed transactions")]
+    [TestCase(ExecutionOptions.CommitAndRestore, false, 0, TestName = "Block gas metrics skip call-and-restore transactions")]
+    [TestCase(ExecutionOptions.SkipValidationAndCommit, true, 1, TestName = "Block gas metrics count committed system transactions with extra flags")]
+    public void Block_gas_metrics_track_only_block_like_execution_modes(ExecutionOptions options, bool useSystemCall, long expectedTransactions)
+    {
+        Metrics.ResetBlockStats();
+
+        Transaction tx = useSystemCall ? CreateSystemCall() : CreateCommittedTransfer();
+        Block block = _harness.CreateBlock(tx);
+
+        _ = _harness.ProcessTx(tx, block, options);
+
+        Assert.That(Metrics.BlockTransactions, Is.EqualTo(expectedTransactions));
+    }
+
+    private Transaction CreateCommittedTransfer()
+    {
+        PrivateKey sender = TestItem.PrivateKeyA;
+        _harness.WorldState.CreateAccount(sender.Address, 10.Ether);
+
+        return Build.A.Transaction.WithTo(TestItem.AddressB).WithValue(1.Ether)
+            .WithGasPrice(1.GWei)
+            .WithGasLimit(21_000)
+            .SignedAndResolved(_harness.Ecdsa, sender, true)
+            .TestObject;
+    }
+
+    private static SystemCall CreateSystemCall() => new()
+    {
+        SenderAddress = Address.SystemUser,
+        To = TestItem.AddressC,
+        Value = UInt256.Zero,
+        GasPrice = 1.GWei,
+        GasLimit = 30_000_000,
+        Data = Array.Empty<byte>(),
+    };
 }

--- a/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
@@ -163,6 +163,7 @@ public class MetricsIntegrationTests
     [TestCase(ExecutionOptions.Commit, false, 1, TestName = "Block gas metrics count committed transactions")]
     [TestCase(ExecutionOptions.CommitAndRestore, false, 0, TestName = "Block gas metrics skip call-and-restore transactions")]
     [TestCase(ExecutionOptions.SkipValidationAndCommit, true, 0, TestName = "Block gas metrics skip trace-style system calls")]
+    [TestCase(ExecutionOptions.SkipValidationAndCommit | ExecutionOptions.OriginalValidate, true, 1, TestName = "Block gas metrics count committed system transactions with original validate marker")]
     public void Block_gas_metrics_track_only_block_like_execution_modes(ExecutionOptions options, bool useSystemCall, long expectedTransactions)
     {
         Metrics.ResetBlockStats();
@@ -173,19 +174,6 @@ public class MetricsIntegrationTests
         _ = _harness.ProcessTx(tx, block, options);
 
         Assert.That(Metrics.BlockTransactions, Is.EqualTo(expectedTransactions));
-    }
-
-    [Test]
-    public void Block_gas_metrics_count_committed_system_transactions_with_original_validate_marker()
-    {
-        Metrics.ResetBlockStats();
-
-        Transaction tx = CreateSystemCall();
-        Block block = _harness.CreateBlock(tx);
-
-        _ = _harness.ProcessTx(tx, block, ExecutionOptions.SkipValidationAndCommit | ExecutionOptionFlags.OriginalValidate);
-
-        Assert.That(Metrics.BlockTransactions, Is.EqualTo(1));
     }
 
     private Transaction CreateCommittedTransfer()

--- a/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/MetricsIntegrationTests.cs
@@ -162,7 +162,7 @@ public class MetricsIntegrationTests
 
     [TestCase(ExecutionOptions.Commit, false, 1, TestName = "Block gas metrics count committed transactions")]
     [TestCase(ExecutionOptions.CommitAndRestore, false, 0, TestName = "Block gas metrics skip call-and-restore transactions")]
-    [TestCase(ExecutionOptions.SkipValidationAndCommit, true, 1, TestName = "Block gas metrics count committed system transactions with extra flags")]
+    [TestCase(ExecutionOptions.SkipValidationAndCommit, true, 0, TestName = "Block gas metrics skip trace-style system calls")]
     public void Block_gas_metrics_track_only_block_like_execution_modes(ExecutionOptions options, bool useSystemCall, long expectedTransactions)
     {
         Metrics.ResetBlockStats();
@@ -173,6 +173,19 @@ public class MetricsIntegrationTests
         _ = _harness.ProcessTx(tx, block, options);
 
         Assert.That(Metrics.BlockTransactions, Is.EqualTo(expectedTransactions));
+    }
+
+    [Test]
+    public void Block_gas_metrics_count_committed_system_transactions_with_original_validate_marker()
+    {
+        Metrics.ResetBlockStats();
+
+        Transaction tx = CreateSystemCall();
+        Block block = _harness.CreateBlock(tx);
+
+        _ = _harness.ProcessTx(tx, block, ExecutionOptions.SkipValidationAndCommit | ExecutionOptionFlags.OriginalValidate);
+
+        Assert.That(Metrics.BlockTransactions, Is.EqualTo(1));
     }
 
     private Transaction CreateCommittedTransfer()

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -49,7 +49,7 @@ public enum ExecutionOptions
     CommitAndRestore = Commit | Restore | SkipValidation,
 
     /// <summary>
-    /// Preserve original validation semantics for system transactions that are re-routed through skip-validation execution.
+    /// Internal marker set for committed system-transaction paths that still need original validation semantics.
     /// </summary>
-    OriginalValidate = 2 << 30,
+    OriginalValidate = 1 << 30,
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -46,10 +46,10 @@ public enum ExecutionOptions
     /// <summary>
     /// Commit and later restore state also skip validation, use for CallAndRestore
     /// </summary>
-    CommitAndRestore = Commit | Restore | SkipValidation
-}
+    CommitAndRestore = Commit | Restore | SkipValidation,
 
-internal static class ExecutionOptionFlags
-{
-    internal const ExecutionOptions OriginalValidate = (ExecutionOptions)(2 << 30);
+    /// <summary>
+    /// Preserve original validation semantics for system transactions that are re-routed through skip-validation execution.
+    /// </summary>
+    OriginalValidate = 2 << 30,
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -48,8 +48,4 @@ public enum ExecutionOptions
     /// </summary>
     CommitAndRestore = Commit | Restore | SkipValidation,
 
-    /// <summary>
-    /// Internal marker set for committed system-transaction paths that still need original validation semantics.
-    /// </summary>
-    OriginalValidate = 1 << 30,
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -48,3 +48,8 @@ public enum ExecutionOptions
     /// </summary>
     CommitAndRestore = Commit | Restore | SkipValidation
 }
+
+internal static class ExecutionOptionFlags
+{
+    internal const ExecutionOptions OriginalValidate = (ExecutionOptions)(2 << 30);
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -47,5 +47,4 @@ public enum ExecutionOptions
     /// Commit and later restore state also skip validation, use for CallAndRestore
     /// </summary>
     CommitAndRestore = Commit | Restore | SkipValidation,
-
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -17,6 +17,10 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
     private readonly bool _isAura;
+    /// <summary>
+    /// Hacky flag to execution options, to pass information how original validate should behave.
+    /// Needed to decide if we need to subtract transaction value.
+    /// </summary>
     private const ExecutionOptions OriginalValidate = (ExecutionOptions)(1 << 30);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -45,7 +45,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
         return base.Execute(tx, tracer, ((coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit))
-            ? opts | ExecutionOptionFlags.OriginalValidate | ExecutionOptions.SkipValidationAndCommit
+            ? opts | ExecutionOptions.OriginalValidate | ExecutionOptions.SkipValidationAndCommit
             : opts);
     }
 
@@ -71,7 +71,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
     protected override void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
     {
-        if (opts.HasFlag(ExecutionOptionFlags.OriginalValidate))
+        if (opts.HasFlag(ExecutionOptions.OriginalValidate))
         {
             base.PayValue(tx, spec, opts);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -17,6 +17,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
     private readonly bool _isAura;
+    private const ExecutionOptions OriginalValidate = (ExecutionOptions)(1 << 30);
 
     /// <summary>
     /// Initializes a processor for system-transaction execution paths.
@@ -44,7 +45,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
         return base.Execute(tx, tracer, !coreOpts.HasFlag(ExecutionOptions.SkipValidation)
-            ? opts | ExecutionOptions.OriginalValidate | ExecutionOptions.SkipValidationAndCommit
+            ? opts | OriginalValidate | ExecutionOptions.SkipValidationAndCommit
             : opts);
     }
 
@@ -70,7 +71,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
     protected override void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
     {
-        if (opts.HasFlag(ExecutionOptions.OriginalValidate))
+        if (opts.HasFlag(OriginalValidate))
         {
             base.PayValue(tx, spec, opts);
         }
@@ -82,7 +83,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
             effectiveGasPrice);
 
     private static bool ShouldUpdateCommittedSystemMetrics(ExecutionOptions opts) =>
-        opts.HasFlag(ExecutionOptions.OriginalValidate)
+        opts.HasFlag(OriginalValidate)
         && !opts.HasFlag(ExecutionOptions.Restore)
         && !opts.HasFlag(ExecutionOptions.Warmup);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -22,8 +22,6 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
     /// Hacky flag to execution options, to pass information how original validate should behave.
     /// Needed to decide if we need to subtract transaction value.
     /// </summary>
-    private const int OriginalValidate = 2 << 30;
-
     public SystemTransactionProcessor(
         ITransactionProcessor.IBlobBaseFeeCalculator blobBaseFeeCalculator,
         ISpecProvider? specProvider,
@@ -47,7 +45,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
         return base.Execute(tx, tracer, ((coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit))
-            ? opts | (ExecutionOptions)OriginalValidate | ExecutionOptions.SkipValidationAndCommit
+            ? opts | ExecutionOptionFlags.OriginalValidate | ExecutionOptions.SkipValidationAndCommit
             : opts);
     }
 
@@ -73,7 +71,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
 
     protected override void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
     {
-        if (opts.HasFlag((ExecutionOptions)OriginalValidate))
+        if (opts.HasFlag(ExecutionOptionFlags.OriginalValidate))
         {
             base.PayValue(tx, spec, opts);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -76,6 +76,16 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
         }
     }
 
+    protected override void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice) =>
+        base.UpdateMetrics(
+            ShouldUpdateCommittedSystemMetrics(opts) ? ExecutionOptions.Commit : opts,
+            effectiveGasPrice);
+
+    private static bool ShouldUpdateCommittedSystemMetrics(ExecutionOptions opts) =>
+        opts.HasFlag(ExecutionOptions.OriginalValidate)
+        && !opts.HasFlag(ExecutionOptions.Restore)
+        && !opts.HasFlag(ExecutionOptions.Warmup);
+
     protected override IntrinsicGas<TGasPolicy> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec, long blockGasLimit)
     {
         if (tx is not SystemCall)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -19,8 +19,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
     private readonly bool _isAura;
 
     /// <summary>
-    /// Hacky flag to execution options, to pass information how original validate should behave.
-    /// Needed to decide if we need to subtract transaction value.
+    /// Initializes a processor for system-transaction execution paths.
     /// </summary>
     public SystemTransactionProcessor(
         ITransactionProcessor.IBlobBaseFeeCalculator blobBaseFeeCalculator,
@@ -44,7 +43,7 @@ public sealed class SystemTransactionProcessor<TGasPolicy> : TransactionProcesso
         }
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
-        return base.Execute(tx, tracer, ((coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit))
+        return base.Execute(tx, tracer, !coreOpts.HasFlag(ExecutionOptions.SkipValidation)
             ? opts | ExecutionOptions.OriginalValidate | ExecutionOptions.SkipValidationAndCommit
             : opts);
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
 
-            UpdateMetrics(tx, opts, effectiveGasPrice);
+            UpdateMetrics(opts, effectiveGasPrice);
 
             bool deleteCallerAccount = RecoverSenderIfNeeded(tx, spec, opts, effectiveGasPrice);
 
@@ -566,9 +566,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual IReleaseSpec GetSpec(BlockHeader header) => VirtualMachine.BlockExecutionContext.Spec;
 
-        private static void UpdateMetrics(Transaction tx, ExecutionOptions opts, UInt256 effectiveGasPrice)
+        private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
-            if (ShouldUpdateBlockGasMetrics(tx, opts) && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
+            if (ShouldUpdateBlockGasMetrics(opts) && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
             {
                 float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
 
@@ -581,10 +581,9 @@ namespace Nethermind.Evm.TransactionProcessing
             }
         }
 
-        private static bool ShouldUpdateBlockGasMetrics(Transaction tx, ExecutionOptions opts) =>
+        private static bool ShouldUpdateBlockGasMetrics(ExecutionOptions opts) =>
             opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp
-                || tx.IsSystem()
-                && opts.HasFlag(ExecutionOptions.Commit)
+                || opts.HasFlag(ExecutionOptionFlags.OriginalValidate)
                 && !opts.HasFlag(ExecutionOptions.Restore)
                 && !opts.HasFlag(ExecutionOptions.Warmup);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -583,7 +583,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private static bool ShouldUpdateBlockGasMetrics(ExecutionOptions opts) =>
             opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp
-                || opts.HasFlag(ExecutionOptionFlags.OriginalValidate)
+                || opts.HasFlag(ExecutionOptions.OriginalValidate)
                 && !opts.HasFlag(ExecutionOptions.Restore)
                 && !opts.HasFlag(ExecutionOptions.Warmup);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
 
-            UpdateMetrics(opts, effectiveGasPrice);
+            UpdateMetrics(tx, opts, effectiveGasPrice);
 
             bool deleteCallerAccount = RecoverSenderIfNeeded(tx, spec, opts, effectiveGasPrice);
 
@@ -566,9 +566,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual IReleaseSpec GetSpec(BlockHeader header) => VirtualMachine.BlockExecutionContext.Spec;
 
-        private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
+        private static void UpdateMetrics(Transaction tx, ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
-            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
+            if (ShouldUpdateBlockGasMetrics(tx, opts) && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
             {
                 float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
 
@@ -580,6 +580,13 @@ namespace Nethermind.Evm.TransactionProcessing
                 Metrics.BlockTransactions++;
             }
         }
+
+        private static bool ShouldUpdateBlockGasMetrics(Transaction tx, ExecutionOptions opts) =>
+            opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp
+                || tx.IsSystem()
+                && opts.HasFlag(ExecutionOptions.Commit)
+                && !opts.HasFlag(ExecutionOptions.Restore)
+                && !opts.HasFlag(ExecutionOptions.Warmup);
 
         /// <summary>
         /// Validates the transaction, in a static manner (i.e. without accessing state/storage).

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -566,7 +566,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual IReleaseSpec GetSpec(BlockHeader header) => VirtualMachine.BlockExecutionContext.Spec;
 
-        private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
+        protected virtual void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
             if (ShouldUpdateBlockGasMetrics(opts) && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
             {
@@ -581,11 +581,8 @@ namespace Nethermind.Evm.TransactionProcessing
             }
         }
 
-        private static bool ShouldUpdateBlockGasMetrics(ExecutionOptions opts) =>
-            opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp
-                || opts.HasFlag(ExecutionOptions.OriginalValidate)
-                && !opts.HasFlag(ExecutionOptions.Restore)
-                && !opts.HasFlag(ExecutionOptions.Warmup);
+        protected static bool ShouldUpdateBlockGasMetrics(ExecutionOptions opts) =>
+            opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp;
 
         /// <summary>
         /// Validates the transaction, in a static manner (i.e. without accessing state/storage).


### PR DESCRIPTION
Fixes #11813

## Changes

- keep the existing block-like modes: `Commit`, `None`, and `BuildUp`
- count committed system-processor paths that carry `OriginalValidate` alongside `SkipValidationAndCommit`
- keep `CommitAndRestore` out of block gas metrics
- add regression coverage for the block-metric boundaries:
  - `Commit` counts
  - `CommitAndRestore` does not count
  - trace-style system calls do not count
  - committed system paths marked with `OriginalValidate` do count

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Ran:
`dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release --filter "FullyQualifiedName\~MetricsIntegrationTests"`

Result:
`11` passed, `0` failed

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

`ExecutionOptions` is a `[Flags]` enum, but the original `UpdateMetrics(...)` gate relied on exact matches. That dropped committed system-processor executions once the system path added `SkipValidationAndCommit` and its internal `OriginalValidate` marker.

This patch keeps the old semantic set for block gas metrics instead of widening it to every execution mode that happens to carry `Commit`. In particular, trace-style system calls and `CommitAndRestore` still stay out of the metric.

