### PR TITLE
fix(flatdb): detect legacy raw slot DBs by slot presence, not the Layout marker

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -44,7 +44,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
         // These tests seed the Storage column with raw (un-wrapped) bytes via WriteStorageDirectToDb, so the
         // persistence must read in raw mode. The persistence is built before those bytes are written, so pin the
-        // recorded raw slot encoding directly rather than relying on slot-presence detection.
+        // raw slot encoding up front rather than relying on slot-presence detection.
         BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = layout == FlatLayout.PreimageFlat
             ? new PreimageRocksdbPersistence(_columnsDb, _logManager)

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -43,9 +43,9 @@ public class FlatTrieVerifierTests(FlatLayout layout)
 
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
         // These tests seed the Storage column with raw (un-wrapped) bytes via WriteStorageDirectToDb, so the
-        // persistence must read in raw mode. Raw mode is only reached for a pre-feature DB, detected via a
-        // recorded Layout with no SlotEncoding key — seed that marker for the fixture's layout.
-        BasePersistence.SetLayout(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), layout);
+        // persistence must read in raw mode. The persistence is built before those bytes are written, so pin the
+        // recorded raw slot encoding directly rather than relying on slot-presence detection.
+        BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = layout == FlatLayout.PreimageFlat
             ? new PreimageRocksdbPersistence(_columnsDb, _logManager)
             : new RocksDbPersistence(_columnsDb, _logManager);

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -42,9 +42,8 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         _logManager = LimboLogs.Instance;
 
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
-        // These tests seed the Storage column with raw (un-wrapped) bytes via WriteStorageDirectToDb, so the
-        // persistence must read in raw mode. The persistence is built before those bytes are written, so pin the
-        // raw slot encoding up front rather than relying on slot-presence detection.
+        // These tests seed the Storage column with raw (un-wrapped) bytes after the persistence is built,
+        // so slot-presence detection can't kick in — pin the raw encoding up front.
         BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = layout == FlatLayout.PreimageFlat
             ? new PreimageRocksdbPersistence(_columnsDb, _logManager)

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
@@ -3,7 +3,6 @@
 
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
-using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.State.Flat.Persistence;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
+using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.State.Flat.Persistence;
 using NUnit.Framework;
@@ -29,6 +31,18 @@ public class LayoutMetadataTests
         BasePersistence.SetLayout(metadata, layout);
 
         Assert.That(BasePersistence.ReadLayout(metadata), Is.EqualTo(layout));
+    }
+
+    [Test]
+    public void SetLayout_AlsoRecords_RlpSlotEncoding()
+    {
+        using MemColumnsDb<FlatDbColumns> db = new();
+        IDb metadata = db.GetColumnDb(FlatDbColumns.Metadata);
+
+        BasePersistence.SetLayout(metadata, FlatLayout.Flat);
+
+        Assert.That(metadata.Get(Keccak.Compute("SlotEncoding").BytesToArray()),
+            Is.EqualTo(new[] { BasePersistence.SlotEncodingRlp }));
     }
 
     [TestCase(FlatLayout.Flat)]

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
@@ -27,8 +27,7 @@ public class SlotRlpEncodingTests
 
     private static RocksDbPersistence CreatePersistence(IColumnsDb<FlatDbColumns> db, bool rlpWrap = true)
     {
-        // Wrapping is always on for fresh DBs; raw mode only exists for DBs synced before the feature. Pin the
-        // raw slot encoding to exercise the legacy raw path on an otherwise-empty DB.
+        // Raw mode only exists for DBs synced before the feature; pin it to exercise the legacy path.
         if (!rlpWrap) BasePersistence.SetSlotEncoding(db.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         return new RocksDbPersistence(db, LimboLogs.Instance);
     }
@@ -138,10 +137,8 @@ public class SlotRlpEncodingTests
         Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("820102")));
     }
 
-    // Regression: a DB synced before this feature holds raw slot values and may lack BOTH the SlotEncoding and
-    // the Layout marker — the Layout key postdates flat sync, and tooling can provision a DB while bypassing the
-    // metadata column. Detection must key on existing raw slots, not the Layout marker; otherwise those raw
-    // values are misread as RLP and crash on decode (RlpException) during the first SLOAD.
+    // Regression: a pre-feature DB holds raw slots but may lack BOTH metadata markers, so detection must key
+    // on slot presence — otherwise the raw values are misread as RLP and crash on the first SLOAD.
     [TestCase(true)]
     [TestCase(false)]
     public void Pre_feature_db_with_raw_slots_falls_back_to_raw(bool seedLayoutMarker)
