### PR TITLE
Add eth forkid to node records

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryV5AppTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryV5AppTests.cs
@@ -3,7 +3,9 @@
 
 using Autofac;
 using Autofac.Features.AttributeFilters;
+using Nethermind.Blockchain;
 using Nethermind.Config;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
@@ -48,7 +50,7 @@ public class DiscoveryV5AppTests
             Bootnodes = [],
             ExternalIp = externalIp.ToString()
         };
-        IProtectedPrivateKey nodeKey = new InsecureProtectedPrivateKey(TestItem.PrivateKeyF);
+        IProtectedPrivateKey nodeKey = new InsecureProtectedPrivateKey(new PrivateKey(TestItem.PrivateKeyF.KeyBytes));
         IEnode enode = new Enode(nodeKey.PublicKey, externalIp, networkConfig.P2PPort, networkConfig.DiscoveryPort);
         IIPResolver ipResolver = new FixedIpResolver(networkConfig);
         EthereumEcdsa ecdsa = new(0);
@@ -62,6 +64,9 @@ public class DiscoveryV5AppTests
         builder.RegisterInstance(new CryptoRandom()).As<ICryptoRandom>();
         builder.RegisterInstance(new NetworkStorage(_discoveryDb, LimboLogs.Instance)).Keyed<INetworkStorage>(DbNames.DiscoveryV5Nodes);
         builder.RegisterInstance(Substitute.For<INodeStatsManager>()).As<INodeStatsManager>();
+        builder.RegisterInstance(Timestamper.Default).As<ITimestamper>();
+        builder.RegisterInstance(Substitute.For<IBlockTree>()).As<IBlockTree>();
+        builder.RegisterInstance(Substitute.For<IForkInfo>()).As<IForkInfo>();
         builder.RegisterType<NodeRecordProvider>().As<INodeRecordProvider>().WithAttributeFiltering().SingleInstance();
         IContainer container = builder.Build();
         _containers.Add(container);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryMessageSerializerTests.cs
@@ -119,9 +119,37 @@ public class DiscoveryMessageSerializerTests
             Assert.That(deserializedMessage.MsgType, Is.EqualTo(message.MsgType));
             Assert.That(deserializedMessage.FarPublicKey, Is.EqualTo(message.FarPublicKey));
             Assert.That(deserializedMessage.ExpirationTime, Is.EqualTo(message.ExpirationTime));
-
             Assert.That(deserializedMessage.PingMdc, Is.EqualTo(message.PingMdc));
+            Assert.That(deserializedMessage.EnrSequence, Is.Null);
         }
+    }
+
+    [Test]
+    public void Pong_with_enr_sequence_there_and_back()
+    {
+        PongMsg pongMsg = new(TestItem.PublicKeyA, long.MaxValue, TestItem.KeccakA.ValueHash256, 3)
+        {
+            FarAddress = _farAddress
+        };
+
+        using DisposableByteBuffer serialized = _messageSerializationService.ZeroSerialize(pongMsg).AsDisposable();
+        pongMsg = _messageSerializationService.Deserialize<PongMsg>(serialized);
+
+        Assert.That(pongMsg.EnrSequence, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Pong_with_enr_sequence_and_extra_tail_reads_enr_sequence()
+    {
+        PongMsg pongMsg = new(TestItem.PublicKeyA, long.MaxValue, TestItem.KeccakA.ValueHash256, 3)
+        {
+            FarAddress = _farAddress
+        };
+        byte[] serialized = CreatePongWithExtraTail(pongMsg, [4, 5, 6]);
+
+        pongMsg = _messageSerializationService.Deserialize<PongMsg>(serialized);
+
+        Assert.That(pongMsg.EnrSequence, Is.EqualTo(3));
     }
 
     [Test]
@@ -337,6 +365,51 @@ public class DiscoveryMessageSerializerTests
         NodeRecordSigner signer = new(new Ecdsa(), _privateKey);
         signer.Sign(nodeRecord);
         return new EnrResponseMsg(TestItem.PublicKeyA, nodeRecord, TestItem.KeccakA);
+    }
+
+    private byte[] CreatePongWithExtraTail(PongMsg message, byte[] extraTail)
+    {
+        byte[] addressBytes = message.FarAddress!.Address.GetAddressBytes();
+        int farAddressLength =
+            Rlp.LengthOf(addressBytes) +
+            Rlp.LengthOf(message.FarAddress.Port) +
+            Rlp.LengthOf(message.FarAddress.Port);
+        int contentLength =
+            Rlp.LengthOfSequence(farAddressLength) +
+            Rlp.LengthOf(message.PingMdc) +
+            Rlp.LengthOf(message.ExpirationTime) +
+            Rlp.LengthOf(message.EnrSequence.GetValueOrDefault()) +
+            Rlp.LengthOf(extraTail);
+        byte[] messageRlp = new byte[Rlp.LengthOfSequence(contentLength)];
+        RlpStream rlpStream = new(messageRlp);
+        rlpStream.StartSequence(contentLength);
+        rlpStream.StartSequence(farAddressLength);
+        rlpStream.Encode(addressBytes);
+        rlpStream.Encode(message.FarAddress.Port);
+        rlpStream.Encode(message.FarAddress.Port);
+        rlpStream.Encode(message.PingMdc);
+        rlpStream.Encode(message.ExpirationTime);
+        rlpStream.Encode(message.EnrSequence.GetValueOrDefault());
+        rlpStream.Encode(extraTail);
+
+        byte[] signedPayload = new byte[1 + messageRlp.Length];
+        signedPayload[0] = (byte)MsgType.Pong;
+        messageRlp.CopyTo(signedPayload.AsSpan(1));
+
+        Ecdsa ecdsa = new();
+        ValueHash256 toSign = ValueKeccak.Compute(signedPayload);
+        Signature signature = ecdsa.Sign(_privateKey, in toSign);
+
+        byte[] signatureAndPayload = new byte[65 + signedPayload.Length];
+        signature.Bytes.CopyTo(signatureAndPayload.AsSpan(0, 64));
+        signatureAndPayload[64] = signature.RecoveryId;
+        signedPayload.CopyTo(signatureAndPayload.AsSpan(65));
+
+        ValueHash256 mdc = ValueKeccak.Compute(signatureAndPayload);
+        byte[] packet = new byte[32 + signatureAndPayload.Length];
+        mdc.Bytes.CopyTo(packet.AsSpan(0, 32));
+        signatureAndPayload.CopyTo(packet.AsSpan(32));
+        return packet;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
 using Nethermind.Kademlia;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -91,11 +92,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             _networkConfig.MaxActivePeers.Returns(25);
             _kademliaConfig = new KademliaConfig<Node> { CurrentNodeId = _testNode };
 
-            _selfNodeRecord = TestEnrBuilder.BuildSigned(
-                TestItem.PrivateKeyA,
-                IPAddress.Parse("192.168.1.1"),
-                tcpPort: _networkConfig.P2PPort,
-                udpPort: _networkConfig.DiscoveryPort);
+            _selfNodeRecord = CreateNodeRecord();
 
             _logManager = LimboLogs.Instance;
             _timestamper = Substitute.For<ITimestamper>();
@@ -146,6 +143,23 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             _nodeStatsManager.Received(1).GetOrAdd(Arg.Is<Node>(node => node.Id == _receiver.Id));
         }
 
+        private NodeRecord CreateNodeRecord()
+            => CreateNodeRecord(
+                TestItem.PrivateKeyA,
+                IPAddress.Parse("192.168.1.1"),
+                _networkConfig.P2PPort,
+                _networkConfig.DiscoveryPort,
+                1);
+
+        private static NodeRecord CreateNodeRecord(PrivateKey privateKey, IPAddress ipAddress, int tcpPort, int udpPort, ulong enrSequence)
+            => TestEnrBuilder.BuildSigned(
+                privateKey,
+                ipAddress,
+                tcpPort,
+                udpPort,
+                enrSequence: enrSequence,
+                configureExtras: static enr => enr.SetEntry(IdEntry.Instance));
+
         [TearDown]
         public async Task TearDown() => await _adapter.DisposeAsync();
 
@@ -156,6 +170,16 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             msg = _receiverSerializationManager.Deserialize<T>(buffer);
             msg.FarAddress = farAddress;
             return msg;
+        }
+
+        private PingMsg CreatePingWithEnrSequence(ulong enrSequence)
+        {
+            PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = enrSequence,
+                FarAddress = _receiver.Address
+            };
+            return AddReceiverFarAddress(pingMsg);
         }
 
         private async Task<bool> HasResponse(NoResponseRequest request, CancellationToken token) =>
@@ -381,6 +405,232 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             await _msgSender.Received(1).SendMsg(Arg.Is<PongMsg>(m =>
                 m.FarAddress!.Equals(_receiver.Address) &&
                 m.PingMdc == expectedPingMdc));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task OnIncomingMsg_ping_with_newer_enr_sequence_should_request_and_apply_enr(CancellationToken token)
