### PR TITLE
feat(flatdb): persist at finalized boundary with reverse diffs for snap serving

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.State.Flat;
@@ -19,6 +20,9 @@ internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbMa
     public SnapshotBundle GatherSnapshotBundle(in StateId stateId, ResourcePool.Usage usage) => flatDbManager.GatherSnapshotBundle(NormalizeState(stateId), usage);
 
     public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId));
+
+    public bool TryGatherReadOnlySnapshotBundle(in StateId stateId, [NotNullWhen(true)] out ReadOnlySnapshotBundle? bundle) =>
+        flatDbManager.TryGatherReadOnlySnapshotBundle(NormalizeState(stateId), out bundle);
 
     public bool HasStateForBlock(in StateId stateId)
     {

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -7,6 +7,7 @@ namespace Nethermind.Db;
 
 public class FlatDbConfig : IFlatDbConfig
 {
+    public bool EarlyPersist { get; set; } = false;
     public bool Enabled { get; set; } = false;
     public bool EnablePreimageRecording { get; set; } = false;
     public bool ImportFromPruningTrieState { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -16,6 +16,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Compact size", DefaultValue = "32")]
     int CompactSize { get; set; }
 
+    [ConfigItem(Description = "Persist state at the finalized compaction boundary instead of keeping MinReorgDepth blocks in memory. Historical state for snap serving is kept as in-memory reverse diffs.", DefaultValue = "false")]
+    bool EarlyPersist { get; set; }
+
     [ConfigItem(Description = "Enabled", DefaultValue = "false")]
     bool Enabled { get; set; }
 

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -48,6 +48,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 ctx.Resolve<IPersistenceManager>(),
                 ctx.Resolve<IFlatDbConfig>(),
                 ctx.Resolve<IBlocksConfig>(),
+                ctx.Resolve<ISyncConfig>(),
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IMetricsConfig>().EnableDetailedMetric))
             .AddSingleton<IResourcePool, ResourcePool>()

--- a/src/Nethermind/Nethermind.State.Flat.Test/EarlyPersistScenarioTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/EarlyPersistScenarioTests.cs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Autofac;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Evm.State;
+using Nethermind.Init.Modules;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Monitoring.Config;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.State.Flat.ScopeProvider;
+using Nethermind.State.Flat.Sync.Snap;
+using Nethermind.State.Snap;
+using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+/// <summary>
+/// End-to-end scenario for early persistence with reverse diffs: blocks are committed through the real
+/// scope provider, persisted at finalized compaction boundaries far closer to head than the snap-serving
+/// window, and historical states below the persisted state are then read back (values and snap ranges
+/// with proofs) through the reverse-diff chain.
+/// </summary>
+[TestFixture]
+public class EarlyPersistScenarioTests
+{
+    private const int CompactSize = 4;
+    private const int ServingWindow = 8;
+    private const long HeadBlock = 20;
+    private const long ExpectedPersisted = 16; // last boundary at or below finalized (head - 2)
+    private const long OldestServed = 12;      // chunk boundary at or below head - ServingWindow
+
+    private readonly Address _contract = TestItem.AddressA;
+
+    private CancellationTokenSource _cts = null!;
+    private IContainer _container = null!;
+    private TestFinalizedStateProvider _finalizedStateProvider = null!;
+    private TestStateRootIndex _stateRootIndex = null!;
+    private FlatWorldStateManager _manager = null!;
+    private IFlatDbManager _flatDbManager = null!;
+    private IPersistenceManager _persistenceManager = null!;
+    private readonly Dictionary<long, StateId> _stateIds = [];
+
+    [SetUp]
+    public void SetUp()
+    {
+        FlatDbConfig config = new()
+        {
+            Enabled = true,
+            EarlyPersist = true,
+            CompactSize = CompactSize,
+            CompactionOffset = 0,
+            InlineCompaction = true,
+            TrieWarmerWorkerCount = 0,
+        };
+
+        _cts = new CancellationTokenSource();
+        _finalizedStateProvider = new TestFinalizedStateProvider();
+        _stateRootIndex = new TestStateRootIndex();
+        _stateIds.Clear();
+
+        ContainerBuilder builder = new ContainerBuilder()
+            .AddModule(new FlatWorldStateModule(config))
+            .AddSingleton<IFlatDbConfig>(config)
+            .AddSingleton<ISyncConfig>(new SyncConfig { SnapServingMaxDepth = ServingWindow })
+            .AddSingleton<IBlocksConfig>(new BlocksConfig())
+            .AddSingleton<IMetricsConfig>(new MetricsConfig())
+            .AddSingleton<IFinalizedStateProvider>(_finalizedStateProvider)
+            .AddSingleton<IFlatStateRootIndex>(_stateRootIndex)
+            .AddSingleton<IPersistence>(new RocksDbPersistence(new SnapshotableMemColumnsDb<FlatDbColumns>(), LimboLogs.Instance))
+            .AddSingleton<IProcessExitSource>(new CancellationTokenSourceProcessExitSource(_cts))
+            .AddSingleton<ILogManager>(LimboLogs.Instance)
+            .AddSingleton<IWorldStateScopeProvider.ICodeDb>(new TrieStoreScopeProvider.KeyValueWithBatchingBackedCodeDb(new TestMemDb()));
+        builder.RegisterInstance<IDb>(new TestMemDb()).Keyed<IDb>(DbNames.Code);
+        builder.RegisterInstance<IDb>(new TestMemDb()).Keyed<IDb>(DbNames.Metadata);
+        _container = builder.Build();
+
+        _manager = _container.Resolve<FlatWorldStateManager>();
+        _flatDbManager = _container.Resolve<IFlatDbManager>();
+        _persistenceManager = _container.Resolve<IPersistenceManager>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _cts.Cancel();
+        _container.Dispose();
+        _cts.Dispose();
+    }
+
+    [Test]
+    public void EarlyPersist_ServesHistoricalStateAndSnapRangesBelowPersistedState()
+    {
+        ProcessChain();
+
+        Assert.That(
+            () => _persistenceManager.GetCurrentPersistedStateId().BlockNumber,
+            Is.EqualTo(ExpectedPersisted).After(10000, 50),
+            "persistence should advance to the last finalized boundary, far past head - SnapServingMaxDepth");
+
+        // Pruning runs on the persistence task after the last block's job; wait for quiescence.
+        Assert.That(
+            () => CanGather(_stateIds[OldestServed - 1]),
+            Is.False.After(10000, 50),
+            "states below the serving window should be pruned");
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Every state in the serving window stays readable: historical states below the persisted
+            // state through the reverse-diff chain, the persisted state itself, and live states above it.
+            for (long number = OldestServed; number <= HeadBlock; number++)
+            {
+                AssertStateAt(number);
+            }
+
+            Assert.That(CanGather(_stateIds[5]), Is.False, "deep historical state should be pruned");
+        }
+
+        AssertSnapRangesAt(OldestServed + 1);
+
+        // FlushCache persists everything to head; in-window states must remain served via reverse diffs.
+        _manager.FlushCache(CancellationToken.None);
+        Assert.That(_persistenceManager.GetCurrentPersistedStateId().BlockNumber, Is.EqualTo(HeadBlock));
+        AssertStateAt(HeadBlock - 2);
+        AssertSnapRangesAt(HeadBlock - 2);
+    }
+
+    /// <summary>
+    /// Commits blocks 0..<see cref="HeadBlock"/>: the contract account's balance and slot 1 change every
+    /// block, and each block adds one fresh account and one fresh slot. Finalization trails head by 2.
+    /// </summary>
+    private void ProcessChain()
+    {
+        IWorldStateScopeProvider worldState = _manager.GlobalWorldState;
+
+        BlockHeader? parent = null;
+        for (long number = 0; number <= HeadBlock; number++)
+        {
+            using (IWorldStateScopeProvider.IScope scope = worldState.BeginScope(parent))
+            {
+                using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(2))
+                {
+                    writeBatch.Set(_contract, Build.An.Account.WithBalance(BalanceAt(number)).TestObject);
+                    writeBatch.Set(AccountOfBlock(number), Build.An.Account.WithBalance(1).TestObject);
+
+                    using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = writeBatch.CreateStorageWriteBatch(_contract, 2);
+                    storageBatch.Set(1, Slot1ValueAt(number));
+                    storageBatch.Set(SlotOfBlock(number), [0xab]);
+                }
+                scope.Commit(number);
+                parent = Build.A.BlockHeader.WithNumber(number).WithStateRoot(scope.RootHash).TestObject;
+            }
+
+            StateId stateId = new(number, parent.StateRoot!);
+            _stateIds[number] = stateId;
+            _stateRootIndex.Add(stateId);
+            _finalizedStateProvider.SetStateRoot(number, parent.StateRoot!);
+            _finalizedStateProvider.FinalizedBlockNumber = number - 2;
+        }
+    }
+
+    private static UInt256 BalanceAt(long number) => (UInt256)(number + 1);
+    private static byte[] Slot1ValueAt(long number) => [(byte)(number + 1)];
+    private static UInt256 SlotOfBlock(long number) => (UInt256)(1000 + number);
+    private static Address AccountOfBlock(long number) => Address.FromNumber((UInt256)(10000 + number));
+
+    private bool CanGather(in StateId stateId)
+    {
+        if (_flatDbManager.TryGatherReadOnlySnapshotBundle(stateId, out ReadOnlySnapshotBundle? bundle))
+        {
+            bundle.Dispose();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsNullOrZero(byte[]? value) => value is null || value.IsZero();
+
+    private void AssertStateAt(long number)
+    {
+        StateId stateId = _stateIds[number];
+        Assert.That(_flatDbManager.TryGatherReadOnlySnapshotBundle(stateId, out ReadOnlySnapshotBundle? bundle), Is.True, $"state {number} should be gatherable");
+
+        using (bundle)
+        {
+            int selfDestructIdx = bundle!.DetermineSelfDestructSnapshotIdx(_contract);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(bundle.GetAccount(_contract)?.Balance, Is.EqualTo(BalanceAt(number)), $"contract balance at {number}");
+                Assert.That(bundle.GetAccount(AccountOfBlock(number)), Is.Not.Null, $"account created at {number}");
+                Assert.That(bundle.GetAccount(AccountOfBlock(number + 1)), Is.Null, $"account created at {number + 1} must not leak into state {number}");
+
+                Assert.That(bundle.GetSlot(_contract, 1, selfDestructIdx), Is.EqualTo(Slot1ValueAt(number)), $"slot 1 at {number}");
+                Assert.That(bundle.GetSlot(_contract, SlotOfBlock(number), selfDestructIdx), Is.EqualTo(new byte[] { 0xab }), $"slot of block {number}");
+
+                // Written one block later, so it is in persistence (which is ahead of this state); the
+                // reverse diff's null marker must shadow it.
+                Assert.That(IsNullOrZero(bundle.GetSlot(_contract, SlotOfBlock(number + 1), selfDestructIdx)), Is.True, $"slot of block {number + 1} must not leak into state {number}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serves account and storage ranges for a state through the snap server and validates the proofs
+    /// against the historical root the same way a syncing client would.
+    /// </summary>
+    private void AssertSnapRangesAt(long number)
+    {
+        Hash256 root = _stateIds[number].StateRoot.ToCommitment();
+        PatriciaSnapTrieFactory clientFactory = new(new NodeStorage(new MemDb()), LimboLogs.Instance);
+
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) = _manager.SnapServer.GetAccountRanges(
+            root, ValueKeccak.Zero, ValueKeccak.MaxValue, 1_000_000, CancellationToken.None);
+        using IOwnedReadOnlyList<PathWithAccount> accountsDisposer = accounts;
+        using IByteArrayList proofsDisposer = proofs;
+
+        Assert.That(accounts.Count, Is.EqualTo(number + 2), $"contract + one account per block at {number}");
+
+        (AddRangeResult result, _, List<PathWithAccount> storageRoots, _, _) = SnapProviderHelper.AddAccountRange(
+            clientFactory, number, root, ValueKeccak.Zero, ValueKeccak.MaxValue, accounts, proofs);
+        Assert.That(result, Is.EqualTo(AddRangeResult.OK), $"account range proof at {number}");
+
+        PathWithAccount contractAccount = storageRoots.Find(a => a.Path == _contract.ToAccountPath)!;
+        Assert.That(contractAccount, Is.Not.Null, "contract should be reported as having storage");
+
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slots, IByteArrayList? storageProofs) = _manager.SnapServer.GetStorageRanges(
+            root, new[] { contractAccount }, ValueKeccak.Zero, ValueKeccak.MaxValue, 1_000_000, CancellationToken.None);
+        using IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slotsDisposer = slots;
+        using IDisposable? storageProofsDisposer = storageProofs;
+
+        Assert.That(slots.Count, Is.EqualTo(1));
+        (AddRangeResult storageResult, _, _, _) = SnapProviderHelper.AddStorageRange(
+            clientFactory, contractAccount, slots[0], ValueKeccak.Zero, ValueKeccak.MaxValue, storageProofs);
+        Assert.That(storageResult, Is.EqualTo(AddRangeResult.OK), $"storage range proof at {number}");
+    }
+
+    private sealed class TestStateRootIndex : IFlatStateRootIndex
+    {
+        private readonly Dictionary<Hash256, StateId> _roots = [];
+
+        public void Add(in StateId stateId) => _roots[stateId.StateRoot.ToCommitment()] = stateId;
+
+        public bool TryGetStateId(Hash256 stateRoot, out StateId stateId) => _roots.TryGetValue(stateRoot, out stateId);
+
+        public bool HasStateRoot(Hash256 stateRoot) => _roots.ContainsKey(stateRoot);
+    }
+
+    private sealed class TestFinalizedStateProvider : IFinalizedStateProvider
+    {
+        private readonly Dictionary<long, Hash256> _roots = [];
+
+        public long FinalizedBlockNumber { get; set; }
+
+        public void SetStateRoot(long blockNumber, Hash256 stateRoot) => _roots[blockNumber] = stateRoot;
+
+        public Hash256? GetFinalizedStateRootAt(long blockNumber) => _roots.TryGetValue(blockNumber, out Hash256? root) ? root : null;
+    }
+
+    private sealed class CancellationTokenSourceProcessExitSource(CancellationTokenSource cancellationTokenSource) : IProcessExitSource
+    {
+        public CancellationToken Token => cancellationTokenSource.Token;
+
+        public void Exit(int exitCode) => throw new NotSupportedException();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
@@ -59,6 +60,7 @@ public class FlatDbManagerTests
         _persistenceManager,
         _config,
         _blocksConfig,
+        new SyncConfig(),
         LimboLogs.Instance,
         enableDetailedMetrics: false);
 
@@ -174,6 +176,72 @@ public class FlatDbManagerTests
         _persistenceManager.ClearReceivedCalls();
         using (ReadOnlySnapshotBundle bundle3 = manager.GatherReadOnlySnapshotBundle(stateId)) { }
         _persistenceManager.Received(1).LeaseReader();
+    }
+
+    [Test]
+    public async Task FlushCache_EarlyPersistFlag_ArchivesInsteadOfRemoves([Values] bool earlyPersist)
+    {
+        _config.EarlyPersist = earlyPersist;
+        StateId persisted = CreateStateId(10);
+        _persistenceManager.FlushToPersistence().Returns(persisted);
+
+        await using FlatDbManager manager = CreateManager();
+        manager.FlushCache(CancellationToken.None);
+
+        if (earlyPersist)
+        {
+            _snapshotRepository.Received(1).ArchiveStatesUntil(persisted);
+            _snapshotRepository.DidNotReceive().RemoveStatesUntil(Arg.Any<StateId>());
+        }
+        else
+        {
+            _snapshotRepository.Received(1).RemoveStatesUntil(persisted);
+            _snapshotRepository.DidNotReceive().ArchiveStatesUntil(Arg.Any<StateId>());
+        }
+    }
+
+    [Test]
+    public async Task GatherReadOnlySnapshotBundle_BelowPersistedState_UsesHistoricalAssembly()
+    {
+        StateId persisted = CreateStateId(20);
+        StateId historical = CreateStateId(10);
+        IPersistence.IPersistenceReader mockReader = Substitute.For<IPersistence.IPersistenceReader>();
+        mockReader.CurrentState.Returns(persisted);
+        _persistenceManager.LeaseReader().Returns(mockReader);
+
+        ResourcePool realResourcePool = new(_config);
+        Snapshot reverseDiff = realResourcePool.CreateSnapshot(persisted, historical, ResourcePool.Usage.ReverseDiff);
+        _snapshotRepository.AssembleHistoricalSnapshots(historical, persisted, Arg.Any<int>())
+            .Returns(FlatTestHelpers.SnapshotList(reverseDiff));
+
+        await using FlatDbManager manager = CreateManager();
+        bool gathered = manager.TryGatherReadOnlySnapshotBundle(historical, out ReadOnlySnapshotBundle? bundle);
+
+        Assert.That(gathered, Is.True);
+        using (bundle)
+        {
+            Assert.That(bundle!.SnapshotCount, Is.EqualTo(1));
+        }
+        _snapshotRepository.DidNotReceive().AssembleSnapshots(Arg.Any<StateId>(), Arg.Any<StateId>(), Arg.Any<int>());
+    }
+
+    [Test]
+    public async Task TryGatherReadOnlySnapshotBundle_HistoricalStatePruned_ReturnsFalseAndGatherThrows()
+    {
+        StateId persisted = CreateStateId(20);
+        StateId pruned = CreateStateId(5);
+        IPersistence.IPersistenceReader mockReader = Substitute.For<IPersistence.IPersistenceReader>();
+        mockReader.CurrentState.Returns(persisted);
+        _persistenceManager.LeaseReader().Returns(mockReader);
+        _snapshotRepository.AssembleHistoricalSnapshots(pruned, persisted, Arg.Any<int>())
+            .Returns(_ => SnapshotPooledList.Empty());
+        _snapshotRepository.HasHistoricalState(pruned).Returns(false);
+
+        await using FlatDbManager manager = CreateManager();
+
+        Assert.That(manager.TryGatherReadOnlySnapshotBundle(pruned, out ReadOnlySnapshotBundle? bundle), Is.False);
+        Assert.That(bundle, Is.Null);
+        Assert.Throws<InvalidOperationException>(() => manager.GatherReadOnlySnapshotBundle(pruned));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
@@ -86,3 +86,46 @@ internal sealed class FakeWriteBatch : IPersistence.IWriteBatch
 
     public void Dispose() => DisposeCount++;
 }
+
+/// <summary>
+/// Hand-rolled fake for <see cref="IPersistence.IPersistenceReader"/> backed by dictionaries.
+/// Used in place of an NSubstitute mock because configuring methods with <c>in</c>/<c>ref</c>
+/// struct parameters (e.g. <see cref="IPersistence.IPersistenceReader.TryGetSlot"/>) is unwieldy.
+/// </summary>
+internal sealed class FakePersistenceReader : IPersistence.IPersistenceReader
+{
+    public Dictionary<Address, Account?> Accounts { get; } = [];
+    public Dictionary<(Address, UInt256), SlotValue> Slots { get; } = [];
+    public Dictionary<TreePath, byte[]> StateRlp { get; } = [];
+    public Dictionary<(Hash256, TreePath), byte[]> StorageRlp { get; } = [];
+    public StateId CurrentState { get; set; } = StateId.PreGenesis;
+
+    public Account? GetAccount(Address address) => Accounts.TryGetValue(address, out Account? account) ? account : null;
+
+    public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue)
+    {
+        if (Slots.TryGetValue((address, slot), out SlotValue value))
+        {
+            outValue = value;
+            return true;
+        }
+
+        return false;
+    }
+
+    public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) => StateRlp.TryGetValue(path, out byte[]? rlp) ? rlp : null;
+
+    public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => StorageRlp.TryGetValue((address, path), out byte[]? rlp) ? rlp : null;
+
+    public byte[]? GetAccountRaw(in ValueHash256 addrHash) => null;
+
+    public bool TryGetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, ref SlotValue value) => false;
+
+    public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey) => throw new NotSupportedException();
+
+    public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey) => throw new NotSupportedException();
+
+    public bool IsPreimageMode => false;
+
+    public void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -46,14 +46,17 @@ public class PersistenceManagerTests
         persistenceReader.CurrentState.Returns(Block0);
         _persistence.CreateReader().Returns(persistenceReader);
 
