### PR TITLE
chore: Update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,7 +79,7 @@
     <PackageVersion Include="Prometheus.Client.MetricPusher" Version="3.3.0" />
     <PackageVersion Include="Pyroscope" Version="1.0.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageVersion Include="RocksDB" Version="[10.4.2.64152]" />
+    <PackageVersion Include="RocksDB" Version="[10.10.1.649]" />
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.300" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.1" />
@@ -82,7 +82,7 @@
     <PackageVersion Include="RocksDB" Version="[10.10.1.649]" />
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
-    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="Spectre.Console" Version="0.56.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.9" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
@@ -91,7 +91,7 @@
     <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="6.6.0" />
     <PackageVersion Include="Websocket.Client" Version="5.5.0" />
-    <PackageVersion Include="YamlDotNet" Version="17.0.1" />
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
@@ -25,8 +24,8 @@
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.300" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
@@ -39,13 +38,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
@@ -86,10 +84,10 @@
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.9" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="6.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
@@ -87,7 +88,6 @@
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="6.6.0" />
     <PackageVersion Include="Websocket.Client" Version="5.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,44 +11,43 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
-    <PackageVersion Include="Ckzg.Bindings" Version="2.1.7.1596" />
+    <PackageVersion Include="Ckzg.Bindings" Version="2.1.7.1614" />
     <PackageVersion Include="Collections.Pooled" Version="1.0.82" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
     <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageVersion Include="Crc32.NET" Version="1.2.0" />
     <PackageVersion Include="DnsClient" Version="1.8.0" />
     <PackageVersion Include="FastEnum" Version="2.0.6" />
-    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
-    <PackageVersion Include="Google.Protobuf.Tools" Version="3.34.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
+    <PackageVersion Include="Google.Protobuf.Tools" Version="3.35.0" />
     <PackageVersion Include="Grpc" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.300" />
-    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.5" />
     <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.6.0" />
@@ -65,20 +64,20 @@
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />
     <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.3" />
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
-    <PackageVersion Include="NJsonSchema" Version="11.3.2" />
+    <PackageVersion Include="NJsonSchema" Version="11.6.1" />
     <PackageVersion Include="NLog" Version="5.5.1" />
     <PackageVersion Include="NLog.Targets.Seq" Version="4.0.2" />
     <PackageVersion Include="NonBlocking" Version="2.1.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Open.NAT.Core" Version="2.1.0.5" />
     <PackageVersion Include="PierTwo.Lantern.Discv5.WireProtocol" Version="1.0.0-preview.8" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageVersion Include="Prometheus.Client.MetricPusher" Version="3.3.0" />
-    <PackageVersion Include="Pyroscope" Version="0.14.5" />
+    <PackageVersion Include="Pyroscope" Version="1.0.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="RocksDB" Version="[10.4.2.64152]" />
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
@@ -90,9 +89,9 @@
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
-    <PackageVersion Include="Testably.Abstractions.Testing" Version="6.2.0" />
-    <PackageVersion Include="Websocket.Client" Version="5.3.0" />
+    <PackageVersion Include="Testably.Abstractions.Testing" Version="6.6.0" />
+    <PackageVersion Include="Websocket.Client" Version="5.5.0" />
     <PackageVersion Include="YamlDotNet" Version="17.0.1" />
-    <PackageVersion Include="ZstdSharp.Port" Version="0.8.7" />
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -43,9 +43,9 @@
       },
       "Pyroscope": {
         "type": "Direct",
-        "requested": "[0.14.5, )",
-        "resolved": "0.14.5",
-        "contentHash": "qKFyqeul4N9hK7LWTgGZNYtAtweVYbe7SRqL3K0ijmq4BvLYFRFmjKS4mnMOmyEZZr7QCuQVsZhaAQfohBfsIA=="
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "a+nwslnEERaD6aPzkkMuZl//cf2McOfhDUUn4TWKYipX3vZLdkS2o9Ns0R/y60n6sCbJZLWftcQqhex+ev0ckQ=="
       },
       "System.CommandLine": {
         "type": "Direct",
@@ -173,15 +173,20 @@
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
+      },
       "Microsoft.ClearScript.Core": {
         "type": "Transitive",
-        "resolved": "7.5.0",
-        "contentHash": "7BfzQZA7LdgpfJGSy/GBzKuURb32UpJGQObH5WAavkUxS/u9h/KaEl8N4812F6f4UWVrtwI5XdRgLMu6ukt38A=="
+        "resolved": "7.5.1",
+        "contentHash": "GuCo9rODubVJGR/cTS4+PIfLsXBz2JUtrUg3II3i+vb1GI0WWO4SLGZfnixtALeKhgBP+5hiKRE3pdmkC4pgFg=="
       },
       "Microsoft.ClearScript.V8.ICUData": {
         "type": "Transitive",
-        "resolved": "7.5.0",
-        "contentHash": "brX7rIjvZPt/ZDSZOPf36ULxhlsFcEgg2WLeOXCFkexTH7MWgUGy//6vMry/QvTLhSgDrs5z+8SbEU1krnuxRg=="
+        "resolved": "7.5.1",
+        "contentHash": "QuyrzwPU54Np1zxF8NVKQjPghCGs3WEaEsgYWfdCwBHKWLjprtkKH1dl0+lE0gf8hkGalAOH5B5wOctrZ6jEoA=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
@@ -256,23 +261,24 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.17.0",
-        "contentHash": "6NrxQGcZg6IunkN8K2F0UVMavNpfCjbjjjON7PYcL8FwI8aULKUreiHsRX/yaA8j3XsTJnQKUYpoQk5gBjULZw=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.17.0",
-        "contentHash": "w1vjfri0BWqW7RkSZY3ZsqekNfIJJg5BQSFs2j+a+pCXOVrkezmJcn74pT3djwjXJh71577C6wJQgNc2UPz30w==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.17.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.17.0",
-        "contentHash": "teaW35URIV2x78Tzk+dVJiC4M62/9mQoSEoDjDGoEZmcQa3H2rE+XQpm9Tmdo9KK1Lcrnve4zoyLavl69kCFGg==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.17.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -592,8 +598,8 @@
       },
       "System.Reactive": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "31kfaW4ZupZzPsI5PVe77VhnvFF55qgma7KZr/E0iFTs6fmdhhG8j0mgEx620iLTey1EynOkEfnyTjtNEpJzGw=="
