### PR TITLE
fix: pass DOTNET_HOST_PATH to JsonRpc generator Exec

### DIFF
--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -52,7 +52,11 @@
       BuildInParallel="false"
       Condition="!Exists('$(_RpcJsonContextGeneratorPath)')" />
 
-    <Exec Command="dotnet &quot;$(_RpcJsonContextGeneratorPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
+    <PropertyGroup>
+      <_DotnetHost Condition="'$(_DotnetHost)' == '' and '$(DOTNET_HOST_PATH)' != ''">$(DOTNET_HOST_PATH)</_DotnetHost>
+      <_DotnetHost Condition="'$(_DotnetHost)' == ''">dotnet</_DotnetHost>
+    </PropertyGroup>
+    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;$(_RpcJsonContextGeneratorPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_RpcJsonContextSourcesFile)" />


### PR DESCRIPTION
## Summary

The JsonRpc source generator (`Nethermind.JsonRpc.SourceGenerator.Build`) is run from `src/Nethermind/Directory.Build.targets` via:

```xml
<Exec Command="dotnet &quot;$(_RpcJsonContextGeneratorPath)&quot; ..." />
```

When MSBuild's `<Exec>` spawns `cmd.exe` to run this, the child process inherits the parent's environment but the `dotnet` host directory is not always on `PATH`. This depends on how the parent build was launched — for example:

- CI matrix legs that install the .NET SDK to a non-PATH location.
- Visual Studio / IDE-launched MSBuild that doesn't push the SDK host onto child-process `PATH`.
- Standalone `MSBuild.exe` invocations outside a `dotnet build` wrapper.

In those environments, the `<Exec>` fails with `MSB3073` / exit code `9009` ("'dotnet' is not recognized as an internal or external command").

## Fix

Use `$(DOTNET_HOST_PATH)` — an MSBuild property the .NET SDK sets to the absolute path of the `dotnet` host that launched MSBuild — as the explicit executable, with a `dotnet` fallback for environments where it isn't set:

```xml
<PropertyGroup>
  <_DotnetHost Condition="'$(_DotnetHost)' == '' and '$(DOTNET_HOST_PATH)' != ''">$(DOTNET_HOST_PATH)</_DotnetHost>
  <_DotnetHost Condition="'$(_DotnetHost)' == ''">dotnet</_DotnetHost>
</PropertyGroup>
<Exec Command="&quot;$(_DotnetHost)&quot; &quot;$(_RpcJsonContextGeneratorPath)&quot; ..." />
```

This guarantees the child process uses the same `dotnet` host as the parent MSBuild instead of relying on `PATH` lookup.

## Origin

This change was originally part of commit `bcdd15cc22` on the `feature/block-stm-integration` branch (which also bundled an unrelated Block-STM config default change). Splitting it out so master-only contributors and CI legs benefit from the fix without having to wait for Block-STM to merge.

## Test plan

- [x] Local build: `dotnet build src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj -c release --nologo` succeeds (the generator `<Exec>` step still runs and produces the JSON context output file).
- [ ] CI build matrix succeeds on environments that previously failed with MSB3073 / 9009.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>