### PR TITLE
fix(nethtest): BLOCKHASH recency window in state-test runner

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/TestBlockhashProvider.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestBlockhashProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -12,8 +13,16 @@ namespace Ethereum.Test.Base
 {
     public class TestBlockhashProvider : IBlockhashProvider
     {
-        public Hash256? GetBlockhash(BlockHeader currentBlock, long number, IReleaseSpec? spec) =>
-            number != 0 ? Keccak.Zero : Keccak.Compute(number.ToString());
+        public Hash256? GetBlockhash(BlockHeader currentBlock, long number, IReleaseSpec? spec)
+        {
+            long depth = currentBlock.Number - number;
+            if (depth <= 0 || depth > BlockhashProvider.MaxDepth)
+            {
+                return null;
+            }
+
+            return number != 0 ? Keccak.Zero : Keccak.Compute(number.ToString());
+        }
 
         public Task Prefetch(BlockHeader currentBlock, CancellationToken token) => Task.CompletedTask;
     }


### PR DESCRIPTION

## Changes

`nethtest`'s `TestBlockhashProvider` skipps the recency-window check, so `BLOCKHASH(0)` returns `keccak256("0")` even when block 0 was far outside the 256-block window, making Nethermind diverge from geth/besu/erigon/evmone/reth/EELS under differential state-test fuzzing. this fix applies the same `BlockhashProvider.MaxDepth` bound the production provider already uses (mainnet was never affected)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)


## Testing

#### If yes, did you write tests?

- [x] Yes, you can see a test in this [execution-specs PR](https://github.com/ethereum/execution-specs/pull/2943)
- [ ] No