+        "resolved": "6.1.0",
+        "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
       },
       "Testably.Abstractions.FileSystem.Interface": {
         "type": "Transitive",
@@ -647,12 +653,12 @@
         "type": "Project",
         "dependencies": {
           "Collections.Pooled": "[1.0.82, )",
-          "Microsoft.ClearScript.V8": "[7.5.0, )",
-          "Microsoft.ClearScript.V8.Native.linux-arm64": "[7.5.0, )",
-          "Microsoft.ClearScript.V8.Native.linux-x64": "[7.5.0, )",
-          "Microsoft.ClearScript.V8.Native.osx-arm64": "[7.5.0, )",
-          "Microsoft.ClearScript.V8.Native.osx-x64": "[7.5.0, )",
-          "Microsoft.ClearScript.V8.Native.win-x64": "[7.5.0, )",
+          "Microsoft.ClearScript.V8": "[7.5.1, )",
+          "Microsoft.ClearScript.V8.Native.linux-arm64": "[7.5.1, )",
+          "Microsoft.ClearScript.V8.Native.linux-x64": "[7.5.1, )",
+          "Microsoft.ClearScript.V8.Native.osx-arm64": "[7.5.1, )",
+          "Microsoft.ClearScript.V8.Native.osx-x64": "[7.5.1, )",
+          "Microsoft.ClearScript.V8.Native.win-x64": "[7.5.1, )",
           "Nethermind.Abi": "[1.39.0-unstable, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.Db": "[1.39.0-unstable, )",
@@ -727,7 +733,7 @@
           "Autofac.Extensions.DependencyInjection": "[11.0.0, )",
           "FastEnum": "[2.0.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, )",
-          "Microsoft.IdentityModel.JsonWebTokens": "[8.17.0, )",
+          "Microsoft.IdentityModel.JsonWebTokens": "[8.19.1, )",
           "Nethermind.Crypto.SecP256k1": "[1.6.0, )",
           "Nethermind.Logging": "[1.39.0-unstable, )",
           "Nethermind.Numerics.Int256": "[1.5.0, )",
@@ -740,7 +746,7 @@
         "type": "Project",
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.6.2, )",
-          "Ckzg.Bindings": "[2.1.7.1596, )",
+          "Ckzg.Bindings": "[2.1.7.1614, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.Crypto.Bls": "[1.0.5, )",
           "Nethermind.Serialization.Rlp": "[1.39.0-unstable, )",
@@ -818,7 +824,7 @@
           "Nethermind.JsonRpc": "[1.39.0-unstable, )",
           "Nethermind.Logging": "[1.39.0-unstable, )",
           "Nethermind.Network": "[1.39.0-unstable, )",
-          "Websocket.Client": "[5.3.0, )"
+          "Websocket.Client": "[5.5.0, )"
         }
       },
       "nethermind.evm": {
@@ -871,8 +877,8 @@
       "nethermind.grpc": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.34.1, )",
-          "Google.Protobuf.Tools": "[3.34.1, )",
+          "Google.Protobuf": "[3.35.0, )",
+          "Google.Protobuf.Tools": "[3.35.0, )",
           "Grpc": "[2.46.6, )",
           "Nethermind.Config": "[1.39.0-unstable, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
@@ -923,7 +929,7 @@
         "dependencies": {
           "Nethermind.Api": "[1.39.0-unstable, )",
           "Nethermind.Init": "[1.39.0-unstable, )",
-          "ZstdSharp.Port": "[0.8.7, )"
+          "ZstdSharp.Port": "[0.8.8, )"
         }
       },
       "nethermind.jsonrpc": {
@@ -1072,7 +1078,7 @@
       "nethermind.optimism": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.34.1, )",
+          "Google.Protobuf": "[3.35.0, )",
           "Nethermind.Api": "[1.39.0-unstable, )",
           "Nethermind.Blockchain": "[1.39.0-unstable, )",
           "Nethermind.Consensus": "[1.39.0-unstable, )",
