### PR TITLE
Flat: force-persist the head-reachable fork instead of an arbitrary one

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -124,6 +124,7 @@ public class FlatDbManagerTests
         manager.AddSnapshot(snapshot, transientResource);
 
         _snapshotRepository.DidNotReceive().TryAddSnapshot(Arg.Any<Snapshot>());
+        _snapshotRepository.DidNotReceive().SetLastCommittedStateId(Arg.Any<StateId>());
     }
 
     [Test]
@@ -143,6 +144,7 @@ public class FlatDbManagerTests
         manager.AddSnapshot(snapshot, transientResource);
 
         _snapshotRepository.Received(1).TryAddSnapshot(snapshot);
+        _snapshotRepository.Received(1).SetLastCommittedStateId(snapshotTo);
     }
 
     [Test]
@@ -193,5 +195,6 @@ public class FlatDbManagerTests
         manager.AddSnapshot(snapshot, transientResource);
 
         _resourcePool.Received(1).ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+        _snapshotRepository.DidNotReceive().SetLastCommittedStateId(Arg.Any<StateId>());
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -198,8 +198,40 @@ public class PersistenceManagerTests
         using Snapshot fork1 = CreateSnapshot(persisted, target1, compacted: true);
         using Snapshot fork2 = CreateSnapshot(persisted, target2, compacted: true);
         using Snapshot toHead = CreateSnapshot(target2, head, compacted: true); // head reachable only via target2
+        _snapshotRepository.SetLastCommittedStateId(head);
 
         Snapshot? result = _persistenceManager.DetermineSnapshotToPersist(head);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.From, Is.EqualTo(persisted));
+        Assert.That(result.To, Is.EqualTo(target2));
+
+        result.Dispose();
+    }
+
+    [Test]
+    public void DetermineSnapshotToPersist_LongerNonCanonicalFork_PersistsCommittedHeadChain()
+    {
+        // The longest in-memory chain runs through target1 up to block 300, but the committed head is the
+        // shorter chain through target2 (at block 32). The forced persist must follow the committed head
+        // (target2), not the longer fork (target1) that GetLastSnapshotId would pick.
+        StateId persisted = Block0;
+        StateId target1 = CreateStateId(16, rootByte: 1); // boundary state on the longer, non-canonical fork
+        StateId target2 = CreateStateId(16, rootByte: 2); // boundary state on the committed head's chain
+        StateId longHead = CreateStateId(300); // longest chain (the max), but not committed
+        StateId committedHead = CreateStateId(32, rootByte: 2);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(0); // unfinalized at the boundary
+
+        using Snapshot fork1 = CreateSnapshot(persisted, target1, compacted: true);
+        using Snapshot fork2 = CreateSnapshot(persisted, target2, compacted: true);
+        using Snapshot toLongHead = CreateSnapshot(target1, longHead, compacted: true); // makes target1 the max chain
+        using Snapshot toCommittedHead = CreateSnapshot(target2, committedHead, compacted: true);
+        _snapshotRepository.SetLastCommittedStateId(committedHead);
+
+        // latestSnapshot at 300 (the longest chain) makes the in-memory depth exceed MaxReorgDepth (256),
+        // triggering the force-persist branch.
+        Snapshot? result = _persistenceManager.DetermineSnapshotToPersist(longHead);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result!.From, Is.EqualTo(persisted));
@@ -522,6 +554,7 @@ public class PersistenceManagerTests
         using Snapshot fork1 = CreateSnapshot(Block0, target1, compacted: true);
         using Snapshot fork2 = CreateSnapshot(Block0, target2, compacted: true);
         using Snapshot toHead = CreateSnapshot(target2, head, compacted: true); // head reachable only via target2
+        _snapshotRepository.SetLastCommittedStateId(head);
 
         IPersistence.IWriteBatch writeBatch = Substitute.For<IPersistence.IWriteBatch>();
         _persistence.CreateWriteBatch(Arg.Any<StateId>(), Arg.Any<StateId>()).Returns(writeBatch);
@@ -529,6 +562,36 @@ public class PersistenceManagerTests
         StateId result = _persistenceManager.FlushToPersistence();
 
         Assert.That(result, Is.EqualTo(head));
