### PR TITLE
perf(bal): build BAL validation index on the sequential execution path

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Serialization.Rlp.Eip7928;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace Nethermind.Blockchain.Test;
+
+/// <summary>
+/// Direct coverage for the column-index fast path on the sequential execution path. The fast
+/// path (<c>BlockAccessListManager.TryFastPath</c>) is only reachable on the sequential path
+/// because <c>MergeAndReturnBal</c> now feeds each per-tx slice into the generated validation
+/// index via <c>RegisterGeneratedSlice</c>. These tests drive real transaction execution
+/// through the sequential <c>ParallelBlockValidationTransactionsExecutor</c>, generate the BAL
+/// the executor produces, then re-validate it: a matching BAL must take the fast path and be
+/// accepted, a tampered BAL must be rejected.
+/// </summary>
+[Parallelizable(ParallelScope.All)]
+public class BlockAccessListSequentialValidationTests
+{
+    [Test]
+    public void Sequential_validation_accepts_matching_bal_via_fast_path()
+    {
+        ReadOnlyBlockAccessList generated = GenerateBlockAccessList();
+
+        BlockAccessListManager balManager = null!;
+        Assert.DoesNotThrow(() => balManager = RunSequentialValidation(generated));
+
+        // The matching BAL must be accepted by the column-index fast path, not merely by the
+        // slow-path fallback (which would also accept and hide a regression of the wiring).
+        Assert.That(balManager.FastPathHits, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Sequential_validation_rejects_mismatched_bal()
+    {
+        ReadOnlyBlockAccessList generated = GenerateBlockAccessList();
+
+        // Tamper: append an extra storage read to the sender's entry. The generated BAL the
+        // re-execution produces no longer matches, so the fast-path row compare diverges and the
+        // fallback walk must reject.
+        ReadOnlyBlockAccessList tampered = Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressA)
+                .WithStorageReads((UInt256)1)
+                .TestObject)
+            .TestObject;
+
+        Assert.Throws<BlockAccessListBasedWorldState.InvalidBlockLevelAccessListException>(
+            () => RunSequentialValidation(tampered));
+    }
+
+    /// <summary>
+    /// Runs the block once on the sequential path with no suggested BAL so the executor
+    /// constructs the generated BAL, then re-encodes it as a wire <see cref="ReadOnlyBlockAccessList"/>.
+    /// </summary>
+    private static ReadOnlyBlockAccessList GenerateBlockAccessList()
+    {
+        (IWorldState stateProvider, BlockAccessListManager balManager) = CreateFundedAmsterdamSetup();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        FundSender(stateProvider);
+
+        Block block = BuildBlock();
+        RunSequential(stateProvider, balManager, block, blockAccessList: null);
+
+        byte[] encoded = BlockAccessListDecoder.EncodeToBytes(balManager.GeneratedBlockAccessList);
+        return Rlp.Decode<ReadOnlyBlockAccessList>(encoded);
+    }
+
+    private static BlockAccessListManager RunSequentialValidation(ReadOnlyBlockAccessList suggested)
+    {
+        (IWorldState stateProvider, BlockAccessListManager balManager) = CreateFundedAmsterdamSetup();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        FundSender(stateProvider);
+
+        Block block = BuildBlock();
+        block.Header.BlockAccessListHash = Keccak.Zero;
+        RunSequential(stateProvider, balManager, block, suggested);
+        return balManager;
+    }
+
+    private static void RunSequential(IWorldState stateProvider, BlockAccessListManager balManager, Block block, ReadOnlyBlockAccessList? blockAccessList)
+    {
+        block.BlockAccessList = blockAccessList;
+
+        IBlockProcessor.IBlockTransactionsExecutor inner = Substitute.For<IBlockProcessor.IBlockTransactionsExecutor>();
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor = new(
+            inner,
+            stateProvider,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            balManager,
+            LimboLogs.Instance);
+
+        BlockExecutionContext executionContext = new(block.Header, Amsterdam.Instance);
+        balManager.PrepareForProcessing(block, Amsterdam.Instance, ProcessingOptions.None);
+        executor.SetBlockExecutionContext(executionContext);
+        balManager.Setup(block);
+
+        BlockReceiptsTracer tracer = new();
+        tracer.StartNewBlockTrace(block);
+
+        executor.ProcessTransactions(block, ProcessingOptions.None, tracer, CancellationToken.None);
+    }
+
+    private static (IWorldState, BlockAccessListManager) CreateFundedAmsterdamSetup()
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        TestSingleReleaseSpecProvider specProvider = new(Amsterdam.Instance);
+        BlockAccessListManager balManager = new(
+            stateProvider,
+            specProvider,
+            Substitute.For<IBlockhashProvider>(),
+            LimboLogs.Instance,
+            new BlocksConfig { ParallelExecution = false },
+            new WithdrawalProcessorFactory(LimboLogs.Instance));
+        return (stateProvider, balManager);
+    }
+
+    private static void FundSender(IWorldState stateProvider)
+    {
+        stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);
+        stateProvider.Commit(Amsterdam.Instance);
+        stateProvider.CommitTree(0);
+    }
+
+    private static Block BuildBlock()
+    {
+        Transaction tx = Build.A.Transaction
+            .WithNonce(0)
+            .WithValue(1)
+            .WithGasPrice(0)
+            .WithGasLimit(GasCostOf.Transaction)
+            .WithTo(TestItem.AddressB)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+
+        return Build.A.Block
+            .WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithGasLimit(GasCostOf.Transaction * 4)
+            .WithTransactions(tx)
+            .TestObject;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -47,9 +47,10 @@ public class BlockAccessListSequentialValidationTests
         BlockAccessListManager balManager = null!;
         Assert.DoesNotThrow(() => balManager = RunSequentialValidation(generated));
 
-        // The matching BAL must be accepted by the column-index fast path, not merely by the
-        // slow-path fallback (which would also accept and hide a regression of the wiring).
-        Assert.That(balManager.FastPathHits, Is.GreaterThan(0));
+        // The generated column index received per-tx slices on the sequential path. This gates
+        // TryFastPath, so with a matching BAL the fast path is what accepted it (the slow-path
+        // fallback would also accept and hide a regression of the sequential wiring).
+        Assert.That(balManager.HasGeneratedValidationIndexUpdates, Is.True);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -28,13 +28,10 @@ using System.Threading;
 namespace Nethermind.Blockchain.Test;
 
 /// <summary>
-/// Direct coverage for the column-index fast path on the sequential execution path. The fast
-/// path (<c>BlockAccessListManager.TryFastPath</c>) is only reachable on the sequential path
-/// because <c>MergeAndReturnBal</c> now feeds each per-tx slice into the generated validation
-/// index via <c>RegisterGeneratedSlice</c>. These tests drive real transaction execution
-/// through the sequential <c>ParallelBlockValidationTransactionsExecutor</c>, generate the BAL
-/// the executor produces, then re-validate it: a matching BAL must take the fast path and be
-/// accepted, a tampered BAL must be rejected.
+/// Covers the column-index fast path on the sequential execution path, reachable only because
+/// <c>MergeAndReturnBal</c> feeds each per-tx slice into the generated validation index. Drives
+/// real execution to produce a BAL, then re-validates it: a matching BAL is accepted via the
+/// fast path, a tampered BAL is rejected.
 /// </summary>
 [Parallelizable(ParallelScope.All)]
 public class BlockAccessListSequentialValidationTests
@@ -47,9 +44,8 @@ public class BlockAccessListSequentialValidationTests
         BlockAccessListManager balManager = null!;
         Assert.DoesNotThrow(() => balManager = RunSequentialValidation(generated));
 
-        // The generated column index received per-tx slices on the sequential path. This gates
-        // TryFastPath, so with a matching BAL the fast path is what accepted it (the slow-path
-        // fallback would also accept and hide a regression of the sequential wiring).
+        // Index fed on the sequential path gates TryFastPath, so a matching BAL was accepted via
+        // the fast path rather than the slow-path fallback that would mask a wiring regression.
         Assert.That(balManager.HasGeneratedValidationIndexUpdates, Is.True);
     }
 
