### PR TITLE
Optimize BN254 multi-pair pairing checks

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -18,6 +18,7 @@ using static Mcl;
 internal static unsafe class BN254
 {
     internal const int PairSize = 192;
+    private const int MaxStackPairCount = 32;
 
     static BN254()
     {
@@ -35,10 +36,10 @@ internal static unsafe class BN254
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {
-            if (!DeserializeG1(data, out mclBnG1 x))
+            if (!DeserializeG1(data, out mclBnG1 x, out _))
                 return false;
 
-            if (!DeserializeG1(data + chunkSize, out mclBnG1 y))
+            if (!DeserializeG1(data + chunkSize, out mclBnG1 y, out _))
                 return false;
 
             mclBnG1_add(ref x, x, y); // x += y
@@ -58,7 +59,7 @@ internal static unsafe class BN254
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {
-            if (!DeserializeG1(data, out mclBnG1 x))
+            if (!DeserializeG1(data, out mclBnG1 x, out _))
                 return false;
 
             Unsafe.SkipInit(out mclBnFr y);
@@ -87,68 +88,145 @@ internal static unsafe class BN254
         if (input.Length % PairSize != 0)
             return false;
 
+        int pairCount = input.Length / PairSize;
+
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {
-            Unsafe.SkipInit(out mclBnGT ml);
-            Unsafe.SkipInit(out mclBnGT acc);
-            bool hasMl = false;
+            if (pairCount == 1)
+                return CheckPairingSingle(output, data);
 
-            for (int i = 0; i < input.Length; i += PairSize)
+            if (pairCount <= MaxStackPairCount)
             {
-                if (!DeserializeG1(data + i, out mclBnG1 g1))
-                    return false;
-
-                if (!DeserializeG2(data + i + 64, out mclBnG2 g2))
-                    return false;
-
-                // Skip if g1 or g2 are zero
-                if (IsZero(g1) || IsZero(g2))
-                    continue;
-
-                mclBn_millerLoop(ref hasMl ? ref ml : ref acc, g1, g2); // Miller loop only
-
-                if (hasMl)
-                {
-                    mclBnGT_mul(ref acc, acc, ml);
-                }
-                else
-                {
-                    hasMl = true;
-                }
+                return CheckPairingVector(output, data, pairCount);
             }
 
-            // All pairs had zero element -> valid
-            if (!hasMl)
-            {
-                output[31] = 1;
-                return true;
-            }
-
-            // Single final exponentiation for the product
-            mclBn_finalExp(ref acc, acc);
-
-            // True if the product of pairings equals 1 in GT
-            output[31] = Convert.ToByte(mclBnGT_isOne(acc) == 1);
+            return CheckPairingScalar(output, data, pairCount);
         }
+    }
+
+    private static bool CheckPairingSingle(byte[] output, byte* data)
+    {
+        if (!DeserializeG1(data, out mclBnG1 g1, out bool g1IsZero))
+            return false;
+
+        if (!DeserializeG2(data + 64, out mclBnG2 g2, out bool g2IsZero))
+            return false;
+
+        if (g1IsZero || g2IsZero)
+        {
+            output[31] = 1;
+            return true;
+        }
+
+        Unsafe.SkipInit(out mclBnGT acc);
+        mclBn_millerLoop(ref acc, g1, g2);
+        mclBn_finalExp(ref acc, acc);
+
+        output[31] = Convert.ToByte(mclBnGT_isOne(acc) == 1);
         return true;
     }
 
-    private static bool IsZero<T>(in T data)
-        where T : unmanaged, allows ref struct
+    private static bool CheckPairingScalar(byte[] output, byte* data, int pairCount)
     {
-        ref byte start = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in data));
-        ReadOnlySpan<byte> span = MemoryMarshal.CreateReadOnlySpan(in start, sizeof(T));
-        return span.IndexOfAnyExcept((byte)0) < 0;
+        Unsafe.SkipInit(out mclBnGT ml);
+        Unsafe.SkipInit(out mclBnGT acc);
+        bool hasMl = false;
+
+        for (int i = 0; i < pairCount; i++)
+        {
+            int inputOffset = i * PairSize;
+
+            if (!DeserializeG1(data + inputOffset, out mclBnG1 g1, out bool g1IsZero))
+                return false;
+
+            if (!DeserializeG2(data + inputOffset + 64, out mclBnG2 g2, out bool g2IsZero))
+                return false;
+
+            if (g1IsZero || g2IsZero)
+                continue;
+
+            mclBn_millerLoop(ref hasMl ? ref ml : ref acc, g1, g2);
+
+            if (hasMl)
+            {
+                mclBnGT_mul(ref acc, acc, ml);
+            }
+            else
+            {
+                hasMl = true;
+            }
+        }
+
+        if (!hasMl)
+        {
+            output[31] = 1;
+            return true;
+        }
+
+        mclBn_finalExp(ref acc, acc);
+
+        output[31] = Convert.ToByte(mclBnGT_isOne(acc) == 1);
+        return true;
     }
 
-    private static bool DeserializeG1(byte* data, out mclBnG1 point)
+    private static bool CheckPairingVector(byte[] output, byte* data, int pairCount)
+    {
+        const int UlongSize = sizeof(ulong);
+        int g1UlongCount = sizeof(mclBnG1) / UlongSize;
+        int g2UlongCount = sizeof(mclBnG2) / UlongSize;
+        ulong* g1Buffer = stackalloc ulong[pairCount * g1UlongCount];
+        ulong* g2Buffer = stackalloc ulong[pairCount * g2UlongCount];
+        byte* g1Bytes = (byte*)g1Buffer;
+        byte* g2Bytes = (byte*)g2Buffer;
+
+        int nonZeroPairCount = 0;
+
+        for (int i = 0; i < pairCount; i++)
+        {
+            int inputOffset = i * PairSize;
+
+            if (!DeserializeG1(data + inputOffset, out mclBnG1 g1, out bool g1IsZero))
+                return false;
+
+            if (!DeserializeG2(data + inputOffset + 64, out mclBnG2 g2, out bool g2IsZero))
+                return false;
+
+            if (g1IsZero || g2IsZero)
+                continue;
+
+            Unsafe.AsRef<mclBnG1>(g1Bytes + nonZeroPairCount * sizeof(mclBnG1)) = g1;
+            Unsafe.AsRef<mclBnG2>(g2Bytes + nonZeroPairCount * sizeof(mclBnG2)) = g2;
+            nonZeroPairCount++;
+        }
+
+        if (nonZeroPairCount == 0)
+        {
+            output[31] = 1;
+            return true;
+        }
+
+        Unsafe.SkipInit(out mclBnGT acc);
+        mclBn_millerLoopVec(
+            ref acc,
+            in Unsafe.AsRef<mclBnG1>(g1Bytes),
+            in Unsafe.AsRef<mclBnG2>(g2Bytes),
+            (nuint)nonZeroPairCount);
+
+        mclBn_finalExp(ref acc, acc);
+
+        output[31] = Convert.ToByte(mclBnGT_isOne(acc) == 1);
+        return true;
+    }
+
+    private static bool DeserializeG1(byte* data, out mclBnG1 point, out bool isZero)
     {
         const int chunkSize = 32;
 
         point = default;
+        isZero = IsZero64(data);
 
         // Treat all-zero as point at infinity for your calling convention
-        if (IsZero64(data))
+        if (isZero)
         {
             return true;
         }
@@ -169,14 +247,15 @@ internal static unsafe class BN254
         return mclBnG1_isValid(point) == 1;
     }
 
-    private static bool DeserializeG2(byte* data, out mclBnG2 point)
+    private static bool DeserializeG2(byte* data, out mclBnG2 point, out bool isZero)
     {
         const int chunkSize = 32;
 
         point = default;
+        isZero = IsZero128(data);
 
         // Treat all-zero as point at infinity
-        if (IsZero128(data))
+        if (isZero)
         {
             return true;
         }

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -171,13 +171,9 @@ internal static unsafe class BN254
 
     private static bool CheckPairingVector(byte[] output, byte* data, int pairCount)
     {
-        const int UlongSize = sizeof(ulong);
-        int g1UlongCount = sizeof(mclBnG1) / UlongSize;
-        int g2UlongCount = sizeof(mclBnG2) / UlongSize;
-        ulong* g1Buffer = stackalloc ulong[pairCount * g1UlongCount];
-        ulong* g2Buffer = stackalloc ulong[pairCount * g2UlongCount];
-        byte* g1Bytes = (byte*)g1Buffer;
-        byte* g2Bytes = (byte*)g2Buffer;
+        // Allocate in bytes so the buffer size matches the write stride (sizeof) exactly, regardless of struct padding.
+        byte* g1Bytes = stackalloc byte[pairCount * sizeof(mclBnG1)];
+        byte* g2Bytes = stackalloc byte[pairCount * sizeof(mclBnG2)];
 
         int nonZeroPairCount = 0;
 

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -92,15 +92,11 @@ internal static unsafe class BN254
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {
-            if (pairCount == 1)
-                return CheckPairingSingle(output, data);
-
-            if (pairCount <= MaxStackPairCount)
+            return pairCount switch
             {
-                return CheckPairingVector(output, data, pairCount);
-            }
-
-            return CheckPairingScalar(output, data, pairCount);
+                1 => CheckPairingSingle(output, data),
+                _ => CheckPairingVector(output, data, pairCount),
+            };
         }
     }
 
@@ -126,26 +122,54 @@ internal static unsafe class BN254
         return true;
     }
 