@@ -158,13 +155,11 @@ public class SlotRlpEncodingTests
             Assert.That(read.ToEvmBytes(), Is.EqualTo(Bytes.FromHexString("0102")));
         }
 
-        // A write batch on the legacy DB stays raw and does not stamp any marker (only current-format DBs record
-        // the layout/encoding), so the slot is stored raw and the DB keeps no SlotEncoding key.
+        // Writes on the legacy DB stay raw and never stamp the metadata markers.
         WriteSlot(persistence, SlotValue.FromSpanWithoutLeadingZero(Bytes.FromHexString("abcd")));
         Assert.That(db.GetColumnDb(FlatDbColumns.Metadata).Get(SlotEncodingKey), Is.Null);
         Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("abcd"))); // raw, not RLP(0x82abcd)
 
-        // Re-opening still resolves to raw from the existing raw slots and reads them correctly.
         RocksDbPersistence reopened = new(db, LimboLogs.Instance);
         using IPersistence.IPersistenceReader reader2 = reopened.CreateReader();
         SlotValue read2 = default;
@@ -172,8 +167,7 @@ public class SlotRlpEncodingTests
         Assert.That(read2.ToEvmBytes(), Is.EqualTo(Bytes.FromHexString("abcd")));
     }
 
-    // An empty DB with no recorded SlotEncoding is brand-new and wraps, even if a Layout marker is already
-    // present (e.g. accounts synced but no storage yet) — there are no raw slots to misread.
+    // A Layout marker without slots (e.g. accounts synced but no storage yet) is still a brand-new DB — it wraps.
     [Test]
     public void Empty_db_with_layout_marker_defaults_to_rlp()
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
@@ -28,8 +28,8 @@ public class SlotRlpEncodingTests
     private static RocksDbPersistence CreatePersistence(IColumnsDb<FlatDbColumns> db, bool rlpWrap = true)
     {
         // Wrapping is always on for fresh DBs; raw mode only exists for DBs synced before the feature. Pin the
-        // recorded raw slot encoding to exercise the legacy raw path on an otherwise-empty DB.
-        if (!rlpWrap) db.GetColumnDb(FlatDbColumns.Metadata).Set(SlotEncodingKey, new[] { BasePersistence.SlotEncodingRaw });
+        // raw slot encoding to exercise the legacy raw path on an otherwise-empty DB.
+        if (!rlpWrap) BasePersistence.SetSlotEncoding(db.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         return new RocksDbPersistence(db, LimboLogs.Instance);
     }
 
@@ -158,13 +158,13 @@ public class SlotRlpEncodingTests
             Assert.That(read.ToEvmBytes(), Is.EqualTo(Bytes.FromHexString("0102")));
         }
 
-        // A write batch on the legacy DB stays raw and pins SlotEncoding = 0.
+        // A write batch on the legacy DB stays raw and does not stamp any marker (only current-format DBs record
+        // the layout/encoding), so the slot is stored raw and the DB keeps no SlotEncoding key.
         WriteSlot(persistence, SlotValue.FromSpanWithoutLeadingZero(Bytes.FromHexString("abcd")));
-        Assert.That(db.GetColumnDb(FlatDbColumns.Metadata).Get(SlotEncodingKey),
-            Is.EqualTo(new[] { BasePersistence.SlotEncodingRaw }));
+        Assert.That(db.GetColumnDb(FlatDbColumns.Metadata).Get(SlotEncodingKey), Is.Null);
         Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("abcd"))); // raw, not RLP(0x82abcd)
 
