### PR TITLE
Fix BALs network encoding

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Blockchain.Synchronization
         void NotifyOfNewRange(BlockHeader earliest, BlockHeader latest) { }
         Task<IOwnedReadOnlyList<TxReceipt[]?>> GetReceipts(IReadOnlyList<Hash256> blockHash, CancellationToken token);
         Task<IByteArrayList> GetNodeData(IReadOnlyList<Hash256> hashes, CancellationToken token);
-        Task<IByteArrayList> GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token) =>
-            Task.FromResult<IByteArrayList>(EmptyByteArrayList.Instance);
+        Task<IOwnedReadOnlyList<byte[]?>> GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token) =>
+            Task.FromResult(IOwnedReadOnlyList<byte[]?>.Empty);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
@@ -112,12 +112,9 @@ public class BlockAccessListsMessageSerializerTests
 
         for (int i = 0; i < expected.BlockAccessLists.Count; i++)
         {
-            Assert.That(SameBytesOrMissing(actual.BlockAccessLists[i], expected.BlockAccessLists[i]), Is.True);
+            Assert.That(actual.BlockAccessLists[i], Is.EqualTo(expected.BlockAccessLists[i]));
         }
     }
-
-    private static bool SameBytesOrMissing(byte[]? actual, byte[]? expected) =>
-        expected is null ? actual is null : actual is not null && actual.AsSpan().SequenceEqual(expected);
 }
 
 [Parallelizable(ParallelScope.All)]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
@@ -62,8 +62,12 @@ public class BlockAccessListsMessageSerializerTests
                 "c32bc180")
             .SetName("Roundtrip_single_absent_bal");
         yield return new TestCaseData(
-                new Func<BlockAccessListsMessage>(() => BuildMessage(44, [0xc1, 0x80], [0xc2, 0x01, 0x02], null)),
-                null)
+                new Func<BlockAccessListsMessage>(() => BuildMessage(44, [0xc0])),
+                "c32cc1c0")
+            .SetName("Roundtrip_single_empty_bal");
+        yield return new TestCaseData(
+                new Func<BlockAccessListsMessage>(() => BuildMessage(45, [0xc1, 0x80], [0xc2, 0x01, 0x02], null)),
+                "c82dc6c180c2010280")
             .SetName("Roundtrip_multiple_bals");
         yield return new TestCaseData(
                 new Func<BlockAccessListsMessage>(() => BuildMessage(-1)),
@@ -99,21 +103,7 @@ public class BlockAccessListsMessageSerializerTests
     }
 
     private static BlockAccessListsMessage BuildMessage(long requestId, params byte[]?[] blockAccessLists) =>
-        new(requestId, BuildBlockAccessLists(blockAccessLists));
-
-    private static IByteArrayList BuildBlockAccessLists(params byte[]?[] blockAccessLists)
-    {
-        using DeferredRlpItemList.Builder builder = new(entryCapacity: blockAccessLists.Length);
-        using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
-        {
-            for (int i = 0; i < blockAccessLists.Length; i++)
-            {
-                writer.WriteValue(blockAccessLists[i] ?? ReadOnlySpan<byte>.Empty);
-            }
-        }
-
-        return new RlpByteArrayList(builder.ToRlpItemList());
-    }
+        new(requestId, new ArrayPoolList<byte[]?>(blockAccessLists));
 
     private static void AssertBlockAccessListsMessage(BlockAccessListsMessage actual, BlockAccessListsMessage expected)
     {
@@ -122,9 +112,12 @@ public class BlockAccessListsMessageSerializerTests
 
         for (int i = 0; i < expected.BlockAccessLists.Count; i++)
         {
-            Assert.That(actual.BlockAccessLists[i].SequenceEqual(expected.BlockAccessLists[i]), Is.True);
+            Assert.That(SameBytesOrMissing(actual.BlockAccessLists[i], expected.BlockAccessLists[i]), Is.True);
         }
     }
+
+    private static bool SameBytesOrMissing(byte[]? actual, byte[]? expected) =>
+        expected is null ? actual is null : actual is not null && actual.AsSpan().SequenceEqual(expected);
 }
 
 [Parallelizable(ParallelScope.All)]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
