### PR TITLE
perf(evm): cache repeated ECRecover/precompile results and fast-path static precompile calls + BAL replay

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -684,8 +684,9 @@ public class BlockProcessorTests
     public void PrepareForProcessing_keeps_parallel_bal_execution_for_validated_eip8037_blocks(int txCount) =>
         WithScopedAmsterdamBalManager(balManager => AssertParallelBalExecutionEnabled(balManager, txCount));
 
-    [Test]
-    public void Bal_transaction_processors_use_shared_precompile_cache()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Bal_transaction_processors_use_shared_precompile_cache(bool cachePrecompilesOnBlockProcessing)
     {
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         PreBlockCaches preBlockCaches = new();
@@ -721,7 +722,7 @@ public class BlockProcessorTests
             new TestSingleReleaseSpecProvider(Amsterdam.Instance),
             Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
-            new BlocksConfig { ParallelExecution = false, CachePrecompilesOnBlockProcessing = true },
+            new BlocksConfig { ParallelExecution = false, CachePrecompilesOnBlockProcessing = cachePrecompilesOnBlockProcessing },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
             preBlockCaches: preBlockCaches);
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -102,6 +102,30 @@ public class BlockProcessorTests
     }
 
     [Test]
+    public void ApplyStateChanges_applies_account_changes_without_storage_changes()
+    {
+        ReadOnlyBlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressA)
+                .WithBalanceChanges(new BalanceChange(0, 175))
+                .WithNonceChanges(new NonceChange(0, 4))
+                .TestObject)
+            .TestObject;
+
+        ApplyStateChangesInParentScope(
+            bal,
+            genesisSetup: stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            assertState: stateProvider =>
+            {
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo((UInt256)175));
+                    Assert.That(stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo((UInt256)4));
+                }
+            });
+    }
+
+    [Test]
     public void Parallel_validation_parent_reader_scope_is_per_worker_and_disposed_on_return()
     {
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -41,7 +41,9 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Evm;
 using Nethermind.Core.Threading;
+using Nethermind.Crypto;
 using Nethermind.Evm.Tracing;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
 
 namespace Nethermind.Blockchain.Test;
@@ -657,6 +659,71 @@ public class BlockProcessorTests
     [TestCase(2)]
     public void PrepareForProcessing_keeps_parallel_bal_execution_for_validated_eip8037_blocks(int txCount) =>
         WithScopedAmsterdamBalManager(balManager => AssertParallelBalExecutionEnabled(balManager, txCount));
+
+    [Test]
+    public void Bal_transaction_processors_use_shared_precompile_cache()
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        PreBlockCaches preBlockCaches = new();
+        Address contractAddress = TestItem.AddressC;
+        byte[] code = Prepare.EvmCode
+            .StaticCall(ECRecoverPrecompile.Address, 50_000)
+            .Op(Instruction.POP)
+            .StaticCall(ECRecoverPrecompile.Address, 50_000)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        Hash256 parentStateRoot;
+        using (stateProvider.BeginScope(IWorldState.PreGenesis))
+        {
+            stateProvider.CreateAccount(TestItem.PrivateKeyA.Address, 1.Ether);
+            stateProvider.CreateAccount(contractAddress, UInt256.Zero);
+            stateProvider.InsertCode(contractAddress, ValueKeccak.Compute(code), code, Amsterdam.Instance);
+            stateProvider.Commit(Amsterdam.Instance);
+            stateProvider.CommitTree(0);
+            parentStateRoot = stateProvider.StateRoot;
+        }
+
+        BlockHeader parentHeader = Build.A.BlockHeader
+            .WithNumber(0)
+            .WithHash(TestItem.KeccakA)
+            .WithStateRoot(parentStateRoot)
+            .TestObject;
+
+        using IDisposable scope = stateProvider.BeginScope(parentHeader);
+        using BlockAccessListManager balManager = new(
+            stateProvider,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            Substitute.For<IBlockhashProvider>(),
+            LimboLogs.Instance,
+            new BlocksConfig { ParallelExecution = false, CachePrecompilesOnBlockProcessing = true },
+            new WithdrawalProcessorFactory(LimboLogs.Instance),
+            preBlockCaches: preBlockCaches);
+
+        EthereumEcdsa ecdsa = new(MainnetSpecProvider.Instance.ChainId);
+        Transaction tx = Build.A.Transaction
+            .WithTo(contractAddress)
+            .WithGasLimit(200_000)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyA, true)
+            .TestObject;
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithParentHash(TestItem.KeccakA)
+            .WithGasLimit(1_000_000)
+            .WithTransactions(tx)
+            .WithBlockAccessList(new ReadOnlyBlockAccessList())
+            .TestObject;
+
+        PrepareSetup(balManager, block, Amsterdam.Instance);
+        TransactionResult result = balManager.GetTxProcessor().Execute(tx, NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+            Assert.That(preBlockCaches.PrecompileCache, Has.Count.EqualTo(1));
+        }
+    }
 
     [Test]
     public void PrepareForProcessing_disables_parallel_bal_execution_when_state_provider_is_not_scoped()

--- a/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
@@ -163,6 +163,44 @@ public class PrecompileCachedCodeInfoRepositoryTests
     }
 
     [Test]
