### PR TITLE
ci: chunk Synchronization.Test on macOS to avoid 15-min timeout

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -88,7 +88,7 @@ jobs:
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
         chunk: ['']
-        exclude: # Synchronization.Test on ARM is chunked (see include block) — its unchunked variant hits the 15-min wall.
+        exclude: # Synchronization.Test on ARM/macOS is chunked (see include block) — its unchunked variant hits the 15-min wall.
           - runner: ubuntu-24.04-arm
             project: Nethermind.Synchronization.Test
             chunk: ''
@@ -102,7 +102,10 @@ jobs:
           - { runner: macos-latest, project: Nethermind.Network.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Runner.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.Sockets.Test, chunk: '' }
-          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: '' }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: macos-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 1of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 3of4 }


### PR DESCRIPTION
## Summary

- Successful `Nethermind.Synchronization.Test (macos-latest)` runs take 8:30–12:10 with a 15-min job timeout — the slowest macOS runners intermittently hit the wall and get cancelled (e.g. [run 27386696578](https://github.com/NethermindEth/nethermind/actions/runs/27386696578/job/80935166218)).
- Mirror the existing `ubuntu-24.04-arm` fix: split macOS Sync.Test into 4 chunks.
- No code changes; workflow matrix only.

## Test plan

- [ ] CI matrix expands to include 4 macOS Sync.Test chunks
- [ ] Each chunk completes well within the 15-min timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)