### PR TITLE
Fix SSZ Accept negotiation to inspect every media range

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -239,6 +239,7 @@ public class SszMiddlewareTests
     [TestCase("application/octet-stream; charset=utf-8", true)]
     [TestCase("application/octet-streamx", false)]
     [TestCase("application/json", false)]
+    [TestCase(" application/octet-stream", false)]
     public async Task Post_negotiates_ssz_on_content_type_boundary(string contentType, bool handledAsSsz)
     {
         bool nextInvoked = false;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -202,6 +202,7 @@ public class SszMiddlewareTests
         yield return new TestCaseData((object)new[] { OctetStream + ", application/json" }, true).SetName("single_octet_first");
         yield return new TestCaseData((object)new[] { "application/json, " + OctetStream }, true).SetName("single_octet_last");
         yield return new TestCaseData((object)new[] { "text/html, " + OctetStream + ";q=0.9, */*" }, true).SetName("single_octet_middle_with_q");
+        yield return new TestCaseData((object)new[] { OctetStream + " , application/json" }, true).SetName("single_octet_trailing_ows");
         yield return new TestCaseData((object)new[] { "application/json" }, false).SetName("single_no_octet");
         yield return new TestCaseData((object)new[] { "application/json, text/html" }, false).SetName("single_csv_no_octet");
         yield return new TestCaseData((object)new[] { "application/octet-streamx" }, false).SetName("single_octet_substring");

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -219,13 +219,38 @@ public class SszMiddlewareTests
         bool nextInvoked = false;
         SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
 
-        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v1/payloads/0x0102030405060708", AuthenticatedPort);
+        // Use an unrouted engine resource: a recognized SSZ request resolves to 404 without invoking
+        // any handler, so the test isolates the negotiation decision and never depends on engine
+        // module return values. Recognized -> middleware answers it (404) and never delegates;
+        // not recognized -> it passes through to next().
+        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v1/negotiation-probe", AuthenticatedPort);
         ctx.Request.Headers.Accept = acceptValues;
         ctx.Request.Body = Stream.Null;
 
         await mw.InvokeAsync(ctx);
 
-        // Recognized as SSZ -> middleware answers it and never delegates; otherwise it passes through.
+        Assert.That(nextInvoked, Is.EqualTo(!handledAsSsz));
+    }
+
+    // POST negotiation uses the raw-string HasOctetMediaValue boundary check on Content-Type
+    // (single-valued, hot path). Guards both directions: a substring like "...streamx" must NOT
+    // match, while a parameterized "...; charset=utf-8" must (the ';' is a valid token boundary).
+    [TestCase(OctetStream, true)]
+    [TestCase("application/octet-stream; charset=utf-8", true)]
+    [TestCase("application/octet-streamx", false)]
+    [TestCase("application/json", false)]
+    public async Task Post_negotiates_ssz_on_content_type_boundary(string contentType, bool handledAsSsz)
+    {
+        bool nextInvoked = false;
+        SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
+
+        DefaultHttpContext ctx = MakeBaseContext("POST", "/engine/v1/negotiation-probe", AuthenticatedPort);
+        ctx.Request.ContentType = contentType;
+        ctx.Request.ContentLength = 0;
+        ctx.Request.Body = Stream.Null;
+
+        await mw.InvokeAsync(ctx);
+
         Assert.That(nextInvoked, Is.EqualTo(!handledAsSsz));
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -191,6 +191,44 @@ public class SszMiddlewareTests
         await _engineModule.Received(version == 2 ? 1 : 0).engine_getPayloadV2(Arg.Any<byte[]>());
     }
 
