### PR TITLE
test(merge): fix flaky AlreadyKnown_not_cached_block_should_return_valid

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -807,9 +807,12 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task AlreadyKnown_not_cached_block_should_return_valid()
     {
+        // Disable the latestBlocks cache so the second b5 submission below routes
+        // through the AddBlockResult.AlreadyKnown branch (what the test name asserts)
+        // rather than a cache hit.
         using MergeTestBlockchain? chain = await CreateBlockchain(mergeConfig: new MergeConfig()
         {
-            NewPayloadBlockProcessingTimeout = 100
+            NewPayloadCacheSize = 0
         });
 
         IEngineRpcModule? rpc = chain.EngineRpcModule;


### PR DESCRIPTION
## Changes

- Drop the spurious `NewPayloadBlockProcessingTimeout = 100` in `AlreadyKnown_not_cached_block_should_return_valid` and restore `NewPayloadCacheSize = 0`.

The test name promises the second `b5` submission goes through the `AddBlockResult.AlreadyKnown` branch, but with the default cache size of 50 the latest-blocks cache short-circuits the check, so the test has not been exercising the path its name describes.

The 100 ms timeout it had been carrying since #8929 served no purpose here — the test does not throttle processing or assert timeout→SYNCING behavior — and was flaking the Flat-DB `Nethermind.Merge.AuRa.Test` CI variant whenever validation of an empty block exceeded 100 ms (e.g. [run 27484336508](https://github.com/NethermindEth/nethermind/actions/runs/27484336508/job/81237625149)).

The cache-disable was the test's original intent: in #8929 (commit `8cdb82cd5d`) when `NewPayloadTimeout = 0.1` (seconds) was renamed to `NewPayloadBlockProcessingTimeout = 100` (ms), the paired `NewPayloadCacheSize = 0` was accidentally dropped, leaving the test with only the irrelevant tight timeout. Restoring `NewPayloadCacheSize = 0` makes the test exercise the branch its name describes, and the removed explicit timeout falls back to the 60 s value `BaseEngineModuleTests` already applies to non-timeout tests — same pattern as #11731.

Verified locally with 5 consecutive runs of the AuRa variant — 2/2 pass each time, no failures.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Existing test now exercises the `AlreadyKnown` branch it was named after, and no longer races a 100 ms timeout.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No