+        _persistence.Received().CreateWriteBatch(Block0, target2);
+        _persistence.DidNotReceive().CreateWriteBatch(Block0, target1);
+    }
+
+    [Test]
+    public void FlushToPersistence_LongerNonCanonicalFork_PersistsCommittedHeadChain()
+    {
+        // The longest in-memory chain runs through target1 to block 300, but the committed head is the
+        // shorter chain through target2 (at block 32). The flush must follow the committed head (target2),
+        // stopping at its block, not chase the longer non-canonical fork through target1.
+        StateId target1 = CreateStateId(16, rootByte: 1); // boundary state on the longer, non-canonical fork
+        StateId target2 = CreateStateId(16, rootByte: 2); // boundary state on the committed head's chain
+        StateId longHead = CreateStateId(300); // longest chain (the max), but not committed
+        StateId committedHead = CreateStateId(32, rootByte: 2);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(0); // nothing finalized
+
+        using Snapshot fork1 = CreateSnapshot(Block0, target1, compacted: true);
+        using Snapshot fork2 = CreateSnapshot(Block0, target2, compacted: true);
+        // Not `using`: the flush prunes this orphaned non-canonical descendant and disposes it itself.
+        Snapshot toLongHead = CreateSnapshot(target1, longHead, compacted: true);
+        using Snapshot toCommittedHead = CreateSnapshot(target2, committedHead, compacted: true);
+        _snapshotRepository.SetLastCommittedStateId(committedHead);
+
+        IPersistence.IWriteBatch writeBatch = Substitute.For<IPersistence.IWriteBatch>();
+        _persistence.CreateWriteBatch(Arg.Any<StateId>(), Arg.Any<StateId>()).Returns(writeBatch);
+
+        StateId result = _persistenceManager.FlushToPersistence();
+
+        Assert.That(result, Is.EqualTo(committedHead));
         _persistence.Received().CreateWriteBatch(Block0, target2);
         _persistence.DidNotReceive().CreateWriteBatch(Block0, target1);
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -182,6 +182,32 @@ public class PersistenceManagerTests
         result.Dispose();
     }
 
+    [Test]
+    public void DetermineSnapshotToPersist_UnfinalizedForkAtBoundary_PersistsHeadReachableFork()
+    {
+        // Two unfinalized forks at the boundary block 16, both starting from Block0. The head's chain runs
+        // through target2 (the higher root, not the arbitrary "first"). The forced persist must follow the
+        // head's chain (target2), otherwise persisting target1 would orphan the head.
+        StateId persisted = Block0;
+        StateId target1 = CreateStateId(16, rootByte: 1); // arbitrary "first" (lowest root)
+        StateId target2 = CreateStateId(16, rootByte: 2); // on the head's chain
+        StateId head = CreateStateId(300);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(10); // unfinalized at the boundary
+
+        using Snapshot fork1 = CreateSnapshot(persisted, target1, compacted: true);
+        using Snapshot fork2 = CreateSnapshot(persisted, target2, compacted: true);
+        using Snapshot toHead = CreateSnapshot(target2, head, compacted: true); // head reachable only via target2
+
+        Snapshot? result = _persistenceManager.DetermineSnapshotToPersist(head);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.From, Is.EqualTo(persisted));
+        Assert.That(result.To, Is.EqualTo(target2));
+
+        result.Dispose();
+    }
+
     #endregion
 
     #region Edge Cases

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -509,6 +509,31 @@ public class PersistenceManagerTests
     }
 
     [Test]
+    public void FlushToPersistence_UnfinalizedForkAtBoundary_PersistsHeadReachableFork()
+    {
+        // Two unfinalized forks at the boundary block 16; the head's chain runs through target2. The flush
+        // must persist target2 (head-reachable), not the arbitrary first fork target1.
+        StateId target1 = CreateStateId(16, rootByte: 1); // arbitrary "first" (lowest root)
+        StateId target2 = CreateStateId(16, rootByte: 2); // on the head's chain
+        StateId head = CreateStateId(32);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(0); // nothing finalized
+
+        using Snapshot fork1 = CreateSnapshot(Block0, target1, compacted: true);
+        using Snapshot fork2 = CreateSnapshot(Block0, target2, compacted: true);
+        using Snapshot toHead = CreateSnapshot(target2, head, compacted: true); // head reachable only via target2
+
+        IPersistence.IWriteBatch writeBatch = Substitute.For<IPersistence.IWriteBatch>();
+        _persistence.CreateWriteBatch(Arg.Any<StateId>(), Arg.Any<StateId>()).Returns(writeBatch);
+
+        StateId result = _persistenceManager.FlushToPersistence();
+
+        Assert.That(result, Is.EqualTo(head));
+        _persistence.Received().CreateWriteBatch(Block0, target2);
+        _persistence.DidNotReceive().CreateWriteBatch(Block0, target1);
+    }
+
+    [Test]
     public void FlushToPersistence_PrefersFinalizedOverUnfinalized()
     {
         // Arrange - two snapshots at same block, one finalized

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -341,6 +341,9 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             return;
         }
 
