### PR TITLE
evm: include blob fees in eth_call upfront want

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -123,6 +123,42 @@ internal class TransactionProcessorEip4844Tests
         }
     }
 
+    [Test]
+    public void Rejects_blob_tx_with_combined_upfront_cost_in_error_detail()
+    {
+        _stateProvider.CreateAccount(TestItem.AddressA, UInt256.Zero);
+        _stateProvider.Commit(_specProvider.GenesisSpec);
+        _stateProvider.CommitTree(0);
+
+        Transaction blobTx = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithGasLimit(0x100000)
+            .WithValue(UInt256.Zero)
+            .WithMaxFeePerGas((UInt256)10_000_000_000)
+            .WithMaxPriorityFeePerGas((UInt256)1_000_000_000)
+            .WithMaxFeePerBlobGas((UInt256)10_000_000_000)
+            .WithShardBlobTxTypeAndFields(1)
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+            .TestObject;
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithTransactions(blobTx)
+            .WithGasLimit(0x100000)
+            .WithExcessBlobGas(0ul)
+            .WithBaseFeePerGas(1)
+            .TestObject;
+
+        BlockExecutionContext blkCtx = new(block.Header, _specProvider.GetSpec(block.Header));
+        TransactionResult result = _transactionProcessor.Execute(blobTx, blkCtx, NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.ErrorDescription, Does.Contain("want 11796480000000000"));
+        }
+    }
+
     public static IEnumerable<TestCaseData> BalanceIsAffectedByBlobGasTestCaseSource()
     {
         yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob), 1, 1ul, 0ul, 0ul)

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -159,6 +159,43 @@ internal class TransactionProcessorEip4844Tests
         }
     }
 
+    [Test]
+    public void Rejects_blob_tx_when_gas_upfront_cost_overflows_even_if_blob_fee_multiplication_does_not()
+    {
+        _stateProvider.CreateAccount(TestItem.AddressA, UInt256.Zero);
+        _stateProvider.Commit(_specProvider.GenesisSpec);
+        _stateProvider.CommitTree(0);
+
+        Transaction blobTx = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithGasLimit(long.MaxValue)
+            .WithValue(UInt256.Zero)
+            .WithMaxFeePerGas(UInt256.MaxValue)
+            .WithMaxPriorityFeePerGas(UInt256.Zero)
+            .WithMaxFeePerBlobGas(UInt256.One)
+            .WithShardBlobTxTypeAndFields(1)
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+            .TestObject;
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithTransactions(blobTx)
+            .WithGasLimit(long.MaxValue)
+            .WithExcessBlobGas(0ul)
+            .WithBaseFeePerGas(0)
+            .TestObject;
+
+        BlockExecutionContext blkCtx = new(block.Header, _specProvider.GetSpec(block.Header));
+        TransactionResult result = _transactionProcessor.Execute(blobTx, blkCtx, NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.ErrorDescription, Does.Contain("insufficient sender balance for gas * price + value"));
+            Assert.That(result.ErrorDescription, Does.Contain("want"));
+        }
+    }
+
     public static IEnumerable<TestCaseData> BalanceIsAffectedByBlobGasTestCaseSource()
     {
         yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob), 1, 1ul, 0ul, 0ul)

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -123,8 +123,14 @@ internal class TransactionProcessorEip4844Tests
         }
     }
 
