### PR TITLE
fix(flatdb): preserve format markers when clearing the flat DB

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
 using NUnit.Framework;
 
@@ -15,6 +16,9 @@ public class BaseFlatPersistenceReaderTests
     // Regression: a slot value longer than SlotValue.ByteCount must fail loudly instead of underflowing
     // the unchecked Unsafe.InitBlockUnaligned in TryGetStorage (which produced a wild memset / SIGSEGV).
     // Shorter values are right-aligned into the 32-byte slot with leading zeros.
+    // Cases use rlpWrapSlots:false (the corrupted-DB path). There is no rlpWrapSlots:true throwing case: the
+    // value is read into a RlpSlotValueBufferSize (33) byte buffer, so the decoded length cannot exceed 32 —
+    // see TryGetStorage_RlpWrapped_DecodesToSlotValue for the wrapped golden path.
     [TestCase(33, true)]
     [TestCase(32, false)]
     [TestCase(16, false)]
@@ -45,6 +49,25 @@ public class BaseFlatPersistenceReaderTests
 
         Assert.That(found, Is.True);
         Assert.That(result.AsReadOnlySpan.ToArray(), Is.EqualTo(expected));
+    }
+
+    // Golden path: a correctly RLP-wrapped 32-byte value (0xa0 + 32 = 33 bytes on disk) decodes cleanly with
+    // rlpWrapSlots:true and must not trip the over-length guard (which checks the decoded length, not 33).
+    [Test]
+    public void TryGetStorage_RlpWrapped_DecodesToSlotValue()
+    {
+        byte[] payload = new byte[SlotValue.ByteCount];
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i + 1);
+        byte[] rlp = Rlp.Encode(payload).Bytes; // 0xa0 + 32 bytes
+
+        FixedValueStore store = new(rlp);
+        BaseFlatPersistence.Reader reader = new(store, store, isPreimageMode: false, rlpWrapSlots: true);
+
+        SlotValue result = default;
+        bool found = reader.TryGetStorage(default, default, ref result);
+
+        Assert.That(found, Is.True);
+        Assert.That(result.AsReadOnlySpan.ToArray(), Is.EqualTo(payload));
     }
 
     /// <summary>Returns the same value for any key; enough to exercise <c>TryGetStorage</c>'s decode path.</summary>

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Exceptions;
+using Nethermind.State.Flat.Persistence;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Persistence;
+
+[TestFixture]
+public class BaseFlatPersistenceReaderTests
+{
+    // Regression: a slot value longer than SlotValue.ByteCount must fail loudly instead of underflowing
+    // the unchecked Unsafe.InitBlockUnaligned in TryGetStorage (which produced a wild memset / SIGSEGV).
+    // Shorter values are right-aligned into the 32-byte slot with leading zeros.
+    [TestCase(33, true)]
+    [TestCase(32, false)]
+    [TestCase(16, false)]
+    [TestCase(1, false)]
+    public void TryGetStorage_RejectsOverLengthValue_ElseRightAligns(int valueLength, bool shouldThrow)
+    {
+        byte[] value = new byte[valueLength];
+        for (int i = 0; i < valueLength; i++) value[i] = (byte)(i + 1);
+
+        FixedValueStore store = new(value);
+        BaseFlatPersistence.Reader reader = new(store, store, isPreimageMode: false, rlpWrapSlots: false);
+
+        if (shouldThrow)
+        {
+            Assert.Throws<InvalidConfigurationException>(() =>
+            {
+                SlotValue outValue = default;
+                reader.TryGetStorage(default, default, ref outValue);
+            });
+            return;
+        }
+
+        SlotValue result = default;
+        bool found = reader.TryGetStorage(default, default, ref result);
+
+        byte[] expected = new byte[SlotValue.ByteCount];
+        value.CopyTo(expected, SlotValue.ByteCount - valueLength);
+
+        Assert.That(found, Is.True);
+        Assert.That(result.AsReadOnlySpan.ToArray(), Is.EqualTo(expected));
+    }
+
+    /// <summary>Returns the same value for any key; enough to exercise <c>TryGetStorage</c>'s decode path.</summary>
+    private sealed class FixedValueStore(byte[] value) : ISortedKeyValueStore
+    {
+        public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => value;
+        public byte[]? FirstKey => null;
+        public byte[]? LastKey => null;
+        public ISortedView GetViewBetween(ReadOnlySpan<byte> firstKeyInclusive, ReadOnlySpan<byte> lastKeyExclusive) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/ClearColumnsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/ClearColumnsTests.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Db;
+using Nethermind.State.Flat.Persistence;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Persistence;
+
+[TestFixture]
+public class ClearColumnsTests
+{
+    // Regression: the flat snap-sync clear (FlatSnapTrieFactory.EnsureInitialize -> Clear) must keep the
+    // on-disk format markers, otherwise a re-synced RLP DB is later misread as legacy raw, leading to a
+    // 33-byte slot value being read as raw and overflowing the slot buffer. Only the state metadata resets.
+    [Test]
+    public void ClearAllColumns_PreservesFormatMarkers_ResetsStateMetadata_AndWipesData()
+    {
+        using MemColumnsDb<FlatDbColumns> db = new();
+        IDb metadata = db.GetColumnDb(FlatDbColumns.Metadata);
+
+        BasePersistence.SetLayout(metadata, FlatLayout.Flat); // writes Layout + SlotEncoding=Rlp
+        BasePersistence.SetCurrentState(metadata,
+            new StateId(123, new ValueHash256("0x1111111111111111111111111111111111111111111111111111111111111111")));
+
+        byte[] slotKey = Bytes.FromHexString("0x0102");
+        db.GetColumnDb(FlatDbColumns.Storage)[slotKey] = Bytes.FromHexString("0xabcdef");
+
+        BasePersistence.ClearAllColumns(db);
+
+        Assert.That(BasePersistence.ReadLayout(metadata), Is.EqualTo(FlatLayout.Flat));
+        Assert.That(metadata.Get(Keccak.Compute("SlotEncoding").BytesToArray()),
+            Is.EqualTo(new[] { BasePersistence.SlotEncodingRlp }));
+        Assert.That(BasePersistence.ReadCurrentState(metadata),
+            Is.EqualTo(new StateId(-1, ValueKeccak.EmptyTreeHash)));
+        Assert.That(db.GetColumnDb(FlatDbColumns.Storage).Get(slotKey), Is.Null);
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/ClearColumnsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/ClearColumnsTests.cs
@@ -30,11 +30,13 @@ public class ClearColumnsTests
 
         BasePersistence.ClearAllColumns(db);
 
-        Assert.That(BasePersistence.ReadLayout(metadata), Is.EqualTo(FlatLayout.Flat));
-        Assert.That(metadata.Get(Keccak.Compute("SlotEncoding").BytesToArray()),
-            Is.EqualTo(new[] { BasePersistence.SlotEncodingRlp }));
-        Assert.That(BasePersistence.ReadCurrentState(metadata),
-            Is.EqualTo(new StateId(-1, ValueKeccak.EmptyTreeHash)));
-        Assert.That(db.GetColumnDb(FlatDbColumns.Storage).Get(slotKey), Is.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(BasePersistence.ReadLayout(metadata), Is.EqualTo(FlatLayout.Flat));
+            Assert.That(BasePersistence.ReadSlotEncoding(metadata), Is.EqualTo(BasePersistence.SlotEncodingRlp));
+            Assert.That(BasePersistence.ReadCurrentState(metadata),
+                Is.EqualTo(new StateId(-1, ValueKeccak.EmptyTreeHash)));
+            Assert.That(db.GetColumnDb(FlatDbColumns.Storage).Get(slotKey), Is.Null);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Rlp;
 
@@ -97,9 +100,11 @@ public static class BaseFlatPersistence
                 value = ctx.DecodeByteArraySpan();
             }
 
-            // Bypass bounds check on the slice - the length is already validated by the if guard above.
-            // This writes the variable-length DB value into the end of the 32-byte struct.
             int len = value.Length;
+            if (len > SlotValue.ByteCount) ThrowSlotValueTooLong(len, rlpWrapSlots);
+
+            // len is now guaranteed <= SlotValue.ByteCount, so the unchecked writes below stay in bounds.
+            // This writes the variable-length DB value into the end of the 32-byte struct.
             if (len == SlotValue.ByteCount)
             {
                 outValue = Unsafe.As<byte, SlotValue>(ref MemoryMarshal.GetReference(value));
@@ -123,6 +128,13 @@ public static class BaseFlatPersistence
         }
 
         private int GetStorageBuffer(ReadOnlySpan<byte> key, Span<byte> outBuffer) => storage.Get(key, outBuffer);
+
+        [DoesNotReturn, StackTraceHidden]
+        private static void ThrowSlotValueTooLong(int length, bool rlpWrapSlots) =>
+            throw new InvalidConfigurationException(
+                $"Flat DB storage slot value is {length} bytes, exceeding the {SlotValue.ByteCount}-byte maximum " +
+                $"(rlpWrapSlots={rlpWrapSlots}). The slot-encoding metadata is likely missing or mismatched " +
+                $"(RLP-wrapped values read as raw). Re-sync the flat DB to recover.", -1);
 
         public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey)
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -69,6 +69,13 @@ public static class BaseFlatPersistence
         return buffer[..StorageKeyLength];
     }
 
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowSlotValueTooLong(int length, bool rlpWrapSlots) =>
+        throw new InvalidConfigurationException(
+            $"Flat DB storage slot value is {length} bytes, exceeding the {SlotValue.ByteCount}-byte maximum " +
+            $"(rlpWrapSlots={rlpWrapSlots}). The slot-encoding metadata is likely missing or mismatched " +
+            $"(RLP-wrapped values read as raw). Re-sync the flat DB to recover.", -1);
+
     public readonly struct Reader(
         ISortedKeyValueStore state,
         ISortedKeyValueStore storage,
@@ -100,6 +107,9 @@ public static class BaseFlatPersistence
                 value = ctx.DecodeByteArraySpan();
             }
 
+            // The value was read into a RlpSlotValueBufferSize-byte buffer, so len is at most that size; this
+            // guard catches a 33-byte RLP-wrapped slot mistakenly read as raw (len 33 > 32), which would
+            // otherwise underflow the unchecked InitBlock below into a multi-GB wild memset.
             int len = value.Length;
             if (len > SlotValue.ByteCount) ThrowSlotValueTooLong(len, rlpWrapSlots);
 
@@ -128,13 +138,6 @@ public static class BaseFlatPersistence
         }
 
         private int GetStorageBuffer(ReadOnlySpan<byte> key, Span<byte> outBuffer) => storage.Get(key, outBuffer);
-
-        [DoesNotReturn, StackTraceHidden]
-        private static void ThrowSlotValueTooLong(int length, bool rlpWrapSlots) =>
-            throw new InvalidConfigurationException(
-                $"Flat DB storage slot value is {length} bytes, exceeding the {SlotValue.ByteCount}-byte maximum " +
-                $"(rlpWrapSlots={rlpWrapSlots}). The slot-encoding metadata is likely missing or mismatched " +
-                $"(RLP-wrapped values read as raw). Re-sync the flat DB to recover.", -1);
 
         public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey)
         {
@@ -210,8 +213,14 @@ public static class BaseFlatPersistence
 
                 // Extract the 32-byte slot hash from the middle of the key
                 _currentKey = new ValueHash256(view.CurrentKey.Slice(StoragePrefixPortion, StorageSlotKeySize));
-                ReadOnlySpan<byte> rawValue = view.CurrentValue;
-                _currentValue = rlpWrapSlots ? rawValue.AsRlpValueContext().DecodeByteArraySpan().ToArray() : rawValue.ToArray();
+                ReadOnlySpan<byte> slotValue = rlpWrapSlots
+                    ? view.CurrentValue.AsRlpValueContext().DecodeByteArraySpan()
+                    : view.CurrentValue;
+                // Mirror TryGetStorage: a slot value over 32 bytes means the encoding is mismatched (e.g. a
+                // marker-less DB read as raw). Fail loudly here too, rather than handing snap-sync healing a
+                // bad value that would build wrong trie nodes.
+                if (slotValue.Length > SlotValue.ByteCount) ThrowSlotValueTooLong(slotValue.Length, rlpWrapSlots);
+                _currentValue = slotValue.ToArray();
                 return true;
             }
             return false;

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -179,6 +179,15 @@ public static class BasePersistence
         using IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch();
         foreach (FlatDbColumns column in Enum.GetValues<FlatDbColumns>())
         {
+            if (column == FlatDbColumns.Metadata)
+            {
+                // Reset only the state metadata. The on-disk format markers (layout, slot encoding)
+                // and any other metadata are preserved, otherwise a re-synced DB would be read back
+                // with the wrong slot encoding (e.g. RLP-wrapped slots misread as legacy raw).
+                batch.GetColumnBatch(column).Remove(CurrentStateKey);
+                continue;
+            }
+
             IWriteBatch columnBatch = batch.GetColumnBatch(column);
             foreach (byte[] key in db.GetColumnDb(column).GetAllKeys())
             {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -125,7 +125,7 @@ public static class BasePersistence
         }
     }
 