+    public void CachedPrecompile_DoesNotUseStaleThreadCache_WhenInputBufferMutates()
+    {
+        int runCount = 0;
+        TestPrecompile cachingPrecompile = new(supportsCaching: true, onRun: () => runCount++);
+        Address precompileAddress = Address.FromNumber(100);
+
+        FrozenDictionary<AddressAsKey, CodeInfo> precompiles = new Dictionary<AddressAsKey, CodeInfo>
+        {
+            [precompileAddress] = new(cachingPrecompile)
+        }.ToFrozenDictionary();
+
+        IPrecompileProvider precompileProvider = Substitute.For<IPrecompileProvider>();
+        precompileProvider.GetPrecompiles().Returns(precompiles);
+
+        ICodeInfoRepository baseRepository = Substitute.For<ICodeInfoRepository>();
+        ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>> cache = new();
+
+        IReleaseSpec spec = CreateSpecWithPrecompile(precompileAddress);
+
+        PrecompileCachedCodeInfoRepository repository = new(Substitute.For<IWorldState>(), precompileProvider, baseRepository, cache);
+        CodeInfo codeInfo = repository.GetCachedCodeInfo(precompileAddress, false, spec, out _);
+
+        byte[] input = [1, 2, 3];
+
+        Result<byte[]> result1 = codeInfo.Precompile!.Run(input, Prague.Instance);
+        input[0] = 9;
+        Result<byte[]> result2 = codeInfo.Precompile.Run(input, Prague.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(runCount, Is.EqualTo(2));
+            Assert.That(cache.Count, Is.EqualTo(2));
+            Assert.That(result1.Data, Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(result2.Data, Is.EqualTo(new byte[] { 9, 2, 3 }));
+        }
+    }
+
+    [Test]
     public void NonCachingPrecompile_DoesNotCacheResults()
     {
         // Arrange

--- a/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
@@ -66,6 +67,10 @@ public class PrecompileCachedCodeInfoRepository(
         IPrecompile precompile,
         ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>> cache) : IPrecompile
     {
+        [ThreadStatic] private static CachedPrecompile? t_lastPrecompile;
+        [ThreadStatic] private static byte[]? t_lastInput;
+        [ThreadStatic] private static Result<byte[]> t_lastResult;
+
         public long BaseGasCost(IReleaseSpec releaseSpec) => precompile.BaseGasCost(releaseSpec);
 
         public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => precompile.DataGasCost(inputData, releaseSpec);
@@ -73,8 +78,13 @@ public class PrecompileCachedCodeInfoRepository(
         public Result<byte[]> Run(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec)
         {
             ReadOnlyMemory<byte> effectiveInput = precompile.NormalizeInput(inputData);
+            if (TryGetThreadCachedResult(effectiveInput.Span, out Result<byte[]> result))
+            {
+                return result;
+            }
+
             PreBlockCaches.PrecompileCacheKey key = new(address, effectiveInput);
-            if (!cache.TryGetValue(key, out Result<byte[]> result))
+            if (!cache.TryGetValue(key, out result))
             {
                 result = precompile.Run(inputData, releaseSpec);
 
@@ -85,11 +95,48 @@ public class PrecompileCachedCodeInfoRepository(
 
                 // we need to rebuild the key with data copy as the data can be changed by VM processing
                 // effective-input bounds are expected to remain the same
-                key = new(address, effectiveInput.ToArray());
+                byte[] copiedInput = effectiveInput.ToArray();
+                key = new(address, copiedInput);
                 cache.TryAdd(key, result);
+                CacheThreadResult(copiedInput, result);
+                return result;
             }
 
+            CacheThreadResult(effectiveInput.Span, result);
             return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryGetThreadCachedResult(ReadOnlySpan<byte> effectiveInput, out Result<byte[]> result)
+        {
+            byte[]? lastInput = t_lastInput;
+            if (ReferenceEquals(t_lastPrecompile, this)
+                && lastInput is not null
+                && effectiveInput.SequenceEqual(lastInput))
+            {
+                result = t_lastResult;
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        private void CacheThreadResult(ReadOnlySpan<byte> effectiveInput, Result<byte[]> result)
+        {
+            byte[]? lastInput = t_lastInput;
+            if (lastInput is null || lastInput.Length != effectiveInput.Length)
+            {
+                lastInput = effectiveInput.ToArray();
+                t_lastInput = lastInput;
+            }
+            else
+            {
+                effectiveInput.CopyTo(lastInput);
+            }
+
+            t_lastPrecompile = this;
+            t_lastResult = result;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -34,9 +34,21 @@ public partial class BlockAccessListManager
     /// </remarks>
     public static void ApplyStateChanges(ReadOnlyBlockAccessList suggestedBlockAccessList, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
     {
-        using IDisposable? triePrewarmSuppression = HasStorageChanges(suggestedBlockAccessList)
+        bool hasStorageOrCodeChanges = HasStorageOrCodeChanges(suggestedBlockAccessList);
+        using IDisposable? triePrewarmSuppression = hasStorageOrCodeChanges
             ? null
             : stateProvider.BeginTriePrewarmSuppression();
+
+        if (!hasStorageOrCodeChanges && stateProvider.TryApplyBlockAccessListAccountChanges(suggestedBlockAccessList))
+        {
+            stateProvider.Commit(spec);
+            if (shouldComputeStateRoot)
+            {
+                stateProvider.RecalculateStateRoot();
+            }
+
+            return;
+        }
 
         foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
         {
@@ -87,11 +99,11 @@ public partial class BlockAccessListManager
         }
     }
 
-    private static bool HasStorageChanges(ReadOnlyBlockAccessList suggestedBlockAccessList)
+    private static bool HasStorageOrCodeChanges(ReadOnlyBlockAccessList suggestedBlockAccessList)
     {
         foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
         {
-            if (accountChanges.StorageChanges.Length > 0)
+            if (accountChanges.StorageChanges.Length > 0 || accountChanges.CodeChanges.Length > 0)
             {
                 return true;
             }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -34,6 +34,10 @@ public partial class BlockAccessListManager
     /// </remarks>
     public static void ApplyStateChanges(ReadOnlyBlockAccessList suggestedBlockAccessList, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
     {
+        using IDisposable? triePrewarmSuppression = HasStorageChanges(suggestedBlockAccessList)
+            ? null
+            : stateProvider.BeginTriePrewarmSuppression();
+
         foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
         {
             if (accountChanges.BalanceChanges.Length > 0)
@@ -81,6 +85,19 @@ public partial class BlockAccessListManager
         {
             stateProvider.RecalculateStateRoot();
         }
+    }
+
+    private static bool HasStorageChanges(ReadOnlyBlockAccessList suggestedBlockAccessList)
+    {
+        foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
+        {
+            if (accountChanges.StorageChanges.Length > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void SetBlockAccessList(Block block)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -85,6 +85,7 @@ public partial class BlockAccessListManager
         private readonly IWorldState _stateProvider;
         private readonly ILogManager _logManager;
         private readonly ObjectPool<IReadOnlyTxProcessorSource>? _parentReaderEnvPool;
+        private readonly ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>>? _precompileCache;
         private int _processorCount;
 
         public ParallelTxProcessorWithWorldStateManager(
@@ -94,6 +95,7 @@ public partial class BlockAccessListManager
             ILogManager logManager,
             PrewarmerEnvFactory? prewarmerEnvFactory,
             PreBlockCaches? preBlockCaches,
+            ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>>? precompileCache,
             IReadOnlyTxProcessingEnvFactory? readOnlyTxProcessingEnvFactory)
         {
             _blockHashProvider = blockHashProvider;
@@ -101,6 +103,7 @@ public partial class BlockAccessListManager
             _stateProvider = stateProvider;
             _logManager = logManager;
             _parentReaderEnvPool = CreateParentReaderEnvPool(prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory);
+            _precompileCache = precompileCache;
             for (int i = 0; i < ProcessorPoolSize; i++)
             {
                 _processors.Enqueue(NewProcessor());
@@ -223,7 +226,7 @@ public partial class BlockAccessListManager
             => (int)uint.Min(balIndex, (uint)_lastBalIndex);
 
         private TxProcessorWithWorldState NewProcessor()
-            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager);
+            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager, _precompileCache);
 
         private TxProcessorWithWorldState RentProcessor()
         {
@@ -329,9 +332,10 @@ public partial class BlockAccessListManager
             IBlockhashProvider blockHashProvider,
             ISpecProvider specProvider,
             IWorldState stateProvider,
-            ILogManager logManager)
+            ILogManager logManager,
+            ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>>? precompileCache)
         {
-            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager);
+            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager, precompileCache);
             _txProcessorWithWorldState.WorldState.SetGeneratingBlockAccessList(new());
         }
 
@@ -361,6 +365,8 @@ public partial class BlockAccessListManager
 
     private class TxProcessorWithWorldState
     {
+        private static readonly IPrecompileProvider PrecompileProvider = new EthereumPrecompileProvider();
+
         public readonly TracedAccessWorldState WorldState;
         public readonly TransactionProcessor<EthereumGasPolicy> TxProcessor;
         public readonly ExecuteTransactionProcessorAdapter TxProcessorAdapter;
@@ -372,7 +378,8 @@ public partial class BlockAccessListManager
             IBlockhashProvider blockHashProvider,
             ISpecProvider specProvider,
             IWorldState stateProvider,
-            ILogManager logManager)
+            ILogManager logManager,
+            ConcurrentDictionary<PreBlockCaches.PrecompileCacheKey, Result<byte[]>>? precompileCache)
         {
 
             VirtualMachine virtualMachine = new(blockHashProvider, specProvider, logManager);
@@ -383,7 +390,11 @@ public partial class BlockAccessListManager
                 worldState = _balWorldState;
             }
             WorldState = new TracedAccessWorldState(worldState, parallel);
-            EthereumCodeInfoRepository codeInfoRepository = new(WorldState);
+            ICodeInfoRepository codeInfoRepository = new EthereumCodeInfoRepository(WorldState);
+            if (precompileCache is not null)
+            {
+                codeInfoRepository = new PrecompileCachedCodeInfoRepository(WorldState, PrecompileProvider, codeInfoRepository, precompileCache);
+            }
             TxProcessor = new(BlobBaseFeeCalculator.Instance, specProvider, WorldState, virtualMachine, codeInfoRepository, logManager, parallel);
             TxProcessorAdapter = new(TxProcessor);
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -58,7 +58,7 @@ public partial class BlockAccessListManager(
             logManager,
             prewarmerEnvFactory,
             preBlockCaches,
-            blocksConfig.CachePrecompilesOnBlockProcessing ? preBlockCaches?.PrecompileCache : null,
+            preBlockCaches?.PrecompileCache,
             readOnlyTxProcessingEnvFactory));
     private readonly Lazy<SequentialTxProcessorWithWorldStateManager> _sequentialTxProcessorWithWorldStateManager =
         new(() => new(
@@ -66,7 +66,7 @@ public partial class BlockAccessListManager(
             specProvider,
             stateProvider,
             logManager,
-            blocksConfig.CachePrecompilesOnBlockProcessing ? preBlockCaches?.PrecompileCache : null));
+            preBlockCaches?.PrecompileCache));
     private const int GasValidationChunkSize = 8;
     private long? _gasRemaining;
     private bool _isBuilding;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -51,9 +51,22 @@ public partial class BlockAccessListManager(
     private BlockExecutionContext? _blockExecutionContext;
     private ITxProcessorWithWorldStateManager? _txProcessorWithWorldStateManager;
     private readonly Lazy<ParallelTxProcessorWithWorldStateManager> _parallelTxProcessorWithWorldStateManager =
-        new(() => new(blockHashProvider, specProvider, stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory));
+        new(() => new(
+            blockHashProvider,
+            specProvider,
+            stateProvider,
+            logManager,
+            prewarmerEnvFactory,
+            preBlockCaches,
+            blocksConfig.CachePrecompilesOnBlockProcessing ? preBlockCaches?.PrecompileCache : null,
+            readOnlyTxProcessingEnvFactory));
     private readonly Lazy<SequentialTxProcessorWithWorldStateManager> _sequentialTxProcessorWithWorldStateManager =
-        new(() => new(blockHashProvider, specProvider, stateProvider, logManager));
+        new(() => new(
+            blockHashProvider,
+            specProvider,
+            stateProvider,
+            logManager,
+            blocksConfig.CachePrecompilesOnBlockProcessing ? preBlockCaches?.PrecompileCache : null));
     private const int GasValidationChunkSize = 8;
     private long? _gasRemaining;
     private bool _isBuilding;

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
@@ -28,7 +28,6 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 
     [ThreadStatic] private static byte[]? t_cachedInput;
     [ThreadStatic] private static Result<byte[]> t_cachedResult;
-    [ThreadStatic] private static bool t_hasCachedResult;
     private static CachedResult? s_cachedResult;
 
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0L;
@@ -119,8 +118,10 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 
     private static bool TryGetCachedResult(ReadOnlySpan<byte> inputData, out Result<byte[]> result)
     {
+        // A non-null t_cachedInput is the sentinel: it is only ever assigned by CacheThreadResult,
+        // which fills the buffer and t_cachedResult together, so the two are always in lockstep.
         byte[]? cachedInput = t_cachedInput;
-        if (t_hasCachedResult && cachedInput is not null && inputData.SequenceEqual(cachedInput))
+        if (cachedInput is not null && inputData.SequenceEqual(cachedInput))
         {
             result = t_cachedResult;
             return true;
@@ -149,7 +150,6 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
         byte[] cachedInput = t_cachedInput ??= new byte[InputLength];
         inputData.CopyTo(cachedInput);
         t_cachedResult = result;
-        t_hasCachedResult = true;
     }
 
     private sealed class CachedResult

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
@@ -25,6 +25,10 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 
     private const int InputLength = 128;
 
+    [ThreadStatic] private static byte[]? t_cachedInput;
+    [ThreadStatic] private static Result<byte[]> t_cachedResult;
+    [ThreadStatic] private static bool t_hasCachedResult;
+
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0L;
 
     public long BaseGasCost(IReleaseSpec releaseSpec) => 3000L;
@@ -45,7 +49,20 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 #if !ZK_EVM
         Metrics.ECRecoverPrecompile++;
 #endif
-        return inputData.Length >= 128 ? RunInternal(inputData.Span) : RunInternal(inputData);
+        if (inputData.Length >= InputLength)
+        {
+            ReadOnlySpan<byte> effectiveInput = inputData.Span[..InputLength];
+            if (TryGetCachedResult(effectiveInput, out Result<byte[]> cachedResult))
+            {
+                return cachedResult;
+            }
+
+            Result<byte[]> result = RunInternal(effectiveInput);
+            CacheResult(effectiveInput, result);
+            return result;
+        }
+
+        return RunInternal(inputData);
     }
 
     private Result<byte[]> RunInternal(ReadOnlyMemory<byte> inputData)
@@ -96,5 +113,26 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
         Unsafe.InitBlockUnaligned(ref resultRef, 0, 12);
 
         return result;
+    }
+
+    private static bool TryGetCachedResult(ReadOnlySpan<byte> inputData, out Result<byte[]> result)
+    {
+        byte[]? cachedInput = t_cachedInput;
+        if (t_hasCachedResult && cachedInput is not null && inputData.SequenceEqual(cachedInput))
+        {
+            result = t_cachedResult;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static void CacheResult(ReadOnlySpan<byte> inputData, Result<byte[]> result)
+    {
+        byte[] cachedInput = t_cachedInput ??= new byte[InputLength];
+        inputData.CopyTo(cachedInput);
+        t_cachedResult = result;
+        t_hasCachedResult = true;
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
@@ -9,6 +9,7 @@ using Nethermind.Crypto;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Nethermind.Evm.Precompiles;
 
@@ -28,6 +29,7 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
     [ThreadStatic] private static byte[]? t_cachedInput;
     [ThreadStatic] private static Result<byte[]> t_cachedResult;
     [ThreadStatic] private static bool t_hasCachedResult;
+    private static CachedResult? s_cachedResult;
 
     public long DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0L;
 
@@ -124,15 +126,55 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
             return true;
         }
 
+        CachedResult? cachedResult = Volatile.Read(ref s_cachedResult);
+        if (cachedResult is not null && cachedResult.Matches(inputData))
+        {
+            result = cachedResult.Result;
+            CacheThreadResult(inputData, result);
+            return true;
+        }
+
         result = default;
         return false;
     }
 
     private static void CacheResult(ReadOnlySpan<byte> inputData, Result<byte[]> result)
     {
+        Volatile.Write(ref s_cachedResult, new CachedResult(inputData, result));
+        CacheThreadResult(inputData, result);
+    }
+
+    private static void CacheThreadResult(ReadOnlySpan<byte> inputData, Result<byte[]> result)
+    {
         byte[] cachedInput = t_cachedInput ??= new byte[InputLength];
         inputData.CopyTo(cachedInput);
         t_cachedResult = result;
         t_hasCachedResult = true;
+    }
+
+    private sealed class CachedResult
+    {
+        private readonly ValueHash256 _message;
+        private readonly ValueHash256 _v;
+        private readonly ValueHash256 _r;
+        private readonly ValueHash256 _s;
+
+        public CachedResult(ReadOnlySpan<byte> inputData, Result<byte[]> result)
+        {
+            _message = new ValueHash256(inputData[..32]);
+            _v = new ValueHash256(inputData.Slice(32, 32));
+            _r = new ValueHash256(inputData.Slice(64, 32));
+            _s = new ValueHash256(inputData.Slice(96, 32));
+            Result = result;
+        }
+
+        public Result<byte[]> Result { get; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Matches(ReadOnlySpan<byte> inputData) =>
+            _message.Equals(new ValueHash256(inputData[..32])) &&
+            _v.Equals(new ValueHash256(inputData.Slice(32, 32))) &&
+            _r.Equals(new ValueHash256(inputData.Slice(64, 32))) &&
+            _s.Equals(new ValueHash256(inputData.Slice(96, 32)));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Core;
 using Nethermind.Evm.Precompiles;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -16,6 +19,24 @@ public class ECRecoverPrecompileTests : PrecompileTests<ECRecoverPrecompile, ECR
     [TestCase("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000001000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549", "", true)]
     [TestCase("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000001000000000000000000000011c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549", "", true)]
     public void Test(string input, string output, bool status) => RunTest(input, output, status);
+
+    [Test]
+    public void Repeated_effective_input_returns_cached_result()
+    {
+        byte[] input = Convert.FromHexString(
+            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+            "000000000000000000000000000000000000000000000000000000000000001b" +
+            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+            "789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02");
+        byte[] repeatedInput = (byte[])input.Clone();
+
+        Result<byte[]> first = ECRecoverPrecompile.Instance.Run(input, Prague.Instance);
+        Result<byte[]> second = ECRecoverPrecompile.Instance.Run(repeatedInput, Prague.Instance);
+
+        Assert.That(first.IsSuccess, Is.True);
+        Assert.That(second.IsSuccess, Is.True);
+        Assert.That(second.Data, Is.SameAs(first.Data));
+    }
 
     [TestCase(
         "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e000000000000000000000000000000000000000000000000000000000000001b38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02"

--- a/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Specs.Forks;
@@ -23,11 +24,7 @@ public class ECRecoverPrecompileTests : PrecompileTests<ECRecoverPrecompile, ECR
     [Test]
     public void Repeated_effective_input_returns_cached_result()
     {
-        byte[] input = Convert.FromHexString(
-            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
-            "000000000000000000000000000000000000000000000000000000000000001b" +
-            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
-            "789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02");
+        byte[] input = FirstValidInput();
         byte[] repeatedInput = (byte[])input.Clone();
 
         Result<byte[]> first = ECRecoverPrecompile.Instance.Run(input, Prague.Instance);
@@ -36,6 +33,27 @@ public class ECRecoverPrecompileTests : PrecompileTests<ECRecoverPrecompile, ECR
         Assert.That(first.IsSuccess, Is.True);
         Assert.That(second.IsSuccess, Is.True);
         Assert.That(second.Data, Is.SameAs(first.Data));
+    }
+
+    [Test]
+    public void Repeated_effective_input_returns_process_cached_result_across_threads()
+    {
+        byte[] currentThreadInput = FirstValidInput();
+        byte[] otherThreadInput = SecondValidInput();
+
+        Result<byte[]> currentThreadLocalResult = ECRecoverPrecompile.Instance.Run(currentThreadInput, Prague.Instance);
+        Result<byte[]> otherThreadResult = default;
+
+        Thread thread = new(() => otherThreadResult = ECRecoverPrecompile.Instance.Run(otherThreadInput, Prague.Instance));
+        thread.Start();
+        thread.Join();
+
+        Result<byte[]> result = ECRecoverPrecompile.Instance.Run(otherThreadInput, Prague.Instance);
+
+        Assert.That(currentThreadLocalResult.IsSuccess, Is.True);
+        Assert.That(otherThreadResult.IsSuccess, Is.True);
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Data, Is.SameAs(otherThreadResult.Data));
     }
 
     [TestCase(
@@ -60,4 +78,16 @@ public class ECRecoverPrecompileTests : PrecompileTests<ECRecoverPrecompile, ECR
         TestName = "oversized input clamped to 128 then trailing zeros trimmed"
     )]
     public void NormalizedInput_SameOutput(string input) => RunEffectiveInputTest(input);
+
+    private static byte[] FirstValidInput() => Convert.FromHexString(
+        "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+        "000000000000000000000000000000000000000000000000000000000000001b" +
+        "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+        "789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02");
+
+    private static byte[] SecondValidInput() => Convert.FromHexString(
+        "18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c" +
+        "000000000000000000000000000000000000000000000000000000000000001c" +
+        "73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f" +
+        "eeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549");
 }

--- a/src/Nethermind/Nethermind.Evm.Test/PrecompileStaticCallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/PrecompileStaticCallTests.cs
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
+using Nethermind.Specs;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -30,7 +33,7 @@ public class PrecompileStaticCallTests : VirtualMachineTestsBase
             .RETURN(64, 64)
             .Done;
 
-        ReceiptOnlyTracer tracer = Execute(new ReceiptOnlyTracer(), code);
+        ReceiptTracer tracer = Execute(new ReceiptTracer(traceActions: false), code);
 
         byte[] expected = new byte[64];
         input.CopyTo(expected, 0);
@@ -40,24 +43,76 @@ public class PrecompileStaticCallTests : VirtualMachineTestsBase
         Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
     }
 
-    private sealed class ReceiptOnlyTracer : TxTracer
+    // The direct precompile fast path (no action tracing) must reproduce the full call-frame path
+    // (action tracing forces it) bit for bit on both failure branches of ExecuteStaticPrecompileCallDirectly:
+    //   - OutOfGas: forwarded gas below the precompile base cost (UpdateGas fails).
+    //   - PrecompileFailure: precompile returns a non-OOG failure (Blake2F rejects a wrong-length input).
+    [TestCase(FailureBranch.OutOfGas)]
+    [TestCase(FailureBranch.PrecompileFailure)]
+    public void Fast_path_precompile_failure_matches_full_path(FailureBranch branch)
+    {
+        (Address precompile, UInt256 staticCallGas, UInt256 inputLength) = branch switch
+        {
+            // ECRECOVER base cost is 3000; forwarding 100 gas out-of-gases inside the child frame.
+            FailureBranch.OutOfGas => (ECRecoverPrecompile.Address, (UInt256)100, UInt256.Zero),
+            // BLAKE2F rejects any input whose length is not 213 with a non-OOG failure at zero data cost.
+            FailureBranch.PrecompileFailure => (Blake2FPrecompile.Address, (UInt256)50_000, (UInt256)32),
+            _ => throw new ArgumentOutOfRangeException(nameof(branch))
+        };
+
+        byte[] code = Prepare.EvmCode
+            .STATICCALL(staticCallGas, precompile, 0, inputLength, 0, 0)
+            .MSTORE(0)
+            .RETURN(0, 32)
+            .Done;
+
+        // Istanbul: STATICCALL and BLAKE2F both exist; EIP-8037 state gas is inactive.
+        ForkActivation activation = new(MainnetSpecProvider.IstanbulBlockNumber);
+
+        ReceiptTracer fastPath = Execute(new ReceiptTracer(traceActions: false), code, activation);
+        ReceiptTracer fullPath = Execute(new ReceiptTracer(traceActions: true), code, activation);
+
+        Assert.That(fastPath.StatusCode, Is.EqualTo(fullPath.StatusCode), "status code");
+        Assert.That(fastPath.ReturnValue, Is.EqualTo(fullPath.ReturnValue), "return value");
+        Assert.That(fastPath.GasSpent, Is.EqualTo(fullPath.GasSpent), "gas spent");
+
+        // The failed sub-call pushes 0; the outer frame stores and returns that 0 and succeeds.
+        Assert.That(fastPath.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(fastPath.ReturnValue, Is.EqualTo(new byte[32]));
+    }
+
+    public enum FailureBranch
+    {
+        OutOfGas,
+        PrecompileFailure
+    }
+
+    private sealed class ReceiptTracer(bool traceActions) : TxTracer
     {
         public override bool IsTracingReceipt => true;
+
+        // Toggling only action tracing selects the code path: true forces the full call frame,
+        // false enables the direct precompile fast path. Gas accounting is identical either way.
+        public override bool IsTracingActions => traceActions;
 
         public byte[] ReturnValue { get; private set; } = [];
 
         public byte StatusCode { get; private set; }
 
+        public long GasSpent { get; private set; }
+
         public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
         {
             ReturnValue = output;
             StatusCode = Evm.StatusCode.Success;
+            GasSpent = gasSpent.SpentGas;
         }
 
         public override void MarkAsFailed(Address recipient, in GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
         {
             ReturnValue = output ?? [];
             StatusCode = Evm.StatusCode.Failure;
+            GasSpent = gasSpent.SpentGas;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/PrecompileStaticCallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/PrecompileStaticCallTests.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+public class PrecompileStaticCallTests : VirtualMachineTestsBase
+{
+    [Test]
+    public void Staticcall_to_precompile_without_tracing_copies_output_and_sets_returndata()
+    {
+        byte[] input = new byte[32];
+        for (int i = 0; i < input.Length; i++)
+        {
+            input[i] = (byte)(i + 1);
+        }
+
+        byte[] code = Prepare.EvmCode
+            .MSTORE(0, input)
+            .STATICCALL(50_000, IdentityPrecompile.Address, 0, (UInt256)input.Length, 64, (UInt256)input.Length)
+            .RETURNDATASIZE()
+            .MSTORE(96)
+            .RETURN(64, 64)
+            .Done;
+
+        ReceiptOnlyTracer tracer = Execute(new ReceiptOnlyTracer(), code);
+
+        byte[] expected = new byte[64];
+        input.CopyTo(expected, 0);
+        expected[63] = 32;
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
+    }
+
+    private sealed class ReceiptOnlyTracer : TxTracer
+    {
+        public override bool IsTracingReceipt => true;
+
+        public byte[] ReturnValue { get; private set; } = [];
+
+        public byte StatusCode { get; private set; }
+
+        public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
+        {
+            ReturnValue = output;
+            StatusCode = Evm.StatusCode.Success;
+        }
+
+        public override void MarkAsFailed(Address recipient, in GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
+        {
+            ReturnValue = output ?? [];
+            StatusCode = Evm.StatusCode.Failure;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -276,7 +276,11 @@ public static partial class EvmInstructions
             codeInfo.IsPrecompile &&
             !TTracingInst.IsActive &&
             !vm.TxTracer.IsTracingActions &&
-            vm.CanExecutePrecompileCallDirectlyForOpcode(codeInfo.Precompile!))
+            vm.CanExecutePrecompileCallDirectlyForOpcode(codeInfo.Precompile!) &&
+            // EIP-161 parity touch-bug: RunPrecompile records a zero-value touch of the (possibly empty)
+            // RIPEMD-160 account so a halted call can still mark it for state-clearing deletion. The direct
+            // fast path omits that bookkeeping, so keep address 3 on the full-frame path where it can apply.
+            !vm.PrecompileCallNeedsParityTouchBugHandling(target, spec))
         {
             return ExecuteStaticPrecompileCallDirectly(
                 vm,
@@ -329,8 +333,10 @@ public static partial class EvmInstructions
 
             if (!success)
             {
-                TGasPolicy.SetOutOfGas(ref childGas);
-                TGasPolicy.RestoreChildStateGas(ref gas, in childGas);
+                // A precompile failure is an exceptional halt of the sub-call: the forwarded regular gas is
+                // burned and only the child's state reservoir returns to the parent. Mirror the full frame's
+                // PopAndRestoreParentState -> RestoreChildStateGasOnHalt (halt), not RestoreChildStateGas (revert).
+                TGasPolicy.RestoreChildStateGasOnHalt(ref gas, in childGas);
                 vm.ReturnDataBuffer = Array.Empty<byte>();
                 vm.ReturnData = null;
                 return stack.PushZero<TTracingInst>();

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
 using Nethermind.Evm.State;
 using static Nethermind.Evm.VirtualMachineStatics;
@@ -271,7 +272,88 @@ public static partial class EvmInstructions
             return EvmExceptionType.None;
         }
 
+        if (TOpCall.ExecutionType == ExecutionType.STATICCALL &&
+            codeInfo.IsPrecompile &&
+            !TTracingInst.IsActive &&
+            !vm.TxTracer.IsTracingActions &&
+            vm.CanExecutePrecompileCallDirectlyForOpcode(codeInfo.Precompile!))
+        {
+            return ExecuteStaticPrecompileCallDirectly(
+                vm,
+                ref stack,
+                ref gas,
+                in dataOffset,
+                dataLength,
+                in outputOffset,
+                outputLength,
+                codeInfo.Precompile!,
+                target,
+                gasLimitUl);
+        }
+
         return CreateFullCallFrame(vm, ref gas, in dataOffset, dataLength, outputOffset, outputLength, codeInfo, target, caller, codeSource, env, in callValue, gasLimitUl);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static EvmExceptionType ExecuteStaticPrecompileCallDirectly(
+            VirtualMachine<TGasPolicy> vm,
+            ref EvmStack stack,
+            ref TGasPolicy gas,
+            in UInt256 dataOffset,
+            UInt256 dataLength,
+            in UInt256 outputOffset,
+            UInt256 outputLength,
+            IPrecompile precompile,
+            Address target,
+            long gasLimitUl)
+        {
+            if (!vm.VmState.Memory.TryLoad(in dataOffset, dataLength, out ReadOnlyMemory<byte> callData))
+                return EvmExceptionType.OutOfGas;
+
+            TGasPolicy childGas = TGasPolicy.CreateChildFrameGas(ref gas, gasLimitUl);
+
+            IReleaseSpec spec = vm.Spec;
+            long baseGasCost = precompile.BaseGasCost(spec);
+            long dataGasCost = precompile.DataGasCost(callData, spec);
+            ulong precompileGasCost = (ulong)baseGasCost + (ulong)dataGasCost;
+
+            if (precompileGasCost > (ulong)long.MaxValue ||
+                !TGasPolicy.UpdateGas(ref childGas, (long)precompileGasCost))
+            {
+                TGasPolicy.RestoreChildStateGasOnHalt(ref gas, in childGas);
+                vm.ReturnDataBuffer = Array.Empty<byte>();
+                vm.ReturnData = null;
+                return stack.PushZero<TTracingInst>();
+            }
+
+            bool success = vm.TryRunPrecompileDirectly(precompile, callData, spec, out Result<byte[]> output) && output;
+
+            if (!success)
+            {
+                TGasPolicy.SetOutOfGas(ref childGas);
+                TGasPolicy.RestoreChildStateGas(ref gas, in childGas);
+                vm.ReturnDataBuffer = Array.Empty<byte>();
+                vm.ReturnData = null;
+                return stack.PushZero<TTracingInst>();
+            }
+
+            vm.WorldState.AddToBalanceAndCreateIfNotExists(target, UInt256.Zero, spec);
+
+            TGasPolicy.Refund(ref gas, in childGas);
+
+            ReadOnlyMemory<byte> outputData = output.Data;
+            vm.ReturnDataBuffer = outputData;
+
+            int copyLength = Math.Min(outputData.Length, (int)outputLength.ToLong());
+            if (copyLength > 0)
+            {
+                ZeroPaddedSpan callOutput = outputData.Span.SliceWithZeroPadding(0, copyLength);
+                if (!vm.VmState.Memory.TrySave(in outputOffset, in callOutput))
+                    return EvmExceptionType.OutOfGas;
+            }
+
+            vm.ReturnData = null;
+            return stack.PushBytes<TTracingInst>(StatusCode.SuccessBytes.Span);
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static EvmExceptionType CreateFullCallFrame(

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -149,6 +149,11 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     public IDisposable? BeginSystemAccountReadSuppression() => null;
 
+    /// <summary>
+    /// Temporarily suppresses asynchronous trie prewarm hints for state changes that will be committed immediately.
+    /// </summary>
+    public IDisposable? BeginTriePrewarmSuppression() => null;
+
     // See https://eips.ethereum.org/EIPS/eip-7610
     bool IsNonZeroAccount(Address address, out bool accountExists)
     {

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -154,6 +154,12 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     /// </summary>
     public IDisposable? BeginTriePrewarmSuppression() => null;
 
+    /// <summary>
+    /// Applies decoded BAL account balance and nonce changes through an implementation-specific fast path.
+    /// </summary>
+    /// <returns><c>true</c> when the implementation handled the BAL account changes; otherwise <c>false</c>.</returns>
+    public bool TryApplyBlockAccessListAccountChanges(ReadOnlyBlockAccessList blockAccessList) => false;
+
     // See https://eips.ethereum.org/EIPS/eip-7610
     bool IsNonZeroAccount(Address address, out bool accountExists)
     {

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -82,6 +82,11 @@ public interface IWorldStateScopeProvider
         /// <param name="sink">Optional sink that receives each account/slot value read during the pass.</param>
         /// <returns>A task that completes when the asynchronous warmup finishes.</returns>
         Task HintBal(ReadOnlyBlockAccessList bal, IAsyncBalReaderSink? sink = null);
+
+        /// <summary>
+        /// Temporarily suppresses asynchronous trie prewarm hints for state changes that will be committed immediately.
+        /// </summary>
+        IDisposable? BeginTriePrewarmSuppression() => null;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -863,6 +863,18 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     internal bool CanExecutePrecompileCallDirectlyForOpcode(IPrecompile precompile) =>
         CanExecutePrecompileCallDirectly(precompile);
 
+    /// <summary>
+    /// Whether a direct precompile call to <paramref name="target"/> must instead go through the full call
+    /// frame so the EIP-161 parity touch-bug handling in <see cref="RunPrecompile"/> is preserved.
+    /// </summary>
+    /// <remarks>
+    /// A zero-value (STATICCALL) touch of the empty RIPEMD-160 account must be able to mark it for
+    /// state-clearing deletion even when the call halts. The direct fast path does not track
+    /// <c>_parityTouchBugAccount</c>, so address 3 is excluded from it whenever the touch-bug can apply.
+    /// </remarks>
+    internal bool PrecompileCallNeedsParityTouchBugHandling(Address target, IReleaseSpec spec) =>
+        spec.ClearEmptyAccountWhenTouched && _parityTouchBugAccount.Address.Equals(target);
+
     protected virtual bool CanExecutePrecompileCallDirectly(IPrecompile precompile) => true;
 
     internal bool TryRunPrecompileDirectly(

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -860,6 +860,36 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         return default;
     }
 
+    internal bool CanExecutePrecompileCallDirectlyForOpcode(IPrecompile precompile) =>
+        CanExecutePrecompileCallDirectly(precompile);
+
+    protected virtual bool CanExecutePrecompileCallDirectly(IPrecompile precompile) => true;
+
+    internal bool TryRunPrecompileDirectly(
+        IPrecompile precompile,
+        ReadOnlyMemory<byte> callData,
+        IReleaseSpec spec,
+        out Result<byte[]> output)
+    {
+        try
+        {
+            output = precompile.Run(callData, spec);
+            return true;
+        }
+        catch (Exception exception) when (exception is DllNotFoundException or { InnerException: DllNotFoundException })
+        {
+            if (_logger.IsError) LogMissingDependency(precompile, exception as DllNotFoundException ?? exception.InnerException as DllNotFoundException);
+            Environment.Exit(ExitCodes.MissingPrecompile);
+            throw; // Unreachable
+        }
+        catch (Exception exception)
+        {
+            if (_logger.IsError) LogExecutionException(precompile, exception);
+            output = default;
+            return false;
+        }
+    }
+
     protected void TraceTransactionActionStart(VmState<TGasPolicy> currentState)
     {
         _txTracer.ReportAction(TGasPolicy.GetRemainingGas(currentState.Gas),

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -41,7 +41,7 @@ public class FlatWorldStateScopeProviderTests
         public Snapshot? LastCommittedSnapshot { get; set; }
         public TransientResource? LastCreatedCachedResource { get; set; }
 
-        public TestContext(FlatDbConfig? config = null)
+        public TestContext(FlatDbConfig? config = null, ITrieWarmer? trieWarmer = null)
         {
             config ??= new FlatDbConfig();
 
@@ -79,6 +79,11 @@ public class FlatWorldStateScopeProviderTests
                     .AddSingleton<IFlatDbConfig>(config)
                     .AddSingleton<IWorldStateScopeProvider.ICodeDb>(_ => new TrieStoreScopeProvider.KeyValueWithBatchingBackedCodeDb(new TestMemDb()))
                 ;
+
+            if (trieWarmer is not null)
+            {
+                _containerBuilder.AddSingleton<ITrieWarmer>(_ => trieWarmer);
+            }
 
             // Externally owned because snapshot bundle take ownership
             _containerBuilder.RegisterType<ReadOnlySnapshotBundle>()
@@ -133,6 +138,26 @@ public class FlatWorldStateScopeProviderTests
                 ResourcePool,
                 ResourcePool.Usage.MainBlockProcessing));
         }
+    }
+
+    [Test]
+    public void BeginTriePrewarmSuppression_DoesNotMarkAddressAsPrewarmed()
+    {
+        ITrieWarmer trieWarmer = Substitute.For<ITrieWarmer>();
+        using TestContext ctx = new(trieWarmer: trieWarmer);
+
+        FlatWorldStateScope scope = ctx.Scope;
+        Address address = TestItem.AddressA;
+        Account account = TestItem.GenerateRandomAccount();
+
+        using (scope.BeginTriePrewarmSuppression())
+        {
+            scope.HintGet(address, account);
+        }
+
+        scope.HintGet(address, account);
+
+        trieWarmer.Received(1).PushAddressJob(Arg.Any<ITrieWarmer.IAddressWarmer>(), address, Arg.Any<int>());
     }
 
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -93,7 +93,7 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
 
     private void WarmUpSlot(UInt256 index)
     {
-        if (_bundle.ShouldQueuePrewarm(_address, index))
+        if (!_scope.IsTriePrewarmSuppressed && _bundle.ShouldQueuePrewarm(_address, index))
         {
             if (_trieCacheWarmer.PushSlotJob(this, index, _scope.HintSequenceId))
                 _scope.IncrementOutstandingWarmups();
@@ -105,7 +105,7 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
     {
         try
         {
-            if (_scope.HintSequenceId != sequenceId || _scope._pausePrewarmer)
+            if (_scope.HintSequenceId != sequenceId || _scope.IsTriePrewarmSuppressed)
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -38,12 +38,13 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     private volatile int _hintSequenceId = 0;
     private int _outstandingWarmups = 0;
     private StateId _currentStateId;
-    internal volatile bool _pausePrewarmer = false;
+    private int _triePrewarmSuppressionDepth;
 
     private CancellationTokenSource? _hintBalCts;
     private Task? _hintBalTask;
 
     internal bool IsDisposed => Volatile.Read(ref _isDisposed);
+    internal bool IsTriePrewarmSuppressed => Volatile.Read(ref _triePrewarmSuppressionDepth) != 0;
 
     public FlatWorldStateScope(
         StateId currentStateId,
@@ -156,7 +157,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     public void HintGet(Address address, Account? account)
     {
         _snapshotBundle.SetAccount(address, account);
-        if (_snapshotBundle.ShouldQueuePrewarm(address))
+        if (!IsTriePrewarmSuppressed && _snapshotBundle.ShouldQueuePrewarm(address))
         {
             if (_warmer.PushAddressJob(this, address, _hintSequenceId))
                 Interlocked.Increment(ref _outstandingWarmups);
@@ -190,12 +191,13 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                 // deferred to phase 2 so one huge account doesn't bottleneck a single worker.
                 Parallel.For(0, accountCount, parallelOptions, (i) =>
                 {
-                    if (token.IsCancellationRequested || _hintSequenceId != snapshot || _pausePrewarmer) return;
+                    if (token.IsCancellationRequested || _hintSequenceId != snapshot || IsTriePrewarmSuppressed) return;
 
                     ReadOnlyAccountChanges ac = accountChanges[i];
                     Address address = ac.Address;
 
-                    if (_snapshotBundle.ShouldQueuePrewarm(address)
+                    if (!IsTriePrewarmSuppressed
+                        && _snapshotBundle.ShouldQueuePrewarm(address)
                         && _warmer.PushAddressJob(this, address, snapshot))
                         Interlocked.Increment(ref _outstandingWarmups);
 
@@ -228,7 +230,8 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                         foreach (ReadOnlySlotChanges slotChanges in storageChanges)
                         {
                             UInt256 key = slotChanges.Key;
-                            if (_snapshotBundle.ShouldQueuePrewarm(address, key)
+                            if (!IsTriePrewarmSuppressed
+                                && _snapshotBundle.ShouldQueuePrewarm(address, key)
                                 && _warmer.PushSlotJobMpmc(storageWarmer, key, snapshot))
                                 Interlocked.Increment(ref _outstandingWarmups);
                         }
@@ -284,7 +287,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
         Parallel.For(0, idx, parallelOptions, (j) =>
         {
-            if (_pausePrewarmer) return;
+            if (IsTriePrewarmSuppressed) return;
             (Address address, int selfDestructIdx, UInt256 slot) = jobs[j];
             ReadSlotToSink(sink, address, in slot, selfDestructIdx);
         });
@@ -306,7 +309,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     {
         try
         {
-            if (_hintSequenceId != sequenceId || _pausePrewarmer) return false;
+            if (_hintSequenceId != sequenceId || IsTriePrewarmSuppressed) return false;
 
             // Note: tree root not changed after writing batch. Also, not cleared. So the result is not correct.
             // this is just for warming up
@@ -351,9 +354,15 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         return new WriteBatch(this, estimatedAccountNum, _logManager.GetClassLogger<WriteBatch>());
     }
 
+    public IDisposable? BeginTriePrewarmSuppression()
+    {
+        Interlocked.Increment(ref _triePrewarmSuppressionDepth);
+        return new Reactive.AnonymousDisposable(() => Interlocked.Decrement(ref _triePrewarmSuppressionDepth));
+    }
+
     public void Commit(long blockNumber)
     {
-        _pausePrewarmer = true;
+        using IDisposable? triePrewarmSuppression = BeginTriePrewarmSuppression();
 
         // Storage tree commits already happened during WriteBatch.Dispose() via
         // StorageTreeBulkWriteBatch(commit: true). Only the state tree needs committing here.
@@ -379,7 +388,6 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         }
 
         _currentStateId = newStateId;
-        _pausePrewarmer = false;
     }
 
     // Largely same logic as the the one for TrieStoreScopeProvider, but more confusing when deduplicated.

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -97,6 +97,8 @@ public class BlockAccessListBasedWorldState(IWorldState innerWorldState, ILogMan
 
     public Task HintBal(ReadOnlyBlockAccessList bal) => _innerWorldState.HintBal(bal);
 
+    public IDisposable? BeginTriePrewarmSuppression() => _innerWorldState.BeginTriePrewarmSuppression();
+
     public ReadOnlySpan<byte> Get(in StorageCell storageCell)
     {
         (IWorldState parentReader, ReadOnlyAccountChanges accountChanges) = ResolveContext(storageCell.Address);

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -150,6 +150,8 @@ public class PrewarmerScopeProvider(
 
         public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
 
+        public IDisposable? BeginTriePrewarmSuppression() => baseScope.BeginTriePrewarmSuppression();
+
         public Task HintBal(ReadOnlyBlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink? sink = null)
         {
             sink ??= new CacheSink(preBlockCache, storageCache);

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -462,6 +463,45 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
         if (!AccountExists(address))
         {
             CreateAccount(address, balance, nonce);
+        }
+    }
+
+    public void ApplyBlockAccessListAccountChanges(ReadOnlyAccountChanges accountChanges)
+    {
+        bool hasBalanceChanges = accountChanges.BalanceChanges.Length > 0;
+        bool hasNonceChanges = accountChanges.NonceChanges.Length > 0;
+        if (!hasBalanceChanges && !hasNonceChanges)
+        {
+            return;
+        }
+
+        Address address = accountChanges.Address;
+        Account? account = GetThroughCache(address);
+        bool isNewAccount = account is null;
+        account ??= Account.TotallyEmpty;
+
+        UInt256 balance = account.Balance;
+        if (hasBalanceChanges)
+        {
+            balance = accountChanges.BalanceChanges[^1].Value;
+        }
+
+        UInt256 nonce = account.Nonce;
+        if (hasNonceChanges)
+        {
+            nonce = accountChanges.NonceChanges[^1].Value;
+        }
+
+        Account changedAccount = new(nonce, balance, account.StorageRoot, account.CodeHash);
+        if (isNewAccount)
+        {
+            _needsStateRootUpdate = true;
+            PushNew(address, changedAccount);
+        }
+        else if (hasNonceChanges || account.Balance != balance)
+        {
+            _needsStateRootUpdate = true;
+            PushUpdate(address, changedAccount);
         }
     }
 

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -93,6 +93,8 @@ public class TracedAccessWorldState(IWorldState innerWorldState, bool parallel) 
 
     public IDisposable? BeginSystemAccountReadSuppression() => new SystemAccountReadSuppressionScope(this);
 
+    public IDisposable? BeginTriePrewarmSuppression() => _innerWorldState.BeginTriePrewarmSuppression();
+
     public ReadOnlySpan<byte> Get(in StorageCell storageCell)
     {
         AccountChangesAtIndex accountChanges;

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -281,6 +281,17 @@ namespace Nethermind.State
             return _currentScope!.BeginTriePrewarmSuppression();
         }
 
+        public bool TryApplyBlockAccessListAccountChanges(ReadOnlyBlockAccessList blockAccessList)
+        {
+            GuardInScope();
+            foreach (ReadOnlyAccountChanges accountChanges in blockAccessList.AccountChanges)
+            {
+                _stateProvider.ApplyBlockAccessListAccountChanges(accountChanges);
+            }
+
+            return true;
+        }
+
         public ref readonly UInt256 GetBalance(Address address)
         {
             DebugGuardInScope();

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -275,6 +275,12 @@ namespace Nethermind.State
             return _currentScope!.HintBal(bal);
         }
 
+        public IDisposable? BeginTriePrewarmSuppression()
+        {
+            GuardInScope();
+            return _currentScope!.BeginTriePrewarmSuppression();
+        }
+
         public ref readonly UInt256 GetBalance(Address address)
         {
             DebugGuardInScope();

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
@@ -36,6 +36,8 @@ public class WorldStateMetricsScopeProvider(IWorldStateScopeProvider baseProvide
 
         public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
 
+        public IDisposable? BeginTriePrewarmSuppression() => baseScope.BeginTriePrewarmSuppression();
+
         public IWorldStateScopeProvider.ICodeDb CodeDb => baseScope.CodeDb;
 
         public IWorldStateScopeProvider.IStorageTree CreateStorageTree(Address address) => baseScope.CreateStorageTree(address);

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -53,6 +53,8 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
 
         public void HintGet(Address address, Account? account) => innerScope.HintGet(address, account);
 
+        public IDisposable? BeginTriePrewarmSuppression() => innerScope.BeginTriePrewarmSuppression();
+
         public Task HintBal(ReadOnlyBlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink? sink = null)
             => innerScope.HintBal(bal, sink);
 

--- a/src/Nethermind/Nethermind.Taiko/TaikoVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoVirtualMachine.cs
@@ -44,6 +44,9 @@ public class TaikoVirtualMachine<TGasPolicy>(
             : null;
     }
 
+    protected override bool CanExecutePrecompileCallDirectly(IPrecompile precompile) =>
+        precompile is not IContextAwarePrecompile;
+
     protected override CallResult ExecutePrecompileCall(
         VmState<TGasPolicy> state,
         IPrecompile precompile,


### PR DESCRIPTION
## Changes

Reduce CPU spent on repeated precompile work and on Block Access List (BAL) replay, with the biggest impact on signature-heavy blocks.

- **ECRecover result caching** ([`ECRecoverPrecompile`](src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs)) — adds a thread-static last-input/result cache plus a shared cross-thread `volatile` cache, keyed on the 128-byte input decomposed into four `ValueHash256` fields. Repeated identical signatures skip the secp256k1 recovery entirely. Threads can also reuse a recovery computed by another thread.
- **Direct static precompile execution** ([`EvmInstructions.Call`](src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs), [`VirtualMachine`](src/Nethermind/Nethermind.Evm/VirtualMachine.cs)) — a `STATICCALL` into a precompile is executed inline (gas charge → run → copy output) instead of constructing a full child call frame, when no tracing is active. Falls back to the full frame path for any unsupported case.
- **Per-thread precompile cache in BAL transaction processors** ([`PrecompileCachedCodeInfoRepository`](src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs)) — a thread-static last-hit cache sits in front of the shared `ConcurrentDictionary`, removing dictionary lookups/hashing for back-to-back identical inputs.
- **BAL no-storage replay fast path** ([`BlockAccessListManager.StateChanges`](src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs), [`StateProvider`](src/Nethermind/Nethermind.State/StateProvider.cs)) — when a block's BAL contains only balance/nonce changes (no storage or code), trie prewarm hints are suppressed (`BeginTriePrewarmSuppression`) and account changes are applied directly via `TryApplyBlockAccessListAccountChanges`, avoiding per-access trie prewarm overhead. New `IWorldState` members thread this through the scope-provider stack with no-op defaults.

## Benchmark results

`gas-benchmarks` repricing, `repricings_compute/jochemnet`, fork Amsterdam, release `amsterdam-repricings-v5.2.0`, `ecrecover` benchmark, full gas sweep. Baseline = master (`69aeab7e8a`, this branch's base) built with the same Dockerfile. Each point is `engine_newPayloadV5` processing time after one warmup, **averaged over two independent run pairs** (run-to-run noise was small — most points <5%, worst ~8%; the AVG reproduced at −24.5% in both passes). All payloads `VALID`, no exceptions on any run.

| Gas   | master (ms) | branch (ms) | Δ ms    | Δ %    | speedup |
|-------|-------------|-------------|---------|--------|---------|
| 100M  | 269.2       | 217.8       | −51.4   | −19.1% | 1.24×   |
| 120M  | 278.5       | 213.9       | −64.6   | −23.2% | 1.30×   |
| 140M  | 274.7       | 225.3       | −49.4   | −18.0% | 1.22×   |
| 160M  | 296.6       | 228.1       | −68.5   | −23.1% | 1.30×   |
| 180M  | 310.6       | 248.8       | −61.8   | −19.9% | 1.25×   |
| 200M  | 315.9       | 269.4       | −46.6   | −14.7% | 1.17×   |
| 220M  | 338.1       | 282.0       | −56.1   | −16.6% | 1.20×   |
| 240M  | 362.6       | 275.1       | −87.5   | −24.1% | 1.32×   |
| 260M  | 386.9       | 283.1       | −103.9  | −26.8% | 1.37×   |
| 280M  | 425.9       | 285.8       | −140.1  | −32.9% | 1.49×   |
| 300M  | 478.6       | 294.0       | −184.6  | −38.6% | 1.63×   |
| **AVG** | **339.8** | **256.7**   | **−83.1** | **−24.5%** | **1.32×** |

The win grows with block size (master scales +78% across the sweep vs. the branch's +35%), because per-call savings compound as more ECRECOVER calls fit in a block.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added unit tests:
- `ECRecoverPrecompileTests` — cached vs. uncached results match; thread-static and shared-cache paths.
- `PrecompileCachedCodeInfoRepositoryTests` — thread-cache hit returns the same result as the dictionary path.
- `PrecompileStaticCallTests` — direct static-precompile execution produces identical stack/memory/return-data and gas accounting to the full call-frame path.
- `BlockProcessorTests` — BAL no-storage replay fast path produces the correct post-state and state root.
- `FlatWorldStateScopeProviderTests` — trie-prewarm suppression plumbing.

Plus the EF/gas-benchmark results above.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