-        // Re-opening resolves via the recorded SlotEncoding = 0 and still reads raw.
+        // Re-opening still resolves to raw from the existing raw slots and reads them correctly.
         RocksDbPersistence reopened = new(db, LimboLogs.Instance);
         using IPersistence.IPersistenceReader reader2 = reopened.CreateReader();
         SlotValue read2 = default;

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlotRlpEncodingTests.cs
@@ -27,9 +27,9 @@ public class SlotRlpEncodingTests
 
     private static RocksDbPersistence CreatePersistence(IColumnsDb<FlatDbColumns> db, bool rlpWrap = true)
     {
-        // Wrapping is always on for fresh DBs; raw mode only exists for DBs synced before the feature, detected
-        // via a recorded Layout with no SlotEncoding key. Seed that marker to exercise the legacy raw path.
-        if (!rlpWrap) db.GetColumnDb(FlatDbColumns.Metadata).Set(LayoutKey, new[] { (byte)FlatLayout.Flat });
+        // Wrapping is always on for fresh DBs; raw mode only exists for DBs synced before the feature. Pin the
+        // recorded raw slot encoding to exercise the legacy raw path on an otherwise-empty DB.
+        if (!rlpWrap) db.GetColumnDb(FlatDbColumns.Metadata).Set(SlotEncodingKey, new[] { BasePersistence.SlotEncodingRaw });
         return new RocksDbPersistence(db, LimboLogs.Instance);
     }
 
@@ -138,15 +138,19 @@ public class SlotRlpEncodingTests
         Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("820102")));
     }
 
-    [Test]
-    public void Pre_feature_db_falls_back_to_raw_and_reads_legacy_values()
+    // Regression: a DB synced before this feature holds raw slot values and may lack BOTH the SlotEncoding and
+    // the Layout marker — the Layout key postdates flat sync, and tooling can provision a DB while bypassing the
+    // metadata column. Detection must key on existing raw slots, not the Layout marker; otherwise those raw
+    // values are misread as RLP and crash on decode (RlpException) during the first SLOAD.
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Pre_feature_db_with_raw_slots_falls_back_to_raw(bool seedLayoutMarker)
     {
         using SnapshotableMemColumnsDb<FlatDbColumns> db = new();
-        // Simulate a DB synced before this feature: Layout recorded, SlotEncoding absent, raw slot bytes.
-        db.GetColumnDb(FlatDbColumns.Metadata).Set(LayoutKey, new[] { (byte)FlatLayout.Flat });
+        if (seedLayoutMarker) db.GetColumnDb(FlatDbColumns.Metadata).Set(LayoutKey, new[] { (byte)FlatLayout.Flat });
         WriteRawSlotToDb(db, Bytes.FromHexString("0102"));
 
-        RocksDbPersistence persistence = CreatePersistence(db, rlpWrap: true); // config asks for RLP, DB wins
+        RocksDbPersistence persistence = new(db, LimboLogs.Instance); // no recorded SlotEncoding; raw slots win
         using (IPersistence.IPersistenceReader reader = persistence.CreateReader())
         {
             SlotValue read = default;
@@ -160,12 +164,28 @@ public class SlotRlpEncodingTests
             Is.EqualTo(new[] { BasePersistence.SlotEncodingRaw }));
         Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("abcd"))); // raw, not RLP(0x82abcd)
 
-        // Re-opening resolves via the recorded SlotEncoding = 0 (not the Layout heuristic) and still reads raw.
-        RocksDbPersistence reopened = CreatePersistence(db, rlpWrap: true);
+        // Re-opening resolves via the recorded SlotEncoding = 0 and still reads raw.
+        RocksDbPersistence reopened = new(db, LimboLogs.Instance);
         using IPersistence.IPersistenceReader reader2 = reopened.CreateReader();
         SlotValue read2 = default;
         Assert.That(reader2.TryGetSlot(Addr, Slot, ref read2), Is.True);
         Assert.That(read2.ToEvmBytes(), Is.EqualTo(Bytes.FromHexString("abcd")));
