### PR TITLE
Rework TrieWarmer to ThreadPool processors

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/CacheLinePaddedLong.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/CacheLinePaddedLong.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Threading;
+
+/// <summary>
+/// A <see cref="long"/> isolated on its own cache line so that concurrent atomic updates to it do not
+/// suffer false sharing with neighbouring fields.
+/// </summary>
+/// <remarks>
+/// The field sits at offset 64 within a <see cref="CacheLineSize"/>-byte block, so the padding follows the
+/// value. This isolates it from anything laid out after it; callers must not place another hot field
+/// immediately before an instance.
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = CacheLineSize)]
+public struct CacheLinePaddedLong(long value)
+{
+    // Cache line is 64 bytes on Intel and 128 bytes on Apple Silicon; pad to the larger to be safe.
+    private const int CacheLineSize = 128;
+    private const int CacheLinePadding = CacheLineSize / 2;
+
+    [FieldOffset(CacheLinePadding)]
+    public long Value = value;
+}

--- a/src/Nethermind/Nethermind.Core/Threading/CacheLinePaddedLong.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/CacheLinePaddedLong.cs
@@ -10,9 +10,9 @@ namespace Nethermind.Core.Threading;
 /// suffer false sharing with neighbouring fields.
 /// </summary>
 /// <remarks>
-/// The field sits at offset 64 within a <see cref="CacheLineSize"/>-byte block, so the padding follows the
-/// value. This isolates it from anything laid out after it; callers must not place another hot field
-/// immediately before an instance.
+/// The field sits at offset 64 within a <see cref="CacheLineSize"/>-byte block. This separates it from
+/// fields laid out before the struct on 64-byte cache-line machines; callers should avoid placing another
+/// hot field immediately after an instance unless the surrounding layout and alignment are known.
 /// </remarks>
 [StructLayout(LayoutKind.Explicit, Size = CacheLineSize)]
 public struct CacheLinePaddedLong(long value)

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -167,20 +166,13 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     /// </summary>
     private class SharedCounter(int fromInclusive)
     {
-        private PaddedValue _index = new(fromInclusive);
+        private CacheLinePaddedLong _index = new(fromInclusive);
 
         /// <summary>
         /// Gets the next index in a thread-safe manner.
         /// </summary>
         /// <returns>The next index.</returns>
-        public int GetNext() => Interlocked.Increment(ref _index.Value) - 1;
-
-        [StructLayout(LayoutKind.Explicit, Size = 128)]
-        private struct PaddedValue(int value)
-        {
-            [FieldOffset(64)]
-            public int Value = value;
-        }
+        public int GetNext() => (int)(Interlocked.Increment(ref _index.Value) - 1);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Core/Utils/RefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/RefCountingDisposable.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using System.Threading;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.Core.Utils;
 
@@ -15,7 +15,7 @@ public abstract class RefCountingDisposable : IDisposable
     private const int NoAccessors = 0;
     private const int Disposing = -1;
 
-    protected PaddedValue _leases;
+    protected CacheLinePaddedLong _leases;
 
     protected RefCountingDisposable(int initialCount = Single) => _leases.Value = initialCount;
 
@@ -119,12 +119,5 @@ public abstract class RefCountingDisposable : IDisposable
     {
         long leases = Volatile.Read(ref _leases.Value);
         return leases == Disposing ? "Disposed" : $"Leases: {leases}";
-    }
-
-    [StructLayout(LayoutKind.Explicit, Size = 128)]
-    protected struct PaddedValue
-    {
-        [FieldOffset(64)]
-        public long Value;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/MpmcRingBufferTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/MpmcRingBufferTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -10,6 +11,32 @@ namespace Nethermind.State.Flat.Test;
 
 public class MpmcRingBufferTests
 {
+    [Test]
+    public void HasReadyItem_TracksPublishedItems()
+    {
+        MpmcRingBuffer<int> jobQueue = new(4);
+
+        Assert.That(jobQueue.HasReadyItem, Is.False);
+
+        Assert.That(jobQueue.TryEnqueue(1), Is.True);
+        Assert.That(jobQueue.HasReadyItem, Is.True);
+
+        Assert.That(jobQueue.TryDequeue(out int item), Is.True);
+        Assert.That(item, Is.EqualTo(1));
+        Assert.That(jobQueue.HasReadyItem, Is.False);
+
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.That(jobQueue.TryEnqueue(i), Is.True);
+            Assert.That(jobQueue.TryDequeue(out item), Is.True);
+            Assert.That(item, Is.EqualTo(i));
+            Assert.That(jobQueue.HasReadyItem, Is.False);
+        }
+
+        Assert.That(jobQueue.TryEnqueue(42), Is.True);
+        Assert.That(jobQueue.HasReadyItem, Is.True);
+    }
+
     [Test]
     public void SmokeTest()
     {
@@ -84,6 +111,20 @@ public class MpmcRingBufferTests
     }
 
     [Test]
+    public void TryDequeue_ClearsReferenceContainingEntry()
+    {
+        MpmcRingBuffer<ReferenceJob> jobQueue = new(4);
+        ReferenceJob job = new(new object());
+
+        Assert.That(jobQueue.TryEnqueue(job), Is.True);
+        Assert.That(jobQueue.TryDequeue(out ReferenceJob dequeued), Is.True);
+        Assert.That(dequeued, Is.EqualTo(job));
+
+        ReferenceJob[] entries = GetEntries(jobQueue);
+        Assert.That(entries[0].Value, Is.Null);
+    }
+
+    [Test]
     public async Task HighConcurrency_StressTest_NoDataLoss()
     {
         int Capacity = 1024;
@@ -143,4 +184,13 @@ public class MpmcRingBufferTests
             Assert.That(consumedCounts[i] == 1, $"Item {i} was consumed {consumedCounts[i]} times!");
         }
     }
+
+    private static T[] GetEntries<T>(MpmcRingBuffer<T> buffer)
+    {
+        FieldInfo? entriesField = typeof(MpmcRingBuffer<T>).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(entriesField, Is.Not.Null);
+        return (T[])entriesField!.GetValue(buffer)!;
+    }
+
+    private readonly record struct ReferenceJob(object? Value);
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SpmcRingBufferTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SpmcRingBufferTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -10,6 +11,32 @@ namespace Nethermind.State.Flat.Test;
 
 public class SpmcRingBufferTests
 {
+    [Test]
+    public void HasReadyItem_TracksPublishedItems()
+    {
+        SpmcRingBuffer<int> jobQueue = new(4);
+
+        Assert.That(jobQueue.HasReadyItem, Is.False);
+
+        Assert.That(jobQueue.TryEnqueue(1), Is.True);
+        Assert.That(jobQueue.HasReadyItem, Is.True);
+
+        Assert.That(jobQueue.TryDequeue(out int item), Is.True);
+        Assert.That(item, Is.EqualTo(1));
+        Assert.That(jobQueue.HasReadyItem, Is.False);
+
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.That(jobQueue.TryEnqueue(i), Is.True);
+            Assert.That(jobQueue.TryDequeue(out item), Is.True);
+            Assert.That(item, Is.EqualTo(i));
+            Assert.That(jobQueue.HasReadyItem, Is.False);
+        }
+
+        Assert.That(jobQueue.TryEnqueue(42), Is.True);
+        Assert.That(jobQueue.HasReadyItem, Is.True);
+    }
+
     [Test]
     public void SmokeTest()
     {
@@ -84,6 +111,20 @@ public class SpmcRingBufferTests
     }
 
     [Test]
+    public void TryDequeue_ClearsReferenceContainingEntry()
+    {
+        SpmcRingBuffer<ReferenceJob> jobQueue = new(4);
+        ReferenceJob job = new(new object());
+
+        Assert.That(jobQueue.TryEnqueue(job), Is.True);
+        Assert.That(jobQueue.TryDequeue(out ReferenceJob dequeued), Is.True);
+        Assert.That(dequeued, Is.EqualTo(job));
+
+        ReferenceJob[] entries = GetEntries(jobQueue);
+        Assert.That(entries[0].Value, Is.Null);
+    }
+
+    [Test]
     public async Task HighConcurrency_StressTest_NoDataLoss()
     {
         int Capacity = 1024;
@@ -135,4 +176,13 @@ public class SpmcRingBufferTests
             Assert.That(consumedCounts[i] == 1, $"Item {i} was consumed {consumedCounts[i]} times!");
         }
     }