-        _persistenceManager = new PersistenceManager(
-            _config,
-            ScheduleHelper.CreateWithOffset(_config, 0),
-            _finalizedStateProvider,
-            _persistence,
-            _snapshotRepository,
-            LimboLogs.Instance);
+        _persistenceManager = CreateManager();
     }
+
+    private PersistenceManager CreateManager(int offset = 0) => new(
+        _config,
+        ScheduleHelper.CreateWithOffset(_config, offset),
+        _finalizedStateProvider,
+        _persistence,
+        _snapshotRepository,
+        _resourcePool,
+        LimboLogs.Instance);
 
     [TearDown]
     public void TearDown()
@@ -397,13 +400,7 @@ public class PersistenceManagerTests
     {
         // Fresh DB: currentPersistedState = Block0 (block 0).
         // With CompactSize=16 and offset=N, the next full compaction boundary is at block 16-N.
-        PersistenceManager pm = new(
-            _config,
-            ScheduleHelper.CreateWithOffset(_config, offset),
-            _finalizedStateProvider,
-            _persistence,
-            _snapshotRepository,
-            LimboLogs.Instance);
+        PersistenceManager pm = CreateManager(offset);
 
         StateId target = CreateStateId(expectedTargetBlock);
         StateId latest = CreateStateId(200);
@@ -535,6 +532,136 @@ public class PersistenceManagerTests
             _persistence.CreateWriteBatch(state1, state2);
             _persistence.CreateWriteBatch(state2, state3);
         });
