### PR TITLE
CI - more fixes

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,31 @@
+name: Checkout with submodule retry
+description: Checks out the repo and fetches submodules with retry + exponential backoff.
+
+inputs:
+  submodules:
+    description: "'false' to skip submodules, 'recursive' for nested, anything else for top-level only."
+    default: recursive
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: false
+
+    - if: inputs.submodules != 'false'
+      shell: bash
+      env:
+        RECURSIVE: ${{ inputs.submodules == 'recursive' && '--recursive' || '' }}
+      run: |
+        set -euo pipefail
+        delay=15
+        for i in 1 2 3; do
+          git submodule update --init $RECURSIVE --jobs 4 && exit 0
+          echo "::warning::Submodule fetch failed (attempt $i/3)"
+          git submodule deinit -f --all || true
+          sleep $delay
+          delay=$((delay * 2))
+        done
+        echo "::error::Submodule fetch failed after 3 attempts"
+        exit 1

--- a/.github/actions/fetch-submodules/action.yaml
+++ b/.github/actions/fetch-submodules/action.yaml
@@ -1,5 +1,5 @@
-name: Checkout with submodule retry
-description: Checks out the repo and fetches submodules with retry + exponential backoff.
+name: Fetch submodules with retry
+description: Fetches submodules with retry + exponential backoff. Must run after actions/checkout.
 
 inputs:
   submodules:
@@ -9,10 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: false
-
     - if: inputs.submodules != 'false'
       shell: bash
       env:

--- a/.github/actions/fetch-submodules/action.yaml
+++ b/.github/actions/fetch-submodules/action.yaml
@@ -17,7 +17,7 @@ runs:
         set -euo pipefail
         delay=15
         for i in 1 2 3; do
-          git submodule update --init $RECURSIVE --jobs 4 && exit 0
+          git submodule update --init --depth 1 $RECURSIVE --jobs 4 && exit 0
           echo "::warning::Submodule fetch failed (attempt $i/3)"
           git submodule deinit -f --all || true
           sleep $delay

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -221,6 +221,9 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
         with:
           submodules: ${{ startsWith(matrix.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   tests:
-    name: Run ${{ matrix.project }} (${{ matrix.runner }})
+    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     outputs:
@@ -85,27 +85,61 @@ jobs:
           - Nethermind.TxPool.Test
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
+        chunk: ['']
+        exclude: # Nethermind.Synchronization.Test unchunked replaced by 4 chunks below (P99 hits 15-min wall on ARM otherwise).
+          - project: Nethermind.Synchronization.Test
+            chunk: ''
         include: # macOS only for OS-sensitive tests (I/O, networking, sockets)
-          - { runner: macos-latest, project: Nethermind.Db.Test }
-          - { runner: macos-latest, project: Nethermind.JsonRpc.Test }
-          - { runner: macos-latest, project: Nethermind.KeyStore.Test }
-          - { runner: macos-latest, project: Nethermind.Network.Discovery.Test }
-          - { runner: macos-latest, project: Nethermind.Network.Dns.Test }
-          - { runner: macos-latest, project: Nethermind.Network.Enr.Test }
-          - { runner: macos-latest, project: Nethermind.Network.Test }
-          - { runner: macos-latest, project: Nethermind.Runner.Test }
-          - { runner: macos-latest, project: Nethermind.Sockets.Test }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test }
+          - { runner: macos-latest, project: Nethermind.Db.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.KeyStore.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Network.Discovery.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Network.Dns.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Network.Enr.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Network.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Runner.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Sockets.Test, chunk: '' }
+          # Nethermind.Synchronization.Test chunked across all four runners (2438 standalone tests).
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
     steps:
       - name: Check out repository
+        id: checkout-1
+        uses: actions/checkout@v6
+        continue-on-error: true
+
+      - name: Check out repository (retry 1)
+        id: checkout-2
+        if: steps.checkout-1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+
+      - name: Check out repository (retry 2)
+        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
         uses: actions/checkout@v6
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
 
-      - name: ${{ matrix.project }}
+      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
         working-directory: src/Nethermind/${{ matrix.project }}
+        env:
+          TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           dotnet build ${{ matrix.project }}.csproj -c release
@@ -129,7 +163,7 @@ jobs:
         if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.project }}-coverage
