### PR TITLE
test: lock trace_callMany gas cap defaults

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1069,20 +1069,7 @@ public class TraceRpcModuleTests
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = context.TraceRpcModule.trace_callMany(
-            new(new(1)
-            {
-                new()
-                {
-                    Transaction = new LegacyTransactionForRpc
-                    {
-                        From = TestItem.AddressA,
-                        To = TestItem.AddressC,
-                        Gas = 100_000
-                    },
-                    TraceTypes = ["trace"]
-                }
-            }));
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = TraceCallMany(context, gas: 100_000);
 
         Assert.That(traces.Data.Single().Action!.Gas, Is.LessThan(gasCap));
     }
@@ -1113,7 +1100,9 @@ public class TraceRpcModuleTests
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = 50_000;
 
-        Assert.That(() => TraceCallMany(context, gas: 0),
+        // Force enumeration with .Single(): the intrinsic-gas check is hit inside
+        // TraceBlock, surfaced through the lazy IEnumerable returned in Data.
+        Assert.That(() => TraceCallMany(context, gas: 0).Data.Single(),
             Throws.InstanceOf<InvalidTransactionException>()
                 .With.Message.Contains("intrinsic gas too low"));
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1097,19 +1097,7 @@ public class TraceRpcModuleTests
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = context.TraceRpcModule.trace_callMany(
-            new(new(1)
-            {
-                new()
-                {
-                    Transaction = new LegacyTransactionForRpc
-                    {
-                        From = TestItem.AddressA,
-                        To = TestItem.AddressC
-                    },
-                    TraceTypes = ["trace"]
-                }
-            }));
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = TraceCallMany(context);
 
         traces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
     }
@@ -1124,21 +1112,17 @@ public class TraceRpcModuleTests
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = context.TraceRpcModule.trace_callMany(
-            new(new(1)
-            {
-                new()
-                {
-                    Transaction = new LegacyTransactionForRpc
-                    {
-                        From = TestItem.AddressA,
-                        To = TestItem.AddressC
-                    },
-                    TraceTypes = ["trace"]
-                }
-            }));
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = TraceCallMany(context);
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> zeroGasTraces = TraceCallMany(context, gas: 0);
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> zeroGasTraces = context.TraceRpcModule.trace_callMany(
+        omittedGasTraces.Result.Error.Should().BeNull();
+        zeroGasTraces.Result.Error.Should().BeNull();
+        zeroGasTraces.Data.Single().Action!.Gas.Should().Be(omittedGasTraces.Data.Single().Action!.Gas);
+        zeroGasTraces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
+    }
+
+    private static ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> TraceCallMany(Context context, long? gas = null) =>
+        context.TraceRpcModule.trace_callMany(
             new(new(1)
             {
                 new()
@@ -1147,17 +1131,11 @@ public class TraceRpcModuleTests
                     {
                         From = TestItem.AddressA,
                         To = TestItem.AddressC,
-                        Gas = 0
+                        Gas = gas
                     },
                     TraceTypes = ["trace"]
                 }
             }));
-
-        omittedGasTraces.Result.Error.Should().BeNull();
-        zeroGasTraces.Result.Error.Should().BeNull();
-        zeroGasTraces.Data.Single().Action!.Gas.Should().Be(omittedGasTraces.Data.Single().Action!.Gas);
-        zeroGasTraces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
-    }
 
     [TestCase(0, 0, false)]
     [TestCase(2, 2, false)]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1106,21 +1106,16 @@ public class TraceRpcModuleTests
     }
 
     [Test]
-    public async Task Trace_callMany_with_zero_gas_matches_omitted_gas_path()
+    public async Task Trace_callMany_with_zero_gas_keeps_literal_zero_gas_semantics()
     {
         Context context = new();
         await context.Build();
-        long blockGasLimit = context.Blockchain.BlockTree.Head!.Header.GasLimit;
-        long gasCap = blockGasLimit * 10;
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
-        config.GasCap = gasCap;
+        config.GasCap = 50_000;
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = TraceCallMany(context);
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> zeroGasTraces = TraceCallMany(context, gas: 0);
-
-        Assert.That(omittedGasTraces.Result.Error, Is.Null);
-        Assert.That(zeroGasTraces.Result.Error, Is.Null);
-        Assert.That(zeroGasTraces.Data.Single().Action!.Gas, Is.EqualTo(omittedGasTraces.Data.Single().Action!.Gas));
+        Assert.That(() => TraceCallMany(context, gas: 0),
+            Throws.InstanceOf<InvalidTransactionException>()
+                .With.Message.Contains("intrinsic gas too low"));
     }
 
     private static ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> TraceCallMany(Context context, long? gas = null) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1097,9 +1097,12 @@ public class TraceRpcModuleTests
         IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = TraceCallMany(context);
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = TraceCallMany(context);
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> explicitGasCapTraces = TraceCallMany(context, gas: gasCap);
 
-        traces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
+        omittedGasTraces.Result.Error.Should().BeNull();
+        explicitGasCapTraces.Result.Error.Should().BeNull();
+        omittedGasTraces.Data.Single().Action!.Gas.Should().Be(explicitGasCapTraces.Data.Single().Action!.Gas);
     }
 
     [Test]