+        {
+            await BondReceiver(token);
+
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            byte[] requestHash = TestItem.KeccakA.BytesToArray();
+            TaskCompletionSource enrRefreshCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _nodeHealthTracker
+                .When(x => x.OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                    n.Id.Equals(_receiver.Id) &&
+                    TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence))))
+                .Do(_ => enrRefreshCompleted.TrySetResult());
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(ci =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)ci[0]!;
+                    sent.Hash = new ValueHash256(requestHash);
+                    EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                        _receiver.Address,
+                        remoteRecord,
+                        new Hash256(requestHash)));
+                    _adapter.OnIncomingMsg(response).GetAwaiter().GetResult();
+                });
+
+            PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = remoteRecord.EnrSequence
+            };
+            pingMsg.FarAddress = _receiver.Address;
+            pingMsg = AddReceiverFarAddress(pingMsg);
+
+            await _adapter.OnIncomingMsg(pingMsg);
+            await enrRefreshCompleted.Task.WaitAsync(token);
+
+            await _msgSender.Received(1).SendMsg(Arg.Is<EnrRequestMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
+            _nodeHealthTracker.Received().OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                n.Id.Equals(_receiver.Id) &&
+                TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task OnIncomingMsg_ping_with_newer_enr_sequence_should_apply_udp_discovery_port(CancellationToken token)
+        {
+            await BondReceiver(token);
+
+            int udpPort = _receiver.Address.Port;
+            int tcpPort = udpPort + 1;
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                tcpPort,
+                udpPort,
+                2);
+            byte[] requestHash = TestItem.KeccakA.BytesToArray();
+            TaskCompletionSource enrRefreshCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _nodeHealthTracker
+                .When(x => x.OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                    n.Id.Equals(_receiver.Id) &&
+                    n.Address.Port == udpPort &&
+                    TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence))))
+                .Do(_ => enrRefreshCompleted.TrySetResult());
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(ci =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)ci[0]!;
+                    sent.Hash = new ValueHash256(requestHash);
+                    EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                        _receiver.Address,
+                        remoteRecord,
+                        new Hash256(requestHash)));
+                    _adapter.OnIncomingMsg(response).GetAwaiter().GetResult();
+                });
+
+            PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = remoteRecord.EnrSequence
+            };
+            pingMsg.FarAddress = _receiver.Address;
+            pingMsg = AddReceiverFarAddress(pingMsg);
+
+            await _adapter.OnIncomingMsg(pingMsg);
+            await enrRefreshCompleted.Task.WaitAsync(token);
+
+            _nodeHealthTracker.Received().OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                n.Id.Equals(_receiver.Id) &&
+                n.Address.Port == udpPort &&
+                TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task Ping_with_newer_pong_enr_sequence_should_request_and_apply_enr(CancellationToken token)
+        {
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            byte[] requestHash = TestItem.KeccakA.BytesToArray();
+            TaskCompletionSource enrRefreshCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _nodeHealthTracker
+                .When(x => x.OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                    n.Id.Equals(_receiver.Id) &&
+                    TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence))))
+                .Do(_ => enrRefreshCompleted.TrySetResult());
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<PingMsg>()))
+                .Do(ci =>
+                {
+                    PingMsg sent = (PingMsg)ci[0]!;
+                    using DisposableByteBuffer buffer = _receiverSerializationManager.ZeroSerialize(sent).AsDisposable();
+                    PingMsg msg = _receiverSerializationManager.Deserialize<PingMsg>(buffer);
+                    PongMsg pong = new(msg.FarPublicKey!, _timestamper.UnixTime.SecondsLong + 1, sent.Mdc!.Value, remoteRecord.EnrSequence)
+                    {
+                        FarAddress = _receiver.Address
+                    };
+                    _adapter.OnIncomingMsg(pong).GetAwaiter().GetResult();
+                });
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(ci =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)ci[0]!;
+                    sent.Hash = new ValueHash256(requestHash);
+                    EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                        _receiver.Address,
+                        remoteRecord,
+                        new Hash256(requestHash)));
+                    _adapter.OnIncomingMsg(response).GetAwaiter().GetResult();
+                });
+
+            bool result = await _adapter.Ping(_receiver, token);
+            await enrRefreshCompleted.Task.WaitAsync(token);
+
+            Assert.That(result, Is.True);
+            await _msgSender.Received(1).SendMsg(Arg.Is<EnrRequestMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
+            _nodeHealthTracker.Received().OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                n.Id.Equals(_receiver.Id) &&
+                TestEnrBuilder.HasEnrSequence(n, remoteRecord.EnrSequence)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task Out_of_order_enr_response_should_not_downgrade_known_record(CancellationToken token)
+        {
+            await BondReceiver(token);
+
+            NodeRecord staleRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            NodeRecord newerRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                3);
+            byte[] firstRequestHash = TestItem.KeccakA.BytesToArray();
+            byte[] secondRequestHash = TestItem.KeccakB.BytesToArray();
+            TaskCompletionSource firstRequestSent = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource secondRequestSent = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource newerRecordApplied = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int enrRequestCount = 0;
+            _nodeHealthTracker
+                .When(x => x.OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                    n.Id.Equals(_receiver.Id) &&
+                    TestEnrBuilder.HasEnrSequence(n, newerRecord.EnrSequence))))
+                .Do(_ => newerRecordApplied.TrySetResult());
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(ci =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)ci[0]!;
+                    int requestNumber = Interlocked.Increment(ref enrRequestCount);
+                    if (requestNumber == 1)
+                    {
+                        sent.Hash = new ValueHash256(firstRequestHash);
+                        firstRequestSent.TrySetResult();
+                    }
+                    else if (requestNumber == 2)
+                    {
+                        sent.Hash = new ValueHash256(secondRequestHash);
+                        secondRequestSent.TrySetResult();
+                    }
+                    else
+                    {
+                        Assert.Fail("Unexpected extra ENR request.");
+                    }
+                });
+
+            await _adapter.OnIncomingMsg(CreatePingWithEnrSequence(staleRecord.EnrSequence));
+            await firstRequestSent.Task.WaitAsync(token);
+            await _adapter.OnIncomingMsg(CreatePingWithEnrSequence(newerRecord.EnrSequence));
+            await secondRequestSent.Task.WaitAsync(token);
+
+            EnrResponseMsg newerResponse = AddReceiverFarAddress(new EnrResponseMsg(
+                _receiver.Address,
+                newerRecord,
+                new Hash256(secondRequestHash)));
+            await _adapter.OnIncomingMsg(newerResponse);
+            await newerRecordApplied.Task.WaitAsync(token);
+
+            EnrResponseMsg staleResponse = AddReceiverFarAddress(new EnrResponseMsg(
+                _receiver.Address,
+                staleRecord,
+                new Hash256(firstRequestHash)));
+            await _adapter.OnIncomingMsg(staleResponse);
+            _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                n.Id.Equals(_receiver.Id) &&
+                TestEnrBuilder.HasEnrSequence(n, staleRecord.EnrSequence)));
+            Assert.That(enrRequestCount, Is.EqualTo(2));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
@@ -60,6 +60,42 @@ public class WireTests
     }
 
     [Test]
+    public async Task Ping_Refreshes_Remote_Enr_When_Pong_Advertises_Newer_Sequence()
+    {
+        IPEndPoint endpointA = IPEndPoint.Parse("127.0.0.1:10000");
+        IPEndPoint endpointB = IPEndPoint.Parse("127.0.0.1:10001");
+        TestPeer peerA = CreatePeer(TestItem.PrivateKeyA, endpointA);
+        TestPeer peerB = CreatePeer(TestItem.PrivateKeyB, endpointB, enrSequence: 2);
+        NodeRecord staleRecord = BuildNodeRecord(TestItem.PrivateKeyB, endpointB, includeEndpoint: true, enrSequence: 1);
+        Node nodeB = new(TestItem.PrivateKeyB.PublicKey, endpointB)
+        {
+            Enr = staleRecord.EnrString
+        };
+
+        using CancellationTokenSource cancellationSource = new(10_000);
+        Task runA = peerA.Adapter.RunAsync(cancellationSource.Token);
+        Task runB = peerB.Adapter.RunAsync(cancellationSource.Token);
+
+        Task pingTask = peerA.Adapter.Ping(nodeB, cancellationSource.Token);
+        await PumpUntilComplete(pingTask, peerA, peerB, cancellationSource.Token);
+        await pingTask;
+
+        await PumpUntil(
+            () => peerA.Kademlia.ReceivedCallsMatching(
+                kademlia => kademlia.AddOrRefresh(Arg.Is<Node>(node =>
+                    node.Id.Equals(TestItem.PrivateKeyB.PublicKey) &&
+                    TestEnrBuilder.HasEnrSequence(node, peerB.NodeRecordProvider.Current.EnrSequence))),
+                requiredNumberOfCalls: 1,
+                maxNumberOfCalls: int.MaxValue),
+            peerA,
+            peerB,
+            cancellationSource.Token);
+
+        await cancellationSource.CancelAsync();
+        await Task.WhenAll(runA, runB);
+    }
+
+    [Test]
     public async Task Ping_Rehandshakes_After_RemoteSessionLost()
     {
         IPEndPoint endpointA = IPEndPoint.Parse("127.0.0.1:10000");
@@ -197,14 +233,18 @@ public class WireTests
         peerA.Kademlia.Received().AddOrRefresh(Arg.Is<Node>(node => node.Id.Equals(TestItem.PrivateKeyC.PublicKey)));
     }
 
-    private static TestPeer CreatePeer(PrivateKey privateKey, IPEndPoint endpoint, bool includeEndpointInRecord = true)
+    private static TestPeer CreatePeer(
+        PrivateKey privateKey,
+        IPEndPoint endpoint,
+        bool includeEndpointInRecord = true,
+        ulong enrSequence = 1)
     {
         IKademlia<PublicKey, Node> kademlia = Substitute.For<IKademlia<PublicKey, Node>>();
         NettyDiscoveryV5Handler handler = new(new TestLogManager());
         EmbeddedChannel channel = new();
         handler.InitializeChannel(channel);
 
-        TestNodeRecordProvider nodeRecordProvider = new(privateKey, endpoint, includeEndpointInRecord);
+        TestNodeRecordProvider nodeRecordProvider = new(privateKey, endpoint, includeEndpointInRecord, enrSequence);
         PacketCodec packetCodec = new(
             new InsecureProtectedPrivateKey(privateKey),
             new CryptoRandom(),
@@ -222,6 +262,20 @@ public class WireTests
 
         return new TestPeer(adapter, handler, channel, packetCodec, kademlia, nodeRecordProvider, endpoint);
     }
+
+    private static NodeRecord BuildNodeRecord(PrivateKey privateKey, IPEndPoint endpoint, bool includeEndpoint, ulong enrSequence)
+        => includeEndpoint
+            ? TestEnrBuilder.BuildSigned(
+                privateKey,
+                endpoint.Address,
+                tcpPort: endpoint.Port,
+                udpPort: endpoint.Port,
+                enrSequence: enrSequence,
+                configureExtras: static enr => enr.SetEntry(IdEntry.Instance))
+            : TestEnrBuilder.BuildSignedWithoutEndpoint(
+                privateKey,
+                enrSequence,
+                configureExtras: static enr => enr.SetEntry(IdEntry.Instance));
 
     private static async Task PumpUntilComplete(Task task, TestPeer peerA, TestPeer peerB, CancellationToken token)
     {
@@ -284,11 +338,10 @@ public class WireTests
         }
     }
 
