### PR TITLE
fix(tests): pin Microsoft.Testing.Platform to fix flaky CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.5" />
     <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.6.0" />


### PR DESCRIPTION
  `NUnit3TestAdapter 6.2.0`  bumped MTP from `2.0.2` to `2.1.0` which crashes when two tests with the same name overlap in execution. Tests using `[Repeat]` always have the same name so this can't be fixed by
  deduplication. The fail is flaky because it only happens when two repetitions overlap, which depends on timing.

  Bug: https://github.com/microsoft/testfx/issues/7442
  Crash: https://github.com/NethermindEth/nethermind/actions/runs/26568129795/job/78267981307
