### PR TITLE
JsonRpc: default omitted block to latest for eth_getStorageValues

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -217,7 +217,7 @@ public partial class EthRpcModule(
 
     public ResultWrapper<StorageValuesResult> eth_getStorageValues(
         StorageValuesRequest requests,
-        BlockParameter blockParameter)
+        BlockParameter? blockParameter = null)
     {
         if (requests.TooManySlots)
             return TooManySlotsError();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -104,7 +104,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             Description = "Returns storage values for multiple slots across multiple accounts in a single request. Total slot count across all addresses must not exceed 1024.",
             IsSharable = true,
             ExampleResponse = "{\"0xdac17f958d2ee523a2206206994597c13d831ec7\":[\"0x00000000000000000000000000000000000000000000000000000000000f4240\"]}")]
-        ResultWrapper<StorageValuesResult> eth_getStorageValues([JsonRpcParameter(ExampleValue = "[{\"0xdac17f958d2ee523a2206206994597c13d831ec7\":[\"0x0000000000000000000000000000000000000000000000000000000000000002\"]}]")] StorageValuesRequest requests, BlockParameter blockParameter);
+        ResultWrapper<StorageValuesResult> eth_getStorageValues([JsonRpcParameter(ExampleValue = "[{\"0xdac17f958d2ee523a2206206994597c13d831ec7\":[\"0x0000000000000000000000000000000000000000000000000000000000000002\"]}]")] StorageValuesRequest requests, BlockParameter? blockParameter = null);
 
         [JsonRpcMethod(IsImplemented = true,
             Description = "Returns account nonce (number of transactions from the account since genesis) at the given block number",


### PR DESCRIPTION
## Summary

`eth_getStorageValues` declares a **non-nullable** `BlockParameter` with no default:

```csharp
ResultWrapper<StorageValuesResult> eth_getStorageValues(StorageValuesRequest requests, BlockParameter blockParameter);
```

so omitting the block parameter fails with `-32602 missing value for required argument 1`. Its five sibling state methods — `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_getProof` — already declare `BlockParameter? blockParameter = null` and default an omitted block to `latest`.

This PR makes `eth_getStorageValues` consistent with them:

```csharp
ResultWrapper<StorageValuesResult> eth_getStorageValues(StorageValuesRequest requests, BlockParameter? blockParameter = null);
```

`_blockFinder.SearchForHeader(blockParameter)` already resolves `null` to latest, so the nullable signature is the whole fix (interface + implementation).

## Motivation

This aligns Nethermind with **ethereum/execution-apis#812** by **@manusw7**, which marks the `Block` parameter `required: false` (default `latest`) on the six state-reading methods. Full credit to @manusw7 for the standards proposal.

Found via `hive` `rpc-compat`: with the default-block conformance fixtures, Nethermind already passed five of the six state methods and only `eth_getStorageValues` rejected an omitted block. With this change, all six pass.

## Testing

Verified against `hive` `rpc-compat` using a default-block fixture for `eth_getStorageValues` (block parameter omitted): a Nethermind build with this fix returns the latest-block values and the combined cross-client run is green.

## Related

- Source proposal: ethereum/execution-apis#812 (by @manusw7)
- execution-apis spec + conformance tests: ethereum/execution-apis#814
- go-ethereum implementation: ethereum/go-ethereum#35100
- Erigon implementation: erigontech/erigon#21586
- Besu implementation: besu-eth/besu#10587
- ethrex implementation: lambdaclass/ethrex#6780