@@ -1094,14 +1100,14 @@
       "nethermind.serialization.json": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ClearScript.V8": "[7.5.0, )",
+          "Microsoft.ClearScript.V8": "[7.5.1, )",
           "Nethermind.Core": "[1.39.0-unstable, )"
         }
       },
       "nethermind.serialization.rlp": {
         "type": "Project",
         "dependencies": {
-          "Ckzg.Bindings": "[2.1.7.1596, )",
+          "Ckzg.Bindings": "[2.1.7.1614, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.DotNetty.Buffers": "[1.0.2.76, )"
         }
@@ -1115,7 +1121,7 @@
       "nethermind.shutter": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.34.1, )",
+          "Google.Protobuf": "[3.35.0, )",
           "Nethermind.Blockchain": "[1.39.0-unstable, )",
           "Nethermind.Consensus": "[1.39.0-unstable, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
@@ -1143,7 +1149,7 @@
           "Nethermind.Config": "[1.39.0-unstable, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Json": "[1.39.0-unstable, )",
-          "ZstdSharp.Port": "[0.8.7, )"
+          "ZstdSharp.Port": "[0.8.8, )"
         }
       },
       "nethermind.state": {
@@ -1300,9 +1306,9 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Collections.Pooled": {
         "type": "CentralTransitive",
@@ -1349,15 +1355,15 @@
       },
       "Google.Protobuf": {
         "type": "CentralTransitive",
-        "requested": "[3.34.1, )",
-        "resolved": "3.34.1",
-        "contentHash": "212vdYxRuVopGE5bess6Jg5oXWyizA6hcLPTI7G+qA4PthQEvfeof3njT+7VSY5v/+O0P22xTydiP5fSJJpGEA=="
+        "requested": "[3.35.0, )",
+        "resolved": "3.35.0",
+        "contentHash": "OrUZCUzBXqdSmsQSWp/EPeINjOBcMU+PrZEJegw0aLgOGFHZ9ZI37X/SFrIxo8C9ghKynaKpPr3BVPc4EujWYg=="
       },
       "Google.Protobuf.Tools": {
         "type": "CentralTransitive",
-        "requested": "[3.34.1, )",
-        "resolved": "3.34.1",
-        "contentHash": "S/3uOvLZttS7+WOIzbI4QJR6r66xGZKuNy/kPYVV0HxM+SHzi4ZGtlFsQipzRInLNJImaJ36JVJQKK5ACag7gA=="
+        "requested": "[3.35.0, )",
+        "resolved": "3.35.0",
+        "contentHash": "W1pG23GZsTt6YrInU5EllMSxu1kmhBhCS/z0LN5jLueLQD2ai60qRwCqnxdZ4UTqbz3LeOxdWUsTdGYe8vj7fQ=="
       },
       "Grpc": {
         "type": "CentralTransitive",
@@ -1390,44 +1396,44 @@
       },
       "Microsoft.ClearScript.V8": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "k2xS9o6Oz57xx24nVhOqrkmJN/sDdkYTwdfmu2XS5KpnmAyqeVJBCfc9Wh83UvKUYb7lQBHSCk7gk2hLyJoG4Q==",
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "RflEJEMkidCKIOKALPwjvZXjjIUrIjgyXhgiyfrb8Ybnd2yxmNct7DOX3eWQYuHCyDe+wuTYBZaj3XaAlDMNDg==",
         "dependencies": {
-          "Microsoft.ClearScript.Core": "7.5.0",
-          "Microsoft.ClearScript.V8.ICUData": "7.5.0",
+          "Microsoft.ClearScript.Core": "7.5.1",
+          "Microsoft.ClearScript.V8.ICUData": "7.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
@@ -1458,11 +1464,11 @@
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "CentralTransitive",
-        "requested": "[8.17.0, )",
-        "resolved": "8.17.0",
-        "contentHash": "JbFZ3OVwtvqcqgBL0cIkhRYbIP7u9GIUYLOgbNqLWtBtZY8tGDpdGyXMzUVX0gVHq1ovuHsKZrkVv+ziHEnBHw==",
+        "requested": "[8.19.1, )",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.17.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IO.RecyclableMemoryStream": {
@@ -1679,12 +1685,12 @@
       },
       "Websocket.Client": {
         "type": "CentralTransitive",
-        "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "uhdDM+gruCEhHRCKCoyali1HJp0wSS/HBs5X9XZwULNKM2y5ML188TsvcEgWEFOx0NOaHfGNtfoC0cd1p2NOIg==",
+        "requested": "[5.5.0, )",
+        "resolved": "5.5.0",
+        "contentHash": "xJ5pTXiNSfwOzJVFcrUF1JROo63zjETJgIA4+ik/JxOJdNEv15e3NZ6bgpNQkyWhapcedP5HCa96hn9YCXwenw==",
         "dependencies": {
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "System.Reactive": "6.0.0"
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "System.Reactive": "6.1.0"
         }
       },
       "YamlDotNet": {
@@ -1695,9 +1701,9 @@
       },
       "ZstdSharp.Port": {
         "type": "CentralTransitive",
-        "requested": "[0.8.7, )",
-        "resolved": "0.8.7",
-        "contentHash": "+4VpxvzEKaHpfTjsLRMhQHx6brqGBkIA+fjUM3wUW8ZoWpPFAeKrO2Nf4uZDeBjjzNDNxSRvLQH4b3S9Ku4JJQ=="
+        "requested": "[0.8.8, )",
+        "resolved": "0.8.8",
+        "contentHash": "UIDFkA5DC3en3tOJ3Mof11yBx9kUQLsaeo/oFdvN6Bbkr9E9+VCqfIadHci8cu+I51K2Sl7XYWVl2R/mA75NBQ=="
       }
     },
     "net10.0/linux-arm64": {
@@ -1721,39 +1727,39 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Nethermind.Crypto.Bls": {
         "type": "CentralTransitive",
@@ -1819,39 +1825,39 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Nethermind.Crypto.Bls": {
         "type": "CentralTransitive",
@@ -1917,39 +1923,39 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Nethermind.Crypto.Bls": {
         "type": "CentralTransitive",
@@ -2015,39 +2021,39 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Nethermind.Crypto.Bls": {
         "type": "CentralTransitive",
@@ -2113,39 +2119,39 @@
       },
       "Ckzg.Bindings": {
         "type": "CentralTransitive",
-        "requested": "[2.1.7.1596, )",
-        "resolved": "2.1.7.1596",
-        "contentHash": "KOyRwQv0PwL/WVumNK7ooWyR9R9TOmR2uq51rvaR3ozcidKsjVdE8inA1D7sXC8wP2xtxjp0iGGI1ErhF9xQLg=="
+        "requested": "[2.1.7.1614, )",
+        "resolved": "2.1.7.1614",
+        "contentHash": "gruivbilVgQdH59yjJRHFLSLsyqRn24QSyHKskeJvm4lpfh7j5JRm44LYCuwy3JPr0HvwUpI7ZCL1lB6/4lheg=="
       },
       "Microsoft.ClearScript.V8.Native.linux-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "UU+3Bef3UnwQgP8hKobT09ucYuYubVFiseAsuRUvmjvOBVu7yHRES+nXBNYSvDi88fMTp/HBUknpYQdrfoDemQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "9QwgJVIAWlO/ltBuvVHj40dSKyctir7DUWe0zgWnaqeM4sgTO8QVrG5f+qjwo8uRYDKt15EPfqhAD8Y6+I3sXQ=="
       },
       "Microsoft.ClearScript.V8.Native.linux-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "snoN9oRwKqShA32IsuCanLjNtP8hros2WOrOBL7g+ED3AV40qwrsbfKwWq37BzogrfsF1aEVoDkBpE19Az7DVQ=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "B+JPK6ZnflitblwHl7WZ/6argp3+czixo10vYXbF9D5KgjclJbeppxj5FpJnH6Hv1Ua0Ql+TduoSX53fhYh5AQ=="
       },
       "Microsoft.ClearScript.V8.Native.osx-arm64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "CkMgeX0I0+bXUzoaVoJdV86/k0H2PEukqCoZ8zQ28msB6YHeRX6FJTfvOQ0l6UTX5HaBHGG3CWUI04uBYe6M+A=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "Fir3WvZX4e+rrLb+Py9+O4940STW9/UUBO2bXYxNE8lZhEIJwTvMnGeJ/KdrioHmAsJRMbcYN1P2PjQf2oNQ/Q=="
       },
       "Microsoft.ClearScript.V8.Native.osx-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "yXoXLWKJJgW5V6ez1aMa+ZS2nCef0X4iTYzPS9bTSYl9y7D4R2Ie2KrfR8nLO2rhOKimIMx3MH49Zh1CYruN/g=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "e31DyJwiTDLsCWEv2wkAtOPJqKGi5qQ2tnILjeqe6RD7b0EazXXq2wEFmEbx9aQs++mrb1oWpCOeLur+Qlb0Ig=="
       },
       "Microsoft.ClearScript.V8.Native.win-x64": {
         "type": "CentralTransitive",
-        "requested": "[7.5.0, )",
-        "resolved": "7.5.0",
-        "contentHash": "DKMxDLboTNflYkwDQ/ELrSf1vXTpew5UZ8xzrXSVKYFBU570VA6NKh1etEGhufuCuDyU7Je5L2g6H+19Dbl+tA=="
+        "requested": "[7.5.1, )",
+        "resolved": "7.5.1",
+        "contentHash": "fkCJta+xF2W3+L6NwRzqIV0VYD/WVcrZHyxgbOe5iTl321Td0w5loBWGVXlgG5fsuv2FEcba1GLE1CbeJrzMRw=="
       },
       "Nethermind.Crypto.Bls": {
         "type": "CentralTransitive",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -769,7 +769,7 @@
           "Nethermind.Api": "[1.39.0-unstable, )",
           "Nethermind.Db": "[1.39.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "RocksDB": "[10.10.1.649, )"
+          "RocksDB": "[10.10.1.649, 10.10.1.649]"
         }
       },
       "nethermind.db.rpc": {
@@ -1698,7 +1698,7 @@
       },
       "YamlDotNet": {
         "type": "CentralTransitive",
-        "requested": "[17.0.1, )",
+        "requested": "[18.0.0, )",
         "resolved": "16.3.0",
         "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
       },

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -168,11 +168,6 @@
         "resolved": "5.0.0",
         "contentHash": "pg1W2VwaEQMAiTpGK840hZgzavnqjlCMTVSbtVCXVyT+7AX4mc1o89SPv4TBlAjhgCOo9c1Y+jZ5m3ti2YgGgA=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
