### PR TITLE
fix(build): pass DOTNET_HOST_PATH to JsonRpc generator Exec

### DIFF
--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -52,7 +52,11 @@
       BuildInParallel="false"
       Condition="!Exists('$(_RpcJsonContextGeneratorPath)')" />
 
-    <Exec Command="dotnet &quot;$(_RpcJsonContextGeneratorPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
+    <PropertyGroup>
+      <_DotnetHost Condition="'$(_DotnetHost)' == '' and '$(DOTNET_HOST_PATH)' != ''">$(DOTNET_HOST_PATH)</_DotnetHost>
+      <_DotnetHost Condition="'$(_DotnetHost)' == ''">dotnet</_DotnetHost>
+    </PropertyGroup>
+    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;$(_RpcJsonContextGeneratorPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_RpcJsonContextSourcesFile)" />


### PR DESCRIPTION
## Summary

- `Nethermind.JsonRpc.SourceGenerator.Build` is invoked via `<Exec Command="dotnet ..." />` in `src/Nethermind/Directory.Build.targets`.
- When MSBuild's `Exec` task spawns `cmd.exe`, the inherited PATH may not include the dotnet host directory (depends on how the parent build was launched), producing `MSB3073` / error `9009` (`'dotnet' is not recognized`).
- Use `$(DOTNET_HOST_PATH)` — set by the .NET SDK when it launches MSBuild — with a bare `dotnet` fallback for cases where the property is not provided.

## Changes

- `src/Nethermind/Directory.Build.targets`: prefer `\$(DOTNET_HOST_PATH)` over a bare `dotnet` in the generator `<Exec>` command.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

### Test plan

- [ ] `dotnet build src/Nethermind/Nethermind.slnx -c release` succeeds from a shell where `dotnet` is on PATH.
- [ ] Build succeeds in environments where the spawned Exec shell does not have the dotnet host directory on PATH (the originally failing scenario).

### Requires documentation update

- [ ] No