+    }
+
+    #endregion
+
+    #region Early Persist (reverse diff)
+
+    [Test]
+    public void DetermineSnapshotToPersist_EarlyPersist_IgnoresMinReorgDepthButKeepsFinalizationGate()
+    {
+        _config.EarlyPersist = true;
+        PersistenceManager pm = CreateManager();
+
+        // Depth 20 is far below MinReorgDepth (64); only the finalization gate should matter.
+        StateId target = CreateStateId(16);
+        StateId latest = CreateStateId(20);
+        using Snapshot expected = CreateSnapshot(Block0, target, compacted: true);
+        _finalizedStateProvider.SetFinalizedStateRootAt(16, new Hash256(target.StateRoot.Bytes));
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(10);
+        Snapshot? whileUnfinalized = pm.DetermineSnapshotToPersist(latest);
+
+        _finalizedStateProvider.SetFinalizedBlockNumber(18);
+        Snapshot? whenFinalized = pm.DetermineSnapshotToPersist(latest);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(whileUnfinalized, Is.Null, "boundary above finalized must not persist");
+            Assert.That(whenFinalized, Is.Not.Null, "finalized boundary should persist regardless of depth");
+            Assert.That(whenFinalized?.To, Is.EqualTo(target));
+        }
+
+        whenFinalized?.Dispose();
+    }
+
+    [Test]
+    public void PersistSnapshot_EarlyPersist_BuildsReverseDiffWithOldValuesAndNullMarkers()
+    {
+        _config.EarlyPersist = true;
+        PersistenceManager pm = CreateManager();
+
+        Account oldAccount = new(5, 500);
+        SlotValue oldSlot = SlotValue.FromSpanWithoutLeadingZero([7]);
+        byte[] oldNodeRlp = [1, 2, 3];
+        byte[] oldStorageNodeRlp = [4, 5, 6];
+        TreePath presentPath = TreePath.FromHexString("12");
+        TreePath absentPath = TreePath.FromHexString("34");
+
+        FakePersistenceReader oldState = new() { CurrentState = Block0 };
+        oldState.Accounts[TestItem.AddressA] = oldAccount;
+        oldState.Slots[(TestItem.AddressA, (UInt256)1)] = oldSlot;
+        oldState.StateRlp[presentPath] = oldNodeRlp;
+        oldState.StorageRlp[(TestItem.KeccakA, presentPath)] = oldStorageNodeRlp;
+        _persistence.CreateReader().Returns(oldState);
+
+        StateId to = CreateStateId(16);
+        using Snapshot snapshot = _resourcePool.CreateSnapshot(Block0, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        snapshot.Content.Accounts[TestItem.AddressA] = new Account(1, 100);
+        snapshot.Content.Accounts[TestItem.AddressB] = new Account(2, 200);
+        snapshot.Content.Storages[(TestItem.AddressA, (UInt256)1)] = SlotValue.FromSpanWithoutLeadingZero([42]);
+        snapshot.Content.Storages[(TestItem.AddressA, (UInt256)2)] = SlotValue.FromSpanWithoutLeadingZero([99]);
+        snapshot.Content.StateNodes[presentPath] = new TrieNode(NodeType.Leaf, Keccak.Zero);
+        snapshot.Content.StateNodes[absentPath] = new TrieNode(NodeType.Leaf, Keccak.Zero);
+        snapshot.Content.StorageNodes[(TestItem.KeccakA, presentPath)] = new TrieNode(NodeType.Leaf, Keccak.Zero);
+
+        FakeWriteBatch writeBatch = new();
+        _persistence.CreateWriteBatch(Block0, to).Returns(writeBatch);
+
+        pm.PersistSnapshot(snapshot);
+
+        using SnapshotPooledList assembled = _snapshotRepository.AssembleHistoricalSnapshots(Block0, to, 1);
+        Assert.That(assembled.Count, Is.EqualTo(1), "reverse diff should be registered");
+        Snapshot reverseDiff = assembled[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reverseDiff.From, Is.EqualTo(to));
+            Assert.That(reverseDiff.To, Is.EqualTo(Block0));
+
+            Assert.That(reverseDiff.TryGetAccount(TestItem.AddressA, out Account? capturedAccount), Is.True);
+            Assert.That(capturedAccount, Is.EqualTo(oldAccount));
+            Assert.That(reverseDiff.TryGetAccount(TestItem.AddressB, out Account? absentAccount), Is.True, "absent old account needs a null marker");
+            Assert.That(absentAccount, Is.Null);
+
+            Assert.That(reverseDiff.TryGetStorage((TestItem.AddressA, (UInt256)1), out SlotValue? capturedSlot), Is.True);
+            Assert.That(capturedSlot?.ToEvmBytes(), Is.EqualTo(oldSlot.ToEvmBytes()));
+            Assert.That(reverseDiff.TryGetStorage((TestItem.AddressA, (UInt256)2), out SlotValue? absentSlot), Is.True, "absent old slot needs a null marker");
+            Assert.That(absentSlot, Is.Null);
+
+            Assert.That(reverseDiff.TryGetStateNode(presentPath, out TrieNode? capturedNode), Is.True);
+            Assert.That(capturedNode?.FullRlp.ToArray(), Is.EqualTo(oldNodeRlp));
+            Assert.That(capturedNode?.IsPersisted, Is.True);
+            Assert.That(reverseDiff.TryGetStateNode(absentPath, out _), Is.False, "node absent at old state is skipped, not marked");
+
+            Assert.That(reverseDiff.TryGetStorageNode((TestItem.KeccakA, presentPath), out TrieNode? capturedStorageNode), Is.True);
+            Assert.That(capturedStorageNode?.FullRlp.ToArray(), Is.EqualTo(oldStorageNodeRlp));
+        }
+    }
+
+    [Test]
+    public void PersistSnapshot_EarlyPersist_SelfDestruct([Values] bool isNewAccount)
+    {
+        _config.EarlyPersist = true;
+        PersistenceManager pm = CreateManager();
+        _persistence.CreateReader().Returns(new FakePersistenceReader { CurrentState = Block0 });
+
+        // Pre-existing history that an irreversible self-destruct must truncate.
+        StateId priorBoundary = CreateStateId(4);
+        StateId priorPersisted = CreateStateId(8);
+        _snapshotRepository.TryAddReverseDiff(_resourcePool.CreateSnapshot(priorPersisted, priorBoundary, ResourcePool.Usage.ReverseDiff));
+
+        StateId to = CreateStateId(16);
+        using Snapshot snapshot = _resourcePool.CreateSnapshot(Block0, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        snapshot.Content.Accounts[TestItem.AddressB] = new Account(1, 100);
+        snapshot.Content.SelfDestructedStorageAddresses[TestItem.AddressA] = isNewAccount;
+
+        FakeWriteBatch writeBatch = new();
+        _persistence.CreateWriteBatch(Block0, to).Returns(writeBatch);
+
+        pm.PersistSnapshot(snapshot);
+
+        using SnapshotPooledList priorHistory = _snapshotRepository.AssembleHistoricalSnapshots(priorBoundary, priorPersisted, 1);
+        using SnapshotPooledList newDiff = _snapshotRepository.AssembleHistoricalSnapshots(Block0, to, 1);
+        using (Assert.EnterMultipleScope())
+        {
+            // Same-tx created account (true) is reversible: nothing was ever persisted for it.
+            // An account with persisted storage (false) is not: the window is truncated instead.
+            Assert.That(priorHistory.Count, Is.EqualTo(isNewAccount ? 1 : 0), "prior history");
+            Assert.That(newDiff.Count, Is.EqualTo(isNewAccount ? 1 : 0), "new reverse diff");
+            Assert.That(writeBatch.SelfDestructCalls, isNewAccount ? Is.Empty : Is.EqualTo(new[] { TestItem.AddressA }));
+        }
     }
 
     #endregion

--- a/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
@@ -191,6 +191,47 @@ public class ReadOnlySnapshotBundleTests
     }
 
     [Test]