+    }
+
+    // An empty DB with no recorded SlotEncoding is brand-new and wraps, even if a Layout marker is already
+    // present (e.g. accounts synced but no storage yet) — there are no raw slots to misread.
+    [Test]
+    public void Empty_db_with_layout_marker_defaults_to_rlp()
+    {
+        using SnapshotableMemColumnsDb<FlatDbColumns> db = new();
+        db.GetColumnDb(FlatDbColumns.Metadata).Set(LayoutKey, new[] { (byte)FlatLayout.Flat });
+
+        RocksDbPersistence persistence = new(db, LimboLogs.Instance);
+        WriteSlot(persistence, SlotValue.FromSpanWithoutLeadingZero(Bytes.FromHexString("0102")));
+
+        Assert.That(db.GetColumnDb(FlatDbColumns.Metadata).Get(SlotEncodingKey),
+            Is.EqualTo(new[] { BasePersistence.SlotEncodingRlp }));
+        Assert.That(ReadStoredSlotBytes(db), Is.EqualTo(Bytes.FromHexString("820102")));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -27,8 +27,8 @@ public class FlatTreeSyncStoreTests
     {
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
         // WriteStorageDirectToDb seeds the Storage column with raw (un-wrapped) bytes, so read in raw mode. The
-        // persistence is built before those bytes are written, so pin the recorded raw slot encoding directly
-        // rather than relying on slot-presence detection.
+        // persistence is built before those bytes are written, so pin the raw slot encoding up front rather than
+        // relying on slot-presence detection.
         BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = new RocksDbPersistence(_columnsDb, LimboLogs.Instance);
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -26,9 +26,8 @@ public class FlatTreeSyncStoreTests
     public void SetUp()
     {
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
-        // WriteStorageDirectToDb seeds the Storage column with raw (un-wrapped) bytes, so read in raw mode. The
-        // persistence is built before those bytes are written, so pin the raw slot encoding up front rather than
-        // relying on slot-presence detection.
+        // WriteStorageDirectToDb seeds the Storage column with raw (un-wrapped) bytes after the persistence
+        // is built, so slot-presence detection can't kick in — pin the raw encoding up front.
         BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = new RocksDbPersistence(_columnsDb, LimboLogs.Instance);
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -26,9 +26,10 @@ public class FlatTreeSyncStoreTests
     public void SetUp()
     {
         _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
-        // WriteStorageDirectToDb seeds the Storage column with raw (un-wrapped) bytes, so read in raw mode.
-        // Raw mode is only reached for a pre-feature DB, detected via a recorded Layout with no SlotEncoding.
-        BasePersistence.SetLayout(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), FlatLayout.Flat);
+        // WriteStorageDirectToDb seeds the Storage column with raw (un-wrapped) bytes, so read in raw mode. The
+        // persistence is built before those bytes are written, so pin the recorded raw slot encoding directly
+        // rather than relying on slot-presence detection.
+        BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
         _persistence = new RocksDbPersistence(_columnsDb, LimboLogs.Instance);
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -71,11 +71,17 @@ public static class BasePersistence
         return (FlatLayout)bytes[0];
     }
 
+    /// <summary>
+    /// Records the flat DB's on-disk format markers: the <see cref="FlatLayout"/> and the RLP slot encoding.
+    /// Both are written together so any DB that records a layout also records the current slot encoding. This is
+    /// only ever called for DBs on the current (RLP-wrapped) format; legacy raw DBs are never re-stamped.
+    /// </summary>
     internal static void SetLayout(IWriteOnlyKeyValueStore kv, FlatLayout layout)
     {
         Span<byte> bytes = stackalloc byte[1];
         bytes[0] = (byte)layout;
         kv.PutSpan(LayoutKey, bytes);
+        SetSlotEncoding(kv, SlotEncodingRlp);
     }
 
     /// <summary>
@@ -108,10 +114,11 @@ public static class BasePersistence
     }
 
     /// <summary>
-    /// On the first call, records the persistence's <see cref="FlatLayout"/> in the supplied batch's
-    /// metadata column. Subsequent calls are no-ops. The write goes through the batch, so it is
-    /// committed atomically with the rest of the batch's contents.
+    /// On the first call, records the persistence's <see cref="FlatLayout"/> and slot encoding in the supplied
+    /// batch's metadata column via <see cref="SetLayout"/>. Subsequent calls are no-ops. The write goes through
+    /// the batch, so it is committed atomically with the rest of the batch's contents.
     /// </summary>
+    /// <remarks>Callers must only invoke this for DBs on the current RLP-wrapped format; see <see cref="SetLayout"/>.</remarks>
     internal static void RecordLayoutOnFirstBatch(IWriteOnlyKeyValueStore metadataBatch, ref int flag, FlatLayout layout)
     {
         if (Interlocked.CompareExchange(ref flag, 1, 0) == 0)
@@ -171,14 +178,6 @@ public static class BasePersistence
     private static void WarnRawDeprecated(ILogger logger)
     {
         if (logger.IsWarn) logger.Warn(RawSlotDeprecationMessage);
-    }
-
-    internal static void RecordSlotEncodingOnFirstBatch(IWriteOnlyKeyValueStore metadataBatch, ref int flag, bool rlpWrap)
-    {
-        if (Interlocked.CompareExchange(ref flag, 1, 0) == 0)
-        {
-            SetSlotEncoding(metadataBatch, rlpWrap ? SlotEncodingRlp : SlotEncodingRaw);
-        }
     }
 
     internal static void ClearAllColumns(IColumnsDb<FlatDbColumns> db)

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -73,8 +73,7 @@ public static class BasePersistence
 
     /// <summary>
     /// Records the flat DB's on-disk format markers: the <see cref="FlatLayout"/> and the RLP slot encoding.
-    /// Both are written together so any DB that records a layout also records the current slot encoding. This is
-    /// only ever called for DBs on the current (RLP-wrapped) format; legacy raw DBs are never re-stamped.
+    /// Only for DBs on the current (RLP-wrapped) format; legacy raw DBs are never re-stamped.
     /// </summary>
     internal static void SetLayout(IWriteOnlyKeyValueStore kv, FlatLayout layout)
     {
@@ -118,7 +117,6 @@ public static class BasePersistence
     /// batch's metadata column via <see cref="SetLayout"/>. Subsequent calls are no-ops. The write goes through
     /// the batch, so it is committed atomically with the rest of the batch's contents.
     /// </summary>
-    /// <remarks>Callers must only invoke this for DBs on the current RLP-wrapped format; see <see cref="SetLayout"/>.</remarks>
     internal static void RecordLayoutOnFirstBatch(IWriteOnlyKeyValueStore metadataBatch, ref int flag, FlatLayout layout)
     {
         if (Interlocked.CompareExchange(ref flag, 1, 0) == 0)
@@ -146,13 +144,10 @@ public static class BasePersistence
     /// version of an existing DB always wins so its on-disk format is read back correctly.
     /// </summary>
     /// <remarks>
-    /// An absent <see cref="SlotEncodingKey"/> is ambiguous: a brand-new DB and a DB synced before this feature
-    /// existed both lack it. They are distinguished by <paramref name="slotStore"/>: wrapping is only safe when no
-    /// pre-existing slot values are present, since any already-stored slot is in the raw encoding and would be
-    /// misread as RLP. A non-empty slot column therefore pins the DB to raw (with a deprecation warning).
-    /// The <see cref="LayoutKey"/> is not a reliable discriminator here: it postdates flat sync, so a DB synced
-    /// before the Layout marker existed (or one provisioned by tooling that bypasses the metadata column) holds
-    /// raw slots without a Layout key and must not be treated as brand-new.
+    /// An absent <see cref="SlotEncodingKey"/> is ambiguous: a brand-new DB and a pre-feature DB both lack it.
+    /// A non-empty <paramref name="slotStore"/> pins the DB to raw (with a deprecation warning), as its slots
+    /// are raw-encoded and would be misread as RLP. The <see cref="LayoutKey"/> is no discriminator: it
+    /// postdates flat sync and tooling can bypass the metadata column, so legacy raw DBs may lack it too.
     /// </remarks>
     /// <param name="slotStore">The column that holds storage slot values for this layout.</param>
     internal static bool ResolveSlotEncoding(IColumnsDb<FlatDbColumns> db, ISortedKeyValueStore slotStore, ILogger logger)
@@ -162,8 +157,7 @@ public static class BasePersistence
         {
             SlotEncodingRlp => true,
             SlotEncodingRaw => false,
-            // No recorded version: only a DB with no existing slots is brand-new and safe to wrap; a DB that
-            // already holds slots predates this feature and is on the raw encoding.
+            // No recorded version: brand-new (no slots) wraps; existing slots are legacy raw.
             null => slotStore.FirstKey is null,
             byte version => throw new InvalidConfigurationException(
                 $"Flat DB metadata contains an unrecognized slot encoding version '{version}'. The DB may be corrupt or was written by a newer version.",

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -127,7 +127,7 @@ public static class BasePersistence
     }
 
     [SkipLocalsInit]
-    private static void SetSlotEncoding(IWriteOnlyKeyValueStore kv, byte version)
+    internal static void SetSlotEncoding(IWriteOnlyKeyValueStore kv, byte version)
     {
         Span<byte> bytes = stackalloc byte[1];
         bytes[0] = version;
@@ -139,20 +139,25 @@ public static class BasePersistence
     /// version of an existing DB always wins so its on-disk format is read back correctly.
     /// </summary>
     /// <remarks>
-    /// An absent <see cref="SlotEncodingKey"/> is ambiguous: a brand-new DB and a DB synced before this
-    /// feature existed both lack it. They are distinguished via the <see cref="LayoutKey"/>, which any
-    /// previously-synced DB will already have recorded — its presence means raw legacy data, so wrapping is
-    /// disabled (with a deprecation warning) to avoid misreading raw values as RLP.
+    /// An absent <see cref="SlotEncodingKey"/> is ambiguous: a brand-new DB and a DB synced before this feature
+    /// existed both lack it. They are distinguished by <paramref name="slotStore"/>: wrapping is only safe when no
+    /// pre-existing slot values are present, since any already-stored slot is in the raw encoding and would be
+    /// misread as RLP. A non-empty slot column therefore pins the DB to raw (with a deprecation warning).
+    /// The <see cref="LayoutKey"/> is not a reliable discriminator here: it postdates flat sync, so a DB synced
+    /// before the Layout marker existed (or one provisioned by tooling that bypasses the metadata column) holds
+    /// raw slots without a Layout key and must not be treated as brand-new.
     /// </remarks>
-    internal static bool ResolveSlotEncoding(IColumnsDb<FlatDbColumns> db, ILogger logger)
+    /// <param name="slotStore">The column that holds storage slot values for this layout.</param>
+    internal static bool ResolveSlotEncoding(IColumnsDb<FlatDbColumns> db, ISortedKeyValueStore slotStore, ILogger logger)
     {
         IReadOnlyKeyValueStore meta = db.GetColumnDb(FlatDbColumns.Metadata);
         bool rlpWrap = ReadSlotEncoding(meta) switch
         {
             SlotEncodingRlp => true,
             SlotEncodingRaw => false,
-            // No recorded version: a brand-new DB wraps; a previously-synced DB (Layout present) is legacy raw.
-            null => ReadLayout(meta) is null,
+            // No recorded version: only a DB with no existing slots is brand-new and safe to wrap; a DB that
+            // already holds slots predates this feature and is on the raw encoding.
+            null => slotStore.FirstKey is null,
             byte version => throw new InvalidConfigurationException(
                 $"Flat DB metadata contains an unrecognized slot encoding version '{version}'. The DB may be corrupt or was written by a newer version.",
                 -1),

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
@@ -16,7 +16,6 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.FlatInTrie);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.StorageNodes), logManager.GetClassLogger<FlatInTriePersistence>());
-    private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();
 
@@ -106,8 +105,8 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
             {
                 if (fromCopy != StateId.Sync && toCopy != StateId.Sync)
                     BasePersistence.SetCurrentState(batch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
-                BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.FlatInTrie);
-                BasePersistence.RecordSlotEncodingOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _slotEncodingPersisted, _rlpWrapSlots);
+                if (_rlpWrapSlots)
+                    BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.FlatInTrie);
                 batch.Dispose();
                 dbSnap.Dispose();
                 _adjuster.OnBatchDisposed();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
@@ -15,7 +15,7 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
 {
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.FlatInTrie);
-    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, logManager.GetClassLogger<FlatInTriePersistence>());
+    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.StorageNodes), logManager.GetClassLogger<FlatInTriePersistence>());
     private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -26,7 +26,7 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
     private static readonly AccountDecoder SlimAccountDecoder = AccountDecoder.Slim;
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.PreimageFlat);
-    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, logManager.GetClassLogger<PreimageRocksdbPersistence>());
+    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<PreimageRocksdbPersistence>());
     private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -27,7 +27,6 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.PreimageFlat);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<PreimageRocksdbPersistence>());