+          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage
           path: src/Nethermind/artifacts/bin/${{ matrix.project }}/release/TestResults/*.cobertura.xml
           retention-days: 1
 
@@ -174,6 +208,22 @@ jobs:
           - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 8of8 }
     steps:
       - name: Check out repository
+        id: checkout-1
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          submodules: recursive
+
+      - name: Check out repository (retry 1)
+        id: checkout-2
+        if: steps.checkout-1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          submodules: recursive
+
+      - name: Check out repository (retry 2)
+        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
         uses: actions/checkout@v6
         with:
           submodules: recursive
@@ -265,6 +315,22 @@ jobs:
           swap-storage: false
 
       - name: Check out repository
+        id: checkout-1
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
+
+      - name: Check out repository (retry 1)
+        id: checkout-2
+        if: steps.checkout-1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
+
+      - name: Check out repository (retry 2)
+        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
         uses: actions/checkout@v6
         with:
           submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -86,7 +86,7 @@ jobs:
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
         chunk: ['']
-        exclude: # Nethermind.Synchronization.Test unchunked replaced by 4 chunks below (P99 hits 15-min wall on ARM otherwise).
+        exclude: # Synchronization.Test is chunked (see include block) — its unchunked variant hits the 15-min wall on ARM.
           - project: Nethermind.Synchronization.Test
             chunk: ''
         include: # macOS only for OS-sensitive tests (I/O, networking, sockets)

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -117,9 +117,7 @@ jobs:
           - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-submodules
-        with:
-          submodules: 'false'
+        uses: actions/checkout@v6
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
@@ -197,7 +195,10 @@ jobs:
           - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 8of8 }
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-submodules
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
         with:
           submodules: recursive
 
@@ -288,7 +289,10 @@ jobs:
           swap-storage: false
 
       - name: Check out repository
-        uses: ./.github/actions/checkout-submodules
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
         with:
           submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -99,7 +99,6 @@ jobs:
           - { runner: macos-latest, project: Nethermind.Network.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Runner.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Sockets.Test, chunk: '' }
-          # Nethermind.Synchronization.Test chunked across all four runners (2438 standalone tests).
           - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
           - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -117,19 +117,9 @@ jobs:
           - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
     steps:
       - name: Check out repository
-        id: checkout-1
-        uses: actions/checkout@v6
-        continue-on-error: true
-
-      - name: Check out repository (retry 1)
-        id: checkout-2
-        if: steps.checkout-1.outcome == 'failure'
-        uses: actions/checkout@v6
-        continue-on-error: true
-
-      - name: Check out repository (retry 2)
-        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
-        uses: actions/checkout@v6
+        uses: ./.github/actions/checkout-submodules
+        with:
+          submodules: 'false'
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
@@ -207,23 +197,7 @@ jobs:
           - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 8of8 }
     steps:
       - name: Check out repository
-        id: checkout-1
-        uses: actions/checkout@v6
-        continue-on-error: true
-        with:
-          submodules: recursive
-
-      - name: Check out repository (retry 1)
-        id: checkout-2
-        if: steps.checkout-1.outcome == 'failure'
-        uses: actions/checkout@v6
-        continue-on-error: true
-        with:
-          submodules: recursive
-
-      - name: Check out repository (retry 2)
-        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
-        uses: actions/checkout@v6
+        uses: ./.github/actions/checkout-submodules
         with:
           submodules: recursive
 
@@ -314,23 +288,7 @@ jobs:
           swap-storage: false
 
       - name: Check out repository
-        id: checkout-1
-        uses: actions/checkout@v6
-        continue-on-error: true
-        with:
-          submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
-
-      - name: Check out repository (retry 1)
-        id: checkout-2
-        if: steps.checkout-1.outcome == 'failure'
-        uses: actions/checkout@v6
-        continue-on-error: true
-        with:
-          submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
-
-      - name: Check out repository (retry 2)
-        if: steps.checkout-1.outcome == 'failure' && steps.checkout-2.outcome == 'failure'
-        uses: actions/checkout@v6
+        uses: ./.github/actions/checkout-submodules
         with:
           submodules: ${{ startsWith(matrix.test.project, 'Ethereum.Blockchain.Pyspec') && 'false' || 'recursive' }}
 

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -86,8 +86,9 @@ jobs:
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
         chunk: ['']
-        exclude: # Synchronization.Test is chunked (see include block) — its unchunked variant hits the 15-min wall on ARM.
-          - project: Nethermind.Synchronization.Test
+        exclude: # Synchronization.Test on ARM is chunked (see include block) — its unchunked variant hits the 15-min wall.
+          - runner: ubuntu-24.04-arm
+            project: Nethermind.Synchronization.Test
             chunk: ''
         include: # macOS only for OS-sensitive tests (I/O, networking, sockets)
           - { runner: macos-latest, project: Nethermind.Db.Test, chunk: '' }
@@ -99,22 +100,11 @@ jobs:
           - { runner: macos-latest, project: Nethermind.Network.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Runner.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Sockets.Test, chunk: '' }
-          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
-          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
-          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
-          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: '' }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 1of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 4of4 }
-          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
-          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
-          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
-          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/src/Nethermind/Ethereum.Basic.Test/TestChunkFilterTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/TestChunkFilterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Ethereum.Test.Base;
 using NUnit.Framework;
 
@@ -39,6 +40,93 @@ public class TestChunkFilterTests
 
         Assert.That(result, Is.EqualTo(new[] { 1, 4, 7 }));
         Assert.That(enumeratedCount, Is.EqualTo(9));
+    }
+
+    [Test]
+    public void ShouldRunInChunk_WithoutTestChunkSet_ReturnsTrueForEverything()
+    {
+        Environment.SetEnvironmentVariable("TEST_CHUNK", null);
+
+        Assert.That(TestChunkFilter.ShouldRunInChunk(""), Is.True);
+        Assert.That(TestChunkFilter.ShouldRunInChunk("Some.Test.FullName"), Is.True);
+        Assert.That(TestChunkFilter.ShouldRunInChunk("Another.Test"), Is.True);
+    }
+
+    [Test]
+    public void ShouldRunInChunk_PartitionsTestsAcrossAllChunksWithoutGapsOrOverlap()
+    {
+        const int chunkTotal = 4;
+        const int testCount = 1000;
+        int[] runsPerChunk = new int[chunkTotal];
+
+        for (int chunkIndex = 1; chunkIndex <= chunkTotal; chunkIndex++)
+        {
+            Environment.SetEnvironmentVariable("TEST_CHUNK", $"{chunkIndex}of{chunkTotal}");
+            for (int testIndex = 0; testIndex < testCount; testIndex++)
+            {
+                if (TestChunkFilter.ShouldRunInChunk($"Nethermind.Tests.Fixture.Method({testIndex})"))
+                {
+                    runsPerChunk[chunkIndex - 1]++;
+                }
+            }
+        }
+
+        Assert.That(runsPerChunk.Sum(), Is.EqualTo(testCount), "every test must be claimed by exactly one chunk");
+        foreach (int count in runsPerChunk)
+        {
+            Assert.That(count, Is.GreaterThan(testCount / chunkTotal / 2), "partitioning should not collapse all tests into one chunk");
+        }
+    }
+
+    [Test]
+    public void ShouldRunInChunk_IsStableAcrossInvocations()
+    {
+        Environment.SetEnvironmentVariable("TEST_CHUNK", "2of5");
+        const string name = "Nethermind.Synchronization.Test.FastSync.SomeTest.Bar(arg=42)";
+
+        bool first = TestChunkFilter.ShouldRunInChunk(name);
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.That(TestChunkFilter.ShouldRunInChunk(name), Is.EqualTo(first));
+        }
+    }
+
+    [TestCase("0of4")]
+    [TestCase("5of4")]
+    [TestCase("-1of4")]
+    [TestCase("1of0")]
+    [TestCase("1of-1")]
+    [TestCase("badformat")]
+    [TestCase("1of")]
+    [TestCase("of4")]
+    public void TryGetChunkConfig_RejectsInvalidFormat(string invalid)
+    {
+        Environment.SetEnvironmentVariable("TEST_CHUNK", invalid);
+
+        Assert.Throws<ArgumentException>(() => TestChunkFilter.TryGetChunkConfig());
+    }
+
+    [TestCase("1of1", 1, 1)]
+    [TestCase("1of4", 1, 4)]
+    [TestCase("4of4", 4, 4)]
+    [TestCase("3of10", 3, 10)]
+    public void TryGetChunkConfig_ParsesValidFormat(string env, int expectedIndex, int expectedTotal)
+    {
+        Environment.SetEnvironmentVariable("TEST_CHUNK", env);
+
+        (int Index, int Total)? config = TestChunkFilter.TryGetChunkConfig();
+
+        Assert.That(config, Is.Not.Null);
+        Assert.That(config!.Value.Index, Is.EqualTo(expectedIndex));
+        Assert.That(config.Value.Total, Is.EqualTo(expectedTotal));
+    }
+
+    [Test]
+    public void TryGetChunkConfig_WhenUnset_ReturnsNull()
+    {
+        Environment.SetEnvironmentVariable("TEST_CHUNK", null);
+
+        Assert.That(TestChunkFilter.TryGetChunkConfig(), Is.Null);
     }
 
     private static IEnumerable<int> CountedRange(int count, Action onEnumerated)

--- a/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
@@ -9,7 +9,12 @@ namespace Ethereum.Test.Base;
 /// <summary>
 /// Filters tests into chunks for parallel CI execution.
 /// Set TEST_CHUNK environment variable to "1of3", "2of3", "3of3" etc.
-/// Partitions tests by index for consistent and even distribution.
+/// Two partitioning modes are supported:
+///   - <see cref="FilterByChunk{T}"/> for index-based partitioning over an
+///     ordered enumeration (used by [TestCaseSource]-driven projects).
+///   - <see cref="ShouldRunInChunk(string)"/> for hash-based partitioning by
+///     stable test name (used by [Test]/[TestCase] projects via an assembly
+///     <c>ITestAction</c>).
 /// </summary>
 public static class TestChunkFilter
 {
@@ -27,6 +32,33 @@ public static class TestChunkFilter
         (int chunkIndex, int totalChunks) = chunkConfig.Value;
         return FilterByChunkIterator(tests, chunkIndex, totalChunks);
     }
+
+    /// <summary>
+    /// Returns true when the given test name belongs to the currently selected
+    /// chunk, or when no chunk is configured (no-op pass-through).
+    /// Partitioning is deterministic across runs and processes — it uses a
+    /// stable FNV-1a hash of <paramref name="stableTestName"/> rather than
+    /// <see cref="string.GetHashCode()"/> (which is randomized per-process).
+    /// </summary>
+    public static bool ShouldRunInChunk(string stableTestName)
+    {
+        (int Index, int Total)? chunkConfig = GetChunkConfig();
+
+        if (chunkConfig is null)
+        {
+            return true;
+        }
+
+        (int chunkIndex, int totalChunks) = chunkConfig.Value;
+        uint hash = StableHash(stableTestName);
+        return (hash % (uint)totalChunks) == (uint)(chunkIndex - 1);
+    }
+
+    /// <summary>
+    /// Returns the currently selected chunk (1-based index, total) or null
+    /// when <c>TEST_CHUNK</c> is unset.
+    /// </summary>
+    public static (int Index, int Total)? TryGetChunkConfig() => GetChunkConfig();
 
     private static IEnumerable<T> FilterByChunkIterator<T>(IEnumerable<T> tests, int chunkIndex, int totalChunks)
     {
@@ -64,5 +96,27 @@ public static class TestChunkFilter
         }
 
         return (index, total);
+    }
+
+    /// <summary>
+    /// 32-bit FNV-1a hash. Deterministic across processes and platforms,
+    /// unlike <see cref="string.GetHashCode()"/> which is randomized.
+    /// </summary>
+    private static uint StableHash(string value)
+    {
+        const uint offsetBasis = 2166136261u;
+        const uint prime = 16777619u;
+
+        uint hash = offsetBasis;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            hash ^= (byte)(c & 0xFF);
+            hash *= prime;
+            hash ^= (byte)((c >> 8) & 0xFF);
+            hash *= prime;
+        }
+
+        return hash;
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
@@ -36,9 +36,10 @@ public static class TestChunkFilter
     /// <summary>
     /// Returns true when the given test name belongs to the currently selected
     /// chunk, or when no chunk is configured (no-op pass-through).
-    /// Partitioning is deterministic across runs and processes — it uses a
-    /// stable FNV-1a hash of <paramref name="stableTestName"/> rather than
-    /// <see cref="string.GetHashCode()"/> (which is randomized per-process).
+    /// Partitioning is deterministic across runs, processes, and platforms — it
+    /// uses a stable FNV-1a-style hash of <paramref name="stableTestName"/>
+    /// rather than <see cref="string.GetHashCode()"/> (which is randomized
+    /// per-process).
     /// </summary>
     public static bool ShouldRunInChunk(string stableTestName)
     {
@@ -99,8 +100,11 @@ public static class TestChunkFilter
     }
 
     /// <summary>
-    /// 32-bit FNV-1a hash. Deterministic across processes and platforms,
+    /// 32-bit FNV-1a-style stable hash. Deterministic across processes and platforms,
     /// unlike <see cref="string.GetHashCode()"/> which is randomized.
+    /// Processes each UTF-16 char as two byte rounds (low byte then high byte), which
+    /// deviates from canonical byte-stream FNV-1a but preserves the only property we
+    /// rely on here: identical input ⇒ identical hash across runners.
     /// </summary>
     private static uint StableHash(string value)
     {

--- a/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestChunkFilter.cs
@@ -7,14 +7,10 @@ using System.Collections.Generic;
 namespace Ethereum.Test.Base;
 
 /// <summary>
-/// Filters tests into chunks for parallel CI execution.
-/// Set TEST_CHUNK environment variable to "1of3", "2of3", "3of3" etc.
-/// Two partitioning modes are supported:
-///   - <see cref="FilterByChunk{T}"/> for index-based partitioning over an
-///     ordered enumeration (used by [TestCaseSource]-driven projects).
-///   - <see cref="ShouldRunInChunk(string)"/> for hash-based partitioning by
-///     stable test name (used by [Test]/[TestCase] projects via an assembly
-///     <c>ITestAction</c>).
+/// Partitions tests into chunks for parallel CI execution. Driven by the
+/// <c>TEST_CHUNK</c> environment variable (format: <c>"1of4"</c>).
+/// <see cref="FilterByChunk{T}"/> slices an enumeration by index;
+/// <see cref="ShouldRunInChunk"/> picks per-test by stable name hash.
 /// </summary>
 public static class TestChunkFilter
 {
@@ -34,12 +30,9 @@ public static class TestChunkFilter
     }
 
     /// <summary>
-    /// Returns true when the given test name belongs to the currently selected
-    /// chunk, or when no chunk is configured (no-op pass-through).
-    /// Partitioning is deterministic across runs, processes, and platforms — it
-    /// uses a stable FNV-1a-style hash of <paramref name="stableTestName"/>
-    /// rather than <see cref="string.GetHashCode()"/> (which is randomized
-    /// per-process).
+    /// True when <paramref name="stableTestName"/> belongs to the currently
+    /// selected chunk, or when no chunk is configured. Hash is deterministic
+    /// across processes (unlike <see cref="string.GetHashCode()"/>).
     /// </summary>
     public static bool ShouldRunInChunk(string stableTestName)
     {
@@ -55,16 +48,12 @@ public static class TestChunkFilter
         return (hash % (uint)totalChunks) == (uint)(chunkIndex - 1);
     }
 
-    /// <summary>
-    /// Returns the currently selected chunk (1-based index, total) or null
-    /// when <c>TEST_CHUNK</c> is unset.
-    /// </summary>
+    /// <summary>1-based chunk index and total, or null when <c>TEST_CHUNK</c> is unset.</summary>
     public static (int Index, int Total)? TryGetChunkConfig() => GetChunkConfig();
 
     private static IEnumerable<T> FilterByChunkIterator<T>(IEnumerable<T> tests, int chunkIndex, int totalChunks)
     {
-        // Interleaved distribution: test 0→chunk 1, test 1→chunk 2, etc.
-        // Spreads heavy tests evenly across chunks instead of clustering them.
+        // Interleaved (test[i] → chunk i % N) so heavy tests don't cluster.
         int testIndex = 0;
         foreach (T test in tests)
         {
@@ -99,13 +88,8 @@ public static class TestChunkFilter
         return (index, total);
     }
 
-    /// <summary>
-    /// 32-bit FNV-1a-style stable hash. Deterministic across processes and platforms,
-    /// unlike <see cref="string.GetHashCode()"/> which is randomized.
-    /// Processes each UTF-16 char as two byte rounds (low byte then high byte), which
-    /// deviates from canonical byte-stream FNV-1a but preserves the only property we
-    /// rely on here: identical input ⇒ identical hash across runners.
-    /// </summary>
+    // FNV-1a-style 32-bit hash, byte-by-byte over each UTF-16 char. Only property
+    // we rely on: same input ⇒ same output across processes/platforms.
     private static uint StableHash(string value)
     {
         const uint offsetBasis = 2166136261u;

--- a/src/Nethermind/Nethermind.Synchronization.Test/ChunkFilterAttribute.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ChunkFilterAttribute.cs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+// Apply the chunk filter at assembly scope so every [Test]/[TestCase] in
+// Nethermind.Synchronization.Test is partitioned when TEST_CHUNK is set.
+// When TEST_CHUNK is unset the attribute is a no-op (current behavior).
+[assembly: Nethermind.Synchronization.Test.ChunkFilterAttribute]
+
+namespace Nethermind.Synchronization.Test;
+
+/// <summary>
+/// NUnit assembly-level action that partitions standalone test methods into
+/// chunks for parallel CI execution. Activated by the <c>TEST_CHUNK</c>
+/// environment variable (format <c>"1of4"</c>, <c>"2of4"</c>, ...).
+/// </summary>
+/// <remarks>
+/// Standalone <c>[Test]</c> / <c>[TestCase]</c> methods cannot be partitioned
+/// by <see cref="TestChunkFilter.FilterByChunk{T}"/> because there is no
+/// <c>IEnumerable</c> source to slice. This action runs in NUnit's BeforeTest
+/// pipeline and calls <see cref="Assert.Ignore(string)"/> for every test
+/// whose stable hash falls outside the selected chunk.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class ChunkFilterAttribute : Attribute, ITestAction
+{
+    public ActionTargets Targets => ActionTargets.Test;
+
+    public void BeforeTest(ITest test)
+    {
+        // Only filter individual test cases, not fixtures or the suite.
+        if (test.IsSuite)
+        {
+            return;
+        }
+
+        // FullName includes namespace + type + method + parameter values, so
+        // it is unique and stable across processes and platforms.
+        if (!TestChunkFilter.ShouldRunInChunk(test.FullName))
+        {
+            Assert.Ignore("chunk filter: skipped by TEST_CHUNK partition");
+        }
+    }
+
+    public void AfterTest(ITest test)
+    {
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ChunkFilterAttribute.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ChunkFilterAttribute.cs
@@ -6,25 +6,14 @@ using Ethereum.Test.Base;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 
-// Apply the chunk filter at assembly scope so every [Test]/[TestCase] in
-// Nethermind.Synchronization.Test is partitioned when TEST_CHUNK is set.
-// When TEST_CHUNK is unset the attribute is a no-op (current behavior).
 [assembly: Nethermind.Synchronization.Test.ChunkFilterAttribute]
 
 namespace Nethermind.Synchronization.Test;
 
 /// <summary>
-/// NUnit assembly-level action that partitions standalone test methods into
-/// chunks for parallel CI execution. Activated by the <c>TEST_CHUNK</c>
-/// environment variable (format <c>"1of4"</c>, <c>"2of4"</c>, ...).
+/// Assembly-scoped <see cref="ITestAction"/> that partitions tests by stable
+/// name hash when <c>TEST_CHUNK</c> is set (e.g. <c>"1of4"</c>). No-op otherwise.
 /// </summary>
-/// <remarks>
-/// Standalone <c>[Test]</c> / <c>[TestCase]</c> methods cannot be partitioned
-/// by <see cref="TestChunkFilter.FilterByChunk{T}"/> because there is no
-/// <c>IEnumerable</c> source to slice. This action runs in NUnit's BeforeTest
-/// pipeline and calls <see cref="Assert.Ignore(string)"/> for every test
-/// whose stable hash falls outside the selected chunk.
-/// </remarks>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
 public sealed class ChunkFilterAttribute : Attribute, ITestAction
 {
@@ -32,14 +21,7 @@ public sealed class ChunkFilterAttribute : Attribute, ITestAction
 
     public void BeforeTest(ITest test)
     {
-        // Only filter individual test cases, not fixtures or the suite.
-        if (test.IsSuite)
-        {
-            return;
-        }
-
-        // FullName includes namespace + type + method + parameter values, so
-        // it is unique and stable across processes and platforms.
+        if (test.IsSuite) return;
         if (!TestChunkFilter.ShouldRunInChunk(test.FullName))
         {
             Assert.Ignore("chunk filter: skipped by TEST_CHUNK partition");

--- a/src/Nethermind/Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Nethermind.Synchronization.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Ethereum.Test.Base\Ethereum.Test.Base.csproj" />
     <ProjectReference Include="..\Nethermind.Blockchain\Nethermind.Blockchain.csproj" />
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj" />


### PR DESCRIPTION
## Changes

- **Sync.Test 15-min wall (ubuntu-24.04-arm)** — chunk `Nethermind.Synchronization.Test` into 4 parts via a new assembly-level `ITestAction` driven by `TEST_CHUNK`. Each chunk runs ~1.5 min vs 5.5 min baseline; ARM P99 stays well under the 15-min wall. Stable FNV-1a hash (not `String.GetHashCode`, which is per-process randomized) keeps partitioning deterministic across runners. No-op when `TEST_CHUNK` is unset.
- **Checkout retry** — 3-attempt pattern around `actions/checkout@v6` in all three `nethermind-tests.yml` jobs. Helps transient submodule-fetch failures.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No