@@ -107,12 +107,19 @@ public class BlockAccessListsMessageSerializerTests
 
     private static void AssertBlockAccessListsMessage(BlockAccessListsMessage actual, BlockAccessListsMessage expected)
     {
-        Assert.That(actual.RequestId, Is.EqualTo(expected.RequestId));
-        Assert.That(actual.BlockAccessLists.Count, Is.EqualTo(expected.BlockAccessLists.Count));
-
-        for (int i = 0; i < expected.BlockAccessLists.Count; i++)
+        using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.BlockAccessLists[i], Is.EqualTo(expected.BlockAccessLists[i]));
+            Assert.That(actual.RequestId, Is.EqualTo(expected.RequestId));
+            Assert.That(actual.BlockAccessLists.Count, Is.EqualTo(expected.BlockAccessLists.Count));
+            if (actual.BlockAccessLists.Count != expected.BlockAccessLists.Count)
+            {
+                return;
+            }
+
+            for (int i = 0; i < expected.BlockAccessLists.Count; i++)
+            {
+                Assert.That(actual.BlockAccessLists[i], Is.EqualTo(expected.BlockAccessLists[i]));
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
@@ -29,7 +29,6 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V71;
 using Nethermind.Network.P2P.Subprotocols.Eth.V71.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test.Builders;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -165,21 +164,23 @@ public class Eth71ProtocolHandlerTests
         _session.When(s => s.DeliverMessage(Arg.Any<GetBlockAccessListsMessage>())).Do(call =>
         {
             sentRequest = (GetBlockAccessListsMessage)call[0];
-            response = new BlockAccessListsMessage(sentRequest.RequestId, BuildBlockAccessLists(bal1, bal2));
+            response = BuildBlockAccessListsMessage(sentRequest.RequestId, bal1, bal2);
         });
 
         HandleIncomingStatusMessage();
-        Task<IByteArrayList> task = viaSyncPeerInterface
+        Task<IOwnedReadOnlyList<byte[]?>> task = viaSyncPeerInterface
             ? ((ISyncPeer)_handler).GetBlockAccessLists(new[] { Keccak.Zero, TestItem.KeccakA }, CancellationToken.None)
             : _handler.GetBlockAccessLists(new[] { Keccak.Zero, TestItem.KeccakA }, CancellationToken.None);
 
         _session.Received(1).DeliverMessage(Arg.Any<GetBlockAccessListsMessage>());
         HandleZeroMessage(response!, Eth71MessageCode.BlockAccessLists);
 
-        using IByteArrayList result = await task;
-        Assert.That(result.Count, Is.EqualTo(2));
-        Assert.That(result[0].SequenceEqual(bal1), Is.True);
-        Assert.That(result[1].SequenceEqual(bal2), Is.True);
+        using IOwnedReadOnlyList<byte[]?> result = await task;
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result[0], Is.Not.Null);
+        Assert.That(result[0]!.AsSpan().SequenceEqual(bal1), Is.True);
+        Assert.That(result[1], Is.Not.Null);
+        Assert.That(result[1]!.AsSpan().SequenceEqual(bal2), Is.True);
         Assert.Throws<ObjectDisposedException>(() => _ = sentRequest!.Hashes[0]);
         response?.Dispose();
     }
@@ -187,7 +188,7 @@ public class Eth71ProtocolHandlerTests
     [Test]
     public void Should_throw_when_receiving_unrequested_block_access_lists()
     {
-        using BlockAccessListsMessage msg = new(9999, EmptyByteArrayList.Instance);
+        using BlockAccessListsMessage msg = new(9999, IOwnedReadOnlyList<byte[]?>.Empty);
 
         HandleIncomingStatusMessage();
         Assert.Throws<SubprotocolException>(() => HandleZeroMessage(msg, Eth71MessageCode.BlockAccessLists));
@@ -197,7 +198,7 @@ public class Eth71ProtocolHandlerTests
     public async Task Should_return_empty_list_when_requesting_zero_hashes()
     {
         HandleIncomingStatusMessage();
-        IByteArrayList result = await _handler.GetBlockAccessLists(
+        IOwnedReadOnlyList<byte[]?> result = await _handler.GetBlockAccessLists(
             Array.Empty<Hash256>(), CancellationToken.None);
 
         Assert.That(result.Count, Is.EqualTo(0));
@@ -288,20 +289,9 @@ public class Eth71ProtocolHandlerTests
         return true;
     }
 
-    private static bool SameBytesOrMissing(ReadOnlySpan<byte> actual, byte[]? expected) =>
-        expected is null ? actual.IsEmpty : actual.SequenceEqual(expected);
+    private static bool SameBytesOrMissing(byte[]? actual, byte[]? expected) =>
+        expected is null ? actual is null : actual is not null && actual.AsSpan().SequenceEqual(expected);
 
-    private static IByteArrayList BuildBlockAccessLists(params byte[]?[] blockAccessLists)
-    {
-        using DeferredRlpItemList.Builder builder = new(entryCapacity: blockAccessLists.Length);
-        using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
-        {
-            for (int i = 0; i < blockAccessLists.Length; i++)
-            {
-                writer.WriteValue(blockAccessLists[i] ?? ReadOnlySpan<byte>.Empty);
-            }
-        }
-
-        return new RlpByteArrayList(builder.ToRlpItemList());
-    }
+    private static BlockAccessListsMessage BuildBlockAccessListsMessage(long requestId, params byte[]?[] blockAccessLists) =>
+        new(requestId, new ArrayPoolList<byte[]?>(blockAccessLists));
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
@@ -138,6 +138,10 @@ public class Eth71ProtocolHandlerTests
         Hash256[] hashes,
         byte[]?[] expectedBlockAccessLists)
     {
+        BlockAccessListsMessage? response = null;
+        _session.When(s => s.DeliverMessage(Arg.Any<BlockAccessListsMessage>())).Do(call =>
+            response = (BlockAccessListsMessage)call[0]);
+
         for (int i = 0; i < hashes.Length; i++)
         {
             _syncManager.GetBlockAccessListRlp(hashes[i]).Returns(ArrayMemoryManager.From(expectedBlockAccessLists[i]));
@@ -148,8 +152,14 @@ public class Eth71ProtocolHandlerTests
         using GetBlockAccessListsMessage request = new(requestId, hashes.ToPooledList(hashes.Length));
         HandleZeroMessage(request, Eth71MessageCode.GetBlockAccessLists);
 
-        _session.Received(1).DeliverMessage(Arg.Is<BlockAccessListsMessage>(m =>
-            MatchesBlockAccessListsMessage(m, requestId, expectedBlockAccessLists)));
+        _session.Received(1).DeliverMessage(Arg.Any<BlockAccessListsMessage>());
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response!.RequestId, Is.EqualTo(requestId));
+        Assert.That(response.BlockAccessLists, Has.Count.EqualTo(expectedBlockAccessLists.Length));
+        for (int i = 0; i < expectedBlockAccessLists.Length; i++)
+        {
+            Assert.That(response.BlockAccessLists[i], Is.EqualTo(expectedBlockAccessLists[i]));
+        }
     }
 
     [TestCaseSource(nameof(BlockAccessListsRequestCases))]
@@ -164,7 +174,8 @@ public class Eth71ProtocolHandlerTests
         _session.When(s => s.DeliverMessage(Arg.Any<GetBlockAccessListsMessage>())).Do(call =>
         {
             sentRequest = (GetBlockAccessListsMessage)call[0];
-            response = BuildBlockAccessListsMessage(sentRequest.RequestId, bal1, bal2);
+            byte[]?[] blockAccessLists = [bal1, bal2];
+            response = new BlockAccessListsMessage(sentRequest.RequestId, new ArrayPoolList<byte[]?>(blockAccessLists));
         });
 
         HandleIncomingStatusMessage();
@@ -268,30 +279,4 @@ public class Eth71ProtocolHandlerTests
             .SetName("Can_request_and_handle_block_access_lists_via_sync_peer_interface")
     ];
 
