### PR TITLE
feat(FlatDB): add CompactionOffset config to pin the compaction schedule

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -20,5 +20,6 @@ public class FlatDbConfig : IFlatDbConfig
     public int MinReorgDepth { get; set; } = 128;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public long BlockCacheSizeBudget { get; set; } = 1.GiB;
+    public long CompactionOffset { get; set; } = -1;
     public long TrieCacheMemoryBudget { get; set; } = 512.MiB;
 }

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -10,6 +10,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Block cache size budget", DefaultValue = "1073741824")]
     long BlockCacheSizeBudget { get; set; }
 
+    [ConfigItem(Description = "Fixed compaction schedule offset in blocks. When 0 or greater, overrides the per-instance offset in the metadata DB, which is neither read nor updated. Only the value modulo CompactSize matters. -1 to use the stored offset, generating a random one when absent.", DefaultValue = "-1")]
+    long CompactionOffset { get; set; }
+
     [ConfigItem(Description = "Compact size", DefaultValue = "32")]
     int CompactSize { get; set; }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -44,6 +44,33 @@ public class CompactionScheduleTests
         Assert.That(after, Is.EqualTo(before));
     }
 
+    [Test]
+    public void Constructor_ConfiguredOffset_UsedWithoutTouchingDb()
+    {
+        MemDb metadataDb = new();
+        FlatDbConfig config = new() { CompactSize = 32, CompactionOffset = 7 };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.EqualTo(7));
+        Assert.That(metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset), Is.Null);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Constructor_ConfiguredOffset_TakesPrecedenceOverStoredValue(bool regenerateFlag)
+    {
+        MemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.FlatDbCompactionOffset, EncodedOffset(5));
+        FlatDbConfig config = new() { CompactSize = 32, CompactionOffset = 7, RegenerateCompactionOffset = regenerateFlag };
+
+        CompactionSchedule schedule = new(metadataDb, config, LimboLogs.Instance);
+
+        Assert.That(schedule.Offset, Is.EqualTo(7));
+        long stored = metadataDb.Get(MetadataDbKeys.FlatDbCompactionOffset)!.AsRlpValueContext().DecodeLong();
+        Assert.That(stored, Is.EqualTo(5), "configured offset should not modify the stored offset");
+    }
+
     [TestCase(1_000_000L)]
     [TestCase(int.MaxValue - 1L)]
     public void Constructor_StoredLargePositiveValue_KeptAsIs(long stored)

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -49,6 +49,12 @@ public sealed class CompactionSchedule : ICompactionSchedule
     {
         if (_compactSize <= 1) return 0;
 
+        if (config.CompactionOffset >= 0)
+        {
+            if (logger.IsInfo) logger.Info($"Using configured FlatDb compaction offset {config.CompactionOffset}");
+            return config.CompactionOffset;
+        }
+
         if (config.RegenerateCompactionOffset)
         {
             long regenerated = GenerateAndPersist(metadataDb);


### PR DESCRIPTION
## Changes

- Add `FlatDb.CompactionOffset` config (`long`, default `-1`). When set to a non-negative value, `CompactionSchedule` uses it as the compaction schedule offset directly: the per-instance offset in the metadata DB is neither read nor updated, and the value takes precedence over `RegenerateCompactionOffset`. Only the value modulo `CompactSize` matters. `-1` (default) keeps the current behavior: load the stored offset, generating and persisting a random one when absent.

### Why

#11756 staggers compaction with a random per-instance offset persisted in the metadata DB. Environments that restore a DB image on every run (e.g. reproducible gas benchmarks) lose the stored offset and re-roll a random one each startup, so the compaction phase changes run-to-run. This broke the benchmarks: the offset moved the payload height from a tier-1 (no-op) to a tier-4 compact size, and since the benchmark replays hundreds of payloads as siblings of a single parent, every sibling built its own permanent 4-block compacted bundle until the process ran out of memory (`OutOfMemoryException` in `SnapshotCompactor.CompactSnapshotBundle`).

Pinning the offset (e.g. `--FlatDb.CompactionOffset 0`) restores a deterministic, pre-#11756-identical compaction schedule for such setups, while production deployments keep the random per-instance stagger by default.

Note this is a mitigation for the benchmark setup, not a fix for the underlying amplification: compacted bundles for sibling states at the same height accumulate without bound (one per sibling state root, released only by persistence progress). A follow-up should evict same-height sibling bundles in `SnapshotRepository.TryAddCompactedSnapshot`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`CompactionScheduleTests` cover: configured offset used without reading/writing the metadata DB, and precedence over both a stored offset and `RegenerateCompactionOffset=true`. `StandardTests.All_default_values_are_correct` validates the config default.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No