### PR TITLE
feat(sync): add Sync.StaticSnapPivot for fixed-pivot snap sync from a frozen peer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -62,7 +62,7 @@ public interface ISyncConfig : IConfig
     [ConfigItem(Description = "The max number of attempts to update the pivot block based on the FCU message from the consensus client. Set to `-1` to retry forever (recommended for nodes that may start before the consensus client is available).", DefaultValue = "-1")]
     int MaxAttemptsToUpdatePivot { get; set; }
 
-    [ConfigItem(Description = "Whether to snap-sync state for a fixed, pre-configured pivot (`PivotNumber`/`PivotHash`) served by a peer sitting at that pivot, without requiring a live forkchoice head above the pivot. Used to clone the exact state root of a frozen source node. Requires `SnapSync` to be enabled and `PivotNumber`/`PivotHash` to be set.", DefaultValue = "false", HiddenFromDocs = true)]
+    [ConfigItem(Description = "_Technical._ Whether to snap-sync state for a fixed, pre-configured pivot (`PivotNumber`/`PivotHash`) served by a peer sitting at that pivot, without requiring a live forkchoice head above the pivot. Used to clone the exact state root of a frozen source node. Requires `SnapSync` to be enabled and `PivotNumber`/`PivotHash` to be set.", DefaultValue = "false", HiddenFromDocs = true)]
     bool StaticSnapPivot { get; set; }
 
     [ConfigItem(Description = $$"""

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -62,7 +62,7 @@ public interface ISyncConfig : IConfig
     [ConfigItem(Description = "The max number of attempts to update the pivot block based on the FCU message from the consensus client. Set to `-1` to retry forever (recommended for nodes that may start before the consensus client is available).", DefaultValue = "-1")]
     int MaxAttemptsToUpdatePivot { get; set; }
 
-    [ConfigItem(Description = "_Technical._ Snap-sync state for a fixed, pre-configured pivot (PivotNumber/PivotHash) served by a peer sitting at that pivot, without requiring a live forkchoice head above the pivot. Use to clone the exact state root of a frozen source node.", DefaultValue = "false", HiddenFromDocs = true)]
+    [ConfigItem(Description = "Whether to snap-sync state for a fixed, pre-configured pivot (`PivotNumber`/`PivotHash`) served by a peer sitting at that pivot, without requiring a live forkchoice head above the pivot. Used to clone the exact state root of a frozen source node. Requires `SnapSync` to be enabled and `PivotNumber`/`PivotHash` to be set.", DefaultValue = "false", HiddenFromDocs = true)]
     bool StaticSnapPivot { get; set; }
 
     [ConfigItem(Description = $$"""

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -62,6 +62,9 @@ public interface ISyncConfig : IConfig
     [ConfigItem(Description = "The max number of attempts to update the pivot block based on the FCU message from the consensus client. Set to `-1` to retry forever (recommended for nodes that may start before the consensus client is available).", DefaultValue = "-1")]
     int MaxAttemptsToUpdatePivot { get; set; }
 
+    [ConfigItem(Description = "_Technical._ Snap-sync state for a fixed, pre-configured pivot (PivotNumber/PivotHash) served by a peer sitting at that pivot, without requiring a live forkchoice head above the pivot. Use to clone the exact state root of a frozen source node.", DefaultValue = "false", HiddenFromDocs = true)]
+    bool StaticSnapPivot { get; set; }
+
     [ConfigItem(Description = $$"""
         The earliest body downloaded with fast sync when `{{nameof(DownloadBodiesInFastSync)}}` is set to `true`. The actual value is determined as follows:
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -54,6 +54,7 @@ namespace Nethermind.Blockchain.Synchronization
         }
         public int MaxAttemptsToUpdatePivot { get; set; } = ISyncConfig.InfiniteAttempts;
         public bool SnapSync { get; set; } = false;
+        public bool StaticSnapPivot { get; set; } = false;
         public int SnapSyncAccountRangePartitionCount { get; set; } = 8;
         public bool FixReceipts { get; set; } = false;
         public bool FixTotalDifficulty { get; set; } = false;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -10,6 +10,7 @@ using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
+using Nethermind.Core.Exceptions;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network;
@@ -98,6 +99,14 @@ public class InitializeNetwork : IStep
     private async Task Initialize(CancellationToken cancellationToken)
     {
         if (_api.BlockTree is null) throw new StepDependencyException(nameof(_api.BlockTree));
+
+        if (_syncConfig.StaticSnapPivot)
+        {
+            if (!_syncConfig.SnapSync)
+                throw new InvalidConfigurationException("Sync.StaticSnapPivot requires Sync.SnapSync to be enabled.", -1);
+            if (_syncConfig.PivotNumber <= 0 || string.IsNullOrWhiteSpace(_syncConfig.PivotHash))
+                throw new InvalidConfigurationException("Sync.StaticSnapPivot requires Sync.PivotNumber and Sync.PivotHash to be set to the target (frozen) pivot block.", -1);
+        }
 
         if (_networkConfig.DiagTracerEnabled)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -57,7 +57,7 @@ public class StartingSyncPivotUpdater : IDisposable
         _maxAttempts = syncConfig.MaxAttemptsToUpdatePivot; // Note: Blocktree would have set this to 0 if sync pivot is in DB
         _attemptsLeft = syncConfig.MaxAttemptsToUpdatePivot;
 
-        if (_maxAttempts != 0)
+        if (_maxAttempts != 0 && !syncConfig.StaticSnapPivot)
         {
             _syncModeSelector.Changed += OnSyncModeChanged;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -176,6 +176,20 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 .TheSyncModeShouldBe(SyncMode.None);
 
         [Test]
+        public void StaticSnapPivot_peer_at_pivot_behind_pivot_enters_fast_sync() => Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeIsBehindThePivotInFastSync()
+                .AndAPeerExactlyAtThePivotIsKnown()
+                .WhenStaticSnapPivotIsConfigured()
+                .TheSyncModeShouldBe(GetExpectationsIfNeedToWaitForHeaders(SyncMode.FastHeaders | SyncMode.FastSync));
+
+        [Test]
+        public void StaticSnapPivot_peer_at_pivot_state_downloaded_idles() => Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeJustFinishedFastBlocksAndFastSync(stateFinished: true)
+                .AndAPeerExactlyAtThePivotIsKnown()
+                .WhenStaticSnapPivotIsConfigured()
+                .TheSyncModeShouldBe(SyncMode.None);
+
+        [Test]
         public void Finished_fast_sync_but_not_snap_ranges_IsFarFromHead() => Scenario.GoesLikeThis(_needToWaitForHeaders)
                 .IfThisNodeJustFinishedFastBlocksAndFastSync(bestHeader: Scenario.ChainHead.Number - 1000)
                 .AndGoodPeersAreKnown()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -162,6 +162,20 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 .TheSyncModeShouldBe(SyncMode.StateNodes);
 
         [Test]
+        public void StaticSnapPivot_peer_at_pivot_enters_state_nodes() => Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeJustFinishedFastBlocksAndFastSync()
+                .AndAPeerExactlyAtThePivotIsKnown()
+                .WhenStaticSnapPivotIsConfigured()
+                .TheSyncModeShouldBe(SyncMode.StateNodes);
+
+        [Test]
+        public void Without_StaticSnapPivot_peer_at_pivot_does_not_enter_state_nodes() => Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeJustFinishedFastBlocksAndFastSync()
+                .AndAPeerExactlyAtThePivotIsKnown()
+                .WhenSnapSyncIsConfigured()
+                .TheSyncModeShouldBe(SyncMode.None);
+
+        [Test]
         public void Finished_fast_sync_but_not_snap_ranges_IsFarFromHead() => Scenario.GoesLikeThis(_needToWaitForHeaders)
                 .IfThisNodeJustFinishedFastBlocksAndFastSync(bestHeader: Scenario.ChainHead.Number - 1000)
                 .AndGoodPeersAreKnown()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
@@ -310,6 +310,23 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
+                public ScenarioBuilder IfThisNodeIsBehindThePivotInFastSync()
+                {
+                    _syncProgressSetups.Add(
+                        () =>
+                        {
+                            SyncProgressResolver.FindBestHeader().Returns(MidWayToPivot.Number);
+                            SyncProgressResolver.FindBestFullBlock().Returns(0);
+                            SyncProgressResolver.FindBestFullState().Returns(0);
+                            SyncProgressResolver.FindBestProcessedBlock().Returns(0);
+                            SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.None);
+                            SyncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
+                            return "behind the pivot in fast sync";
+                        }
+                    );
+                    return this;
+                }
+
                 public ScenarioBuilder IfThisNodeFinishedFastBlocksButNotFastSync()
                 {
                     _syncProgressSetups.Add(

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
@@ -624,6 +624,25 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
+                public ScenarioBuilder AndAPeerExactlyAtThePivotIsKnown()
+                {
+                    AddPeeringSetup("peer at pivot", AddPeer(Pivot));
+                    return this;
+                }
+
+                public ScenarioBuilder WhenStaticSnapPivotIsConfigured()
+                {
+                    _configActions.Add(() =>
+                    {
+                        SyncConfig.FastSync = true;
+                        SyncConfig.SnapSync = true;
+                        SyncConfig.StaticSnapPivot = true;
+                        return "static snap pivot";
+                    });
+
+                    return this;
+                }
+
                 public ScenarioBuilder WhenSynchronizationIsDisabled()
                 {
                     _overwrites.Add(() => SyncConfig.SynchronizationEnabled = false);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -44,7 +44,9 @@ namespace Nethermind.Synchronization.FastSync
             // The new pivot must be at least one block after the sync pivot as the forward downloader does not
             // download the block at the sync pivot which may cause state not found error if state was downloaded
             // at exactly sync pivot.
-            targetBlockNumber = Math.Max(targetBlockNumber, blockTree.SyncPivot.BlockNumber + 1);
+            targetBlockNumber = syncConfig.StaticSnapPivot
+                ? blockTree.SyncPivot.BlockNumber
+                : Math.Max(targetBlockNumber, blockTree.SyncPivot.BlockNumber + 1);
 
             BlockHeader bestHeader = blockTree.FindHeader(targetBlockNumber);
             if (bestHeader is not null)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -54,6 +54,10 @@ namespace Nethermind.Synchronization.FastSync
                 if (_logger.IsInfo) _logger.Info($"Snap - {msg} - Pivot changed from {_bestHeader?.Number} to {bestHeader.Number}");
                 _bestHeader = bestHeader;
             }
+            else if (syncConfig.StaticSnapPivot && _logger.IsDebug)
+            {
+                _logger.Debug($"Snap - static pivot header {targetBlockNumber} not yet available in the block tree; waiting for fast headers.");
+            }
         }
 
         public ConcurrentHashSet<Hash256> UpdatedStorages { get; } = [];

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -122,6 +122,8 @@ public class StateSyncRunner(
     {
         await syncModeSelector.WaitUntilMode(m => (m & SyncMode.StateNodes) != 0, token);
 
+        if (syncConfig.StaticSnapPivot) return;
+
         int totalSyncLag = syncConfig.StateMinDistanceFromHead + syncConfig.HeaderStateDistance;
 
         while (!token.IsCancellationRequested)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncRunner.cs
@@ -54,6 +54,9 @@ public class StateSyncRunner(
                 }
 
                 await RunStateSyncRounds(token);
+
+                if (syncConfig.StaticSnapPivot && _logger.IsInfo)
+                    _logger.Info($"StaticSnapPivot: state sync complete at block {syncConfig.PivotNumber} - node is idle (no further sync without a consensus client). Set Sync.ExitOnSynced=true to exit on completion.");
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -321,6 +321,8 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInUpdatingPivot()
         {
+            if (_syncConfig.StaticSnapPivot) return false;
+
             bool updateRequestedAndNotFinished = _syncConfig.MaxAttemptsToUpdatePivot is > 0 or ISyncConfig.InfiniteAttempts;
             bool isPostMerge = _beaconSyncStrategy.MergeTransitionFinished;
             bool stateSyncNotFinished = _syncProgressResolver.FindBestFullState() == 0;
@@ -360,7 +362,7 @@ namespace Nethermind.Synchronization.ParallelSync
 
             // Shared with fast sync
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
-            bool postPivotPeerAvailable = best.AnyPostPivotPeerKnown;
+            bool postPivotPeerAvailable = best.AnyPostPivotPeerKnown || (_syncConfig.StaticSnapPivot && best.Peer.Block >= best.PivotNumber);
 
             // We stop `FastSyncLag` block before the highest known block in case the highest known block is non-canon
             // and we need to sync away from it.
@@ -568,7 +570,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool notInUpdatingPivot = !best.IsInUpdatingPivot;
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
             bool hasFastSyncBeenActive = best.Header >= best.PivotNumber;
-            bool hasAnyPostPivotPeer = best.AnyPostPivotPeerKnown;
+            bool hasAnyPostPivotPeer = best.AnyPostPivotPeerKnown || (_syncConfig.StaticSnapPivot && best.Peer.Block >= best.PivotNumber);
             bool notInFastSync = !best.IsInFastSync;
             bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
             bool stickyStateNodes = best.TargetBlock - best.Header < (_syncConfig.StateMinDistanceFromHead + StickyStateNodesDelta);


### PR DESCRIPTION
## Summary

Adds an opt-in sync config flag **`Sync.StaticSnapPivot`** (default `false`) that lets a node snap-sync state for a **fixed, pre-configured pivot** (`Sync.PivotNumber`/`Sync.PivotHash`) served by a peer that sits **at** that pivot — without requiring a live forkchoice head above the pivot and without a Consensus Layer driving `engine_forkchoiceUpdated`.

The motivating use case is **cloning the exact state root of a frozen / archive source node** (e.g. reproducible snap-sync benchmarking against a fixed state snapshot). With the flag set and the pivot configured to the source's head block `H`, the target reconstructs **exactly `stateRoot(H)`**.

## Why it's needed

Snap state download today requires three things that a strictly frozen, CL-less source cannot provide simultaneously:
1. `hasAnyPostPivotPeer` — a peer strictly **above** the pivot (`Peer.Block > PivotNumber`);
2. exiting the post-merge `UpdatingPivot` state, which blocks on a CL forkchoice ("Waiting for Forkchoice message from Consensus Layer to set fresh pivot block");
3. a snap state pivot resolved at `SyncPivot + 1`, which doesn't exist when the pivot is the source's head.

`StaticSnapPivot` treats the configured pivot as authoritative and relaxes exactly these gates.

## Changes (all gated behind `_syncConfig.StaticSnapPivot`, default `false`)

- **`ISyncConfig` / `SyncConfig`** — new `StaticSnapPivot` flag (technical, hidden from docs).
- **`MultiSyncModeSelector`** — `ShouldBeInUpdatingPivot()` returns `false` under the flag (the configured pivot is the fresh pivot); the post-pivot-peer gate in `ShouldBeInStateSyncMode`/`ShouldBeInFastSyncMode` also accepts a peer **at** the pivot (`Peer.Block >= PivotNumber`).
- **`StartingSyncPivotUpdater`** — does not subscribe the CL-driven pivot updater under the flag.
- **`StateSyncRunner.StateSyncPrecursorWait`** — returns immediately under the flag (no live head to stay close to).
- **`StateSyncPivot.TrySetNewBestHeader`** — targets the configured `SyncPivot` block exactly (instead of `SyncPivot + 1`), so the downloaded state root equals `stateRoot(pivot)`. The `+1` exists to avoid a forward-downloader edge case that does not apply to a static pivot (the pivot block itself is served).

No existing method signatures or hot paths are modified; the `Snapshot` ref struct is untouched. With the flag off, behavior is byte-for-byte unchanged.

## Tests

- `MultiSyncModeSelectorFastSyncTests`: a peer exactly at the pivot + `StaticSnapPivot=true` enters `StateNodes`.
- Negative regression: the same scenario with `StaticSnapPivot=false` stays `None` (proves default behavior unchanged).

## Validation

Validated end-to-end on an isolated two-node LAN: a frozen Nethermind source (no CL) serving snap at its head `H`, and a Nethermind target with `--Sync.SnapSync=true --Sync.StaticSnapPivot=true --Sync.PivotNumber=H --Sync.PivotHash=<hash(H)>` and **no forkchoice driver**. The target boots straight into snap sync (no "Waiting for Forkchoice…"), dispatches account ranges, and downloads state for `stateRoot(H)`.

Draft pending a full state-download completion run (bit-identical root verification) and maintainer feedback on the approach.

## Related

Part of NethermindEth's mainnet 10x state-growth benchmarking effort — this flag is the mechanism that lets the benchmark harness snap-sync the **frozen** milestone state snapshots (x1…x10):

- Snap-sync tests: [state-benchmarks#16](https://github.com/NethermindEth/state-benchmarks/issues/16) (5x), [#17](https://github.com/NethermindEth/state-benchmarks/issues/17) (7x), [#18](https://github.com/NethermindEth/state-benchmarks/issues/18) (10x)
- Benchmark harness: [state-benchmarks#33](https://github.com/NethermindEth/state-benchmarks/issues/33)
- Project board: [Road to 10x](https://github.com/orgs/NethermindEth/projects/141)