+    public void ReverseDiffStack_ReadsForwardThenNearestReverseDiffThenPersistence()
+    {
+        // Historical stack: ascending list [R_top (nearest persisted), R_boundary, F]. The newest-first
+        // read loop must check F, then R_boundary, then R_top, then persistence.
+        Address inForward = TestItem.AddressA;
+        Address inBothDiffs = TestItem.AddressB;
+        Address nullMarker = TestItem.AddressC;
+        Address onlyPersisted = TestItem.AddressD;
+
+        Account forwardValue = TestItem.GenerateIndexedAccount(1);
+        Account boundaryValue = TestItem.GenerateIndexedAccount(2);
+        Account topValue = TestItem.GenerateIndexedAccount(3);
+        Account persistedValue = TestItem.GenerateIndexedAccount(4);
+
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.GetAccount(onlyPersisted).Returns(persistedValue);
+
+        using ReadOnlySnapshotBundle bundle = Bundle(FlatTestHelpers.SnapshotList(
+            MakeSnapshot(c =>
+            {
+                c.Accounts[new HashedKey<Address>(inBothDiffs)] = topValue;
+                c.Accounts[new HashedKey<Address>(nullMarker)] = topValue;
+            }),
+            MakeSnapshot(c =>
+            {
+                c.Accounts[new HashedKey<Address>(inBothDiffs)] = boundaryValue;
+                c.Accounts[new HashedKey<Address>(nullMarker)] = null;
+            }),
+            MakeSnapshot(c => c.Accounts[new HashedKey<Address>(inForward)] = forwardValue)), reader);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bundle.GetAccount(inForward), Is.EqualTo(forwardValue));
+            Assert.That(bundle.GetAccount(inBothDiffs), Is.EqualTo(boundaryValue), "diff nearest the served state wins");
+            Assert.That(bundle.GetAccount(nullMarker), Is.Null, "null marker shadows the newer persisted value");
+            Assert.That(bundle.GetAccount(onlyPersisted), Is.EqualTo(persistedValue));
+        }
+        reader.DidNotReceive().GetAccount(nullMarker);
+    }
+
+    [Test]
     public void TryLease_ReturnsTrueWhileAlive_ThrowsAfterDispose()
     {
         ReadOnlySnapshotBundle bundle = Bundle(FlatTestHelpers.SnapshotList(MakeSnapshot()));

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -442,5 +443,143 @@ public class SnapshotRepositoryTests
 
         Assert.That(_repository.HasState(CreateStateId(7)), Is.True);
         Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.True);
+    }
+
+    private Snapshot AddReverseDiff(long fromBlock, long toBlock)
+    {
+        Snapshot reverseDiff = CreateSnapshot(CreateStateId(fromBlock), CreateStateId(toBlock));
+        Assert.That(_repository.TryAddReverseDiff(reverseDiff), Is.True, $"Failed to add reverse diff {fromBlock}->{toBlock}");
+        return reverseDiff;
+    }
+
+    /// <summary>
+    /// Per-block chain 0..12 archived in chunks of 4 with reverse diffs (4→0), (8→4), (12→8).
+    /// Historical forwards left: 1-3, 5-7, 9-11 (each chunk's upper boundary snapshot is released on archive).
+    /// </summary>
+    private void BuildArchivedChunks()
+    {
+        BuildSnapshotChain(0, 12);
+        for (long boundary = 4; boundary <= 12; boundary += 4)
+        {
+            _repository.ArchiveStatesUntil(CreateStateId(boundary));
+            AddReverseDiff(boundary, boundary - 4);
+        }
+    }
+
+    private static void AssertContiguousChain(SnapshotPooledList assembled, StateId persisted, StateId baseState)
+    {
+        Assert.That(assembled[0].From, Is.EqualTo(persisted), "topmost reverse diff starts at the persisted state");
+        Assert.That(assembled[^1].To, Is.EqualTo(baseState), "list ends at the requested state");
+        for (int i = 1; i < assembled.Count; i++)
+        {
+            Assert.That(assembled[i].From, Is.EqualTo(assembled[i - 1].To), $"chain broken at index {i}");
+        }
+    }
+
+    [Test]
+    public void ArchiveStatesUntil_MovesCanonicalChainAndReleasesRest()
+    {
+        BuildSnapshotChain(0, 6);
+        AddSnapshotToRepository(0, 4, compacted: true);
+        AddSnapshotToRepository(CreateStateId(3), CreateStateId(4, rootByte: 1));
+
+        _repository.ArchiveStatesUntil(CreateStateId(4));
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (long block = 1; block <= 4; block++)
+            {
+                Assert.That(_repository.HasState(CreateStateId(block)), Is.False, $"state {block} should leave the live set");
+            }
+            for (long block = 1; block <= 3; block++)
+            {
+                Assert.That(_repository.HasHistoricalState(CreateStateId(block)), Is.True, $"state {block} should be historical");
+            }
+            Assert.That(_repository.HasHistoricalState(CreateStateId(4)), Is.False, "persisted state's snapshot is released, not archived");
+            Assert.That(_repository.TryLeaseCompactedState(CreateStateId(4), out _), Is.False, "compacted snapshot should be released");
+            Assert.That(_repository.HasState(CreateStateId(4, rootByte: 1)), Is.False, "non-canonical leftover should be released");
+            Assert.That(_repository.HasState(CreateStateId(5)), Is.True, "states above the persisted block stay live");
+            Assert.That(_repository.HasState(CreateStateId(6)), Is.True, "states above the persisted block stay live");
+        }
+    }
+
+    [TestCase(10, 3, Description = "mid-chunk: one reverse diff then forwards")]
+    [TestCase(8, 1, Description = "exactly at a chunk boundary: reverse diff only")]
+    [TestCase(11, 4)]
+    [TestCase(2, 5, Description = "oldest chunk: all reverse diffs then forwards")]
+    public void AssembleHistoricalSnapshots_ReturnsContiguousChainFromPersistedToBase(long baseBlock, int expectedCount)
+    {
+        BuildArchivedChunks();
+        StateId persisted = CreateStateId(12);
+        StateId baseState = CreateStateId(baseBlock);
+
+        using SnapshotPooledList assembled = _repository.AssembleHistoricalSnapshots(baseState, persisted, 4);
+
+        Assert.That(assembled.Count, Is.EqualTo(expectedCount));
+        AssertContiguousChain(assembled, persisted, baseState);
+    }
+
+    [Test]
+    public void AssembleHistoricalSnapshots_UnknownOrPrunedState_ReturnsEmpty()
+    {
+        BuildArchivedChunks();
+        _repository.PruneHistory(9, CreateStateId(12));
+
+        using SnapshotPooledList unknownState = _repository.AssembleHistoricalSnapshots(CreateStateId(10, rootByte: 1), CreateStateId(12), 4);
+        using SnapshotPooledList prunedState = _repository.AssembleHistoricalSnapshots(CreateStateId(6), CreateStateId(12), 4);
+
+        Assert.That(unknownState.Count, Is.EqualTo(0));
+        Assert.That(prunedState.Count, Is.EqualTo(0));
+    }
+
+    [TestCase(9, 8, new long[] { 9, 10, 11 }, Description = "inside newest chunk: keep one reverse diff")]
+    [TestCase(8, 8, new long[] { 9, 10, 11 }, Description = "at boundary: same keep set")]
+    [TestCase(5, 4, new long[] { 5, 6, 7, 9, 10, 11 })]
+    [TestCase(-1, 0, new long[] { 1, 2, 3, 5, 6, 7, 9, 10, 11 }, Description = "window beyond oldest: keep everything")]
+    public void PruneHistory_KeepsChainDownToChunkBoundaryBelowOldestServed(long oldestServed, long expectedBoundary, long[] keptHistorical)
+    {
+        BuildArchivedChunks();
+        StateId persisted = CreateStateId(12);
+
+        _repository.PruneHistory(oldestServed, persisted);
+
+        using SnapshotPooledList boundaryChain = _repository.AssembleHistoricalSnapshots(CreateStateId(expectedBoundary), persisted, 4);
+        using (Assert.EnterMultipleScope())
+        {
+            for (long block = 1; block < 12; block++)
+            {
+                bool expected = Array.IndexOf(keptHistorical, block) >= 0;
+                Assert.That(_repository.HasHistoricalState(CreateStateId(block)), Is.EqualTo(expected), $"historical {block}");
+            }
+            Assert.That(boundaryChain.Count, Is.GreaterThan(0), "keep-boundary should stay reachable");
+        }
+
+        if (expectedBoundary > 0)
+        {
+            using SnapshotPooledList belowBoundary = _repository.AssembleHistoricalSnapshots(CreateStateId(expectedBoundary - 4), persisted, 4);
+            Assert.That(belowBoundary.Count, Is.EqualTo(0), "chunk below the keep-boundary should be released");
+        }
+    }
+
+    [Test]
+    public void ClearHistory_ReleasesEverything_AndDuplicateReverseDiffIsRejected()
+    {
+        BuildArchivedChunks();
+        Snapshot duplicate = CreateSnapshot(CreateStateId(12), CreateStateId(8));
+        bool addedDuplicate = _repository.TryAddReverseDiff(duplicate);
+        if (!addedDuplicate) duplicate.Dispose();
+
+        _repository.ClearHistory();
+
+        using SnapshotPooledList assembled = _repository.AssembleHistoricalSnapshots(CreateStateId(8), CreateStateId(12), 4);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(addedDuplicate, Is.False);
+            Assert.That(assembled.Count, Is.EqualTo(0));
+            for (long block = 1; block < 12; block++)
+            {
+                Assert.That(_repository.HasHistoricalState(CreateStateId(block)), Is.False, $"historical {block}");
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -3,7 +3,9 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -47,6 +49,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private readonly Task _clearBundleCacheTask;
 
     private readonly int _compactSize;
+    private readonly bool _earlyPersist;
+    private readonly int _historicalWindow;
     private readonly TimeSpan _compactorStallTimeout;
 
     // For debugging. Do the compaction synchronously
@@ -66,6 +70,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         IPersistenceManager persistenceManager,
         IFlatDbConfig config,
         IBlocksConfig blocksConfig,
+        ISyncConfig syncConfig,
         ILogManager logManager,
         bool enableDetailedMetrics)
     {
@@ -78,6 +83,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         _enableDetailedMetrics = enableDetailedMetrics;
 
         _compactSize = config.CompactSize;
+        _earlyPersist = config.EarlyPersist;
+        _historicalWindow = syncConfig.SnapServingMaxDepth;
 
         // We assume that the state must be able to be persisted in half the slot time at the very
         // least. If block processing is stalled for longer than this, persistence is simply too slow
@@ -160,7 +167,15 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         StateId currentPersistedStateId = _persistenceManager.GetCurrentPersistedStateId();
         if (currentPersistedStateId == StateId.PreGenesis) return;
 
-        _snapshotRepository.RemoveStatesUntil(currentPersistedStateId);
+        if (_earlyPersist)
+        {
+            _snapshotRepository.ArchiveStatesUntil(currentPersistedStateId);
+            _snapshotRepository.PruneHistory(latestSnapshot.BlockNumber - _historicalWindow, currentPersistedStateId);
+        }
+        else
+        {
+            _snapshotRepository.RemoveStatesUntil(currentPersistedStateId);
+        }
         ClearReadOnlyBundleCache();
         ReorgBoundaryReached?.Invoke(this, new ReorgBoundaryReached(currentPersistedStateId.BlockNumber));
     }
@@ -241,6 +256,11 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     }
 
     public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock)
