### PR TITLE
perf(discovery): replace timeout exceptions with value results in discv4

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
@@ -110,9 +110,9 @@ namespace Nethermind.Network.Discovery.Test
             _networkStorage.UpdateNodes([NodeA, NodeB]);
 
             _discv4Adapter.Ping(Arg.Is<Node>(n => n.Id.Equals(NodeA.NodeId)), Arg.Any<CancellationToken>())
-                .Returns(Task.CompletedTask);
+                .Returns(true);
             _discv4Adapter.Ping(Arg.Is<Node>(n => n.Id.Equals(NodeB.NodeId)), Arg.Any<CancellationToken>())
-                .Returns(x => throw new Exception("Test exception"));
+                .Returns(Task.FromException<bool>(new Exception("Test exception")));
 
             await _persistenceManager.LoadPersistedNodes(cancellationToken);
         }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryPersistenceManagerTests.cs
@@ -119,6 +119,20 @@ namespace Nethermind.Network.Discovery.Test
 
         [Test]
         [CancelAfter(10000)]
+        public void AddPersistedNodes_Should_Propagate_Cancellation(CancellationToken cancellationToken)
+        {
+            // A non-cancellation exception is swallowed (above), but a cancelled ping is lifecycle
+            // shutdown and must stop the load promptly rather than be swallowed.
+            _networkStorage.UpdateNodes([NodeA]);
+            _discv4Adapter.Ping(Arg.Is<Node>(n => n.Id.Equals(NodeA.NodeId)), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<bool>(new OperationCanceledException()));
+
+            Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await _persistenceManager.LoadPersistedNodes(cancellationToken));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
         public async Task AddPersistedNodes_Should_Restore_Reputation(CancellationToken cancellationToken)
         {
             const int reputation = 123;

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/IteratorNodeLookupTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/IteratorNodeLookupTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4
 
         private void FindNeighboursThrows(Node from, Exception exception) =>
             _msgSender.FindNeighbours(from, _targetKey, Arg.Any<CancellationToken>())
-                .Returns(Task.FromException<Node[]>(exception));
+                .Returns(Task.FromException<Node[]?>(exception));
 
         private Task AssertFindNeighboursCalledOnce(Node node) =>
             _msgSender.Received(1).FindNeighbours(

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaDiscv4AdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaDiscv4AdapterTests.cs
@@ -80,7 +80,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
 
             _logManager = LimboLogs.Instance;
             _timestamper = Substitute.For<ITimestamper>();
-            _timestamper.UnixTime.Returns(new UnixTime(new(2021, 5, 3, 0, 0, 0, DateTimeKind.Utc)));
+            DateTime now = new(2021, 5, 3, 0, 0, 0, DateTimeKind.Utc);
+            _timestamper.UtcNow.Returns(now);
+            _timestamper.UnixTime.Returns(new UnixTime(now));
             _msgSender = Substitute.For<IMsgSender>();
             _msgSender.SendMsg(Arg.Any<DiscoveryMsg>()).Returns(Task.CompletedTask);
 
@@ -97,7 +99,13 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             _adapter = new KademliaDiscv4Adapter(
                 new Lazy<IKademlia<PublicKey, Node>>(() => _kademliaMessageReceiver),
                 new Lazy<INodeHealthTracker<Node>>(() => _nodeHealthTracker),
-                new DiscoveryConfig(),
+                new DiscoveryConfig
+                {
+                    EnrTimeout = 100,
+                    PingTimeout = 100,
+                    SendNodeTimeout = 100,
+                    BondWaitTime = 1,
+                },
                 _kademliaConfig,
                 nodeRecordProvider,
                 _nodeStatsManager,
@@ -156,8 +164,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
         {
             ConfigureBondCallback();
 
-            await _adapter.Ping(_receiver, token);
+            bool result = await _adapter.Ping(_receiver, token);
 
+            Assert.That(result, Is.True);
             await _msgSender.Received(1).SendMsg(Arg.Is<PingMsg>(m =>
                 m.FarAddress!.Equals(_receiver.Address)));
         }
@@ -186,7 +195,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                     Task.Run(() => _adapter.OnIncomingMsg(neighbors2));
                 });
 
-            Node[] result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
+            Node[]? result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
             Assert.That(result, Is.EquivalentTo(expected));
         }
 
@@ -207,15 +216,15 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                     Task.Run(() => _adapter.OnIncomingMsg(response));
                 });
 
-            EnrResponseMsg result = await _adapter.SendEnrRequest(_receiver, token);
+            EnrResponseMsg? result = await _adapter.SendEnrRequest(_receiver, token);
 
             await _msgSender.Received(1).SendMsg(Arg.Is<EnrRequestMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
-            Assert.That(result.NodeRecord.GetHex(), Is.EqualTo(_selfNodeRecord.GetHex()));
+            Assert.That(result?.NodeRecord.GetHex(), Is.EqualTo(_selfNodeRecord.GetHex()));
         }
 
         [Test]
         [CancelAfter(10000)]
-        public void SendEnrRequest_should_reject_unsolicited_response_with_wrong_keccak(CancellationToken token)
+        public async Task SendEnrRequest_should_reject_unsolicited_response_with_wrong_keccak(CancellationToken token)
         {
             ConfigureBondCallback();
 
@@ -229,11 +238,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                     Task.Run(() => _adapter.OnIncomingMsg(response));
                 });
 
-            using CancellationTokenSource shortTimeout = CancellationTokenSource.CreateLinkedTokenSource(token);
-            shortTimeout.CancelAfter(500);
+            EnrResponseMsg? result = await _adapter.SendEnrRequest(_receiver, token);
 
-            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(),
-                async () => await _adapter.SendEnrRequest(_receiver, shortTimeout.Token));
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -247,10 +254,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             pingMsg = AddReceiverFarAddress(pingMsg);
             await _adapter.OnIncomingMsg(pingMsg);
 
-            using CancellationTokenSource requestTimeout = CancellationTokenSource.CreateLinkedTokenSource(token);
-            requestTimeout.CancelAfter(50);
+            EnrResponseMsg? result = await _adapter.SendEnrRequest(_receiver, token);
 
-            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await _adapter.SendEnrRequest(_receiver, requestTimeout.Token));
+            Assert.That(result, Is.Null);
 
             _nodeHealthTracker.ClearReceivedCalls();
 
@@ -260,6 +266,73 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                 new(new byte[32]));
             response = AddReceiverFarAddress(response);
 
