### PR TITLE
diag: support periodic dotMemory snapshots via env var

### DIFF
--- a/scripts/diag-entrypoint.sh
+++ b/scripts/diag-entrypoint.sh
@@ -12,10 +12,20 @@ start_dotmemory() {
   # Optional periodic snapshots when DIAG_DOTMEMORY_TIMER is set (e.g. "00:00:30" → every 30s).
   # Without this the run only collects the timeline graph, not heap snapshots.
   if [ -n "${DIAG_DOTMEMORY_TIMER:-}" ]; then
+    if [[ ! "$DIAG_DOTMEMORY_TIMER" =~ ^[0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]; then
+      echo "Error: DIAG_DOTMEMORY_TIMER must be in HH:MM:SS format (got: $DIAG_DOTMEMORY_TIMER)" >&2
+      exit 1
+    fi
     args+=("--trigger-on-timer=$DIAG_DOTMEMORY_TIMER")
     if [ -n "${DIAG_DOTMEMORY_MAX_SNAPSHOTS:-}" ]; then
+      if [[ ! "$DIAG_DOTMEMORY_MAX_SNAPSHOTS" =~ ^[1-9][0-9]*$ ]]; then
+        echo "Error: DIAG_DOTMEMORY_MAX_SNAPSHOTS must be a positive integer (got: $DIAG_DOTMEMORY_MAX_SNAPSHOTS)" >&2
+        exit 1
+      fi
       args+=("--trigger-max-snapshots=$DIAG_DOTMEMORY_MAX_SNAPSHOTS")
     fi
+  elif [ -n "${DIAG_DOTMEMORY_MAX_SNAPSHOTS:-}" ]; then
+    echo "Warning: DIAG_DOTMEMORY_MAX_SNAPSHOTS is set but DIAG_DOTMEMORY_TIMER is not; snapshot cap will be ignored." >&2
   fi
 
   exec dotmemory start "${args[@]}" ./nethermind -- "$@"

--- a/scripts/diag-entrypoint.sh
+++ b/scripts/diag-entrypoint.sh
@@ -16,7 +16,7 @@ start_dotmemory() {
       echo "Error: DIAG_DOTMEMORY_TIMER must be in HH:MM:SS format (got: $DIAG_DOTMEMORY_TIMER)" >&2
       exit 1
     fi
-    args+=("--trigger-on-timer=$DIAG_DOTMEMORY_TIMER")
+    args+=("--trigger-timer=$DIAG_DOTMEMORY_TIMER")
     if [ -n "${DIAG_DOTMEMORY_MAX_SNAPSHOTS:-}" ]; then
       if [[ ! "$DIAG_DOTMEMORY_MAX_SNAPSHOTS" =~ ^[1-9][0-9]*$ ]]; then
         echo "Error: DIAG_DOTMEMORY_MAX_SNAPSHOTS must be a positive integer (got: $DIAG_DOTMEMORY_MAX_SNAPSHOTS)" >&2

--- a/scripts/diag-entrypoint.sh
+++ b/scripts/diag-entrypoint.sh
@@ -7,10 +7,18 @@ set -eo pipefail
 start_dotmemory() {
   echo "Starting dotMemory..."
 
-  exec dotmemory start \
-    --save-to-dir=/nethermind/diag/dotmemory \
-    --service-output \
-    ./nethermind -- "$@"
+  local args=(--save-to-dir=/nethermind/diag/dotmemory --service-output)
+
+  # Optional periodic snapshots when DIAG_DOTMEMORY_TIMER is set (e.g. "00:00:30" → every 30s).
+  # Without this the run only collects the timeline graph, not heap snapshots.
+  if [ -n "${DIAG_DOTMEMORY_TIMER:-}" ]; then
+    args+=("--trigger-on-timer=$DIAG_DOTMEMORY_TIMER")
+    if [ -n "${DIAG_DOTMEMORY_MAX_SNAPSHOTS:-}" ]; then
+      args+=("--trigger-max-snapshots=$DIAG_DOTMEMORY_MAX_SNAPSHOTS")
+    fi
+  fi
+
+  exec dotmemory start "${args[@]}" ./nethermind -- "$@"
 }
 
 start_dotnet_trace() {


### PR DESCRIPTION
## Summary

The diag entrypoint launches `dotmemory` with the minimum flags:

```bash
dotmemory start --save-to-dir=/nethermind/diag/dotmemory --service-output ./nethermind -- ...
```

That records the **timeline graph** (memory-over-time) but never triggers a heap snapshot. So `.dmw` workspaces collected from CI runs contain no snapshots to drill into — just the high-level timeline. Confirmed empirically on [gas-benchmarks run 26641799006](https://github.com/NethermindEth/gas-benchmarks/actions/runs/26641799006) (jochemnet stateful sweep, bal-devnet-7-diag image): the 606 MB `.dmw` opened in dotMemory has no snapshots, just the timeline.

This PR adds an optional `DIAG_DOTMEMORY_TIMER` env var that forwards to dotmemory's `--trigger-on-timer` and an optional `DIAG_DOTMEMORY_MAX_SNAPSHOTS` cap.

## Behavior

| Configuration | Effect |
|---|---|
| Neither env var set (default) | Unchanged from today — timeline only, no snapshots |
| `DIAG_DOTMEMORY_TIMER=00:00:30` | Snapshot every 30 seconds, no cap |
| `DIAG_DOTMEMORY_TIMER=00:00:30` + `DIAG_DOTMEMORY_MAX_SNAPSHOTS=20` | Snapshot every 30 seconds, stop after 20 snapshots |

Backward compatible: existing dispatches that don't set either var get exactly the current behavior.

## Why env vars vs CLI flags

The diag entrypoint already passes its `"$@"` straight to `./nethermind`, so we can't pull dotMemory-specific flags out of the arg list. Env vars are the standard channel for this entrypoint (`DIAG_WITH` already exists).

## Companion change

The gas-benchmarks repricing workflow needs to plumb these env vars through to the docker container — separate PR will follow there.

## Test plan
- [ ] Build a `-diag` image off this branch.
- [ ] Run the diag image standalone with `DIAG_WITH=dotmemory DIAG_DOTMEMORY_TIMER=00:00:30 DIAG_DOTMEMORY_MAX_SNAPSHOTS=5` — expect `dotmemory start … --trigger-on-timer=00:00:30 --trigger-max-snapshots=5 …` in stdout.
- [ ] Run it without the env vars — expect the original `dotmemory start --save-to-dir=… --service-output …` invocation (no trigger flags).
- [ ] Open the resulting `.dmw` in JetBrains dotMemory — expect to see snapshot entries in the workspace tree.