+    // The Accept header reaches the middleware as StringValues, which carries BOTH forms a client
+    // may send: a single header line holding a comma-separated list of media ranges, and several
+    // distinct header lines (a string[]). SSZ negotiation must inspect every range across every
+    // entry, so octet-stream is honored regardless of which entry or position it appears in.
+    private static IEnumerable<TestCaseData> AcceptHeaderCases()
+    {
+        // Single StringValues entry (one header line), octet-stream in various positions.
+        yield return new TestCaseData((object)new[] { OctetStream }, true).SetName("single_octet_only");
+        yield return new TestCaseData((object)new[] { OctetStream + ", application/json" }, true).SetName("single_octet_first");
+        yield return new TestCaseData((object)new[] { "application/json, " + OctetStream }, true).SetName("single_octet_last");
+        yield return new TestCaseData((object)new[] { "text/html, " + OctetStream + ";q=0.9, */*" }, true).SetName("single_octet_middle_with_q");
+        yield return new TestCaseData((object)new[] { "application/json" }, false).SetName("single_no_octet");
+        yield return new TestCaseData((object)new[] { "application/json, text/html" }, false).SetName("single_csv_no_octet");
+        yield return new TestCaseData((object)new[] { "application/octet-streamx" }, false).SetName("single_octet_substring");
+
+        // Multiple StringValues entries (Accept sent as separate header lines / string[]).
+        yield return new TestCaseData((object)new[] { OctetStream, "application/json" }, true).SetName("multi_octet_first_entry");
+        yield return new TestCaseData((object)new[] { "application/json", OctetStream }, true).SetName("multi_octet_last_entry");
+        yield return new TestCaseData((object)new[] { "application/json", "text/html, " + OctetStream }, true).SetName("multi_octet_in_csv_entry");
+        yield return new TestCaseData((object)new[] { "application/json", "text/html" }, false).SetName("multi_no_octet");
+    }
+
+    [TestCaseSource(nameof(AcceptHeaderCases))]
+    public async Task Get_negotiates_ssz_across_all_accept_ranges(string[] acceptValues, bool handledAsSsz)
+    {
+        bool nextInvoked = false;
+        SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
+
+        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v1/payloads/0x0102030405060708", AuthenticatedPort);
+        ctx.Request.Headers.Accept = acceptValues;
+        ctx.Request.Body = Stream.Null;
+
+        await mw.InvokeAsync(ctx);
+
+        // Recognized as SSZ -> middleware answers it and never delegates; otherwise it passes through.
+        Assert.That(nextInvoked, Is.EqualTo(!handledAsSsz));
+    }
+
     [TestCase("/engine/v1/forkchoice", 1)]
     [TestCase("/engine/v2/forkchoice", 2)]
     [TestCase("/engine/v3/forkchoice", 3)]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -206,6 +206,7 @@ public class SszMiddlewareTests
         yield return new TestCaseData((object)new[] { "application/json" }, false).SetName("single_no_octet");
         yield return new TestCaseData((object)new[] { "application/json, text/html" }, false).SetName("single_csv_no_octet");
         yield return new TestCaseData((object)new[] { "application/octet-streamx" }, false).SetName("single_octet_substring");
