### PR TITLE
Networking - fix flaky test

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
@@ -55,17 +55,23 @@ public class LookupKNearestNeighbourTests
 
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(token);
 
+        // Signalled once a findNeighbour request is actually dispatched, so cancellation deterministically
+        // interrupts an in-flight request (which records OnRequestFailed) instead of racing worker startup.
+        TaskCompletionSource requestInFlight = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         Task<ValueHash256[]> task = lookup.Lookup(
             Seed1,
             8,
             async (_, t) =>
             {
+                requestInFlight.TrySetResult();
                 await Task.Delay(Timeout.Infinite, t);
                 return null;
             },
             cts.Token);
 
-        cts.CancelAfter(100);
+        await requestInFlight.Task;
+        await cts.CancelAsync();
 
         _ = await task;
         health.Received().OnRequestFailed(Seed1);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
@@ -70,7 +70,7 @@ public class LookupKNearestNeighbourTests
             },
             cts.Token);
 
-        await requestInFlight.Task;
+        await requestInFlight.Task.WaitAsync(token);
         await cts.CancelAsync();
 
         _ = await task;


### PR DESCRIPTION
## Changes

### Root cause 
A test race, not a product bug: in Lookup, OnRequestFailed(node) is only called from WrappedFindNeighbourOp's catch (OperationCanceledException) — i.e., only if the request was actually dispatched before cancellation. The test did cts.CancelAfter(100), racing worker startup: on a loaded CI runner the 100 ms timer could fire before the worker entered WrappedFindNeighbourOp(Seed1), so the worker bailed at the top-of-loop ThrowIfCancellationRequested() and OnRequestFailed was never called → assertion failed. (It surfaced on alpha=3 because more workers = more scheduling contention.)

### Fix
Cancel only once a request is genuinely in flight. The findNeighbourOp lambda now signals a TaskCompletionSource when it's entered; the test awaits that before cts.CancelAsync(). That guarantees cancellation interrupts the in-flight request (hitting the OnRequestFailed path) instead of racing startup — so the assertion is now deterministic. No change to product code or to what the test verifies; just made the timing explicit.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No