+        => TryGatherReadOnlySnapshotBundle(baseBlock, out ReadOnlySnapshotBundle? bundle)
+            ? bundle
+            : throw new InvalidOperationException($"State {baseBlock} no longer exists; concurrently removed.");
+
+    public bool TryGatherReadOnlySnapshotBundle(in StateId baseBlock, [NotNullWhen(true)] out ReadOnlySnapshotBundle? bundle)
     {
         // Note to self: The current verdict on trying to use a linked list of snapshots is that it is error prone and
         // hard to pull of due to the constantly moving chain making invalidation hard.
@@ -249,7 +269,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (baseBlock == StateId.PreGenesis)
         {
             // Special case for pregenesis. Note: nethermind always tries to generate genesis.
-            return new ReadOnlySnapshotBundle(new SnapshotPooledList(0), new NoopPersistenceReader(), _enableDetailedMetrics);
+            bundle = new ReadOnlySnapshotBundle(new SnapshotPooledList(0), new NoopPersistenceReader(), _enableDetailedMetrics);
+            return true;
         }
 
         long sw = 0;
@@ -257,7 +278,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         while (true)
         {
             // Fastpath: Share a recently created ReadOnlySnapshotBundle
-            if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
+            if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out bundle) && bundle.TryLease()) return true;
 
             if (attempt == 1) sw = Stopwatch.GetTimestamp();
             if (attempt != 0)
@@ -273,12 +294,17 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
             IPersistence.IPersistenceReader persistenceReader = _persistenceManager.LeaseReader();
             SnapshotPooledList snapshots;
+            bool isHistorical;
             try
             {
-                snapshots = _snapshotRepository.AssembleSnapshots(
-                    baseBlock,
-                    persistenceReader.CurrentState,
-                    estimatedSize: Math.Max(1, _snapshotRepository.SnapshotCount / _compactSize));
+                StateId persistedState = persistenceReader.CurrentState;
+                isHistorical = baseBlock.BlockNumber < persistedState.BlockNumber;
+                snapshots = isHistorical
+                    ? _snapshotRepository.AssembleHistoricalSnapshots(baseBlock, persistedState, estimatedSize: _compactSize)
+                    : _snapshotRepository.AssembleSnapshots(
+                        baseBlock,
+                        persistedState,
+                        estimatedSize: Math.Max(1, _snapshotRepository.SnapshotCount / _compactSize));
             }
             catch (Exception)
             {
@@ -288,15 +314,19 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
 
             // Empty result + reader not at baseBlock means the path was removed concurrently;
-            // retry unless baseBlock itself was pruned (orphaned), which no retry can recover.
+            // retry unless baseBlock itself was pruned (orphaned) or fell out of the historical serving
+            // window, which no retry can recover.
             if (snapshots.Count == 0 && persistenceReader.CurrentState != baseBlock)
             {
                 snapshots.Dispose();
                 persistenceReader.Dispose();
 
-                if (!_snapshotRepository.HasState(baseBlock))
+                if (isHistorical
+                    ? !_snapshotRepository.HasHistoricalState(baseBlock)
+                    : !_snapshotRepository.HasState(baseBlock))
                 {
-                    throw new InvalidOperationException($"State {baseBlock} no longer exists; concurrently removed.");
+                    bundle = null;
+                    return false;
                 }
 
                 attempt++;
@@ -314,7 +344,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             }
 
             Metrics.SnapshotBundleSize = snapshots.Count;
-            return res;
+            bundle = res;
+            return true;
         }
     }
 
@@ -416,7 +447,14 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (cancellationToken.IsCancellationRequested) return;
         if (persistedState.BlockNumber < 0) return;
 
-        _snapshotRepository.RemoveStatesUntil(persistedState);
+        if (_earlyPersist)
+        {
+            _snapshotRepository.ArchiveStatesUntil(persistedState);
+        }
+        else
+        {
+            _snapshotRepository.RemoveStatesUntil(persistedState);
+        }
 
         ClearReadOnlyBundleCache();
         _trieNodeCache.Clear();

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Flat;
@@ -10,6 +11,13 @@ public interface IFlatDbManager : IFlatCommitTarget
     event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
     SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
     ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock);
+
+    /// <summary>
+    /// Like <see cref="GatherReadOnlySnapshotBundle"/> but returns false instead of throwing when the
+    /// state was pruned or fell out of the historical serving window. Still throws on timeout.
+    /// </summary>
+    bool TryGatherReadOnlySnapshotBundle(in StateId baseBlock, [NotNullWhen(true)] out ReadOnlySnapshotBundle? bundle);
+
     void FlushCache(CancellationToken cancellationToken);
     bool HasStateForBlock(in StateId stateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -36,4 +36,43 @@ public interface ISnapshotRepository
     /// </remarks>
     /// <param name="canonicalStateId">The canonical state being persisted.</param>
     void RemoveSiblingAndDescendents(in StateId canonicalStateId);
+
+    /// <summary>
+    /// Registers the reverse diff of a persisted chunk, keyed by its older end (<see cref="Snapshot.To"/>),
+    /// so historical reads can walk the chain from a chunk boundary up to the persisted state.
+    /// </summary>
+    bool TryAddReverseDiff(Snapshot reverseDiff);
+
+    /// <summary>
+    /// True when <paramref name="stateId"/> is kept as a historical snapshot below the persisted state.
+    /// </summary>
+    bool HasHistoricalState(in StateId stateId);
+
+    /// <summary>
+    /// Early-persist replacement for <see cref="RemoveStatesUntil"/>: moves the canonical per-block
+    /// chain at or below <paramref name="persistedStateId"/> into the historical set (releasing the
+    /// persisted state's own snapshot, compacted snapshots, and non-canonical leftovers) so it stays
+    /// available for snap serving.
+    /// </summary>
+    void ArchiveStatesUntil(in StateId persistedStateId);
+
+    /// <summary>
+    /// Assembles the snapshot stack for a historical state below the persisted state: per-block forward
+    /// snapshots down to the nearest chunk boundary, then reverse diffs up to <paramref name="persistedState"/>.
+    /// Returns an empty list when the chain is broken or the state is outside the serving window.
+    /// </summary>
+    SnapshotPooledList AssembleHistoricalSnapshots(in StateId baseBlock, in StateId persistedState, int estimatedSize);
+
+    /// <summary>
+    /// Releases reverse diffs and historical snapshots no longer needed to serve states at or above
+    /// <paramref name="oldestServedBlockNumber"/>, keeping the reverse chain connected from
+    /// <paramref name="persistedState"/> down to the chunk boundary at or below it.
+    /// </summary>
+    void PruneHistory(long oldestServedBlockNumber, in StateId persistedState);
+
+    /// <summary>
+    /// Releases all reverse diffs and historical snapshots, collapsing the historical serving window.
+    /// Used when a chunk cannot be reversed (irreversible self-destruct).
+    /// </summary>
+    void ClearHistory();
 }