@@ -58,9 +54,8 @@ public class BlockAccessListSequentialValidationTests
     {
         ReadOnlyBlockAccessList generated = GenerateBlockAccessList();
 
-        // Tamper: append an extra storage read to the sender's entry. The generated BAL the
-        // re-execution produces no longer matches, so the fast-path row compare diverges and the
-        // fallback walk must reject.
+        // Tamper: an extra storage read on the sender no longer matches what re-execution
+        // produces, so the fast-path row compare diverges and the fallback walk must reject.
         ReadOnlyBlockAccessList tampered = Build.A.BlockAccessList
             .WithAccountChanges(Build.An.AccountChanges
                 .WithAddress(TestItem.AddressA)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -353,7 +353,12 @@ public partial class BlockAccessListManager
 
         public void MergeAndReturnBal(uint _, GeneratedBlockAccessList? target, Action<BlockAccessListAtIndex>? onSlice = null)
         {
-            if (target is not null) _txProcessorWithWorldState.WorldState.MergeGeneratingBal(target);
+            // The single reusable slice still holds this tx's changes (NextTransaction clears it
+            // only afterwards). Both Merge and the validation-index Add copy the data out, so
+            // feeding the same slice to onSlice is safe.
+            BlockAccessListAtIndex slice = _txProcessorWithWorldState.WorldState.GetGeneratingBlockAccessList()!;
+            if (target is not null) target.Merge(slice);
+            onSlice?.Invoke(slice);
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -353,11 +353,8 @@ public partial class BlockAccessListManager
 
         public void MergeAndReturnBal(uint _, GeneratedBlockAccessList? target, Action<BlockAccessListAtIndex>? onSlice = null)
         {
-            // The single reusable slice still holds this tx's changes (NextTransaction clears it
-            // only afterwards). Both Merge and the validation-index Add copy the data out, so
-            // feeding the same slice to onSlice is safe.
             BlockAccessListAtIndex slice = _txProcessorWithWorldState.WorldState.GetGeneratingBlockAccessList()!;
-            if (target is not null) target.Merge(slice);
+            target?.Merge(slice);
             onSlice?.Invoke(slice);
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
@@ -168,7 +168,6 @@ public partial class BlockAccessListManager
         {
             throw new InvalidBlockLevelAccessListException(block.Header, "Suggested block-level access list contained invalid storage reads.");
         }
-        FastPathHits++;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
@@ -168,6 +168,7 @@ public partial class BlockAccessListManager
         {
             throw new InvalidBlockLevelAccessListException(block.Header, "Suggested block-level access list contained invalid storage reads.");
         }
+        FastPathHits++;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -77,7 +77,7 @@ public partial class BlockAccessListManager(
     private int _suggestedChargeableStorageReads;
     private int _generatedChargeableStorageReads;
     private bool _hasGeneratedValidationIndexUpdates;
-    // Exposed read-only for tests: gates TryFastPath and is set only when slices are fed via RegisterGeneratedSlice.
+    // for tests
     internal bool HasGeneratedValidationIndexUpdates => _hasGeneratedValidationIndexUpdates;
     // Latched when a per-tx slice surfaces a generated-only account that the column index
     // can't see (no lane data on either side). Forces the validator's fallback walk so the
@@ -136,9 +136,7 @@ public partial class BlockAccessListManager(
             // Build the column-oriented validation index once per block; per-tx ChangesEqual
             // then collapses to row-aligned span compares. Tally suggested chargeable storage
             // reads here so the per-tx surplus-reads gas check avoids re-walking the BAL.
-            // Built on every validating path (parallel and sequential) — both feed the generated
-            // side via RegisterGeneratedSlice. Skipped only when building a block (no suggested
-            // BAL to compare against) or when the BAL body isn't decoded (RLP fixtures).
+            // Skipped when building a block or in RLP fixtures (no suggested)
             if (!_isBuilding && suggestedBlock.BlockAccessList is not null)
             {
                 BlockAccessListValidationIndex.AddressIndex addressIndex = new();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -77,10 +77,11 @@ public partial class BlockAccessListManager(
     private int _suggestedChargeableStorageReads;
     private int _generatedChargeableStorageReads;
     private bool _hasGeneratedValidationIndexUpdates;
-    // Count of validation calls resolved by the column-index fast path. Exposed for tests to
-    // assert the perf-critical path is actually taken — the fast and slow paths are otherwise
-    // behaviourally identical, so a silent regression to the slow path is invisible without it.
-    internal int FastPathHits { get; private set; }
+    // Whether the generated column index has received any per-tx slices. On the sequential path
+    // this only becomes true when MergeAndReturnBal feeds slices through RegisterGeneratedSlice;
+    // exposed read-only so tests can confirm the fast path is reachable (it gates TryFastPath)
+    // without adding any per-call work to the validation hot path.
+    internal bool HasGeneratedValidationIndexUpdates => _hasGeneratedValidationIndexUpdates;
     // Latched when a per-tx slice surfaces a generated-only account that the column index
     // can't see (no lane data on either side). Forces the validator's fallback walk so the
     // same "missing account changes" error fires as on the sequential path.
@@ -264,7 +265,6 @@ public partial class BlockAccessListManager(
         _hasGeneratedValidationIndexUpdates = false;
         _hasGeneratedRequiredReadAccountMismatch = false;
         _currentGeneratedBlockAccessList = null;
-        FastPathHits = 0;
     }
 
     [DoesNotReturn]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -77,6 +77,10 @@ public partial class BlockAccessListManager(
     private int _suggestedChargeableStorageReads;
     private int _generatedChargeableStorageReads;
     private bool _hasGeneratedValidationIndexUpdates;
+    // Count of validation calls resolved by the column-index fast path. Exposed for tests to
+    // assert the perf-critical path is actually taken — the fast and slow paths are otherwise
+    // behaviourally identical, so a silent regression to the slow path is invisible without it.
+    internal int FastPathHits { get; private set; }
     // Latched when a per-tx slice surfaces a generated-only account that the column index
     // can't see (no lane data on either side). Forces the validator's fallback walk so the
     // same "missing account changes" error fires as on the sequential path.
@@ -260,6 +264,7 @@ public partial class BlockAccessListManager(
         _hasGeneratedValidationIndexUpdates = false;
         _hasGeneratedRequiredReadAccountMismatch = false;
         _currentGeneratedBlockAccessList = null;
+        FastPathHits = 0;
     }
 
     [DoesNotReturn]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -134,10 +134,10 @@ public partial class BlockAccessListManager(
             // Build the column-oriented validation index once per block; per-tx ChangesEqual
             // then collapses to row-aligned span compares. Tally suggested chargeable storage
             // reads here so the per-tx surplus-reads gas check avoids re-walking the BAL.
-            // Only the parallel path feeds the generated side (via RegisterGeneratedSlice in
-            // MergeAndReturnBal); the sequential NextTransaction merges directly into
-            // GeneratedBlockAccessList, so the fast path never fires there — skip the build.
-            if (ParallelExecutionEnabled && suggestedBlock.BlockAccessList is not null)
+            // Built on every validating path (parallel and sequential) — both feed the generated
+            // side via RegisterGeneratedSlice. Skipped only when building a block (no suggested
+            // BAL to compare against) or when the BAL body isn't decoded (RLP fixtures).
+            if (!_isBuilding && suggestedBlock.BlockAccessList is not null)
             {
                 BlockAccessListValidationIndex.AddressIndex addressIndex = new();
                 ReadOnlyBlockAccessList suggested = suggestedBlock.BlockAccessList;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -77,10 +77,7 @@ public partial class BlockAccessListManager(
     private int _suggestedChargeableStorageReads;
     private int _generatedChargeableStorageReads;
     private bool _hasGeneratedValidationIndexUpdates;
-    // Whether the generated column index has received any per-tx slices. On the sequential path
-    // this only becomes true when MergeAndReturnBal feeds slices through RegisterGeneratedSlice;
-    // exposed read-only so tests can confirm the fast path is reachable (it gates TryFastPath)
-    // without adding any per-call work to the validation hot path.
+    // Exposed read-only for tests: gates TryFastPath and is set only when slices are fed via RegisterGeneratedSlice.
     internal bool HasGeneratedValidationIndexUpdates => _hasGeneratedValidationIndexUpdates;
     // Latched when a per-tx slice surfaces a generated-only account that the column index
     // can't see (no lane data on either side). Forces the validator's fallback walk so the

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -230,9 +230,6 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         _systemAccountReadSuppressionDepth = 0;
     }
 
-    public void MergeGeneratingBal(GeneratedBlockAccessList target)
-        => target.Merge(_generatingBlockAccessList);
-
     BlockAccessListAtIndex? IBlockAccessListSource.GeneratedBlockAccessList => _generatingBlockAccessList;
 
     public void Restore(Snapshot snapshot)


### PR DESCRIPTION
The column-oriented BAL validation index was only built when parallel execution was enabled, so the sequential validation path always fell back to a full per-tx walk over the generated and suggested BALs (~O(txCount × accounts)). The intent was to skip the index only during block building.

Build the index whenever a block is validated (not building) and wire the sequential MergeAndReturnBal to feed RegisterGeneratedSlice, so the column-index fast path fires on the sequential path too. The end-of-block BAL-hash comparison remains the authoritative structural check.

## Changes

- see above

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No