### PR TITLE
rpc: zero hashes for absent eth_getProof accounts

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1545,6 +1545,23 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_get_proof_for_non_existent_account_returns_zero_hashes()
+    {
+        using Context ctx = await Context.Create();
+        string serialized = await ctx.Test.TestEthRpc("eth_getProof", "0x000000000000000000000000000000000000dead", "[]", "0x2");
+
+        JObject result = (JObject)JToken.Parse(serialized)["result"]!;
+        Assert.Multiple(() =>
+        {
+            Assert.That((string?)result["address"], Is.EqualTo("0x000000000000000000000000000000000000dead"));
+            Assert.That((string?)result["balance"], Is.EqualTo("0x0"));
+            Assert.That((string?)result["nonce"], Is.EqualTo("0x0"));
+            Assert.That((string?)result["codeHash"], Is.EqualTo(Hash256.Zero.ToString()));
+            Assert.That((string?)result["storageHash"], Is.EqualTo(Hash256.Zero.ToString()));
+        });
+    }
+
+    [Test]
     public async Task Eth_get_block_by_number_empty_param()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -405,8 +405,28 @@ namespace Nethermind.Store.Test.Proofs
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Balance, Is.EqualTo((UInt256)0));
             Assert.That(proof.Nonce, Is.EqualTo(UInt256.Zero));
-            Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
-            Assert.That(proof.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+            Assert.That(proof.CodeHash, Is.EqualTo(Hash256.Zero));
+            Assert.That(proof.StorageRoot, Is.EqualTo(Hash256.Zero));
+        }
+
+        [Test]
+        public void Existing_empty_account_keeps_canonical_empty_hashes()
+        {
+            StateTree tree = new();
+            tree.Set(TestItem.AddressA, Account.TotallyEmpty);
+            tree.Commit();
+
+            AccountProofCollector accountProofCollector = new(TestItem.AddressA);
+            tree.Accept(accountProofCollector, tree.RootHash);
+            AccountProof proof = accountProofCollector.BuildResult();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(proof.Balance, Is.EqualTo(UInt256.Zero));
+                Assert.That(proof.Nonce, Is.EqualTo(UInt256.Zero));
+                Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
+                Assert.That(proof.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -95,10 +95,8 @@ namespace Nethermind.Store.Test.Proofs
             tree.Accept(accountProofCollector, tree.RootHash);
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressA));
-            Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
-            Assert.That(proof.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
-            Assert.That(proof.CodeHash, Is.EqualTo(ValueKeccak.OfAnEmptyString));
-            Assert.That(proof.StorageRoot, Is.EqualTo(ValueKeccak.EmptyTreeHash));
+            Assert.That(proof.CodeHash, Is.EqualTo(Hash256.Zero));
+            Assert.That(proof.StorageRoot, Is.EqualTo(Hash256.Zero));
             Assert.That(proof.Balance, Is.EqualTo(UInt256.Zero));
             Assert.That(proof.StorageProofs?[0].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
             Assert.That(proof.StorageProofs?[1].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
@@ -121,8 +119,8 @@ namespace Nethermind.Store.Test.Proofs
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Proof, Has.Length.EqualTo(1));
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressC));
-            Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
-            Assert.That(proof.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+            Assert.That(proof.CodeHash, Is.EqualTo(Hash256.Zero));
+            Assert.That(proof.StorageRoot, Is.EqualTo(Hash256.Zero));
             Assert.That(proof.Balance, Is.EqualTo(UInt256.Zero));
             Assert.That(proof.StorageProofs?[0].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
             Assert.That(proof.StorageProofs?[1].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
@@ -143,8 +141,8 @@ namespace Nethermind.Store.Test.Proofs
             AccountProof proof = accountProofCollector.BuildResult();
             Assert.That(proof.Proof, Has.Length.EqualTo(1));
             Assert.That(proof.Address, Is.EqualTo(TestItem.AddressC));
-            Assert.That(proof.CodeHash, Is.EqualTo(Keccak.OfAnEmptyString));
-            Assert.That(proof.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+            Assert.That(proof.CodeHash, Is.EqualTo(Hash256.Zero));
+            Assert.That(proof.StorageRoot, Is.EqualTo(Hash256.Zero));
             Assert.That(proof.Balance, Is.EqualTo(UInt256.Zero));
             Assert.That(proof.StorageProofs?[0].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
             Assert.That(proof.StorageProofs?[1].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -23,6 +23,7 @@ namespace Nethermind.State.Proofs
     {
         private readonly Address _address = Address.Zero;
         private readonly AccountProof _accountProof;
+        private bool _accountExists;
 
         private readonly Nibble[] _fullAccountPath;
         private readonly Nibble[][] _fullStoragePaths;
@@ -91,6 +92,14 @@ namespace Nethermind.State.Proofs
 
         public AccountProof BuildResult()
         {
+            // EIP-1186 distinguishes a non-existent account from an empty existing account by
+            // returning zero hashes for the absent account case instead of the canonical empty hashes.
+            if (!_accountExists)
+            {
+                _accountProof.CodeHash = Hash256.Zero;
+                _accountProof.StorageRoot = Hash256.Zero;
+            }
+
             _accountProof.Proof = _accountProofItems.ToArray();
             for (int i = 0; i < _storageProofItems.Length; i++)
             {
@@ -156,6 +165,7 @@ namespace Nethermind.State.Proofs
             // ctx.Path here already includes the leaf's key (it's leafContext, not nodeContext).
             if (!IsFullPathMatch(_fullAccountPath, ctx.Path)) return;
 
+            _accountExists = true;
             _accountProof.Nonce = account.Nonce;
             _accountProof.Balance = account.Balance;
             _accountProof.StorageRoot = account.StorageRoot.ToCommitment();


### PR DESCRIPTION
Closes #11837

eth_getProof was still returning the canonical empty-account hashes for non-existent accounts.
That happened because AccountProof kept empty-account defaults and AccountProofCollector only overwrote them when the trie walk actually hit an account leaf.

This patch tracks whether the target account exists during proof collection and rewrites the absent-account result to zero hashes before returning it.
It stays local to the eth_getProof proof path and keeps the existing empty-account path returning the canonical empty hashes.

Tests:
- AccountProofCollectorTests -> 26 passed
- EthRpcModuleTests.Eth_get_proof* + ProofConverterTests -> 7 passed