--- a/src/Nethermind/Nethermind.State.Flat/Metrics.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Metrics.cs
@@ -59,6 +59,26 @@ public static class Metrics
     [Description("Total estimated snapshot memory in bytes")]
     public static long TotalSnapshotMemory { get; set; }
 
+    [GaugeMetric]
+    [Description("Number of historical snapshots kept below the persisted state for snap serving")]
+    public static long HistoricalSnapshotCount { get; set; }
+
+    [GaugeMetric]
+    [Description("Estimated memory used by historical snapshots in bytes")]
+    public static long HistoricalSnapshotMemory { get; set; }
+
+    [GaugeMetric]
+    [Description("Number of reverse diffs kept for serving state below the persisted state")]
+    public static long ReverseDiffCount { get; set; }
+
+    [GaugeMetric]
+    [Description("Estimated memory used by reverse diffs in bytes")]
+    public static long ReverseDiffMemory { get; set; }
+
+    [CounterMetric]
+    [Description("Number of times the historical serving window was truncated due to an irreversible self-destruct")]
+    public static long HistoricalWindowTruncations { get; set; }
+
     [DetailedMetric]
     [Description("Active pooled resources by category and type")]
     [KeyIsLabel("category", "resource_type")]

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -25,12 +25,14 @@ public class PersistenceManager(
     IFinalizedStateProvider finalizedStateProvider,
     IPersistence persistence,
     ISnapshotRepository snapshotRepository,
+    IResourcePool resourcePool,
     ILogManager logManager) : IPersistenceManager
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PersistenceManager>();
     private readonly int _minReorgDepth = configuration.MinReorgDepth;
     private readonly int _maxReorgDepth = configuration.MaxReorgDepth;
     private readonly int _compactSize = configuration.CompactSize;
+    private readonly bool _earlyPersist = configuration.EarlyPersist;
     private readonly ICompactionSchedule _schedule = compactionSchedule;
     private readonly List<(Hash256, TreePath)> _trieNodesSortBuffer = []; // Presort make it faster
     private readonly Lock _persistenceLock = new();
@@ -116,9 +118,10 @@ public class PersistenceManager(
         StateId currentPersistedState = GetCurrentPersistedStateId();
         long finalizedBlockNumber = finalizedStateProvider.FinalizedBlockNumber;
         long inMemoryStateDepth = lastSnapshotNumber - currentPersistedState.BlockNumber;
-        if (inMemoryStateDepth - _compactSize < _minReorgDepth)
+        if (!_earlyPersist && inMemoryStateDepth - _compactSize < _minReorgDepth)
         {
-            // Keep some state in memory
+            // Keep some state in memory. With early persist the finalization gate below is the sole
+            // gate; historical state for snap serving is kept as reverse diffs instead.
             return null;
         }
 
@@ -243,95 +246,174 @@ public class PersistenceManager(
         // Usually at the start of the application
         if (compactLength != _compactSize && _logger.IsTrace) _logger.Trace($"Persisting non compacted state of length {compactLength}");
 
-        long sw = Stopwatch.GetTimestamp();
-        using (IPersistence.IWriteBatch batch = persistence.CreateWriteBatch(snapshot.From, snapshot.To))
+        Snapshot? reverseDiff = null;
+        IPersistence.IPersistenceReader? oldStateReader = null;
+        if (_earlyPersist)
         {
-            foreach (KeyValuePair<HashedKey<Address>, bool> toSelfDestructStorage in snapshot.SelfDestructedStorageAddresses)
+            if (HasIrreversibleSelfDestruct(snapshot))
             {
-                if (toSelfDestructStorage.Value)
+                // Reversing a self-destruct of an account with persisted storage would need all its old
+                // slots and storage trie nodes, which is unbounded. Collapse the serving window instead;
+                // it restarts at the new persisted state. Post EIP-6780 this effectively never happens.
+                snapshotRepository.ClearHistory();
+                Metrics.HistoricalWindowTruncations++;
+                if (_logger.IsDebug) _logger.Debug($"Snapshot {snapshot.To} self-destructs an account with persisted storage; truncating the historical serving window.");
+            }
+            else
+            {
+                // The reader sees the pre-batch state for the whole batch, so old values can be captured
+                // next to each overwriting write.
+                oldStateReader = persistence.CreateReader();
+                reverseDiff = resourcePool.CreateSnapshot(from: snapshot.To, to: snapshot.From, ResourcePool.Usage.ReverseDiff);
+            }
+        }
+
+        long sw = Stopwatch.GetTimestamp();
+        try
+        {
+            using (IPersistence.IWriteBatch batch = persistence.CreateWriteBatch(snapshot.From, snapshot.To))
+            {
+                foreach (KeyValuePair<HashedKey<Address>, bool> toSelfDestructStorage in snapshot.SelfDestructedStorageAddresses)
                 {
-                    continue;
-                }
-
-                batch.SelfDestruct(toSelfDestructStorage.Key.Key);
-            }
-
-            foreach (KeyValuePair<HashedKey<Address>, Account?> kv in snapshot.Accounts)
-            {
-                batch.SetAccount(kv.Key.Key, kv.Value);
-            }
-
-            foreach (KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?> kv in snapshot.Storages)
-            {
-                (Address addr, UInt256 slot) = kv.Key.Key;
-
-                batch.SetStorage(addr, slot, kv.Value);
-            }
-
-            _trieNodesSortBuffer.Clear();
-            foreach (TreePath path in snapshot.StateNodeKeys)
-            {
-                _trieNodesSortBuffer.Add((Hash256.Zero, path)); // Hash256.Zero is a placeholder; state node keys don't have an address component
-            }
-            _trieNodesSortBuffer.Sort();
-
-            long stateNodesSize = 0;
-            // foreach (var tn in snapshot.TrieNodes)
-            foreach ((Hash256, TreePath) k in _trieNodesSortBuffer)
-            {
-                (_, TreePath path) = k;
-
-                snapshot.TryGetStateNode(new HashedKey<TreePath>(path), out TrieNode? node);
-
-                if (node!.FullRlp.Length == 0)
-                {
-                    // TODO: Need to double check this case. Does it need a rewrite or not?
-                    if (node.NodeType == NodeType.Unknown)
+                    if (toSelfDestructStorage.Value)
                     {
                         continue;
                     }
+
+                    batch.SelfDestruct(toSelfDestructStorage.Key.Key);
                 }
 
-                stateNodesSize += node.FullRlp.Length;
-                // Note: Even if the node already marked as persisted, we still re-persist it
-                batch.SetStateTrieNode(path, node.FullRlp.AsSpan());
-
-                node.IsPersisted = true;
-                node.PrunePersistedRecursively(1);
-            }
-
-            _trieNodesSortBuffer.Clear();
-            _trieNodesSortBuffer.AddRange(snapshot.StorageTrieNodeKeys);
-            _trieNodesSortBuffer.Sort();
-
-            long storageNodesSize = 0;
-            // foreach (var tn in snapshot.TrieNodes)
-            foreach ((Hash256, TreePath) k in _trieNodesSortBuffer)
-            {
-                (Hash256 address, TreePath path) = k;
-
-                snapshot.TryGetStorageNode(new HashedKey<(Hash256, TreePath)>((address, path)), out TrieNode? node);
-
-                if (node!.FullRlp.Length == 0)
+                foreach (KeyValuePair<HashedKey<Address>, Account?> kv in snapshot.Accounts)
                 {
-                    // TODO: Need to double check this case. Does it need a rewrite or not?
-                    if (node.NodeType == NodeType.Unknown)
-                    {
-                        continue;
-                    }
+                    if (reverseDiff is not null) reverseDiff.Content.Accounts[kv.Key] = oldStateReader!.GetAccount(kv.Key.Key);
+
+                    batch.SetAccount(kv.Key.Key, kv.Value);
                 }
 
-                storageNodesSize += node.FullRlp.Length;
-                // Note: Even if the node already marked as persisted, we still re-persist it
-                batch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
-                node.IsPersisted = true;
-                node.PrunePersistedRecursively(1);
-            }
+                foreach (KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?> kv in snapshot.Storages)
+                {
+                    (Address addr, UInt256 slot) = kv.Key.Key;
 
-            Metrics.FlatPersistenceSnapshotSize.Observe(stateNodesSize, labels: new StringLabel("state_nodes"));
-            Metrics.FlatPersistenceSnapshotSize.Observe(storageNodesSize, labels: new StringLabel("storage_nodes"));
+                    if (reverseDiff is not null)
+                    {
+                        SlotValue oldValue = new();
+                        reverseDiff.Content.Storages[kv.Key] = oldStateReader!.TryGetSlot(addr, slot, ref oldValue) ? oldValue : null;
+                    }
+
+                    batch.SetStorage(addr, slot, kv.Value);
+                }
+
+                _trieNodesSortBuffer.Clear();
+                foreach (TreePath path in snapshot.StateNodeKeys)
+                {
+                    _trieNodesSortBuffer.Add((Hash256.Zero, path)); // Hash256.Zero is a placeholder; state node keys don't have an address component
+                }
+                _trieNodesSortBuffer.Sort();
+
+                long stateNodesSize = 0;
+                // foreach (var tn in snapshot.TrieNodes)
+                foreach ((Hash256, TreePath) k in _trieNodesSortBuffer)
+                {
+                    (_, TreePath path) = k;
+
+                    snapshot.TryGetStateNode(new HashedKey<TreePath>(path), out TrieNode? node);
+
+                    if (node!.FullRlp.Length == 0)
+                    {
+                        // TODO: Need to double check this case. Does it need a rewrite or not?
+                        if (node.NodeType == NodeType.Unknown)
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (reverseDiff is not null)
+                    {
+                        // A node absent at the old state is never reached when traversing from an old
+                        // root, so absent keys need no marker.
+                        byte[]? oldRlp = oldStateReader!.TryLoadStateRlp(path, ReadFlags.None);
+                        if (oldRlp is not null) reverseDiff.Content.StateNodes[new HashedKey<TreePath>(path)] = CreateOldStateNode(oldRlp);
+                    }
+
+                    stateNodesSize += node.FullRlp.Length;
+                    // Note: Even if the node already marked as persisted, we still re-persist it
+                    batch.SetStateTrieNode(path, node.FullRlp.AsSpan());
+
+                    node.IsPersisted = true;
+                    node.PrunePersistedRecursively(1);
+                }
+
+                _trieNodesSortBuffer.Clear();
+                _trieNodesSortBuffer.AddRange(snapshot.StorageTrieNodeKeys);
+                _trieNodesSortBuffer.Sort();
+
+                long storageNodesSize = 0;
+                // foreach (var tn in snapshot.TrieNodes)
+                foreach ((Hash256, TreePath) k in _trieNodesSortBuffer)
+                {
+                    (Hash256 address, TreePath path) = k;
+
+                    snapshot.TryGetStorageNode(new HashedKey<(Hash256, TreePath)>((address, path)), out TrieNode? node);
+
+                    if (node!.FullRlp.Length == 0)
+                    {
+                        // TODO: Need to double check this case. Does it need a rewrite or not?
+                        if (node.NodeType == NodeType.Unknown)
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (reverseDiff is not null)
+                    {
+                        byte[]? oldRlp = oldStateReader!.TryLoadStorageRlp(address, path, ReadFlags.None);
+                        if (oldRlp is not null) reverseDiff.Content.StorageNodes[new HashedKey<(Hash256, TreePath)>((address, path))] = CreateOldStateNode(oldRlp);
+                    }
+
+                    storageNodesSize += node.FullRlp.Length;
+                    // Note: Even if the node already marked as persisted, we still re-persist it
+                    batch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
+                    node.IsPersisted = true;
+                    node.PrunePersistedRecursively(1);
+                }
+
+                Metrics.FlatPersistenceSnapshotSize.Observe(stateNodesSize, labels: new StringLabel("state_nodes"));
+                Metrics.FlatPersistenceSnapshotSize.Observe(storageNodesSize, labels: new StringLabel("storage_nodes"));
+            }
+        }
+        catch
+        {
+            reverseDiff?.Dispose();
+            throw;
+        }
+        finally
+        {
+            oldStateReader?.Dispose();
+        }
+
+        // Registered only after the batch commits so a reader can never see the diff alongside the old
+        // persisted state. The opposite window (new state, diff not yet registered) is covered by the
+        // bundle gather retry.
+        if (reverseDiff is not null && !snapshotRepository.TryAddReverseDiff(reverseDiff))
+        {
+            reverseDiff.Dispose();
         }
 
         Metrics.FlatPersistenceTime.Observe(Stopwatch.GetTimestamp() - sw);
     }
+
+    private static bool HasIrreversibleSelfDestruct(Snapshot snapshot)
+    {
+        foreach (KeyValuePair<HashedKey<Address>, bool> toSelfDestructStorage in snapshot.SelfDestructedStorageAddresses)
+        {
+            // false marks an account whose storage already reached persistence; true is a same-tx
+            // created account with nothing on disk (nothing to reverse).
+            if (!toSelfDestructStorage.Value) return true;
+        }
+
+        return false;
+    }
+
+    private static TrieNode CreateOldStateNode(byte[] rlp) =>
+        new(NodeType.Unknown, Keccak.Compute(rlp), rlp) { IsPersisted = true };
 }

--- a/src/Nethermind/Nethermind.State.Flat/ResourcePool.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ResourcePool.cs
@@ -28,6 +28,9 @@ public class ResourcePool(IFlatDbConfig flatConfig) : IResourcePool
         // Note: readonly here means it's never committed to the flat repo, but within the worldscope itself it may be committed.
         { Usage.ReadOnlyProcessingEnv, new ResourcePoolCategory(Usage.ReadOnlyProcessingEnv, Environment.ProcessorCount * 4, Environment.ProcessorCount * 4) },
 
+        // Reverse diffs of persisted chunks; about SnapServingMaxDepth/CompactSize alive at a time plus slack.
+        { Usage.ReverseDiff, new ResourcePoolCategory(Usage.ReverseDiff, 8, 1) },
+
         // Per-power-of-2 compact pools. Each level only has ~1 active snapshot at a time.
         { Usage.Compact2, new ResourcePoolCategory(Usage.Compact2, 2, 1) },
         { Usage.Compact4, new ResourcePoolCategory(Usage.Compact4, 2, 1) },
@@ -79,6 +82,7 @@ public class ResourcePool(IFlatDbConfig flatConfig) : IResourcePool
         MainBlockProcessing,
         PostMainBlockProcessing,
         ReadOnlyProcessingEnv,
+        ReverseDiff,
         Compact2,
         Compact4,
         Compact8,

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -21,6 +21,12 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     private readonly ConcurrentDictionary<StateId, Snapshot> _snapshots = new();
     private readonly ReadWriteLockBox<SortedSet<StateId>> _sortedSnapshotStateIds = new([]);
 
+    // History kept below the persisted state for snap serving (early persist mode). Per-block forward
+    // snapshots keyed by To, and per-chunk reverse diffs keyed by To (their older end) so the chain can
+    // be walked from any chunk boundary up to the persisted state.
+    private readonly ConcurrentDictionary<StateId, Snapshot> _historicalSnapshots = new();
+    private readonly ConcurrentDictionary<StateId, Snapshot> _reverseDiffs = new();
+
     public int SnapshotCount => _snapshots.Count;
     public int CompactedSnapshotCount => _compactedSnapshots.Count;
 
@@ -127,21 +133,15 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
     }
 
     public bool TryLeaseCompactedState(in StateId stateId, [NotNullWhen(true)] out Snapshot? entry)