-    [Test]
-    public void Rejects_blob_tx_with_combined_upfront_cost_in_error_detail()
+    [TestCaseSource(nameof(BlobTxUpfrontRejectionCases))]
+    public void Rejects_blob_tx_when_upfront_cost_check_fails(
+        long gasLimit,
+        UInt256 maxFeePerGas,
+        UInt256 maxPriorityFeePerGas,
+        UInt256 maxFeePerBlobGas,
+        ulong baseFeePerGas,
+        params string[] errorFragments)
     {
         _stateProvider.CreateAccount(TestItem.AddressA, UInt256.Zero);
         _stateProvider.Commit(_specProvider.GenesisSpec);
@@ -132,11 +138,11 @@ internal class TransactionProcessorEip4844Tests
 
         Transaction blobTx = Build.A.Transaction
             .WithTo(TestItem.AddressB)
-            .WithGasLimit(0x100000)
+            .WithGasLimit(gasLimit)
             .WithValue(UInt256.Zero)
-            .WithMaxFeePerGas((UInt256)10_000_000_000)
-            .WithMaxPriorityFeePerGas((UInt256)1_000_000_000)
-            .WithMaxFeePerBlobGas((UInt256)10_000_000_000)
+            .WithMaxFeePerGas(maxFeePerGas)
+            .WithMaxPriorityFeePerGas(maxPriorityFeePerGas)
+            .WithMaxFeePerBlobGas(maxFeePerBlobGas)
             .WithShardBlobTxTypeAndFields(1)
             .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
             .TestObject;
@@ -144,9 +150,9 @@ internal class TransactionProcessorEip4844Tests
         Block block = Build.A.Block
             .WithNumber(1)
             .WithTransactions(blobTx)
-            .WithGasLimit(0x100000)
+            .WithGasLimit(gasLimit)
             .WithExcessBlobGas(0ul)
-            .WithBaseFeePerGas(1)
+            .WithBaseFeePerGas(baseFeePerGas)
             .TestObject;
 
         BlockExecutionContext blkCtx = new(block.Header, _specProvider.GetSpec(block.Header));
@@ -155,44 +161,10 @@ internal class TransactionProcessorEip4844Tests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(result.ErrorDescription, Does.Contain("want 11796480000000000"));
-        }
-    }
-
-    [Test]
-    public void Rejects_blob_tx_when_gas_upfront_cost_overflows_even_if_blob_fee_multiplication_does_not()
-    {
-        _stateProvider.CreateAccount(TestItem.AddressA, UInt256.Zero);
-        _stateProvider.Commit(_specProvider.GenesisSpec);
-        _stateProvider.CommitTree(0);
-
-        Transaction blobTx = Build.A.Transaction
-            .WithTo(TestItem.AddressB)
-            .WithGasLimit(long.MaxValue)
-            .WithValue(UInt256.Zero)
-            .WithMaxFeePerGas(UInt256.MaxValue)
-            .WithMaxPriorityFeePerGas(UInt256.Zero)
-            .WithMaxFeePerBlobGas(UInt256.One)
-            .WithShardBlobTxTypeAndFields(1)
-            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
-            .TestObject;
-
-        Block block = Build.A.Block
-            .WithNumber(1)
-            .WithTransactions(blobTx)
-            .WithGasLimit(long.MaxValue)
-            .WithExcessBlobGas(0ul)
-            .WithBaseFeePerGas(0)
-            .TestObject;
-
-        BlockExecutionContext blkCtx = new(block.Header, _specProvider.GetSpec(block.Header));
-        TransactionResult result = _transactionProcessor.Execute(blobTx, blkCtx, NullTxTracer.Instance);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(result.ErrorDescription, Does.Contain("insufficient sender balance for gas * price + value"));
-            Assert.That(result.ErrorDescription, Does.Contain("want"));
+            foreach (string errorFragment in errorFragments)
+            {
+                Assert.That(result.ErrorDescription, Does.Contain(errorFragment));
+            }
         }
     }
 