+        yield return new TestCaseData((object)new[] { "application/json;v=\"a, application/octet-stream, b\"" }, false).SetName("octet_inside_quoted_parameter");
 
         // Multiple StringValues entries (Accept sent as separate header lines / string[]).
         yield return new TestCaseData((object)new[] { OctetStream, "application/json" }, true).SetName("multi_octet_first_entry");

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -198,21 +198,29 @@ public class SszMiddlewareTests
     private static IEnumerable<TestCaseData> AcceptHeaderCases()
     {
         // Single StringValues entry (one header line), octet-stream in various positions.
-        yield return new TestCaseData((object)new[] { OctetStream }, true).SetName("single_octet_only");
-        yield return new TestCaseData((object)new[] { OctetStream + ", application/json" }, true).SetName("single_octet_first");
-        yield return new TestCaseData((object)new[] { "application/json, " + OctetStream }, true).SetName("single_octet_last");
-        yield return new TestCaseData((object)new[] { "text/html, " + OctetStream + ";q=0.9, */*" }, true).SetName("single_octet_middle_with_q");
-        yield return new TestCaseData((object)new[] { OctetStream + " , application/json" }, true).SetName("single_octet_trailing_ows");
-        yield return new TestCaseData((object)new[] { "application/json" }, false).SetName("single_no_octet");
-        yield return new TestCaseData((object)new[] { "application/json, text/html" }, false).SetName("single_csv_no_octet");
-        yield return new TestCaseData((object)new[] { "application/octet-streamx" }, false).SetName("single_octet_substring");
-        yield return new TestCaseData((object)new[] { "application/json;v=\"a, application/octet-stream, b\"" }, false).SetName("octet_inside_quoted_parameter");
+        yield return new TestCaseData(new[] { OctetStream }, true).SetName("single_octet_only");
+        yield return new TestCaseData(new[] { OctetStream + ", application/json" }, true).SetName("single_octet_first");
+        yield return new TestCaseData(new[] { "application/json, " + OctetStream }, true).SetName("single_octet_last");
+        yield return new TestCaseData(new[] { "text/html, " + OctetStream + ";q=0.9, */*" }, true).SetName("single_octet_middle_with_q");
+        yield return new TestCaseData(new[] { OctetStream + " , application/json" }, true).SetName("single_octet_trailing_ows");
+        yield return new TestCaseData(new[] { "application/json" }, false).SetName("single_no_octet");
+        yield return new TestCaseData(new[] { "application/json, text/html" }, false).SetName("single_csv_no_octet");
+        yield return new TestCaseData(new[] { "application/octet-streamx" }, false).SetName("single_octet_substring");
+        yield return new TestCaseData(new[] { "application/json;v=\"a, application/octet-stream, b\"" }, false).SetName("octet_inside_quoted_parameter");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0" }, false).SetName("octet_explicit_zero_quality");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0.0" }, false).SetName("octet_zero_quality_decimal");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0.000" }, false).SetName("octet_zero_quality_decimals");
+        yield return new TestCaseData(new[] { OctetStream + ";Q=0" }, false).SetName("octet_zero_quality_uppercase");
+        yield return new TestCaseData(new[] { OctetStream + ";q=1" }, true).SetName("octet_unit_quality");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0.5" }, true).SetName("octet_positive_quality");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0, application/json" }, false).SetName("multi_octet_zero_then_other");
+        yield return new TestCaseData(new[] { OctetStream + ";q=0, " + OctetStream }, true).SetName("multi_octet_zero_then_octet_default");
 
         // Multiple StringValues entries (Accept sent as separate header lines / string[]).
-        yield return new TestCaseData((object)new[] { OctetStream, "application/json" }, true).SetName("multi_octet_first_entry");
-        yield return new TestCaseData((object)new[] { "application/json", OctetStream }, true).SetName("multi_octet_last_entry");
-        yield return new TestCaseData((object)new[] { "application/json", "text/html, " + OctetStream }, true).SetName("multi_octet_in_csv_entry");
-        yield return new TestCaseData((object)new[] { "application/json", "text/html" }, false).SetName("multi_no_octet");
+        yield return new TestCaseData(new[] { OctetStream, "application/json" }, true).SetName("multi_octet_first_entry");
+        yield return new TestCaseData(new[] { "application/json", OctetStream }, true).SetName("multi_octet_last_entry");
+        yield return new TestCaseData(new[] { "application/json", "text/html, " + OctetStream }, true).SetName("multi_octet_in_csv_entry");
+        yield return new TestCaseData(new[] { "application/json", "text/html" }, false).SetName("multi_no_octet");
     }
 
     [TestCaseSource(nameof(AcceptHeaderCases))]

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -386,8 +386,34 @@ public sealed class SszMiddleware
         {
             ReadOnlySpan<char> token = range.TrimStart();
             int semi = IndexOfUnquoted(token, ';');
-            if (semi >= 0) token = token[..semi];
-            return token.TrimEnd().Equals(Octet, StringComparison.OrdinalIgnoreCase);
+            ReadOnlySpan<char> type = (semi >= 0 ? token[..semi] : token).TrimEnd();
+            if (!type.Equals(Octet, StringComparison.OrdinalIgnoreCase))
+                return false;
+            return semi < 0 || !HasZeroQValue(token[(semi + 1)..]);
+        }
+
+        static bool HasZeroQValue(ReadOnlySpan<char> parameters)
+        {
+            while (!parameters.IsEmpty)
+            {
+                int next = IndexOfUnquoted(parameters, ';');
+                ReadOnlySpan<char> param = (next < 0 ? parameters : parameters[..next]).Trim();
+                if (param.Length >= 2 && (param[0] | 0x20) == 'q' && param[1] == '=')
+                    return IsZeroQ(param[2..]);
+                if (next < 0) break;
+                parameters = parameters[(next + 1)..];
+            }
+            return false;
+        }
+
+        static bool IsZeroQ(ReadOnlySpan<char> qValue)
+        {
+            if (qValue.IsEmpty || qValue[0] != '0') return false;
+            for (int i = 1; i < qValue.Length; i++)
+            {
+                if (qValue[i] != '.' && qValue[i] != '0') return false;
+            }
+            return true;
         }
 
         static int IndexOfUnquoted(ReadOnlySpan<char> s, char target)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 using Nethermind.Config;
 using Nethermind.Core.Authentication;
 using Nethermind.JsonRpc;