-    private static byte? ReadSlotEncoding(IReadOnlyKeyValueStore kv)
+    internal static byte? ReadSlotEncoding(IReadOnlyKeyValueStore kv)
     {
         byte[]? bytes = kv.Get(SlotEncodingKey);
         return bytes is null || bytes.Length == 0 ? null : bytes[0];


### PR DESCRIPTION
## Changes

The flat snap-sync init (`FlatSnapTrieFactory.EnsureInitialize` → `persistence.Clear()` → `BasePersistence.ClearAllColumns`) wiped **every** key in **every** column, including the `Metadata` column's on-disk format markers (`Layout` and `SlotEncoding`). Those markers are only re-stamped later in a write-batch dispose, gated behind `_rlpWrapSlots` and the per-instance `_layoutPersisted` latch that `Clear()` does not reset — so a clear-then-sync can leave RLP-wrapped slots on disk with the `SlotEncoding` marker **absent**.

On the next open, `ResolveSlotEncoding` then sees the marker absent with slots present and falls back to *legacy raw*. An RLP-wrapped 32-byte slot is 33 bytes (`0xa0` + 32); read as raw, `TryGetStorage` computes `(uint)(SlotValue.ByteCount - len)`, which underflows to ~4 GB and is passed to `Unsafe.InitBlockUnaligned` — a wild memset that **segfaults** the process (reproduced and confirmed from a core dump + JIT-perfmap-symbolized managed stack).

- `BasePersistence.ClearAllColumns` now removes **only** the state metadata (`CurrentState`) from the `Metadata` column and preserves the format markers; all other columns are still cleared in full.
- `BaseFlatPersistence.Reader.TryGetStorage` gains a guard that rejects an over-length slot value with a descriptive `InvalidConfigurationException` instead of underflowing the unchecked write (defense-in-depth; the comment that previously *claimed* the length was validated is now accurate).
- `BaseFlatPersistence.StorageIterator.MoveNext` gains the same over-length guard (shared `ThrowSlotValueTooLong` helper), so all read paths from a corrupted DB fail loudly with the same diagnostic rather than feeding a bad value to snap-sync healing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two new fixtures in `Nethermind.State.Flat.Test/Persistence/`:

- `ClearColumnsTests` — a clear preserves the `Layout` + `SlotEncoding` markers, resets `CurrentState` to the default empty state, and wipes data columns.
- `BaseFlatPersistenceReaderTests` — parameterized: a 33-byte slot value throws (no longer corrupts memory); 32/16/1-byte values round-trip with correct right-alignment; plus an `rlpWrapSlots: true` golden path proving a correctly wrapped value decodes without tripping the guard.

Full `Nethermind.State.Flat.Test` suite passes (506 passed, 4 skipped).

> [!NOTE]
> A DB already corrupted by the old behavior (RLP slots, marker absent) will now throw the clear `InvalidConfigurationException` at the affected block instead of segfaulting; it must be re-synced to recover. This change prevents the marker from being wiped on future syncs.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No