### PR TITLE
perf(bal): reduce per-access BAL/state recording overhead on warm reads

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -18,7 +18,7 @@ public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManag
             worldStateManager.CreateResettableWorldState(),
             preBlockCaches,
             logManager,
-            populatePreBlockCache: true
+            isPrewarmer: true
         );
 
         ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
@@ -29,18 +29,34 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
 
     public uint Index { get; set; }
 
-    private readonly Dictionary<Address, AccountChangesAtIndex> _accountChanges = new(GenericEqualityComparer.GetOptimized<Address>());
+    private readonly Dictionary<AddressAsKey, AccountChangesAtIndex> _accountChanges = new(GenericEqualityComparer.GetOptimized<AddressAsKey>());
     private readonly List<Change> _changes = new(InitialChangeCapacity);
 
     private readonly List<CodeChange> _previousCodeChanges = [];
 
     private readonly Stack<AccountChangesAtIndex> _accountChangesPool = new();
 
-    public Dictionary<Address, AccountChangesAtIndex>.ValueCollection AccountChanges => _accountChanges.Values;
+    // Single-slot cache: repeated same-address reads skip the dict probe. Reset in Clear() (pooled);
+    // safe as entries are never individually removed.
+    private Address? _lastReadAddress;
+    private AccountChangesAtIndex? _lastReadChanges;
+
+    public Dictionary<AddressAsKey, AccountChangesAtIndex>.ValueCollection AccountChanges => _accountChanges.Values;
     public int AccountCount => _accountChanges.Count;
     public bool HasAccount(Address address) => _accountChanges.ContainsKey(address);
     public AccountChangesAtIndex? GetAccountChanges(Address address)
-        => _accountChanges.TryGetValue(address, out AccountChangesAtIndex? value) ? value : null;
+    {
+        // Read-only fast path reusing the single-slot cache (see RecordReadAndGet). Never creates an
+        // entry; only memoizes a dict hit, so it cannot change recorded BAL contents.
+        if (address.Equals(_lastReadAddress)) return _lastReadChanges;
+        if (_accountChanges.TryGetValue(address, out AccountChangesAtIndex? value))
+        {
+            _lastReadAddress = address;
+            _lastReadChanges = value;
+            return value;
+        }
+        return null;
+    }
 
     public void Clear()
     {
@@ -54,6 +70,8 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
         _accountChanges.Clear();
         _changes.Clear();
         _previousCodeChanges.Clear();
+        _lastReadAddress = null;
+        _lastReadChanges = null;
     }
 
     public void Reset()
@@ -145,12 +163,26 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
         accountChanges.NonceChange = new NonceChange(Index, newNonce);
     }
 
