### PR TITLE
rpc: treat zero createAccessList gas as unset

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2110,6 +2110,20 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_createAccessList_with_explicit_zero_gas_treats_it_as_omitted()
+    {
+        using Context ctx = await Context.Create();
+
+        string transaction = $$"""{"from":"{{CreateAccessListSender}}","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","gas":"0x0"}""";
+
+        (JToken result, long gasUsed) = await CallCreateAccessList(ctx, transaction, stateOverrideJson: null, optimize: true);
+
+        Assert.That(result["error"], Is.Null);
+        Assert.That(gasUsed, Is.EqualTo(21_000));
+        Assert.That(result["accessList"]!.ToArray(), Is.Empty);
+    }
+
+    [Test]
     public async Task Eth_create_access_list_with_state_override()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2124,6 +2124,24 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_createAccessList_with_explicit_zero_gas_and_uncapped_config_treats_it_as_omitted()
+    {
+        using Context ctx = await Context.Create();
+        ctx.Test.RpcConfig.GasCap = 0;
+
+        string withoutGas = $$"""{"from":"{{CreateAccessListSender}}","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""";
+        string withZeroGas = $$"""{"from":"{{CreateAccessListSender}}","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","gas":"0x0"}""";
+
+        (JToken omittedResult, long omittedGasUsed) = await CallCreateAccessList(ctx, withoutGas, stateOverrideJson: null, optimize: true);
+        (JToken zeroGasResult, long zeroGasUsed) = await CallCreateAccessList(ctx, withZeroGas, stateOverrideJson: null, optimize: true);
+
+        Assert.That(omittedResult["error"], Is.Null);
+        Assert.That(zeroGasResult["error"], Is.Null);
+        Assert.That(zeroGasUsed, Is.EqualTo(omittedGasUsed));
+        Assert.That(zeroGasResult["accessList"]!.ToArray(), Is.EqualTo(omittedResult["accessList"]!.ToArray()));
+    }
+
+    [Test]
     public async Task Eth_create_access_list_with_state_override()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -193,6 +193,22 @@ namespace Nethermind.JsonRpc.Modules.Eth
         private class CreateAccessListTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider, bool optimize)
             : TxExecutor<AccessListResultForRpc?>(blockchainBridge, blockFinder, rpcConfig, specProvider)
         {
+            public override ResultWrapper<AccessListResultForRpc?> Execute(
+                TransactionForRpc transactionCall,
+                BlockParameter? blockParameter,
+                Dictionary<Address, AccountOverride>? stateOverride = null,
+                SearchResult<BlockHeader>? searchResult = null)
+            {
+                // Match Geth: eth_createAccessList treats gas: 0x0 the same as an omitted gas field and
+                // defaults to gasCap through ToTransaction rather than passing a literal zero gas limit.
+                if (transactionCall.Gas is null or 0)
+                {
+                    transactionCall.Gas = _rpcConfig.GasCap;
+                }
+
+                return base.Execute(transactionCall, blockParameter, stateOverride, searchResult);
+            }
+
             protected override ResultWrapper<AccessListResultForRpc?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
                 CallOutput result = _blockchainBridge.CreateAccessList(header, tx, stateOverride, optimize, BlobBaseFeeOverride, token);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -199,11 +199,12 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 Dictionary<Address, AccountOverride>? stateOverride = null,
                 SearchResult<BlockHeader>? searchResult = null)
             {
-                // Match Geth: eth_createAccessList treats gas: 0x0 the same as an omitted gas field and
-                // defaults to gasCap through ToTransaction rather than passing a literal zero gas limit.
+                // Match Geth: eth_createAccessList treats gas: 0x0 the same as an omitted gas field.
+                // With a configured gasCap we normalize to that cap; with gasCap unset/0 ("no cap")
+                // we leave Gas omitted so ToTransaction keeps the uncapped default path.
                 if (transactionCall.Gas is null or 0)
                 {
-                    transactionCall.Gas = _rpcConfig.GasCap;
+                    transactionCall.Gas = _rpcConfig.GasCap is null or 0 ? null : _rpcConfig.GasCap;
                 }
 
                 return base.Execute(transactionCall, blockParameter, stateOverride, searchResult);


### PR DESCRIPTION
Closes #11827

1. Failure mechanism

eth_createAccessList routed through CreateAccessListTxExecutor, but unlike the sibling EstimateGasTxExecutor, it had no endpoint-local normalization for gas: 0x0.

That let explicit zero gas survive ToTransaction(...) as GasLimit = 0 and reach access-list generation as a literal zero-gas transaction, which failed with:
failed to apply transaction: ... err: intrinsic gas too low: have 0, want 21000

There was one extra edge case in the first draft: when GasCap = 0 (the uncapped configuration), the zero-gas normalization still assigned a literal 0 back into the request, so the call could fall back to the same intrinsic-gas failure instead of following the omitted-gas path.

2. Semantic change

This patch makes CreateAccessListTxExecutor.Execute(...) treat gas: 0x0 the same as an omitted gas field.

With a configured gasCap, it normalizes to that cap before ToTransaction(...).
With GasCap unset or 0, it leaves Gas omitted so the existing uncapped default path stays in control.

3. Preserved invariants

The change stays local to eth_createAccessList. ToTransaction(...) still preserves explicit gas = 0 globally, and existing gas-cap behavior and out-of-gas behavior in eth_createAccessList stay intact.

4. Tests

dotnet test --project src/Nethermind/Nethermind.JsonRpc.Test/Nethermind.JsonRpc.Test.csproj -c Release --filter "Name=Eth_createAccessList_with_explicit_zero_gas_treats_it_as_omitted|Name=Eth_createAccessList_with_explicit_zero_gas_and_uncapped_config_treats_it_as_omitted|Name=Eth_createAccessList_without_gas_defaults_to_gas_cap_not_block_gas_limit|Name=Eth_createAccessList_gas_calculation|Name=Eth_createAccessList_gas_calculation_reverting_sstore_returns_access_list_and_vm_error|Name=Eth_createAccessList_returns_out_of_gas_when_al_intrinsic_cost_exceeds_gas_limit"

Covered tests:
Eth_createAccessList_with_explicit_zero_gas_treats_it_as_omitted
Eth_createAccessList_with_explicit_zero_gas_and_uncapped_config_treats_it_as_omitted
Eth_createAccessList_without_gas_defaults_to_gas_cap_not_block_gas_limit
Eth_createAccessList_gas_calculation
Eth_createAccessList_gas_calculation_reverting_sstore_returns_access_list_and_vm_error
Eth_createAccessList_returns_out_of_gas_when_al_intrinsic_cost_exceeds_gas_limit

Result:
6 total, 6 passed