+        // The latest block the main processing scope committed; used as the head for forced persists.
+        _snapshotRepository.SetLastCommittedStateId(endBlock);
+
         if (_inlineCompaction)
         {
             RunCompactJobSync(endBlock, transientResource, _cancelTokenSource.Token).Wait();

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -21,6 +21,22 @@ public interface ISnapshotRepository
     SnapshotPooledList AssembleSnapshots(in StateId stateId, in StateId targetStateId, int estimatedSize);
     SnapshotPooledList AssembleSnapshotsUntil(in StateId stateId, long minBlockNumber, int estimatedSize);
     StateId? GetLastSnapshotId();
+
+    /// <summary>
+    /// Records <paramref name="stateId"/> as the most recently committed state (the block the main
+    /// processing scope just committed).
+    /// </summary>
+    /// <remarks>
+    /// Always overwrites the previous value with no monotonic guard: a reorg legitimately moves the head
+    /// to a same- or lower-numbered state with a different root. Unlike <see cref="GetLastSnapshotId"/>
+    /// (the longest in-memory chain) this follows the canonical head, so a forced persist does not start
+    /// its ancestor walk from a longer non-canonical fork.
+    /// </remarks>
+    void SetLastCommittedStateId(in StateId stateId);
+
+    /// <summary>Returns the most recently committed state, or <c>null</c> if nothing was committed this session.</summary>
+    StateId? GetLastCommittedStateId();
+
     bool TryFindAncestorStateAtBlock(in StateId head, long blockNumber, out StateId ancestor);
     ArrayPoolList<StateId> GetStatesAtBlockNumber(long blockNumber);
     void RemoveStatesUntil(in StateId currentPersistedStateId);

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -21,6 +21,7 @@ public interface ISnapshotRepository
     SnapshotPooledList AssembleSnapshots(in StateId stateId, in StateId targetStateId, int estimatedSize);
     SnapshotPooledList AssembleSnapshotsUntil(in StateId stateId, long minBlockNumber, int estimatedSize);
     StateId? GetLastSnapshotId();
+    bool TryFindAncestorStateAtBlock(in StateId head, long blockNumber, out StateId ancestor);
     ArrayPoolList<StateId> GetStatesAtBlockNumber(long blockNumber);
     void RemoveStatesUntil(in StateId currentPersistedStateId);
 

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -134,7 +134,8 @@ public class PersistenceManager(
             }
 
             if (_logger.IsWarn) _logger.Warn($"Very long unfinalized state. Force persisting to conserve memory. finalized block number is {finalizedBlockNumber}.");
-            StateId head = snapshotRepository.GetLastSnapshotId() ?? latestSnapshot;
+            // Follow the committed head; fall back to the longest chain when nothing was committed this session.
+            StateId head = snapshotRepository.GetLastCommittedStateId() ?? snapshotRepository.GetLastSnapshotId() ?? latestSnapshot;
             snapshotToPersist = GetHeadAncestorAtBlockNumber(nextCompactedBoundary, currentPersistedState, head, true) ??
                                 GetHeadAncestorAtBlockNumber(currentPersistedState.BlockNumber + 1, currentPersistedState, head, false);
         }