-    public void AddAccountRead(Address address)
+    public void AddAccountRead(Address address) => RecordReadAndGet(address);
+
+    /// <summary>Records an account read and returns its entry; one-slot cache skips repeat same-address probes.</summary>
+    public AccountChangesAtIndex RecordReadAndGet(Address address)
     {
-        if (!_accountChanges.ContainsKey(address))
+        if (!address.Equals(_lastReadAddress))
         {
-            _accountChanges.Add(address, RentAccountChanges(address));
+            _lastReadChanges = GetOrAddAccountChanges(address);
+            _lastReadAddress = address;
         }
+        return _lastReadChanges!;
+    }
+
+    /// <summary>Records a storage-slot read and returns the account entry in a single account resolution.</summary>
+    public AccountChangesAtIndex RecordStorageReadAndGet(Address address, UInt256 key)
+    {
+        AccountChangesAtIndex accountChanges = RecordReadAndGet(address);
+        if (!accountChanges.HasStorageChange(key))
+            accountChanges.AddStorageRead(key);
+        return accountChanges;
     }
 
     public void AddStorageChange(Address address, UInt256 key, UInt256 before, UInt256 after)

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
@@ -288,6 +288,8 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
 
     public void Restore(int snapshot)
     {
+        // Intentionally does not reset _lastReadAddress/_lastReadChanges: Restore reverts entry values
+        // in place and never evicts an entry, so the cached reference stays valid. See class invariant.
         snapshot = int.Max(0, snapshot);
         Span<Change> span = CollectionsMarshal.AsSpan(_changes);
         int end = span.Length;

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChangesView.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedAccountChangesView.cs
@@ -14,13 +14,13 @@ namespace Nethermind.Core.BlockAccessLists;
 /// </summary>
 public readonly struct GeneratedAccountChangesView : IEnumerable<GeneratedAccountChanges>
 {
-    private readonly Dictionary<Address, GeneratedAccountChanges> _accounts;
+    private readonly Dictionary<AddressAsKey, GeneratedAccountChanges> _accounts;
 
-    internal GeneratedAccountChangesView(Dictionary<Address, GeneratedAccountChanges> accounts) => _accounts = accounts;
+    internal GeneratedAccountChangesView(Dictionary<AddressAsKey, GeneratedAccountChanges> accounts) => _accounts = accounts;
 
     public int Count => _accounts.Count;
 
-    public Dictionary<Address, GeneratedAccountChanges>.ValueCollection.Enumerator GetEnumerator()
+    public Dictionary<AddressAsKey, GeneratedAccountChanges>.ValueCollection.Enumerator GetEnumerator()
         => _accounts.Values.GetEnumerator();
 
     IEnumerator<GeneratedAccountChanges> IEnumerable<GeneratedAccountChanges>.GetEnumerator()

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Core.BlockAccessLists;
 /// </remarks>
 public class GeneratedBlockAccessList
 {
-    private readonly Dictionary<Address, GeneratedAccountChanges> _accountChanges = new(GenericEqualityComparer.GetOptimized<Address>());
+    private readonly Dictionary<AddressAsKey, GeneratedAccountChanges> _accountChanges = new(GenericEqualityComparer.GetOptimized<AddressAsKey>());
 
     /// <summary>
     /// Insertion-ordered view over the BAL's accounts.

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyBlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/ReadOnlyBlockAccessList.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Core.BlockAccessLists;
 /// </summary>
 public class ReadOnlyBlockAccessList : IEquatable<ReadOnlyBlockAccessList>
 {
-    private readonly Dictionary<Address, ReadOnlyAccountChanges> _accountChanges;
+    private readonly Dictionary<AddressAsKey, ReadOnlyAccountChanges> _accountChanges;
     private readonly ReadOnlyAccountChanges[] _orderedAccounts;
 
     [JsonIgnore]
@@ -71,7 +71,7 @@ public class ReadOnlyBlockAccessList : IEquatable<ReadOnlyBlockAccessList>
     public ReadOnlyBlockAccessList(ReadOnlyAccountChanges[] orderedAccounts, int itemCount, Hash256? wireHash)
     {
         _orderedAccounts = orderedAccounts;
-        _accountChanges = new Dictionary<Address, ReadOnlyAccountChanges>(orderedAccounts.Length);
+        _accountChanges = new Dictionary<AddressAsKey, ReadOnlyAccountChanges>(orderedAccounts.Length);
         int totalReads = 0;
         int totalChangeEvents = 0;
         foreach (ReadOnlyAccountChanges a in orderedAccounts)
@@ -90,7 +90,7 @@ public class ReadOnlyBlockAccessList : IEquatable<ReadOnlyBlockAccessList>
     {
         if (other is null) return false;
         if (_accountChanges.Count != other._accountChanges.Count) return false;
-        foreach (KeyValuePair<Address, ReadOnlyAccountChanges> kv in _accountChanges)
+        foreach (KeyValuePair<AddressAsKey, ReadOnlyAccountChanges> kv in _accountChanges)
         {
             if (!other._accountChanges.TryGetValue(kv.Key, out ReadOnlyAccountChanges? otherAcc)) return false;
             if (!kv.Value.Equals(otherAcc)) return false;

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -223,6 +223,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
 
         // WarmUp first so the warm path skips IsPrecompile; charged gas matches (!IsPrecompile && WarmUp).
+        // Precompiles are pre-warmed at tx start, so WarmUp(precompile) is already-warm and the reorder is moot.
         return (accessTracker.WarmUp(address) && !spec.IsPrecompile(address)) switch
         {
             true => UpdateGas(ref gas, GasCostOf.ColdAccountAccess),

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -222,7 +222,8 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             accessTracker.WarmUp(address);
         }
 
-        return (!spec.IsPrecompile(address) && accessTracker.WarmUp(address)) switch
+        // WarmUp first so the warm path skips IsPrecompile; charged gas matches (!IsPrecompile && WarmUp).
+        return (accessTracker.WarmUp(address) && !spec.IsPrecompile(address)) switch
         {
             true => UpdateGas(ref gas, GasCostOf.ColdAccountAccess),
             false when kind == AccountAccessKind.SelfDestructBeneficiary => true,

--- a/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PrewarmerModule.cs
@@ -52,7 +52,7 @@ public class PrewarmerModule(IBlocksConfig blocksConfig) : Module
                         worldStateScopeProvider,
                         ctx.Resolve<PreBlockCaches>(),
                         ctx.Resolve<ILogManager>(),
-                        populatePreBlockCache: false
+                        isPrewarmer: false
                     );
                 })
                 .AddDecorator<ICodeInfoRepository>((ctx, originalCodeInfoRepository) =>

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -278,9 +278,9 @@ public class ScopeProviderTests(bool useFlat)
             stateRoot = scope.RootHash;
         }
 
-        // populatePreBlockCache: false targets the main-processing scope where HintBal actually runs.
+        // isPrewarmer: false targets the main-processing scope where HintBal actually runs.
         PreBlockCaches caches = new();
-        PrewarmerScopeProvider prewarmer = new(ctx.ScopeProvider, caches, LimboLogs.Instance, populatePreBlockCache: false);
+        PrewarmerScopeProvider prewarmer = new(ctx.ScopeProvider, caches, LimboLogs.Instance, isPrewarmer: false);
 
         ReadOnlyBlockAccessList bal = Build.A.BlockAccessList
             .WithAccountChanges(

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -754,7 +754,7 @@ public class StorageProviderTests(bool useFlat)
 
             if (preBlockCaches is not null)
             {
-                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, LimboLogs.Instance, populatePreBlockCache: true);
+                scopeProvider = new PrewarmerScopeProvider(scopeProvider, preBlockCaches, LimboLogs.Instance, isPrewarmer: true);
             }
 
             if (trackWrittenData)

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -94,6 +94,8 @@ public class WorldStateManagerTests
                 .Build();
 
             IWorldState worldState = ctx.Resolve<IMainProcessingContext>().WorldState;
+            // Model production: the driver clears prewarmer caches between blocks; do the same here.
+            IPreBlockCaches preBlockCaches = worldState.ScopeProvider as IPreBlockCaches;
 
             Hash256 stateRoot;
 
@@ -112,6 +114,7 @@ public class WorldStateManagerTests
                     .WithNumber(i - 1)
                     .TestObject;
 
+                preBlockCaches?.Caches?.ClearCaches();
                 using (worldState.BeginScope(baseBlock))
                 {
                     worldState.IncrementNonce(TestItem.AddressA, 1);

--- a/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/WorldStateManagerTests.cs
@@ -94,8 +94,6 @@ public class WorldStateManagerTests
                 .Build();
 
             IWorldState worldState = ctx.Resolve<IMainProcessingContext>().WorldState;
-            // Model production: the driver clears prewarmer caches between blocks; do the same here.
-            IPreBlockCaches preBlockCaches = worldState.ScopeProvider as IPreBlockCaches;
 
             Hash256 stateRoot;
 
@@ -114,7 +112,8 @@ public class WorldStateManagerTests
                     .WithNumber(i - 1)
                     .TestObject;
 
-                preBlockCaches?.Caches?.ClearCaches();
+                // Model production: the driver clears prewarmer caches between blocks; do the same here.
+                (worldState.ScopeProvider as IPreBlockCaches)?.Caches?.ClearCaches();
                 using (worldState.BeginScope(baseBlock))
                 {
                     worldState.IncrementNonce(TestItem.AddressA, 1);

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -141,7 +141,7 @@ public class PrewarmerScopeProvider(
             else
             {
                 account = GetFromBaseTree(in addressAsKey);
-                // Backfill so other readers reuse this resolve.
+                // Backfill so other readers reuse this resolve; SeqlockCache.Set is safe under concurrent writers.
                 preBlockCache.Set(in addressAsKey, account);
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
             }
@@ -211,7 +211,7 @@ public class PrewarmerScopeProvider(
             else
             {
                 value = LoadFromTreeStorage(in storageCell);
-                // Backfill so other readers reuse this resolve.
+                // Backfill so other readers reuse this resolve; SeqlockCache.Set is safe under concurrent writers.
                 preBlockCache.Set(in storageCell, value);
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
             }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -31,29 +31,38 @@ internal class PrewarmerGetTimeLabels(bool isPrewarmer)
     public PrewarmerGetTimeLabel WriteBatchLifetime { get; } = new("write_batch_lifetime", isPrewarmer);
 }
 
+/// <summary>
+/// Decorates a scope provider with the shared <see cref="PreBlockCaches"/>. A miss always backfills;
+/// relies on the driver clearing the caches between blocks (see <c>BranchProcessor</c>).
+/// </summary>
+/// <param name="isPrewarmer">
+/// True for read-only populator envs (prewarmer, parallel-worker parent readers); false for the
+/// read-write main world state. Only effect: on a cache hit a consumer seeds the scope-local cache
+/// via <c>HintGet</c> (for its later commit); a populator does not.
+/// </param>
 public class PrewarmerScopeProvider(
     IWorldStateScopeProvider baseProvider,
     PreBlockCaches preBlockCaches,
     ILogManager logManager,
-    bool populatePreBlockCache = true
+    bool isPrewarmer = true
 ) : IWorldStateScopeProvider, IPreBlockCaches
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, logManager, populatePreBlockCache);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, logManager, isPrewarmer);
 
     public PreBlockCaches? Caches => preBlockCaches;
-    public bool IsWarmWorldState => !populatePreBlockCache;
+    public bool IsWarmWorldState => !isPrewarmer;
 
-    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, ILogManager logManager, bool populatePreBlockCache) : IWorldStateScopeProvider.IScope
+    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, ILogManager logManager, bool isPrewarmer) : IWorldStateScopeProvider.IScope
     {
         private readonly IWorldStateScopeProvider.IScope baseScope = baseScope;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache = preBlockCaches.StateCache;
         private readonly SeqlockCache<StorageCell, byte[]> storageCache = preBlockCaches.StorageCache;
-        private readonly bool populatePreBlockCache = populatePreBlockCache;
+        private readonly bool isPrewarmer = isPrewarmer;
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
-        private readonly PrewarmerGetTimeLabels _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+        private readonly PrewarmerGetTimeLabels _labels = isPrewarmer ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
         private readonly ILogger _logger = logManager.GetClassLogger<ScopeWrapper>();
         private long _writeBatchTime = 0;
 
@@ -72,7 +81,7 @@ public class PrewarmerScopeProvider(
                 baseScope.CreateStorageTree(address),
                 storageCache,
                 address,
-                populatePreBlockCache);
+                isPrewarmer);
 
         public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
         {
@@ -87,7 +96,7 @@ public class PrewarmerScopeProvider(
                 baseScope.StartWriteBatch(estimatedAccountNum),
                 _metricObserver,
                 sw,
-                populatePreBlockCache);
+                isPrewarmer);
         }
 
         public void Commit(long blockNumber)
@@ -122,36 +131,21 @@ public class PrewarmerScopeProvider(
         {
             AddressAsKey addressAsKey = address;
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (populatePreBlockCache)
+            if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
             {
-                if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
-                else
-                {
-                    account = GetFromBaseTree(in addressAsKey);
-                    preBlockCache.Set(in addressAsKey, account);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
-                }
-                return account;
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
+                // Consumers seed the scope-local cache on a hit for their later commit; populators don't.
+                if (!isPrewarmer) baseScope.HintGet(address, account);
+                Metrics.IncrementStateTreeCacheHits();
             }
             else
             {
-                if (preBlockCache.TryGetValue(in addressAsKey, out Account? account))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
-                    baseScope.HintGet(address, account);
-                    Metrics.IncrementStateTreeCacheHits();
-                }
-                else
-                {
-                    account = GetFromBaseTree(in addressAsKey);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
-                }
-                return account;
+                account = GetFromBaseTree(in addressAsKey);
+                // Backfill so other readers reuse this resolve.
+                preBlockCache.Set(in addressAsKey, account);
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
             }
+            return account;
         }
 
         public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
@@ -193,15 +187,15 @@ public class PrewarmerScopeProvider(
         IWorldStateScopeProvider.IStorageTree baseStorageTree,
         SeqlockCache<StorageCell, byte[]> preBlockCache,
         Address address,
-        bool populatePreBlockCache) : IWorldStateScopeProvider.IStorageTree
+        bool isPrewarmer) : IWorldStateScopeProvider.IStorageTree
     {
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree = baseStorageTree;
         private readonly SeqlockCache<StorageCell, byte[]> preBlockCache = preBlockCache;
         private readonly Address address = address;
-        private readonly bool populatePreBlockCache = populatePreBlockCache;
+        private readonly bool isPrewarmer = isPrewarmer;
         private readonly IMetricObserver _metricObserver = Db.Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Db.Metrics.DetailedMetricsEnabled;
-        private readonly PrewarmerGetTimeLabels _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+        private readonly PrewarmerGetTimeLabels _labels = isPrewarmer ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
 
         public Hash256 RootHash => baseStorageTree.RootHash;
 
@@ -209,35 +203,19 @@ public class PrewarmerScopeProvider(
         {
             StorageCell storageCell = new(address, in index); // TODO: Make the dictionary use UInt256 directly
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (populatePreBlockCache)
+            if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
             {
-                if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    Db.Metrics.IncrementStorageTreeCache();
-                }
-                else
-                {
-                    value = LoadFromTreeStorage(in storageCell);
-                    preBlockCache.Set(in storageCell, value);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
-                }
-                return value;
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
+                Db.Metrics.IncrementStorageTreeCache();
             }
             else
             {
-                if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
-                {
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                    Db.Metrics.IncrementStorageTreeCache();
-                }
-                else
-                {
-                    value = LoadFromTreeStorage(in storageCell);
-                    if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
-                }
-                return value;
+                value = LoadFromTreeStorage(in storageCell);
+                // Backfill so other readers reuse this resolve.
+                preBlockCache.Set(in storageCell, value);
+                if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetMiss);
             }
+            return value;
         }
 
         public void HintSet(in UInt256 index, byte[]? value) => baseStorageTree.HintSet(in index, value);
@@ -256,9 +234,9 @@ public class PrewarmerScopeProvider(
             baseStorageTree.Get(in hash);
     }
 
-    private class WriteBatchLifetimeMeasurer(IWorldStateScopeProvider.IWorldStateWriteBatch baseWriteBatch, IMetricObserver metricObserver, long startTime, bool populatePreBlockCache) : IWorldStateScopeProvider.IWorldStateWriteBatch
+    private class WriteBatchLifetimeMeasurer(IWorldStateScopeProvider.IWorldStateWriteBatch baseWriteBatch, IMetricObserver metricObserver, long startTime, bool isPrewarmer) : IWorldStateScopeProvider.IWorldStateWriteBatch
     {
-        private readonly PrewarmerGetTimeLabels _labels = populatePreBlockCache ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
+        private readonly PrewarmerGetTimeLabels _labels = isPrewarmer ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -45,6 +45,11 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     // Scratch buffer for intra-tx SLOAD on the parallel path (see GetInternal). Per-worker —
     // the returned span is consumed by the EVM stack push before another GetInternal runs.
     private readonly byte[] _scratchStorage = new byte[32];
+    // Single-slot cache for the last storage cell read: a repeated same-cell SLOAD skips the BAL
+    // read-recording. Reset in Clear() and Restore() (a revert can un-record the cell's slot).
+    private StorageCell _lastReadStorageCell;
+    private AccountChangesAtIndex? _lastReadStorageChanges;
+    private bool _hasLastReadCell;
     public BlockAccessListAtIndex? GetGeneratingBlockAccessList() => _generatingBlockAccessList;
     public void SetGeneratingBlockAccessList(BlockAccessListAtIndex? bal) => _generatingBlockAccessList = bal;
 
@@ -90,8 +95,20 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     public ReadOnlySpan<byte> Get(in StorageCell storageCell)
     {
-        _generatingBlockAccessList.AddStorageRead(storageCell);
-        return GetInternal(storageCell);
+        AccountChangesAtIndex accountChanges;
+        if (_hasLastReadCell && _lastReadStorageCell.Equals(storageCell))
+        {
+            // Already recorded this exact cell; reuse its entry and skip the read-recording.
+            accountChanges = _lastReadStorageChanges!;
+        }
+        else
+        {
+            accountChanges = _generatingBlockAccessList.RecordStorageReadAndGet(storageCell.Address, storageCell.Index);
+            _lastReadStorageCell = storageCell;
+            _lastReadStorageChanges = accountChanges;
+            _hasLastReadCell = true;
+        }
+        return GetInternal(accountChanges, in storageCell);
     }
 
     public ReadOnlySpan<byte> GetOriginal(in StorageCell storageCell)
@@ -127,8 +144,7 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     public ref readonly UInt256 GetBalance(Address address)
     {
-        AddAccountRead(address);
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
+        AccountChangesAtIndex? accountChanges = RecordReadAndGetChanges(address);
         if (accountChanges?.BalanceChange is { } bc)
         {
             _scratchBalance = bc.Value;
@@ -145,8 +161,7 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     public ref readonly ValueHash256 GetCodeHash(Address address)
     {
-        AddAccountRead(address);
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
+        AccountChangesAtIndex? accountChanges = RecordReadAndGetChanges(address);
         if (accountChanges?.CodeChange is { } cc)
         {
             _scratchCodeHash = cc.CodeHash;
@@ -218,6 +233,17 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         }
     }
 
+    /// <summary>Records the account read (honoring SystemUser suppression) and returns its change entry in one probe.</summary>
+    private AccountChangesAtIndex? RecordReadAndGetChanges(Address address)
+    {
+        // Suppressed SystemUser reads must not be recorded: use a non-mutating lookup.
+        if (_systemAccountReadSuppressionDepth != 0 && address == Address.SystemUser)
+        {
+            return _generatingBlockAccessList.GetAccountChanges(address);
+        }
+        return _generatingBlockAccessList.RecordReadAndGet(address);
+    }
+
     public void SetIndex(uint index)
         => _generatingBlockAccessList.Index = index;
 
@@ -228,12 +254,15 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     {
         _generatingBlockAccessList.Clear();
         _systemAccountReadSuppressionDepth = 0;
+        _hasLastReadCell = false;
     }
 
     BlockAccessListAtIndex? IBlockAccessListSource.GeneratedBlockAccessList => _generatingBlockAccessList;
 
     public void Restore(Snapshot snapshot)
     {
+        // A revert can un-record the last cell's slot, so drop the single-slot cache.
+        _hasLastReadCell = false;
         _generatingBlockAccessList.Restore(snapshot.BlockAccessListSnapshot);
         _innerWorldState.Restore(snapshot);
     }
@@ -355,19 +384,18 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         => GetCodeHashCurrent(address, out ValueHash256? hash) ? hash.Value : _innerWorldState.GetCodeHash(address);
 
     private ReadOnlySpan<byte> GetInternal(in StorageCell storageCell)
+        => GetInternal(parallel ? _generatingBlockAccessList.GetAccountChanges(storageCell.Address) : null, in storageCell);
+
+    private ReadOnlySpan<byte> GetInternal(AccountChangesAtIndex? accountChanges, in StorageCell storageCell)
     {
-        if (parallel)
+        if (parallel && accountChanges is not null && accountChanges.TryGetStorageChange(storageCell.Index, out StorageChange? change))
         {
-            AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(storageCell.Address);
-            if (accountChanges is not null && accountChanges.TryGetStorageChange(storageCell.Index, out StorageChange? change))
-            {
-                // Copy the BE word into _scratchStorage so the returned span outlives this
-                // frame without allocating a new byte[32] per SLOAD.
-                EvmWord value = change.Value.Value;
-                MemoryMarshal.CreateReadOnlySpan(
-                    ref Unsafe.As<EvmWord, byte>(ref value), 32).CopyTo(_scratchStorage);
-                return _scratchStorage;
-            }
+            // Copy the BE word into _scratchStorage so the returned span outlives this
+            // frame without allocating a new byte[32] per SLOAD.
+            EvmWord value = change.Value.Value;
+            MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<EvmWord, byte>(ref value), 32).CopyTo(_scratchStorage);
+            return _scratchStorage;
         }
 
         return _innerWorldState.Get(storageCell);

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -235,14 +235,10 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     /// <summary>Records the account read (honoring SystemUser suppression) and returns its change entry in one probe.</summary>
     private AccountChangesAtIndex? RecordReadAndGetChanges(Address address)
-    {
         // Suppressed SystemUser reads must not be recorded: use a non-mutating lookup.
-        if (_systemAccountReadSuppressionDepth != 0 && address == Address.SystemUser)
-        {
-            return _generatingBlockAccessList.GetAccountChanges(address);
-        }
-        return _generatingBlockAccessList.RecordReadAndGet(address);
-    }
+        => _systemAccountReadSuppressionDepth != 0 && address == Address.SystemUser
+            ? _generatingBlockAccessList.GetAccountChanges(address)
+            : _generatingBlockAccessList.RecordReadAndGet(address);
 
     public void SetIndex(uint index)
         => _generatingBlockAccessList.Index = index;
@@ -390,13 +386,12 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     private ReadOnlySpan<byte> GetInternal(AccountChangesAtIndex? accountChanges, in StorageCell storageCell)
     {
-        if (parallel && accountChanges is not null && accountChanges.TryGetStorageChange(storageCell.Index, out StorageChange? change))
+        if (parallel && accountChanges?.TryGetStorageChange(storageCell.Index, out StorageChange? change) == true)
         {
             // Copy the BE word into _scratchStorage so the returned span outlives this
             // frame without allocating a new byte[32] per SLOAD.
             EvmWord value = change.Value.Value;
-            MemoryMarshal.CreateReadOnlySpan(
-                ref Unsafe.As<EvmWord, byte>(ref value), 32).CopyTo(_scratchStorage);
+            MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<EvmWord, byte>(ref value), 32).CopyTo(_scratchStorage);
             return _scratchStorage;
         }
 

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -388,10 +388,9 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     {
         if (parallel && accountChanges?.TryGetStorageChange(storageCell.Index, out StorageChange? change) == true)
         {
-            // Copy the BE word into _scratchStorage so the returned span outlives this
+            // Store the 32-byte word straight into _scratchStorage; the returned span outlives this
             // frame without allocating a new byte[32] per SLOAD.
-            EvmWord value = change.Value.Value;
-            MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<EvmWord, byte>(ref value), 32).CopyTo(_scratchStorage);
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(_scratchStorage), change.Value.Value);
             return _scratchStorage;
         }
 

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -255,6 +255,7 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
         _generatingBlockAccessList.Clear();
         _systemAccountReadSuppressionDepth = 0;
         _hasLastReadCell = false;
+        _lastReadStorageChanges = null;
     }
 
     BlockAccessListAtIndex? IBlockAccessListSource.GeneratedBlockAccessList => _generatingBlockAccessList;
@@ -263,6 +264,7 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
     {
         // A revert can un-record the last cell's slot, so drop the single-slot cache.
         _hasLastReadCell = false;
+        _lastReadStorageChanges = null;
         _generatingBlockAccessList.Restore(snapshot.BlockAccessListSnapshot);
         _innerWorldState.Restore(snapshot);
     }


### PR DESCRIPTION
## Changes

- Account reads:
  - Collapse the double generating-BAL probe in GetBalance/GetCodeHash into one suppression-aware RecordReadAndGet
  - Single-slot last-read account cache in BlockAccessListAtIndex; read-only GetAccountChanges reuses it
  - Reorder the EIP-2929 account-access check so the warm path skips IsPrecompile
- Storage reads:
  - Collapse the SLOAD double-probe via RecordStorageReadAndGet (one account resolution) and add a last-cell short-circuit, invalidated on Clear/Restore
- PrewarmerScopeProvider: always backfill the shared cache on a consumer miss; rename populatePreBlockCache -> isPrewarmer
- BAL dictionaries keyed by AddressAsKey.
- Gas (EIP-2929) and serialized BAL output (EIP-7928) unchanged; verified by Eip7928/Eip2929 (316), Consensus BAL validation (83), and the State suites.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No - existing tests