### PR TITLE
fix(state-test): default SLOTNUM slot to 0 when env omits it (EIP-7843)

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/Ethereum.Blockchain.Block.Test.csproj
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/Ethereum.Blockchain.Block.Test.csproj
@@ -17,6 +17,9 @@
       <None Update="Blockhash\blockhash.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+      <None Update="Slotnum\slotnum.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/Slotnum/slotnum.json
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/Slotnum/slotnum.json
@@ -1,0 +1,51 @@
+{
+  "slotnum_default_when_env_omits_slot": {
+    "_info": {
+      "comment": "EIP-7843 SLOTNUM (0x4b) with an env that omits the slot number. On Amsterdam the opcode must execute and push 0 (matching geth and other clients), not abort with BadInstruction. Regression for the state-test harness defaulting SlotNumber to 0 when EIP-7843 is active. Code: SLOTNUM PUSH1 0 SSTORE -> stores the slot number (0) at slot 0, a no-op, so storage stays empty."
+    },
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x0000000000000000000000707690000000008024": {
+        "code": "0x4b600055",
+        "storage": {},
+        "balance": "0x3b9aca00",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0x",
+        "storage": {},
+        "balance": "0xffffffffff",
+        "nonce": "0x0"
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0x0",
+      "to": "0x0000000000000000000000707690000000008024",
+      "data": ["0x"],
+      "gasLimit": ["0x100000"],
+      "value": ["0x0"],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    },
+    "out": "0x",
+    "post": {
+      "Amsterdam": [
+        {
+          "hash": "0x7b8e9fcbf409db592f7263787cb6440e5a0b534efd3dd92e9b287dda0a84c080",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "indexes": { "data": 0, "gas": 0, "value": 0 }
+        }
+      ]
+    }
+  }
+}

--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/SlotnumTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/SlotnumTests.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+
+namespace Ethereum.Blockchain.Block.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class SlotnumTests : GeneralStateTestBase
+{
+    [TestCaseSource(nameof(LoadTests))]
+    public void Test(GeneralStateTest test) => Assert.That(RunTest(test).Pass, Is.True);
+
+    public static IEnumerable<GeneralStateTest> LoadTests()
+    {
+        TestsSourceLoader loader = new(new LoadGeneralStateTestsStrategy(), Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Slotnum"));
+        return loader.LoadTests<GeneralStateTest>();
+    }
+}

--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
@@ -128,7 +128,7 @@ namespace Ethereum.Test.Base
                 WithdrawalsRoot = test.CurrentWithdrawalsRoot ?? (spec.WithdrawalsEnabled ? PatriciaTree.EmptyTreeHash : null),
                 ParentBeaconBlockRoot = test.CurrentBeaconRoot,
                 ExcessBlobGas = test.CurrentExcessBlobGas ?? (test.Fork.IsEip4844Enabled ? 0ul : null),
-                SlotNumber = test.CurrentSlotNumber,
+                SlotNumber = test.CurrentSlotNumber ?? (test.Fork.IsEip7843Enabled ? 0ul : null),
                 BlobGasUsed = BlobGasCalculator.CalculateBlobGas(test.Transaction),
                 RequestsHash = test.RequestsHash ?? (spec.RequestsEnabled ? ExecutionRequestExtensions.EmptyRequestsHash : null),
                 BlockAccessListHash = spec.IsEip7928Enabled ? Keccak.OfAnEmptySequenceRlp : null,


### PR DESCRIPTION
## Changes

- Default `BlockHeader.SlotNumber` to `0` in the general state-test harness (`GeneralStateTestBase`) when EIP-7843 (Amsterdam) is active and the fixture's `env` omits the slot number, mirroring the adjacent EIP-4844 `ExcessBlobGas` default.
- Add a regression state test (`SlotnumTests` + `Slotnum/slotnum.json`) that runs `SLOTNUM` (`0x4b`) under Amsterdam with an `env` that omits the slot number, asserting the opcode executes and pushes `0` (state root `0x7b8e...`) rather than aborting.

### Background

EIP-7843 models `SLOTNUM` over a nullable header slot in Nethermind; the opcode handler treats a null slot as `BadInstruction`. The state-test harness left `SlotNumber` null whenever a fixture's `env` had no slot field, so the opcode aborted under Amsterdam and consumed all gas, producing a divergent state root.

geth (and besu, erigon, revm, ethrex) model the slot as a non-nullable value that defaults to `0`, so they push `0` and continue. goevmlab-generated state tests never emit a slot field, so `nethtest` diverged from every other client during differential fuzzing. This was surfaced via goevmlab statetest fuzzing of EIP-7843.

Real Amsterdam blocks always carry a slot number from the consensus layer, so the EVM null-guard never trips in production; only the test harness left it unset. The fix is therefore confined to the harness.

Note: PR #10697 wired `env.slotNumber` into the header, which fixes EEST fixtures that *carry* the field. This PR covers the complementary case (field absent), which is what goevmlab emits.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

Requires testing: **Yes**. Tests written: **Yes**.

New regression `SlotnumTests` passes; verified the exact goevmlab repro now executes `SLOTNUM` to `0` (root `0x7b8e...`) via `nethtest`, whereas before the fix it aborted with `BadInstruction` (root `0xa0f7...`).

## Documentation

Requires documentation update: No. Requires Release Notes: No.