@@ -180,7 +181,8 @@ public class PersistenceManager(
         using Lock.Scope scope = _persistenceLock.EnterScope();
 
         StateId currentPersistedState = GetCurrentPersistedStateId();
-        StateId? latestStateId = snapshotRepository.GetLastSnapshotId();
+        // Follow the committed head; fall back to the longest chain when nothing was committed this session.
+        StateId? latestStateId = snapshotRepository.GetLastCommittedStateId() ?? snapshotRepository.GetLastSnapshotId();
 
         if (latestStateId is null)
         {

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -80,31 +80,31 @@ public class PersistenceManager(
         return null;
     }
 
-    private Snapshot? GetFirstSnapshotAtBlockNumber(long blockNumber, StateId currentPersistedState, bool compactedSnapshot)
+    private Snapshot? GetHeadAncestorAtBlockNumber(long blockNumber, StateId currentPersistedState, in StateId head, bool compactedSnapshot)
     {
-        using ArrayPoolList<StateId> states = snapshotRepository.GetStatesAtBlockNumber(blockNumber);
-        foreach (StateId stateId in states)
+        // Pick the state at blockNumber that is the head's ancestor rather than an arbitrary fork, so the
+        // forced persist follows the chain leading to the head instead of orphaning it.
+        if (!snapshotRepository.TryFindAncestorStateAtBlock(head, blockNumber, out StateId stateId))
+            return null;
+
+        Snapshot? snapshot;
+        if (compactedSnapshot)
         {
-            Snapshot? snapshot;
-            if (compactedSnapshot)
-            {
-                if (!snapshotRepository.TryLeaseCompactedState(stateId, out snapshot)) continue;
-            }
-            else
-            {
-                if (!snapshotRepository.TryLeaseState(stateId, out snapshot)) continue;
-            }
-
-            if (snapshot.From == currentPersistedState)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Force persisting state {stateId}");
-
-                return snapshot;
-            }
-
-            snapshot.Dispose();
+            if (!snapshotRepository.TryLeaseCompactedState(stateId, out snapshot)) return null;
+        }
+        else
+        {
+            if (!snapshotRepository.TryLeaseState(stateId, out snapshot)) return null;
         }
 
+        if (snapshot.From == currentPersistedState)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Force persisting state {stateId}");
+
+            return snapshot;
+        }
+
+        snapshot.Dispose();
         return null;
     }
 
@@ -134,8 +134,9 @@ public class PersistenceManager(
             }
 
             if (_logger.IsWarn) _logger.Warn($"Very long unfinalized state. Force persisting to conserve memory. finalized block number is {finalizedBlockNumber}.");