@@ -261,6 +233,31 @@ internal class TransactionProcessorEip4844Tests
         {
             TestName = $"Rejected if balance does not cover {nameof(Transaction.MaxFeePerBlobGas)} + {nameof(Transaction.Value)}, all funds are returned",
             ExpectedResult = UInt256.Zero,
+        };
+    }
+
+    public static IEnumerable<TestCaseData> BlobTxUpfrontRejectionCases()
+    {
+        yield return new TestCaseData(
+            0x100000L,
+            (UInt256)10_000_000_000,
+            (UInt256)1_000_000_000,
+            (UInt256)10_000_000_000,
+            1ul,
+            new[] { "want 11796480000000000" })
+        {
+            TestName = "Rejected blob tx reports combined upfront cost in error detail",
+        };
+
+        yield return new TestCaseData(
+            long.MaxValue,
+            UInt256.MaxValue,
+            UInt256.Zero,
+            UInt256.One,
+            0ul,
+            new[] { "insufficient sender balance for gas * price + value", "want" })
+        {
+            TestName = "Rejected blob tx preserves gas upfront overflow even when blob fee multiplication does not overflow",
         };
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -790,7 +790,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 overflows = UInt256.MultiplyOverflow((UInt256)tx.GasLimit, tx.MaxFeePerGas, out UInt256 maxUpfrontCost);
 
-                if (tx.SupportsBlobs)
+                if (!overflows && tx.SupportsBlobs)
                 {
                     overflows = UInt256.MultiplyOverflow(BlobGasCalculator.CalculateBlobGas(tx), (UInt256)tx.MaxFeePerBlobGas!, out UInt256 maxBlobGasFee);
                     if (!overflows)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -788,21 +788,22 @@ namespace Nethermind.Evm.TransactionProcessing
             bool overflows;
             if (spec.IsEip1559Enabled && !tx.IsFree())
             {
-                overflows = UInt256.MultiplyOverflow((UInt256)tx.GasLimit, tx.MaxFeePerGas, out UInt256 maxGasFee);
-                if (overflows || balanceLeft < maxGasFee)
-                {
-                    TraceLogInvalidTx(tx, $"INSUFFICIENT_MAX_FEE_PER_GAS_FOR_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}, MAX_FEE_PER_GAS: {tx.MaxFeePerGas}");
-                    return InsufficientFundsForGas(tx, senderBalance, tx.MaxFeePerGas);
-                }
+                overflows = UInt256.MultiplyOverflow((UInt256)tx.GasLimit, tx.MaxFeePerGas, out UInt256 maxUpfrontCost);
 
                 if (tx.SupportsBlobs)
                 {
                     overflows = UInt256.MultiplyOverflow(BlobGasCalculator.CalculateBlobGas(tx), (UInt256)tx.MaxFeePerBlobGas!, out UInt256 maxBlobGasFee);
-                    if (overflows || UInt256.AddOverflow(maxGasFee, maxBlobGasFee, out UInt256 multidimGasFee) || multidimGasFee > balanceLeft)
-                    {
-                        TraceLogInvalidTx(tx, $"INSUFFICIENT_MAX_FEE_PER_BLOB_GAS_FOR_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}");
-                        return InsufficientFundsForGas(tx, senderBalance, effectiveGasPrice);
-                    }
+                    if (!overflows)
+                        overflows = UInt256.AddOverflow(maxUpfrontCost, maxBlobGasFee, out maxUpfrontCost);
+                }
+
+                if (overflows || balanceLeft < maxUpfrontCost)
+                {
+                    TraceLogInvalidTx(tx,
+                        tx.SupportsBlobs
+                            ? $"INSUFFICIENT_MAX_FEE_PER_BLOB_GAS_FOR_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}"
+                            : $"INSUFFICIENT_MAX_FEE_PER_GAS_FOR_SENDER_BALANCE: ({tx.SenderAddress})_BALANCE = {senderBalance}, MAX_FEE_PER_GAS: {tx.MaxFeePerGas}");
+                    return InsufficientFundsForGas(tx, senderBalance, tx.MaxFeePerGas, tx.SupportsBlobs ? tx.MaxFeePerBlobGas : null, tx.GetBlobCount());
                 }
             }
 
@@ -836,10 +837,17 @@ namespace Nethermind.Evm.TransactionProcessing
             TransactionResult.ErrorType.InsufficientSenderBalance.WithDetail(
                 $"insufficient sender balance for transfer: address {tx.SenderAddress?.ToString(withEip55Checksum: true)} have {senderBalance} want {tx.Value}");
 
-        private static TransactionResult InsufficientFundsForGas(Transaction tx, UInt256 senderBalance, UInt256 gasPrice)
+        private static TransactionResult InsufficientFundsForGas(Transaction tx, UInt256 senderBalance, UInt256 gasPrice, UInt256? maxFeePerBlobGas = null, int blobCount = 0)
         {
             UInt256.MultiplyOverflow((UInt256)tx.GasLimit, gasPrice, out UInt256 gasCost);
             UInt256.AddOverflow(gasCost, tx.Value, out UInt256 want);
+
+            if (maxFeePerBlobGas is not null && blobCount > 0 &&
+                BlobGasCalculator.TryCalculateBlobMaxFee(blobCount, maxFeePerBlobGas.Value, out UInt256 blobWant))
+            {
+                UInt256.AddOverflow(want, blobWant, out want);
+            }
+
             return TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance.WithDetail(
                 $"insufficient sender balance for gas * price + value: address {tx.SenderAddress?.ToString(withEip55Checksum: true)} have {senderBalance} want {want}");
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -985,6 +985,30 @@ public partial class EthRpcModuleTests
             Does.Contain(BlockErrorMessages.InsufficientMaxFeePerBlobGas));
     }
 
+    [Test]
+    public async Task Eth_call_insufficient_funds_includes_blob_gas_in_want_amount()
+    {
+        ISpecProvider specProvider = new TestSpecProvider(Cancun.Instance);
+        Block[] blocks = [Build.A.Block.WithNumber(0).WithExcessBlobGas(0ul).TestObject];
+        BlockTree blockTree = Build.A.BlockTree(blocks[0]).WithBlocks(blocks).TestObject;
+
+        using TestRpcBlockchain test = await TestRpcBlockchain
+            .ForTest(SealEngineType.NethDev)
+            .WithBlockFinder(blockTree)
+            .Build(specProvider);
+
+        object? tx = JsonSerializer.Deserialize<object>(
+            """{"from":"0x1111111111111111111111111111111111111111","to":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","gas":"0x100000","value":"0x0","maxFeePerGas":"0x2540BE400","maxPriorityFeePerGas":"0x3B9ACA00","maxFeePerBlobGas":"0x2540BE400","blobVersionedHashes":["0x0100000000000000000000000000000000000000000000000000000000000000"]}""");
+        object? stateOverride = JsonSerializer.Deserialize<object>(
+            """{"0x1111111111111111111111111111111111111111":{"balance":"0x0"}}""");
+
+        string serialized = await test.TestEthRpc("eth_call", tx, "latest", stateOverride);
+
+        Assert.That(
+            JToken.Parse(serialized)["error"]!["message"]!.Value<string>(),
+            Does.Contain("want 11796480000000000"));
+    }
+
     [TestCase(
         """{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","value":"0x0","type":"0x4","authorizationList":[]}""",
         TxErrorMessages.MissingAuthorizationList,


### PR DESCRIPTION
Closes #11860

eth_call was understating the upfront balance requirement for blob transactions.
The EIP-1559 path checked gasLimit * maxFeePerGas before adding blobGas * maxFeePerBlobGas, so blob transactions could return an insufficient-funds detail with the blob fee missing from the final want amount.

This patch folds the blob max fee into the same upfront balance check in TransactionProcessor.BuyGas(...).
It also updates the insufficient-funds detail builder so the shared execution path reports the combined want amount for blob transactions.
The later blob base fee validation path stays unchanged.

Tests:
- Nethermind.Evm.Test Rejects_blob_tx_with_combined_upfront_cost_in_error_detail
- Nethermind.Evm.Test Rejects_blob_tx_when_max_fee_per_blob_gas_is_below_current_blob_fee
- Nethermind.JsonRpc.Test Eth_call_insufficient_funds_includes_blob_gas_in_want_amount
- Nethermind.JsonRpc.Test Eth_call_blob_transaction_rejected_when_blobBaseFee_block_override_exceeds_maxFeePerBlobGas
- Nethermind.JsonRpc.Test Eth_estimateGas_blob_transaction