-    private static bool MatchesBlockAccessListsMessage(
-        BlockAccessListsMessage message,
-        long requestId,
-        byte[]?[] expectedBlockAccessLists)
-    {
-        if (message.RequestId != requestId || message.BlockAccessLists.Count != expectedBlockAccessLists.Length)
-        {
-            return false;
-        }
-
-        for (int i = 0; i < expectedBlockAccessLists.Length; i++)
-        {
-            if (!SameBytesOrMissing(message.BlockAccessLists[i], expectedBlockAccessLists[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool SameBytesOrMissing(byte[]? actual, byte[]? expected) =>
-        expected is null ? actual is null : actual is not null && actual.AsSpan().SequenceEqual(expected);
-
-    private static BlockAccessListsMessage BuildBlockAccessListsMessage(long requestId, params byte[]?[] blockAccessLists) =>
-        new(requestId, new ArrayPoolList<byte[]?>(blockAccessLists));
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
@@ -153,12 +153,21 @@ public class Eth71ProtocolHandlerTests
         HandleZeroMessage(request, Eth71MessageCode.GetBlockAccessLists);
 
         _session.Received(1).DeliverMessage(Arg.Any<BlockAccessListsMessage>());
-        Assert.That(response, Is.Not.Null);
-        Assert.That(response!.RequestId, Is.EqualTo(requestId));
-        Assert.That(response.BlockAccessLists, Has.Count.EqualTo(expectedBlockAccessLists.Length));
-        for (int i = 0; i < expectedBlockAccessLists.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            Assert.That(response.BlockAccessLists[i], Is.EqualTo(expectedBlockAccessLists[i]));
+            Assert.That(response, Is.Not.Null);
+            if (response is not null)
+            {
+                Assert.That(response.RequestId, Is.EqualTo(requestId));
+                Assert.That(response.BlockAccessLists, Has.Count.EqualTo(expectedBlockAccessLists.Length));
+                if (response.BlockAccessLists.Count == expectedBlockAccessLists.Length)
+                {
+                    for (int i = 0; i < expectedBlockAccessLists.Length; i++)
+                    {
+                        Assert.That(response.BlockAccessLists[i], Is.EqualTo(expectedBlockAccessLists[i]));
+                    }
+                }
+            }
         }
     }
 
@@ -187,11 +196,15 @@ public class Eth71ProtocolHandlerTests
         HandleZeroMessage(response!, Eth71MessageCode.BlockAccessLists);
 
         using IOwnedReadOnlyList<byte[]?> result = await task;
-        Assert.That(result, Has.Count.EqualTo(2));
-        Assert.That(result[0], Is.Not.Null);
-        Assert.That(result[0]!.AsSpan().SequenceEqual(bal1), Is.True);
-        Assert.That(result[1], Is.Not.Null);
-        Assert.That(result[1]!.AsSpan().SequenceEqual(bal2), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Has.Count.EqualTo(2));
+            if (result.Count == 2)
+            {
+                Assert.That(result[0], Is.EqualTo(bal1));
+                Assert.That(result[1], Is.EqualTo(bal2));
+            }
+        }
         Assert.Throws<ObjectDisposedException>(() => _ = sentRequest!.Hashes[0]);
         response?.Dispose();
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandlerTests.cs
@@ -252,12 +252,12 @@ public class Eth71ProtocolHandlerTests
                 2222L,
                 new[] { Keccak.Zero, TestItem.KeccakA },
                 new byte[]?[] { null, null })
-            .SetName("Should_return_empty_BAL_for_unavailable_blocks"),
+            .SetName("Should_return_absent_BAL_for_unavailable_blocks"),
         new TestCaseData(
                 3333L,
                 new[] { Keccak.Zero, TestItem.KeccakA, TestItem.KeccakB },
                 new byte[]?[] { [0xc3, 0x01, 0x02, 0x03], null, null })
-            .SetName("Should_return_mixed_available_and_empty_BALs")
+            .SetName("Should_return_mixed_available_and_absent_BALs")
     ];
 
     private static TestCaseData[] BlockAccessListsRequestCases =>

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Eth71ProtocolHandler.cs
@@ -18,7 +18,6 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.P2P.Subprotocols.Eth.V70;
 using Nethermind.Network.P2P.Subprotocols.Eth.V71.Messages;
 using Nethermind.Network.Rlpx;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
 using Nethermind.TxPool;
@@ -91,42 +90,42 @@ public class Eth71ProtocolHandler : Eth70ProtocolHandler, ISyncPeer, IStaticProt
         IOwnedReadOnlyList<Hash256> hashes = req.Hashes;
         ReadOnlySpan<Hash256> hashesSpan = hashes.AsSpan();
         long totalSize = 0;
-        RlpByteArrayList results;
+        ArrayPoolList<byte[]?> results = new(hashesSpan.Length);
 
-        using (DeferredRlpItemList.Builder builder = new(entryCapacity: hashesSpan.Length))
+        try
         {
-            using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
+            for (int i = 0; i < hashesSpan.Length; i++)
             {
-                for (int i = 0; i < hashesSpan.Length; i++)
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        break;
-                    }
+                    break;
+                }
 
-                    using MemoryManager<byte>? balRlp = SyncServer.GetBlockAccessListRlp(hashesSpan[i]);
-                    ReadOnlySpan<byte> balRlpSpan = balRlp is null ? ReadOnlySpan<byte>.Empty : balRlp.Memory.Span;
-                    writer.WriteValue(balRlpSpan);
-                    totalSize += Rlp.LengthOf(balRlpSpan);
+                using MemoryManager<byte>? balRlp = SyncServer.GetBlockAccessListRlp(hashesSpan[i]);
+                byte[]? balRlpBytes = balRlp is null ? null : balRlp.Memory.Span.ToArray();
+                results.Add(balRlpBytes);
+                totalSize += BlockAccessListsMessageSerializer.GetBlockAccessListEntryLength(balRlpBytes);
 
-                    if (totalSize > BalResponseSoftLimit)
-                    {
-                        break;
-                    }
+                if (totalSize > BalResponseSoftLimit)
+                {
+                    break;
                 }
             }
 