-      },
       "Microsoft.Bcl.Cryptography": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -190,21 +185,21 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "lwAbIZNdnY0SUNoDmZHkVUwLO8UyNnyyh1t/4XsbFxi4Ounb3xszIYZaWhyj5ZjyfcwqwmtMbE7fUTVCqQEIdQ==",
+        "resolved": "5.3.0",
+        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.3.3"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "l4dDRmGELXG72XZaonnOeORyD/T5RpEu5LGHOUIhnv+MmUWDY/m1kWXGwtcgQ5CJ5ynkFiRnIYzTKXYjUs7rbw==",
+        "resolved": "5.3.0",
+        "contentHash": "QSf1ge9A+XFZbGL+gIqXYBIKlm8QdQVLvHDPZiydG11W6mJY7XBMusrsgIEz6L8GYMzGJKTM78m9icliGMF7NA==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.CodeAnalysis.Common": "[4.5.0]",
-          "System.Composition": "6.0.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
+          "System.Composition": "9.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {
@@ -550,50 +545,50 @@
       },
       "System.Composition": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "d7wMuKQtfsxUa7S13tITC8n1cQzewuhD5iDjZtK2prwFfKVzdYtgrTHgjaV03Zq7feGQ5gkP85tJJntXwInsJA==",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
         "dependencies": {
-          "System.Composition.AttributedModel": "6.0.0",
-          "System.Composition.Convention": "6.0.0",
-          "System.Composition.Hosting": "6.0.0",
-          "System.Composition.Runtime": "6.0.0",
-          "System.Composition.TypedParts": "6.0.0"
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
         }
       },
       "System.Composition.AttributedModel": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "WK1nSDLByK/4VoC7fkNiFuTVEiperuCN/Hyn+VN30R+W2ijO1d0Z2Qm0ScEl9xkSn1G2MyapJi8xpf4R8WRa/w=="
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
       },
       "System.Composition.Convention": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "XYi4lPRdu5bM4JVJ3/UIHAiG6V6lWWUlkhB9ab4IOq0FrRsp0F4wTyV4Dj+Ds+efoXJ3qbLqlvaUozDO7OLeXA==",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
         "dependencies": {
-          "System.Composition.AttributedModel": "6.0.0"
+          "System.Composition.AttributedModel": "9.0.0"
         }
       },
       "System.Composition.Hosting": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "w/wXjj7kvxuHPLdzZ0PAUt++qJl03t7lENmb2Oev0n3zbxyNULbWBlnd5J5WUMMv15kg5o+/TCZFb6lSwfaUUQ==",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
         "dependencies": {
-          "System.Composition.Runtime": "6.0.0"
+          "System.Composition.Runtime": "9.0.0"
         }
       },
       "System.Composition.Runtime": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "qkRH/YBaMPTnzxrS5RDk1juvqed4A6HOD/CwRcDGyPpYps1J27waBddiiq1y93jk2ZZ9wuA/kynM+NO0kb3PKg=="
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
       },
       "System.Composition.TypedParts": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "iUR1eHrL8Cwd82neQCJ00MpwNIBs4NZgXzrPqx8NJf/k4+mwBO0XCRmHYJT4OLSwDDqh5nBLJWkz5cROnrGhRA==",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "6.0.0",