@@ -1118,7 +1121,6 @@ public class TraceRpcModuleTests
         omittedGasTraces.Result.Error.Should().BeNull();
         zeroGasTraces.Result.Error.Should().BeNull();
         zeroGasTraces.Data.Single().Action!.Gas.Should().Be(omittedGasTraces.Data.Single().Action!.Gas);
-        zeroGasTraces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
     }
 
     private static ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> TraceCallMany(Context context, long? gas = null) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1100,9 +1100,9 @@ public class TraceRpcModuleTests
         ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = TraceCallMany(context);
         ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> explicitGasCapTraces = TraceCallMany(context, gas: gasCap);
 
-        omittedGasTraces.Result.Error.Should().BeNull();
-        explicitGasCapTraces.Result.Error.Should().BeNull();
-        omittedGasTraces.Data.Single().Action!.Gas.Should().Be(explicitGasCapTraces.Data.Single().Action!.Gas);
+        Assert.That(omittedGasTraces.Result.Error, Is.Null);
+        Assert.That(explicitGasCapTraces.Result.Error, Is.Null);
+        Assert.That(omittedGasTraces.Data.Single().Action!.Gas, Is.EqualTo(explicitGasCapTraces.Data.Single().Action!.Gas));
     }
 
     [Test]
@@ -1118,9 +1118,9 @@ public class TraceRpcModuleTests
         ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = TraceCallMany(context);
         ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> zeroGasTraces = TraceCallMany(context, gas: 0);
 
-        omittedGasTraces.Result.Error.Should().BeNull();
-        zeroGasTraces.Result.Error.Should().BeNull();
-        zeroGasTraces.Data.Single().Action!.Gas.Should().Be(omittedGasTraces.Data.Single().Action!.Gas);
+        Assert.That(omittedGasTraces.Result.Error, Is.Null);
+        Assert.That(zeroGasTraces.Result.Error, Is.Null);
+        Assert.That(zeroGasTraces.Data.Single().Action!.Gas, Is.EqualTo(omittedGasTraces.Data.Single().Action!.Gas));
     }
 
     private static ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> TraceCallMany(Context context, long? gas = null) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1087,6 +1087,78 @@ public class TraceRpcModuleTests
         Assert.That(traces.Data.Single().Action!.Gas, Is.LessThan(gasCap));
     }
 
+    [Test]
+    public async Task Trace_callMany_without_gas_defaults_to_gas_cap_not_block_gas_limit()
+    {
+        Context context = new();
+        await context.Build();
+        long blockGasLimit = context.Blockchain.BlockTree.Head!.Header.GasLimit;
+        long gasCap = blockGasLimit * 10;
+        IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
+        config.GasCap = gasCap;
+
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> traces = context.TraceRpcModule.trace_callMany(
+            new(new(1)
+            {
+                new()
+                {
+                    Transaction = new LegacyTransactionForRpc
+                    {
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressC
+                    },
+                    TraceTypes = ["trace"]
+                }
+            }));
+
+        traces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
+    }
+
+    [Test]
+    public async Task Trace_callMany_with_zero_gas_matches_omitted_gas_path()
+    {
+        Context context = new();
+        await context.Build();
+        long blockGasLimit = context.Blockchain.BlockTree.Head!.Header.GasLimit;
+        long gasCap = blockGasLimit * 10;
+        IJsonRpcConfig config = context.Blockchain.Container.Resolve<IJsonRpcConfig>();
+        config.GasCap = gasCap;
+
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> omittedGasTraces = context.TraceRpcModule.trace_callMany(
+            new(new(1)
+            {
+                new()
+                {
+                    Transaction = new LegacyTransactionForRpc
+                    {
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressC
+                    },
+                    TraceTypes = ["trace"]
+                }
+            }));
+
+        ResultWrapper<IEnumerable<ParityTxTraceFromReplay>> zeroGasTraces = context.TraceRpcModule.trace_callMany(
+            new(new(1)
+            {
+                new()
+                {
+                    Transaction = new LegacyTransactionForRpc
+                    {
+                        From = TestItem.AddressA,
+                        To = TestItem.AddressC,
+                        Gas = 0
+                    },
+                    TraceTypes = ["trace"]
+                }
+            }));
+
+        omittedGasTraces.Result.Error.Should().BeNull();
+        zeroGasTraces.Result.Error.Should().BeNull();
+        zeroGasTraces.Data.Single().Action!.Gas.Should().Be(omittedGasTraces.Data.Single().Action!.Gas);
+        zeroGasTraces.Data.Single().Action!.Gas.Should().BeGreaterThan(blockGasLimit);
+    }
+
     [TestCase(0, 0, false)]
     [TestCase(2, 2, false)]
     [TestCase(3, 3, false)]


### PR DESCRIPTION
Closes #11898

trace_callMany already calls `EnsureDefaults(jsonRpcConfig.GasCap)` in the trace path, but the existing regression only covered the explicit over-cap case.
That left the defaulting paths easy to misread when touching nearby trace or simulate code.

This patch stays in `TraceRpcModuleTests`.
It proves omitted gas resolves to the same traced gas as an explicit `gasCap` request, and that explicit `gas: 0x0` still matches the omitted-gas path.
It does not change `trace_callMany` runtime behavior.

Tests:
- targeted `trace_callMany` gas-default checks -> 3 passed
- broader `Trace_callMany_` suite -> 7 passed