-            results = new RlpByteArrayList(builder.ToRlpItemList());
+            return Task.FromResult(new BlockAccessListsMessage(req.RequestId, results));
         }
-
-        return Task.FromResult(new BlockAccessListsMessage(req.RequestId, results));
+        catch
+        {
+            results.Dispose();
+            throw;
+        }
     }
 
-    public async Task<IByteArrayList> GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token)
+    public async Task<IOwnedReadOnlyList<byte[]?>> GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token)
     {
         if (blockHashes.Count == 0)
         {
-            return EmptyByteArrayList.Instance;
+            return IOwnedReadOnlyList<byte[]?>.Empty;
         }
 
         ArrayPoolList<Hash256> hashList = new(blockHashes.Count);
@@ -141,8 +140,8 @@ public class Eth71ProtocolHandler : Eth70ProtocolHandler, ISyncPeer, IStaticProt
         try
         {
             _balRequests.Send(req);
-            BlockAccessListsMessage response = await HandleResponse(req, TransferSpeedType.BlockAccessLists, static _ => nameof(GetBlockAccessListsMessage), token);
-            return response.BlockAccessLists;
+            using BlockAccessListsMessage response = await HandleResponse(req, TransferSpeedType.BlockAccessLists, static _ => nameof(GetBlockAccessListsMessage), token);
+            return response.DisownBlockAccessLists();
         }
         finally
         {
@@ -150,6 +149,6 @@ public class Eth71ProtocolHandler : Eth70ProtocolHandler, ISyncPeer, IStaticProt
         }
     }
 
-    Task<IByteArrayList> ISyncPeer.GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token)
+    Task<IOwnedReadOnlyList<byte[]?>> ISyncPeer.GetBlockAccessLists(IReadOnlyList<Hash256> blockHashes, CancellationToken token)
         => GetBlockAccessLists(blockHashes, token);
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessage.cs
@@ -8,25 +8,44 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V71.Messages;
 
 /// <summary>
-/// Response to GetBlockAccessLists. Each element corresponds to a block hash from the request, in order.
-/// Elements are RLP-encoded BALs (raw bytes). The RLP empty string (0x80) is returned where the BAL is unavailable.
+/// Response to GetBlockAccessLists. Each entry is an already RLP-encoded BAL, or null when the BAL is unavailable.
 /// </summary>