-          "System.Composition.Hosting": "6.0.0",
-          "System.Composition.Runtime": "6.0.0"
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
         }
       },
       "System.Reactive": {
@@ -1438,28 +1433,31 @@
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "3.3.3",
-        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
+        "resolved": "5.3.0",
+        "contentHash": "KuLhbZwB0L8JikL86AE5VWEp3RLNjIcp+j8yz9EJ/UBgRz4+qDEjHg/tluRFbpYpD/e37BqaaNFbQ0vqawBwWQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "4.5.0",
-        "contentHash": "cM59oMKAOxvdv76bdmaKPy5hfj+oR+zxikWoueEB7CwTko7mt9sVKZI8Qxlov0C/LuKEG+WQwifepqL3vuTiBQ==",
+        "resolved": "5.3.0",
+        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[4.5.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "4.5.0",
-        "contentHash": "h74wTpmGOp4yS4hj+EvNzEiPgg/KVs2wmSfTZ81upJZOtPkJsVkgfsgtxxqmAeapjT/vLKfmYV0bS8n5MNVP+g==",
+        "resolved": "5.3.0",
+        "contentHash": "mRwxchBs3ewXK4dqK4R/eVCx99VIq1k/lhwArlu+fJuV0uzmbkTTRw4jR9gN9sOcAQfX0uV9KQlmCk1yC0JNog==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.CSharp": "[4.5.0]",
-          "Microsoft.CodeAnalysis.Common": "[4.5.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.5.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.3.0]",
+          "System.Composition": "9.0.0"
         }
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
@@ -1699,8 +1697,8 @@
       "YamlDotNet": {
         "type": "CentralTransitive",
         "requested": "[18.0.0, )",
-        "resolved": "16.3.0",
-        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
+        "resolved": "18.0.0",
+        "contentHash": "ptHVgcYmLejGuWXV7RMFoEqFKYMXnieOlWLPzEslfDtzZ9ngMhjYwykfqjBN2+fMEAEyobozkj07lKEpR4dssA=="
       },
       "ZstdSharp.Port": {
         "type": "CentralTransitive",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -769,7 +769,7 @@
           "Nethermind.Api": "[1.39.0-unstable, )",
           "Nethermind.Db": "[1.39.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "RocksDB": "[10.4.2.64152, 10.4.2.64152]"
+          "RocksDB": "[10.10.1.649, )"
         }
       },
       "nethermind.db.rpc": {
@@ -1637,9 +1637,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       },
       "SCrypt": {
         "type": "CentralTransitive",
@@ -1799,9 +1802,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       }
     },
     "net10.0/linux-x64": {
@@ -1897,9 +1903,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       }
     },
     "net10.0/osx-arm64": {
@@ -1995,9 +2004,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       }
     },
     "net10.0/osx-x64": {
@@ -2093,9 +2105,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       }
     },
     "net10.0/win-x64": {
@@ -2191,9 +2206,12 @@
       },
       "RocksDB": {
         "type": "CentralTransitive",
-        "requested": "[10.4.2.64152, 10.4.2.64152]",
-        "resolved": "10.4.2.64152",
-        "contentHash": "AQ42+Bs36uSVCw6P2ilHW9r5Cq5rI/T9GMuI1s6XpMZ4yx8IMyTryk8yqZb8/5bBjJMjnqw6zJvwur+OsgZ2oA=="
+        "requested": "[10.10.1.649, 10.10.1.649]",
+        "resolved": "10.10.1.649",
+        "contentHash": "2zZnjtrhKjZFv/YhhGhGbZRW9Ddl2dXbJ1HKxulx9U+E41nxIsHA9vG2BOEUm6e3519V++Kz8ORHoioEyHenzg==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.7"
+        }
       }
     }
   }

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "Wv9s0rmrmUEma268HCqqcHGgJI30O9mqMxnORZ/QFxtbjoTFEuMvnqL2kIfbZcOGD6XF6II47Hc6YSff0jKGkw=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "UpRgjjSUmF7KYZTIv1Zd2Y0Wv2oK9jE+Jmyp4UMynTowjvJGG1yrRe2JodYyVgcDgZF2auGwYEl+U0J1+YhBRw=="
       },
       "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
         "type": "Direct",
