### PR TITLE
fix(test runner): robustness fix for fuzzing

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
@@ -32,7 +32,7 @@ namespace Ethereum.Test.Base
 {
     public abstract class GeneralStateTestBase
     {
-        private static ILogger _logger;
+        protected static ILogger _logger;
         private static ILogManager _logManager = new TestLogManager(LogLevel.Warn);
         private static readonly UInt256 _defaultBaseFeeForStateTest = 0xA;
 

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,7 +95,15 @@ namespace Nethermind.Test.Runner
                     StateTestTxTrace txTrace = txTracer.BuildResult();
                     txTrace.Result.Time = result.TimeInMs;
                     txTrace.State.StateRoot = result.StateRoot;
-                    txTrace.Result.GasUsed -= IntrinsicGasCalculator.Calculate(test.Transaction, test.Fork).Standard;
+
+                    try
+                    {
+                        txTrace.Result.GasUsed -= IntrinsicGasCalculator.Calculate(test.Transaction, test.Fork).Standard;
+                    }
+                    catch (InvalidDataException e)
+                    {
+                        _logger.Info($"Skipping intrinsic-gas trace adjustment for {test.Name}: {e.Message}");
+                    }
                     WriteErr(txTrace);
                 }
 


### PR DESCRIPTION
during fuzzing i noticed that currently, the state-test runner crashes with an unhandled `InvalidDataException` when run with tracing on a transaction whose features aren't enabled by the test's fork (e.g. an authorization list before its activation fork), even though the transaction was already correctly rejected during execution. the cause is a trace-only line that recomputes intrinsic gas purely to decorate the reported `GasUsed`, where `IntrinsicGasCalculator.Calculate` throws for such transactions. 

this PR guards that recompute so the runner logs and skips the adjustment instead of aborting, letting these negative tests report as failed with a proper state root

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No