-public class BlockAccessListsMessage(IByteArrayList blockAccessLists, bool generateRandomRequestId = true)
-    : Eth66MessageBase(generateRandomRequestId)
+public class BlockAccessListsMessage : Eth66MessageBase
 {
-    public IByteArrayList BlockAccessLists { get; } = blockAccessLists ?? throw new ArgumentNullException(nameof(blockAccessLists));
+    private IOwnedReadOnlyList<byte[]?>? _blockAccessLists;
 
     public override int PacketType => Eth71MessageCode.BlockAccessLists;
     public override string Protocol => "eth";
 
-    public BlockAccessListsMessage(long requestId, IByteArrayList blockAccessLists)
+    public BlockAccessListsMessage(IOwnedReadOnlyList<byte[]?> blockAccessLists, bool generateRandomRequestId = true)
+        : base(generateRandomRequestId)
+    {
+        ArgumentNullException.ThrowIfNull(blockAccessLists);
+        _blockAccessLists = blockAccessLists;
+    }
+
+    public IOwnedReadOnlyList<byte[]?> BlockAccessLists =>
+        _blockAccessLists ?? throw new ObjectDisposedException(nameof(BlockAccessListsMessage));
+
+    public BlockAccessListsMessage(long requestId, IOwnedReadOnlyList<byte[]?> blockAccessLists)
         : this(blockAccessLists, false) => RequestId = requestId;
+
+    /// <summary>
+    /// Transfers the owned BAL response list to the caller so disposing this message will not dispose it.
+    /// </summary>
+    public IOwnedReadOnlyList<byte[]?> DisownBlockAccessLists()
+    {
+        IOwnedReadOnlyList<byte[]?> blockAccessLists = BlockAccessLists;
+        _blockAccessLists = null;
+        return blockAccessLists;
+    }
 
     public override string ToString() => $"BlockAccessLists({RequestId}, {BlockAccessLists.Count})";
 
     public override void Dispose()
     {
         base.Dispose();
-        BlockAccessLists.Dispose();
+        _blockAccessLists?.Dispose();
+        _blockAccessLists = null;
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessage.cs
@@ -10,19 +10,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V71.Messages;
 /// <summary>
 /// Response to GetBlockAccessLists. Each entry is an already RLP-encoded BAL, or null when the BAL is unavailable.
 /// </summary>
-public class BlockAccessListsMessage : Eth66MessageBase
+public class BlockAccessListsMessage(IOwnedReadOnlyList<byte[]?> blockAccessLists, bool generateRandomRequestId = true)
+    : Eth66MessageBase(generateRandomRequestId)
 {
-    private IOwnedReadOnlyList<byte[]?>? _blockAccessLists;
+    private IOwnedReadOnlyList<byte[]?>? _blockAccessLists = blockAccessLists;
 
     public override int PacketType => Eth71MessageCode.BlockAccessLists;
     public override string Protocol => "eth";
-
-    public BlockAccessListsMessage(IOwnedReadOnlyList<byte[]?> blockAccessLists, bool generateRandomRequestId = true)
-        : base(generateRandomRequestId)
-    {
-        ArgumentNullException.ThrowIfNull(blockAccessLists);
-        _blockAccessLists = blockAccessLists;
-    }
 
     public IOwnedReadOnlyList<byte[]?> BlockAccessLists =>
         _blockAccessLists ?? throw new ObjectDisposedException(nameof(BlockAccessListsMessage));

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
@@ -21,7 +21,7 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
     protected override void SerializeInternal(IByteBuffer byteBuffer, BlockAccessListsMessage message)
     {
         IOwnedReadOnlyList<byte[]?> blockAccessLists = message.BlockAccessLists;
-        NettyRlpStream rlpStream = new(byteBuffer);
+        RlpStream rlpStream = new NettyRlpStream(byteBuffer);
         rlpStream.StartSequence(GetBlockAccessListsContentLength(blockAccessLists));
         for (int i = 0; i < blockAccessLists.Count; i++)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
@@ -13,6 +13,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V71.Messages;
 
 public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccessListsMessage>
 {
+    private const int UnavailableBlockAccessListLength = 1;
+
     private static readonly RlpLimit RlpLimit = RlpLimit.For<BlockAccessListsMessage>(
         GethSyncLimits.MaxBodyFetch, nameof(BlockAccessListsMessage.BlockAccessLists));
 
@@ -22,7 +24,7 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
     public override BlockAccessListsMessage Deserialize(IByteBuffer byteBuffer)
     {
         using NettyBufferMemoryOwner memoryOwner = new(byteBuffer);
-        Rlp.ValueDecoderContext ctx = new(memoryOwner.Memory, sliceMemory: true);
+        Rlp.ValueDecoderContext ctx = new(memoryOwner.Memory);
         int startPosition = ctx.Position;
         ArrayPoolList<byte[]?>? blockAccessLists = null;
 
@@ -52,7 +54,7 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
         new(requestId, DecodeBlockAccessLists(ref ctx));
 
     internal static int GetBlockAccessListEntryLength(byte[]? blockAccessListRlp) =>
-        blockAccessListRlp is null ? Rlp.LengthOf(ReadOnlySpan<byte>.Empty) : blockAccessListRlp.Length;
+        blockAccessListRlp is null ? UnavailableBlockAccessListLength : blockAccessListRlp.Length;
 
     private static void WriteBlockAccessLists(IByteBuffer byteBuffer, IOwnedReadOnlyList<byte[]?> blockAccessLists)
     {
@@ -118,7 +120,7 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
     {
         int length = ctx.PeekNextRlpLength();
         ReadOnlySpan<byte> blockAccessListRlp = ctx.Read(length);
-        return length == 1 && blockAccessListRlp[0] == 0x80
+        return length == UnavailableBlockAccessListLength && blockAccessListRlp[0] == Rlp.EmptyByteArrayByte
             ? null
             : blockAccessListRlp.ToArray();
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
@@ -19,7 +19,23 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
         GethSyncLimits.MaxBodyFetch, nameof(BlockAccessListsMessage.BlockAccessLists));
 
     protected override void SerializeInternal(IByteBuffer byteBuffer, BlockAccessListsMessage message)
-        => WriteBlockAccessLists(byteBuffer, message.BlockAccessLists);
+    {
+        IOwnedReadOnlyList<byte[]?> blockAccessLists = message.BlockAccessLists;
+        NettyRlpStream rlpStream = new(byteBuffer);
+        rlpStream.StartSequence(GetBlockAccessListsContentLength(blockAccessLists));
+        for (int i = 0; i < blockAccessLists.Count; i++)
+        {
+            byte[]? blockAccessListRlp = blockAccessLists[i];
+            if (blockAccessListRlp is null)
+            {
+                rlpStream.Encode(ReadOnlySpan<byte>.Empty);
+            }
+            else
+            {
+                rlpStream.Write(blockAccessListRlp);
+            }
+        }
+    }
 
     public override BlockAccessListsMessage Deserialize(IByteBuffer byteBuffer)
     {
@@ -48,37 +64,13 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
     }
 
     protected override int GetLengthInternal(BlockAccessListsMessage message) =>
-        GetBlockAccessListsLength(message.BlockAccessLists);
+        Rlp.LengthOfSequence(GetBlockAccessListsContentLength(message.BlockAccessLists));
 
     protected override BlockAccessListsMessage DeserializeInternal(ref Rlp.ValueDecoderContext ctx, long requestId) =>
         new(requestId, DecodeBlockAccessLists(ref ctx));
 
     internal static int GetBlockAccessListEntryLength(byte[]? blockAccessListRlp) =>
         blockAccessListRlp is null ? UnavailableBlockAccessListLength : blockAccessListRlp.Length;
-
-    private static void WriteBlockAccessLists(IByteBuffer byteBuffer, IOwnedReadOnlyList<byte[]?> blockAccessLists)
-    {
-        NettyRlpStream rlpStream = new(byteBuffer);
-        rlpStream.StartSequence(GetBlockAccessListsContentLength(blockAccessLists));
-        for (int i = 0; i < blockAccessLists.Count; i++)
-        {
-            WriteBlockAccessListEntry(rlpStream, blockAccessLists[i]);
-        }
-    }
-
-    private static void WriteBlockAccessListEntry(RlpStream stream, byte[]? blockAccessListRlp)
-    {
-        if (blockAccessListRlp is null)
-        {
-            stream.Encode(ReadOnlySpan<byte>.Empty);
-            return;
-        }
-
-        stream.Write(blockAccessListRlp);
-    }
-
-    private static int GetBlockAccessListsLength(IOwnedReadOnlyList<byte[]?> blockAccessLists) =>
-        Rlp.LengthOfSequence(GetBlockAccessListsContentLength(blockAccessLists));
 
     private static int GetBlockAccessListsContentLength(IOwnedReadOnlyList<byte[]?> blockAccessLists)
     {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
@@ -28,7 +28,7 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
             byte[]? blockAccessListRlp = blockAccessLists[i];
             if (blockAccessListRlp is null)
             {
-                rlpStream.Encode(ReadOnlySpan<byte>.Empty);
+                rlpStream.WriteByte(Rlp.EmptyByteArrayByte);
             }
             else
             {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V71/Messages/BlockAccessListsMessageSerializer.cs
@@ -4,6 +4,7 @@
 using System;
 using DotNetty.Buffers;
 using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.SyncLimits;
@@ -16,14 +17,14 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
         GethSyncLimits.MaxBodyFetch, nameof(BlockAccessListsMessage.BlockAccessLists));
 
     protected override void SerializeInternal(IByteBuffer byteBuffer, BlockAccessListsMessage message)
-        => NettyRlpStream.WriteByteArrayList(byteBuffer, message.BlockAccessLists);
+        => WriteBlockAccessLists(byteBuffer, message.BlockAccessLists);
 
     public override BlockAccessListsMessage Deserialize(IByteBuffer byteBuffer)
     {
-        NettyBufferMemoryOwner? memoryOwner = new(byteBuffer);
+        using NettyBufferMemoryOwner memoryOwner = new(byteBuffer);
         Rlp.ValueDecoderContext ctx = new(memoryOwner.Memory, sliceMemory: true);
         int startPosition = ctx.Position;
-        RlpByteArrayList? blockAccessLists = null;
+        ArrayPoolList<byte[]?>? blockAccessLists = null;
 
         try
         {
@@ -31,25 +32,94 @@ public class BlockAccessListsMessageSerializer : Eth66SerializerBase<BlockAccess
             int checkPosition = ctx.Position + sequenceLength;
             long requestId = ctx.DecodeLong();
 
-            blockAccessLists = RlpByteArrayList.DecodeList(ref ctx, memoryOwner);
-            Rlp.GuardLimit(blockAccessLists.Count, sequenceLength, RlpLimit);
+            blockAccessLists = DecodeBlockAccessLists(ref ctx);
             ctx.Check(checkPosition);
 
-            memoryOwner = null;
             byteBuffer.SetReaderIndex(byteBuffer.ReaderIndex + ctx.Position - startPosition);
             return new BlockAccessListsMessage(requestId, blockAccessLists);
         }
         catch
         {
             blockAccessLists?.Dispose();
-            memoryOwner?.Dispose();
             throw;
         }
     }
 
     protected override int GetLengthInternal(BlockAccessListsMessage message) =>
-        Rlp.LengthOfByteArrayList(message.BlockAccessLists);
+        GetBlockAccessListsLength(message.BlockAccessLists);
 
     protected override BlockAccessListsMessage DeserializeInternal(ref Rlp.ValueDecoderContext ctx, long requestId) =>
-        throw new NotSupportedException($"{nameof(BlockAccessListsMessageSerializer)} requires {nameof(NettyBufferMemoryOwner)} to avoid BAL copies.");
+        new(requestId, DecodeBlockAccessLists(ref ctx));
+
+    internal static int GetBlockAccessListEntryLength(byte[]? blockAccessListRlp) =>
+        blockAccessListRlp is null ? Rlp.LengthOf(ReadOnlySpan<byte>.Empty) : blockAccessListRlp.Length;
+
+    private static void WriteBlockAccessLists(IByteBuffer byteBuffer, IOwnedReadOnlyList<byte[]?> blockAccessLists)
+    {
+        NettyRlpStream rlpStream = new(byteBuffer);
+        rlpStream.StartSequence(GetBlockAccessListsContentLength(blockAccessLists));
+        for (int i = 0; i < blockAccessLists.Count; i++)
+        {
+            WriteBlockAccessListEntry(rlpStream, blockAccessLists[i]);
+        }
+    }
+
+    private static void WriteBlockAccessListEntry(RlpStream stream, byte[]? blockAccessListRlp)
+    {
+        if (blockAccessListRlp is null)
+        {
+            stream.Encode(ReadOnlySpan<byte>.Empty);
+            return;
+        }
+
+        stream.Write(blockAccessListRlp);
+    }
+
+    private static int GetBlockAccessListsLength(IOwnedReadOnlyList<byte[]?> blockAccessLists) =>
+        Rlp.LengthOfSequence(GetBlockAccessListsContentLength(blockAccessLists));
+
+    private static int GetBlockAccessListsContentLength(IOwnedReadOnlyList<byte[]?> blockAccessLists)
+    {
+        int contentLength = 0;
+        for (int i = 0; i < blockAccessLists.Count; i++)
+        {
+            contentLength += GetBlockAccessListEntryLength(blockAccessLists[i]);
+        }
+
+        return contentLength;
+    }
+
+    private static ArrayPoolList<byte[]?> DecodeBlockAccessLists(ref Rlp.ValueDecoderContext ctx)
+    {
+        int blockAccessListsContentLength = ctx.ReadSequenceLength();
+        int checkPosition = ctx.Position + blockAccessListsContentLength;
+        int entryCount = ctx.PeekNumberOfItemsRemaining(checkPosition, GethSyncLimits.MaxBodyFetch + 1);
+        Rlp.GuardLimit(entryCount, blockAccessListsContentLength, RlpLimit);
+        ArrayPoolList<byte[]?> blockAccessLists = new(entryCount);
+
+        try
+        {
+            while (ctx.Position < checkPosition)
+            {
+                blockAccessLists.Add(DecodeBlockAccessListEntry(ref ctx));
+            }
+
+            ctx.Check(checkPosition);
+            return blockAccessLists;
+        }
+        catch
+        {
+            blockAccessLists.Dispose();
+            throw;
+        }
+    }
+
+    private static byte[]? DecodeBlockAccessListEntry(ref Rlp.ValueDecoderContext ctx)
+    {
+        int length = ctx.PeekNextRlpLength();
+        ReadOnlySpan<byte> blockAccessListRlp = ctx.Read(length);
+        return length == 1 && blockAccessListRlp[0] == 0x80
+            ? null
+            : blockAccessListRlp.ToArray();
+    }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.BlockAccessLists.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.BlockAccessLists.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.BlockAccessLists.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.BlockAccessLists.cs
@@ -12,7 +12,6 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Network.Contract.P2P;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Blocks;
@@ -193,18 +192,7 @@ public partial class BlockDownloaderTests
             .Returns(Task.FromResult<int?>(1));
     }
 
-    private static IByteArrayList BuildBlockAccessLists(params byte[]?[] blockAccessLists)
-    {
-        using DeferredRlpItemList.Builder builder = new(entryCapacity: blockAccessLists.Length);
-        using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
-        {
-            for (int i = 0; i < blockAccessLists.Length; i++)
-            {
-                writer.WriteValue(blockAccessLists[i] ?? ReadOnlySpan<byte>.Empty);
-            }
-        }
-
-        return new RlpByteArrayList(builder.ToRlpItemList());
-    }
+    private static IOwnedReadOnlyList<byte[]?> BuildBlockAccessLists(params byte[]?[] blockAccessLists) =>
+        new ArrayPoolList<byte[]?>(blockAccessLists);
 
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BlockAccessListsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BlockAccessListsSyncFeedTests.cs
@@ -17,7 +17,6 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -293,17 +292,6 @@ public class BlockAccessListsSyncFeedTests
         return syncPeerPool;
     }
 
-    private static IByteArrayList BuildBlockAccessLists(params byte[]?[] blockAccessLists)
-    {
-        using DeferredRlpItemList.Builder builder = new(entryCapacity: blockAccessLists.Length);
-        using (DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer())
-        {
-            for (int i = 0; i < blockAccessLists.Length; i++)
-            {
-                writer.WriteValue(blockAccessLists[i] ?? ReadOnlySpan<byte>.Empty);
-            }
-        }
-
-        return new RlpByteArrayList(builder.ToRlpItemList());
-    }
+    private static IOwnedReadOnlyList<byte[]?> BuildBlockAccessLists(params byte[]?[] blockAccessLists) =>
+        new ArrayPoolList<byte[]?>(blockAccessLists);
 }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -418,7 +418,7 @@ namespace Nethermind.Synchronization.Blocks
             using BlocksRequest _ = response;
             BlockBody[]? bodies = response.OwnedBodies?.Bodies;
             response.OwnedBodies?.Disown();
-            IByteArrayList? blockAccessLists = response.BlockAccessLists;
+            IOwnedReadOnlyList<byte[]?>? blockAccessLists = response.BlockAccessLists;
             bool unsupportedBlockAccessListsPeer = response.BlockAccessListsRequests.Count > 0 &&
                                                    peer is not null &&
                                                    !peer.SyncPeer.SupportsBlockAccessLists();
@@ -572,7 +572,7 @@ namespace Nethermind.Synchronization.Blocks
         private bool TryHandleBlockAccessListResponse(
             BlockHeader header,
             BlockEntry entry,
-            IByteArrayList? blockAccessLists,
+            IOwnedReadOnlyList<byte[]?>? blockAccessLists,
             int index,
             bool unsupportedBlockAccessListsPeer,
             PeerInfo? peer,
@@ -589,8 +589,8 @@ namespace Nethermind.Synchronization.Blocks
                 return false;
             }
 
-            ReadOnlySpan<byte> encodedAccessList = blockAccessLists[index];
-            if (encodedAccessList.IsEmpty)
+            byte[]? encodedAccessList = blockAccessLists[index];
+            if (encodedAccessList is null)
             {
                 entry.RetryAccessListRequest();
                 return false;
@@ -606,11 +606,10 @@ namespace Nethermind.Synchronization.Blocks
                 return false;
             }
 
-            byte[] ownedEncodedAccessList = encodedAccessList.ToArray();
-            entry.EncodedAccessList = ownedEncodedAccessList;
+            entry.EncodedAccessList = encodedAccessList;
             if (entry.Block is not null)
             {
-                entry.Block.EncodedBlockAccessList = ownedEncodedAccessList;
+                entry.Block.EncodedBlockAccessList = encodedAccessList;
             }
 
             entry.PeerInfo = peer;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlocksRequest.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlocksRequest.cs
@@ -13,7 +13,7 @@ public sealed class BlocksRequest : IDisposable
     public IOwnedReadOnlyList<BlockHeader> BodiesRequests { get; set; } = IOwnedReadOnlyList<BlockHeader>.Empty;
     public OwnedBlockBodies? OwnedBodies { get; set; }
     public IOwnedReadOnlyList<BlockHeader> BlockAccessListsRequests { get; set; } = IOwnedReadOnlyList<BlockHeader>.Empty;
-    public IByteArrayList? BlockAccessLists { get; set; }
+    public IOwnedReadOnlyList<byte[]?>? BlockAccessLists { get; set; }
     public IOwnedReadOnlyList<BlockHeader> ReceiptsRequests { get; set; } = IOwnedReadOnlyList<BlockHeader>.Empty;
     public IOwnedReadOnlyList<TxReceipt[]?>? Receipts { get; set; }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BlockAccessListsSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BlockAccessListsSyncBatch.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Synchronization.FastBlocks;
 public class BlockAccessListsSyncBatch(BlockInfo?[] infos) : FastBlocksBatch
 {
     public BlockInfo?[] Infos { get; } = infos;
-    public IByteArrayList? Response { get; set; }
+    public IOwnedReadOnlyList<byte[]?>? Response { get; set; }
 
     public override void Dispose()
     {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BlockAccessListsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BlockAccessListsSyncFeed.cs
@@ -237,11 +237,11 @@ public class BlockAccessListsSyncFeed : BarrierSyncFeed<BlockAccessListsSyncBatc
         {
             BlockInfo? blockInfo = blockInfos[i];
             bool hasAccessListResponse = (batch.Response?.Count ?? 0) > i;
-            ReadOnlySpan<byte> accessListRlp = hasAccessListResponse
+            byte[]? accessListRlp = hasAccessListResponse
                 ? batch.Response![i]
-                : ReadOnlySpan<byte>.Empty;
+                : null;
 
-            if (!accessListRlp.IsEmpty)
+            if (accessListRlp is not null)
             {
                 // last batch
                 if (blockInfo is null)


### PR DESCRIPTION
## Changes

- Fix eth/71 `BlockAccessLists` response encoding so unavailable BALs are encoded as the RLP empty string (`0x80`) while present BALs are sent as raw encoded BAL RLP items, including empty BALs (`0xc0`).
- Carry BAL responses as nullable raw RLP byte arrays through `ISyncPeer`, multi-block sync, and fast-block BAL sync so `null` represents unavailable data explicitly.
- Remove the temporary private-handler debug test and keep protocol regression coverage on the serializer and sync consumers.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project .\src\Nethermind\Nethermind.Network.Test\Nethermind.Network.Test.csproj -c Release -p:SaveDiskSpace=true --filter FullyQualifiedName~BlockAccessListsMessageSerializerTests`
- `dotnet test --project .\src\Nethermind\Nethermind.Network.Test\Nethermind.Network.Test.csproj -c Release -p:SaveDiskSpace=true --filter FullyQualifiedName~Eth71ProtocolHandlerTests`
- `dotnet test --project .\src\Nethermind\Nethermind.Synchronization.Test\Nethermind.Synchronization.Test.csproj -c Release -p:SaveDiskSpace=true --filter FullyQualifiedName~BlockDownloaderTests`
- `dotnet test --project .\src\Nethermind\Nethermind.Synchronization.Test\Nethermind.Synchronization.Test.csproj -c Release -p:SaveDiskSpace=true --filter FullyQualifiedName~BlockAccessListsSyncFeedTests`
- `dotnet test --project .\src\Nethermind\Nethermind.Network.Test\Nethermind.Network.Test.csproj -c Release -p:SaveDiskSpace=true --filter FullyQualifiedName~RlpByteArrayListTests`
- `dotnet build .\src\Nethermind\Nethermind.slnx -c Release -p:SaveDiskSpace=true -warnaserror`
- `dotnet build .\src\Nethermind\EthereumTests.slnx -c Release -p:SaveDiskSpace=true -warnaserror`
- `dotnet build .\src\Nethermind\Benchmarks.slnx -c Release -p:SaveDiskSpace=true -warnaserror`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Base branch: `master`.