@@ -49,9 +49,9 @@
       },
       "System.CommandLine": {
         "type": "Direct",
-        "requested": "[2.0.8, )",
-        "resolved": "2.0.8",
-        "contentHash": "FbpgF8p/ClXnoXEWLjQB34kNh5rsLewEgIgLyVzLDucAOQ4cNs7ec9Cam7gdKPruSb6zp4Mx8htZGTL4/5PJPg=="
+        "requested": "[2.0.9, )",
+        "resolved": "2.0.9",
+        "contentHash": "SW0WhEk4NFVZ4lOnsLrHQOV/7s0eTidezNybHQWXfqhuXWB17X3RXbrifeWBbUx1iu+NcYchVSufmW7svjUEnA=="
       },
       "AspNetCore.HealthChecks.UI.Core": {
         "type": "Transitive",
@@ -168,6 +168,11 @@
         "resolved": "5.0.0",
         "contentHash": "pg1W2VwaEQMAiTpGK840hZgzavnqjlCMTVSbtVCXVyT+7AX4mc1o89SPv4TBlAjhgCOo9c1Y+jZ5m3ti2YgGgA=="
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
       "Microsoft.ClearScript.Core": {
         "type": "Transitive",
         "resolved": "7.5.0",
@@ -180,21 +185,21 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
+        "resolved": "4.5.0",
+        "contentHash": "lwAbIZNdnY0SUNoDmZHkVUwLO8UyNnyyh1t/4XsbFxi4Ounb3xszIYZaWhyj5ZjyfcwqwmtMbE7fUTVCqQEIdQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1"
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.3"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "QSf1ge9A+XFZbGL+gIqXYBIKlm8QdQVLvHDPZiydG11W6mJY7XBMusrsgIEz6L8GYMzGJKTM78m9icliGMF7NA==",
+        "resolved": "4.5.0",
+        "contentHash": "l4dDRmGELXG72XZaonnOeORyD/T5RpEu5LGHOUIhnv+MmUWDY/m1kWXGwtcgQ5CJ5ynkFiRnIYzTKXYjUs7rbw==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
-          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
-          "System.Composition": "9.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.CodeAnalysis.Common": "[4.5.0]",
+          "System.Composition": "6.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {
@@ -539,50 +544,50 @@
       },
       "System.Composition": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "resolved": "6.0.0",
+        "contentHash": "d7wMuKQtfsxUa7S13tITC8n1cQzewuhD5iDjZtK2prwFfKVzdYtgrTHgjaV03Zq7feGQ5gkP85tJJntXwInsJA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0",
-          "System.Composition.Convention": "9.0.0",
-          "System.Composition.Hosting": "9.0.0",
-          "System.Composition.Runtime": "9.0.0",
-          "System.Composition.TypedParts": "9.0.0"
+          "System.Composition.AttributedModel": "6.0.0",
+          "System.Composition.Convention": "6.0.0",
+          "System.Composition.Hosting": "6.0.0",
+          "System.Composition.Runtime": "6.0.0",
+          "System.Composition.TypedParts": "6.0.0"
         }
       },
       "System.Composition.AttributedModel": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+        "resolved": "6.0.0",
