### PR TITLE
Add EIP-7594 to Hoodi Unzen

### DIFF
--- a/src/Nethermind/Chains/taiko-hoodi.json
+++ b/src/Nethermind/Chains/taiko-hoodi.json
@@ -240,6 +240,7 @@
     "eip7251TransitionTimestamp": "0x6a33ebd0",
     "eip7623TransitionTimestamp": "0x6a33ebd0",
     "eip7702TransitionTimestamp": "0x6a33ebd0",
+    "eip7594TransitionTimestamp": "0x6a33ebd0",
     "eip7823TransitionTimestamp": "0x6a33ebd0",
     "eip7825TransitionTimestamp": "0x6a33ebd0",
     "eip7883TransitionTimestamp": "0x6a33ebd0",

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoChainSpecEngineParametersTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoChainSpecEngineParametersTests.cs
@@ -178,6 +178,7 @@ public class TaikoChainSpecEngineParametersTests
             (nameof(ITaikoReleaseSpec.IsEip7251Enabled), static s => s.IsEip7251Enabled),
             (nameof(ITaikoReleaseSpec.IsEip7623Enabled), static s => s.IsEip7623Enabled),
             (nameof(ITaikoReleaseSpec.IsEip7702Enabled), static s => s.IsEip7702Enabled),
+            (nameof(ITaikoReleaseSpec.IsEip7594Enabled), static s => s.IsEip7594Enabled),
             (nameof(ITaikoReleaseSpec.IsEip7823Enabled), static s => s.IsEip7823Enabled),
             (nameof(ITaikoReleaseSpec.IsEip7825Enabled), static s => s.IsEip7825Enabled),
             (nameof(ITaikoReleaseSpec.IsEip7883Enabled), static s => s.IsEip7883Enabled),


### PR DESCRIPTION
Add the missing `eip7594TransitionTimestamp` to the Taiko Hoodi Unzen, as a follow-up to #11977, which was missed in the original PR by mistake. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