@@ -36,6 +35,7 @@ public sealed class SszMiddleware
 
     // Path: /engine/v{N}/{resource}[/{extra}]
     private const string EnginePrefix = "/engine/v";
+    private const string Octet = MediaTypeNames.Application.Octet;
 
     /// <summary>
     /// Maximum allowed request body size in bytes (16 MiB).
@@ -350,10 +350,8 @@ public sealed class SszMiddleware
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSszRequest(HttpContext ctx)
     {
-        const string Octet = MediaTypeNames.Application.Octet;
-
         PathString path = ctx.Request.Path;
-        if (!path.HasValue || path.Value?.StartsWith("/engine/", StringComparison.OrdinalIgnoreCase) != true)
+        if (!path.HasValue || !path.Value!.StartsWith("/engine/", StringComparison.OrdinalIgnoreCase))
             return false;
 
         return AcceptsSszResponse(ctx);
@@ -369,20 +367,21 @@ public sealed class SszMiddleware
 
         static bool AcceptsOctet(HttpRequest request)
         {
-            // GetTypedHeaders parses the Accept header per RFC: each entry is one media range
-            // with commas, quoted-strings and ;q= parameters already split out. So MediaType
-            // is the bare type/subtype, and an exact match is all that's needed here. This
-            // allocates a RequestHeaders wrapper and a List<MediaTypeHeaderValue> (one per range):
-            // acceptable on the comparatively cold GET path - the hot POST/newPayload path keeps
-            // the raw-string HasOctetMediaValue check below.
-            IList<MediaTypeHeaderValue> accept = request.GetTypedHeaders().Accept;
-            int count = accept.Count;
-            for (int i = 0; i < count; i++)
+            foreach (string? entry in request.Headers.Accept)
             {
-                if (accept[i].MediaType.Equals(Octet, StringComparison.OrdinalIgnoreCase))
-                    return true;
+                if (entry is null) continue;
+                ReadOnlySpan<char> span = entry.AsSpan();
+                while (!span.IsEmpty)
+                {
+                    int comma = span.IndexOf(',');
+                    ReadOnlySpan<char> token = (comma < 0 ? span : span[..comma]).TrimStart();
+                    int semi = token.IndexOf(';');
+                    if (semi >= 0) token = token[..semi].TrimEnd();
+                    if (token.Equals(Octet, StringComparison.OrdinalIgnoreCase)) return true;
+                    if (comma < 0) break;
+                    span = span[(comma + 1)..];
+                }
             }
-
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -371,18 +371,20 @@ public sealed class SszMiddleware
             {
                 if (entry is null) continue;
                 ReadOnlySpan<char> span = entry.AsSpan();
-                while (!span.IsEmpty)
+                foreach (Range range in span.Split(','))
                 {
-                    int comma = span.IndexOf(',');
-                    ReadOnlySpan<char> token = (comma < 0 ? span : span[..comma]).TrimStart();
-                    int semi = token.IndexOf(';');
-                    if (semi >= 0) token = token[..semi].TrimEnd();
-                    if (token.Equals(Octet, StringComparison.OrdinalIgnoreCase)) return true;
-                    if (comma < 0) break;
-                    span = span[(comma + 1)..];
+                    if (IsOctetMediaRange(span[range])) return true;
                 }
             }
             return false;
+        }
+
+        static bool IsOctetMediaRange(ReadOnlySpan<char> range)
+        {
+            ReadOnlySpan<char> token = range.TrimStart();
+            int semi = token.IndexOf(';');
+            if (semi >= 0) token = token[..semi].TrimEnd();
+            return token.Equals(Octet, StringComparison.OrdinalIgnoreCase);
         }
 
         static bool HasOctetMediaValue(string? headerValue)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -8,9 +8,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net.Mime;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 using Nethermind.Config;
 using Nethermind.Core.Authentication;
 using Nethermind.JsonRpc;
@@ -345,29 +347,46 @@ public sealed class SszMiddleware
         return false;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSszRequest(HttpContext ctx)
     {
-        string path = ctx.Request.Path.Value ?? string.Empty;
-        if (!path.StartsWith("/engine/", StringComparison.OrdinalIgnoreCase))
+        const string Octet = MediaTypeNames.Application.Octet;
+
+        PathString path = ctx.Request.Path;
+        if (!path.HasValue || path.Value?.StartsWith("/engine/", StringComparison.OrdinalIgnoreCase) != true)
             return false;
 
-        switch (ctx.Request.Method)
-        {
-            case "POST":
-                return ctx.Request.ContentType?.Contains(MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase) == true;
-            case "GET":
-                {
-                    foreach (string? v in ctx.Request.Headers.Accept)
-                    {
-                        if (v is not null && v.Contains(MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase))
-                            return true;
-                    }
+        return AcceptsSszResponse(ctx);
 
-                    return false;
-                }
-            default:
-                return false;
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool AcceptsSszResponse(HttpContext ctx) =>
+            ctx.Request.Method switch
+            {
+                "POST" => HasOctetMediaValue(ctx.Request.ContentType),
+                "GET" => AcceptsOctet(ctx.Request),
+                _ => false
+            };
+
+
+        static bool AcceptsOctet(HttpRequest request)
+        {
+            // GetTypedHeaders parses the Accept header per RFC: each entry is one media range
+            // with commas, quoted-strings and ;q= parameters already split out. So MediaType
+            // is the bare type/subtype, and an exact match is all that's needed here.
+            IList<MediaTypeHeaderValue> accept = request.GetTypedHeaders().Accept;
+            int count = accept.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (accept[i].MediaType.Equals(Octet, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
         }
+
+        static bool HasOctetMediaValue(string? headerValue)
+            => headerValue  is not null && headerValue.StartsWith(Octet, StringComparison.OrdinalIgnoreCase) &&
+                (headerValue.Length == Octet.Length || headerValue[Octet.Length] is ';' or ' ' or '\t');
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -367,12 +367,14 @@ public sealed class SszMiddleware
                 _ => false
             };
 
-
         static bool AcceptsOctet(HttpRequest request)
         {
             // GetTypedHeaders parses the Accept header per RFC: each entry is one media range
             // with commas, quoted-strings and ;q= parameters already split out. So MediaType
-            // is the bare type/subtype, and an exact match is all that's needed here.
+            // is the bare type/subtype, and an exact match is all that's needed here. This
+            // allocates a RequestHeaders wrapper and a List<MediaTypeHeaderValue> (one per range):
+            // acceptable on the comparatively cold GET path - the hot POST/newPayload path keeps
+            // the raw-string HasOctetMediaValue check below.
             IList<MediaTypeHeaderValue> accept = request.GetTypedHeaders().Accept;
             int count = accept.Count;
             for (int i = 0; i < count; i++)
@@ -385,7 +387,7 @@ public sealed class SszMiddleware
         }
 
         static bool HasOctetMediaValue(string? headerValue)
-            => headerValue  is not null && headerValue.StartsWith(Octet, StringComparison.OrdinalIgnoreCase) &&
+            => headerValue is not null && headerValue.StartsWith(Octet, StringComparison.OrdinalIgnoreCase) &&
                 (headerValue.Length == Octet.Length || headerValue[Octet.Length] is ';' or ' ' or '\t');
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -383,8 +383,8 @@ public sealed class SszMiddleware
         {
             ReadOnlySpan<char> token = range.TrimStart();
             int semi = token.IndexOf(';');
-            if (semi >= 0) token = token[..semi].TrimEnd();
-            return token.Equals(Octet, StringComparison.OrdinalIgnoreCase);
+            if (semi >= 0) token = token[..semi];
+            return token.TrimEnd().Equals(Octet, StringComparison.OrdinalIgnoreCase);
         }
 
         static bool HasOctetMediaValue(string? headerValue)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -371,9 +371,12 @@ public sealed class SszMiddleware
             {
                 if (entry is null) continue;
                 ReadOnlySpan<char> span = entry.AsSpan();
-                foreach (Range range in span.Split(','))
+                while (!span.IsEmpty)
                 {
-                    if (IsOctetMediaRange(span[range])) return true;
+                    int comma = IndexOfUnquoted(span, ',');
+                    if (IsOctetMediaRange(comma < 0 ? span : span[..comma])) return true;
+                    if (comma < 0) break;
+                    span = span[(comma + 1)..];
                 }
             }
             return false;
@@ -382,9 +385,22 @@ public sealed class SszMiddleware
         static bool IsOctetMediaRange(ReadOnlySpan<char> range)
         {
             ReadOnlySpan<char> token = range.TrimStart();
-            int semi = token.IndexOf(';');
+            int semi = IndexOfUnquoted(token, ';');
             if (semi >= 0) token = token[..semi];
             return token.TrimEnd().Equals(Octet, StringComparison.OrdinalIgnoreCase);
+        }
+
+        static int IndexOfUnquoted(ReadOnlySpan<char> s, char target)
+        {
+            bool inQuote = false;
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (inQuote && c == '\\' && i + 1 < s.Length) { i++; continue; }
+                if (c == '"') inQuote = !inQuote;
+                else if (c == target && !inQuote) return i;
+            }
+            return -1;
         }
 
         static bool HasOctetMediaValue(string? headerValue)


### PR DESCRIPTION
## Changes

- Master matched content negotiation with `string.Contains("application/octet-stream")` on the `Content-Type` (POST) and on each `Accept` entry (GET). Substring matching has no media-type token boundary, so it **falsely accepted** unrelated or malformed types that merely embed the substring - e.g. `application/octet-streamx`, or `application/octet-stream` appearing inside a quoted parameter of another range.
- Route the GET path through `GetTypedHeaders().Accept`, which RFC-parses each media range (commas, quoted-strings and `;q=` params) across both `StringValues` shapes - one comma-separated header line and multiple distinct header lines - then exact-match the bare `MediaType`. This removes the false positives while still matching octet-stream in any position or entry.
- POST keeps a lightweight raw-string `Content-Type` check, but tightened to require a token boundary (`;`, whitespace, or end) after `application/octet-stream` rather than a loose substring. `Content-Type` is single-valued and on the hot newPayload path.
- Adds `Get_negotiates_ssz_across_all_accept_ranges` covering octet-stream in every position across single-entry and multi-entry `StringValues`, including the `application/octet-streamx` false-positive guard.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
