### PR TITLE
Fix EngineApiProxy rejecting its own blocks: forward EIP-7685 executionRequests in synthetic newPayload

### DIFF
--- a/tools/EngineApiProxy/Services/RequestOrchestrator.cs
+++ b/tools/EngineApiProxy/Services/RequestOrchestrator.cs
@@ -373,6 +373,11 @@ public class RequestOrchestrator(
             // Extract the executionPayload from the response
             JsonNode executionPayload = (payload["executionPayload"] ?? payload).DeepClone();
 
+            // EIP-7685 executionRequests (getPayloadV4+). The block's requestsHash is
+            // derived from this list, so replaying the payload without it makes the EL
+            // recompute a different block hash and reject the block as invalid.
+            JsonNode executionRequests = payload["executionRequests"]?.DeepClone() ?? new JsonArray();
+
             // Use provided blobVersionedHashes or empty array
             blobVersionedHashes ??= [];
             _logger.Debug($"CreateNewPayloadRequest: Including {blobVersionedHashes.Count} blobVersionedHashes in synthetic newPayload");
@@ -426,10 +431,10 @@ public class RequestOrchestrator(
                 executionPayload,          // First parameter: executionPayload
                 blobVersionedHashes,       // Second parameter: blobVersionedHashes
                 parentBeaconBlockRoot,     // Third parameter: parentBeaconBlockRoot
-                new JsonArray()            // Fourth parameter: execution_payload_preparation_info
+                executionRequests          // Fourth parameter: executionRequests (EIP-7685)
             ];
 
-            _logger.Debug($"Created {_config.NewPayloadMethod} request with {blobVersionedHashes.Count} blobVersionedHashes, parentBeaconBlockRoot: {parentBeaconBlockRoot}");
+            _logger.Debug($"Created {_config.NewPayloadMethod} request with {blobVersionedHashes.Count} blobVersionedHashes, {(executionRequests as JsonArray)?.Count ?? 0} executionRequests, parentBeaconBlockRoot: {parentBeaconBlockRoot}");
 
             return new JsonRpcRequest(
                 _config.NewPayloadMethod,


### PR DESCRIPTION
## Changes

- `EngineApiProxy` Lighthouse validation flow: forward EIP-7685 `executionRequests` from the `engine_getPayloadV4/V5` response as the fourth `engine_newPayloadV4/V5` parameter. It was hardcoded to an empty array (mislabeled `execution_payload_preparation_info`), so the EL recomputed `requestsHash` over an empty list, derived a different block hash, and correctly rejected every block it had just built that carried requests, with `invalid block hash`. Blocks without requests passed, which made the failures look intermittent.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: Description

## Testing

Requires testing

- [ ] Yes
- [x] No

If yes, did you write tests?

- [ ] Yes
- [ ] No

Notes on testing

Observed on the EAPML mainnet smoke test (post-merge-smoke-tests run 27240246182, node `test-EAPML-mainnet-27240246182`): `GetPayloadV5 result: 25283696 (0x6a61d2...908942)` followed immediately by `Rejected invalid block 25283696 (0x6a61d2...908942) ... reason: invalid block hash`, firing `Nethermind-Client-Bad-Block` Grafana alerts on a healthy node. The tool has no test project; the fix is validated by build and will be exercised end-to-end by the EAPML smoke test once merged (success criterion: no more bad-block rejections on request-bearing mainnet blocks).