-    private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();
 
@@ -118,8 +117,8 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
             {
                 if (fromCopy != StateId.Sync && toCopy != StateId.Sync)
                     BasePersistence.SetCurrentState(batch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
-                BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.PreimageFlat);
-                BasePersistence.RecordSlotEncodingOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _slotEncodingPersisted, _rlpWrapSlots);
+                if (_rlpWrapSlots)
+                    BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.PreimageFlat);
                 batch.Dispose();
                 dbSnap.Dispose();
                 _adjuster.OnBatchDisposed();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -12,7 +12,6 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<RocksDbPersistence>());
-    private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();
 
@@ -105,8 +104,8 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             {
                 if (fromCopy != StateId.Sync && toCopy != StateId.Sync)
                     BasePersistence.SetCurrentState(batch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
-                BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
-                BasePersistence.RecordSlotEncodingOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _slotEncodingPersisted, _rlpWrapSlots);
+                if (_rlpWrapSlots)
+                    BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
                 batch.Dispose();
                 dbSnap.Dispose();
                 _adjuster.OnBatchDisposed();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -11,7 +11,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 {
     private readonly WriteBufferAdjuster _adjuster = new(db);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
-    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, logManager.GetClassLogger<RocksDbPersistence>());
+    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<RocksDbPersistence>());
     private int _slotEncodingPersisted = 0;
 
     public void Flush() => db.Flush();