+            await _adapter.OnIncomingMsg(response);
+
+            _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task Ping_timeout_should_return_false_and_record_failure_once(CancellationToken token)
+        {
+            bool result = await _adapter.Ping(_receiver, token);
+
+            Assert.That(result, Is.False);
+            _nodeHealthTracker.Received(1).OnRequestFailed(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task FindNeighbours_timeout_should_return_null_and_record_failure_once(CancellationToken token)
+        {
+            ConfigureBondCallback();
+
+            Node[]? result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
+
+            Assert.That(result, Is.Null);
+            _nodeHealthTracker.Received(1).OnRequestFailed(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task FindNeighbours_should_not_send_find_node_when_bond_ping_times_out(CancellationToken token)
+        {
+            Node[]? result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
+
+            Assert.That(result, Is.Null);
+            await _msgSender.Received(1).SendMsg(Arg.Is<DiscoveryMsg>(m => m is PingMsg));
+            await _msgSender.DidNotReceive().SendMsg(Arg.Is<DiscoveryMsg>(m => m is FindNodeMsg));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public void Ping_should_throw_on_lifecycle_cancellation(CancellationToken token)
+        {
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            cts.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await _adapter.Ping(_receiver, cts.Token));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task Failed_send_should_remove_response_handler(CancellationToken token)
+        {
+            PingMsg? sent = null;
+            _msgSender.SendMsg(Arg.Any<PingMsg>()).Returns(callInfo =>
+            {
+                sent = (PingMsg)callInfo[0]!;
+                return Task.FromException(new InvalidOperationException("send failed"));
+            });
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await _adapter.Ping(_receiver, token));
+            Assert.That(sent, Is.Not.Null);
+            sent = AddReceiverFarAddress(sent!);
+
+            _nodeHealthTracker.ClearReceivedCalls();
+
+            PongMsg response = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 1, sent!.Mdc!);
+            response = AddReceiverFarAddress(response);
             await _adapter.OnIncomingMsg(response);
 
             _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
@@ -289,6 +362,8 @@ namespace Nethermind.Network.Discovery.Test.Discv4
         public async Task OnIncomingMsg_find_node_should_respond_with_neighbors(CancellationToken token)
         {
             ConfigureBondCallback();
+            Assert.That(await _adapter.Ping(_receiver, token), Is.True);
+            _msgSender.ClearReceivedCalls();
 
             FindNodeMsg findNodeMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _testPublicKey.Bytes);
             findNodeMsg = AddReceiverFarAddress(findNodeMsg);
@@ -321,6 +396,8 @@ namespace Nethermind.Network.Discovery.Test.Discv4
         public async Task OnIncomingMsg_enr_request_should_respond_with_enr_response(CancellationToken token)
         {
             ConfigureBondCallback();
+            Assert.That(await _adapter.Ping(_receiver, token), Is.True);
+            _msgSender.ClearReceivedCalls();
 
             EnrRequestMsg enrRequestMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20);
             enrRequestMsg = AddReceiverFarAddress(enrRequestMsg);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaDiscv4AdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaDiscv4AdapterTests.cs
@@ -30,6 +30,13 @@ namespace Nethermind.Network.Discovery.Test.Discv4
     [TestFixture]
     public class KademliaDiscv4AdapterTests
     {
+        public enum NoResponseRequest
+        {
+            Ping,
+            FindNeighbours,
+            SendEnrRequest
+        }
+
         private IKademliaDiscv4Adapter _adapter = null!;
 
         private IKademlia<PublicKey, Node> _kademliaMessageReceiver = null!;
@@ -158,6 +165,15 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             return msg;
         }
 
+        private async Task<bool> HasResponse(NoResponseRequest request, CancellationToken token) =>
+            request switch
+            {
+                NoResponseRequest.Ping => await _adapter.Ping(_receiver, token),
+                NoResponseRequest.FindNeighbours => await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token) is not null,
+                NoResponseRequest.SendEnrRequest => await _adapter.SendEnrRequest(_receiver, token) is not null,
+                _ => throw new ArgumentOutOfRangeException(nameof(request), request, null)
+            };
+
         [Test]
         [CancelAfter(10000)]
         public async Task Ping_should_send_ping_and_receive_pong(CancellationToken token)
@@ -271,25 +287,20 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
         }
 
-        [Test]
+        [TestCase(NoResponseRequest.Ping)]
+        [TestCase(NoResponseRequest.FindNeighbours)]
+        [TestCase(NoResponseRequest.SendEnrRequest)]
         [CancelAfter(10000)]
-        public async Task Ping_timeout_should_return_false_and_record_failure_once(CancellationToken token)
+        public async Task Request_timeout_should_return_no_response_and_record_failure_once(NoResponseRequest request, CancellationToken token)
         {
-            bool result = await _adapter.Ping(_receiver, token);
+            if (request is not NoResponseRequest.Ping)
+            {
+                ConfigureBondCallback();
+            }
 
-            Assert.That(result, Is.False);
-            _nodeHealthTracker.Received(1).OnRequestFailed(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
-        }
+            bool hasResponse = await HasResponse(request, token);
 
-        [Test]
-        [CancelAfter(10000)]
-        public async Task FindNeighbours_timeout_should_return_null_and_record_failure_once(CancellationToken token)
-        {
-            ConfigureBondCallback();
-
-            Node[]? result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
-
-            Assert.That(result, Is.Null);
+            Assert.That(hasResponse, Is.False);
             _nodeHealthTracker.Received(1).OnRequestFailed(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/KademliaNodeSourceTests.cs
@@ -74,9 +74,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             _lookup.Lookup(Arg.Any<PublicKey>(), token)
                 .Returns(CreateAsyncEnumerable(node1, node2));
             _discv4Adapter.Ping(node1, token)
-                .Returns(Task.CompletedTask);
+                .Returns(true);
             _discv4Adapter.Ping(node2, token)
-                .Returns(Task.CompletedTask);
+                .Returns(true);
 
             IAsyncEnumerator<Node> enumerator = _nodeSource.DiscoverNodes(token).GetAsyncEnumerator(token);
             await enumerator.MoveNextAsync();
@@ -94,7 +94,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             Node node = new(TestItem.PublicKeyA, "192.168.1.1", 30303);
             int pingCount = 0;
             _discv4Adapter.Ping(node, token)
-                .Returns(Task.CompletedTask)
+                .Returns(true)
                 .AndDoes(_ => Interlocked.Increment(ref pingCount));
             _lookup.Lookup(Arg.Any<PublicKey>(), token)
                 .Returns(CreateAsyncEnumerable(node));
@@ -147,10 +147,10 @@ namespace Nethermind.Network.Discovery.Test.Discv4
 
             int node1PingCount = 0;
             _discv4Adapter.Ping(node1, token)
-                .Returns(Task.FromException(new OperationCanceledException()))
+                .Returns(false)
                 .AndDoes(_ => Interlocked.Increment(ref node1PingCount));
             _discv4Adapter.Ping(node2, token)
-                .Returns(Task.CompletedTask);
+                .Returns(true);
 
             _lookup.Lookup(Arg.Any<PublicKey>(), token)
                 .Returns(CreateAsyncEnumerable(node1, node2));

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaSimulation.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaSimulation.cs
@@ -252,7 +252,7 @@ public class KademliaSimulation
 
         private class SenderForNode(TestNode sender, TestFabric fabric) : IKademliaMessageSender<ValueHash256, TestNode>
         {
-            public async Task Ping(TestNode node, CancellationToken token)
+            public async Task<bool> Ping(TestNode node, CancellationToken token)
             {
                 Interlocked.Increment(ref fabric.PingCount);
 
@@ -261,13 +261,13 @@ public class KademliaSimulation
                 if (fabric.TryGetReceiver(node, out ReceiverForNode receiver))
                 {
                     await receiver.Ping(sender, token);
-                    return;
+                    return true;
                 }
 
                 throw new Exception($"unknown receiver {node}");
             }
 
-            public async Task<TestNode[]> FindNeighbours(TestNode node, ValueHash256 hash, CancellationToken token)
+            public async Task<TestNode[]?> FindNeighbours(TestNode node, ValueHash256 hash, CancellationToken token)
             {
                 Interlocked.Increment(ref fabric.FindNeighbourCount);
 
@@ -275,7 +275,8 @@ public class KademliaSimulation
                 fabric.Debug($"find neighbours from {sender} to {node}");
                 if (fabric.TryGetReceiver(node, out ReceiverForNode receiver))
                 {
-                    return (await receiver.FindNeighbours(sender, hash, token)).Select((node) => new TestNode(node.Hash)).ToArray();
+                    TestNode[]? neighbours = await receiver.FindNeighbours(sender, hash, token);
+                    return neighbours?.Select((node) => new TestNode(node.Hash)).ToArray();
                 }
 
                 throw new Exception($"unknown receiver {node}");
@@ -284,16 +285,16 @@ public class KademliaSimulation
 
         private class ReceiverForNode(IKademlia<ValueHash256, TestNode> kademlia, INodeHealthTracker<TestNode> nodeHealthTracker)
         {
-            public Task Ping(TestNode node, CancellationToken token)
+            public Task<bool> Ping(TestNode node, CancellationToken token)
             {
                 nodeHealthTracker.OnIncomingMessageFrom(node);
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
 
-            public Task<TestNode[]> FindNeighbours(TestNode node, ValueHash256 hash, CancellationToken token)
+            public Task<TestNode[]?> FindNeighbours(TestNode node, ValueHash256 hash, CancellationToken token)
             {
                 nodeHealthTracker.OnIncomingMessageFrom(node);
-                return Task.FromResult(kademlia.GetKNeighbour(hash, node));
+                return Task.FromResult<TestNode[]?>(kademlia.GetKNeighbour(hash, node));
             }
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaTests.cs
@@ -77,7 +77,7 @@ public class KademliaTests
     [Test]
     public async Task TestTooManyNode()
     {
-        TaskCompletionSource pingSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<bool> pingSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         _kademliaMessageSender
             .Ping(Arg.Any<ValueHash256>(), Arg.Any<CancellationToken>())
             .Returns(pingSource.Task);
@@ -107,7 +107,7 @@ public class KademliaTests
     [Test]
     public void TestGetKNeighbours()
     {
-        TaskCompletionSource pingSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<bool> pingSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         _kademliaMessageSender
             .Ping(Arg.Any<ValueHash256>(), Arg.Any<CancellationToken>())
             .Returns(pingSource.Task);
@@ -146,7 +146,7 @@ public class KademliaTests
     {
         _kademliaMessageSender
             .Ping(Arg.Any<ValueHash256>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+            .Returns(true);
 
         Kademlia<ValueHash256, ValueHash256> kad = CreateKad(new KademliaConfig<ValueHash256>
         {

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
@@ -68,7 +68,44 @@ public class LookupKNearestNeighbourTests
         cts.CancelAfter(100);
 
         _ = await task;
-        health.Received().OnRequestFailed(Seed1);
+        health.DidNotReceive().OnRequestFailed(Seed1);
+    }
+
+    [TestCase(1)]
+    [TestCase(3)]
+    [CancelAfter(10000)]
+    public async Task Lookup_should_record_request_failure_on_hard_timeout(int alpha, CancellationToken token)
+    {
+        (LookupKNearestNeighbour<ValueHash256, ValueHash256> lookup, _, INodeHealthTracker<ValueHash256> health) =
+            CreateLookup(alpha, TimeSpan.FromMilliseconds(100), [Seed1]);
+
+        _ = await lookup.Lookup(
+            Seed1,
+            8,
+            async (_, t) =>
+            {
+                await Task.Delay(Timeout.Infinite, t);
+                return null;
+            },
+            token);
+
+        health.Received(1).OnRequestFailed(Seed1);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Lookup_should_not_mark_node_healthy_when_find_neighbours_returns_null(CancellationToken token)
+    {
+        (LookupKNearestNeighbour<ValueHash256, ValueHash256> lookup, _, INodeHealthTracker<ValueHash256> health) =
+            CreateLookup(1, TimeSpan.FromSeconds(10), [Seed1]);
+
+        _ = await lookup.Lookup(
+            Seed1,
+            8,
+            (_, _) => Task.FromResult<ValueHash256[]?>(null),
+            token);
+
+        health.DidNotReceive().OnIncomingMessageFrom(Seed1);
     }
 
     [TestCase(1)]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
@@ -61,7 +61,7 @@ public class NodeHealthTrackerTests
     {
         IKademliaMessageSender<ValueHash256, string> sender = Substitute.For<IKademliaMessageSender<ValueHash256, string>>();
         sender.Ping(Stale, Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new OperationCanceledException()));
+            .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         (NodeHealthTracker<ValueHash256, string> tracker, RoutingTableStub routing, _) = CreateTracker(
             toRefresh: Stale,
@@ -78,7 +78,7 @@ public class NodeHealthTrackerTests
     public async Task TryRefresh_ShouldKeepNode_WhenPingSucceeds(CancellationToken token)
     {
         IKademliaMessageSender<ValueHash256, string> sender = Substitute.For<IKademliaMessageSender<ValueHash256, string>>();
-        sender.Ping(Stale, Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        sender.Ping(Stale, Arg.Any<CancellationToken>()).Returns(true);
 
         (NodeHealthTracker<ValueHash256, string> tracker, RoutingTableStub routing, _) = CreateTracker(
             toRefresh: Stale,

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
@@ -22,7 +22,6 @@ public class NodeHealthTrackerTests
     private static (NodeHealthTracker<ValueHash256, string> Tracker, RoutingTableStub Routing, IKademliaMessageSender<ValueHash256, string> Sender) CreateTracker(
         string? toRefresh = null,
         int failureThreshold = 5,
-        TimeSpan? refreshPingTimeout = null,
         IKademliaMessageSender<ValueHash256, string>? sender = null)
     {
         RoutingTableStub routing = new() { ToRefresh = toRefresh ?? string.Empty };
@@ -32,7 +31,6 @@ public class NodeHealthTrackerTests
             CurrentNodeId = Self,
             NodeRequestFailureThreshold = failureThreshold,
         };
-        if (refreshPingTimeout is { } timeout) config.RefreshPingTimeout = timeout;
 
         NodeHealthTracker<ValueHash256, string> tracker = new(
             config,
@@ -61,16 +59,16 @@ public class NodeHealthTrackerTests
     {
         IKademliaMessageSender<ValueHash256, string> sender = Substitute.For<IKademliaMessageSender<ValueHash256, string>>();
         sender.Ping(Stale, Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<bool>(new OperationCanceledException()));
+            .Returns(false);
 
         (NodeHealthTracker<ValueHash256, string> tracker, RoutingTableStub routing, _) = CreateTracker(
             toRefresh: Stale,
-            refreshPingTimeout: TimeSpan.FromMilliseconds(50),
             sender: sender);
 
         tracker.OnIncomingMessageFrom(Remote);
 
         await AssertEventuallyAsync(() => routing.RemoveCalls.Contains(ValueKeccak.Compute(Stale)), token);
+        await sender.Received(1).Ping(Stale, Arg.Is<CancellationToken>(t => !t.CanBeCanceled));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
@@ -69,7 +69,10 @@ public class DiscoveryPersistenceManager(
             {
                 // Reputation must be set before Ping so the routing table has the correct reputation when the Pong is received.
                 _nodeStatsManager.GetOrAdd(node).CurrentPersistedNodeReputation = networkNode.Reputation;
-                await _discv4Adapter.Ping(node, cancellationToken);
+                if (!await _discv4Adapter.Ping(node, cancellationToken))
+                {
+                    continue;
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryPersistenceManager.cs
@@ -76,7 +76,8 @@ public class DiscoveryPersistenceManager(
             }
             catch (OperationCanceledException)
             {
-                continue;
+                // Ping returns false on timeout; an OCE here means lifecycle cancellation, so stop promptly.
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscV4KademliaModule.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscV4KademliaModule.cs
@@ -40,7 +40,8 @@ public class DiscV4KademliaModule(PublicKey masterNode, IReadOnlyList<Node> boot
                 Alpha = discoveryConfig.Concurrency,
                 Beta = discoveryConfig.BitsPerHop,
 
-                LookupFindNeighbourHardTimeout = TimeSpan.FromMilliseconds(discoveryConfig.SendNodeTimeout), // TODO: This seems very low.
+                // Lookup wraps bonding plus FindNode; keep one SendNodeTimeout of slack for scheduling/rate-limit delay.
+                LookupFindNeighbourHardTimeout = TimeSpan.FromMilliseconds(discoveryConfig.PingTimeout + discoveryConfig.BondWaitTime + (2L * discoveryConfig.SendNodeTimeout)),
                 RefreshPingTimeout = TimeSpan.FromMilliseconds(discoveryConfig.PingTimeout),
                 RefreshInterval = TimeSpan.FromMilliseconds(discoveryConfig.DiscoveryInterval),
                 BootNodes = bootNodes

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscV4KademliaModule.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscV4KademliaModule.cs
@@ -42,7 +42,6 @@ public class DiscV4KademliaModule(PublicKey masterNode, IReadOnlyList<Node> boot
 
                 // Lookup wraps bonding plus FindNode; keep one SendNodeTimeout of slack for scheduling/rate-limit delay.
                 LookupFindNeighbourHardTimeout = TimeSpan.FromMilliseconds(discoveryConfig.PingTimeout + discoveryConfig.BondWaitTime + (2L * discoveryConfig.SendNodeTimeout)),
-                RefreshPingTimeout = TimeSpan.FromMilliseconds(discoveryConfig.PingTimeout),
                 RefreshInterval = TimeSpan.FromMilliseconds(discoveryConfig.DiscoveryInterval),
                 BootNodes = bootNodes
             })

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryResponse.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryResponse.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Network.Discovery.Discv4;
+
+public readonly struct DiscoveryResponse<T>
+{
+    private DiscoveryResponse(T value)
+    {
+        HasResponse = true;
+        Value = value;
+    }
+
+    public bool HasResponse { get; }
+
+    public T Value { get; }
+
+    public static DiscoveryResponse<T> None => default;
+
+    public static DiscoveryResponse<T> From(T value) => new(value);
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryResponse.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryResponse.cs
@@ -3,6 +3,14 @@
 
 namespace Nethermind.Network.Discovery.Discv4;
 
+/// <summary>
+/// The result of a discovery request: either the peer's response, or nothing when the request timed out.
+/// </summary>
+/// <remarks>
+/// Replaces exception-based timeout signalling on the request hot path. A timed-out request yields
+/// <see cref="None"/> instead of throwing; genuine cancellation still surfaces as an exception.
+/// </remarks>
+/// <typeparam name="T">The response message type.</typeparam>
 public readonly struct DiscoveryResponse<T>
 {
     private DiscoveryResponse(T value)
@@ -11,11 +19,18 @@ public readonly struct DiscoveryResponse<T>
         Value = value;
     }
 
+    /// <summary>Whether a response was received. When <see langword="false"/> the request timed out.</summary>
     public bool HasResponse { get; }
 
+    /// <summary>
+    /// The response message. Only meaningful when <see cref="HasResponse"/> is <see langword="true"/>;
+    /// otherwise it is <see langword="default"/>.
+    /// </summary>
     public T Value { get; }
 
+    /// <summary>A no-response result, representing a timed-out request.</summary>
     public static DiscoveryResponse<T> None => default;
 
+    /// <summary>Creates a result carrying a received response.</summary>
     public static DiscoveryResponse<T> From(T value) => new(value);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/EnrResponseHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/EnrResponseHandler.cs
@@ -8,11 +8,12 @@ namespace Nethermind.Network.Discovery.Discv4;
 
 public class EnrResponseHandler(EnrRequestMsg request) : ITaskCompleter<EnrResponseMsg>
 {
-    public TaskCompletionSource<EnrResponseMsg> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource<DiscoveryResponse<EnrResponseMsg>> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public bool Handle(DiscoveryMsg msg) =>
-        msg is EnrResponseMsg resp
+        !TaskCompletionSource.Task.IsCompleted
+        && msg is EnrResponseMsg resp
         && request.Hash is { } expected
         && Bytes.AreEqual(resp.RequestKeccak.Bytes, expected.Span)
-        && TaskCompletionSource.TrySetResult(resp);
+        && TaskCompletionSource.TrySetResult(DiscoveryResponse<EnrResponseMsg>.From(resp));
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/IKademliaDiscv4Adapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/IKademliaDiscv4Adapter.cs
@@ -30,6 +30,6 @@ public interface IKademliaDiscv4Adapter : IKademliaMessageSender<PublicKey, Node
     /// </summary>
     /// <param name="receiver">The node to send the request to.</param>
     /// <param name="token">Cancellation token.</param>
-    /// <returns>The ENR response message.</returns>
-    Task<EnrResponseMsg> SendEnrRequest(Node receiver, CancellationToken token);
+    /// <returns>The ENR response message, or <see langword="null"/> when the peer does not respond.</returns>
+    Task<EnrResponseMsg?> SendEnrRequest(Node receiver, CancellationToken token);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/ITaskCompleter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/ITaskCompleter.cs
@@ -5,5 +5,5 @@ namespace Nethermind.Network.Discovery.Discv4;
 
 internal interface ITaskCompleter<T> : IMessageHandler
 {
-    TaskCompletionSource<T> TaskCompletionSource { get; }
+    TaskCompletionSource<DiscoveryResponse<T>> TaskCompletionSource { get; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaDiscv4Adapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaDiscv4Adapter.cs
@@ -5,8 +5,6 @@ using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
-using Nethermind.Core.Utils;
 using Nethermind.Logging;
 using Nethermind.Network.Discovery.Kademlia;
 using Nethermind.Network.Discovery.Messages;
@@ -49,35 +47,40 @@ public class KademliaDiscv4Adapter(
         (node, nodeStatsManager, timestamper),
         static (_, state) => new NodeSession(state.nodeStatsManager.GetOrAdd(state.node), state.timestamper));
 
-    private async Task EnsureOutgoingMessageBondedPeer(Node node, NodeSession nodeSession, CancellationToken token)
+    private async Task<bool> EnsureOutgoingMessageBondedPeer(Node node, NodeSession nodeSession, CancellationToken token)
     {
         // If we have received ping, then we have ponged which mean we should be bonded from their point of view
-        if (nodeSession is { HasReceivedPing: true, NotTooManyFailure: true }) return;
+        if (nodeSession is { HasReceivedPing: true, NotTooManyFailure: true }) return true;
 
         if (_logger.IsTrace) _logger.Trace($"Ensure session for node {node}");
-        await Ping(node, token);
+        if (!await Ping(node, token)) return false;
         // We send them ping. But expect that eventually they send back another a ping so that we can pong.
         // Give some time for peer to process pong. Such is the logic from geth codebase.
         await Task.Delay(_waitAfterPongDelay, token);
 
         if (_logger.IsTrace) _logger.Trace($"Node {node} pong sent.");
+        return true;
     }
 
-    private async Task<T> RunAuthenticatedRequest<T>(Node node, NodeSession session, Func<CancellationToken, Task<T>> callRequest, CancellationToken token)
+    private async Task<DiscoveryResponse<T>> RunAuthenticatedRequest<T>(Node node, NodeSession session, Func<CancellationToken, Task<DiscoveryResponse<T>>> callRequest, CancellationToken token)
     {
-        await EnsureOutgoingMessageBondedPeer(node, session, token);
-        try
-        {
-            T resp = await callRequest(token);
-            session.ResetAuthenticatedRequestFailure();
-            return resp;
-        }
-        catch (OperationCanceledException)
+        if (!await EnsureOutgoingMessageBondedPeer(node, session, token))
         {
             session.OnAuthenticatedRequestFailure();
-
-            throw;
+            return DiscoveryResponse<T>.None;
         }
+
+        DiscoveryResponse<T> resp = await callRequest(token);
+        if (resp.HasResponse)
+        {
+            session.ResetAuthenticatedRequestFailure();
+        }
+        else
+        {
+            session.OnAuthenticatedRequestFailure();
+        }
+
+        return resp;
     }
 
     private void AddMessageHandler(
@@ -125,27 +128,45 @@ public class KademliaDiscv4Adapter(
         }
     }
 
-    private async Task<T> CallAndWaitForResponse<T>(
+    private async Task<DiscoveryResponse<T>> CallAndWaitForResponse<T>(
         MsgType msgType,
         ITaskCompleter<T> messageHandler,
         Node receiver,
         NodeSession session,
         DiscoveryMsg msg,
+        TimeSpan timeout,
         CancellationToken token
     )
     {
-        await using CancellationTokenRegistration unregister = token.RegisterToCompletionSource(messageHandler.TaskCompletionSource);
-        AddMessageHandler(msgType, receiver.IdHash, messageHandler);
+        using CancellationTokenSource timeoutCts = new(timeout);
+        using CancellationTokenSource sendCts = CancellationTokenSource.CreateLinkedTokenSource(token, timeoutCts.Token);
+        using CancellationTokenRegistration cancelRegistration = token.Register(
+            static state => ((TaskCompletionSource<DiscoveryResponse<T>>)state!).TrySetCanceled(),
+            messageHandler.TaskCompletionSource);
+        using CancellationTokenRegistration timeoutRegistration = timeoutCts.Token.Register(
+            static state => ((TaskCompletionSource<DiscoveryResponse<T>>)state!).TrySetResult(DiscoveryResponse<T>.None),
+            messageHandler.TaskCompletionSource);
 
-        await SendMessage(session, msg, token);
+        AddMessageHandler(msgType, receiver.IdHash, messageHandler);
         try
         {
-            return await messageHandler.TaskCompletionSource.Task;
-        }
-        catch (OperationCanceledException)
-        {
-            nodeHealthTracker.Value.OnRequestFailed(receiver);
-            throw;
+            try
+            {
+                await SendMessage(session, msg, sendCts.Token);
+            }
+            catch (OperationCanceledException) when (!token.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+            {
+                messageHandler.TaskCompletionSource.TrySetResult(DiscoveryResponse<T>.None);
+            }
+
+            DiscoveryResponse<T> response = await messageHandler.TaskCompletionSource.Task;
+            if (!response.HasResponse)
+            {
+                token.ThrowIfCancellationRequested();
+                nodeHealthTracker.Value.OnRequestFailed(receiver);
+            }
+
+            return response;
         }
         finally
         {
@@ -166,10 +187,8 @@ public class KademliaDiscv4Adapter(
 
     private long CalculateExpirationTime() => (long)(_expirationTime.TotalSeconds + timestamper.UnixTime.SecondsLong);
 
-    public async Task Ping(Node receiver, CancellationToken token)
+    public async Task<bool> Ping(Node receiver, CancellationToken token)
     {
-        using AutoCancelTokenSource cts = token.CreateChildTokenSource(_pingTimeout);
-        token = cts.Token;
         NodeSession session = GetSession(receiver);
 
         PingMsg msg = new(receiver.Address, CalculateExpirationTime(), kademliaConfig.CurrentNodeId.Address)
@@ -177,36 +196,37 @@ public class KademliaDiscv4Adapter(
             EnrSequence = nodeRecordProvider.Current.EnrSequence // optional and does not seem to be used anywhere.
         };
         session.OnPingSent();
-        _ = await CallAndWaitForResponse(MsgType.Pong, new PongMsgHandler(msg), receiver, session, msg, token);
+        DiscoveryResponse<PongMsg> response = await CallAndWaitForResponse(MsgType.Pong, new PongMsgHandler(msg), receiver, session, msg, _pingTimeout, token);
+        if (!response.HasResponse) return false;
+
         session.OnPongReceived();
+        return true;
     }
 
-    public async Task<Node[]> FindNeighbours(Node receiver, PublicKey target, CancellationToken token)
+    public async Task<Node[]?> FindNeighbours(Node receiver, PublicKey target, CancellationToken token)
     {
         NodeSession session = GetSession(receiver);
-        return await RunAuthenticatedRequest(receiver, session, async token =>
+        DiscoveryResponse<Node[]> response = await RunAuthenticatedRequest(receiver, session, token =>
         {
-            using AutoCancelTokenSource cts = token.CreateChildTokenSource(_findNeighbourTimeout);
-            token = cts.Token;
-
             FindNodeMsg msg = new(receiver.Address, CalculateExpirationTime(), target.Bytes);
 
-            return await CallAndWaitForResponse(MsgType.Neighbors, new NeighbourMsgHandler(discoveryConfig.BucketSize), receiver, session, msg, token);
+            return CallAndWaitForResponse(MsgType.Neighbors, new NeighbourMsgHandler(discoveryConfig.BucketSize), receiver, session, msg, _findNeighbourTimeout, token);
         }, token);
+
+        return response.HasResponse ? response.Value : null;
     }
 
-    public async Task<EnrResponseMsg> SendEnrRequest(Node receiver, CancellationToken token)
+    public async Task<EnrResponseMsg?> SendEnrRequest(Node receiver, CancellationToken token)
     {
         NodeSession session = GetSession(receiver);
-        return await RunAuthenticatedRequest(receiver, session, async token =>
+        DiscoveryResponse<EnrResponseMsg> response = await RunAuthenticatedRequest(receiver, session, token =>
         {
-            using AutoCancelTokenSource cts = token.CreateChildTokenSource(_requestEnrTimeout);
-            token = cts.Token;
-
             EnrRequestMsg msg = new(receiver.Address, CalculateExpirationTime());
 
-            return await CallAndWaitForResponse(MsgType.EnrResponse, new EnrResponseHandler(msg), receiver, session, msg, token);
+            return CallAndWaitForResponse(MsgType.EnrResponse, new EnrResponseHandler(msg), receiver, session, msg, _requestEnrTimeout, token);
         }, token);
+
+        return response.HasResponse ? response.Value : null;
     }
 
     private async Task HandleEnrRequest(Node node, NodeSession session, EnrRequestMsg msg, CancellationToken token)
@@ -255,7 +275,7 @@ public class KademliaDiscv4Adapter(
         {
             // If we have never received any pong, then this peer is not bonded and we should not respond to any auth request.
             // Send a ping to bond the peer.
-            await Ping(node, token);
+            _ = await Ping(node, token);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
@@ -45,14 +45,8 @@ public class KademliaNodeSource(
                         // Tried ping before and did not receive a response
                         continue;
                     }
-                    try
-                    {
-                        if (!await discv4Adapter.Ping(node, token))
-                        {
-                            continue;
-                        }
-                    }
-                    catch (OperationCanceledException) when (!token.IsCancellationRequested)
+                    // Ping returns false on timeout; it only throws on lifecycle cancellation, which we let propagate.
+                    if (!await discv4Adapter.Ping(node, token))
                     {
                         continue;
                     }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
@@ -45,7 +45,6 @@ public class KademliaNodeSource(
                         // Tried ping before and did not receive a response
                         continue;
                     }
-                    // Ping returns false on timeout; it only throws on lifecycle cancellation, which we let propagate.
                     if (!await discv4Adapter.Ping(node, token))
                     {
                         continue;

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/KademliaNodeSource.cs
@@ -47,9 +47,12 @@ public class KademliaNodeSource(
                     }
                     try
                     {
-                        await discv4Adapter.Ping(node, token);
+                        if (!await discv4Adapter.Ping(node, token))
+                        {
+                            continue;
+                        }
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (!token.IsCancellationRequested)
                     {
                         continue;
                     }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NeighbourMsgHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NeighbourMsgHandler.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Network.Discovery.Discv4;
 public class NeighbourMsgHandler(int k) : ITaskCompleter<Node[]>
 {
     private Node[] _current = [];
-    public TaskCompletionSource<Node[]> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource<DiscoveryResponse<Node[]>> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     // The peer should send the two packet pretty much immediately. In any case, if the second packet is loss, its not a huge deal.
     private static readonly TimeSpan _secondRequestTimeout = TimeSpan.FromMilliseconds(100);
@@ -17,29 +17,36 @@ public class NeighbourMsgHandler(int k) : ITaskCompleter<Node[]>
 
     public bool Handle(DiscoveryMsg msg)
     {
+        if (TaskCompletionSource.Task.IsCompleted) return false;
+
         NeighborsMsg neighborsMsg = (NeighborsMsg)msg;
 
         while (true)
         {
+            if (TaskCompletionSource.Task.IsCompleted) return false;
+
             Node[] current = _current;
             if (current.Length >= k || current.Length + neighborsMsg.Nodes.Count > k) return false;
-            if (Interlocked.CompareExchange(ref _current, [.. _current, .. neighborsMsg.Nodes], current) == current) break;
+            if (Interlocked.CompareExchange(ref _current, [.. current, .. neighborsMsg.Nodes], current) == current) break;
         }
 
         if (_current.Length == k)
         {
-            TaskCompletionSource.TrySetResult(_current);
+            return TaskCompletionSource.TrySetResult(DiscoveryResponse<Node[]>.From(_current));
         }
         else
         {
             // Some client (nethermind, besu) only respond with one request.
-            Task.Run(async () =>
+            _ = CompleteAfterDelay();
+
+            async Task CompleteAfterDelay()
             {
                 if (Interlocked.CompareExchange(ref _timeoutInitiated, true, false)) return;
                 await Task.Delay(_secondRequestTimeout);
-                TaskCompletionSource.TrySetResult(_current);
-            });
+                TaskCompletionSource.TrySetResult(DiscoveryResponse<Node[]>.From(_current));
+            }
         }
-        return true;
+
+        return !TaskCompletionSource.Task.IsCompleted;
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/PongMsgHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/PongMsgHandler.cs
@@ -8,8 +8,11 @@ namespace Nethermind.Network.Discovery.Discv4;
 
 public class PongMsgHandler(PingMsg ping) : ITaskCompleter<PongMsg>
 {
-    public TaskCompletionSource<PongMsg> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource<DiscoveryResponse<PongMsg>> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public bool Handle(DiscoveryMsg msg) =>
-        msg is PongMsg pong && Bytes.AreEqual(pong.PingMdc, ping.Mdc) && TaskCompletionSource.TrySetResult(pong);
+        !TaskCompletionSource.Task.IsCompleted
+        && msg is PongMsg pong
+        && Bytes.AreEqual(pong.PingMdc, ping.Mdc)
+        && TaskCompletionSource.TrySetResult(DiscoveryResponse<PongMsg>.From(pong));
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/IKademliaMessageSender.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/IKademliaMessageSender.cs
@@ -10,6 +10,6 @@ namespace Nethermind.Network.Discovery.Kademlia;
 /// <typeparam name="TNode"></typeparam>
 public interface IKademliaMessageSender<TKey, TNode>
 {
-    Task Ping(TNode receiver, CancellationToken token);
-    Task<TNode[]> FindNeighbours(TNode receiver, TKey target, CancellationToken token);
+    Task<bool> Ping(TNode receiver, CancellationToken token);
+    Task<TNode[]?> FindNeighbours(TNode receiver, TKey target, CancellationToken token);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/IteratorNodeLookup.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/IteratorNodeLookup.cs
@@ -176,15 +176,29 @@ public class IteratorNodeLookup<TKey, TNode>(
     {
         try
         {
-            return _unreachableNodes.TryGet(keyOperator.GetNodeHash(node), out DateTimeOffset lastAttempt) &&
-                   lastAttempt + TimeSpan.FromMinutes(5) > timestamper.UtcNowOffset
-                ? []
-                : await msgSender.FindNeighbours(node, target, token);
+            ValueHash256 nodeHash = keyOperator.GetNodeHash(node);
+            if (_unreachableNodes.TryGet(nodeHash, out DateTimeOffset lastAttempt) &&
+                lastAttempt + TimeSpan.FromMinutes(5) > timestamper.UtcNowOffset)
+            {
+                return [];
+            }
+
+            TNode[]? result = await msgSender.FindNeighbours(node, target, token);
+            if (result is null)
+            {
+                _unreachableNodes.Set(nodeHash, timestamper.UtcNowOffset);
+            }
+
+            return result;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!token.IsCancellationRequested)
         {
             _unreachableNodes.Set(keyOperator.GetNodeHash(node), timestamper.UtcNowOffset);
             return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/Kademlia.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/Kademlia.cs
@@ -113,12 +113,14 @@ public class Kademlia<TKey, TNode> : IKademlia<TKey, TNode> where TNode : notnul
             try
             {
                 // Should be added on Pong.
-                await _kademliaMessageSender.Ping(node, token);
-                System.Threading.Interlocked.Increment(ref onlineBootNodes);
+                if (await _kademliaMessageSender.Ping(node, token))
+                {
+                    System.Threading.Interlocked.Increment(ref onlineBootNodes);
+                }
             }
             catch (OperationCanceledException)
             {
-                // Unreachable
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/KademliaConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/KademliaConfig.cs
@@ -41,11 +41,6 @@ public class KademliaConfig<TNode>
     public TimeSpan LookupFindNeighbourHardTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// The timeout for a ping message during a refresh after which the node is considered to be offline.
-    /// </summary>
-    public TimeSpan RefreshPingTimeout { get; set; } = TimeSpan.FromSeconds(1);
-
-    /// <summary>
     /// How many time a request for a node failed before we remove it from the routing table.
     /// </summary>
     public int NodeRequestFailureThreshold { get; set; } = 5;

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/LookupKNearestNeighbour.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/LookupKNearestNeighbour.cs
@@ -133,14 +133,20 @@ public class LookupKNearestNeighbour<TKey, TNode>(
             {
                 // targetHash is implied in findNeighbourOp
                 TNode[]? ret = await findNeighbourOp(node, cts.Token);
+                if (ret is null) return (node, null);
+
                 nodeHealthTracker.OnIncomingMessageFrom(node);
 
                 return (node, ret);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!token.IsCancellationRequested && cts.IsCancellationRequested)
             {
                 nodeHealthTracker.OnRequestFailed(node);
                 return (node, null);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/LookupKNearestNeighbour.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/LookupKNearestNeighbour.cs
@@ -139,7 +139,7 @@ public class LookupKNearestNeighbour<TKey, TNode>(
 
                 return (node, ret);
             }
-            catch (OperationCanceledException) when (!token.IsCancellationRequested && cts.IsCancellationRequested)
+            catch (OperationCanceledException) when (!token.IsCancellationRequested)
             {
                 nodeHealthTracker.OnRequestFailed(node);
                 return (node, null);

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/NodeHealthTracker.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/NodeHealthTracker.cs
@@ -43,10 +43,12 @@ public class NodeHealthTracker<TKey, TNode>(
                 using CancellationTokenSource cts = new(_refreshPingTimeout);
                 try
                 {
-                    await kademliaMessageSender.Ping(toRefresh, cts.Token);
-                    OnIncomingMessageFrom(toRefresh);
+                    if (await kademliaMessageSender.Ping(toRefresh, cts.Token))
+                    {
+                        OnIncomingMessageFrom(toRefresh);
+                    }
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
                     OnRequestFailed(toRefresh);
                 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/NodeHealthTracker.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/NodeHealthTracker.cs
@@ -21,7 +21,6 @@ public class NodeHealthTracker<TKey, TNode>(
     private readonly ConcurrentDictionary<ValueHash256, bool> _isRefreshing = new();
     private readonly LruCache<ValueHash256, int> _peerFailures = new(1024, "peer failure");
     private readonly ValueHash256 _currentNodeIdAsHash = nodeHashProvider.GetHash(config.CurrentNodeId);
-    private readonly TimeSpan _refreshPingTimeout = config.RefreshPingTimeout;
 
     private bool SameAsSelf(TNode node) => nodeHashProvider.GetHash(node) == _currentNodeIdAsHash;
 
@@ -40,17 +39,12 @@ public class NodeHealthTracker<TKey, TNode>(
                 }
 
                 // OK, fine, we'll ping it.
-                using CancellationTokenSource cts = new(_refreshPingTimeout);
                 try
                 {
-                    if (await kademliaMessageSender.Ping(toRefresh, cts.Token))
+                    if (await kademliaMessageSender.Ping(toRefresh, CancellationToken.None))
                     {
                         OnIncomingMessageFrom(toRefresh);
                     }
-                }
-                catch (OperationCanceledException) when (cts.IsCancellationRequested)
-                {
-                    OnRequestFailed(toRefresh);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
## Changes

During discv4 discovery, peer non-response is the dominant, expected outcome (most pings and find-node requests during bootstrap/lookups time out). Today each timeout is modelled as an `OperationCanceledException`: a per-request timeout cancels the response `TaskCompletionSource`, and the resulting `OperationCanceledException` is re-raised at every `await` frame as it unwinds through `Ping`/`FindNeighbours`/`SendEnrRequest` -> `RunAuthenticatedRequest` -> `EnsureOutgoingMessageBondedPeer` -> the Kademlia lookup worker, only to be caught and turned back into a `null`/no-op at the top.

A profile of `KademliaDiscv4Adapter.CallAndWaitForResponse` showed **~77% of `MoveNext` self-time in `ExceptionDispatchInfo.Throw`** - the client was spending the bulk of discovery CPU manufacturing and re-dispatching exceptions for an outcome it fully expects.

This PR replaces that exception-driven control flow with value-based results:

- **`DiscoveryResponse<T>`** (present value vs `None`). The per-request `TaskCompletionSource` is now completed with this struct instead of being cancelled. A fired request timeout yields `None`; only genuine lifecycle cancellation (shutdown / caller stop) still throws.
- **`CallAndWaitForResponse<T>`** now owns the per-request timeout, kept separate from the lifecycle token, returns `DiscoveryResponse<T>`, and no longer throws on timeout.
- **Value-returning signatures**: `IKademliaMessageSender.Ping -> Task<bool>`, `FindNeighbours -> Task<TNode[]?>`, and `IKademliaDiscv4Adapter.SendEnrRequest -> Task<EnrResponseMsg?>` (`null`/`false` = no response). All callers (`Kademlia.Bootstrap`, `NodeHealthTracker`, `KademliaNodeSource`, `DiscoveryPersistenceManager`, `HandlePing`, and both `LookupKNearestNeighbour` and `IteratorNodeLookup`) branch on the value instead of catching `OperationCanceledException`.

### Correctness fixes uncovered along the way

- **Handler leak**: `AddMessageHandler` + `SendMessage` + the response await are now under one `try/finally`, so the one-shot handler is always removed even when the rate-limiter wait or `SendMsg` throws/cancels before the response is awaited. Previously it leaked permanently into `_incomingMessageHandlers`.
- **Failure double-count**: `NodeHealthTracker.OnRequestFailed` is now recorded exactly once, at the single chokepoint (`CallAndWaitForResponse`), and is no longer recorded on shutdown. The redundant calls in `NodeHealthTracker.TryRefresh` and `LookupKNearestNeighbour` are removed; each lookup's own safety timeout still counts once.
- **Timeout-budget overlap**: `LookupFindNeighbourHardTimeout` was bound to `SendNodeTimeout` (500ms), so it expired during bonding (ping + bond-wait, up to 1500ms) before `FindNode` was ever sent. It now budgets `PingTimeout + BondWaitTime + 2 * SendNodeTimeout` to cover the full authenticated flow with scheduling/rate-limit slack.
- **Bonding fail-fast**: when a bond ping gets no pong, the authenticated request is no longer sent to an unbonded peer (which would be dropped on `!HasReceivedPong` and cost a second full timeout).
- **`NeighbourMsgHandler` late-response guard**: a late neighbours packet on an already-completed (timed-out) request no longer mutates state or gets "consumed".
- Removed the now-unused `KademliaConfig.RefreshPingTimeout` (refresh pings reuse `Ping`'s own timeout, same effective value).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New and updated tests in `Nethermind.Network.Discovery.Test`:

- A timed-out request returns no-response and records `OnRequestFailed` exactly once (parameterized over Ping/FindNeighbours/SendEnrRequest).
- `FindNeighbours` does not send `FindNode` when the bond ping times out (fail-fast).
- Lifecycle cancellation still throws `OperationCanceledException`.
- A failed send removes the response handler and a later unsolicited message is not consumed by the stale handler.
- Existing timeout tests converted from `Assert.ThrowsAsync<OperationCanceledException>` to asserting the no-response value.
- Test doubles (`KademliaSimulation`, NSubstitute setups) updated for the new signatures.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The interface signature changes (`IKademliaMessageSender`, `IKademliaDiscv4Adapter`) are internal discovery wiring, not stable plugin contracts. The ENR-request path (`SendEnrRequest` / `EnrResponseHandler`) is currently exercised only by tests; it is kept and converted rather than removed.