+        "contentHash": "WK1nSDLByK/4VoC7fkNiFuTVEiperuCN/Hyn+VN30R+W2ijO1d0Z2Qm0ScEl9xkSn1G2MyapJi8xpf4R8WRa/w=="
       },
       "System.Composition.Convention": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "resolved": "6.0.0",
+        "contentHash": "XYi4lPRdu5bM4JVJ3/UIHAiG6V6lWWUlkhB9ab4IOq0FrRsp0F4wTyV4Dj+Ds+efoXJ3qbLqlvaUozDO7OLeXA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0"
+          "System.Composition.AttributedModel": "6.0.0"
         }
       },
       "System.Composition.Hosting": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "resolved": "6.0.0",
+        "contentHash": "w/wXjj7kvxuHPLdzZ0PAUt++qJl03t7lENmb2Oev0n3zbxyNULbWBlnd5J5WUMMv15kg5o+/TCZFb6lSwfaUUQ==",
         "dependencies": {
-          "System.Composition.Runtime": "9.0.0"
+          "System.Composition.Runtime": "6.0.0"
         }
       },
       "System.Composition.Runtime": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+        "resolved": "6.0.0",
+        "contentHash": "qkRH/YBaMPTnzxrS5RDk1juvqed4A6HOD/CwRcDGyPpYps1J27waBddiiq1y93jk2ZZ9wuA/kynM+NO0kb3PKg=="
       },
       "System.Composition.TypedParts": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "resolved": "6.0.0",