-            snapshotToPersist = GetFirstSnapshotAtBlockNumber(nextCompactedBoundary, currentPersistedState, true) ??
-                                GetFirstSnapshotAtBlockNumber(currentPersistedState.BlockNumber + 1, currentPersistedState, false);
+            StateId head = snapshotRepository.GetLastSnapshotId() ?? latestSnapshot;
+            snapshotToPersist = GetHeadAncestorAtBlockNumber(nextCompactedBoundary, currentPersistedState, head, true) ??
+                                GetHeadAncestorAtBlockNumber(currentPersistedState.BlockNumber + 1, currentPersistedState, head, false);
         }
         else
         {
@@ -202,15 +203,17 @@ public class PersistenceManager(
                 currentPersistedState,
                 compactedSnapshot: false);
 
-            // Fall back to the first available snapshot if finalized not available
-            snapshotToPersist ??= GetFirstSnapshotAtBlockNumber(
+            // Fall back to the head's chain if finalized not available
+            snapshotToPersist ??= GetHeadAncestorAtBlockNumber(
                 nextCompactedBoundary,
                 currentPersistedState,
+                latestStateId.Value,
                 compactedSnapshot: true);
 
-            snapshotToPersist ??= GetFirstSnapshotAtBlockNumber(
+            snapshotToPersist ??= GetHeadAncestorAtBlockNumber(
                 currentPersistedState.BlockNumber + 1,
                 currentPersistedState,
+                latestStateId.Value,
                 compactedSnapshot: false);
 
             if (snapshotToPersist is null)

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -222,7 +222,7 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
             return true;
         }
 
-        using SnapshotPooledList path = AssembleSnapshotsUntil(head, blockNumber, estimatedSize: 16);
+        using SnapshotPooledList path = AssembleSnapshotsUntil(head, blockNumber, estimatedSize: 16); // BFS initial capacity hint
         if (path.Count == 0)
         {
             ancestor = default;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -208,6 +208,32 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         return sortedSnapshots.Count == 0 ? null : sortedSnapshots.Max;
     }
 
+    public bool TryFindAncestorStateAtBlock(in StateId head, long blockNumber, out StateId ancestor)
+    {
+        if (head.BlockNumber < blockNumber)
+        {
+            ancestor = default;
+            return false;
+        }
+
+        if (head.BlockNumber == blockNumber)
+        {
+            ancestor = head;
+            return true;
+        }
+
+        using SnapshotPooledList path = AssembleSnapshotsUntil(head, blockNumber, estimatedSize: 16);
+        if (path.Count == 0)
+        {
+            ancestor = default;
+            return false;
+        }
+
+        // result[0].From is the terminus: the state at blockNumber on the head's chain.
+        ancestor = path[0].From;
+        return true;
+    }
+
     public bool RemoveAndReleaseCompactedKnownState(in StateId stateId)
     {
         if (_compactedSnapshots.TryRemove(stateId, out Snapshot? existingState))

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -21,6 +21,11 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     private readonly ConcurrentDictionary<StateId, Snapshot> _snapshots = new();
     private readonly ReadWriteLockBox<SortedSet<StateId>> _sortedSnapshotStateIds = new([]);
 
+    // StateId is larger than a machine word, so its read/write across threads must be synchronized.
+    private readonly Lock _lastCommittedLock = new();
+    private StateId _lastCommittedStateId;
+    private bool _hasLastCommitted;
+
     public int SnapshotCount => _snapshots.Count;
     public int CompactedSnapshotCount => _compactedSnapshots.Count;
 
@@ -206,6 +211,19 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     {
         using ReadWriteLockBox<SortedSet<StateId>>.Lock _ = _sortedSnapshotStateIds.EnterReadLock(out SortedSet<StateId> sortedSnapshots);
         return sortedSnapshots.Count == 0 ? null : sortedSnapshots.Max;
+    }
+
+    public void SetLastCommittedStateId(in StateId stateId)
+    {
+        using Lock.Scope _ = _lastCommittedLock.EnterScope();
+        _lastCommittedStateId = stateId;
+        _hasLastCommitted = true;
+    }
+
+    public StateId? GetLastCommittedStateId()
+    {
+        using Lock.Scope _ = _lastCommittedLock.EnterScope();
+        return _hasLastCommitted ? _lastCommittedStateId : null;
     }
 
     public bool TryFindAncestorStateAtBlock(in StateId head, long blockNumber, out StateId ancestor)


### PR DESCRIPTION
## Changes

When the flat DB is **forced to persist** because in-memory state grew past `MaxReorgDepth` while there is **no finalized state** to anchor on, it previously picked the *first* state at the next compaction boundary — where "first" is just the lowest state-root hash in a `SortedSet`, i.e. an arbitrary fork.

If forks exist at the boundary block, that arbitrary choice may not be on the chain leading to the current head. After persisting it, `RemoveSiblingAndDescendents` prunes every in-memory state above the boundary that cannot reach the persisted state — **orphaning the real head** and the chain leading to it.

This PR selects the boundary state that is the **ancestor of the last committed state (the head)**, found by BFS back from the head through the snapshot graph. Compacted snapshots are wide-jump edges, so the existing BFS (which tries the compacted edge first) accelerates the walk automatically.

- `SnapshotRepository.TryFindAncestorStateAtBlock(head, blockNumber, out ancestor)` — new helper built on the existing `AssembleSnapshotsUntil` BFS; returns the head's ancestor state at the target block.
- `PersistenceManager` — replaced the arbitrary-first `GetFirstSnapshotAtBlockNumber` with `GetHeadAncestorAtBlockNumber`, used by both the forced branch of `DetermineSnapshotToPersist` (head = `GetLastSnapshotId()`) and the unfinalized fallback in `FlushToPersistence` (head = latest snapshot).
- Added a regression test exercising a fork at the boundary where the head's chain runs through the non-first fork.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New `DetermineSnapshotToPersist_UnfinalizedForkAtBoundary_PersistsHeadReachableFork` verifies the forced persist follows the head's chain rather than the arbitrary first fork. Full `Nethermind.State.Flat.Test` suite passes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)