+
+    private static T[] GetEntries<T>(SpmcRingBuffer<T> buffer)
+    {
+        FieldInfo? entriesField = typeof(SpmcRingBuffer<T>).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(entriesField, Is.Not.Null);
+        return (T[])entriesField!.GetValue(buffer)!;
+    }
+
+    private readonly record struct ReferenceJob(object? Value);
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Db;
@@ -26,28 +25,20 @@ public class TrieWarmerTests
         new TestCaseData(SlotPushMode.Mpmc).SetName("PushSlotJobMpmc_CallsWarmUpStorageTrie")
     ];
 
-    private IProcessExitSource _processExitSource = null!;
-    private CancellationTokenSource _cts = null!;
     private ILogManager _logManager = null!;
     private FlatDbConfig _config = null!;
 
     [SetUp]
     public void SetUp()
     {
-        _cts = new CancellationTokenSource();
-        _processExitSource = Substitute.For<IProcessExitSource>();
-        _processExitSource.Token.Returns(_cts.Token);
         _logManager = LimboLogs.Instance;
         _config = new FlatDbConfig { TrieWarmerWorkerCount = 2 };
     }
 
-    [TearDown]
-    public void TearDown() => _cts?.Dispose();
-
     [Test]
     public async Task PushAddressJob_CallsWarmUpStateTrie()
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
 
         ITrieWarmer.IAddressWarmer addressWarmer = Substitute.For<ITrieWarmer.IAddressWarmer>();
         Address address = new("0x1234567890123456789012345678901234567890");
@@ -56,14 +47,13 @@ public class TrieWarmerTests
 
         await Eventually.AssertAsync<ReceivedCallsException>(() => addressWarmer.Received().WarmUpStateTrie(address, 1));
 
-        _cts.Cancel();
         await warmer.DisposeAsync();
     }
 
     [TestCaseSource(nameof(SlotJobCases))]
     public async Task PushSlotJob_CallsWarmUpStorageTrie(SlotPushMode slotPushMode)
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
 
         ITrieWarmer.IStorageWarmer storageWarmer = Substitute.For<ITrieWarmer.IStorageWarmer>();
         UInt256 index = 42;
@@ -75,14 +65,13 @@ public class TrieWarmerTests
         Assert.That(enqueued, Is.True);
         await Eventually.AssertAsync<ReceivedCallsException>(() => storageWarmer.Received().WarmUpStorageTrie(index, 5));
 
-        _cts.Cancel();
         await warmer.DisposeAsync();
     }
 
     [Test]
     public async Task PushAddressJob_PassesCorrectSequenceId()
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
 
         ITrieWarmer.IAddressWarmer addressWarmer = Substitute.For<ITrieWarmer.IAddressWarmer>();
         Address address = new("0x1111111111111111111111111111111111111111");
@@ -91,14 +80,13 @@ public class TrieWarmerTests
 
         await Eventually.AssertAsync<ReceivedCallsException>(() => addressWarmer.Received().WarmUpStateTrie(address, 999));
 
-        _cts.Cancel();
         await warmer.DisposeAsync();
     }
 
     [Test]
     public async Task PushAddressJob_AfterProcessorIdle_ProcessesNextJob()
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
         CountingAddressWarmer addressWarmer = new();
         Address address = new("0x2222222222222222222222222222222222222222");
 
@@ -110,7 +98,6 @@ public class TrieWarmerTests
         Assert.That(warmer.PushAddressJob(addressWarmer, address, sequenceId: 2), Is.True);
         await Eventually.AssertAsync<AssertionException>(() => Assert.That(addressWarmer.Calls, Is.EqualTo(2)));
 
-        _cts.Cancel();
         await warmer.DisposeAsync();
     }
 
@@ -121,7 +108,7 @@ public class TrieWarmerTests
         const int JobCount = 16;
 
         _config.TrieWarmerWorkerCount = WorkerCount;
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
         using BlockingStorageWarmer storageWarmer = new(parallelismTarget: 2);
 
         try