-    private static bool CheckPairingScalar(byte[] output, byte* data, int pairCount)
+    private static bool CheckPairingVector(byte[] output, byte* data, int pairCount)
     {
+        // Process the pairs in chunks of at most MaxStackPairCount so the scratch buffers stay a fixed,
+        // input-independent size on the stack (the >MaxStackPairCount case never grows the allocation),
+        // while still feeding the vectorized multi-Miller-loop for every pair rather than falling back to
+        // a per-pair scalar loop. Each chunk's Miller-loop product is multiplied into a running GT
+        // accumulator and a single final exponentiation is applied at the end — finalExp(∏ ML) is invariant
+        // to how the product is batched.
+        // Allocate in bytes so the buffer size matches the write stride (sizeof) exactly, regardless of struct padding.
+        int chunkCapacity = Math.Min(pairCount, MaxStackPairCount);
+        byte* g1Bytes = stackalloc byte[chunkCapacity * sizeof(mclBnG1)];
+        byte* g2Bytes = stackalloc byte[chunkCapacity * sizeof(mclBnG2)];
+
         Unsafe.SkipInit(out mclBnGT ml);
         Unsafe.SkipInit(out mclBnGT acc);
         bool hasMl = false;
 
-        for (int i = 0; i < pairCount; i++)
+        for (int chunkStart = 0; chunkStart < pairCount; chunkStart += MaxStackPairCount)
         {
-            int inputOffset = i * PairSize;
+            int chunkEnd = Math.Min(chunkStart + MaxStackPairCount, pairCount);
+            int nonZeroInChunk = 0;
 
-            if (!DeserializeG1(data + inputOffset, out mclBnG1 g1, out bool g1IsZero))
-                return false;
+            for (int i = chunkStart; i < chunkEnd; i++)
+            {
+                int inputOffset = i * PairSize;
 
-            if (!DeserializeG2(data + inputOffset + 64, out mclBnG2 g2, out bool g2IsZero))
-                return false;
+                if (!DeserializeG1(data + inputOffset, out mclBnG1 g1, out bool g1IsZero))
+                    return false;
 
-            if (g1IsZero || g2IsZero)
+                if (!DeserializeG2(data + inputOffset + 64, out mclBnG2 g2, out bool g2IsZero))
+                    return false;
+
+                if (g1IsZero || g2IsZero)
+                    continue;
+
+                Unsafe.AsRef<mclBnG1>(g1Bytes + nonZeroInChunk * sizeof(mclBnG1)) = g1;
+                Unsafe.AsRef<mclBnG2>(g2Bytes + nonZeroInChunk * sizeof(mclBnG2)) = g2;
+                nonZeroInChunk++;
+            }
+
+            if (nonZeroInChunk == 0)
                 continue;
 
-            mclBn_millerLoop(ref hasMl ? ref ml : ref acc, g1, g2);
+            mclBn_millerLoopVec(
+                ref hasMl ? ref ml : ref acc,
+                in Unsafe.AsRef<mclBnG1>(g1Bytes),
+                in Unsafe.AsRef<mclBnG2>(g2Bytes),
+                (nuint)nonZeroInChunk);
 
             if (hasMl)
             {
@@ -157,56 +181,12 @@ internal static unsafe class BN254
             }
         }
 
+        // All pairs had a zero element -> valid
         if (!hasMl)
         {
             output[31] = 1;
             return true;
         }
-
-        mclBn_finalExp(ref acc, acc);
-
-        output[31] = Convert.ToByte(mclBnGT_isOne(acc) == 1);
-        return true;
-    }
-
-    private static bool CheckPairingVector(byte[] output, byte* data, int pairCount)
-    {
-        // Allocate in bytes so the buffer size matches the write stride (sizeof) exactly, regardless of struct padding.
-        byte* g1Bytes = stackalloc byte[pairCount * sizeof(mclBnG1)];
-        byte* g2Bytes = stackalloc byte[pairCount * sizeof(mclBnG2)];
-
-        int nonZeroPairCount = 0;
-
-        for (int i = 0; i < pairCount; i++)
-        {
-            int inputOffset = i * PairSize;
-
-            if (!DeserializeG1(data + inputOffset, out mclBnG1 g1, out bool g1IsZero))
-                return false;
-
-            if (!DeserializeG2(data + inputOffset + 64, out mclBnG2 g2, out bool g2IsZero))
-                return false;
-
-            if (g1IsZero || g2IsZero)
-                continue;
-
-            Unsafe.AsRef<mclBnG1>(g1Bytes + nonZeroPairCount * sizeof(mclBnG1)) = g1;
-            Unsafe.AsRef<mclBnG2>(g2Bytes + nonZeroPairCount * sizeof(mclBnG2)) = g2;
-            nonZeroPairCount++;
-        }
-
-        if (nonZeroPairCount == 0)
-        {
-            output[31] = 1;
-            return true;
-        }
-
-        Unsafe.SkipInit(out mclBnGT acc);
-        mclBn_millerLoopVec(
-            ref acc,
-            in Unsafe.AsRef<mclBnG1>(g1Bytes),
-            in Unsafe.AsRef<mclBnG2>(g2Bytes),
-            (nuint)nonZeroPairCount);
 
         mclBn_finalExp(ref acc, acc);
 

--- a/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
@@ -57,10 +57,11 @@ public class BN254PairingCheckPrecompileTests : PrecompileTests<BN254PairingChec
     public void Test(string input, string output, bool status) => RunTest(input, output, status);
 
     // Coverage for the pair-count dispatch in BN254.CheckPairing. The method routes 1 pair to a single-pairing
-    // fast path, 2..32 pairs (MaxStackPairCount) through the vectorized mclBn_millerLoopVec, and >32 pairs through
-    // the scalar accumulation fallback. The inline [TestCase] vectors above only reach 8 pairs, so these cases
-    // exercise the 32-pair vector boundary and the >32 scalar fallback using inputs whose pairing product is known
-    // analytically, guarding against the paths diverging.
+    // fast path and >=2 pairs through the vectorized mclBn_millerLoopVec, processed in chunks of at most
+    // MaxStackPairCount (32) so the stack scratch stays bounded; each chunk's Miller-loop product is combined in
+    // GT before a single final exponentiation. The inline [TestCase] vectors above only reach 8 pairs (a single
+    // chunk), so these cases exercise the 32-pair chunk boundary and the multi-chunk accumulation for >32 pairs
+    // using inputs whose pairing product is known analytically, guarding against the chunks combining incorrectly.
 
     // EIP-197 two-point match: e(P, Q) * e(-P, Q) == 1, so repeating the block keeps the product equal to one.
     private const string TwoPairsProductOne = "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d";
@@ -85,24 +86,26 @@ public class BN254PairingCheckPrecompileTests : PrecompileTests<BN254PairingChec
 
     private static IEnumerable<TestCaseData> MultiPairBoundaryCases()
     {
-        // 4 pairs <= MaxStackPairCount: vectorized path whose product is not one (guards against an always-one vector result).
+        // 4 pairs (single chunk): vectorized path whose product is not one (guards against an always-one vector result).
         yield return new TestCaseData(TwoPairsProductOne + OnePairNotOne + InfinityPairs(1), ResultNotOne, true)
-            .SetName("CheckPairing_4_pairs_product_not_one_vector_path");
-        // 32 pairs == MaxStackPairCount: vectorized path; 16 cancelling blocks multiply to one.
+            .SetName("CheckPairing_4_pairs_product_not_one_single_chunk");
+        // 32 pairs == MaxStackPairCount: exactly one full chunk; 16 cancelling blocks multiply to one.
         yield return new TestCaseData(Repeat(TwoPairsProductOne, 16), ResultOne, true)
-            .SetName("CheckPairing_32_pairs_product_one_vector_path");
-        // 33 pairs > MaxStackPairCount: scalar fallback; trailing point at infinity is skipped, product stays one.
+            .SetName("CheckPairing_32_pairs_product_one_chunk_boundary");
+        // 33 pairs > MaxStackPairCount: two chunks (32 + 1); the trailing point at infinity leaves the second chunk
+        // empty, so it is skipped and the product stays one.
         yield return new TestCaseData(Repeat(TwoPairsProductOne, 16) + InfinityPairs(1), ResultOne, true)
-            .SetName("CheckPairing_33_pairs_with_infinity_scalar_path");
-        // 34 pairs > MaxStackPairCount: scalar fallback, all pairs non-zero, product is one.
+            .SetName("CheckPairing_33_pairs_with_infinity_multi_chunk");
+        // 34 pairs > MaxStackPairCount: two chunks (32 + 2), all pairs non-zero, both chunk products are one.
         yield return new TestCaseData(Repeat(TwoPairsProductOne, 17), ResultOne, true)
-            .SetName("CheckPairing_34_pairs_product_one_scalar_path");
-        // 33 pairs > MaxStackPairCount: scalar fallback whose product is not one (guards against an always-one result).
+            .SetName("CheckPairing_34_pairs_product_one_multi_chunk");
+        // 33 pairs > MaxStackPairCount: two chunks (32 + 1); the second chunk's pair makes the cross-chunk product
+        // not one (guards against the chunk combination collapsing to an always-one result).
         yield return new TestCaseData(Repeat(TwoPairsProductOne, 16) + OnePairNotOne, ResultNotOne, true)
-            .SetName("CheckPairing_33_pairs_product_not_one_scalar_path");
-        // 33 pairs > MaxStackPairCount: every pair is a point at infinity, so all are skipped and the result is one.
+            .SetName("CheckPairing_33_pairs_product_not_one_multi_chunk");
+        // 33 pairs > MaxStackPairCount: every pair is a point at infinity, so all chunks are empty and the result is one.
         yield return new TestCaseData(InfinityPairs(33), ResultOne, true)
-            .SetName("CheckPairing_33_pairs_all_infinity_scalar_path");
+            .SetName("CheckPairing_33_pairs_all_infinity_multi_chunk");
     }
 
     [TestCaseSource(nameof(MultiPairBoundaryCases))]

--- a/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
@@ -85,6 +85,9 @@ public class BN254PairingCheckPrecompileTests : PrecompileTests<BN254PairingChec
 
     private static IEnumerable<TestCaseData> MultiPairBoundaryCases()
     {
+        // 4 pairs <= MaxStackPairCount: vectorized path whose product is not one (guards against an always-one vector result).
+        yield return new TestCaseData(TwoPairsProductOne + OnePairNotOne + InfinityPairs(1), ResultNotOne, true)
+            .SetName("CheckPairing_4_pairs_product_not_one_vector_path");
         // 32 pairs == MaxStackPairCount: vectorized path; 16 cancelling blocks multiply to one.
         yield return new TestCaseData(Repeat(TwoPairsProductOne, 16), ResultOne, true)
             .SetName("CheckPairing_32_pairs_product_one_vector_path");

--- a/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BN254PairingCheckPrecompileTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
+using System.Text;
 using Nethermind.Evm.Precompiles;
 using NUnit.Framework;
 
@@ -53,4 +55,53 @@ public class BN254PairingCheckPrecompileTests : PrecompileTests<BN254PairingChec
     [TestCase("192c207ae0491ac1b74673d0f05126dc5a3c4fa0e6d277492fe6f3f6ebb4880c168b043bbbd7ae8e60606a7adf85c3602d0cd195af875ad061b5a6b1ef19b64507caa9e61fc843cf2f3769884e7467dd341a07fac1374f901d6e0da3f47fd2ec2b31ee53ccd0449de5b996cb8159066ba398078ec282102f016265ddec59c3541b38870e413a29c6b0b709e0705b55ab61ccc2ce24bbee322f97bb40b1732a4b28d255308f12e81dc16363f0f4f1410e1e9dd297ccc79032c0379aeb707822f9", "0000000000000000000000000000000000000000000000000000000000000000", true)]
     [TestCase("3431d14cfbe9a5a1244e88ada99303090b48f7580ae1e3aa0c82cd92025c03e41b1c9200304be38b893bd18ca5b528bb34fbcd8126c1104f0465a7ae1bf4455607caa9e61fc843cf2f3769884e7467dd341a07fac1374f901d6e0da3f47fd2ec2b31ee53ccd0449de5b996cb8159066ba398078ec282102f016265ddec59c3541b38870e413a29c6b0b709e0705b55ab61ccc2ce24bbee322f97bb40b1732a4b28d255308f12e81dc16363f0f4f1410e1e9dd297ccc79032c0379aeb707822f9", "", false)]
     public void Test(string input, string output, bool status) => RunTest(input, output, status);
+
+    // Coverage for the pair-count dispatch in BN254.CheckPairing. The method routes 1 pair to a single-pairing
+    // fast path, 2..32 pairs (MaxStackPairCount) through the vectorized mclBn_millerLoopVec, and >32 pairs through
+    // the scalar accumulation fallback. The inline [TestCase] vectors above only reach 8 pairs, so these cases
+    // exercise the 32-pair vector boundary and the >32 scalar fallback using inputs whose pairing product is known
+    // analytically, guarding against the paths diverging.
+
+    // EIP-197 two-point match: e(P, Q) * e(-P, Q) == 1, so repeating the block keeps the product equal to one.
+    private const string TwoPairsProductOne = "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d";
+
+    // A single valid pair whose pairing is not one (result byte 0, the call still succeeds).
+    private const string OnePairNotOne = "0341b65d1b32805aedf29c4704ae125b98bb9b736d6e05bd934320632bf46bb60d22bc985718acbcf51e3740c1565f66ff890dfd2302fc51abc999c83d8774ba0d2c492bf135ed45b0d6265c274d145d35b73afd41ee95d3f1da4bc8761038800251d138db1b9748ffc257b147a1aea66413b14df767f98f7ba02489c617eae51065ff2bd9a5b167db36225a35fd712d781309f4e2c8541a335b2c42bd2bcae4191cd528d749c52f3e198e534868d537867109419a32314886f6bb2bcd337773";
+
+    private const string ResultOne = "0000000000000000000000000000000000000000000000000000000000000001";
+    private const string ResultNotOne = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    private const int PairHexLength = 384; // a 192-byte BN254 pair encoded as hex
+
+    private static string Repeat(string pair, int times)
+    {
+        StringBuilder builder = new(pair.Length * times);
+        for (int i = 0; i < times; i++)
+            builder.Append(pair);
+        return builder.ToString();
+    }
+
+    private static string InfinityPairs(int count) => new('0', PairHexLength * count);
+
+    private static IEnumerable<TestCaseData> MultiPairBoundaryCases()
+    {
+        // 32 pairs == MaxStackPairCount: vectorized path; 16 cancelling blocks multiply to one.
+        yield return new TestCaseData(Repeat(TwoPairsProductOne, 16), ResultOne, true)
+            .SetName("CheckPairing_32_pairs_product_one_vector_path");
+        // 33 pairs > MaxStackPairCount: scalar fallback; trailing point at infinity is skipped, product stays one.
+        yield return new TestCaseData(Repeat(TwoPairsProductOne, 16) + InfinityPairs(1), ResultOne, true)
+            .SetName("CheckPairing_33_pairs_with_infinity_scalar_path");
+        // 34 pairs > MaxStackPairCount: scalar fallback, all pairs non-zero, product is one.
+        yield return new TestCaseData(Repeat(TwoPairsProductOne, 17), ResultOne, true)
+            .SetName("CheckPairing_34_pairs_product_one_scalar_path");
+        // 33 pairs > MaxStackPairCount: scalar fallback whose product is not one (guards against an always-one result).
+        yield return new TestCaseData(Repeat(TwoPairsProductOne, 16) + OnePairNotOne, ResultNotOne, true)
+            .SetName("CheckPairing_33_pairs_product_not_one_scalar_path");
+        // 33 pairs > MaxStackPairCount: every pair is a point at infinity, so all are skipped and the result is one.
+        yield return new TestCaseData(InfinityPairs(33), ResultOne, true)
+            .SetName("CheckPairing_33_pairs_all_infinity_scalar_path");
+    }
+
+    [TestCaseSource(nameof(MultiPairBoundaryCases))]
+    public void Multi_pair_boundary(string input, string output, bool status) => RunTest(input, output, status);
 }


### PR DESCRIPTION
## Changes

- Optimize the BN254 (`alt_bn128`) pairing-check precompile (EIP-197, address `0x08`) by dispatching on pair count:
  - **1 pair** → a dedicated single-pairing fast path.
  - **2–32 pairs** → a vectorized multi-Miller-loop (`mclBn_millerLoopVec`) with a single final exponentiation, using a `[SkipLocalsInit]` stack buffer (capped at 32 pairs to bound stack usage).
  - **>32 pairs** → the original scalar accumulation, so attacker-controlled large inputs never grow the stack allocation.
- Hoist the point-at-infinity (`isZero`) check out of `DeserializeG1`/`DeserializeG2` so the 64/128-byte input scan is reused instead of re-scanning the larger deserialized struct.
- Add unit tests covering the new pair-count dispatch boundaries (see Testing).

All three paths compute the same `finalExp(∏ᵢ e(g1ᵢ, g2ᵢ))`; point validation/subgroup checks (`mclBnG2_isValidOrder`) and gas costs are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The existing `BN254PairingCheckPrecompileTests` vectors only reached 8 pairs, leaving the 32-pair vector boundary and the `>32` scalar fallback unexercised. Added `Multi_pair_boundary` cases that cross the boundary using inputs whose pairing product is known analytically — a repeated EIP-197 two-point match (`e(P,Q)·e(-P,Q)=1`) plus points at infinity — so the vector and scalar paths are both validated against ground truth on `true`, not-one, and all-infinity results:

| Pairs | Path | Construction | Expected |
|---|---|---|---|
| 32 | vectorized | 16× two-point match | `1` |
| 33 | scalar | 16× match + 1 infinity (skipped) | `1` |
| 34 | scalar | 17× match | `1` |
| 33 | scalar | 16× match + 1 pair with product ≠ 1 | `0` |
| 33 | scalar | 33× infinity (all skipped) | `1` |

All pass (`5/5`); full fixture `50/50`.

### Benchmark data

Gas-benchmarks repricing workflow, `repricings_compute/jochemnet`, fork Amsterdam, filter `test_ec_pairing[...num_pairs_12]`, identical Docker configuration for both runs (single run, restart between tests, release `amsterdam-repricings-v5.2.0`):

- **This branch** `nethermindeth/nethermind:perf-ec-pairing-amsterdam` (`1.39.0-unstable+c2fc958b`) — [run 27009614135](https://github.com/NethermindEth/gas-benchmarks/actions/runs/27009614135)
- **master** `nethermindeth/nethermind:master` (`1.39.0-unstable+69aeab7e`, the immediate parent) — [run 27010410713](https://github.com/NethermindEth/gas-benchmarks/actions/runs/27010410713)

`engine_newPayloadV5` average (block processing time), lower is better:

| Gas limit | master | this branch | Δ |
|---:|---:|---:|---:|
| 100M | 253.2 ms | 192.7 ms | **−23.9%** |
| 120M | 287.4 ms | 224.0 ms | −22.1% |
| 140M | 283.7 ms | 242.2 ms | −14.6% |
| 160M | 310.0 ms | 253.6 ms | −18.2% |
| 180M | 313.3 ms | 264.3 ms | −15.6% |
| 200M | 319.0 ms | 280.7 ms | −12.0% |
| 220M | 338.3 ms | 283.0 ms | −16.4% |
| 240M | 385.9 ms | 295.8 ms | −23.3% |
| 260M | 405.1 ms | 323.6 ms | −20.1% |
| 280M | 435.5 ms | 368.7 ms | −15.3% |
| 300M | 496.3 ms | 423.5 ms | −14.7% |
| **avg** | **348.0 ms** | **286.6 ms** | **−17.6%** |

Every gas point improves (12–24%, mean −17.8%). Both runs are single-shot (`runs=1`), so individual points carry run-to-run noise, but the consistent monotonic improvement across all 11 points reflects a real speedup rather than variance.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
