### PR TITLE
 fix(test): sign state-test transactions instead of using a placeholder signature

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -112,6 +112,7 @@ namespace Ethereum.Test.Base
 
         public static Transaction Convert(PostStateJson postStateJson, TransactionJson transactionJson, ulong chainId = BlockchainIds.Mainnet)
         {
+            PrivateKey privateKey = new(transactionJson.SecretKey);
             Transaction transaction = new()
             {
                 Type = transactionJson.Type,
@@ -122,7 +123,7 @@ namespace Ethereum.Test.Base
                 Nonce = transactionJson.Nonce,
                 To = transactionJson.To,
                 Data = transactionJson.Data[postStateJson.Indexes.Data],
-                SenderAddress = new PrivateKey(transactionJson.SecretKey).Address,
+                SenderAddress = privateKey.Address,
                 Signature = new Signature(1, 1, 27),
                 BlobVersionedHashes = transactionJson.BlobVersionedHashes,
                 MaxFeePerBlobGas = transactionJson.MaxFeePerBlobGas
@@ -206,17 +207,14 @@ namespace Ethereum.Test.Base
                 }
             }
 
-            // State tests identify the sender via `secretKey` and only carry a placeholder
-            // signature. Sign with that key so the signature recovers to the same sender;
-            // otherwise TransactionProcessor.RecoverSenderIfNeeded re-recovers a bogus sender
-            // from the placeholder whenever the sender account is absent from the pre-state
-            // (e.g. a zero-gas-price transaction), which then crashes incrementing the nonce.
+            // State tests identify the sender via `secretKey`, so sign with that key for the
+            // signature to recover to the same sender; otherwise, whenever the sender account is
+            // absent from the pre-state, TransactionProcessor.RecoverSenderIfNeeded re-recovers a
+            // bogus sender from the placeholder signature and then crashes incrementing its nonce.
             // Address.Zero marks an intentionally-invalid transaction, so leave those as-is.
-            if (transaction.SenderAddress != Address.Zero && transactionJson.SecretKey is not null)
+            if (transaction.SenderAddress != Address.Zero)
             {
-                PrivateKey privateKey = new(transactionJson.SecretKey);
                 new EthereumEcdsa(chainId).Sign(privateKey, transaction, isEip155Enabled: false);
-                transaction.SenderAddress = privateKey.Address;
                 transaction.Hash = transaction.CalculateHash();
             }
 

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -110,7 +110,7 @@ namespace Ethereum.Test.Base
         }
 
 
-        public static Transaction Convert(PostStateJson postStateJson, TransactionJson transactionJson)
+        public static Transaction Convert(PostStateJson postStateJson, TransactionJson transactionJson, ulong chainId = BlockchainIds.Mainnet)
         {
             Transaction transaction = new()
             {
@@ -206,6 +206,20 @@ namespace Ethereum.Test.Base
                 }
             }
 
+            // State tests identify the sender via `secretKey` and only carry a placeholder
+            // signature. Sign with that key so the signature recovers to the same sender;
+            // otherwise TransactionProcessor.RecoverSenderIfNeeded re-recovers a bogus sender
+            // from the placeholder whenever the sender account is absent from the pre-state
+            // (e.g. a zero-gas-price transaction), which then crashes incrementing the nonce.
+            // Address.Zero marks an intentionally-invalid transaction, so leave those as-is.
+            if (transaction.SenderAddress != Address.Zero && transactionJson.SecretKey is not null)
+            {
+                PrivateKey privateKey = new(transactionJson.SecretKey);
+                new EthereumEcdsa(chainId).Sign(privateKey, transaction, isEip155Enabled: false);
+                transaction.SenderAddress = privateKey.Address;
+                transaction.Hash = transaction.CalculateHash();
+            }
+
             return transaction;
         }
 
@@ -275,7 +289,7 @@ namespace Ethereum.Test.Base
                         PostReceiptsRoot = stateJson.Logs,
                         PostHash = stateJson.Hash,
                         Pre = testJson.Pre.ToDictionary(p => p.Key, p => p.Value),
-                        Transaction = Convert(stateJson, testJson.Transaction)
+                        Transaction = Convert(stateJson, testJson.Transaction, chainId)
                     };
 
                     if (testJson.Info?.Labels?.ContainsKey(iterationNumber.ToString()) ?? false)


### PR DESCRIPTION
during fuzzing i saw nethtest crash and here is the fix (case is not relevant for mainnet). for more context and instructions on how to reproduce check out the [execution-specs PR](https://github.com/ethereum/execution-specs/pull/2983) which can be used for verifying the current crash and that this fix works. thank you for your attention to this matter

## Changes

- fixes crash in state test tooling

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
