### PR TITLE
ci: block merging PRs labeled "DO NOT MERGE"

### DIFF
--- a/.github/workflows/block-do-not-merge.yml
+++ b/.github/workflows/block-do-not-merge.yml
@@ -1,0 +1,21 @@
+name: Block "DO NOT MERGE"
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+jobs:
+  check:
+    name: Check for "DO NOT MERGE" label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if "DO NOT MERGE" label is present
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.some(l => l.toLowerCase() === 'do not merge')) {
+              core.setFailed('This PR has the "DO NOT MERGE" label and must not be merged.');
+            } else {
+              core.info('No "DO NOT MERGE" label present.');
+            }

--- a/.github/workflows/block-do-not-merge.yml
+++ b/.github/workflows/block-do-not-merge.yml
@@ -1,13 +1,18 @@
 name: Block "DO NOT MERGE"
 
 on:
-  pull_request_target:
-    types: [labeled, unlabeled]
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
     name: Check for "DO NOT MERGE" label
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Fail if "DO NOT MERGE" label is present
         uses: actions/github-script@v8

--- a/.github/workflows/block-do-not-merge.yml
+++ b/.github/workflows/block-do-not-merge.yml
@@ -14,8 +14,9 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (labels.some(l => l.toLowerCase() === 'do not merge')) {
-              core.setFailed('This PR has the "DO NOT MERGE" label and must not be merged.');
+            const blocking = labels.filter(l => l.toLowerCase().includes('do not merge'));
+            if (blocking.length > 0) {
+              core.setFailed(`This PR has a blocking label and must not be merged: ${blocking.join(', ')}`);
             } else {
               core.info('No "DO NOT MERGE" label present.');
             }


### PR DESCRIPTION
## Changes

- Add a `Block "DO NOT MERGE"` GitHub Actions workflow (`.github/workflows/block-do-not-merge.yml`) that triggers on PR `labeled`/`unlabeled` events and fails its check while a `DO NOT MERGE` label (case-insensitive) is present, turning green again once the label is removed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)