+        "contentHash": "iUR1eHrL8Cwd82neQCJ00MpwNIBs4NZgXzrPqx8NJf/k4+mwBO0XCRmHYJT4OLSwDDqh5nBLJWkz5cROnrGhRA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0",
-          "System.Composition.Hosting": "9.0.0",
-          "System.Composition.Runtime": "9.0.0"
+          "System.Composition.AttributedModel": "6.0.0",
+          "System.Composition.Hosting": "6.0.0",
+          "System.Composition.Runtime": "6.0.0"
         }
       },
       "System.Reactive": {
@@ -665,7 +670,7 @@
         "dependencies": {
           "Nethermind.Core": "[1.39.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "System.Configuration.ConfigurationManager": "[10.0.8, )"
+          "System.Configuration.ConfigurationManager": "[10.0.9, )"
         }
       },
       "nethermind.consensus": {
@@ -739,7 +744,7 @@
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.Crypto.Bls": "[1.0.5, )",
           "Nethermind.Serialization.Rlp": "[1.39.0-unstable, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.8, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.9, )"
         }
       },
       "nethermind.db": {
@@ -779,7 +784,6 @@
           "Nethermind.Consensus": "[1.39.0-unstable, )",
           "Nethermind.Core": "[1.39.0-unstable, )",
           "Nethermind.JsonRpc": "[1.39.0-unstable, )",
-          "Nethermind.Merkleization": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Rlp": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Ssz": "[1.39.0-unstable, )",
           "Nethermind.State": "[1.39.0-unstable, )",
@@ -797,7 +801,6 @@
           "Nethermind.Era1": "[1.39.0-unstable, )",
           "Nethermind.History": "[1.39.0-unstable, )",
           "Nethermind.JsonRpc": "[1.39.0-unstable, )",
-          "Nethermind.Merkleization": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Rlp": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Ssz": "[1.39.0-unstable, )",
           "Nethermind.State": "[1.39.0-unstable, )",
@@ -987,14 +990,7 @@
         "type": "Project",
         "dependencies": {
           "Nethermind.Api": "[1.39.0-unstable, )",
-          "Nethermind.Merkleization": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Ssz": "[1.39.0-unstable, )"
-        }
-      },
-      "nethermind.merkleization": {
-        "type": "Project",
-        "dependencies": {
-          "Nethermind.Numerics.Int256": "[1.5.0, )"
         }
       },
       "nethermind.monitoring": {
@@ -1128,7 +1124,6 @@
           "Nethermind.Libp2p": "[1.0.0-preview.45, )",
           "Nethermind.Libp2p.Protocols.PubsubPeerDiscovery": "[1.0.0-preview.45, )",
           "Nethermind.Merge.Plugin": "[1.39.0-unstable, )",
-          "Nethermind.Merkleization": "[1.39.0-unstable, )",
           "Nethermind.Network.Discovery": "[1.39.0-unstable, )",
           "Nethermind.Serialization.Ssz": "[1.39.0-unstable, )",
           "Nethermind.Specs": "[1.39.0-unstable, )"
@@ -1173,7 +1168,7 @@
           "Nethermind.State": "[1.39.0-unstable, )",
           "Nethermind.Synchronization": "[1.39.0-unstable, )",
           "Nethermind.Trie": "[1.39.0-unstable, )",
-          "System.IO.Hashing": "[10.0.8, )"
+          "System.IO.Hashing": "[10.0.9, )"
         }
       },
       "nethermind.statecomposition": {
@@ -1437,31 +1432,28 @@
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "KuLhbZwB0L8JikL86AE5VWEp3RLNjIcp+j8yz9EJ/UBgRz4+qDEjHg/tluRFbpYpD/e37BqaaNFbQ0vqawBwWQ=="
+        "resolved": "3.3.3",
+        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
+        "resolved": "4.5.0",
+        "contentHash": "cM59oMKAOxvdv76bdmaKPy5hfj+oR+zxikWoueEB7CwTko7mt9sVKZI8Qxlov0C/LuKEG+WQwifepqL3vuTiBQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
-          "Microsoft.CodeAnalysis.Common": "[5.3.0]"
+          "Microsoft.CodeAnalysis.Common": "[4.5.0]"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "CentralTransitive",
         "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "mRwxchBs3ewXK4dqK4R/eVCx99VIq1k/lhwArlu+fJuV0uzmbkTTRw4jR9gN9sOcAQfX0uV9KQlmCk1yC0JNog==",
+        "resolved": "4.5.0",
+        "contentHash": "h74wTpmGOp4yS4hj+EvNzEiPgg/KVs2wmSfTZ81upJZOtPkJsVkgfsgtxxqmAeapjT/vLKfmYV0bS8n5MNVP+g==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
-          "Microsoft.CodeAnalysis.CSharp": "[5.3.0]",
-          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.3.0]",
-          "System.Composition": "9.0.0"
+          "Microsoft.CodeAnalysis.CSharp": "[4.5.0]",
+          "Microsoft.CodeAnalysis.Common": "[4.5.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.5.0]"
         }
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
@@ -1657,24 +1649,24 @@
       },
       "System.Configuration.ConfigurationManager": {
         "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "QG+HHwJjLyUiRuA9axr5pDqHAxboo7FXCTRakxMABE9CUAUij/tsd/MsgQPJUEppkf+YBLT+F/P/wKIVCAIcNg==",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "k7kYSTmNjwFYKdUju+rjYyigbcUBj1sElR3ayqszcatPXL9YJoBANJN48xctdXTopYf3ceFX2T4m1xvJRM+CGA==",
         "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "10.0.8"
+          "System.Security.Cryptography.ProtectedData": "10.0.9"
         }
       },
       "System.IO.Hashing": {
         "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "vixglGnKEexAJDeIRhyayZYzxyrgK1K9GU3K/zRZVwDbaDcMkSqj4WDHoVmQMNfsdUtLALfNSJw6mBIpdxie4A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "/ldVgSfImIBp6fLWS7sLH0BnmtFj0ZwGlZo4Xx2q0K3ZhJNDbW45kj2f6zPoC+L+BTINuHdMzTsopuwmkbgcNA=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "vXp+vBQbTkMrDzUiPCxo1KvzfaAvZWuSRS2P7e5orhtV7ZuePKAB3Cqc9dH2YHUavRJyA2uWd2yrL6hl2VoJ5g=="
       },
       "Testably.Abstractions": {
         "type": "CentralTransitive",
@@ -1698,8 +1690,8 @@
       "YamlDotNet": {
         "type": "CentralTransitive",
         "requested": "[17.0.1, )",
-        "resolved": "17.0.1",
-        "contentHash": "qVir5fehR/W5nTJyoJUibypETXaW4iRAF9cQa0FQIC9TJ3VC0qDOwm4o/RxANewj8KzPF8WMF2abBfUgi6LC4w=="
+        "resolved": "16.3.0",
+        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
       },
       "ZstdSharp.Port": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Changes

- Updated .NET packages
- Updated all other packages
- Updated RocksDB to v10.10.1. From the release notes of v10.9.1:
  > Fix a bug where compaction with range deletion can persist kTypeMaxValid in MANIFEST as file metadata. kTypeMaxValid is not supposed to be persisted and can change as new value types are introduced. This can cause a forward compatibility issue where older versions of RocksDB don't recognize kTypeMaxValid from newer versions. A new placeholder value type kTypeTruncatedRangeDeletionSentinel is also introduced to replace kTypeMaxValid when reading existing SST files' metadata from MANIFEST. This allows us to strengthen some checks to avoid using kTypeMaxValid in the future.
  
  This update may potentially prevent users from rolling Nethermind back, keeping the existing database. So, we may not want it, but it's a bugfix.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Package update

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Requires manual testing