### PR TITLE
Increase RLP block withdrawals limit to 64k

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
@@ -26,7 +26,7 @@ public class BlockBodyDecoderTests
     // check for RlpLimitException specifically, which should fire before decoding, so 0xC0 placeholders are fine here.
     [TestCase(60_000, 0, null, TestName = "transactions")]
     [TestCase(0, 3, null, TestName = "uncles")]
-    [TestCase(0, 0, 1_001, TestName = "withdrawals")]
+    [TestCase(0, 0, 64_001, TestName = "withdrawals")]
     public void Decode_count_over_limit_throws(int txCount, int uncleCount, int? withdrawalCount) =>
         Assert.Throws<RlpLimitException>(() => DecodeBody(BuildBodyStream(txCount, uncleCount, withdrawalCount)));
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -17,8 +17,8 @@ public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : Rlp
     private static readonly RlpLimit UnclesCountLimit = RlpLimit.For<BlockBody>(2, nameof(BlockBody.Uncles));
 
     // Actual consensus-level max is 16, see MAX_WITHDRAWALS_PER_PAYLOAD at https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md
-    // Increased here for compatibility with execution spec tests
-    private static readonly RlpLimit WithdrawalsCountLimit = RlpLimit.For<BlockBody>(1_000, nameof(BlockBody.Withdrawals));
+    // Increased here for compatibility with execution spec tests and benchmarks
+    private static readonly RlpLimit WithdrawalsCountLimit = RlpLimit.For<BlockBody>(64_000, nameof(BlockBody.Withdrawals));
 
     private readonly TxDecoder _txDecoder = TxDecoder.Instance;
     private readonly IHeaderDecoder _headerDecoder = headerDecoder ?? new HeaderDecoder();


### PR DESCRIPTION
Needed for benchmarks.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)