-    {
-        SpinWait sw = new();
-        while (_compactedSnapshots.TryGetValue(stateId, out entry))
-        {
-            if (entry.TryAcquire()) return true;
-
-            sw.SpinOnce();
-        }
-        return false;
-    }
+        => TryLeaseFrom(_compactedSnapshots, stateId, out entry);
 
     public bool TryLeaseState(in StateId stateId, [NotNullWhen(true)] out Snapshot? entry)
+        => TryLeaseFrom(_snapshots, stateId, out entry);
+
+    private static bool TryLeaseFrom(ConcurrentDictionary<StateId, Snapshot> snapshots, in StateId stateId, [NotNullWhen(true)] out Snapshot? entry)
     {
         SpinWait sw = new();
-        while (_snapshots.TryGetValue(stateId, out entry))
+        while (snapshots.TryGetValue(stateId, out entry))
         {
             if (entry.TryAcquire()) return true;
 
@@ -266,6 +266,209 @@ public class SnapshotRepository(ILogManager logManager) : ISnapshotRepository
         {
             RemoveAndReleaseCompactedKnownState(stateToRemove);
             RemoveAndReleaseKnownState(stateToRemove);
+        }
+    }
+
+    public bool TryAddReverseDiff(Snapshot reverseDiff)
+    {
+        if (_reverseDiffs.TryAdd(reverseDiff.To, reverseDiff))
+        {
+            Metrics.ReverseDiffCount++;
+
+            // Unlike compacted snapshots, reverse diff values are not shared with other snapshots.
+            long totalBytes = reverseDiff.EstimateMemory();
+            Metrics.ReverseDiffMemory += totalBytes;
+            Metrics.TotalSnapshotMemory += totalBytes;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool HasHistoricalState(in StateId stateId) => _historicalSnapshots.ContainsKey(stateId);
+
+    public void ArchiveStatesUntil(in StateId persistedStateId)
+    {
+        // Move the canonical per-block chain below the persisted state into the historical set. The
+        // persisted state's own snapshot is released instead: that state is fully readable from
+        // persistence and its chunk is covered by the reverse diff. Compacted snapshots are released
+        // outright; historical reads only ever need per-block granularity above a chunk boundary.
+        StateId current = persistedStateId;
+        bool isPersistedState = true;
+        while (_snapshots.TryGetValue(current, out Snapshot? snapshot))
+        {
+            StateId from = snapshot.From;
+
+            RemoveAndReleaseCompactedKnownState(current);
+            if (isPersistedState)
+            {
+                RemoveAndReleaseKnownState(current);
+            }
+            else
+            {
+                MoveToHistorical(current);
+            }
+
+            isPersistedState = false;
+            current = from;
+        }
+
+        // Sweep non-canonical leftovers (orphaned forks at or below the persisted block).
+        using ArrayPoolList<StateId> statesBeforeStateId = GetSnapshotBeforeStateId(persistedStateId);
+        foreach (StateId stateToRemove in statesBeforeStateId)
+        {
+            RemoveAndReleaseCompactedKnownState(stateToRemove);
+            RemoveAndReleaseKnownState(stateToRemove);
+        }
+    }
+
+    /// <summary>
+    /// Assembles the snapshot stack for a historical state <paramref name="baseBlock"/> below the
+    /// persisted state: per-block forward snapshots down to the nearest chunk boundary, then reverse
+    /// diffs up to <paramref name="persistedState"/>.
+    /// </summary>
+    /// <remarks>
+    /// Returned list is in ascending read priority like <see cref="AssembleSnapshots"/>: reverse diffs
+    /// first (topmost last), then forwards ending at <paramref name="baseBlock"/>, so the newest-first
+    /// read loop checks forwards, then reverse diffs from the boundary upward, then persistence.
+    /// Returns an empty list when the chain is broken (pruned concurrently or outside the serving
+    /// window); the caller retries or fails.
+    /// </remarks>
+    public SnapshotPooledList AssembleHistoricalSnapshots(in StateId baseBlock, in StateId persistedState, int estimatedSize)
+    {
+        using ArrayPoolListRef<Snapshot> forwards = new(estimatedSize);
+        using ArrayPoolListRef<Snapshot> reverses = new(4);
+        bool success = false;
+        try
+        {
+            // Per-block forwards downward from baseBlock until a state with a reverse diff (chunk boundary).
+            StateId current = baseBlock;
+            Snapshot? reverse;
+            while (!TryLeaseFrom(_reverseDiffs, current, out reverse))
+            {
+                if (!TryLeaseFrom(_historicalSnapshots, current, out Snapshot? snapshot)) return SnapshotPooledList.Empty();
+
+                forwards.Add(snapshot);
+                current = snapshot.From;
+            }
+
+            // Reverse diffs upward; each diff's From is the chunk boundary above it.
+            while (true)
+            {
+                reverses.Add(reverse);
+                if (reverse.From == persistedState) break;
+                if (!TryLeaseFrom(_reverseDiffs, reverse.From, out reverse)) return SnapshotPooledList.Empty();
+            }
+
+            SnapshotPooledList result = new(forwards.Count + reverses.Count);
+            for (int i = reverses.Count - 1; i >= 0; i--) result.Add(reverses[i]);
+            for (int i = forwards.Count - 1; i >= 0; i--) result.Add(forwards[i]);
+            success = true;
+            return result;
+        }
+        finally
+        {
+            if (!success)
+            {
+                foreach (Snapshot snapshot in forwards) snapshot.Dispose();
+                foreach (Snapshot snapshot in reverses) snapshot.Dispose();
+            }
+        }
+    }
+
+    public void PruneHistory(long oldestServedBlockNumber, in StateId persistedState)
+    {
+        // Walk the reverse chain down from the persisted state; the first diff reaching at or below
+        // oldestServedBlockNumber is the keep-boundary (chunk granularity keeps historical reads able to
+        // reach every state in the serving window). Everything below it or off-chain is released.
+        StateId keepBoundary = persistedState;
+        using PooledSet<StateId> keptDiffs = new();
+        while (TryFindReverseDiffFrom(keepBoundary, out StateId diffTo))
+        {
+            keptDiffs.Add(diffTo);
+            keepBoundary = diffTo;
+            if (diffTo.BlockNumber <= oldestServedBlockNumber) break;
+        }
+
+        foreach (KeyValuePair<StateId, Snapshot> kv in _reverseDiffs)
+        {
+            if (!keptDiffs.Contains(kv.Key)) RemoveAndReleaseReverseDiff(kv.Key);
+        }
+
+        foreach (KeyValuePair<StateId, Snapshot> kv in _historicalSnapshots)
+        {
+            if (kv.Key.BlockNumber <= keepBoundary.BlockNumber) RemoveAndReleaseHistoricalState(kv.Key);
+        }
+    }
+
+    public void ClearHistory()
+    {
+        foreach (KeyValuePair<StateId, Snapshot> kv in _reverseDiffs) RemoveAndReleaseReverseDiff(kv.Key);
+        foreach (KeyValuePair<StateId, Snapshot> kv in _historicalSnapshots) RemoveAndReleaseHistoricalState(kv.Key);
+    }
+
+    private bool TryFindReverseDiffFrom(in StateId from, out StateId diffTo)
+    {
+        foreach (KeyValuePair<StateId, Snapshot> kv in _reverseDiffs)
+        {
+            if (kv.Value.From == from)
+            {
+                diffTo = kv.Key;
+                return true;
+            }
+        }
+
+        diffTo = default;
+        return false;
+    }
+
+    private void MoveToHistorical(in StateId stateId)
+    {
+        if (_snapshots.TryRemove(stateId, out Snapshot? snapshot))
+        {
+            Metrics.SnapshotCount--;
+
+            using (_sortedSnapshotStateIds.EnterWriteLock(out SortedSet<StateId> sortedSnapshots))
+            {
+                sortedSnapshots.Remove(stateId);
+            }
+
+            // TotalSnapshotMemory is unchanged; the snapshot is still alive, just re-homed.
+            long totalBytes = snapshot.EstimateMemory();
+            Metrics.SnapshotMemory -= totalBytes;
+            Metrics.HistoricalSnapshotCount++;
+            Metrics.HistoricalSnapshotMemory += totalBytes;
+
+            _historicalSnapshots[stateId] = snapshot;
+        }
+    }
+
+    private void RemoveAndReleaseHistoricalState(in StateId stateId)
+    {
+        if (_historicalSnapshots.TryRemove(stateId, out Snapshot? snapshot))
+        {
+            Metrics.HistoricalSnapshotCount--;
+
+            long totalBytes = snapshot.EstimateMemory();
+            Metrics.HistoricalSnapshotMemory -= totalBytes;
+            Metrics.TotalSnapshotMemory -= totalBytes;
+
+            snapshot.Dispose();
+        }
+    }
+
+    private void RemoveAndReleaseReverseDiff(in StateId stateId)
+    {
+        if (_reverseDiffs.TryRemove(stateId, out Snapshot? reverseDiff))
+        {
+            Metrics.ReverseDiffCount--;
+
+            long totalBytes = reverseDiff.EstimateMemory();
+            Metrics.ReverseDiffMemory -= totalBytes;
+            Metrics.TotalSnapshotMemory -= totalBytes;
+
+            reverseDiff.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -38,7 +38,15 @@ public class FlatSnapServer(
             return false;
         }
 
-        bundle = flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        // The state can be pruned (or fall out of the historical serving window) between the index
+        // lookup and the gather; respond empty rather than throw.
+        if (!flatDbManager.TryGatherReadOnlySnapshotBundle(stateId, out ReadOnlySnapshotBundle? gathered))
+        {
+            bundle = null!;
+            return false;
+        }
+
+        bundle = gathered;
         return true;
     }
 


### PR DESCRIPTION
## Changes

- Add `IFlatDbConfig.EarlyPersist` (default off). When on, the persisted flat state advances to the finalized compaction boundary instead of trailing head by `MinReorgDepth` (128), so head-state reads traverse far fewer snapshot layers before falling through to RocksDB.
- Build one in-memory **reverse diff** per persisted `CompactSize` chunk in `PersistenceManager.PersistSnapshot`: old values are captured from a persistence reader leased before the write batch (the batch holds a pre-batch DB snapshot, so reads next to each write see the old state). Accounts/slots record null markers for keys absent at the old state; trie nodes capture old RLP (a path absent at the old state is never reached when traversing from an old root, so nodes need no markers).
- Keep per-block forward snapshots below the persisted state in a new historical set (`SnapshotRepository.ArchiveStatesUntil`) instead of deleting them. A historical read stacks: forwards down to the chunk boundary, reverse diffs up to the persisted state, then persistence — the existing newest-first read loop in `ReadOnlySnapshotBundle` is unchanged.
- Prune history at chunk granularity after each persist (`PruneHistory`), bounded by `ISyncConfig.SnapServingMaxDepth` from head.
- A self-destruct of an account with previously-persisted storage cannot be reversed (its old slots and storage trie nodes are range-deleted and unbounded); the historical window is truncated (`ClearHistory`) and persisted without a diff. Post EIP-6780 this effectively never happens; same-tx create+destruct accounts remain reversible.
- Snap server gathers bundles via a new non-throwing `IFlatDbManager.TryGatherReadOnlySnapshotBundle`, responding with empty ranges when a state was pruned or fell out of the serving window (also fixes a pre-existing post-restart throw path).
- New metrics: historical snapshot count/memory, reverse diff count/memory, historical window truncations.

With the flag off (default), every new code path is dormant and behavior is unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Unit tests: `SnapshotRepository` archive/assemble/prune/clear (parameterized over window positions), `PersistenceManager` early-persist gate matrix and reverse-diff content (old values, null markers, skipped absent trie nodes, self-destruct both ways), `FlatDbManager` historical gather routing and `TryGather` semantics, `ReadOnlySnapshotBundle` read precedence through a reverse-diff stack.
- End-to-end (`EarlyPersistScenarioTests`): 21 blocks committed through the real scope provider, compactor, persistence manager, and `RocksDbPersistence`; asserts persistence advances past `head − SnapServingMaxDepth`, every in-window historical state reads back recorded values (including that newer persisted values do not leak past reverse-diff null markers), `FlatSnapServer` serves account and storage ranges for historical roots with proofs validated client-side via `SnapProviderHelper`, out-of-window states respond empty, and history survives `FlushCache`.
- Full `Nethermind.State.Flat.Test` suite green.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

PR authored by Claude (Claude Code, model Fable 5), driven and reviewed by @asdacap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)