-    private sealed class TestNodeRecordProvider(PrivateKey privateKey, IPEndPoint endpoint, bool includeEndpoint) : INodeRecordProvider
+    private sealed class TestNodeRecordProvider(PrivateKey privateKey, IPEndPoint endpoint, bool includeEndpoint, ulong enrSequence)
+        : INodeRecordProvider
     {
-        public NodeRecord Current { get; } = includeEndpoint
-            ? TestEnrBuilder.BuildSigned(privateKey, endpoint.Address, tcpPort: endpoint.Port, udpPort: endpoint.Port)
-            : TestEnrBuilder.BuildSignedWithoutEndpoint(privateKey);
+        public NodeRecord Current { get; } = BuildNodeRecord(privateKey, endpoint, includeEndpoint, enrSequence);
 
         public ValueTask<NodeRecord> GetCurrentAsync(CancellationToken cancellationToken = default) => new(Current);
     }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Crypto;
+using Nethermind.Logging;
+using Nethermind.Network.Config;
+using Nethermind.Network.Enr;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using EnrForkId = Nethermind.Network.Enr.ForkId;
+using NetworkForkId = Nethermind.Network.ForkId;
+
+namespace Nethermind.Network.Discovery.Test;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class NodeRecordProviderTests
+{
+    private static readonly DateTime EnrSequenceTime = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly ulong EnrSequence = (ulong)new DateTimeOffset(EnrSequenceTime).ToUnixTimeMilliseconds();
+
+    [Test]
+    public async Task Current_includes_eth_forkid_entry()
+    {
+        Block head = CreateBlock(64, 1_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(head);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId expectedForkId = new(0x01020304, 128);
+        forkInfo.GetForkId(head.Number, head.Timestamp).Returns(expectedForkId);
+
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+
+        NodeRecord current = await provider.GetCurrentAsync();
+
+        AssertForkId(current, expectedForkId);
+        Assert.That(current.EnrSequence, Is.EqualTo(EnrSequence));
+        AssertForkId(NodeRecord.FromEnrString(current.EnrString), expectedForkId);
+    }
+
+    [Test]
+    public async Task Current_includes_eth_forkid_when_next_exceeds_signed_long_range()
+    {
+        Block head = CreateBlock(64, 1_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(head);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId forkId = new(0x01020304, (ulong)long.MaxValue + 1);
+        forkInfo.GetForkId(head.Number, head.Timestamp).Returns(forkId);
+
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+
+        NodeRecord current = await provider.GetCurrentAsync();
+
+        AssertForkId(current, forkId);
+        Assert.That(current.EnrSequence, Is.EqualTo(EnrSequence));
+        AssertForkId(NodeRecord.FromEnrString(current.EnrString), forkId);
+    }
+
+    [Test]
+    public async Task Current_uses_sync_pivot_when_head_is_genesis()
+    {
+        Block genesis = CreateBlock(0, 1_000);
+        Block pivot = CreateBlock(128, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(genesis);
+        blockTree.Genesis.Returns(genesis.Header);
+        blockTree.SyncPivot.Returns((pivot.Number, pivot.Hash!));
+        const BlockTreeLookupOptions lookupOptions =
+            BlockTreeLookupOptions.TotalDifficultyNotNeeded |
+            BlockTreeLookupOptions.DoNotCreateLevelIfMissing;
+        blockTree.FindHeader(pivot.Hash!, lookupOptions, pivot.Number).Returns(pivot.Header);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId expectedForkId = new(0x01020304, 256);
+        forkInfo.GetForkId(pivot.Number, pivot.Timestamp).Returns(expectedForkId);
+
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+
+        AssertForkId(await provider.GetCurrentAsync(), expectedForkId);
+        forkInfo.Received(1).GetForkId(pivot.Number, pivot.Timestamp);
+    }
+
+    [Test]
+    public async Task Current_reuses_resolved_sync_pivot_header()
+    {
+        Block genesis = CreateBlock(0, 1_000);
+        Block pivot = CreateBlock(128, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(genesis);
+        blockTree.Genesis.Returns(genesis.Header);
+        blockTree.SyncPivot.Returns((pivot.Number, pivot.Hash!));
+        const BlockTreeLookupOptions lookupOptions =
+            BlockTreeLookupOptions.TotalDifficultyNotNeeded |
+            BlockTreeLookupOptions.DoNotCreateLevelIfMissing;
+        blockTree.FindHeader(pivot.Hash!, lookupOptions, pivot.Number).Returns(pivot.Header);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId expectedForkId = new(0x01020304, 256);
+        forkInfo.GetForkId(pivot.Number, pivot.Timestamp).Returns(expectedForkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+
+        NodeRecord initial = await provider.GetCurrentAsync();
+        NodeRecord current = await provider.GetCurrentAsync();
+
+        Assert.That(current, Is.SameAs(initial));
+        blockTree.Received(1).FindHeader(pivot.Hash!, lookupOptions, pivot.Number);
+        forkInfo.Received(1).GetForkId(pivot.Number, pivot.Timestamp);
+    }
+
+    [Test]
+    public async Task Current_refreshes_eth_forkid_when_sync_pivot_becomes_available()
+    {
+        Block genesis = CreateBlock(0, 1_000);
+        Block pivot = CreateBlock(128, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(genesis);
+        blockTree.Genesis.Returns(genesis.Header);
+        blockTree.SyncPivot.Returns((pivot.Number, pivot.Hash!));
+        const BlockTreeLookupOptions lookupOptions =
+            BlockTreeLookupOptions.TotalDifficultyNotNeeded |
+            BlockTreeLookupOptions.DoNotCreateLevelIfMissing;
+        blockTree.FindHeader(pivot.Hash!, lookupOptions, pivot.Number).Returns((BlockHeader?)null, pivot.Header);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId genesisForkId = new(0x01020304, 128);
+        NetworkForkId pivotForkId = new(0x05060708, 256);
+        forkInfo.GetForkId(genesis.Number, genesis.Timestamp).Returns(genesisForkId);
+        forkInfo.GetForkId(pivot.Number, pivot.Timestamp).Returns(pivotForkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+
+        NodeRecord initial = await provider.GetCurrentAsync();
+        NodeRecord updated = await provider.GetCurrentAsync();
+
+        Assert.That(updated, Is.Not.SameAs(initial));
+        Assert.That(updated.EnrSequence, Is.EqualTo(initial.EnrSequence + 1));
+        AssertForkId(updated, pivotForkId);
+    }
+
+    [Test]
+    public async Task NewHeadBlock_updates_eth_forkid_and_bumps_sequence()
+    {
+        Block initialHead = CreateBlock(64, 1_000);
+        Block updatedHead = CreateBlock(128, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(initialHead, updatedHead);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId initialForkId = new(0x01020304, 128);
+        NetworkForkId updatedForkId = new(0x05060708, 0);
+        forkInfo.GetForkId(initialHead.Number, initialHead.Timestamp).Returns(initialForkId);
+        forkInfo.GetForkId(updatedHead.Number, updatedHead.Timestamp).Returns(updatedForkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+        NodeRecord current = await provider.GetCurrentAsync();
+        ulong initialSequence = current.EnrSequence;
+
+        blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(updatedHead));
+
+        NodeRecord updated = await provider.GetCurrentAsync();
+        Assert.That(updated, Is.Not.SameAs(current));
+        Assert.That(updated.EnrSequence, Is.EqualTo(initialSequence + 1));
+        AssertForkId(updated, updatedForkId);
+        AssertForkId(NodeRecord.FromEnrString(updated.EnrString), updatedForkId);
+    }
+
+    [Test]
+    public async Task NewHeadBlock_does_not_bump_sequence_when_forkid_is_unchanged()
+    {
+        Block initialHead = CreateBlock(64, 1_000);
+        Block updatedHead = CreateBlock(65, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(initialHead, updatedHead);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId forkId = new(0x01020304, 128);
+        forkInfo.GetForkId(initialHead.Number, initialHead.Timestamp).Returns(forkId);
+        forkInfo.GetForkId(updatedHead.Number, updatedHead.Timestamp).Returns(forkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+        NodeRecord current = await provider.GetCurrentAsync();
+        ulong initialSequence = current.EnrSequence;
+
+        blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(updatedHead));
+
+        NodeRecord unchanged = await provider.GetCurrentAsync();
+        Assert.That(unchanged, Is.SameAs(current));
+        Assert.That(unchanged.EnrSequence, Is.EqualTo(initialSequence));
+        AssertForkId(unchanged, forkId);
+    }
+
+    [Test]
+    public async Task NewHeadBlock_adds_eth_forkid_when_current_record_has_no_header_context()
+    {
+        Block updatedHead = CreateBlock(64, 1_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId forkId = new(0x01020304, 128);
+        forkInfo.GetForkId(updatedHead.Number, updatedHead.Timestamp).Returns(forkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+        NodeRecord current = await provider.GetCurrentAsync();
+        ulong initialSequence = current.EnrSequence;
+
+        blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(updatedHead));
+
+        NodeRecord updated = await provider.GetCurrentAsync();
+        Assert.That(updated, Is.Not.SameAs(current));
+        Assert.That(updated.EnrSequence, Is.EqualTo(initialSequence + 1));
+        AssertForkId(updated, forkId);
+    }
+
+    [Test]
+    public async Task Dispose_unsubscribes_and_blocks_current_access()
+    {
+        Block initialHead = CreateBlock(64, 1_000);
+        Block updatedHead = CreateBlock(128, 2_000);
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(initialHead, updatedHead);
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        NetworkForkId forkId = new(0x01020304, 128);
+        forkInfo.GetForkId(initialHead.Number, initialHead.Timestamp).Returns(forkId);
+        using NodeRecordProvider provider = CreateProvider(blockTree, forkInfo);
+        _ = await provider.GetCurrentAsync();
+
+        provider.Dispose();
+        forkInfo.ClearReceivedCalls();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+        {
+            _ = await provider.GetCurrentAsync();
+        });
+        Assert.DoesNotThrow(() =>
+        {
+            blockTree.NewHeadBlock += Raise.EventWith(blockTree, new BlockEventArgs(updatedHead));
+        });
+        forkInfo.DidNotReceive().GetForkId(updatedHead.Number, updatedHead.Timestamp);
+    }
+
+    private static Block CreateBlock(long number, ulong timestamp) =>
+        Build.A.Block
+            .WithNumber(number)
+            .WithTimestamp(timestamp)
+            .TestObject;
+
+    private static NodeRecordProvider CreateProvider(IBlockTree blockTree, IForkInfo forkInfo)
+    {
+        NetworkConfig networkConfig = new()
+        {
+            ExternalIp = "8.8.8.8",
+            P2PPort = 30303,
+            DiscoveryPort = 30303
+        };
+        IProtectedPrivateKey nodeKey = new InsecureProtectedPrivateKey(TestItem.PrivateKeyA);
+
+        return new NodeRecordProvider(
+            nodeKey,
+            new FixedIpResolver(networkConfig),
+            new EthereumEcdsa(0),
+            networkConfig,
+            blockTree,
+            forkInfo,
+            new ManualTimestamper(EnrSequenceTime),
+            LimboLogs.Instance);
+    }
+
+    private static void AssertForkId(NodeRecord nodeRecord, NetworkForkId expected)
+    {
+        EnrForkId? forkId = nodeRecord.GetValue<EnrForkId>(EnrContentKey.Eth);
+
+        Assert.That(forkId, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(forkId!.Value.ForkHash, Is.EqualTo(expected.HashBytes));
+            Assert.That(forkId.Value.NextBlock, Is.EqualTo(expected.Next));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/TestEnrBuilder.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/TestEnrBuilder.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using Nethermind.Crypto;
 using Nethermind.Network.Enr;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Discovery.Test;
 
@@ -54,13 +55,34 @@ internal static class TestEnrBuilder
         return enr;
     }
 
-    public static NodeRecord BuildSignedWithoutEndpoint(PrivateKey privateKey, ulong enrSequence = 1)
+    public static NodeRecord BuildSignedWithoutEndpoint(
+        PrivateKey privateKey,
+        ulong enrSequence = 1,
+        Action<NodeRecord>? configureExtras = null)
     {
         NodeRecord enr = new();
         enr.SetEntry(new SecP256k1Entry(privateKey.CompressedPublicKey));
+        configureExtras?.Invoke(enr);
         enr.EnrSequence = enrSequence;
         Sign(enr, privateKey);
         return enr;
+    }
+
+    public static bool HasEnrSequence(Node node, ulong enrSequence)
+    {
+        if (string.IsNullOrEmpty(node.Enr))
+        {
+            return false;
+        }
+
+        try
+        {
+            return NodeRecord.FromEnrString(node.Enr).EnrSequence == enrSequence;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     private static void Sign(NodeRecord enr, PrivateKey privateKey) => new NodeRecordSigner(new EthereumEcdsa(0), privateKey).Sign(enr);

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -9,9 +9,11 @@ using Nethermind.Logging;
 using Nethermind.Kademlia;
 using Nethermind.Network.Discovery.Discv4.Kademlia.Handlers;
 using Nethermind.Network.Discovery.Discv4.Messages;
+using Nethermind.Network.Enr;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using NonBlocking;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Network.Discovery.Discv4.Kademlia;
 
@@ -28,6 +30,7 @@ public sealed class KademliaAdapter(
 ) : IKademliaAdapter
 {
     private const int MaxNodesPerNeighborsMsg = 12;
+    private const int MaxKnownRecords = 16_384;
 
     private readonly TimeSpan _requestEnrTimeout = TimeSpan.FromMilliseconds(discoveryConfig.EnrTimeout);
     private readonly TimeSpan _findNeighbourTimeout = TimeSpan.FromMilliseconds(discoveryConfig.SendNodeTimeout);
@@ -41,6 +44,8 @@ public sealed class KademliaAdapter(
 
     private readonly ConcurrentDictionary<(ValueHash256, MsgType), IMessageHandler[]> _incomingMessageHandlers = new();
     private readonly LruCache<ValueHash256, NodeSession> _sessions = new(discoveryConfig.MaxNodeLifecycleManagersCount, "node_sessions");
+    private readonly LruCache<Hash256, NodeRecord> _knownRecords = new(MaxKnownRecords, "discv4 known records");
+    private readonly LruCache<Hash256, ulong> _pendingRecordSequenceRequests = new(MaxKnownRecords, "discv4 pending record sequence requests");
 
     public NodeSession GetSession(Node node) => _sessions.SetOrGet(
         node.IdHash.ValueHash256,
@@ -189,22 +194,25 @@ public sealed class KademliaAdapter(
 
     public async Task<bool> Ping(Node receiver, CancellationToken token)
     {
+        RegisterKnownRecord(receiver);
         NodeSession session = GetSession(receiver);
 
         PingMsg msg = new(receiver.Address, CalculateExpirationTime(), kademliaConfig.CurrentNodeId.Address)
         {
-            EnrSequence = (await nodeRecordProvider.GetCurrentAsync(token)).EnrSequence // optional and does not seem to be used anywhere.
+            EnrSequence = (await nodeRecordProvider.GetCurrentAsync(token)).EnrSequence
         };
         session.OnPingSent();
         DiscoveryResponse<PongMsg> response = await CallAndWaitForResponse(MsgType.Pong, new PongMsgHandler(msg), receiver, session, msg, _pingTimeout, token);
         if (!response.HasResponse) return false;
 
         session.OnPongReceived(response.Value.FarAddress ?? receiver.Address);
+        StartEnrRefreshIfNeeded(receiver, response.Value.EnrSequence, token);
         return true;
     }
 
     public async Task<Node[]?> FindNeighbours(Node receiver, PublicKey target, CancellationToken token)
     {
+        RegisterKnownRecord(receiver);
         NodeSession session = GetSession(receiver);
         DiscoveryResponse<Node[]> response = await RunAuthenticatedRequest(receiver, session, token =>
         {
@@ -218,6 +226,7 @@ public sealed class KademliaAdapter(
 
     public async Task<EnrResponseMsg?> SendEnrRequest(Node receiver, CancellationToken token)
     {
+        RegisterKnownRecord(receiver);
         NodeSession session = GetSession(receiver);
         DiscoveryResponse<EnrResponseMsg> response = await RunAuthenticatedRequest(receiver, session, token =>
         {
@@ -281,7 +290,7 @@ public sealed class KademliaAdapter(
             return;
         }
 
-        PongMsg msg = new(ping.FarAddress!, CalculateExpirationTime(), pingMdc);
+        PongMsg msg = new(ping.FarAddress!, CalculateExpirationTime(), pingMdc, (await nodeRecordProvider.GetCurrentAsync(token)).EnrSequence);
         session.OnPingReceived();
         await SendMessage(session, msg, token);
 
@@ -291,6 +300,152 @@ public sealed class KademliaAdapter(
             // Send a ping to bond the peer.
             _ = await Ping(node, token);
         }
+
+        StartEnrRefreshIfNeeded(node, ping.EnrSequence, token);
+    }
+
+    private void StartEnrRefreshIfNeeded(Node remoteNode, ulong? advertisedEnrSequence, CancellationToken token)
+    {
+        if (advertisedEnrSequence is not { } sequence ||
+            !ShouldRequestRemoteRecord(remoteNode.IdHash, sequence))
+        {
+            return;
+        }
+
+        _ = RefreshRemoteRecord(remoteNode, sequence, token);
+    }
+
+    private bool ShouldRequestRemoteRecord(Hash256 nodeId, ulong advertisedEnrSequence)
+    {
+        if (advertisedEnrSequence == 0)
+        {
+            return false;
+        }
+
+        if (_knownRecords.TryGet(nodeId, out NodeRecord? knownRecord) &&
+            advertisedEnrSequence <= knownRecord.EnrSequence)
+        {
+            return false;
+        }
+
+        if (_pendingRecordSequenceRequests.TryGet(nodeId, out ulong pendingEnrSequence) &&
+            advertisedEnrSequence <= pendingEnrSequence)
+        {
+            return false;
+        }
+
+        _pendingRecordSequenceRequests.Set(nodeId, advertisedEnrSequence);
+        return true;
+    }
+
+    private async Task RefreshRemoteRecord(Node remoteNode, ulong advertisedEnrSequence, CancellationToken token)
+    {
+        try
+        {
+            EnrResponseMsg? response = await SendEnrRequest(remoteNode, token);
+            if (response is null ||
+                !TryGetNodeFromRecord(remoteNode.IdHash, response.NodeRecord, out Node? node) ||
+                response.NodeRecord.EnrSequence < advertisedEnrSequence)
+            {
+                return;
+            }
+
+            if (TrySetKnownRecord(node.IdHash, response.NodeRecord, out NodeRecord currentRecord))
+            {
+                nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+            }
+            else if (TryGetNodeFromRecord(remoteNode.IdHash, currentRecord, out Node? currentNode))
+            {
+                nodeHealthTracker.Value.OnIncomingMessageFrom(currentNode);
+            }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Discv4 ENR refresh failed for {remoteNode}: {e}");
+        }
+        finally
+        {
+            if (_pendingRecordSequenceRequests.TryGet(remoteNode.IdHash, out ulong pendingEnrSequence) &&
+                pendingEnrSequence == advertisedEnrSequence)
+            {
+                _pendingRecordSequenceRequests.TryRemove(remoteNode.IdHash, out _);
+            }
+        }
+    }
+
+    private void RegisterKnownRecord(Node node)
+    {
+        if (string.IsNullOrEmpty(node.Enr))
+        {
+            return;
+        }
+
+        if (_knownRecords.TryGet(node.IdHash, out NodeRecord? knownRecord) &&
+            knownRecord.EnrString == node.Enr)
+        {
+            return;
+        }
+
+        try
+        {
+            NodeRecord record = NodeRecord.FromEnrString(node.Enr);
+            if (HasExpectedNodeId(record, node.IdHash))
+            {
+                TrySetKnownRecord(node.IdHash, record, out _);
+            }
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Unable to parse known discv4 ENR for {node}: {e}");
+        }
+    }
+
+    private bool TrySetKnownRecord(Hash256 nodeId, NodeRecord record, out NodeRecord currentRecord)
+    {
+        if (_knownRecords.TryGet(nodeId, out NodeRecord? knownRecord) && knownRecord.EnrSequence >= record.EnrSequence)
+        {
+            currentRecord = knownRecord;
+            return false;
+        }
+
+        _knownRecords.Set(nodeId, record);
+        currentRecord = record;
+        return true;
+    }
+
+    private static bool TryGetNodeFromRecord(Hash256 expectedNodeId, NodeRecord record, [NotNullWhen(true)] out Node? node)
+    {
+        node = null;
+        if (!IsValidSignedRecord(record) ||
+            !HasExpectedNodeId(record, expectedNodeId) ||
+            !Node.TryFromDiscoveryEnr(record, out node))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsValidSignedRecord(NodeRecord record)
+    {
+        try
+        {
+            _ = NodeRecord.FromBytes(record.ToRlpBytes());
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasExpectedNodeId(NodeRecord record, Hash256 expectedNodeId)
+    {
+        PublicKey? publicKey = record.GetObj<CompressedPublicKey>(EnrContentKey.SecP256k1)?.Decompress();
+        return publicKey is not null && Keccak.Compute(publicKey.PrefixedBytes).Equals(expectedNodeId);
     }
 
     public async Task OnIncomingMsg(DiscoveryMsg msg)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Messages/PongMsg.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Messages/PongMsg.cs
@@ -10,11 +10,19 @@ public sealed class PongMsg : DiscoveryMsg
 {
     public ValueHash256 PingMdc { get; init; }
 
-    public PongMsg(IPEndPoint farAddress, long expirationTime, ValueHash256 pingMdc)
-        : base(farAddress, expirationTime) => PingMdc = pingMdc;
+    public ulong? EnrSequence { get; set; }
 
-    public PongMsg(PublicKey farPublicKey, long expirationTime, ValueHash256 pingMdc)
-        : base(farPublicKey, expirationTime) => PingMdc = pingMdc;
+    public PongMsg(IPEndPoint farAddress, long expirationTime, ValueHash256 pingMdc, ulong? enrSequence = null) : base(farAddress, expirationTime)
+    {
+        PingMdc = pingMdc;
+        EnrSequence = enrSequence;
+    }
+
+    public PongMsg(PublicKey farPublicKey, long expirationTime, ValueHash256 pingMdc, ulong? enrSequence = null) : base(farPublicKey, expirationTime)
+    {
+        PingMdc = pingMdc;
+        EnrSequence = enrSequence;
+    }
 
     public override string ToString() => base.ToString() + $", PingMdc: {PingMdc}";
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Serializers/PongMsgSerializer.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Serializers/PongMsgSerializer.cs
@@ -29,6 +29,10 @@ public sealed class PongMsgSerializer(IEcdsa ecdsa, [KeyFilter(IProtectedPrivate
         ValueHash256? pingMdc = msg.PingMdc;
         stream.Encode(in pingMdc);
         stream.Encode(msg.ExpirationTime);
+        if (msg.EnrSequence.HasValue)
+        {
+            stream.Encode(msg.EnrSequence.Value);
+        }
 
         byteBuffer.ResetIndex();
 
@@ -41,7 +45,8 @@ public sealed class PongMsgSerializer(IEcdsa ecdsa, [KeyFilter(IProtectedPrivate
 
         Rlp.ValueDecoderContext ctx = data.AsRlpContext();
 
-        ctx.ReadSequenceLength();
+        int contentLength = ctx.ReadSequenceLength();
+        int checkPosition = ctx.Position + contentLength;
         ctx.ReadSequenceLength();
 
         ctx.DecodeByteArraySpan(IpAddressRlpLimit);
@@ -54,9 +59,15 @@ public sealed class PongMsgSerializer(IEcdsa ecdsa, [KeyFilter(IProtectedPrivate
         }
 
         long expirationTime = ctx.DecodeLong();
+        ulong? enrSequence = null;
+        if (ctx.Position < checkPosition && IsNextUnsignedInteger(ctx))
+        {
+            enrSequence = ctx.DecodeULong();
+        }
 
+        ctx.Position = checkPosition;
         data.SetReaderIndex(data.ReaderIndex + ctx.Position);
-        PongMsg msg = new(farPublicKey, expirationTime, new ValueHash256(token));
+        PongMsg msg = new(farPublicKey, expirationTime, new ValueHash256(token), enrSequence);
         return msg;
     }
 
@@ -79,7 +90,22 @@ public sealed class PongMsgSerializer(IEcdsa ecdsa, [KeyFilter(IProtectedPrivate
         ValueHash256? pingMdc = message.PingMdc;
         contentLength += Rlp.LengthOf(in pingMdc);
         contentLength += Rlp.LengthOf(message.ExpirationTime);
+        if (message.EnrSequence.HasValue)
+        {
+            contentLength += Rlp.LengthOf(message.EnrSequence.Value);
+        }
 
         return (Rlp.LengthOfSequence(contentLength), contentLength, farAddressLength);
+    }
+
+    private static bool IsNextUnsignedInteger(Rlp.ValueDecoderContext ctx)
+    {
+        if (ctx.IsSequenceNext())
+        {
+            return false;
+        }
+
+        byte prefix = ctx.PeekByte();
+        return prefix <= 136;
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/Handlers/PongResponseHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/Handlers/PongResponseHandler.cs
@@ -12,8 +12,11 @@ internal sealed class PongResponseHandler(Node receiver) : ResponseHandler<PongM
 
     public override Task Task => _completion.Task;
 
+    public ulong EnrSequence { get; private set; }
+
     public override bool Handle(PongMsg message)
     {
+        EnrSequence = message.EnrSequence;
         receiver.ValidatedProtocol = true;
         _completion.TrySetResult();
         return true;

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/KademliaAdapter.cs
@@ -61,6 +61,7 @@ public sealed class KademliaAdapter(
     private readonly LruCache<ResponseKey, IResponseHandler> _responseHandlers = new(MaxResponseHandlers, "discv5 response handlers");
     private readonly LruCache<ValueHash256, NodeRecord> _knownRecords = new(MaxKnownRecords, "discv5 known records");
     private readonly Lock _knownRecordsLock = new();
+    private readonly LruCache<Hash256, ulong> _pendingRecordSequenceRequests = new(MaxKnownRecords, "discv5 pending record sequence requests");
     private readonly LruCache<SessionKey, long> _endpointChecks = new(MaxEndpointChecks, "discv5 endpoint checks");
     private readonly AddressBurstLimiter _challengeRateLimiter = new(ChallengeRateLimitBurstPerIp, ChallengeRateLimitFilterSize, ChallengeRateLimitWindow);
 
@@ -116,6 +117,7 @@ public sealed class KademliaAdapter(
         }
 
         if (_logger.IsTrace) _logger.Trace($"Discv5 PING {ping.RequestId} to {receiver:s} succeeded.");
+        StartEnrRefreshIfNeeded(receiver, responseHandler.EnrSequence, token);
         kademlia.Value.AddOrRefresh(receiver);
         return true;
     }
@@ -576,6 +578,7 @@ public sealed class KademliaAdapter(
                 }
 
                 kademlia.Value.AddOrRefresh(remoteNode);
+                StartEnrRefreshIfNeeded(remoteNode, ping.EnrSequence, token);
                 if (!string.IsNullOrEmpty(remoteNode.Enr))
                 {
                     StartEndpointCheck(remoteNode, token);
@@ -815,6 +818,107 @@ public sealed class KademliaAdapter(
             currentRecord = record;
             return true;
         }
+    }
+
+    private void StartEnrRefreshIfNeeded(Node remoteNode, ulong advertisedEnrSequence, CancellationToken token)
+    {
+        if (!ShouldRequestRemoteRecord(remoteNode.Id.Hash, advertisedEnrSequence))
+        {
+            return;
+        }
+
+        _ = RefreshRemoteRecord(remoteNode, advertisedEnrSequence, token);
+    }
+
+    private bool ShouldRequestRemoteRecord(Hash256 nodeId, ulong advertisedEnrSequence)
+    {
+        if (advertisedEnrSequence == 0)
+        {
+            return false;
+        }
+
+        lock (_knownRecordsLock)
+        {
+            if (TryGetKnownRecord(nodeId.ValueHash256, out NodeRecord? knownRecord) &&
+                advertisedEnrSequence <= knownRecord.EnrSequence)
+            {
+                return false;
+            }
+
+            if (_pendingRecordSequenceRequests.TryGet(nodeId, out ulong pendingEnrSequence) &&
+                advertisedEnrSequence <= pendingEnrSequence)
+            {
+                return false;
+            }
+
+            _pendingRecordSequenceRequests.Set(nodeId, advertisedEnrSequence);
+            return true;
+        }
+    }
+
+    private async Task RefreshRemoteRecord(Node remoteNode, ulong advertisedEnrSequence, CancellationToken token)
+    {
+        try
+        {
+            Node[]? nodes = await RequestRemoteRecord(remoteNode, token);
+            if (nodes is null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                Node node = nodes[i];
+                if (!node.Id.Equals(remoteNode.Id) || string.IsNullOrEmpty(node.Enr))
+                {
+                    continue;
+                }
+
+                RegisterKnownRecord(node);
+                if (TryGetKnownRecord(node.Id.Hash.ValueHash256, out NodeRecord? knownRecord) &&
+                    knownRecord.EnrSequence >= advertisedEnrSequence)
+                {
+                    kademlia.Value.AddOrRefresh(node);
+                }
+
+                return;
+            }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Discv5 ENR refresh failed for {remoteNode}: {e}");
+        }
+        finally
+        {
+            lock (_knownRecordsLock)
+            {
+                if (_pendingRecordSequenceRequests.TryGet(remoteNode.Id.Hash, out ulong pendingEnrSequence) &&
+                    pendingEnrSequence == advertisedEnrSequence)
+                {
+                    _pendingRecordSequenceRequests.TryRemove(remoteNode.Id.Hash, out _);
+                }
+            }
+        }
+    }
+
+    private async Task<Node[]?> RequestRemoteRecord(Node receiver, CancellationToken token)
+    {
+        RegisterKnownRecord(receiver);
+        int[] selfRecordDistance = [0];
+        using FindNodeMsg findNode = new(CreateRequestId(), new Distances(selfRecordDistance));
+        using NodesResponseHandler responseHandler = new(receiver, findNode.Distances, _distance, recordFilter);
+
+        if (_logger.IsTrace) _logger.Trace($"Sending discv5 FINDNODE {findNode.RequestId} to refresh ENR from {receiver:s}.");
+        if (!await SendRequest(receiver, findNode, responseHandler, _findNodeTimeout, token))
+        {
+            if (_logger.IsTrace) _logger.Trace($"Discv5 ENR refresh FINDNODE {findNode.RequestId} to {receiver:s} timed out.");
+            return null;
+        }
+
+        return responseHandler.GetNodes();
     }
 
     internal static bool IsAcceptableNodeRecord(NodeRecord record, ValueHash256 expectedNodeId, bool allowNonRoutable, IDiscv5RecordFilter recordFilter)

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
@@ -1,58 +1,229 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Net;
 using Autofac.Features.AttributeFilters;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
+using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Enr;
+using NetworkForkId = Nethermind.Network.ForkId;
 
 namespace Nethermind.Network.Discovery;
 
-public sealed class NodeRecordProvider(
-    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
-    IIPResolver ipResolver,
-    IEthereumEcdsa ethereumEcdsa,
-    INetworkConfig networkConfig
-) : INodeRecordProvider
+public sealed class NodeRecordProvider : INodeRecordProvider, IDisposable
 {
+    private readonly IIPResolver _ipResolver;
+    private readonly INetworkConfig _networkConfig;
+    private readonly IBlockTree _blockTree;
+    private readonly IForkInfo _forkInfo;
+    private readonly CompressedPublicKey _publicKey;
+    private readonly PrivateKey _privateKey;
+    private readonly NodeRecordSigner _enrSigner;
+    private readonly ITimestamper _timestamper;
+    private readonly ILogger _logger;
     private readonly Lock _lock = new();
-    private Task<NodeRecord>? _nodeRecordTask;
 
-    public ValueTask<NodeRecord> GetCurrentAsync(CancellationToken cancellationToken = default)
+    private NodeRecord? _nodeRecord;
+    private NetworkForkId? _currentForkId;
+    private long? _currentForkIdHeaderNumber;
+    private ulong? _currentForkIdHeaderTimestamp;
+    private BlockHeader? _currentSyncPivotHeader;
+    private long? _currentSyncPivotNumber;
+    private Hash256? _currentSyncPivotHash;
+    private IPAddress? _currentExternalIp;
+    private bool _disposed;
+
+    public NodeRecordProvider(
+        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+        IIPResolver ipResolver,
+        IEthereumEcdsa ethereumEcdsa,
+        INetworkConfig networkConfig,
+        IBlockTree blockTree,
+        IForkInfo forkInfo,
+        ITimestamper timestamper,
+        ILogManager logManager)
     {
-        Task<NodeRecord>? task = Volatile.Read(ref _nodeRecordTask);
-        if (task is null)
-        {
-            lock (_lock)
-            {
-                // Build once, guarding concurrent callers (Ping/HandleEnrRequest run from concurrent
-                // discovery handlers). Use CancellationToken.None so the cached ENR isn't faulted by a
-                // single caller's token; per-call cancellation is honored via WaitAsync below.
-                task = _nodeRecordTask ??= PrepareNodeRecord(CancellationToken.None);
-            }
-        }
+        ArgumentNullException.ThrowIfNull(nodeKey);
+        ArgumentNullException.ThrowIfNull(ipResolver);
+        ArgumentNullException.ThrowIfNull(ethereumEcdsa);
+        ArgumentNullException.ThrowIfNull(networkConfig);
+        ArgumentNullException.ThrowIfNull(blockTree);
+        ArgumentNullException.ThrowIfNull(forkInfo);
+        ArgumentNullException.ThrowIfNull(timestamper);
+        ArgumentNullException.ThrowIfNull(logManager);
 
-        return new ValueTask<NodeRecord>(task.WaitAsync(cancellationToken));
+        _ipResolver = ipResolver;
+        _networkConfig = networkConfig;
+        _blockTree = blockTree;
+        _forkInfo = forkInfo;
+        _publicKey = nodeKey.CompressedPublicKey;
+        _privateKey = nodeKey.Unprotect();
+        _enrSigner = new NodeRecordSigner(ethereumEcdsa, _privateKey);
+        _timestamper = timestamper;
+        _logger = logManager.GetClassLogger<NodeRecordProvider>();
+
+        _blockTree.NewHeadBlock += OnNewHeadBlock;
     }
 
-    private async Task<NodeRecord> PrepareNodeRecord(CancellationToken cancellationToken)
+    public async ValueTask<NodeRecord> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
-        // TODO: Add forkid
+        using (Lock.Scope _ = _lock.EnterScope())
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+        }
+
+        IIPResolver.NethermindIp ip = await _ipResolver.Resolve(cancellationToken);
+
+        using Lock.Scope __ = _lock.EnterScope();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return GetCurrentNodeRecord(ip.ExternalIp);
+    }
+
+    public void Dispose()
+    {
+        using Lock.Scope _ = _lock.EnterScope();
+        if (_disposed)
+        {
+            return;
+        }
+
+        _blockTree.NewHeadBlock -= OnNewHeadBlock;
+        _privateKey.Dispose();
+        _disposed = true;
+    }
+
+    private NodeRecord PrepareNodeRecord(NetworkForkId? forkId, ulong enrSequence, IPAddress externalIp)
+    {
         NodeRecord selfNodeRecord = new();
         selfNodeRecord.SetEntry(IdEntry.Instance);
-        IIPResolver.NethermindIp ip = await ipResolver.Resolve(cancellationToken);
-        selfNodeRecord.SetEntry(new IpEntry(ip.ExternalIp));
-        selfNodeRecord.SetEntry(new TcpEntry(networkConfig.P2PPort));
-        selfNodeRecord.SetEntry(new UdpEntry(networkConfig.DiscoveryPort));
-        selfNodeRecord.SetEntry(new SecP256k1Entry(nodeKey.CompressedPublicKey));
-        selfNodeRecord.EnrSequence = 1;
-        NodeRecordSigner enrSigner = new(ethereumEcdsa, nodeKey.Unprotect());
-        enrSigner.Sign(selfNodeRecord);
-        if (!enrSigner.Verify(selfNodeRecord))
+        selfNodeRecord.SetEntry(new IpEntry(externalIp));
+        selfNodeRecord.SetEntry(new TcpEntry(_networkConfig.P2PPort));
+        selfNodeRecord.SetEntry(new UdpEntry(_networkConfig.DiscoveryPort));
+        if (forkId is { } currentForkId)
+        {
+            selfNodeRecord.SetEntry(new EthEntry(currentForkId.HashBytes, currentForkId.Next));
+        }
+        selfNodeRecord.SetEntry(new SecP256k1Entry(_publicKey));
+        selfNodeRecord.EnrSequence = enrSequence;
+        SignAndVerify(selfNodeRecord);
+
+        return selfNodeRecord;
+    }
+
+    private BlockHeader? GetCurrentHeader()
+    {
+        Block? head = _blockTree.Head;
+        if (head is null)
+        {
+            return _blockTree.BestSuggestedHeader ?? _blockTree.Genesis;
+        }
+
+        BlockHeader headHeader = head.Header;
+        if (_blockTree.Genesis is { } genesis && head.Hash == genesis.Hash)
+        {
+            (long blockNumber, Hash256 blockHash) = _blockTree.SyncPivot;
+            const BlockTreeLookupOptions lookupOptions =
+                BlockTreeLookupOptions.TotalDifficultyNotNeeded |
+                BlockTreeLookupOptions.DoNotCreateLevelIfMissing;
+            if (_currentSyncPivotHeader is not null &&
+                _currentSyncPivotNumber == blockNumber &&
+                _currentSyncPivotHash == blockHash)
+            {
+                return _currentSyncPivotHeader;
+            }
+
+            BlockHeader? syncPivotHeader = _blockTree.FindHeader(blockHash, lookupOptions, blockNumber);
+            if (syncPivotHeader is not null)
+            {
+                _currentSyncPivotHeader = syncPivotHeader;
+                _currentSyncPivotNumber = blockNumber;
+                _currentSyncPivotHash = blockHash;
+                return syncPivotHeader;
+            }
+
+            return genesis;
+        }
+
+        return headHeader;
+    }
+
+    private void OnNewHeadBlock(object? sender, BlockEventArgs e)
+    {
+        try
+        {
+            using Lock.Scope _ = _lock.EnterScope();
+            if (_disposed || _currentExternalIp is not { } externalIp)
+            {
+                return;
+            }
+
+            UpdateNodeRecord(e.Block.Header, externalIp);
+        }
+        catch (Exception exception)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Failed to update self ENR forkid: {exception}");
+        }
+    }
+
+    private NodeRecord GetCurrentNodeRecord(IPAddress externalIp) => UpdateNodeRecord(GetCurrentHeader(), externalIp);
+
+    private NodeRecord UpdateNodeRecord(BlockHeader? header, IPAddress externalIp)
+    {
+        bool externalIpChanged = _currentExternalIp is null || !_currentExternalIp.Equals(externalIp);
+        if (header is null)
+        {
+            if (_nodeRecord is null || externalIpChanged)
+            {
+                ulong previousSequence = _nodeRecord?.EnrSequence ?? 0;
+                _nodeRecord = PrepareNodeRecord(null, GetNextEnrSequence(previousSequence), externalIp);
+                _currentForkId = null;
+                _currentForkIdHeaderNumber = null;
+                _currentForkIdHeaderTimestamp = null;
+                _currentExternalIp = externalIp;
+            }
+
+            return _nodeRecord;
+        }
+
+        if (_nodeRecord is not null &&
+            !externalIpChanged &&
+            _currentForkIdHeaderNumber == header.Number &&
+            _currentForkIdHeaderTimestamp == header.Timestamp)
+        {
+            return _nodeRecord;
+        }
+
+        NetworkForkId forkId = _forkInfo.GetForkId(header.Number, header.Timestamp);
+        if (_nodeRecord is null || externalIpChanged || !_currentForkId.HasValue || !_currentForkId.Value.Equals(forkId))
+        {
+            ulong previousSequence = _nodeRecord?.EnrSequence ?? 0;
+            _nodeRecord = PrepareNodeRecord(forkId, GetNextEnrSequence(previousSequence), externalIp);
+            _currentForkId = forkId;
+            _currentExternalIp = externalIp;
+        }
+
+        _currentForkIdHeaderNumber = header.Number;
+        _currentForkIdHeaderTimestamp = header.Timestamp;
+        return _nodeRecord;
+    }
+
+    private ulong GetNextEnrSequence(ulong previousSequence = 0)
+    {
+        long unixMilliseconds = _timestamper.UtcNowOffset.ToUnixTimeMilliseconds();
+        ulong timestampSequence = unixMilliseconds > 0 ? (ulong)unixMilliseconds : 1;
+        return timestampSequence > previousSequence ? timestampSequence : checked(previousSequence + 1);
+    }
+
+    private void SignAndVerify(NodeRecord nodeRecord)
+    {
+        _enrSigner.Sign(nodeRecord);
+        if (!_enrSigner.Verify(nodeRecord))
         {
             throw new NetworkingException("Self ENR initialization failed", NetworkExceptionType.Discovery);
         }
-
-        return selfNodeRecord;
     }
 }

--- a/src/Nethermind/Nethermind.Network.Enr.Test/NodeRecordSignerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Enr.Test/NodeRecordSignerTests.cs
@@ -119,10 +119,77 @@ public class NodeRecordSignerTests
     }
 
     [Test]
+    public void Can_deserialize_eth_entry_with_uint64_next_and_extra_values()
+    {
+        byte[] forkHash = [1, 2, 3, 4];
+        ulong nextBlock = (ulong)long.MaxValue + 1;
+        byte[] extraValue = [5, 6, 7];
+        RlpStream rlpStream = CreateRecord(
+            (EnrContentKey.Eth, stream => EncodeEthEntry(stream, forkHash, nextBlock, extraValue), LengthOfEthEntry(forkHash, nextBlock, extraValue)),
+            (EnrContentKey.Id, static stream => stream.Encode("v4"), Rlp.LengthOf("v4")));
+        NodeRecordSigner signer = new(new Ecdsa());
+
+        NodeRecord nodeRecord = signer.Deserialize(rlpStream);
+        ForkId? forkId = nodeRecord.GetValue<ForkId>(EnrContentKey.Eth);
+
+        Assert.That(forkId, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(forkId!.Value.ForkHash, Is.EqualTo(forkHash));
+            Assert.That(forkId.Value.NextBlock, Is.EqualTo(nextBlock));
+        }
+    }
+
+    [TestCase(3)]
+    [TestCase(5)]
+    public void Throws_when_eth_fork_hash_has_invalid_length(int forkHashLength)
+    {
+        byte[] forkHash = new byte[forkHashLength];
+        RlpStream rlpStream = CreateRecord(
+            (EnrContentKey.Eth, stream => EncodeEthEntry(stream, forkHash, 0, []), LengthOfEthEntry(forkHash, 0, [])),
+            (EnrContentKey.Id, static stream => stream.Encode("v4"), Rlp.LengthOf("v4")));
+        NodeRecordSigner signer = new(new Ecdsa());
+
+        Assert.That(() => signer.Deserialize(rlpStream), Throws.Exception);
+    }
+
+    [TestCase(3)]
+    [TestCase(5)]
+    public void Eth_entry_rejects_invalid_fork_hash_length(int forkHashLength)
+    {
+        byte[] forkHash = new byte[forkHashLength];
+
+        Assert.That(() => new EthEntry(forkHash, 0), Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void FromEnrString_can_verify_eth_entry_with_extra_values()
+    {
+        byte[] forkHash = [1, 2, 3, 4];
+        ulong nextBlock = (ulong)long.MaxValue + 1;
+        byte[] recordBytes = CreateSignedRecordWithEthExtraValue(
+            new PrivateKey(TestPrivateKey),
+            forkHash,
+            nextBlock,
+            [5, 6, 7]);
+
+        NodeRecord fromBytes = NodeRecord.FromBytes(recordBytes);
+        NodeRecord fromEnrString = NodeRecord.FromEnrString(CreateEnrString(recordBytes));
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertEthForkId(fromBytes, forkHash, nextBlock);
+            AssertEthForkId(fromEnrString, forkHash, nextBlock);
+            Assert.That(fromBytes.ToRlpBytes(), Is.EqualTo(recordBytes));
+            Assert.That(fromEnrString.ToRlpBytes(), Is.EqualTo(recordBytes));
+        }
+    }
+
+    [Test]
     public void Can_serialize_eth_entry_as_nested_fork_id_list()
     {
         byte[] forkHash = [1, 2, 3, 4];
-        const long nextBlock = 0x0506;
+        const ulong nextBlock = 0x0506;
         byte[] expectedEntryBytes = Bytes.FromHexString("83657468c9c88401020304820506");
 
         Ecdsa ecdsa = new();
@@ -337,6 +404,91 @@ public class NodeRecordSignerTests
         byte[] recordBytes = nodeRecord.ToRlpBytes().AsSpan().ToArray();
         recordBytes[4] ^= 0x01;
         return recordBytes;
+    }
+
+    private static int LengthOfEthEntry(byte[] forkHash, ulong nextBlock, byte[] extraValue)
+    {
+        int forkIdContentLength = Rlp.LengthOf(forkHash) + Rlp.LengthOf(nextBlock);
+        int ethEntryContentLength = Rlp.LengthOfSequence(forkIdContentLength) + Rlp.LengthOf(extraValue);
+        return Rlp.LengthOfSequence(ethEntryContentLength);
+    }
+
+    private static void EncodeEthEntry(RlpStream rlpStream, byte[] forkHash, ulong nextBlock, byte[] extraValue)
+    {
+        int forkIdContentLength = Rlp.LengthOf(forkHash) + Rlp.LengthOf(nextBlock);
+        int ethEntryContentLength = Rlp.LengthOfSequence(forkIdContentLength) + Rlp.LengthOf(extraValue);
+        rlpStream.StartSequence(ethEntryContentLength);
+        rlpStream.StartSequence(forkIdContentLength);
+        rlpStream.Encode(forkHash);
+        rlpStream.Encode(nextBlock);
+        rlpStream.Encode(extraValue);
+    }
+
+    private static byte[] CreateSignedRecordWithEthExtraValue(
+        PrivateKey privateKey,
+        byte[] forkHash,
+        ulong nextBlock,
+        byte[] extraValue)
+    {
+        byte[] publicKey = privateKey.CompressedPublicKey.Bytes;
+        int contentLength = LengthOfRecordContentWithoutSignature(forkHash, nextBlock, extraValue, publicKey);
+        byte[] content = new byte[Rlp.LengthOfSequence(contentLength)];
+        RlpStream contentStream = new(content);
+        contentStream.StartSequence(contentLength);
+        EncodeRecordContentWithoutSignature(contentStream, forkHash, nextBlock, extraValue, publicKey);
+
+        Ecdsa ecdsa = new();
+        ValueHash256 contentHash = ValueKeccak.Compute(content);
+        Signature signature = ecdsa.Sign(privateKey, in contentHash);
+
+        int signedContentLength = Rlp.LengthOf(signature.Bytes) + contentLength;
+        byte[] recordBytes = new byte[Rlp.LengthOfSequence(signedContentLength)];
+        RlpStream recordStream = new(recordBytes);
+        recordStream.StartSequence(signedContentLength);
+        recordStream.Encode(signature.Bytes);
+        EncodeRecordContentWithoutSignature(recordStream, forkHash, nextBlock, extraValue, publicKey);
+        return recordBytes;
+    }
+
+    private static int LengthOfRecordContentWithoutSignature(byte[] forkHash, ulong nextBlock, byte[] extraValue, byte[] publicKey)
+        => Rlp.LengthOf(1UL) +
+           Rlp.LengthOf(EnrContentKey.Eth) +
+           LengthOfEthEntry(forkHash, nextBlock, extraValue) +
+           Rlp.LengthOf(EnrContentKey.Id) +
+           Rlp.LengthOf("v4") +
+           Rlp.LengthOf(EnrContentKey.SecP256k1) +
+           Rlp.LengthOf(publicKey);
+
+    private static void EncodeRecordContentWithoutSignature(
+        RlpStream rlpStream,
+        byte[] forkHash,
+        ulong nextBlock,
+        byte[] extraValue,
+        byte[] publicKey)
+    {
+        rlpStream.Encode(1UL);
+        rlpStream.Encode(EnrContentKey.Eth);
+        EncodeEthEntry(rlpStream, forkHash, nextBlock, extraValue);
+        rlpStream.Encode(EnrContentKey.Id);
+        rlpStream.Encode("v4");
+        rlpStream.Encode(EnrContentKey.SecP256k1);
+        rlpStream.Encode(publicKey);
+    }
+
+    private static string CreateEnrString(byte[] recordBytes)
+    {
+        string base64String = Convert.ToBase64String(recordBytes).Replace('+', '-').Replace('/', '_');
+        int skipLast = base64String[^2] == '=' ? 2 : base64String[^1] == '=' ? 1 : 0;
+        return string.Concat("enr:", base64String.AsSpan(0, base64String.Length - skipLast));
+    }
+
+    private static void AssertEthForkId(NodeRecord nodeRecord, byte[] forkHash, ulong nextBlock)
+    {
+        ForkId? forkId = nodeRecord.GetValue<ForkId>(EnrContentKey.Eth);
+
+        Assert.That(forkId, Is.Not.Null);
+        Assert.That(forkId!.Value.ForkHash, Is.EqualTo(forkHash));
+        Assert.That(forkId.Value.NextBlock, Is.EqualTo(nextBlock));
     }
 
     private static TestCaseData InvalidRecordCase(Func<RlpStream> createRecord, Type exceptionType, string name)

--- a/src/Nethermind/Nethermind.Network.Enr/EthEntry.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/EthEntry.cs
@@ -8,8 +8,10 @@ namespace Nethermind.Network.Enr;
 /// <summary>
 /// https://github.com/ethereum/devp2p/blob/master/enr-entries/eth.md
 /// </summary>
-public class EthEntry(byte[] forkHash, long nextBlock) : EnrContentEntry<ForkId>(new ForkId(forkHash, nextBlock))
+public class EthEntry(byte[] forkHash, ulong nextBlock) : EnrContentEntry<ForkId>(new ForkId(forkHash, nextBlock))
 {
+    public const int ForkHashLength = 4;
+
     public override string Key => EnrContentKey.Eth;
 
     protected override int GetRlpLengthOfValue()

--- a/src/Nethermind/Nethermind.Network.Enr/ForkId.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/ForkId.cs
@@ -6,16 +6,24 @@ namespace Nethermind.Network.Enr;
 /// <summary>
 /// Represents the Ethereum Fork ID (hash of a list of fork block numbers and the next fork block number).
 /// </summary>
-public struct ForkId(byte[] forkHash, long nextBlock)
+public struct ForkId(byte[] forkHash, ulong nextBlock)
 {
 
     /// <summary>
     /// Hash of a list of the past fork block numbers.
     /// </summary>
-    public byte[] ForkHash { get; set; } = forkHash;
+    public byte[] ForkHash { get; set; } = ValidateForkHash(forkHash);
 
     /// <summary>
     /// Block number of the next known fork (or 0 if no fork is expected).
     /// </summary>
-    public long NextBlock { get; set; } = nextBlock;
+    public ulong NextBlock { get; set; } = nextBlock;
+
+    private static byte[] ValidateForkHash(byte[] forkHash)
+    {
+        ArgumentNullException.ThrowIfNull(forkHash);
+        return forkHash.Length == EthEntry.ForkHashLength
+            ? forkHash
+            : throw new ArgumentException("Fork hash must be 4 bytes.", nameof(forkHash));
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
@@ -28,6 +28,8 @@ public class NodeRecord
 
     internal byte[]? OriginalRlp { get; set; }
 
+    internal byte[]? OriginalContentRlp { get; set; }
+
     /// <summary>
     /// Represents the version / id / sequence of the node record data. It should be increased by one with each
     /// update to the node data. Setting sequence on this class wipes out <see cref="EnrString"/> and
@@ -73,6 +75,11 @@ public class NodeRecord
 
     private Hash256 CalculateContentHash()
     {
+        if (OriginalContentRlp is not null)
+        {
+            return ValueKeccak.Compute(OriginalContentRlp).ToCommitment();
+        }
+
         KeccakRlpStream rlpStream = new();
         EncodeContent(rlpStream);
         return rlpStream.GetHash();
@@ -88,6 +95,7 @@ public class NodeRecord
         {
             _signature = value;
             OriginalRlp = null;
+            OriginalContentRlp = null;
             _enrString = null;
             _contentHash = null;
         }
@@ -233,6 +241,7 @@ public class NodeRecord
 
         Entries[entry.Key] = entry;
         OriginalRlp = null;
+        OriginalContentRlp = null;
         _enrString = null;
         _contentHash = null;
         _signature = null;

--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
@@ -63,6 +63,7 @@ public class NodeRecordSigner(IEcdsa? ethereumEcdsa, PrivateKey? privateKey = nu
 
         ReadOnlySpan<byte> sigBytes = ctx.DecodeByteArraySpan(RlpLimit.L65);
         Signature signature = new(sigBytes, 0);
+        int contentStartPosition = ctx.Position;
 
         bool hasV4Id = false;
         ulong enrSequence = ctx.DecodeULong();
@@ -102,10 +103,19 @@ public class NodeRecordSigner(IEcdsa? ethereumEcdsa, PrivateKey? privateKey = nu
                         break;
                     }
                 case 3 when key.SequenceEqual(EnrContentKey.EthU8):
-                    _ = ctx.ReadSequenceLength();
-                    _ = ctx.ReadSequenceLength();
-                    byte[] forkHash = ctx.DecodeByteArray();
-                    long nextBlock = ctx.DecodeLong();
+                    int ethEntryLength = ctx.ReadSequenceLength();
+                    int ethEntryCheck = ctx.Position + ethEntryLength;
+                    int forkIdLength = ctx.ReadSequenceLength();
+                    int forkIdCheck = ctx.Position + forkIdLength;
+                    byte[] forkHash = ctx.DecodeByteArray(RlpLimit.L4, EthEntry.ForkHashLength);
+                    ulong nextBlock = ctx.DecodeULong();
+                    ctx.Check(forkIdCheck);
+
+                    while (ctx.Position < ethEntryCheck)
+                    {
+                        ctx.SkipItem();
+                    }
+                    ctx.Check(ethEntryCheck);
                     nodeRecord.SetEntry(new EthEntry(forkHash, nextBlock));
                     break;
                 case 3 when key.SequenceEqual(EnrContentKey.TcpU8):
@@ -156,8 +166,15 @@ public class NodeRecordSigner(IEcdsa? ethereumEcdsa, PrivateKey? privateKey = nu
         }
 
         int endPosition = ctx.Position;
+        int originalContentLength = endPosition - contentStartPosition;
+        byte[] originalContent = new byte[Rlp.LengthOfSequence(originalContentLength)];
+        RlpStream originalContentStream = new(originalContent);
+        originalContentStream.StartSequence(originalContentLength);
+        originalContentStream.Write(ctx.Data.Slice(contentStartPosition, originalContentLength));
+
         nodeRecord.EnrSequence = enrSequence;
         nodeRecord.Signature = signature;
+        nodeRecord.OriginalContentRlp = originalContent;
         nodeRecord.OriginalRlp = ctx.Data.Slice(startPosition, endPosition - startPosition).ToArray();
 
         return nodeRecord;


### PR DESCRIPTION
## Changes

- Add the devp2p `eth` ENR entry to `NodeRecordProvider` using `IForkInfo` and the current effective chain header.
- Refresh and re-sign node records when the fork ID changes on `NewHeadBlock`, or when sync pivot information becomes available before a new head.
- Keep ENR sequence values monotonic with timestamp-based values plus in-process increments.
- Cover the shared discv4/discv5 node record provider behavior with focused regression tests.
- Return fresh unprotected key instances from `InsecureProtectedPrivateKey` so provider disposal does not mutate shared test keys.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src\Nethermind\Nethermind.Network.Discovery.Test\Nethermind.Network.Discovery.Test.csproj -c release /p:TreatWarningsAsErrors=true -- --filter FullyQualifiedName~NodeRecordProviderTests`
- `dotnet test --project src\Nethermind\Nethermind.Network.Discovery.Test\Nethermind.Network.Discovery.Test.csproj -c release /p:TreatWarningsAsErrors=true`
- `git diff --cached --check`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Based on `generic-kad-2`. Upstream PR #9160 was inspected as a reference; this implementation keeps the provider lifecycle and ENR sequence handling local to the shared node record provider.