### PR DESCRIPTION
## Changes

Follow-up to #11909 (RLP-wrapped storage slot values behind a versioned `SlotEncoding` flag).

`BasePersistence.ResolveSlotEncoding` decides whether to RLP-wrap storage slot values. When a DB has no recorded `SlotEncoding` version, it must distinguish a **brand-new** DB (wrap) from a DB **synced before this feature** (raw). It used the presence of the `Layout` key as the "previously synced" proxy:

```csharp
null => ReadLayout(meta) is null,  // no Layout ⇒ treat as brand-new ⇒ wrap
```

But the `Layout` marker itself postdates flat sync (added in #11271). A flat DB synced before that — or one provisioned by tooling that writes the data columns directly while bypassing the `Metadata` column — holds **raw** slot values with **no** `Layout` key. Such a DB was misdetected as brand-new, wrapping was enabled, and every `SLOAD` decoded a raw value as RLP and threw:

```
Nethermind.Serialization.Rlp.RlpLimitException: Collection count of 18 is over limit 4194304 or 8 bytes left
   at Nethermind.State.Flat.Persistence.BaseFlatPersistence.Reader.TryGetStorage(...)
```

(A raw stripped value with a leading byte ≥ `0x80`, e.g. `0x92`, is read as an 18-byte RLP string but only 8 bytes remain.) This reproduced on a pre-existing benchmark state DB.

**Fix:** gate the brand-new case on the **slot column being empty** rather than on the `Layout` marker. Wrapping is only safe when there are no pre-existing raw slots to misread; any DB that already holds slots predates the feature and stays on the raw encoding. Each persistence passes its slot-holding column (`Storage`, or `StorageNodes` for the `FlatInTrie` layout).

- `ResolveSlotEncoding` now takes the slot column and checks `slotStore.FirstKey is null` for the no-recorded-version case.
- `RocksDbPersistence`, `PreimageRocksdbPersistence`, `FlatInTriePersistence` pass their respective slot column.
- `SetSlotEncoding` made `internal` so tests can pin a recorded encoding.
- Regression test: raw slots present, no `SlotEncoding`, with **and** without the `Layout` marker → resolves to raw (previously crashed in the no-Layout case). Plus a test that an empty DB with a `Layout` marker still wraps.
- Fixtures that simulated raw mode by seeding the `Layout` marker now pin `SlotEncoding=Raw` (they build the persistence before writing the raw slots, so slot-presence detection doesn't apply to them).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Nethermind.State.Flat.Test` passes (489 cases). New/updated cases live in `SlotRlpEncodingTests`, with raw-mode fixtures in `FlatTrieVerifierTests` and `FlatTreeSyncStoreTests` updated to pin the recorded encoding.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

The flat DB is experimental and off by default, so impact is limited to operators running it. Any already-running flat DB on `master`+#11909 records `SlotEncoding` on its first write batch, so this only affects DBs that reach #11909 without a recorded encoding (pre-#11271 syncs and tool-built DBs). No on-disk migration is needed — the crash happens during read, before any bad `SlotEncoding=Rlp` marker is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)