### PR TITLE
test: lock proof_call gas semantics

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -328,9 +328,31 @@ public class ProofRpcModuleTests(bool createZeroAccount, bool useNonZeroGasPrice
         long gasCap = blockGasLimit * 10;
         _container.Resolve<IJsonRpcConfig>().GasCap = gasCap;
 
-        CallResultWithProof result = await TestCallWithCode(code);
+        (IWorldState _, Hash256 root) = CreateInitialState(code);
 
-        Assert.That(result.Result.ToUInt256(), Is.GreaterThan((UInt256)blockGasLimit));
+        Block block = Build.A.Block.WithParent(_blockTree.Head!).WithStateRoot(root).WithBeneficiary(TestItem.AddressD).TestObject;
+        BlockTreeBuilder.AddBlock(_blockTree, block);
+        Block blockOnTop = Build.A.Block.WithParent(block).WithStateRoot(root).WithBeneficiary(TestItem.AddressD).TestObject;
+        BlockTreeBuilder.AddBlock(_blockTree, blockOnTop);
+
+        TransactionForRpc txWithoutGas = new LegacyTransactionForRpc
+        {
+            To = TestItem.AddressB,
+            GasPrice = useNonZeroGasPrice ? 10.GWei : 0
+        };
+
+        TransactionForRpc txWithExplicitGasCap = new LegacyTransactionForRpc
+        {
+            To = TestItem.AddressB,
+            Gas = gasCap,
+            GasPrice = useNonZeroGasPrice ? 10.GWei : 0
+        };
+
+        CallResultWithProof omittedGasResult = _proofRpcModule.proof_call(txWithoutGas, new BlockParameter(blockOnTop.Number)).Data;
+        CallResultWithProof explicitGasCapResult = _proofRpcModule.proof_call(txWithExplicitGasCap, new BlockParameter(blockOnTop.Number)).Data;
+
+        Assert.That(omittedGasResult.Result, Is.EqualTo(explicitGasCapResult.Result));
+        Assert.That(omittedGasResult.Result.ToUInt256(), Is.GreaterThan((UInt256)blockGasLimit));
     }
 
     [TestCase]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -313,6 +313,61 @@ public class ProofRpcModuleTests(bool createZeroAccount, bool useNonZeroGasPrice
     }
 
     [TestCase]
+    public async Task Proof_call_without_gas_defaults_to_gas_cap_not_block_gas_limit()
+    {
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.GAS)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        long blockGasLimit = _blockTree.Head!.Header.GasLimit;
+        long gasCap = blockGasLimit * 10;
+        _container.Resolve<IJsonRpcConfig>().GasCap = gasCap;
+
+        CallResultWithProof result = await TestCallWithCode(code);
+
+        Assert.That(result.Result.ToUInt256(), Is.GreaterThan((UInt256)blockGasLimit));
+    }
+
+    [TestCase]
+    public async Task Proof_call_with_zero_gas_keeps_literal_zero_gas_semantics()
+    {
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.GAS)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        long blockGasLimit = _blockTree.Head!.Header.GasLimit;
+        long gasCap = blockGasLimit * 10;
+        _container.Resolve<IJsonRpcConfig>().GasCap = gasCap;
+
+        (IWorldState _, Hash256 root) = CreateInitialState(code);
+
+        Block block = Build.A.Block.WithParent(_blockTree.Head!).WithStateRoot(root).WithBeneficiary(TestItem.AddressD).TestObject;
+        BlockTreeBuilder.AddBlock(_blockTree, block);
+        Block blockOnTop = Build.A.Block.WithParent(block).WithStateRoot(root).WithBeneficiary(TestItem.AddressD).TestObject;
+        BlockTreeBuilder.AddBlock(_blockTree, blockOnTop);
+
+        TransactionForRpc tx = new LegacyTransactionForRpc
+        {
+            To = TestItem.AddressB,
+            Gas = 0,
+            GasPrice = useNonZeroGasPrice ? 10.GWei : 0
+        };
+
+        string response = await RpcTest.TestSerializedRequest(_proofRpcModule, "proof_call", tx, blockOnTop.Number);
+        Assert.That(response, Does.Contain("intrinsic gas too low"));
+    }
+
+    [TestCase]
     public async Task Can_call_with_block_hashes()
     {
         byte[] code = Prepare.EvmCode


### PR DESCRIPTION
Closes #11902

proof_call still goes through `tx.ToTransaction(validateUserInput: true, gasCap: jsonRpcConfig.GasCap)`, but the suite only had an indirect omitted-gas assertion on that path.

This patch keeps the change in `ProofRpcModuleTests.cs`. The omitted-gas regression now compares the returned gas value against an explicit `gas: gasCap` request, and the zero-gas regression still locks the current literal `gas: 0x0` failure path. It does not change `proof_call` runtime behavior or the nearby trace/debug call paths.

Tests:
- `Proof_call_without_gas_defaults_to_gas_cap_not_block_gas_limit`
- `Proof_call_with_zero_gas_keeps_literal_zero_gas_semantics`
- targeted `Nethermind.JsonRpc.Test` run -> 4 passed
- broader `Proof_call_` run -> 4 passed
