### PR TITLE
test: lock debug_traceCall zero-gas semantics

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -150,7 +150,7 @@ public partial class DebugRpcModuleTests
     // Returns gas available at start of execution as a 32-byte uint256.
     private const string GasReturnContractAddress = "0xc200000000000000000000000000000000000000";
     private static object GasReturnContractStateOverride() => JsonSerializer.Deserialize<object>(
-        $$"""{"{{GasReturnContractAddress}}":{"code":"0x5a60005260206000f3"}}""")!;
+        $$$"""{"{{{GasReturnContractAddress}}}":{"code":"0x5a60005260206000f3"}}""")!;
 
     [Test]
     public async Task Debug_traceCall_caps_gas_to_gas_cap()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -186,18 +186,23 @@ public partial class DebugRpcModuleTests
         object? stateOverride = JsonSerializer.Deserialize<object>(
             """{"0xc200000000000000000000000000000000000000":{"code":"0x5a60005260206000f3"}}""");
 
-        // No gas field — should default to gasCap, not blockGasLimit
-        string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
+        string omittedGasResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
             new { to = "0xc200000000000000000000000000000000000000" },
             null,
             new { stateOverrides = stateOverride }
         );
 
-        UInt256 gasAvailable = ParseReturnValue(response).ToUInt256();
-        Assert.That(
-            gasAvailable > (UInt256)blockGasLimit,
-            Is.True,
-            $"gas available should reflect gasCap ({gasCap}), not block gas limit ({blockGasLimit})");
+        string explicitGasCapResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
+            new { to = "0xc200000000000000000000000000000000000000", gas = $"0x{gasCap:x}" },
+            null,
+            new { stateOverrides = stateOverride }
+        );
+
+        UInt256 omittedGasAvailable = ParseReturnValue(omittedGasResponse).ToUInt256();
+        UInt256 explicitGasCapAvailable = ParseReturnValue(explicitGasCapResponse).ToUInt256();
+
+        Assert.That(omittedGasAvailable, Is.EqualTo(explicitGasCapAvailable));
+        Assert.That(omittedGasAvailable > (UInt256)blockGasLimit, Is.True);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -200,6 +200,28 @@ public partial class DebugRpcModuleTests
             $"gas available should reflect gasCap ({gasCap}), not block gas limit ({blockGasLimit})");
     }
 
+    [Test]
+    public async Task Debug_traceCall_with_zero_gas_keeps_literal_zero_gas_semantics()
+    {
+        using Context ctx = await Context.Create();
+        long gasCap = 50_000;
+        IJsonRpcConfig config = ctx.Blockchain.Container.Resolve<IJsonRpcConfig>();
+        config.GasCap = gasCap;
+
+        object? stateOverride = JsonSerializer.Deserialize<object>(
+            """{"0xc200000000000000000000000000000000000000":{"code":"0x5a60005260206000f3"}}""");
+
+        string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
+            new { to = "0xc200000000000000000000000000000000000000", gas = "0x0" },
+            null,
+            new { stateOverrides = stateOverride }
+        );
+
+        JToken json = JToken.Parse(response);
+        Assert.That(json["result"]?["error"]?.Value<string>(), Does.Contain("intrinsic gas too low"));
+        Assert.That(json["result"]?["gas"]?.Value<long>(), Is.EqualTo(0));
+    }
+
     private static byte[] ParseReturnValue(string responseJson)
     {
         JToken result = JToken.Parse(responseJson)["result"]!;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -146,6 +146,12 @@ public partial class DebugRpcModuleTests
         }
     }
 
+    // Contract: GAS PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
+    // Returns gas available at start of execution as a 32-byte uint256.
+    private const string GasReturnContractAddress = "0xc200000000000000000000000000000000000000";
+    private static object GasReturnContractStateOverride() => JsonSerializer.Deserialize<object>(
+        $$"""{"{{GasReturnContractAddress}}":{"code":"0x5a60005260206000f3"}}""")!;
+
     [Test]
     public async Task Debug_traceCall_caps_gas_to_gas_cap()
     {
@@ -154,16 +160,11 @@ public partial class DebugRpcModuleTests
         IJsonRpcConfig config = ctx.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        // Contract: GAS PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
-        // Returns gas available at start of execution as a 32-byte uint256
-        object? stateOverride = JsonSerializer.Deserialize<object>(
-            """{"0xc200000000000000000000000000000000000000":{"code":"0x5a60005260206000f3"}}""");
-
         // Request 100K gas — should be capped to 50K by GasCap
         string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { to = "0xc200000000000000000000000000000000000000", gas = "0x186A0" },
+            new { to = GasReturnContractAddress, gas = "0x186A0" },
             null,
-            new { stateOverrides = stateOverride }
+            new { stateOverrides = GasReturnContractStateOverride() }
         );
 
         long gasAvailable = (long)ParseReturnValue(response).ToUInt256();
@@ -181,21 +182,16 @@ public partial class DebugRpcModuleTests
         IJsonRpcConfig config = ctx.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        // Contract: GAS PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
-        // Returns gas available at start of execution as a uint256
-        object? stateOverride = JsonSerializer.Deserialize<object>(
-            """{"0xc200000000000000000000000000000000000000":{"code":"0x5a60005260206000f3"}}""");
-
         string omittedGasResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { to = "0xc200000000000000000000000000000000000000" },
+            new { to = GasReturnContractAddress },
             null,
-            new { stateOverrides = stateOverride }
+            new { stateOverrides = GasReturnContractStateOverride() }
         );
 
         string explicitGasCapResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { to = "0xc200000000000000000000000000000000000000", gas = $"0x{gasCap:x}" },
+            new { to = GasReturnContractAddress, gas = $"0x{gasCap:x}" },
             null,
-            new { stateOverrides = stateOverride }
+            new { stateOverrides = GasReturnContractStateOverride() }
         );
 
         UInt256 omittedGasAvailable = ParseReturnValue(omittedGasResponse).ToUInt256();
@@ -213,18 +209,15 @@ public partial class DebugRpcModuleTests
         IJsonRpcConfig config = ctx.Blockchain.Container.Resolve<IJsonRpcConfig>();
         config.GasCap = gasCap;
 
-        object? stateOverride = JsonSerializer.Deserialize<object>(
-            """{"0xc200000000000000000000000000000000000000":{"code":"0x5a60005260206000f3"}}""");
-
+        // No state override needed: tx fails at intrinsic-gas validation before the EVM runs.
         string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { to = "0xc200000000000000000000000000000000000000", gas = "0x0" },
-            null,
-            new { stateOverrides = stateOverride }
+            new { to = GasReturnContractAddress, gas = "0x0" }
         );
 
-        JToken json = JToken.Parse(response);
-        Assert.That(json["result"]?["error"]?.Value<string>(), Does.Contain("intrinsic gas too low"));
-        Assert.That(json["result"]?["gas"]?.Value<long>(), Is.EqualTo(0));
+        JToken result = JToken.Parse(response)["result"]!;
+        Assert.That(result["failed"]?.Value<bool>(), Is.True);
+        Assert.That(result["error"]?.Value<string>(), Does.Contain("intrinsic gas too low"));
+        Assert.That(result["gas"]?.Value<long>(), Is.EqualTo(0));
     }
 
     private static byte[] ParseReturnValue(string responseJson)


### PR DESCRIPTION
Closes #11899

debug_traceCall still goes through `call.ToTransaction(... gasCap ...)`, and that path keeps explicit `gas: 0x0` as a literal gas limit instead of treating it as missing.
The old omitted-gas regression only proved the traced gas was above the block gas limit, so it still left one step of reviewer inference.

This patch stays in `DebugRpcModuleTests.cs`.
It proves omitted gas matches the explicit `gasCap` path, and it keeps the explicit `gas: 0x0` regression that returns the intrinsic-gas error with traced gas `0`.
It does not change `debug_traceCall` semantics or the nearby `debug_traceCallMany` / simulate paths.

Tests:
- targeted `debug_traceCall` gas checks -> 2 passed
- broader `Debug_traceCall_` suite -> 16 passed