@@ -142,7 +129,30 @@ public class TrieWarmerTests
         finally
         {
             storageWarmer.Release();
-            _cts.Cancel();
+            await warmer.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task PushSlotJobMpmc_WithOneBusyProcessor_WakesIdleProcessorForSinglePendingJob()
+    {
+        _config.TrieWarmerWorkerCount = 2;
+        TrieWarmer warmer = new(_logManager, _config);
+        using BlockingStorageWarmer storageWarmer = new(parallelismTarget: 2);
+        UInt256 firstIndex = 1;
+        UInt256 secondIndex = 2;
+
+        try
+        {
+            Assert.That(warmer.PushSlotJobMpmc(storageWarmer, firstIndex, sequenceId: 1), Is.True);
+            Assert.That(storageWarmer.WaitForFirstCall(TimeSpan.FromSeconds(5)), Is.True);
+
+            Assert.That(warmer.PushSlotJobMpmc(storageWarmer, secondIndex, sequenceId: 2), Is.True);
+            Assert.That(storageWarmer.WaitForParallelism(TimeSpan.FromSeconds(5)), Is.True);
+        }
+        finally
+        {
+            storageWarmer.Release();
             await warmer.DisposeAsync();
         }
     }
@@ -150,7 +160,7 @@ public class TrieWarmerTests
     [Test]
     public async Task DisposeAsync_RejectsNewJobs()
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
         await warmer.DisposeAsync();
 
         ITrieWarmer.IAddressWarmer addressWarmer = Substitute.For<ITrieWarmer.IAddressWarmer>();
@@ -169,17 +179,18 @@ public class TrieWarmerTests
     [Test]
     public async Task DisposeAsync_DrainsAcceptedJobs()
     {
-        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        TrieWarmer warmer = new(_logManager, _config);
         using BlockingStorageWarmer storageWarmer = new(parallelismTarget: 1);
         UInt256 index = 45;
 
         Assert.That(warmer.PushSlotJobMpmc(storageWarmer, index, sequenceId: 1), Is.True);
 
-        Task disposeTask = Task.Run(async () => await warmer.DisposeAsync());
+        Task disposeTask = warmer.DisposeAsync().AsTask();
 
         try
         {
             Assert.That(storageWarmer.WaitForFirstCall(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(disposeTask.IsCompleted, Is.False);
             storageWarmer.Release();
             await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.That(storageWarmer.Calls, Is.EqualTo(1));

--- a/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TrieWarmerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
@@ -19,6 +20,12 @@ namespace Nethermind.State.Flat.Test;
 [TestFixture]
 public class TrieWarmerTests
 {
+    private static readonly TestCaseData[] SlotJobCases =
+    [
+        new TestCaseData(SlotPushMode.Spmc).SetName("PushSlotJob_CallsWarmUpStorageTrie"),
+        new TestCaseData(SlotPushMode.Mpmc).SetName("PushSlotJobMpmc_CallsWarmUpStorageTrie")
+    ];
+
     private IProcessExitSource _processExitSource = null!;
     private CancellationTokenSource _cts = null!;
     private ILogManager _logManager = null!;
@@ -53,16 +60,19 @@ public class TrieWarmerTests
         await warmer.DisposeAsync();
     }
 
-    [Test]
-    public async Task PushSlotJob_CallsWarmUpStorageTrie()
+    [TestCaseSource(nameof(SlotJobCases))]
+    public async Task PushSlotJob_CallsWarmUpStorageTrie(SlotPushMode slotPushMode)
     {
         TrieWarmer warmer = new(_processExitSource, _logManager, _config);
 
         ITrieWarmer.IStorageWarmer storageWarmer = Substitute.For<ITrieWarmer.IStorageWarmer>();
         UInt256 index = 42;
 
-        warmer.PushSlotJob(storageWarmer, index, sequenceId: 5);
+        bool enqueued = slotPushMode == SlotPushMode.Spmc
+            ? warmer.PushSlotJob(storageWarmer, index, sequenceId: 5)
+            : warmer.PushSlotJobMpmc(storageWarmer, index, sequenceId: 5);
 
+        Assert.That(enqueued, Is.True);
         await Eventually.AssertAsync<ReceivedCallsException>(() => storageWarmer.Received().WarmUpStorageTrie(index, 5));
 
         _cts.Cancel();
@@ -83,5 +93,175 @@ public class TrieWarmerTests
 
         _cts.Cancel();
         await warmer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PushAddressJob_AfterProcessorIdle_ProcessesNextJob()
+    {
+        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        CountingAddressWarmer addressWarmer = new();
+        Address address = new("0x2222222222222222222222222222222222222222");
+
+        Assert.That(warmer.PushAddressJob(addressWarmer, address, sequenceId: 1), Is.True);
+        await Eventually.AssertAsync<AssertionException>(() => Assert.That(addressWarmer.Calls, Is.EqualTo(1)));
+
+        await Task.Delay(50);
+
+        Assert.That(warmer.PushAddressJob(addressWarmer, address, sequenceId: 2), Is.True);
+        await Eventually.AssertAsync<AssertionException>(() => Assert.That(addressWarmer.Calls, Is.EqualTo(2)));
+
+        _cts.Cancel();
+        await warmer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PushSlotJobMpmc_Bursts_FanOutWithoutExceedingWorkerCount()
+    {
+        const int WorkerCount = 4;
+        const int JobCount = 16;
+
+        _config.TrieWarmerWorkerCount = WorkerCount;
+        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        using BlockingStorageWarmer storageWarmer = new(parallelismTarget: 2);
+
+        try
+        {
+            for (int i = 0; i < JobCount; i++)
+            {
+                UInt256 index = (uint)i;
+                Assert.That(warmer.PushSlotJobMpmc(storageWarmer, index, sequenceId: i), Is.True);
+            }
+
+            Assert.That(storageWarmer.WaitForParallelism(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(storageWarmer.MaxConcurrency, Is.GreaterThan(1));
+            Assert.That(storageWarmer.MaxConcurrency, Is.LessThanOrEqualTo(WorkerCount));
+
+            storageWarmer.Release();
+            await Eventually.AssertAsync<AssertionException>(() => Assert.That(storageWarmer.Calls, Is.EqualTo(JobCount)));
+        }
+        finally
+        {
+            storageWarmer.Release();
+            _cts.Cancel();
+            await warmer.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_RejectsNewJobs()
+    {
+        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        await warmer.DisposeAsync();
+
+        ITrieWarmer.IAddressWarmer addressWarmer = Substitute.For<ITrieWarmer.IAddressWarmer>();
+        ITrieWarmer.IStorageWarmer storageWarmer = Substitute.For<ITrieWarmer.IStorageWarmer>();
+        Address address = new("0x3333333333333333333333333333333333333333");
+        UInt256 index = 44;
+
+        Assert.That(warmer.PushAddressJob(addressWarmer, address, sequenceId: 1), Is.False);
+        Assert.That(warmer.PushSlotJob(storageWarmer, index, sequenceId: 2), Is.False);
+        Assert.That(warmer.PushSlotJobMpmc(storageWarmer, index, sequenceId: 3), Is.False);
+
+        addressWarmer.DidNotReceive().WarmUpStateTrie(Arg.Any<Address>(), Arg.Any<int>());
+        storageWarmer.DidNotReceive().WarmUpStorageTrie(Arg.Any<UInt256>(), Arg.Any<int>());
+    }
+
+    [Test]
+    public async Task DisposeAsync_DrainsAcceptedJobs()
+    {
+        TrieWarmer warmer = new(_processExitSource, _logManager, _config);
+        using BlockingStorageWarmer storageWarmer = new(parallelismTarget: 1);
+        UInt256 index = 45;
+
+        Assert.That(warmer.PushSlotJobMpmc(storageWarmer, index, sequenceId: 1), Is.True);
+
+        Task disposeTask = Task.Run(async () => await warmer.DisposeAsync());
+
+        try
+        {
+            Assert.That(storageWarmer.WaitForFirstCall(TimeSpan.FromSeconds(5)), Is.True);
+            storageWarmer.Release();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(storageWarmer.Calls, Is.EqualTo(1));
+        }
+        finally
+        {
+            storageWarmer.Release();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private sealed class CountingAddressWarmer : ITrieWarmer.IAddressWarmer
+    {
+        private int _calls;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        public bool WarmUpStateTrie(Address address, int sequenceId)
+        {
+            Interlocked.Increment(ref _calls);
+            return true;
+        }
+    }
+
+    private sealed class BlockingStorageWarmer(int parallelismTarget) : ITrieWarmer.IStorageWarmer, IDisposable
+    {
+        private readonly ManualResetEventSlim _firstCall = new(initialState: false);
+        private readonly ManualResetEventSlim _parallelismReached = new(initialState: false);
+        private readonly ManualResetEventSlim _release = new(initialState: false);
+
+        private int _calls;
+        private int _currentConcurrency;
+        private int _maxConcurrency;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        public int MaxConcurrency => Volatile.Read(ref _maxConcurrency);
+
+        public bool WaitForFirstCall(TimeSpan timeout) => _firstCall.Wait(timeout);
+
+        public bool WaitForParallelism(TimeSpan timeout) => _parallelismReached.Wait(timeout);
+
+        public void Release() => _release.Set();
+
+        public bool WarmUpStorageTrie(UInt256 index, int sequenceId)
+        {
+            int currentConcurrency = Interlocked.Increment(ref _currentConcurrency);
+            UpdateMaxConcurrency(currentConcurrency);
+
+            Interlocked.Increment(ref _calls);
+            _firstCall.Set();
+            if (currentConcurrency >= parallelismTarget)
+            {
+                _parallelismReached.Set();
+            }
+
+            _release.Wait(TimeSpan.FromSeconds(5));
+            Interlocked.Decrement(ref _currentConcurrency);
+            return true;
+        }
+
+        public void Dispose()
+        {
+            _firstCall.Dispose();
+            _parallelismReached.Dispose();
+            _release.Dispose();
+        }
+
+        private void UpdateMaxConcurrency(int currentConcurrency)
+        {
+            while (true)
+            {
+                int currentMax = Volatile.Read(ref _maxConcurrency);
+                if (currentConcurrency <= currentMax) return;
+                if (Interlocked.CompareExchange(ref _maxConcurrency, currentConcurrency, currentMax) == currentMax) return;
+            }
+        }
+    }
+
+    public enum SlotPushMode
+    {
+        Spmc,
+        Mpmc
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/MpmcRingBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/MpmcRingBuffer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.State.Flat;
 
@@ -22,23 +23,28 @@ public sealed class MpmcRingBuffer<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            long tail = Volatile.Read(ref _tail);
-            long head = Volatile.Read(ref _head);
+            long tail = Volatile.Read(ref _tail.Value);
+            long head = Volatile.Read(ref _head.Value);
 
             long count = tail - head;
             return count < 0 ? 0 : count; // clamp just in case of a race
         }
     }
 
-#pragma warning disable CS0169 // Field is never used
-    // --- head (consumers) + padding ---
-    private long _head;
-    private long _p1, _p2, _p3, _p4, _p5, _p6, _p7;
+    internal bool HasReadyItem
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            long head = Volatile.Read(ref _head.Value);
+            int index = (int)(head & _mask);
+            long seq = Volatile.Read(ref _sequences[index]);
+            return seq >= head + 1;
+        }
+    }
 
-    // --- tail (producers) + padding ---
-    private long _tail;
-    private long _p8, _p9, _p10, _p11, _p12, _p13, _p14;
-#pragma warning restore CS0169 // Field is never used
+    private CacheLinePaddedLong _head;
+    private CacheLinePaddedLong _tail;
 
     public MpmcRingBuffer(int capacityPowerOfTwo)
     {
@@ -64,14 +70,14 @@ public sealed class MpmcRingBuffer<T>
     {
         while (true)
         {
-            long tail = Volatile.Read(ref _tail);
+            long tail = Volatile.Read(ref _tail.Value);
             int index = (int)(tail & _mask);
             long seq = Volatile.Read(ref _sequences[index]);
 
             if (seq == tail)
             {
                 // Interlocked exchange for multiple producer.
-                if (Interlocked.CompareExchange(ref _tail, tail + 1, tail) == tail)
+                if (Interlocked.CompareExchange(ref _tail.Value, tail + 1, tail) == tail)
                 {
                     // Success
                     _entries[index] = item;
@@ -97,7 +103,7 @@ public sealed class MpmcRingBuffer<T>
     {
         while (true)
         {
-            long head = Volatile.Read(ref _head);
+            long head = Volatile.Read(ref _head.Value);
             int index = (int)(head & _mask);
             long seq = Volatile.Read(ref _sequences[index]);
             long expectedSeq = head + 1;
@@ -105,9 +111,14 @@ public sealed class MpmcRingBuffer<T>
             // If seq == expectedSeq, the producer has finished writing
             if (seq == expectedSeq)
             {
-                if (Interlocked.CompareExchange(ref _head, head + 1, head) == head)
+                if (Interlocked.CompareExchange(ref _head.Value, head + 1, head) == head)
                 {
                     item = _entries[index];
+                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                    {
+                        _entries[index] = default!;
+                    }
+
                     // Mark as ready for the producer's next lap (head + capacity)
                     Volatile.Write(ref _sequences[index], head + _capacity);
                     return true;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -62,6 +62,9 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
     }
 
     public Hash256 RootHash => _tree.RootHash;
+
+    internal bool IsDisposed => _scope.IsDisposed;
+
     public byte[] Get(in UInt256 index)
     {
         byte[]? value = _bundle.GetSlot(_address, index, _selfDestructKnownStateIdx);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -43,6 +43,8 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     private CancellationTokenSource? _hintBalCts;
     private Task? _hintBalTask;
 
+    internal bool IsDisposed => Volatile.Read(ref _isDisposed);
+
     public FlatWorldStateScope(
         StateId currentStateId,
         SnapshotBundle snapshotBundle,

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ITrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ITrieWarmer.cs
@@ -10,7 +10,7 @@ public interface ITrieWarmer
 {
     public bool PushSlotJob(
         IStorageWarmer storageTree,
-        in UInt256? index,
+        in UInt256 index,
         int sequenceId);
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/NoopTrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/NoopTrieWarmer.cs
@@ -8,7 +8,7 @@ namespace Nethermind.State.Flat.ScopeProvider;
 
 public class NoopTrieWarmer : ITrieWarmer
 {
-    public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256? index, int sequenceId) => false;
+    public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId) => false;
 
     public bool PushSlotJobMpmc(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId) => false;
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -22,10 +22,12 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 {
     private const int BufferSize = 1024 * 16;
     private const int SlotBufferSize = 1024;
+    private const int DisposeTimeoutMilliseconds = 1000;
 
     private readonly ILogger _logger;
 
     private bool _isDisposed = false;
+    private int _activeProcessors = 0;
 
     private readonly SpmcRingBuffer<SlotJob> _slotJobBuffer = new(SlotBufferSize);
 
@@ -33,7 +35,7 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
     private readonly MpmcRingBuffer<Job> _jobBufferMultiThreaded = new(BufferSize);
 
     // A job needs to be small, within one cache line (64B) ideally.
-    private record struct Job(
+    private readonly record struct Job(
         // If its warming up address, its a scope, otherwise, its a storage tree.
         object scopeOrStorageTree,
         Address? path,
@@ -41,23 +43,13 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         int sequenceId);
 
     // A slot hint from the main processing thread is called a lot, so it has its own dedicated queue with a smaller job struct.
-    private record struct SlotJob(
+    private readonly record struct SlotJob(
         ITrieWarmer.IStorageWarmer storageTree,
         UInt256 index,
         int sequenceId);
 
-    private readonly Task? _warmerJob = null;
-    private readonly int _secondaryWorkerCount;
-
-    private int _pendingWakeUpSlots = 0;
-    private int _activeSecondaryWorker = 0;
-    private int _shouldWakeUpPrimaryWorker = 0;
-    private readonly ManualResetEventSlim _primaryWorkerLatch = new();
-
-    // Use a full semaphore instead of the slim variant to reduce the spin used and prefer to not wake up thread until
-    // needed. Only the main worker spin.
-    private readonly Semaphore _executionSlots;
-
+    private readonly Processor[] _processors;
+    private readonly ManualResetEventSlim _processorsIdle = new(initialState: true);
     private readonly CancellationTokenSource _cancelTokenSource;
 
     public TrieWarmer(IProcessExitSource processExitSource, ILogManager logManager, IFlatDbConfig flatDbConfig)
@@ -66,177 +58,82 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 
         int configuredWorkerCount = flatDbConfig.TrieWarmerWorkerCount;
         int workerCount = configuredWorkerCount == -1
-            ? Math.Max(Environment.ProcessorCount - 1, 1)
+            ? Math.Max(Environment.ProcessorCount / 2, 1)
             : configuredWorkerCount;
         workerCount = Math.Max(workerCount, 2); // Min worker count is 2
-        _secondaryWorkerCount = workerCount - 1;
-
-        _executionSlots = new Semaphore(0, _secondaryWorkerCount);
 
         _cancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(processExitSource.Token);
 
-        if (_secondaryWorkerCount > 0)
+        _processors = new Processor[workerCount];
+        for (int i = 0; i < _processors.Length; i++)
         {
-            _warmerJob = Task.Run(() =>
-            {
-                using ArrayPoolListRef<Thread> tasks = new(_secondaryWorkerCount);
-                Thread primaryWorkerThread = new(() =>
-                {
-                    RunPrimaryWorker(_cancelTokenSource.Token);
-                })
-                {
-                    Name = "TrieWarmer-Primary",
-                    IsBackground = true
-                };
-                primaryWorkerThread.Start();
-                tasks.Add(primaryWorkerThread);
-
-                for (int i = 0; i < _secondaryWorkerCount; i++)
-                {
-                    Thread t = new(() =>
-                    {
-                        RunSecondaryWorker(_cancelTokenSource.Token);
-                    })
-                    {
-                        Name = $"TrieWarmer-Secondary-{i}",
-                        Priority = ThreadPriority.Lowest,
-                        IsBackground = true
-                    };
-                    t.Start();
-                    tasks.Add(t);
-                }
-
-                foreach (Thread thread in tasks)
-                {
-                    thread.Join();
-                }
-            });
+            _processors[i] = new Processor(this);
         }
     }
 
-    private void RunPrimaryWorker(CancellationToken cancellationToken)
+    private sealed class Processor(TrieWarmer owner) : IThreadPoolWorkItem
     {
-        SpinWait spinWait = new();
-        try
+        private readonly TrieWarmer _owner = owner;
+        private int _scheduled = 0;
+
+        public bool TrySchedule()
         {
-            while (true)
-            {
-                if (cancellationToken.IsCancellationRequested) break;
+            if (Interlocked.CompareExchange(ref _scheduled, 1, 0) != 0) return false;
 
-                if (TryDequeue(out Job job))
-                {
-                    spinWait.Reset();
-                    MaybeWakeOpOtherWorker();
-
-                    HandleJob(job);
-                }
-                else
-                {
-                    if (spinWait.NextSpinWillYield)
-                    {
-                        _primaryWorkerLatch.Reset();
-                        _shouldWakeUpPrimaryWorker = 1;
-                        _primaryWorkerLatch.Wait(1, cancellationToken);
-                        _shouldWakeUpPrimaryWorker = 0;
-                    }
-                    else
-                    {
-                        spinWait.SpinOnce();
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) { }
-        catch (Exception ex)
-        {
-            if (_logger.IsError) _logger.Error("Error in primary warmup job ", ex);
-        }
-    }
-
-    private void RunSecondaryWorker(CancellationToken cancellationToken)
-    {
-        try
-        {
-            Interlocked.Increment(ref _activeSecondaryWorker);
-            while (true)
-            {
-                if (cancellationToken.IsCancellationRequested) break;
-
-                if (TryDequeue(out Job job))
-                {
-                    HandleJob(job);
-                }
-                else
-                {
-                    Interlocked.Decrement(ref _activeSecondaryWorker);
-                    if (WaitForExecutionSlot())
-                    {
-                        Interlocked.Decrement(ref _pendingWakeUpSlots);
-                    }
-                    Interlocked.Increment(ref _activeSecondaryWorker);
-                }
-            }
-        }
-        catch (OperationCanceledException) { }
-        catch (Exception ex)
-        {
-            if (_logger.IsError) _logger.Error("Error in warmup job ", ex);
-        }
-    }
-
-    // Some wait but not forever so that it exit properly
-    private bool WaitForExecutionSlot() => _executionSlots.WaitOne(500);
-
-    private bool ShouldWakeUpMoreWorker()
-    {
-        // Assume that for each pending job, it go to the respective worker.
-        int effectiveActiveWorker = _activeSecondaryWorker + _pendingWakeUpSlots;
-        if (effectiveActiveWorker >= _secondaryWorkerCount) return false; // We cant wake up more worker
-
-        // We should wake up more worker if the num of job is more than effective active worker
-
-        // We go check the queue one by one because they each do a volatile read
-        long jobCount = _jobBufferMultiThreaded.EstimatedJobCount;
-        if (jobCount > effectiveActiveWorker) return true;
-
-        jobCount += _slotJobBuffer.EstimatedJobCount;
-        return jobCount > effectiveActiveWorker;
-    }
-
-    private bool MaybeWakeOpOtherWorker()
-    {
-        bool wokeUpWorker = false;
-
-        // Release one by one until all jobs were dequeued
-        while (ShouldWakeUpMoreWorker())
-        {
-            try
-            {
-                Interlocked.Increment(ref _pendingWakeUpSlots);
-                _executionSlots.Release();
-                wokeUpWorker = true;
-            }
-            catch (SemaphoreFullException)
-            {
-                Interlocked.Decrement(ref _pendingWakeUpSlots);
-                break;
-            }
-        }
-
-        return wokeUpWorker;
-    }
-
-    private bool MaybeWakeupFast()
-    {
-        // Skipping wakeup due to non-atomic read is fine. Doing atomic operation all the time slows down measurably.
-        if (_shouldWakeUpPrimaryWorker == 1)
-        {
-            _primaryWorkerLatch.Set();
-            _shouldWakeUpPrimaryWorker = 0;
+            _owner.OnProcessorScheduled();
+            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
             return true;
         }
 
-        return false;
+        public void ClearScheduled() => Volatile.Write(ref _scheduled, 0);
+
+        public bool TryReacquireAfterEmptyCheck() => Interlocked.Exchange(ref _scheduled, 1) == 0;
+
+        void IThreadPoolWorkItem.Execute() => _owner.Execute(this);
+    }
+
+    private bool HasReadyWork() => _slotJobBuffer.HasReadyItem || _jobBufferMultiThreaded.HasReadyItem;
+
+    private long PendingHint() => _slotJobBuffer.EstimatedJobCount + _jobBufferMultiThreaded.EstimatedJobCount;
+
+    private void KickProcessors()
+    {
+        long pending = PendingHint();
+        int desiredProcessors = (int)Math.Min(_processors.Length, Math.Max(1, pending));
+        for (int i = 0; i < desiredProcessors; i++)
+        {
+            _processors[i].TrySchedule();
+        }
+    }
+
+    private void Execute(Processor processor)
+    {
+        try
+        {
+            while (true)
+            {
+                while (TryDequeue(out Job job))
+                {
+                    HandleJob(in job);
+                }
+
+                processor.ClearScheduled();
+                Thread.MemoryBarrier();
+
+                if (!HasReadyWork()) break;
+                if (!processor.TryReacquireAfterEmptyCheck()) break;
+            }
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error("Error in trie warmer processor", ex);
+            processor.ClearScheduled();
+            KickProcessors();
+        }
+        finally
+        {
+            OnProcessorStopped();
+        }
     }
 
     private bool TryDequeue(out Job job)
@@ -254,23 +151,18 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         return _jobBufferMultiThreaded.TryDequeue(out job);
     }
 
-    private static void HandleJob(Job job)
+    private static void HandleJob(in Job job)
     {
-        (object scopeOrStorageTree,
-            Address? address,
-            UInt256 index,
-            int sequenceId) = job;
-
         try
         {
-            if (scopeOrStorageTree is ITrieWarmer.IAddressWarmer scope)
+            if (job.scopeOrStorageTree is ITrieWarmer.IAddressWarmer scope)
             {
-                scope.WarmUpStateTrie(address!, sequenceId);
+                scope.WarmUpStateTrie(job.path!, job.sequenceId);
             }
             else
             {
-                ITrieWarmer.IStorageWarmer storageTree = (ITrieWarmer.IStorageWarmer)scopeOrStorageTree;
-                storageTree.WarmUpStorageTrie(index, sequenceId);
+                ITrieWarmer.IStorageWarmer storageTree = (ITrieWarmer.IStorageWarmer)job.scopeOrStorageTree;
+                storageTree.WarmUpStorageTrie(job.index, job.sequenceId);
             }
         }
         // It can be missing when the warmer lags so much behind that the node is now gone.
@@ -286,53 +178,83 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool PushAddressJob(ITrieWarmer.IAddressWarmer scope, Address? path, int sequenceId)
     {
+        if (Volatile.Read(ref _isDisposed)) return false;
+
         // Address is not single threaded. In which case, might as well use the same buffer.
         bool enqueued = _jobBufferMultiThreaded.TryEnqueue(new Job(scope, path, default, sequenceId));
-        if (enqueued) MaybeWakeupFast();
+        if (enqueued) KickProcessors();
         return enqueued;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256? index, int sequenceId)
     {
+        if (Volatile.Read(ref _isDisposed)) return false;
+
         bool enqueued = _slotJobBuffer.TryEnqueue(new SlotJob(storageTree, index.GetValueOrDefault(), sequenceId));
-        if (enqueued) MaybeWakeupFast();
+        if (enqueued) KickProcessors();
         return enqueued;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool PushSlotJobMpmc(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId)
     {
+        if (Volatile.Read(ref _isDisposed)) return false;
+
         bool enqueued = _jobBufferMultiThreaded.TryEnqueue(new Job(storageTree, null, index, sequenceId));
-        if (enqueued) MaybeWakeupFast();
+        if (enqueued) KickProcessors();
         return enqueued;
     }
 
-    public void OnEnterScope() => _primaryWorkerLatch.Set();
+    public void OnEnterScope() { }
 
     public void OnExitScope() { }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return;
+        if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return ValueTask.CompletedTask;
 
         _cancelTokenSource.Cancel();
+        KickProcessors();
 
-        // Release semaphore so that worker detects the cancellation quickly
-        while (true)
+        bool processorsStopped = WaitForProcessorsToStop();
+        if (!processorsStopped && _logger.IsWarn)
         {
-            try
-            {
-                _executionSlots.Release();
-            }
-            catch (SemaphoreFullException)
-            {
-                break;
-            }
+            _logger.Warn($"TrieWarmer processors ({Volatile.Read(ref _activeProcessors)}) did not stop within {DisposeTimeoutMilliseconds}ms during dispose");
         }
 
-        if (_warmerJob is not null) await _warmerJob;
-        _executionSlots.Dispose();
         _cancelTokenSource.Dispose();
+        // A push can pass the disposed check before DisposeAsync starts and still need to schedule
+        // accepted work. Keep the process-lifetime wait handle alive so that race cannot observe a
+        // disposed event while flushing the accepted job.
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void OnProcessorScheduled()
+    {
+        Interlocked.Increment(ref _activeProcessors);
+        _processorsIdle.Reset();
+    }
+
+    private void OnProcessorStopped()
+    {
+        if (Interlocked.Decrement(ref _activeProcessors) == 0)
+        {
+            _processorsIdle.Set();
+        }
+    }
+
+    private bool WaitForProcessorsToStop()
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        while (Volatile.Read(ref _activeProcessors) != 0)
+        {
+            int remainingMilliseconds = DisposeTimeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
+            if (remainingMilliseconds <= 0) return Volatile.Read(ref _activeProcessors) == 0;
+            if (!_processorsIdle.Wait(remainingMilliseconds)) return Volatile.Read(ref _activeProcessors) == 0;
+        }
+
+        return true;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Int256;
@@ -49,10 +47,9 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         int sequenceId);
 
     private readonly Processor[] _processors;
-    private readonly ManualResetEventSlim _processorsIdle = new(initialState: true);
-    private readonly CancellationTokenSource _cancelTokenSource;
+    private TaskCompletionSource<bool>? _processorsStopped;
 
-    public TrieWarmer(IProcessExitSource processExitSource, ILogManager logManager, IFlatDbConfig flatDbConfig)
+    public TrieWarmer(ILogManager logManager, IFlatDbConfig flatDbConfig)
     {
         _logger = logManager.GetClassLogger<TrieWarmer>();
 
@@ -61,8 +58,6 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
             ? Math.Max(Environment.ProcessorCount / 2, 1)
             : configuredWorkerCount;
         workerCount = Math.Max(workerCount, 2); // Min worker count is 2
-
-        _cancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(processExitSource.Token);
 
         _processors = new Processor[workerCount];
         for (int i = 0; i < _processors.Length; i++)
@@ -100,9 +95,13 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
     {
         long pending = PendingHint();
         int desiredProcessors = (int)Math.Min(_processors.Length, Math.Max(1, pending));
-        for (int i = 0; i < desiredProcessors; i++)
+        int scheduledProcessors = 0;
+        for (int i = 0; i < _processors.Length && scheduledProcessors < desiredProcessors; i++)
         {
-            _processors[i].TrySchedule();
+            if (_processors[i].TrySchedule())
+            {
+                scheduledProcessors++;
+            }
         }
     }
 
@@ -171,9 +170,17 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         catch (NodeHashMismatchException) { }
         // Because it runs in parallel, it could be that the scope is disposed of early.
         catch (ObjectDisposedException) { }
-        // When the scope is disposed, it set some of the dictionary to null to prevent corrupting later state
-        catch (NullReferenceException) { }
+        // Scope disposal can null pooled snapshot maps while a queued warmup is already inside trie traversal.
+        catch (NullReferenceException) when (IsDisposedJobTarget(in job)) { }
     }
+
+    private static bool IsDisposedJobTarget(in Job job) =>
+        job.scopeOrStorageTree switch
+        {
+            FlatWorldStateScope scope => scope.IsDisposed,
+            FlatStorageTree storageTree => storageTree.IsDisposed,
+            _ => false
+        };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool PushAddressJob(ITrieWarmer.IAddressWarmer scope, Address? path, int sequenceId)
@@ -187,11 +194,11 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256? index, int sequenceId)
+    public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId)
     {
         if (Volatile.Read(ref _isDisposed)) return false;
 
-        bool enqueued = _slotJobBuffer.TryEnqueue(new SlotJob(storageTree, index.GetValueOrDefault(), sequenceId));
+        bool enqueued = _slotJobBuffer.TryEnqueue(new SlotJob(storageTree, index, sequenceId));
         if (enqueued) KickProcessors();
         return enqueued;
     }
@@ -210,51 +217,41 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 
     public void OnExitScope() { }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return ValueTask.CompletedTask;
+        if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return;
 
-        _cancelTokenSource.Cancel();
+        TaskCompletionSource<bool> processorsStopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Volatile.Write(ref _processorsStopped, processorsStopped);
         KickProcessors();
 
-        bool processorsStopped = WaitForProcessorsToStop();
-        if (!processorsStopped && _logger.IsWarn)
+        if (Volatile.Read(ref _activeProcessors) == 0)
+        {
+            processorsStopped.TrySetResult(true);
+        }
+
+        bool processorsStoppedBeforeTimeout = await WaitForProcessorsToStopAsync(processorsStopped.Task).ConfigureAwait(false);
+        if (!processorsStoppedBeforeTimeout && _logger.IsWarn)
         {
             _logger.Warn($"TrieWarmer processors ({Volatile.Read(ref _activeProcessors)}) did not stop within {DisposeTimeoutMilliseconds}ms during dispose");
         }
-
-        _cancelTokenSource.Dispose();
-        // A push can pass the disposed check before DisposeAsync starts and still need to schedule
-        // accepted work. Keep the process-lifetime wait handle alive so that race cannot observe a
-        // disposed event while flushing the accepted job.
-
-        return ValueTask.CompletedTask;
     }
 
-    private void OnProcessorScheduled()
-    {
-        Interlocked.Increment(ref _activeProcessors);
-        _processorsIdle.Reset();
-    }
+    private void OnProcessorScheduled() => Interlocked.Increment(ref _activeProcessors);
 
     private void OnProcessorStopped()
     {
         if (Interlocked.Decrement(ref _activeProcessors) == 0)
         {
-            _processorsIdle.Set();
+            Volatile.Read(ref _processorsStopped)?.TrySetResult(true);
         }
     }
 
-    private bool WaitForProcessorsToStop()
+    private static async ValueTask<bool> WaitForProcessorsToStopAsync(Task processorsStopped)
     {
-        Stopwatch stopwatch = Stopwatch.StartNew();
-        while (Volatile.Read(ref _activeProcessors) != 0)
-        {
-            int remainingMilliseconds = DisposeTimeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
-            if (remainingMilliseconds <= 0) return Volatile.Read(ref _activeProcessors) == 0;
-            if (!_processorsIdle.Wait(remainingMilliseconds)) return Volatile.Read(ref _activeProcessors) == 0;
-        }
+        if (processorsStopped.IsCompleted) return true;
 
-        return true;
+        Task timeout = Task.Delay(DisposeTimeoutMilliseconds);
+        return await Task.WhenAny(processorsStopped, timeout).ConfigureAwait(false) == processorsStopped;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.State.Flat;
 
@@ -24,23 +25,28 @@ public sealed class SpmcRingBuffer<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            long tail = Volatile.Read(ref _tail);
-            long head = Volatile.Read(ref _head);
+            long tail = Volatile.Read(ref _tail.Value);
+            long head = Volatile.Read(ref _head.Value);
 
             long count = tail - head;
             return count < 0 ? 0 : count; // clamp just in case of a race
         }
     }
 
-    // --- head (consumers) + padding to avoid false sharing with _tail ---
-    private long _head;
-#pragma warning disable CS0169 // Field is never used
-    private long _headPad1, _headPad2, _headPad3, _headPad4, _headPad5, _headPad6, _headPad7;
+    internal bool HasReadyItem
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            long head = Volatile.Read(ref _head.Value);
+            int index = (int)(head & _mask);
+            long seq = Volatile.Read(ref _sequences[index]);
+            return seq >= head + 1;
+        }
+    }
 
-    // --- tail (producer) + padding ---
-    private long _tail;
-    private long _tailPad1, _tailPad2, _tailPad3, _tailPad4, _tailPad5, _tailPad6, _tailPad7;
-#pragma warning restore CS0169 // Field is never used
+    private CacheLinePaddedLong _head;
+    private CacheLinePaddedLong _tail;
 
     public SpmcRingBuffer(int capacityPowerOfTwo)
     {
@@ -64,7 +70,7 @@ public sealed class SpmcRingBuffer<T>
     public bool TryEnqueue(in T item)
     {
         // Single producer: no CAS needed on tail.
-        long tail = _tail;
+        long tail = _tail.Value;
         int index = (int)(tail & _mask);
 
         // Slot is free only if its sequence equals the current tail.
@@ -80,7 +86,7 @@ public sealed class SpmcRingBuffer<T>
         // sees the payload after seeing seq.
         Volatile.Write(ref _sequences[index], tail + 1);
 
-        _tail = tail + 1;
+        _tail.Value = tail + 1;
 
         return true;
     }
@@ -90,7 +96,7 @@ public sealed class SpmcRingBuffer<T>
     {
         while (true)
         {
-            long head = Volatile.Read(ref _head);
+            long head = Volatile.Read(ref _head.Value);
             int index = (int)(head & _mask);
             long seq = Volatile.Read(ref _sequences[index]);
             long expectedSeq = head + 1;
@@ -98,9 +104,14 @@ public sealed class SpmcRingBuffer<T>
             // If seq == expectedSeq, the producer has finished writing
             if (seq == expectedSeq)
             {
-                if (Interlocked.CompareExchange(ref _head, head + 1, head) == head)
+                if (Interlocked.CompareExchange(ref _head.Value, head + 1, head) == head)
                 {
                     item = _entries[index];
+                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                    {
+                        _entries[index] = default!;
+                    }
+
                     // Mark as ready for the producer's next lap (head + capacity)
                     Volatile.Write(ref _sequences[index], head + _capacity);
                     return true;

--- a/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
@@ -86,6 +86,7 @@ public sealed class SpmcRingBuffer<T>
         // sees the payload after seeing seq.
         Volatile.Write(ref _sequences[index], tail + 1);
 
+        // Single producer owns tail; EstimatedJobCount only uses this as a stale-tolerant hint.
         _tail.Value = tail + 1;
 
         return true;


### PR DESCRIPTION
## Changes

- Replace the TrieWarmer's bespoke primary/secondary worker-thread model and Semaphore-based wakeup with a ThreadPool-driven Processor model. Each Processor self-schedules via UnsafeQueueUserWorkItem, drains the job queues, then re-checks for ready work before unscheduling to avoid lost wakeups. Push methods now reject jobs once disposed, and DisposeAsync drains accepted work and waits for processors to stop.
- Add HasReadyItem to the SPMC/MPMC ring buffers so processors can detect pending work without dequeuing.
- Consolidate the three hand-rolled cache-line padding structs (State.Flat.CacheLinePaddedLong, ParallelUnbalancedWork.PaddedValue, RefCountingDisposable.PaddedValue) into a single public Nethermind.Core.Threading.CacheLinePaddedLong.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes